### PR TITLE
Issue 4342 - UI - additional fixes for creation instance modal

### DIFF
--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -89,9 +89,11 @@ export class CreateInstanceModal extends React.Component {
         if (dn.endsWith(",")) {
             return false;
         }
-        // Check that the attr is only letters  [A-Za-z]+  and the value is standard
-        // ascii  [ -~]+  that it does not start with a space  \\S
-        let dn_regex = new RegExp("^([A-Za-z]+=\\S[ -~]+$)");
+        // Check that the attr is only letters  [A-Za-z]+  and the value does not
+        // start with a space (?=\\S) AND all the characters are standard
+        // ascii ([ -~]+)
+        let dn_regex = new RegExp("^([A-Za-z]+=(?=\\S)([ -~]+)$)");
+
         let result = dn_regex.test(dn);
         return result;
     }
@@ -109,7 +111,7 @@ export class CreateInstanceModal extends React.Component {
             if (value == "") {
                 all_good = false;
                 errObj['createServerId'] = true;
-            } else if (value > 80) {
+            } else if (value.length > 80) {
                 all_good = false;
                 errObj['createServerId'] = true;
                 modal_msg = "Instance name must be less than 80 characters";
@@ -133,7 +135,7 @@ export class CreateInstanceModal extends React.Component {
             } else if (!valid_port(value)) {
                 all_good = false;
                 errObj['createPort'] = true;
-                modal_msg = "Invalid Port number.  The port must be between 1 and 65534";
+                modal_msg = "Invalid Port number.  The port must be between 1 and 65535";
             }
         } else if (this.state.createPort == "") {
             all_good = false;
@@ -141,7 +143,7 @@ export class CreateInstanceModal extends React.Component {
         } else if (!valid_port(this.state.createPort)) {
             all_good = false;
             errObj['createPort'] = true;
-            modal_msg = "Invalid Port number.  The port must be between 1 and 65534";
+            modal_msg = "Invalid Port number.  The port must be between 1 and 65535";
         }
         if (target_id == 'createSecurePort') {
             if (value == "") {
@@ -150,7 +152,7 @@ export class CreateInstanceModal extends React.Component {
             } else if (!valid_port(value)) {
                 all_good = false;
                 errObj['createSecurePort'] = true;
-                modal_msg = "Invalid Secure Port number.  Port must be between 1 and 65534";
+                modal_msg = "Invalid Secure Port number.  Port must be between 1 and 65535";
             }
         } else if (this.state.createSecurePort == "") {
             all_good = false;
@@ -616,7 +618,7 @@ export class CreateInstanceModal extends React.Component {
                                 <Col
                                     componentClass={ControlLabel}
                                     sm={5}
-                                    title="The DN for the unrestricted  user"
+                                    title="The DN for the unrestricted user"
                                 >
                                     Directory Manager DN
                                 </Col>


### PR DESCRIPTION
Description: In the instance creation modal there is an incorrect warning
             about the port number range. It should state valid port numbers
             are between 1 and 65535. The root DN character validation allows
             non ascii as the first characters after the "=". And we are not
             forewarning about the instance name length if it is greater than
             80 characters

Fixes: https://github.com/389ds/389-ds-base/issues/4342

Reviewed by: ?