### PR TITLE
Issue 4176 - import ldif2cl task should not close all changelogs

### DIFF
--- a/dirsrvtests/tests/suites/replication/changelog_encryption_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_encryption_test.py
@@ -1,0 +1,81 @@
+import logging
+import pytest
+import os
+import time
+from lib389._constants import DEFAULT_SUFFIX,  DN_CHANGELOG,  DN_USERROOT_LDBM
+from lib389.topologies import topology_m1c1 as topo
+from lib389.dseldif import DSEldif
+from lib389.utils import ds_supports_new_changelog
+from lib389.replica import Replicas
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def test_cl_encryption_setup_process(topo):
+    """Take an already working replication deployment, and setup changelog
+    encryption
+
+    :id: 1a1b7d29-69f5-4f0e-91c4-e7f66140ff17
+    :setup: Master Instance, Consumer Instance
+    :steps:
+        1. Enable TLS for the server
+        2. Export changelog
+        3. Enable changelog encryption
+        4. Import changelog
+        5. Verify replication is still working
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+
+    supplier = topo.ms['master1']
+    consumer = topo.cs['consumer1']
+
+    # Enable TLS
+    log.info('Enable TLS ...')
+    supplier.enable_tls()
+    consumer.enable_tls()
+
+    # Export changelog
+    log.info('Export changelog ...')
+    replicas = Replicas(supplier)
+    replica = replicas.get(DEFAULT_SUFFIX)
+    replica.begin_task_cl2ldif()
+    replica.task_finished()
+
+    # Enable changelog encryption
+    log.info('Enable changelog encryption ...')
+    dse_ldif = DSEldif(supplier)
+    supplier.stop()
+    if ds_supports_new_changelog():
+        changelog = 'cn=changelog,{}'.format(DN_USERROOT_LDBM)
+    else:
+        changelog = DN_CHANGELOG
+    dse_ldif.replace(changelog, 'nsslapd-encryptionalgorithm', 'AES')
+    if dse_ldif.get(changelog, 'nsSymmetricKey'):
+        dse_ldif.delete(changelog, 'nsSymmetricKey')
+    supplier.start()
+
+    # Import changelog
+    log.info('Import changelog ...')
+    replica.begin_task_ldif2cl()
+    replica.task_finished()
+
+    # Verify replication is still working
+    log.info('Test replication is still working ...')
+    assert replica.test_replication([consumer])
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -231,7 +231,7 @@ def remove_ldif_files_from_changelogdir(topo, extension):
             else:
                 log.info('Existing changelog %s file: %s removed' % (extension,changelog_file))
 
-                
+
 @pytest.mark.xfail(ds_is_older('1.3.10.1', '1.4.3'), reason="bug bz1685059")
 @pytest.mark.skip(reason="does not work for prefix builds")
 @pytest.mark.bz1685059
@@ -258,7 +258,7 @@ def test_cldump_files_removed(topo):
     :expectedresults:
         1. No remaining .ldif file in the changelog directory
         2. No remaining .ldif.done file in the changelog directory
-        3. ldap operations are replicated and recorded in changelog 
+        3. ldap operations are replicated and recorded in changelog
         4. A result code different from 0 is raised
         5. cl-dump is successfully executed
         6. cl-dump process has finished
@@ -275,7 +275,7 @@ def test_cldump_files_removed(topo):
 
     # Remove existing .ldif.done files in changelog dir
     remove_ldif_files_from_changelogdir(topo, '.done')
-                
+
     _perform_ldap_operations(topo)
 
     # This part to make sure that an error in the cl-dump script execution will be detected,
@@ -290,7 +290,7 @@ def test_cldump_files_removed(topo):
     msg = proc.communicate()
     log.info('output message : %s' % msg[0])
     assert proc.returncode != 0
-    
+
     # Now the core goal of the test case
     # Using cl-dump without -l option
     log.info("Use cl-dump perl script without -l option : no generated ldif files should remain in %s " % changelog_dir)
@@ -345,22 +345,22 @@ def test_dsconf_dump_changelog_files_removed(topo):
         2. Clean the changelog directory, removing .ldif.done files present, if any
         3. Perform ldap operations to record replication changes
         4. Try a dsconf call with invalid arguments to secure the next steps
-        5. Launch dsconf dump-changelog cli without -l option
+        5. Launch dsconf export-changelog cli without -l option
         6. Wait so that all dsconf tasks be finished
         7. Check that all .ldif.done generated files have been removed from the changelog dir
-        8. Launch dsconf dump-changelog cli with -l option
+        8. Launch dsconf export-changelog cli with -l option
         9. Wait so that all dsconf tasks be finished
         10. Check that the generated .ldif.done files are present in the changelog dir
 
     :expectedresults:
         1. No remaining .ldif file in the changelog directory
         2. No remaining .ldif.done file in the changelog directory
-        3. ldap operations are replicated and recorded in changelog 
+        3. ldap operations are replicated and recorded in changelog
         4. A result code different from 0 is raised
-        5. dsconf dump-changelog is successfully executed
+        5. dsconf export-changelog is successfully executed
         6. dsconf process has finished
         7. No .ldif.done files in the changelog dir
-        8. dsconf dump-changelog is successfully executed
+        8. dsconf export-changelog is successfully executed
         9. dsconf process has finished
         10. .ldif.done generated files are present in the changelog dir
      """
@@ -374,55 +374,57 @@ def test_dsconf_dump_changelog_files_removed(topo):
 
     # Remove existing .ldif files in changelog dir
     remove_ldif_files_from_changelogdir(topo, '.ldif')
-      
+
     # Remove existing .ldif.done files from changelog dir
     remove_ldif_files_from_changelogdir(topo, '.done')
-                
+
     _perform_ldap_operations(topo)
 
-    # This part to make sure that an error in the python dsconf dump-changelog execution will be detected,
+    # This part to make sure that an error in the python dsconf export-changelog execution will be detected,
     # primary condition before executing the core goal of this case : management of generated files.
 
-    log.info("Use dsconf dump-changelog with invalid parameters")
-    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', 'badpasswd', 'replication', 'dump-changelog']
+    log.info("Use dsconf export-changelog with invalid parameters")
+    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', 'badpasswd', 'replication', 'export-changelog']
     log.info('Command used : %s' % cmdline)
     proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
     msg = proc.communicate()
     log.info('output message : %s' % msg[0])
     assert proc.returncode != 0
-    
+
     # Now the core goal of the test case
     # Using dsconf replication changelog  without -l option
     log.info('Use dsconf replication changelog without -l option: no generated ldif files should be present in %s ' % changelog_dir)
-    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', PASSWORD, 'replication', 'dump-changelog']
+    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', PASSWORD, 'replication', 'export-changelog',
+             'default', '-r', DEFAULT_SUFFIX]
     log.info('Command used : %s' % cmdline)
     proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
     proc.communicate()
     assert proc.returncode == 0
 
-    log.info('Wait for all dsconf dump-changelog files to be generated')
+    log.info('Wait for all dsconf export-changelog files to be generated')
     time.sleep(1)
 
-    log.info('Check if dsconf dump-changelog generated .ldif.done files are present - should not')
+    log.info('Check if dsconf export-changelog generated .ldif.done files are present - should not')
     for files in os.listdir(changelog_dir):
         if files.endswith('.done'):
-            log.fatal('dump-changelog generated .ldif.done files are present in %s - they should not' % changelog_dir)
+            log.fatal('export-changelog generated .ldif.done files are present in %s - they should not' % changelog_dir)
             assert False
     else:
-        log.info('All dsconf dump-changelog generated .ldif files have been successfully removed from %s ' % changelog_dir)
+        log.info('All dsconf export-changelog generated .ldif files have been successfully removed from %s ' % changelog_dir)
 
     # Using dsconf replication changelog  without -l option
     log.info('Use dsconf replication changelog with -l option: generated ldif files should be kept in %s ' % changelog_dir)
-    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', PASSWORD, 'replication', 'dump-changelog', '-l']
+    cmdline=['/usr/sbin/dsconf', instance_url, '-D', DN_DM, '-w', PASSWORD, 'replication', 'export-changelog',
+             'to-ldif', '-o', changelog_dir + '/test.ldif', '-r', DEFAULT_SUFFIX, '-l']
     log.info('Command used : %s' % cmdline)
     proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
     proc.communicate()
     assert proc.returncode == 0
 
-    log.info('Wait for all dsconf dump-changelog files to be generated')
+    log.info('Wait for all dsconf export-changelog files to be generated')
     time.sleep(1)
 
-    log.info('Check if dsconf dump-changelog generated .ldif.done files are present - should be')
+    log.info('Check if dsconf export-changelog generated .ldif.done files are present - should be')
     for files in os.listdir(changelog_dir):
         if files.endswith('.done'):
             cldump_file = os.path.join(changelog_dir, files)
@@ -484,7 +486,7 @@ def test_verify_changelog_online_backup(topo):
         assert False
 
     if ds_supports_new_changelog():
-        backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, 'changelog.db')
+        backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, BDB_CL_FILENAME)
     else:
         backup_checkdir = os.path.join(backup_dir, '.repl_changelog_backup', DEFAULT_CHANGELOG_DB)
     if os.path.exists(backup_checkdir):
@@ -545,7 +547,7 @@ def test_verify_changelog_offline_backup(topo):
     topo.ms['master1'].start()
 
     if ds_supports_new_changelog():
-        backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, 'changelog.db')
+        backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, BDB_CL_FILENAME)
     else:
         backup_checkdir = os.path.join(backup_dir, '.repl_changelog_backup', DEFAULT_CHANGELOG_DB)
     if os.path.exists(backup_checkdir):

