### PR TITLE
Issue 4322 - Fix a source link

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -177,7 +177,7 @@ Requires:         cracklib-dicts
 # Picks up our systemd deps.
 %{?systemd_requires}
 
-Source0:          https://github.com/389ds/%{name}/archive/%{name}-%{version}%{?prerel}.tar.gz
+Source0:          %{name}-%{version}%{?prerel}.tar.bz2
 # 389-ds-git.sh should be used to generate the source tarball from git
 Source1:          %{name}-git.sh
 Source2:          %{name}-devel.README


### PR DESCRIPTION
Description: Source0 should point to a local file instead of
a remote URL. We use it for testing/development only so
there is no need in external links.

Reviewed by: ?

Fixes: #4322