### PR TITLE
Issue 3996 - Add dsidm rename option

### DIFF
--- a/src/lib389/lib389/cli_idm/account.py
+++ b/src/lib389/lib389/cli_idm/account.py
@@ -20,6 +20,7 @@ from lib389.cli_base import (
     _get_dn_arg,
     _warn,
     )
+from lib389.cli_idm import _generic_rename_dn
 
 MANY = Accounts
 SINGULAR = Account
@@ -43,7 +44,12 @@ def delete(inst, basedn, log, args, warn=True):
 
 def modify(inst, basedn, log, args, warn=True):
     dn = _get_dn_arg(args.dn, msg="Enter dn to modify")
-    _generic_modify_dn(inst, basedn, log.getChild('_generic_modify'), MANY, dn, args)
+    _generic_modify_dn(inst, basedn, log.getChild('_generic_modify_dn'), MANY, dn, args)
+
+
+def rename(inst, basedn, log, args, warn=True):
+    dn = _get_dn_arg(args.dn, msg="Enter dn to modify")
+    _generic_rename_dn(inst, basedn, log.getChild('_generic_rename_dn'), MANY, dn, args)
 
 
 def _print_entry_status(status, dn, log):
@@ -147,6 +153,12 @@ like modify, locking and unlocking. To create an account, see "user" subcommand 
     modify_dn_parser.set_defaults(func=modify)
     modify_dn_parser.add_argument('dn', nargs=1, help='The dn to get and display')
     modify_dn_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_dn_parser = subcommands.add_parser('rename-by-dn', help='rename the object')
+    rename_dn_parser.set_defaults(func=rename)
+    rename_dn_parser.add_argument('dn', help='The dn to rename')
+    rename_dn_parser.add_argument('new_dn', help='A new role dn')
+    rename_dn_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'cn: old_role') should be kept as an attribute of the entry or not")
 
     delete_parser = subcommands.add_parser('delete', help='deletes the account')
     delete_parser.set_defaults(func=delete)

--- a/src/lib389/lib389/cli_idm/group.py
+++ b/src/lib389/lib389/cli_idm/group.py
@@ -13,6 +13,7 @@ from lib389.cli_idm import (
     _generic_get,
     _generic_get_dn,
     _generic_create,
+    _generic_rename,
     _generic_delete,
     _get_arg,
     _get_attributes,
@@ -49,6 +50,10 @@ def delete(inst, basedn, log, args, warn=True):
 def modify(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
     _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY, rdn, args)
+
+def rename(inst, basedn, log, args, warn=True):
+    rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
+    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
 
 def members(inst, basedn, log, args):
     cn = _get_arg( args.cn, msg="Enter %s of group" % RDN)
@@ -106,6 +111,12 @@ def create_parser(subparsers):
     modify_parser.set_defaults(func=modify)
     modify_parser.add_argument('selector', nargs=1, help='The %s to modify' % RDN)
     modify_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_parser = subcommands.add_parser('rename', help='rename the object')
+    rename_parser.set_defaults(func=rename)
+    rename_parser.add_argument('selector', help='The %s to rename' % RDN)
+    rename_parser.add_argument('new_name', help='A new group name')
+    rename_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'cn: old_group') should be kept as an attribute of the entry or not")
 
     members_parser = subcommands.add_parser('members', help="List member dns of a group")
     members_parser.set_defaults(func=members)

--- a/src/lib389/lib389/cli_idm/organizationalunit.py
+++ b/src/lib389/lib389/cli_idm/organizationalunit.py
@@ -13,6 +13,7 @@ from lib389.cli_idm import (
     _generic_get,
     _generic_get_dn,
     _generic_create,
+    _generic_rename,
     _generic_delete,
     _get_arg,
     _get_attributes,
@@ -49,6 +50,10 @@ def modify(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
     _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY, rdn, args)
 
+def rename(inst, basedn, log, args, warn=True):
+    rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
+    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
+
 def create_parser(subparsers):
     ou_parser = subparsers.add_parser('organizationalunit', help='Manage organizational units')
 
@@ -77,6 +82,13 @@ def create_parser(subparsers):
     modify_parser.set_defaults(func=modify)
     modify_parser.add_argument('selector', nargs=1, help='The %s to modify' % RDN)
     modify_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_parser = subcommands.add_parser('rename', help='rename the object')
+    rename_parser.set_defaults(func=rename)
+    rename_parser.add_argument('selector', help='The %s to rename' % RDN)
+    rename_parser.add_argument('new_name', help='A new organizational unit name')
+    rename_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'ou: old_ou') should be kept as an attribute of the entry or not")
+
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/lib389/lib389/cli_idm/posixgroup.py
+++ b/src/lib389/lib389/cli_idm/posixgroup.py
@@ -13,6 +13,7 @@ from lib389.cli_idm import (
     _generic_get,
     _generic_get_dn,
     _generic_create,
+    _generic_rename,
     _generic_delete,
     _get_arg,
     _get_attributes,
@@ -49,6 +50,10 @@ def modify(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
     _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY, rdn, args)
 
+def rename(inst, basedn, log, args, warn=True):
+    rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
+    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
+
 def create_parser(subparsers):
     posixgroup_parser = subparsers.add_parser('posixgroup', help='Manage posix groups')
 
@@ -77,5 +82,11 @@ def create_parser(subparsers):
     modify_parser.set_defaults(func=modify)
     modify_parser.add_argument('selector', nargs=1, help='The %s to modify' % RDN)
     modify_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_parser = subcommands.add_parser('rename', help='rename the object')
+    rename_parser.set_defaults(func=rename)
+    rename_parser.add_argument('selector', help='The %s to rename' % RDN)
+    rename_parser.add_argument('new_name', help='A new posix group name')
+    rename_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'cn: old_group') should be kept as an attribute of the entry or not")
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/lib389/lib389/cli_idm/role.py
+++ b/src/lib389/lib389/cli_idm/role.py
@@ -17,6 +17,7 @@ from lib389.cli_base import (
     _get_dn_arg,
     _warn,
     )
