### PR TITLE
Ticket 4326 - entryuuid fixup did not work correctly

### DIFF
--- a/dirsrvtests/tests/suites/entryuuid/basic_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/basic_test.py
@@ -215,8 +215,6 @@ def test_entryuuid_fixup_task(topology):
     plug.enable()
     topology.standalone.restart()
 
-    raise Exception('stop')
-
     # 4. run the fix up
     # For now set the log level to high!
     topology.standalone.config.loglevel(vals=(ErrorLog.DEFAULT,ErrorLog.TRACE))

--- a/src/slapi_r_plugin/src/constants.rs
+++ b/src/slapi_r_plugin/src/constants.rs
@@ -6,6 +6,11 @@ pub const LDAP_SUCCESS: i32 = 0;
 pub const PLUGIN_DEFAULT_PRECEDENCE: i32 = 50;
 
 #[repr(i32)]
+pub enum OpFlags {
+    ByassReferrals = 0x0040_0000,
+}
+
+#[repr(i32)]
 /// The set of possible function handles we can register via the pblock. These
 /// values correspond to slapi-plugin.h.
 pub enum PluginFnType {

--- a/src/slapi_r_plugin/src/entry.rs
+++ b/src/slapi_r_plugin/src/entry.rs
@@ -70,6 +70,14 @@ impl EntryRef {
         }
     }
 