--- a/dirsrvtests/tests/suites/replication/multiple_changelogs_test.py
+++ b/dirsrvtests/tests/suites/replication/multiple_changelogs_test.py
@@ -1,0 +1,175 @@
+import ldap
+import logging
+import pytest
+import os
+import threading
+import time
+from lib389._constants import *
+from lib389.topologies import topology_m1c1 as topo
+from lib389.idm.directorymanager import DirectoryManager
+from lib389.idm.domain import Domain
+from lib389.backend import Backend
+from lib389.replica import Replicas, ReplicationManager
+
+log = logging.getLogger(__name__)
+
+SECOND_SUFFIX = 'dc=second_suffix'
+MOD_COUNT = 50
+
+class DoMods(threading.Thread):
+    """modify the suffix entry"""
+    def __init__(self, inst, task):
+        """
+        Initialize the thread
+        """
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.inst = inst
+        self.name = inst.serverid
+        self.task = task
+
+    def run(self):
+        """
+        Start adding users
+        """
+        idx = 0
+        conn = DirectoryManager(self.inst).bind()
+        domain = Domain(conn, DEFAULT_SUFFIX)
+        while idx < MOD_COUNT:
+            try:
+                domain.replace('description', str(idx))
+            except:
+                if self.task == "import":
+                    # Failures are expected during an import
+                    pass
+                else:
+                    # export, should not fail
+                    log.fatal('Updates should not fail during an export')
+                    assert False
+            idx += 1
+
+
+def test_multiple_changelogs(topo):
+    """Test the multiple suffixes can be replicated with the new per backend
+    changelog.
+
+    :id: eafcdb57-4ea2-4887-a0a8-9e4d295f4f4d
+    :setup: Master Instance, Consumer Instance
+    :steps:
+        1. Create s second suffix
+        2. Enable replication for second backend
+        3. Perform some updates on both backends and make sure replication is
+           working for both backends
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    supplier = topo.ms['master1']
+    consumer = topo.cs['consumer1']
+
+    # Create second suffix dc=second_backend on both replicas
+    for inst in [supplier, consumer]:
+        # Create the backends
+        props = {'cn': 'secondRoot', 'nsslapd-suffix': SECOND_SUFFIX}
+        be = Backend(inst)
+        be.create(properties=props)
+        be.create_sample_entries('001004002')
+
+    # Setup replication for second suffix
+    repl = ReplicationManager(SECOND_SUFFIX)
+    repl.create_first_master(supplier)
+    repl.join_consumer(supplier, consumer)
+
+    # Test replication works for each backend
+    for suffix in [DEFAULT_SUFFIX, SECOND_SUFFIX]:
+        replicas = Replicas(supplier)
+        replica = replicas.get(suffix)
+        log.info("Testing replication for: " + suffix)
+        assert replica.test_replication([consumer])
+
+
+def test_multiple_changelogs_export_import(topo):
+    """Test that we can export and import the replication changelog
+
+    :id: b74fcaaf-a13f-4ee0-98f9-248b281f8700
+    :setup: Master Instance, Consumer Instance
+    :steps:
+        1. Create s second suffix
+        2. Enable replication for second backend
+        3. Perform some updates on a backend, and export the changelog
+        4. Do an export and import while the server is idle
+        5. Do an import while the server is under load
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+    SECOND_SUFFIX = 'dc=second_suffix'
+    supplier = topo.ms['master1']
+    consumer = topo.cs['consumer1']
+    supplier.config.set('nsslapd-errorlog-level', '0')
+    # Create second suffix dc=second_backend on both replicas
+    for inst in [supplier, consumer]:
+        # Create the backends
+        props = {'cn': 'secondRoot', 'nsslapd-suffix': SECOND_SUFFIX}
+        be = Backend(inst)
+        try:
+            be.create(properties=props)
+            be.create_sample_entries('001004002')
+        except ldap.UNWILLING_TO_PERFORM:
+            pass
+
+    # Setup replication for second suffix
+    try:
+        repl = ReplicationManager(SECOND_SUFFIX)
+        repl.create_first_master(supplier)
+        repl.join_consumer(supplier, consumer)
+    except ldap.ALREADY_EXISTS:
+        pass
+
+    # Put the replica under load, and export the changelog
+    replicas = Replicas(supplier)
+    replica = replicas.get(DEFAULT_SUFFIX)
+    doMods1 = DoMods(supplier, task="export")
+    doMods1.start()
+    replica.begin_task_cl2ldif()
+    doMods1.join()
+    replica.task_finished()
+
+    # allow some time to pass, and test replication
+    time.sleep(1)
+    assert replica.test_replication([consumer])
+
+    # While idle, go an export and import, and make sure replication still works
+    log.info("Testing idle server with CL export and import...")
+    replica.begin_task_cl2ldif()
+    replica.task_finished()
+    replica.begin_task_ldif2cl()
+    replica.task_finished()
+    assert replica.test_replication([consumer])
+
+    # stability test, put the replica under load, import the changelog, and make
+    # sure server did not crash.
+    log.info("Testing busy server with CL import...")
+    doMods2 = DoMods(supplier, task="import")
+    doMods2.start()
+    replica.begin_task_ldif2cl()
+    doMods2.join()
+    replica.task_finished()
+    # Replication will be broken so no need to test it.  This is just make sure
+    # the import works, and the server is stable
+    assert supplier.status()
+    assert consumer.status()
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/plugins/replication/cl5_config.c
+++ b/ldap/servers/plugins/replication/cl5_config.c
@@ -1,4 +1,4 @@
-/** BEGIN COPYRIGHT BLOCK
+ /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
  * Copyright (C) 2005 Red Hat, Inc.
  * All rights reserved.
@@ -313,6 +313,10 @@ cldb_config_modify(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *entryAfter, in
                     config.symmetricKey = slapi_ch_strdup(config_attr_value);
                     /* Storing the encryption symmetric key */
                     /* no need to change any changelog configuration */