+from lib389.cli_idm import _generic_rename_dn
 
 MANY = Roles
 SINGULAR = Role
@@ -40,7 +41,12 @@ def delete(inst, basedn, log, args, warn=True):
 
 def modify(inst, basedn, log, args, warn=True):
     dn = _get_dn_arg(args.dn, msg="Enter dn to modify")
-    _generic_modify_dn(inst, basedn, log.getChild('_generic_modify'), MANY, dn, args)
+    _generic_modify_dn(inst, basedn, log.getChild('_generic_modify_dn'), MANY, dn, args)
+
+
+def rename(inst, basedn, log, args, warn=True):
+    dn = _get_dn_arg(args.dn, msg="Enter dn to modify")
+    _generic_rename_dn(inst, basedn, log.getChild('_generic_rename_dn'), MANY, dn, args)
 
 
 def entry_status(inst, basedn, log, args):
@@ -96,8 +102,14 @@ like modify, locking and unlocking.''')
 
     modify_dn_parser = subcommands.add_parser('modify-by-dn', help='modify-by-dn <dn> <add|delete|replace>:<attribute>:<value> ...')
     modify_dn_parser.set_defaults(func=modify)
-    modify_dn_parser.add_argument('dn', nargs=1, help='The dn to get and display')
+    modify_dn_parser.add_argument('dn', nargs=1, help='The dn to modify')
     modify_dn_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_dn_parser = subcommands.add_parser('rename-by-dn', help='rename the object')
+    rename_dn_parser.set_defaults(func=rename)
+    rename_dn_parser.add_argument('dn', help='The dn to rename')
+    rename_dn_parser.add_argument('new_dn', help='A new account dn')
+    rename_dn_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'cn: old_account') should be kept as an attribute of the entry or not")
 
     delete_parser = subcommands.add_parser('delete', help='deletes the role')
     delete_parser.set_defaults(func=delete)

--- a/src/lib389/lib389/cli_idm/user.py
+++ b/src/lib389/lib389/cli_idm/user.py
@@ -13,6 +13,7 @@ from lib389.cli_idm import (
     _generic_get,
     _generic_get_dn,
     _generic_create,
+    _generic_rename,
     _generic_delete,
     _get_arg,
     _get_attributes,
@@ -50,6 +51,10 @@ def modify(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
     _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY, rdn, args)
 
+def rename(inst, basedn, log, args, warn=True):
+    rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
+    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
+
 def create_parser(subparsers):
     user_parser = subparsers.add_parser('user', help='Manage posix users')
 
@@ -74,6 +79,12 @@ def create_parser(subparsers):
     modify_parser.set_defaults(func=modify)
     modify_parser.add_argument('selector', nargs=1, help='The %s to modify' % RDN)
     modify_parser.add_argument('changes', nargs='+', help="A list of changes to apply in format: <add|delete|replace>:<attribute>:<value>")
+
+    rename_parser = subcommands.add_parser('rename', help='rename the object')
+    rename_parser.set_defaults(func=rename)
+    rename_parser.add_argument('selector', help='The %s to modify' % RDN)
+    rename_parser.add_argument('new_name', help='A new user name')
+    rename_parser.add_argument('--keep-old-rdn', action='store_true', help="Specify whether the old RDN (i.e. 'cn: old_user')should be kept as an attribute of the entry or not")
 
     delete_parser = subcommands.add_parser('delete', help='deletes the object')
     delete_parser.set_defaults(func=delete)

--- a/src/lib389/lib389/idm/account.py
+++ b/src/lib389/lib389/idm/account.py
@@ -44,6 +44,10 @@ class Account(DSLdapObject):
     :type dn: str
     """
 
+    def __init__(self, instance, dn=None):
+        super(Account, self).__init__(instance, dn)
+        self._protected = False
+
     def _format_status_message(self, message, create_time, modify_time, last_login_time, limit, role_dn=None):
         params = {}
         now = time.time()


### PR DESCRIPTION
Description: Add rename option to dsidm CLI.
user, group, posixgroup, organizationalunit - rename by rdn.
account, role - rename by dn.
Set Account._protected = False by default so we can run
rename and delete operations.

Reviewed by: ?

Fixes: #4127 
Fixes: #3996