+    pub fn contains_attr(&self, name: &str) -> bool {
+        let cname = CString::new(name).expect("invalid attr name");
+        let va = unsafe { slapi_entry_attr_get_valuearray(self.raw_e, cname.as_ptr()) };
+
+        // If it's null, it's not present, so flip the logic.
+        !va.is_null()
+    }
+
     pub fn add_value(&mut self, a: &str, v: &ValueRef) {
         // turn the attr to a c string.
         // TODO FIX

--- a/src/slapi_r_plugin/src/lib.rs
+++ b/src/slapi_r_plugin/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dn;
 pub mod entry;
 pub mod error;
 pub mod log;
+pub mod modify;
 pub mod pblock;
 pub mod plugin;
 pub mod search;
@@ -27,6 +28,7 @@ pub mod prelude {
     pub use crate::entry::EntryRef;
     pub use crate::error::{DseCallbackStatus, LDAPError, PluginError, RPluginError};
     pub use crate::log::{log_error, ErrorLevel};
+    pub use crate::modify::{ModType, Modify, SlapiMods};
     pub use crate::pblock::{Pblock, PblockRef};
     pub use crate::plugin::{register_plugin_ext, PluginIdRef, SlapiPlugin3};
     pub use crate::search::{Search, SearchScope};

--- a/src/slapi_r_plugin/src/macros.rs
+++ b/src/slapi_r_plugin/src/macros.rs
@@ -828,7 +828,7 @@ macro_rules! slapi_r_search_callback_mapfn {
                 let e = EntryRef::new(raw_e);
                 let data_ptr = raw_data as *const _;
                 let data = unsafe { &(*data_ptr) };
-                match $cb_mod_ident(e, data) {
+                match $cb_mod_ident(&e, data) {
                     Ok(_) => LDAPError::Success as i32,
                     Err(e) => e as i32,
                 }

--- a/src/slapi_r_plugin/src/modify.rs
+++ b/src/slapi_r_plugin/src/modify.rs
@@ -1,0 +1,118 @@
+use crate::constants::OpFlags;
+use crate::dn::SdnRef;
+use crate::error::{LDAPError, PluginError};
+use crate::pblock::Pblock;
+use crate::plugin::PluginIdRef;
+use crate::value::{slapi_value, ValueArray};
+
+use std::ffi::CString;
+use std::ops::{Deref, DerefMut};
+use std::os::raw::c_char;
+
+extern "C" {
+    fn slapi_modify_internal_set_pb_ext(
+        pb: *const libc::c_void,
+        dn: *const libc::c_void,
+        mods: *const *const libc::c_void,
+        controls: *const *const libc::c_void,
+        uniqueid: *const c_char,
+        plugin_ident: *const libc::c_void,
+        op_flags: i32,
+    );
+    fn slapi_modify_internal_pb(pb: *const libc::c_void);
+    fn slapi_mods_free(smods: *const *const libc::c_void);
+    fn slapi_mods_get_ldapmods_byref(smods: *const libc::c_void) -> *const *const libc::c_void;
+    fn slapi_mods_new() -> *const libc::c_void;
+    fn slapi_mods_add_mod_values(
+        smods: *const libc::c_void,
+        mtype: i32,
+        attrtype: *const c_char,
+        value: *const *const slapi_value,
+    );
+}
+
+#[derive(Debug)]
+#[repr(i32)]
+pub enum ModType {
+    Add = 0,
+    Delete = 1,
+    Replace = 2,
+}
+
+pub struct SlapiMods {
+    inner: *const libc::c_void,
+    vas: Vec<ValueArray>,
+}
+
+impl Drop for SlapiMods {
+    fn drop(&mut self) {
+        unsafe { slapi_mods_free(&self.inner as *const *const libc::c_void) }
+    }
+}
+
+impl SlapiMods {
+    pub fn new() -> Self {
+        SlapiMods {
+            inner: unsafe { slapi_mods_new() },
+            vas: Vec::new(),
+        }
+    }
+
+    pub fn append(&mut self, modtype: ModType, attrtype: &str, values: ValueArray) {
+        // We can get the value array pointer here to push to the inner
+        // because the internal pointers won't change even when we push them
+        // to the list to preserve their lifetime.
+        let vas = values.as_ptr();
+        // We take ownership of this to ensure it lives as least as long as our
+        // slapimods structure.
+        self.vas.push(values);
+        // now we can insert these to the modes.
+        let c_attrtype = CString::new(attrtype).expect("failed to allocate attrtype");
+        unsafe { slapi_mods_add_mod_values(self.inner, modtype as i32, c_attrtype.as_ptr(), vas) };
+    }
+}
+
+pub struct Modify {
+    pb: Pblock,
+    mods: SlapiMods,
+}
+
+pub struct ModifyResult {
+    pb: Pblock,
+}
+
+impl Modify {
+    pub fn new(dn: &SdnRef, mods: SlapiMods, plugin_id: PluginIdRef) -> Result<Self, PluginError> {
+        let pb = Pblock::new();
+        let lmods = unsafe { slapi_mods_get_ldapmods_byref(mods.inner) };
+        // OP_FLAG_ACTION_LOG_ACCESS
+
+        unsafe {
+            slapi_modify_internal_set_pb_ext(
+                pb.deref().as_ptr(),
+                dn.as_ptr(),
+                lmods,
+                std::ptr::null(),
+                std::ptr::null(),
+                plugin_id.raw_pid,
+                OpFlags::ByassReferrals as i32,
+            )
+        };
+
+        Ok(Modify { pb, mods })
+    }
+
+    pub fn execute(self) -> Result<ModifyResult, LDAPError> {
+        let Modify {
+            mut pb,
+            mods: _mods,
+        } = self;
+        unsafe { slapi_modify_internal_pb(pb.deref().as_ptr()) };
+        let result = pb.get_op_result();
+
+        match result {
+            0 => Ok(ModifyResult { pb }),
+            _e => Err(LDAPError::from(result)),
+        }
+    }
+}

--- a/src/slapi_r_plugin/src/pblock.rs
+++ b/src/slapi_r_plugin/src/pblock.rs
@@ -11,6 +11,7 @@ pub use crate::log::{log_error, ErrorLevel};
 extern "C" {
     fn slapi_pblock_set(pb: *const libc::c_void, arg: i32, value: *const libc::c_void) -> i32;
     fn slapi_pblock_get(pb: *const libc::c_void, arg: i32, value: *const libc::c_void) -> i32;
+    fn slapi_pblock_destroy(pb: *const libc::c_void);
     fn slapi_pblock_new() -> *const libc::c_void;
 }
 
@@ -38,6 +39,12 @@ impl Deref for Pblock {
 impl DerefMut for Pblock {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
+    }
+}
+
+impl Drop for Pblock {
+    fn drop(&mut self) {
+        unsafe { slapi_pblock_destroy(self.value.raw_pb) }
     }
 }
 

--- a/src/slapi_r_plugin/src/value.rs
+++ b/src/slapi_r_plugin/src/value.rs
@@ -96,6 +96,10 @@ impl ValueArray {
         let bs = vs.into_boxed_slice();
         Box::leak(bs) as *const _ as *const *const slapi_value
     }
+
+    pub fn as_ptr(&self) -> *const *const slapi_value {
+        self.data.as_ptr() as *const *const slapi_value
+    }
 }
 
 impl FromIterator<Value> for ValueArray {


### PR DESCRIPTION
Bug Description: due to an oversight in how fixup tasks
worked, the entryuuid fixup task did not work correctly and
would not persist over restarts.

Fix Description: Correctly implement entryuuid fixup.

fixes: #4326

Author: William Brown <william@blackhats.net.au>

Review by: ???