+                    goto done;
+                } else if (strcasecmp(config_attr, CONFIG_CHANGELOG_ENCRYPTION_ALGORITHM) == 0) {
+                    /* We should allow the operation to succeed but it requires
+                     * a restart to take effect. */
                     goto done;
                 } else {
                     *returncode = LDAP_UNWILLING_TO_PERFORM;

--- a/ldap/servers/plugins/replication/cl5_init.c
+++ b/ldap/servers/plugins/replication/cl5_init.c
@@ -94,7 +94,6 @@ changelog5_cleanup()
 {
     /* close changelog */
     cl5Close();
-    cl5Cleanup();
 
     /* cleanup config */
     changelog5_config_cleanup();

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -762,8 +762,8 @@ PRBool ignore_error_and_keep_going(int error);
 void replica_check_release_timeout(Replica *r, Slapi_PBlock *pb);
 void replica_lock_replica(Replica *r);
 void replica_unlock_replica(Replica *r);
-void *replica_get_file_info(Replica *r);
-int replica_set_file_info(Replica *r, void *cl);
+void *replica_get_cl_info(Replica *r);
+int replica_set_cl_info(Replica *r, void *cl);
 
 /* The functions below handles the state flag */
 /* Current internal state flags */

--- a/ldap/servers/plugins/replication/repl5_agmt.c
+++ b/ldap/servers/plugins/replication/repl5_agmt.c
@@ -252,6 +252,7 @@ agmt_is_valid(Repl_Agmt *ra)
 Repl_Agmt *
 agmt_new_from_entry(Slapi_Entry *e)
 {
+    Replica *replica = NULL;
     Repl_Agmt *ra;
     Slapi_Attr *sattr;
     char errormsg[SLAPI_DSE_RETURNTEXT_SIZE];
@@ -393,8 +394,6 @@ agmt_new_from_entry(Slapi_Entry *e)
     /* DN of entry at root of replicated area */
     tmpstr = slapi_entry_attr_get_charptr(e, type_nsds5ReplicaRoot);
     if (NULL != tmpstr) {
-        Replica *replica;
-
         ra->replarea = slapi_sdn_new_dn_passin(tmpstr);
 
         /* now that we set the repl area, when can bump our agmt count */
@@ -562,8 +561,9 @@ agmt_new_from_entry(Slapi_Entry *e)
         goto loser;
     }
 
-    /* Now that the agreement is done, just check if changelog is configured */
-    if (cl5GetState() != CL5_STATE_OPEN) {
+    /* Now that the agreement is done, just check if changelog is configured.
+     * This should not with the new per backend changelog design */
+    if (!cldb_is_open(replica)) {
         slapi_log_err(SLAPI_LOG_WARNING, repl_plugin_name, "agmt_new_from_entry: "
                                                            "Replication agreement added but there is no changelog configured. "
                                                            "No change will be replicated until a changelog is configured.\n");

--- a/ldap/servers/plugins/replication/repl5_inc_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_inc_protocol.c
@@ -1964,7 +1964,7 @@ send_updates(Private_Repl_Protocol *prp, RUV *remote_update_vector, PRUint32 *nu
         repl5_inc_rd_destroy(&rd);
 
         cl5_operation_parameters_done(entry.op);
-        cl5DestroyReplayIterator(&changelog_iterator);
+        cl5DestroyReplayIterator(&changelog_iterator, replica);
     }
     return return_value;
 }

--- a/ldap/servers/plugins/replication/repl5_plugins.c
+++ b/ldap/servers/plugins/replication/repl5_plugins.c
@@ -995,7 +995,7 @@ write_changelog_and_ruv(Slapi_PBlock *pb)
         PR_ASSERT(opext);
 
         /* changelog database information to pass to the write function */
-        cldb = replica_get_file_info(r);
+        cldb = replica_get_cl_info(r);
 
         /* for replicated operations, we log the original, non-urp data which is
            saved in the operation extension */

--- a/ldap/servers/plugins/replication/repl_extop.c
+++ b/ldap/servers/plugins/replication/repl_extop.c
@@ -1160,7 +1160,7 @@ multimaster_extop_EndNSDS50ReplicationRequest(Slapi_PBlock *pb)
                    an entry that corresponds to the ruv sent to the consumer and then
                    send it as part of the data */
 /*
-                if (cl5GetState() == CL5_STATE_OPEN) {
+                if (cldb_is_open(r)) {
                     cl5DeleteDBSync(connext->replica_acquired);
                 }
                 no longer needed, the cl was recreated when replication was reenabled
@@ -1173,8 +1173,7 @@ multimaster_extop_EndNSDS50ReplicationRequest(Slapi_PBlock *pb)
                    smallest csn in the new ruv, so that this replica ca supply
                    other servers.
                 */
-                if (replica_is_flag_set(r, REPLICA_LOG_CHANGES) &&
-                    cl5GetState() == CL5_STATE_OPEN) {
+                if (replica_is_flag_set(r, REPLICA_LOG_CHANGES) && cldb_is_open(r)) {
                     replica_log_ruv_elements(r);
                 }
 

--- a/ldap/servers/plugins/replication/replutil.c
+++ b/ldap/servers/plugins/replication/replutil.c
@@ -342,9 +342,9 @@ parse_changes_string(char *str)
             if (strcasecmp(line, "-") == 0) {
                 if (slapi_mod_isvalid(&mod)) {
                     slapi_mods_add_smod(mods, &mod);
-                    /* JCMREPL - ONREPL - slapi_mod_done(&mod) ??? */
                 } else {
-                    /* ONREPL - need to cleanup */
+                    /* need to cleanup */
+                    slapi_mod_done(&mod);
                 }
 
                 line = ldif_getline(&next);

--- a/ldap/servers/plugins/replication/windows_inc_protocol.c
+++ b/ldap/servers/plugins/replication/windows_inc_protocol.c
@@ -1151,6 +1151,7 @@ send_updates(Private_Repl_Protocol *prp, RUV *remote_update_vector, PRUint32 *nu
         int finished = 0;
         ConnResult replay_crc;
         char csn_str[CSN_STRSIZE];
+        Replica *replica = prp->replica;
 
         memset((void *)&op, 0, sizeof(op));
         entry.op = &op;
@@ -1307,7 +1308,7 @@ send_updates(Private_Repl_Protocol *prp, RUV *remote_update_vector, PRUint32 *nu
             }
         } while (!finished);
         w_cl5_operation_parameters_done(entry.op);
-        cl5DestroyReplayIterator(&changelog_iterator);
+        cl5DestroyReplayIterator(&changelog_iterator, replica);
     }
     /* Save the RUV that we successfully replayed, this ensures that next time we start off at the next changelog record */
     if (current_ruv) {

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -111,6 +111,8 @@ typedef unsigned short u_int16_t;
  * newidl format.
  * Starting from DS7.2
  */
+#define BE_CHANGELOG_FILE     "replication_changelog"
+
 #define BDB_IMPL              "bdb"
 #define BDB_BACKEND           "libback-ldbm" /* This backend plugin */
 #define BDB_NEWIDL            "newidl"       /* new idl format */
@@ -118,10 +120,9 @@ typedef unsigned short u_int16_t;
 #define BDB_RDNFORMAT_VERSION "3"            /* rdn-format version (by default, 0) */
 #define BDB_DNFORMAT          "dn-4514"      /* DN format RFC 4514 compliant */
 #define BDB_DNFORMAT_VERSION  "1"            /* DN format version */
-#define BDB_CL_FILENAME       "changelog.db"
+#define BDB_CL_FILENAME       "replication_changelog.db"
 
 #define LMDB_IMPL             "lmdb"
-#define LMDB_CL_FILENAME      "changelog.mdb"
 
 #define DBVERSION_NEWIDL 0x1
 #define DBVERSION_RDNFORMAT 0x2

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -4316,7 +4316,6 @@ dblayer_delete_instance_dir(backend *be)
 static int
 bdb_delete_database_ex(struct ldbminfo *li, char *cldir)
 {
-    dblayer_private *priv = NULL;
     Object *inst_obj;
     PRDir *dirhandle = NULL;
     PRDirEntry *direntry = NULL;
@@ -4326,8 +4325,7 @@ bdb_delete_database_ex(struct ldbminfo *li, char *cldir)
     int ret;
 
     PR_ASSERT(NULL != li);
-    priv = (dblayer_private *)li->li_dblayer_private;
-    PR_ASSERT(NULL != priv);
+    PR_ASSERT(NULL != (dblayer_private *)li->li_dblayer_private);
 
     /* delete each instance */
     for (inst_obj = objset_first_obj(li->li_instance_set); inst_obj;
@@ -5993,10 +5991,10 @@ bdb_get_info(Slapi_Backend *be, int cmd, void **info)
             rc = 0;
         } else {
             DB *db;
-            rc = dblayer_get_changelog(be, &db,DB_CREATE);
+            rc = dblayer_get_changelog(be, &db, DB_CREATE);
         }
         if (rc == 0) {
-           *(DB **)info = inst->inst_changelog;
+            *(DB **)info = inst->inst_changelog;
         } else {
             *(DB **)info = NULL;
         }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -750,7 +750,7 @@ bdb_db2ldif(Slapi_PBlock *pb)
     if (run_from_cmdline && BDB_CONFIG(li)->bdb_private_mem && server_running) {
         slapi_log_err(SLAPI_LOG_ERR,
                       "bdb_db2ldif", "Cannot export the database while the server "
-                                             "is running and nsslapd-db-private-mem option is used, please use ldif2db.pl\n");
+                      "is running and nsslapd-db-private-mem option is used, please use dsconf\n");
         return_value = -1;
         goto bye;
     }
@@ -802,8 +802,8 @@ bdb_db2ldif(Slapi_PBlock *pb)
             slapi_task_log_notice(task,
                     "Backend instance '%s' is already in the middle of another task and cannot be disturbed.",
                     inst->inst_name);
-            slapi_log_err(SLAPI_LOG_ERR, "bdb_db2ldif", "Backend instance '%s' is already in the middle"
-                                                                " of another task and cannot be disturbed.\n",
+            slapi_log_err(SLAPI_LOG_ERR, "bdb_db2ldif",
+                          "Backend instance '%s' is already in the middle of another task and cannot be disturbed.\n",
                           inst->inst_name);
             return_value = LDBM2LDIF_BUSY;
             goto bye;
@@ -959,12 +959,12 @@ bdb_db2ldif(Slapi_PBlock *pb)
         if (NULL == idl) {
             if (err) {
                 /* most likely, indexes are bad. */
-                slapi_log_err(SLAPI_LOG_ERR,
-                              "bdb_db2ldif", "Backend %s: Failed to fetch subtree lists (error %d) %s\n",
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_db2ldif",
+                              "Backend %s: Failed to fetch subtree lists (error %d) %s\n",
                               inst->inst_name, err, dblayer_strerror(err));
-                slapi_log_err(SLAPI_LOG_ERR,
-                              "bdb_db2ldif", "Possibly the entrydn/entryrdn or ancestorid index is "
-                                                     "corrupted or does not exist.\n");
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_db2ldif",
+                              "Possibly the entrydn/entryrdn or ancestorid index is "
+                              "corrupted or does not exist.\n");
                 slapi_log_err(SLAPI_LOG_ERR,
                               "bdb_db2ldif", "Attempting direct unindexed export instead.\n");
             }
@@ -1246,8 +1246,8 @@ bdb_db2ldif(Slapi_PBlock *pb)
         if ((ep->ep_entry) != NULL) {
             ep->ep_id = temp_id;
         } else {
-            slapi_log_err(SLAPI_LOG_WARNING, "bdb_db2ldif", "Skipping "
-                                                                    "badly formatted entry with id %lu\n",
+            slapi_log_err(SLAPI_LOG_WARNING, "bdb_db2ldif",
+                          "Skipping badly formatted entry with id %lu\n",
                           (u_long)temp_id);
             backentry_free(&ep);
             continue;
@@ -1291,7 +1291,7 @@ bdb_db2ldif(Slapi_PBlock *pb)
     if (run_from_cmdline && dump_changelog) {
         return_value = plugin_call_plugins(pb, SLAPI_PLUGIN_BE_POST_EXPORT_FN);
         slapi_log_err(SLAPI_LOG_INFO, "ldbm_back_ldbm2ldif",
-                      "export changelog for %s.\n", inst->inst_name);
+                      "export changelog for %s\n", inst->inst_name);
     }
 
 bye:

--- a/ldap/servers/slapd/back-ldbm/dblayer.c
+++ b/ldap/servers/slapd/back-ldbm/dblayer.c
@@ -92,7 +92,6 @@
 
 #define NEWDIR_MODE 0755
 #define DB_REGION_PREFIX "__db."
-#define BE_CHANGELOG_FILE "changelog"
 
 
 static int dblayer_post_restore = 0;
@@ -664,7 +663,7 @@ int dblayer_get_changelog(backend *be, DB** ppDB, int open_flags)
      * index file and stuff it in the attrinfo.
      */
     return_value = dblayer_open_file(be, BE_CHANGELOG_FILE, open_flags,
-                                   NULL, &pDB);
+                                     NULL, &pDB);
     if (0 == return_value) {
         /* Opened it OK */
         inst->inst_changelog = pDB;

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -1286,7 +1286,7 @@ _back_crypt_cipher_init(Slapi_Backend *be,
                       "the key is wrapped.  To recover the encrypted contents, "
                       "keep the wrapped symmetric key value.\n");
     } else if (ret) {
-        slapi_log_err(SLAPI_LOG_ERR, "_back_crypt_cipher_init",
+        slapi_log_err(SLAPI_LOG_NOTICE, "_back_crypt_cipher_init",
                       "No symmetric key found for cipher "
                       "%s, attempting to create one...\n",
                       acs->cipher_display_name);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -7802,7 +7802,7 @@ struct _back_info_index_key
 struct _back_info_crypt_init
 {
     char *dn;                  /* input -- entry to store nsSymmetricKey */
-    char *encryptionAlgorithm; /* input -- encryption althorithm */
+    char *encryptionAlgorithm; /* input -- encryption algorithm */
     Slapi_Backend *be;         /* input -- backend to use */
     void *state_priv;          /* outout */
 };

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -507,6 +507,7 @@ void
 print_changelog(unsigned char *data, int len __attribute__((unused)))
 {
     uint8_t version;
+    uint8_t encrypted;
     unsigned long operation_type;
     char *pos = (char *)data;
     uint32_t thetime32;
@@ -515,11 +516,17 @@ print_changelog(unsigned char *data, int len __attribute__((unused)))
 
     /* read byte of version */
     version = *((uint8_t *)pos);
-    if (version != 5) {
-        db_printf("Invalid changelog db version %i\nWorks for version 5 only.\n", version);
+    if (version != 5 && version != 6) {
+        db_printf("Invalid changelog db version %i\nWorks for version 5 and 6 only.\n", version);
         exit(1);
     }
     pos += sizeof(version);
+
+    if (version == 6) {
+        /* process the encrypted flag */
+        db_printf("\tencrypted: %s\n", *pos ? "yes" : "no");
+        pos += sizeof(encrypted);
+    }
 
     /* read change type */
     operation_type = (unsigned long)(*(uint8_t *)pos);
@@ -1048,7 +1055,7 @@ is_changelog(char *filename)
         ptr++;
     }
 
-    if (0 == strcmp(ptr,"changelog.db")) return 1;
+    if (0 == strcmp(ptr, "replication_changelog.db")) return 1;
 
     for (; ptr && *ptr; ptr++) {
         if ('.' == *ptr) {

--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -601,7 +601,7 @@ export class DSInstance extends React.Component {
                 )}
                 {serverId !== "" &&
                 (pageLoadingState.state === "success" || pageLoadingState.state === "loading") ? (
-                    <div>
+                    <div className="ds-margin-top-xlg">
                         <div hidden={pageLoadingState.state === "loading"}>
                             <TabContainer
                                 id="basic-tabs-pf"

--- a/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
@@ -1,19 +1,20 @@
 import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
-import { ConfirmPopup } from "../notifications.jsx";
 import { log_cmd } from "../tools.jsx";
 import {
-    noop,
-    Row,
     Button,
     Col,
     ControlLabel,
     Checkbox,
     Form,
-    Icon,
+    FormControl,
+    noop,
+    Row,
     Spinner,
 } from "patternfly-react";
+import { Tooltip } from '@patternfly/react-core';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 
 export class Changelog extends React.Component {
     constructor (props) {
@@ -22,174 +23,71 @@ export class Changelog extends React.Component {
             loading: false,
             errObj: {},
             showConfirmDelete: false,
+            saveOK: false,
             // Changelog settings
-            clDir: this.props.clDir,
             clMaxEntries: this.props.clMaxEntries,
-            clMaxAge: this.props.clMaxAge,
-            clCompactInt: this.props.clCompactInt,
+            clMaxAge: this.props.clMaxAge.slice(0, -1),
+            clMaxAgeUnit: this.props.clMaxAge.slice(-1).toLowerCase(),
             clTrimInt: this.props.clTrimInt,
             clEncrypt: this.props.clEncrypt,
             // Preserve original settings
-            _clDir: this.props.clDir,
             _clMaxEntries: this.props.clMaxEntries,
-            _clMaxAge: this.props.clMaxAge,
-            _clCompactInt: this.props.clCompactInt,
+            _clMaxAge: this.props.clMaxAge.slice(0, -1),
+            _clMaxAgeUnit: this.props.clMaxAge.slice(-1).toLowerCase(),
             _clTrimInt: this.props.clTrimInt,
             _clEncrypt: this.props.clEncrypt,
         };
 
         this.handleChange = this.handleChange.bind(this);
         this.saveSettings = this.saveSettings.bind(this);
-        this.createChangelog = this.createChangelog.bind(this);
-        this.confirmChangelogDelete = this.confirmChangelogDelete.bind(this);
-        this.closeConfirmDelete = this.closeConfirmDelete.bind(this);
-        this.deleteChangelog = this.deleteChangelog.bind(this);
-    }
-
-    componentDidMount() {
-        this.props.enableTree();
-    }
-
-    createChangelog () {
-        this.setState({
-            saving: true
-        });
-        let cmd = [
-            'dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + this.props.serverId + '.socket',
-            'replication', 'create-changelog'
-        ];
-        cockpit
-                .spawn(cmd, {superuser: true, "err": "message"})
-                .done(content => {
-                    this.props.reload();
-                    this.props.addNotification(
-                        "success",
-                        "Successfully created replication changelog"
-                    );
-                    this.setState({
-                        saving: false
-                    });
-                })
-                .fail(err => {
-                    let errMsg = JSON.parse(err);
-                    this.props.reload();
-                    this.setState({
-                        saving: false
-                    });
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
-                    this.props.addNotification(
-                        "error",
-                        `Error creating changelog - ${msg}`
-                    );
-                });
-    }
-
-    confirmChangelogDelete () {
-        this.setState({
-            showConfirmDelete: true
-        });
-    }
-
-    closeConfirmDelete () {
-        this.setState({
-            showConfirmDelete: false
-        });
-    }
-
-    deleteChangelog () {
-        this.setState({
-            saving: true
-        });
-        let cmd = ['dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + this.props.serverId + '.socket',
-            'replication', 'delete-changelog'
-        ];
-        cockpit
-                .spawn(cmd, {superuser: true, "err": "message"})
-                .done(content => {
-                    this.props.reload();
-                    this.props.addNotification(
-                        "success",
-                        "Successfully deleted replication changelog"
-                    );
-                    this.setState({
-                        saving: false
-                    });
-                })
-                .fail(err => {
-                    let errMsg = JSON.parse(err);
-                    this.props.reload();
-                    this.setState({
-                        saving: false
-                    });
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
-                    this.props.addNotification(
-                        "error",
-                        `Error deleting changelog - ${msg}`
-                    );
-                });
     }
 
     saveSettings () {
         let cmd = [
             'dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + this.props.serverId + '.socket',
-            'replication', 'set-changelog'
+            'replication', 'set-changelog', '--suffix', this.props.suffix
         ];
-        if (this.state.clDir != this.state._clDir) {
-            if (this.state.clDir == "") {
-                // Changelog directory can not be empty
-                let errObj = this.state.errObj;
-                errObj["clDir"] = true;
-                this.setState({
-                    errObj: errObj
-                });
-                return;
-            }
-            cmd.push("--cl-dir=" + this.state.clDir);
-        }
+        let msg = "Successfully updated changelog configuration.";
+
         if (this.state.clMaxEntries != this.state._clMaxEntries) {
             cmd.push("--max-entries=" + this.state.clMaxEntries);
         }
-        if (this.state.clMaxAge != this.state._clMaxAge) {
-            cmd.push("--max-age=" + this.state.clMaxAge);
-        }
-        if (this.state.clCompactInt != this.state._clCompactInt) {
-            cmd.push("--compact-interval=" + this.state.clCompactInt);
+        if (this.state.clMaxAge != this.state._clMaxAge || this.state.clMaxAgeUnit != this.state._clMaxAgeUnit) {
+            cmd.push("--max-age=" + this.state.clMaxAge + this.state.clMaxAgeUnit);
         }
         if (this.state.clTrimInt != this.state._clTrimInt) {
             cmd.push("--trim-interval=" + this.state.clTrimInt);
         }
         if (this.state.clEncrypt != this.state._clEncrypt) {
-            // TODO - Not implemented in dsconf yet
-            // cmd.push("--encrypt=" + this.state.clEncrypt);
+            if (this.state.clEncrypt) {
+                cmd.push("--encrypt");
+                msg += "  This requires a server restart to take effect";
+            } else {
+                cmd.push("--disable-encrypt");
+            }
         }
-        if (cmd.length > 5) {
+        if (cmd.length > 6) {
             this.setState({
                 // Start the spinner
                 saving: true
             });
             log_cmd("saveSettings", "Applying replication changelog changes", cmd);
-            let msg = "Successfully updated changelog configuration.";
             cockpit
                     .spawn(cmd, {superuser: true, "err": "message"})
                     .done(content => {
-                        this.props.reload();
+                        this.reloadChangelog();
                         this.props.addNotification(
                             "success",
                             msg
                         );
                         this.setState({
-                            saving: false
+                            saving: false,
+                            saveOK: false,
                         });
                     })
                     .fail(err => {
                         let errMsg = JSON.parse(err);
-                        this.props.reload();
+                        this.reloadChangelog();
                         this.setState({
                             saving: false
                         });
@@ -209,128 +107,194 @@ export class Changelog extends React.Component {
         const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
         let valueErr = false;
         let errObj = this.state.errObj;
-        if (e.target.id == "clDir" && value == "") {
-            valueErr = true;
-        }
+        let all_good = false;
+        let attr = e.target.id;
+
         errObj[e.target.id] = valueErr;
+        if ((attr != 'clMaxEntries' && this.state.clMaxEntries != this.state._clMaxEntries) ||
+            (attr != 'clMaxAge' && this.state.clMaxAge != this.state._clMaxAge) ||
+            (attr != 'clMaxAgeUnit' && this.state.clMaxAgeUnit != this.state._clMaxAgeUnit) ||
+            (attr != 'clTrimInt' && this.state.clTrimInt != this.state._clTrimInt) ||
+            (attr != 'clEncrypt' && this.state.clEncrypt != this.state._clEncrypt)) {
+            all_good = true;
+        }
+        if (attr == 'clMaxEntries' && value != this.state._clMaxEntries) {
+            all_good = true;
+        }
+        if (attr == 'clMaxAge' && value != this.state._clMaxAge) {
+            all_good = true;
+        }
+        if (attr == 'clMaxAgeUnit' && value != this.state._clMaxAgeUnit) {
+            all_good = true;
+        }
+        if (attr == 'clTrimInt' && value != this.state._clTrimInt) {
+            all_good = true;
+        }
+        if (attr == 'clEncrypt' && value != this.state._clEncrypt) {
+            all_good = true;
+        }
+
         this.setState({
             [e.target.id]: value,
-            errObj: errObj
+            errObj: errObj,
+            saveOK: all_good,
         });
+    }
+
+    clMapMaxAgeUnit(unit) {
+        // Max teh unit tothe
+    }
+
+    reloadChangelog () {
+        this.setState({
+            loading: true,
+        });
+        let cmd = ['dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + this.props.serverId + '.socket',
+            'replication', 'get-changelog', '--suffix', this.props.suffix];
+        log_cmd("reloadChangelog", "Load the replication changelog info", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const config = JSON.parse(content);
+                    let clMaxEntries = "";
+                    let clMaxAge = "";
+                    let clMaxAgeUnit = "";
+                    let clTrimInt = "";
+                    let clEncrypt = false;
+                    for (let attr in config['attrs']) {
+                        let val = config['attrs'][attr][0];
+                        if (attr == "nsslapd-changelogmaxentries") {
+                            clMaxEntries = val;
+                        } else if (attr == "nsslapd-changelogmaxage") {
+                            clMaxAge = val.slice(0, -1);
+                            clMaxAgeUnit = val.slice(-1).toLowerCase();
+                        } else if (attr == "nsslapd-changelogtrim-interval") {
+                            clTrimInt = val;
+                        } else if (attr == "nsslapd-encryptionalgorithm") {
+                            clEncrypt = true;
+                        }
+                    }
+                    this.setState({
+                        clMaxEntries: clMaxEntries,
+                        clMaxAge: clMaxAge,
+                        clMaxAgeUnit: clMaxAgeUnit,
+                        clTrimInt: clTrimInt,
+                        clEncrypt: clEncrypt,
+                        _clMaxEntries: clMaxEntries,
+                        _clMaxAge: clMaxAge,
+                        _clTrimInt: clTrimInt,
+                        _clEncrypt: clEncrypt,
+                        saveOK: false,
+                        loading: false,
+                    });
+                })
+                .fail(err => {
+                    let errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        `Failed to reload changelog for "${this.props.suffix}" - ${errMsg.desc}`
+                    );
+                    this.setState({
+                        loading: false,
+                    });
+                });
     }
 
     render() {
         let clPage;
-        if (this.state._clDir == "") {
-            // No changelog, only show clDir and Create button
+        if (this.state.saving) {
             clPage =
-                <div>
-                    <Row>
-                        <Col sm={12} className="ds-word-wrap">
-                            <ControlLabel className="ds-suffix-header">
-                                Replication Changelog
-                                <Icon className="ds-left-margin ds-refresh"
-                                    type="fa" name="refresh" title="Refresh changelog settings"
-                                    onClick={this.props.reload}
-                                />
-                            </ControlLabel>
-                        </Col>
-                    </Row>
-                    <hr />
-                    <div className="ds-margin-top-med ds-center">
-                        <p>There is no Replication Changelog</p>
-                        <Row className="ds-margin-top-lg" title="Create the replication changelog">
-                            <Button
-                                bsStyle="primary"
-                                onClick={this.createChangelog}
-                            >
-                                Create Changelog
-                            </Button>
-                        </Row>
-                    </div>
-                </div>;
-        } else if (this.state.saving) {
-            clPage =
-                <div className="ds-margin-top ds-loading-spinner ds-center">
+                <div className="ds-margin-top-xlg ds-center">
                     <h4>Saving changelog configuration ...</h4>
                     <Spinner className="ds-margin-top-lg" loading size="md" />
                 </div>;
-        } else if (this.props.loading) {
+        } else if (this.loading) {
             clPage =
-                <div className="ds-loading-spinner ds-center">
+                <div className="ds-margin-top ds-center">
                     <h4>Loading changelog configuration ...</h4>
                     <Spinner className="ds-margin-top-lg" loading size="md" />
                 </div>;
         } else {
             clPage =
                 <div>
-                    <Row>
-                        <Col sm={5} className="ds-word-wrap">
-                            <h4>
-                                Replication Changelog
-                                <Icon className="ds-left-margin ds-refresh"
-                                    type="fa" name="refresh" title="Refresh changelog settings"
-                                    onClick={this.props.reload}
-                                />
-                            </h4>
-                        </Col>
-                        <Col sm={7}>
-                            <Button
-                                className="ds-float-right"
-                                bsStyle="danger"
-                                onClick={this.confirmChangelogDelete}
-                            >
-                                Delete Changelog
-                            </Button>
-                        </Col>
-                    </Row>
                     <Form horizontal>
-                        <hr />
-                        <Row className="ds-margin-top" title="The filesystem location of the replication changelog database">
-                            <Col componentClass={ControlLabel} sm={4}>
-                                Changelog Directory
-                            </Col>
-                            <Col sm={8}>
-                                <input value={this.state.clDir} id="clDir" onChange={this.handleChange} className={this.state.errObj.clDir ? "ds-input-auto-bad" : "ds-input-auto"} />
-                            </Col>
-                        </Row>
-                        <Row className="ds-margin-top" title="Changelog trimming parameter.  Set the maximum number of changelog entries allowed in the database (nsslapd-changelogmaxentries).">
+                        <Row className="ds-margin-top-xlg" title="Changelog trimming parameter.  Set the maximum number of changelog entries allowed in the database (nsslapd-changelogmaxentries).">
                             <Col componentClass={ControlLabel} sm={4}>
                                 Changelog Maximum Entries
                             </Col>
-                            <Col sm={8}>
-                                <input value={this.state.clMaxEntries} id="clMaxEntries" onChange={this.handleChange} className="ds-input-auto" />
+                            <Col sm={4}>
+                                <FormControl
+                                    id="clMaxEntries"
+                                    type="number"
+                                    value={this.state.clMaxEntries}
+                                    onChange={this.handleChange}
+                                />
                             </Col>
                         </Row>
-                        <Row className="ds-margin-top" title="Changelog trimming parameter.  This set the maximum age of a changelog entry.  It is recommended to use the same value as the Replication Purge Delay.  (nsslapd-changelogmaxage).">
+                        <Row className="ds-margin-top" title="Changelog trimming parameter.  This set the maximum age of a changelog entry (nsslapd-changelogmaxage).">
                             <Col componentClass={ControlLabel} sm={4}>
                                 Changelog Maximum Age
                             </Col>
-                            <Col sm={8}>
-                                <input value={this.state.clMaxAge} id="clMaxAge" onChange={this.handleChange} className="ds-input-auto" />
+                            <Col sm={2}>
+                                <FormControl
+                                    id="clMaxAge"
+                                    type="number"
+                                    value={this.state.clMaxAge}
+                                    onChange={this.handleChange}
+                                />
+                            </Col>
+                            <Col sm={2}>
+                                <select
+                                    className="btn btn-default dropdown"
+                                    id="clMaxAgeUnit"
+                                    onChange={this.handleChange}
+                                    value={this.state.clMaxAgeUnit}
+                                >
+                                    <option value="s">Seconds</option>
+                                    <option value="m">Minutes</option>
+                                    <option value="h">Hours</option>
+                                    <option value="d">Days</option>
+                                    <option value="w">Weeks</option>
+                                </select>
                             </Col>
                         </Row>
                         <Row className="ds-margin-top" title="The changelog trimming interval.  Set how often the changelog checks if there are entries that can be purged from the changelog based on the trimming parameters (nsslapd-changelogtrim-interval).">
                             <Col componentClass={ControlLabel} sm={4}>
                                 Changelog Trimming Interval
                             </Col>
-                            <Col sm={8}>
-                                <input value={this.state.clTrimInt} id="clTrimInt" onChange={this.handleChange} className="ds-input-auto" />
+                            <Col sm={4}>
+                                <FormControl
+                                    id="clTrimInt"
+                                    type="number"
+                                    value={this.state.clTrimInt}
+                                    onChange={this.handleChange}
+                                />
                             </Col>
                         </Row>
-                        <Row className="ds-margin-top" title="The changelog compaction interval.  Set how often the changelog will compact itself, meaning remove empty/trimmed database slots.  The default is 30 days. (nsslapd-changelogcompactdb-interval).">
-                            <Col componentClass={ControlLabel} sm={4}>
-                                Changelog Compaction Interval
-                            </Col>
-                            <Col sm={8}>
-                                <input value={this.state.clCompactInt} id="clCompactInt" onChange={this.handleChange} className="ds-input-auto" />
-                            </Col>
-                        </Row>
-                        <Row hidden className="ds-margin-top" title="TLS must first be enabled in the server for change encryption to work.  Please consult Administration Guide for more details.">
+                        <Row className="ds-margin-top">
                             <Col componentClass={ControlLabel} sm={4}>
                                 Changelog Encryption
+                                <Tooltip
+                                    id='CLtooltip'
+                                    position="bottom"
+                                    content={
+                                        <div>
+                                            Changelog encryption requires that the server must already be
+                                            configured for security/TLS.  This setting also requires
+                                            that you export and import the changelog which must be done
+                                            while the database is in read-only mode.  So first put the
+                                            database into read-only mode, then export the changelog, enable
+                                            changelog encryption, restart the server, import the changelog,
+                                            and finally unset the database read-only mode.
+                                        </div>
+                                    }
+                                >
+                                    <OutlinedQuestionCircleIcon
+                                        className="ds-left-margin"
+                                    />
+                                </Tooltip>
                             </Col>
-                            <Col sm={2}>
+                            <Col sm={1}>
                                 <Checkbox
                                     id="clEncrypt"
                                     checked={this.state.clEncrypt}
@@ -343,6 +307,7 @@ export class Changelog extends React.Component {
                                 <Button
                                     bsStyle="primary"
                                     onClick={this.saveSettings}
+                                    disabled={!this.state.saveOK}
                                 >
                                     Save
                                 </Button>
@@ -355,13 +320,6 @@ export class Changelog extends React.Component {
         return (
             <div>
                 {clPage}
-                <ConfirmPopup
-                    showModal={this.state.showConfirmDelete}
-                    closeHandler={this.closeConfirmDelete}
-                    actionFunc={this.deleteChangelog}
-                    msg="Are you sure you want to delete the changelog?"
-                    msgContent="This will invalidate all replication agreements, and they will need to be reinitialized."
-                />
             </div>
         );
     }
@@ -369,26 +327,20 @@ export class Changelog extends React.Component {
 
 Changelog.propTypes = {
     serverId: PropTypes.string,
-    clDir: PropTypes.string,
     clMaxEntries: PropTypes.string,
     clMaxAge: PropTypes.string,
-    clCompactInt: PropTypes.string,
     clTrimInt: PropTypes.string,
     clEncrypt: PropTypes.bool,
     addNotification: PropTypes.func,
-    reload: PropTypes.func,
-    enableTree: PropTypes.func,
+    suffix: PropTypes.string,
 };
 
 Changelog.defaultProps = {
     serverId: "",
-    clDir: "",
     clMaxEntries: "",
     clMaxAge: "",
-    clCompactInt: "",
     clTrimInt: "",
     clEncrypt: false,
     addNotification: noop,
-    reload: noop,
-    enableTree: noop,
+    suffix: "",
 };

--- a/src/cockpit/389-console/src/lib/replication/replConfig.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replConfig.jsx
@@ -46,6 +46,10 @@ export class ReplConfig extends React.Component {
             nsds5replicaprotocoltimeout: this.props.data['nsds5replicaprotocoltimeout'],
             nsds5replicabackoffmin: this.props.data['nsds5replicabackoffmin'],
             nsds5replicabackoffmax: this.props.data['nsds5replicabackoffmax'],
+            clMaxEntries: this.props.data['clMaxEntries'],
+            clMaxAge: this.props.data['clMaxAge'],
+            clTrimInt: this.props.data['clTrimInt'],
+            clEncrypt: this.props.data['clEncrypt'],
             // Original settings
             _nsds5replicabinddn: this.props.data['nsds5replicabinddn'],
             _nsds5replicabinddngroup: this.props.data['nsds5replicabinddngroup'],
@@ -57,6 +61,10 @@ export class ReplConfig extends React.Component {
             _nsds5replicaprotocoltimeout: this.props.data['nsds5replicaprotocoltimeout'],
             _nsds5replicabackoffmin: this.props.data['nsds5replicabackoffmin'],
             _nsds5replicabackoffmax: this.props.data['nsds5replicabackoffmax'],
+            _clMaxEntries: this.props.data['clMaxEntries'],
+            _clMaxAge: this.props.data['clMaxAge'],
+            _clTrimInt: this.props.data['clTrimInt'],
+            _clEncrypt: this.props.data['clEncrypt']
 
         };
 
@@ -412,7 +420,7 @@ export class ReplConfig extends React.Component {
                 <Button
                     bsStyle="primary"
                     onClick={this.showPromoteDemoteModal}
-                    title="Promte this Consumer replica to a Master or Hub"
+                    title="Promote this Consumer replica to a Master or Hub"
                     className="ds-inline-btn"
                 >
                     Promote
@@ -435,8 +443,15 @@ export class ReplConfig extends React.Component {
                                     Replica Role
                                 </ControlLabel>
                             </Col>
-                            <Col sm={6}>
-                                <input type="text" defaultValue={this.props.role} size="10" disabled />{roleButton}
+                            <Col sm={2}>
+                                <FormControl
+                                    type="text"
+                                    defaultValue={this.props.role}
+                                    disabled
+                                />
+                            </Col>
+                            <Col sm={1}>
+                                {roleButton}
                             </Col>
                         </Row>
                         <Row className="ds-margin-top">
@@ -445,8 +460,13 @@ export class ReplConfig extends React.Component {
                                     Replica ID
                                 </ControlLabel>
                             </Col>
-                            <Col sm={4}>
-                                <input type="text" defaultValue={this.props.data.nsds5replicaid} size="10" disabled />
+                            <Col sm={2}>
+                                <FormControl
+                                    type="text"
+                                    defaultValue={this.props.data.nsds5replicaid}
+                                    size="10"
+                                    disabled
+                                />
                             </Col>
                         </Row>
                         <hr />

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -10,6 +10,7 @@ import {
     Icon,
     Modal,
     noop,
+    Radio,
     Spinner,
 } from "patternfly-react";
 import PropTypes from "prop-types";
@@ -1555,10 +1556,10 @@ export class ExportModal extends React.Component {
                                 </Col>
                             </Row>
                             <Row className="ds-margin-top-lg" title="Name of the exported LDIF file">
-                                <Col sm={3}>
+                                <Col componentClass={ControlLabel} sm={3}>
                                     <b>LDIF Name</b>
                                 </Col>
-                                <Col sm={9}>
+                                <Col sm={8}>
                                     <FormControl
                                         type="text"
                                         id="ldifLocation"
@@ -1584,6 +1585,159 @@ export class ExportModal extends React.Component {
                             disabled={!saveOK}
                         >
                             Export Replica
+                        </Button>
+                    </Modal.Footer>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+export class ExportCLModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            default: true,
+            debug: false,
+        };
+    }
+
+    render() {
+        const {
+            showModal,
+            closeHandler,
+            handleChange,
+            handleLDIFChange,
+            handleRadioChange,
+            saveHandler,
+            spinning,
+            defaultCL,
+            debugCL,
+            decodeCL,
+            exportCSN,
+            ldifFile,
+            saveOK
+        } = this.props;
+        let spinner = "";
+        let page = "";
+        if (spinning) {
+            spinner =
+                <Row>
+                    <div className="ds-margin-top ds-modal-spinner">
+                        <Spinner loading inline size="lg" />Exporting Replication Change Log... <font size="2">(You can safely close this window)</font>
+                    </div>
+                </Row>;
+        }
+
+        if (defaultCL) {
+            page =
+                <p>
+                    This will export the changelog to the server's LDIF directory.  This
+                    is the only LDIF file that can be imported into the server for enabling
+                    changelog encryption.  Do not edit or rename the file.
+                </p>;
+        } else {
+            page =
+                <div className="ds-margin-left">
+                    <Row className="ds-margin-top-lg">
+                        <Col sm={12}>
+                            <p>
+                                The LDIF file that is generated should <b>not</b> be used
+                                to initialize the Replication Changelog.  It is only
+                                meant for debugging/investigative purposes.
+                            </p>
+                        </Col>
+                    </Row>
+                    <Row className="ds-margin-top-xlg">
+                        <Col componentClass={ControlLabel} sm={2}>
+                            LDIF File
+                        </Col>
+                        <Col sm={10}>
+                            <FormControl
+                                id="ldifFile"
+                                value={ldifFile}
+                                onChange={handleLDIFChange}
+                            />
+                        </Col>
+                    </Row>
+                    <Row className="ds-margin-top-xlg ds-margin-left">
+                        <Checkbox
+                            id="decodeCL"
+                            checked={decodeCL}
+                            onChange={handleChange}
+                        >
+                            Decode base64 changes
+                        </Checkbox>
+                    </Row>
+                    <Row className="ds-margin-top ds-margin-left">
+                        <Checkbox
+                            id="exportCSN"
+                            checked={exportCSN}
+                            onChange={handleChange}
+                        >
+                            Only Export CSN's
+                        </Checkbox>
+                    </Row>
+                </div>;
+        }
+
+        return (
+            <Modal show={showModal} onHide={closeHandler}>
+                <div className="ds-no-horizontal-scrollbar">
+                    <Modal.Header>
+                        <button
+                            className="close"
+                            onClick={closeHandler}
+                            aria-hidden="true"
+                            aria-label="Close"
+                        >
+                            <Icon type="pf" name="close" />
+                        </button>
+                        <Modal.Title>
+                            Create Replication Change Log LDIF File
+                        </Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <Form horizontal autoComplete="off">
+                            <Row className="ds-indent">
+                                <Radio
+                                    name="radioGroup"
+                                    id="defaultCL"
+                                    onChange={handleRadioChange}
+                                    checked={defaultCL} inline
+                                >
+                                    Export to LDIF For Reinitializing The Changelog
+                                </Radio>
+                            </Row>
+                            <Row className="ds-indent">
+                                <Radio
+                                    name="radioGroup"
+                                    id="debugCL"
+                                    onChange={handleRadioChange}
+                                    checked={debugCL} inline
+                                >
+                                    Export to LDIF For Debugging
+                                </Radio>
+                            </Row>
+                            <hr />
+                            {page}
+                            {spinner}
+                        </Form>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            bsStyle="default"
+                            className="btn-cancel"
+                            onClick={closeHandler}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            bsStyle="primary"
+                            onClick={saveHandler}
+                            disabled={!saveOK}
+                        >
+                            Export Changelog
                         </Button>
                     </Modal.Footer>
                 </div>

--- a/src/cockpit/389-console/src/lib/replication/replSuffix.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replSuffix.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
+import { Changelog } from "./replChangelog.jsx";
 import { ReplConfig } from "./replConfig.jsx";
 import { WinsyncAgmts } from "./winsyncAgmts.jsx";
 import { ReplAgmts } from "./replAgmts.jsx";
@@ -279,7 +280,7 @@ export class ReplSuffix extends React.Component {
         if (this.props.disabled) {
             suffixClass = "ds-margin-top-xlg ds-disabled";
         }
-        let replAgmtNavTitle = 'Replication Agreements <font size="2">(' + this.props.agmtRows.length + ')</font>';
+        let replAgmtNavTitle = 'Agreements <font size="2">(' + this.props.agmtRows.length + ')</font>';
         let winsyncNavTitle = 'Winsync Agreements <font size="2">(' + this.props.winsyncRows.length + ')</font>';
 
         let enabledContent =
@@ -297,6 +298,9 @@ export class ReplSuffix extends React.Component {
                                 <div dangerouslySetInnerHTML={{__html: winsyncNavTitle}} />
                             </NavItem>
                             <NavItem eventKey={4}>
+                                <div dangerouslySetInnerHTML={{__html: "Change Log"}} />
+                            </NavItem>
+                            <NavItem eventKey={5}>
                                 <div dangerouslySetInnerHTML={{__html: "RUV's & Tasks"}} />
                             </NavItem>
                         </Nav>
@@ -337,6 +341,18 @@ export class ReplSuffix extends React.Component {
                                 />
                             </TabPane>
                             <TabPane eventKey={4}>
+                                <Changelog
+                                    suffix={this.props.suffix}
+                                    serverId={this.props.serverId}
+                                    addNotification={this.props.addNotification}
+                                    clMaxEntries={this.props.data['clMaxEntries']}
+                                    clMaxAge={this.props.data['clMaxAge']}
+                                    clTrimInt={this.props.data['clTrimInt']}
+                                    clEncrypt={this.props.data['clEncrypt']}
+                                    key={this.props.data}
+                                />
+                            </TabPane>
+                            <TabPane eventKey={5}>
                                 <ReplRUV
                                     suffix={this.props.suffix}
                                     serverId={this.props.serverId}

--- a/src/cockpit/389-console/src/lib/replication/replTasks.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replTasks.jsx
@@ -2,13 +2,14 @@ import cockpit from "cockpit";
 import React from "react";
 import { log_cmd, bad_file_name } from "../tools.jsx";
 import { RUVTable } from "./replTables.jsx";
-import { ExportModal } from "./replModals.jsx";
+import { ExportModal, ExportCLModal } from "./replModals.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import PropTypes from "prop-types";
 import {
     Button,
     Col,
     ControlLabel,
+    Form,
     Icon,
     noop,
     Row,
@@ -27,15 +28,30 @@ export class ReplRUV extends React.Component {
             showConfirmCleanRUV: false,
             modalChecked: false,
             modalSpinning: false,
+            showConfirmCLImport: false,
+            showCLExport: false,
+            defaultCL: true,
+            debugCL: false,
+            decodeCL: false,
+            exportCSN: false,
+            ldifFile: "/tmp/changelog.ldif",
         };
         this.showConfirmCleanRUV = this.showConfirmCleanRUV.bind(this);
         this.closeConfirmCleanRUV = this.closeConfirmCleanRUV.bind(this);
+        this.showConfirmCLImport = this.showConfirmCLImport.bind(this);
+        this.closeConfirmCLImport = this.closeConfirmCLImport.bind(this);
+        this.showCLExport = this.showCLExport.bind(this);
+        this.closeCLExport = this.closeCLExport.bind(this);
         this.showConfirmExport = this.showConfirmExport.bind(this);
         this.closeConfirmExport = this.closeConfirmExport.bind(this);
         this.handleLDIFChange = this.handleLDIFChange.bind(this);
+        this.handleCLLDIFChange = this.handleCLLDIFChange.bind(this);
+        this.handleRadioChange = this.handleRadioChange.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.cleanRUV = this.cleanRUV.bind(this);
         this.doExport = this.doExport.bind(this);
+        this.exportChangelog = this.exportChangelog.bind(this);
+        this.importChangelog = this.importChangelog.bind(this);
     }
 
     showConfirmCleanRUV (rid) {
@@ -55,6 +71,40 @@ export class ReplRUV extends React.Component {
         });
     }
 
+    showConfirmCLImport () {
+        this.setState({
+            showConfirmCLImport: true,
+            modalChecked: false,
+            modalSpinning: false,
+        });
+    }
+
+    closeConfirmCLImport () {
+        this.setState({
+            showConfirmCLImport: false,
+            modalChecked: false,
+            modalSpinning: false,
+        });
+    }
+
+    showCLExport () {
+        this.setState({
+            saveOK: true,
+            showCLExport: true,
+            decodeCL: false,
+            defaultCL: true,
+            debugCL: false,
+            exportChangelog: false,
+            ldifFile: "/tmp/changelog.ldif"
+        });
+    }
+
+    closeCLExport () {
+        this.setState({
+            showCLExport: false,
+        });
+    }
+
     showConfirmExport () {
         this.setState({
             saveOK: false,
@@ -65,6 +115,21 @@ export class ReplRUV extends React.Component {
     closeConfirmExport () {
         this.setState({
             showConfirmExport: false,
+        });
+    }
+
+    handleRadioChange(e) {
+        // Handle the changelog export options
+        let defaultCL = false;
+        let debugCL = false;
+        if (e.target.id == "defaultCL") {
+            defaultCL = true;
+        } else if (e.target.id == "debugCL") {
+            debugCL = true;
+        }
+        this.setState({
+            defaultCL: defaultCL,
+            debugCL: debugCL,
         });
     }
 
@@ -106,9 +171,22 @@ export class ReplRUV extends React.Component {
         });
     }
 
-    handleChange (e) {
+    handleCLLDIFChange (e) {
+        let value = e.target.value;
+        let saveOK = true;
+        if (value == "" || value.indexOf(' ') >= 0) {
+            saveOK = false;
+        }
         this.setState({
-            [e.target.id]: e.target.checked,
+            [e.target.id]: value,
+            saveOK: saveOK
+        });
+    }
+
+    handleChange (e) {
+        let value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+        this.setState({
+            [e.target.id]: value,
         });
     }
 
@@ -150,8 +228,99 @@ export class ReplRUV extends React.Component {
                 });
     }
 
+    importChangelog () {
+        // Do changelog import
+        let cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "replication", "import-changelog", "default", "--replica-root", this.props.suffix
+        ];
+
+        this.setState({
+            modalSpinning: true,
+        });
+
+        log_cmd("importChangelog", "Import relication changelog via LDIF", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    this.props.addNotification(
+                        "success",
+                        `Changelog was successfully initialized`
+                    );
+                    this.setState({
+                        showConfirmCLImport: false,
+                        modalSpinning: false,
+                    });
+                })
+                .fail(err => {
+                    let errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        `Error importing changelog LDIF - ${errMsg.desc}`
+                    );
+                    this.setState({
+                        showConfirmCLImport: false,
+                        modalSpinning: false,
+                    });
+                });
+    }
+
+    exportChangelog () {
+        // Do changelog export
+        let cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "replication", "export-changelog"
+        ];
+
+        if (this.state.defaultCL) {
+            cmd.push("default");
+        } else {
+            cmd.push("to-ldif");
+            if (this.state.exportCSN) {
+                cmd.push("--csn-only");
+            }
+            if (this.state.decodeCL) {
+                cmd.push("--decode");
+            }
+            if (this.state.ldifFile) {
+                cmd.push("--output-file=" + this.state.ldifFile);
+            }
+        }
+        cmd.push("--replica-root=" + this.props.suffix);
+
+        this.setState({
+            exportSpinner: true,
+        });
+
+        log_cmd("exportChangelog", "Import relication changelog via LDIF", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    this.props.addNotification(
+                        "success",
+                        `Changelog was successfully exported`
+                    );
+                    this.setState({
+                        showCLExport: false,
+                        exportSpinner: false,
+                    });
+                })
+                .fail(err => {
+                    let errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        `Error importing changelog LDIF - ${errMsg.desc}`
+                    );
+                    this.setState({
+                        showCLExport: false,
+                        exportSpinner: false,
+                    });
+                });
+    }
+
     render() {
-        // Strip outthe loca RUV and display it diffent then onmly allow cleaning of remote rids
+        // Strip out the local RUV and display it different then only allow
+        // cleaning of remote rids
         let remote_rows = [];
         let localRID = "";
         let localURL = "";
@@ -257,18 +426,67 @@ export class ReplRUV extends React.Component {
                     />
                 </div>
                 <hr />
-                <h4>Create Initialization LDIF File</h4>
-                <div className="ds-left-indent-md ds-margin-top-lg">
-                    <p><i>Export this suffix with the replication metadata needed to initialize another replica</i></p>
-                    <Button
-                        bsStyle="primary"
-                        onClick={this.showConfirmExport}
-                        className="ds-margin-top"
-                        title="See Database Tab -> Backups & LDIFs to manage the new LDIF"
-                    >
-                        Export To LDIF
-                    </Button>
-                </div>
+                <h4 className="ds-margin-top-xlg">Create Replica Initialization LDIF File</h4>
+                <Form className="ds-margin-top-lg ds-left-indent-md" horizontal>
+                    <Row className="ds-margin-top-lg">
+                        <Col sm={3} componentClass={ControlLabel}>
+                            <Button
+                                bsStyle="primary"
+                                onClick={this.showConfirmExport}
+                                title="See Database Tab -> Backups & LDIFs to manage the new LDIF"
+                            >
+                                Export Replica
+                            </Button>
+                        </Col>
+                        <Col sm={8}>
+                            <p className="ds-margin-top">
+                                Export this suffix with the replication metadata to an LDIF file for initializing another replica.
+                            </p>
+                        </Col>
+                    </Row>
+                </Form>
+                <hr />
+                <h4 className="ds-margin-top-xlg">Replication Change Log Tasks</h4>
+                <Form className="ds-margin-top-lg ds-left-indent-md" horizontal>
+                    <Row className="ds-margin-top-lg">
+                        <Col
+                            sm={3} componentClass={ControlLabel}
+                            title="Export the changelog to an LDIF file.  Typically used for changelog encryption purposes, or debugging."
+                        >
+                            <Button
+                                bsStyle="primary"
+                                onClick={this.showCLExport}
+                            >
+                                Export Changelog
+                            </Button>
+                        </Col>
+                        <Col sm={8}>
+                            <p className="ds-margin-top">
+                                Export the replication changelog to a LDIF file.  Used for preparing to encrypt the changelog, or simply for debugging.
+                            </p>
+                        </Col>
+                    </Row>
+                    <Row className="ds-margin-top-lg">
+                        <Col
+                            sm={3} componentClass={ControlLabel}
+                            title="Initialize the changelog with an LDIF file for changelog encryption purposes."
+                        >
+                            <Button
+                                bsStyle="primary"
+                                onClick={this.showConfirmCLImport}
+                            >
+                                Import Changelog
+                            </Button>
+                        </Col>
+                        <Col sm={8}>
+                            <p className="ds-margin-top">
+                                Initialize the replication changelog from an LDIF file.  Used to initialize the change log after encryption has been enabled.
+                            </p>
+                        </Col>
+                    </Row>
+                </Form>
+                <hr />
+
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmCleanRUV}
                     closeHandler={this.closeConfirmCleanRUV}
@@ -282,6 +500,19 @@ export class ReplRUV extends React.Component {
                     mSpinningMsg="Starting cleaning task (CleanAllRUV) ..."
                     mBtnName="Remove RUV Element"
                 />
+                <DoubleConfirmModal
+                    showModal={this.state.showConfirmCLImport}
+                    closeHandler={this.closeConfirmCLImport}
+                    handleChange={this.handleChange}
+                    actionHandler={this.importChangelog}
+                    spinning={this.state.modalSpinning}
+                    item={"Replicated Suffix " + this.props.suffix}
+                    checked={this.state.modalChecked}
+                    mTitle="Initialize Replication Changelog From LDIF"
+                    mMsg="Are you sure you want to attempt to initialize the changelog from LDIF?  This will reject all operations during during the initialization."
+                    mSpinningMsg="Initialzing Replication Change Log ..."
+                    mBtnName="Import Changelog LDIF"
+                />
                 <ExportModal
                     showModal={this.state.showConfirmExport}
                     closeHandler={this.closeConfirmExport}
@@ -290,6 +521,22 @@ export class ReplRUV extends React.Component {
                     spinning={this.state.exportSpinner}
                     saveOK={this.state.saveOK}
                 />
+                <ExportCLModal
+                    showModal={this.state.showCLExport}
+                    closeHandler={this.closeCLExport}
+                    handleChange={this.handleChange}
+                    handleLDIFChange={this.handleCLLDIFChange}
+                    handleRadioChange={this.handleRadioChange}
+                    saveHandler={this.exportChangelog}
+                    defaultCL={this.state.defaultCL}
+                    debugCL={this.state.debugCL}
+                    decodeCL={this.state.decodeCL}
+                    exportCSN={this.state.exportCSN}
+                    ldifFile={this.state.ldifFile}
+                    spinning={this.state.exportSpinner}
+                    saveOK={this.state.saveOK}
+                />
+
             </div>
         );
     }

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -2682,7 +2682,7 @@ class DirSrv(SimpleLDAPObject, object):
     # server is stopped)
     #
     def ldif2db(self, bename, suffixes, excludeSuffixes, encrypt,
-                import_file):
+                import_file, import_cl=False):
         """
         @param bename - The backend name of the database to import
         @param suffixes - List/tuple of suffixes to import
@@ -2726,6 +2726,8 @@ class DirSrv(SimpleLDAPObject, object):
                 cmd.append(excludeSuffix)
         if encrypt:
             cmd.append('-E')
+        if import_cl:
+            cmd.append('-R')
 
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
@@ -2742,7 +2744,7 @@ class DirSrv(SimpleLDAPObject, object):
         return True
 
     def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, repl_data,
-                outputfile):
+                outputfile, export_cl=False):
         """
         @param bename - The backend name of the database to export
         @param suffixes - List/tuple of suffixes to export
@@ -2782,8 +2784,10 @@ class DirSrv(SimpleLDAPObject, object):
                 cmd.append(excludeSuffix)
         if encrypt:
             cmd.append('-E')
-        if repl_data:
+        if repl_data and not export_cl:
             cmd.append('-r')
+        if export_cl:
+            cmd.append('-R')
         if outputfile is not None:
             cmd.append('-a')
             cmd.append(outputfile)

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -47,6 +47,9 @@ REPLICATION_BIND_METHOD = RA_METHOD
 REPLICATION_TRANSPORT = RA_TRANSPORT_PROT
 REPLICATION_TIMEOUT = RA_TIMEOUT
 
+BDB_CL_FILENAME = "replication_changelog.db"
+LMDB_CL_FILENAME = "replication_changelog.mdb"
+
 # Attributes that should be masked from logging output
 SENSITIVE_ATTRS = ['userpassword',
                    'nsslapd-rootpw',

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -36,7 +36,7 @@ def dbtasks_bak2db(inst, log, args):
 
 def dbtasks_db2ldif(inst, log, args):
     if not inst.db2ldif(bename=args.backend, encrypt=args.encrypted, repl_data=args.replication,
-                        outputfile=args.ldif, suffixes=None, excludeSuffixes=None):
+                        outputfile=args.ldif, suffixes=None, excludeSuffixes=None, export_cl=False):
         log.fatal("db2ldif failed")
         return False
     else:
@@ -45,7 +45,7 @@ def dbtasks_db2ldif(inst, log, args):
 
 def dbtasks_ldif2db(inst, log, args):
     if not inst.ldif2db(bename=args.backend, encrypt=args.encrypted, import_file=args.ldif,
-                        suffixes=None, excludeSuffixes=None):
+                        suffixes=None, excludeSuffixes=None, import_cl=False):
         log.fatal("ldif2db failed")
         return False
     else:
@@ -104,6 +104,9 @@ def create_parser(subcommands):
     db2ldif_parser.add_argument('ldif', help="The path to the ldif output location.", nargs='?', default=None)
     db2ldif_parser.add_argument('--replication', help="Export replication information, suitable for importing on a new consumer or backups.",
                                 default=False, action='store_true')
+    # db2ldif_parser.add_argument('--include-changelog', help="Include the changelog as a separate LDIF file which will be named:  <ldif_file_name>_cl.ldif.  "
+    #                                                         "This option also implies the '--replication' option is set.",
+    #                             default=False, action='store_true')
     db2ldif_parser.add_argument('--encrypted', help="Export encrypted attributes", default=False, action='store_true')
     db2ldif_parser.set_defaults(func=dbtasks_db2ldif)
 
@@ -119,6 +122,8 @@ def create_parser(subcommands):
     ldif2db_parser.add_argument('backend', help="The backend to restore from an LDIF. IE userRoot")
     ldif2db_parser.add_argument('ldif', help="The path to the ldif to import")
     ldif2db_parser.add_argument('--encrypted', help="Import encrypted attributes", default=False, action='store_true')
+    # ldif2db_parser.add_argument('--include-changelog', help="Include a replication changelog LDIF file if present.  It must be named like this in order for the import to include it:  <ldif_file_name>_cl.ldif.",
+    #                            default=False, action='store_true')
     ldif2db_parser.set_defaults(func=dbtasks_ldif2db)
 
     backups_parser = subcommands.add_parser('backups', help="List backup's found in the server's default backup directory")


### PR DESCRIPTION
Bug Description:  With the new per-backend replication changelog, the
                  ldif2cl task would incorrectly close all the backends.

Fix Description:  First, the global changelog struct (s_cl5Desc) was
                  completely removed and merged with the replica changelog
                  db handle struct.  The dbState variable is used to
                  synchronize access to the changelog db struct during
                  shutdown, or ldif2cl tasks.

                  The CLI was updated to handle setting changelog encryption,
                  and importing/restoring a changelog ldif.

                  The UI was updated to handle the new per-backlend changelog
                  and its configuration.  Also added the option to
                  export/import the changelog and its various forms.

Fixes: https://github.com/389ds/389-ds-base/issues/4176
