### PR TITLE
4224 openldap entryuuid confusion

### DIFF
--- a/dirsrvtests/tests/suites/syncrepl_plugin/__init__.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/__init__.py
@@ -144,7 +144,7 @@ def syncstate_assert(st, sync):
     # Find the primary uuid we expect to see in syncrepl.
     # This will be None if not present.
     acc_uuid = account.get_attr_val_utf8('entryuuid')
-    if acc_uuid is None:
+    if not sync.openldap:
         nsid = account.get_attr_val_utf8('nsuniqueid')
         # nsunique has a diff format, so we change it up.
         # 431cf081-b44311ea-83fdb082-f24d490e
@@ -173,7 +173,7 @@ def syncstate_assert(st, sync):
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
     ####################################
-    ## assert sync.present == [acc_uuid]
+    assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
     if sync.openldap:
         assert True == sync.refdel
@@ -191,7 +191,7 @@ def syncstate_assert(st, sync):
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
     ####################################
-    ## assert sync.present == [acc_uuid]
+    assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
     if sync.openldap:
         assert True == sync.refdel
@@ -210,12 +210,16 @@ def syncstate_assert(st, sync):
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
     ####################################
-    ## assert sync.present == [acc_uuid]
+    assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
     if sync.openldap:
         assert True == sync.refdel
     else:
         assert False == sync.refdel
+
+    # import time
+    # print("attach now ....")
+    # time.sleep(45)
 
     ## Modrdn (out of scope, then back into scope)
     account.rename('uid=test1_modrdn', newsuperior=DEFAULT_SUFFIX)
@@ -228,11 +232,14 @@ def syncstate_assert(st, sync):
     log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
     assert 0 == len(sync.entries.keys())
     assert 0 == len(sync.present)
-    assert 0 == len(sync.delete)
+    ## WARNING: This test MAY FAIL here if you do not have a new enough python-ldap
+    # due to an ASN.1 parsing bug. You require at least python-ldap 3.3.1
+    assert 1 == len(sync.delete)
+    assert sync.delete == [acc_uuid]
     if sync.openldap:
         assert True == sync.refdel
     else:
-        assert True == sync.refdel
+        assert False == sync.refdel
 
     # Put it back
     account.rename('uid=test1_modrdn', newsuperior=OU_PEOPLE)
@@ -244,7 +251,7 @@ def syncstate_assert(st, sync):
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
     ####################################
-    ## assert sync.present == [acc_uuid]
+    assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
     if sync.openldap:
         assert True == sync.refdel
@@ -253,10 +260,6 @@ def syncstate_assert(st, sync):
 
     ## Delete
     account.delete()
-
-    # import time
-    # print("attach now ....")
-    # time.sleep(45)
 
     # Check
     log.debug("*test* del")
@@ -270,11 +273,11 @@ def syncstate_assert(st, sync):
     log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
     assert 0 == len(sync.entries.keys())
     assert 0 == len(sync.present)
-    assert 0 == len(sync.delete)
+    assert 1 == len(sync.delete)
+    assert sync.delete == [acc_uuid]
     ####################################
-    ## assert sync.delete == [acc_uuid]
     if sync.openldap:
         assert True == sync.refdel
     else:
-        assert True == sync.refdel
+        assert False == sync.refdel
 

--- a/dirsrvtests/tests/suites/syncrepl_plugin/__init__.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/__init__.py
@@ -21,6 +21,8 @@ from lib389._constants import *
 
 log = logging.getLogger(__name__)
 
+OU_PEOPLE = "ou=people,%s" % DEFAULT_SUFFIX
+
 class ISyncRepl(DirSrv, SyncreplConsumer):
     """
     This implements a test harness for checking syncrepl, and allowing us to check various actions or
@@ -28,6 +30,11 @@ class ISyncRepl(DirSrv, SyncreplConsumer):
     later to ensure that syncrepl worked as expected.
     """
     def __init__(self, inst, openldap=False):
+        ### 🚧 WARNING 🚧
+        # There are bugs with python ldap sync repl in ALL VERSIONS below 3.3.1.
+        # These tests WILL FAIL unless you have version 3.3.1 or higher!
+        assert ldap.__version__ >= '3.3.1'
+
         self.inst = inst
         self.msgid = None
 
@@ -55,6 +62,7 @@ class ISyncRepl(DirSrv, SyncreplConsumer):
         self.delete = []
         self.present = []
         self.entries = {}
+        self.refdel = False
         self.next_cookie = None
         # Start the sync
         # If cookie is none, will call "get_cookie" we have.
@@ -89,6 +97,9 @@ class ISyncRepl(DirSrv, SyncreplConsumer):
 
     def syncrepl_present(self, uuids, refreshDeletes=False):
         log.debug(f'=====> refdel -> {refreshDeletes} uuids -> {uuids}')
+        if refreshDeletes:
+            # Indicate we recieved a refdel in the process.
+            self.refdel = True
         if uuids is not None:
             self.present = self.present + uuids
 
@@ -105,8 +116,9 @@ class ISyncRepl(DirSrv, SyncreplConsumer):
 
 def syncstate_assert(st, sync):
     # How many entries do we have?
+    # We setup sync under ou=people so we can modrdn out of the scope.
     r = st.search_ext_s(
-        base=DEFAULT_SUFFIX,
+        base=OU_PEOPLE,
         scope=ldap.SCOPE_SUBTREE,
         filterstr='(objectClass=*)',
         attrsonly=1,
@@ -115,49 +127,154 @@ def syncstate_assert(st, sync):
 
     # Initial sync
     log.debug("*test* initial")
-    sync.syncrepl_search()
+    sync.syncrepl_search(base=OU_PEOPLE)
     sync.syncrepl_complete()
     # check we caught them all
     assert len(r) == len(sync.entries.keys())
     assert len(r) == len(sync.present)
     assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert False == sync.refdel
 
     # Add a new entry
-
     account = nsUserAccounts(st, DEFAULT_SUFFIX).create_test_user()
+
+    # Find the primary uuid we expect to see in syncrepl.
+    # This will be None if not present.
+    acc_uuid = account.get_attr_val_utf8('entryuuid')
+    if acc_uuid is None:
+        nsid = account.get_attr_val_utf8('nsuniqueid')
+        # nsunique has a diff format, so we change it up.
+        # 431cf081-b44311ea-83fdb082-f24d490e
+        # Add a hyphen V
+        # 431cf081-b443-11ea-83fdb082-f24d490e
+        nsid_a = nsid[:13] + '-' + nsid[13:]
+        #           Add a hyphen V
+        # 431cf081-b443-11ea-83fd-b082-f24d490e
+        nsid_b = nsid_a[:23] + '-' + nsid_a[23:]
+        #             Remove a hyphen V
+        # 431cf081-b443-11ea-83fd-b082-f24d490e
+        acc_uuid = nsid_b[:28] + nsid_b[29:]
+        # Tada!
+        # 431cf081-b443-11ea-83fd-b082f24d490e
+        log.debug(f"--> expected sync uuid (from nsuniqueid): {acc_uuid}")
+    else:
+        log.debug(f"--> expected sync uuid (from entryuuid): {acc_uuid}")
+
     # Check
     log.debug("*test* add")
-    sync.syncrepl_search()
+    sync.syncrepl_search(base=OU_PEOPLE)
     sync.syncrepl_complete()
     sync.check_cookie()
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
+
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
+    ####################################
+    ## assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert False == sync.refdel
 
     # Mod
     account.replace('description', 'change')
     # Check
     log.debug("*test* mod")
-    sync.syncrepl_search()
+    sync.syncrepl_search(base=OU_PEOPLE)
     sync.syncrepl_complete()
     sync.check_cookie()
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
     assert 1 == len(sync.entries.keys())
     assert 1 == len(sync.present)
+    ####################################
+    ## assert sync.present == [acc_uuid]
     assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert False == sync.refdel
+
+    ## ModRdn (remain in scope)
+    account.rename('uid=test1_modrdn')
+    # newsuperior=None
+    # Check
+    log.debug("*test* modrdn (in scope)")
+    sync.syncrepl_search(base=OU_PEOPLE)
+    sync.syncrepl_complete()
+    sync.check_cookie()
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
+    assert 1 == len(sync.entries.keys())
+    assert 1 == len(sync.present)
+    ####################################
+    ## assert sync.present == [acc_uuid]
+    assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert False == sync.refdel
+
+    ## Modrdn (out of scope, then back into scope)
+    account.rename('uid=test1_modrdn', newsuperior=DEFAULT_SUFFIX)
+
+    # Check it's gone.
+    log.debug("*test* modrdn (move out of scope)")
+    sync.syncrepl_search(base=OU_PEOPLE)
+    sync.syncrepl_complete()
+    sync.check_cookie()
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
+    assert 0 == len(sync.entries.keys())
+    assert 0 == len(sync.present)
+    assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert True == sync.refdel
+
+    # Put it back
+    account.rename('uid=test1_modrdn', newsuperior=OU_PEOPLE)
+    log.debug("*test* modrdn (move in to scope)")
+    sync.syncrepl_search(base=OU_PEOPLE)
+    sync.syncrepl_complete()
+    sync.check_cookie()
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
+    assert 1 == len(sync.entries.keys())
+    assert 1 == len(sync.present)
+    ####################################
+    ## assert sync.present == [acc_uuid]
+    assert 0 == len(sync.delete)
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert False == sync.refdel
 
     ## Delete
     account.delete()
 
+    # import time
+    # print("attach now ....")
+    # time.sleep(45)
+
     # Check
     log.debug("*test* del")
-    sync.syncrepl_search()
+    sync.syncrepl_search(base=OU_PEOPLE)
     sync.syncrepl_complete()
     # In a delete, the cookie isn't updated (?)
     sync.check_cookie()
     log.debug(f'{sync.entries.keys()}')
     log.debug(f'{sync.present}')
     log.debug(f'{sync.delete}')
+    log.debug(f"sd: {sync.delete}, sp: {sync.present} sek: {sync.entries.keys()}")
     assert 0 == len(sync.entries.keys())
     assert 0 == len(sync.present)
-    assert 1 == len(sync.delete)
+    assert 0 == len(sync.delete)
+    ####################################
+    ## assert sync.delete == [acc_uuid]
+    if sync.openldap:
+        assert True == sync.refdel
+    else:
+        assert True == sync.refdel
 

--- a/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
@@ -109,6 +109,8 @@ def init_sync_repl_plugins(topology, request):
                 pass
     request.addfinalizer(fin)
 
+@pytest.mark.skipif(ldap.__version__ < '3.3.1',
+    reason="python ldap versions less that 3.3.1 have bugs in sync repl that will cause this to fail!")
 def test_syncrepl_basic(topology):
     """ Test basic functionality of the SyncRepl interface
 

--- a/dirsrvtests/tests/suites/syncrepl_plugin/openldap_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/openldap_test.py
@@ -17,6 +17,7 @@ from lib389.paths import Paths
 from lib389.utils import ds_is_older
 from lib389.plugins import RetroChangelogPlugin, ContentSyncPlugin
 from lib389._constants import *
+from lib389.plugins import EntryUUIDPlugin
 
 from . import ISyncRepl, syncstate_assert
 
@@ -25,7 +26,8 @@ pytestmark = pytest.mark.tier1
 
 log = logging.getLogger(__name__)
 
-@pytest.mark.skipif(ds_is_older('1.4.4.0'), reason="Sync repl does not support openldap compat in older versions")
+@pytest.mark.skipif(ldap.__version__ < '3.3.1' or not default_paths.rust_enabled or ds_is_older('1.4.4.0'),
+    reason="Sync repl does not support openldap compat in older versions, and without entryuuid")
 def test_syncrepl_openldap(topology):
     """ Test basic functionality of the openldap syncrepl
     compatability handler.
@@ -45,18 +47,25 @@ def test_syncrepl_openldap(topology):
         1. Success
     """
     st = topology.standalone
+    # Ensure entryuuid is setup
+    plug = EntryUUIDPlugin(st)
+    task = plug.fixup(DEFAULT_SUFFIX)
+    task.wait()
+    st.config.loglevel(vals=(ErrorLog.DEFAULT,ErrorLog.PLUGIN))
+    assert(task.is_complete() and task.get_exit_code() == 0)
+
     # Enable RetroChangelog.
     rcl = RetroChangelogPlugin(st)
     rcl.enable()
     # Set the default targetid
-    rcl.replace('nsslapd-attribute', 'nsuniqueid:targetUniqueId')
+    rcl.add('nsslapd-attribute', 'nsuniqueid:targetUniqueId')
+    rcl.add('nsslapd-attribute', 'entryuuid:targetEntryUUID')
     # Enable sync repl
     csp = ContentSyncPlugin(st)
+    csp.add('syncrepl-allow-openldap', 'on')
     csp.enable()
     # Restart DS
     st.restart()
-    # log.error("+++++++++++")
-    # time.sleep(60)
     # Setup the syncer
     sync = ISyncRepl(st, openldap=True)
     # Run the checks

--- a/ldap/servers/plugins/sync/README.md
+++ b/ldap/servers/plugins/sync/README.md
@@ -1,0 +1,42 @@
+With support from a techwriter at SUSE, we managed to translate RCF4533
+into something we can understand.
+
+* Server issues Sync Operation to search.
+* Search returns entries
+* Each entry has a state add which includes the UUID of the entry
+* Distinguished names can change, but UUIDs are stable.
+* At the end of the search results, a sync done control cookie is sent to indicate that the session is done.
+
+* Clients issue a Sync Operation to search, and include previously returned cookie.
+* Server determines what would be returned in a normal search operation.
+* Server uses cookie to work out what was previously returned.
+* Server issues results of only the things that have changed since last search.
+* Each result sent also includes info about the status (changed or unchanged)
+
+* Server has two phases to sync deleted entries: present or delete.
+* Each phase ends with a sync done control cookie.
+* The present phase ends with sync done control value of searchresultdone=false
+* the delete phase ends with sync done control value of searchresultdone=true
+* The present phase can be followed by the delete phase.
+* Each phase is complete only after a sync info message of refreshdone=false
+
+* During the present phase, the server sends an empty entry with state=present for each unchanged entry.
+* During the present phase, the client is changed to match the server state, in preparation for the delete phase.
+* During the delete phase, the server determines which entries in the client copy are no longer present. It also checks that the the number of changed entries is less than the number of unchanged entries.
+ For each entry that is no longer present, the server sends a state=delete. It does not* return a state=present for each present entry.
+
+* The server can send sync info messages that contain the list of UUIDs of either unchanged present entries, or deleted entries. This is instead of sending individual messages for each entry.
+* If refreshDeletes=false the UUIDs of unchanged present entries are included in the syncUUIDs set.
+* If refreshDeletes=true the UUIDs of unchanged deleted entries are included in the syncUUIDs set.
+* Optionally, you can include a syncIdSet cookie to indicate the state of the content in the syncUUIDs set.
+
+* If the syncDoneValue is refreshDeletes=false the new copy includes:
+- All changed entries returned by the current sync
+- All unchanged entries from a previous sync that have been confirmed to still be present
+- Unchanged entries confirmed as deleted are deleted from the client. In this case, they are assumed to have been deleted or moved.
+
+* If the syncDoneValue is refreshDeletes=true the new copy includes:
+- All changed entries returned by the current sync
+- All entries from a previous sync that have not been marked as deleted.
+
+* Clients can request that the synchronized copy is refreshed at any time.

--- a/ldap/servers/plugins/sync/sync_persist.c
+++ b/ldap/servers/plugins/sync/sync_persist.c
@@ -436,11 +436,11 @@ sync_queue_change(OPERATION_PL_CTX_T *operation)
     }
     /* Were there any matches? */
     if (matched) {
-        slapi_log_err(SLAPI_LOG_TRACE, SYNC_PLUGIN_SUBSYSTEM, "sync_queue_change - enqueued entry "
+        slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_queue_change - enqueued entry "
                                                               "\"%s\" on %d request listeners\n",
                       slapi_entry_get_dn_const(e), matched);
     } else {
-        slapi_log_err(SLAPI_LOG_TRACE, SYNC_PLUGIN_SUBSYSTEM, "sync_queue_change - entry "
+        slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_queue_change - entry "
                                                               "\"%s\" not enqueued on any request search listeners\n",
                       slapi_entry_get_dn_const(e));
     }
@@ -919,9 +919,10 @@ sync_send_results(void *arg)
                     break;
                 }
                 ectrls = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
-                if (req->req_cookie)
+                if (req->req_cookie) {
                     sync_cookie_update(req->req_cookie, ec);
-                sync_create_state_control(ec, &ectrls[0], chg_type, req->req_cookie);
+                }
+                sync_create_state_control(ec, &ectrls[0], chg_type, req->req_cookie, PR_FALSE);
                 rc = slapi_send_ldap_search_entry(req->req_pblock,
                                                   ec, ectrls,
                                                   noattrs ? noattrs : attrs, attrsonly);

--- a/ldap/servers/plugins/sync/sync_refresh.c
+++ b/ldap/servers/plugins/sync/sync_refresh.c
@@ -234,6 +234,8 @@ sync_srch_refresh_post_search(Slapi_PBlock *pb)
          * Point is, if we set refresh to true for openldap mode, it works, and if
          * it's false, the moment we send a single intermediate delete message, we
          * delete literally everything 🔥.
+         *
+         * See README.md for more about how this works.
          */
         if (info->cookie->openldap_compat) {
             sync_create_sync_done_control(&ctrl[0], 1, cookiestr);

--- a/ldap/servers/plugins/sync/sync_refresh.c
+++ b/ldap/servers/plugins/sync/sync_refresh.c
@@ -12,6 +12,7 @@ static SyncOpInfo *new_SyncOpInfo(int flag, PRThread *tid, Sync_Cookie *cookie);
 
 static int sync_extension_type;
 static int sync_extension_handle;
+static PRBool allow_openldap_compat;
 
 static SyncOpInfo *sync_get_operation_extension(Slapi_PBlock *pb);
 static void sync_set_operation_extension(Slapi_PBlock *pb, SyncOpInfo *spec);
@@ -68,7 +69,7 @@ sync_srch_refresh_pre_search(Slapi_PBlock *pb)
         char *cookie = NULL;
         int32_t mode = 1;
         int32_t refresh = 0;
-        bool cookie_refresh = 0;
+        PRBool cookie_refresh = PR_FALSE;
 
         if (sync_parse_control_value(psbvp, &mode,
                                      &refresh, &cookie) != LDAP_SUCCESS) {
@@ -89,7 +90,7 @@ sync_srch_refresh_pre_search(Slapi_PBlock *pb)
              * when using their changelog mode. As a result, we parse the cookie to handle this
              * shenangians to determine if this is valid.
              */
-            client_cookie = sync_cookie_parse(cookie, &cookie_refresh);
+            client_cookie = sync_cookie_parse(cookie, &cookie_refresh, &allow_openldap_compat);
             /*
              * we need to return a cookie in the result message
              * indicating a state to be used in future sessions
@@ -105,6 +106,13 @@ sync_srch_refresh_pre_search(Slapi_PBlock *pb)
              * to catch the mods while the refresh is done
              */
             if (mode == 3) {
+                if (client_cookie && client_cookie->openldap_compat == PR_TRUE) {
+                    /* We don't allow this. */
+                    rc = LDAP_UNWILLING_TO_PERFORM;
+                    sync_result_err(pb, rc, "Invalid session state, openldap compat not supported with persistence");
+                    goto error_return;
+                }
+                /* Launch the thread. */
                 tid = sync_persist_add(pb);
                 if (tid)
                     sync_persist = 1;
@@ -258,9 +266,13 @@ sync_srch_refresh_pre_entry(Slapi_PBlock *pb)
         rc = 0; /* nothing to do */
     } else if (info->send_flag & SYNC_FLAG_ADD_STATE_CTRL) {
         Slapi_Entry *e;
+        PRBool openldap_compat = PR_FALSE;
+        if (info->cookie) {
+            openldap_compat = info->cookie->openldap_compat;
+        }
         slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_ENTRY, &e);
         LDAPControl **ctrl = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
-        sync_create_state_control(e, &ctrl[0], LDAP_SYNC_ADD, NULL);
+        rc = sync_create_state_control(e, &ctrl[0], LDAP_SYNC_ADD, NULL, openldap_compat);
         slapi_pblock_set(pb, SLAPI_SEARCH_CTRLS, ctrl);
     }
     return (rc);
@@ -287,10 +299,12 @@ sync_free_update_nodes(Sync_UpdateNode **updates, int count)
     int i;
 
     for (i = 0; i < count; i++) {
-        if ((*updates)[i].upd_uuid)
-            slapi_ch_free((void **)&((*updates)[i].upd_uuid));
-        if ((*updates)[i].upd_e)
+        /* ch free checks for null for us. */
+        slapi_ch_free((void **)&((*updates)[i].upd_uuid));
+        slapi_ch_free((void **)&((*updates)[i].upd_euuid));
+        if ((*updates)[i].upd_e) {
             slapi_entry_free((*updates)[i].upd_e);
+        }
     }
     slapi_ch_free((void **)updates);
 }
@@ -324,6 +338,7 @@ sync_refresh_update_content(Slapi_PBlock *pb, Sync_Cookie *client_cookie, Sync_C
 
     cb_data.orig_pb = pb;
     cb_data.change_start = client_cookie->cookie_change_info;
+    cb_data.openldap_compat = server_cookie->openldap_compat;
 
     /*
      * The client has already seen up to AND including change_info, so this should
@@ -342,9 +357,16 @@ sync_refresh_update_content(Slapi_PBlock *pb, Sync_Cookie *client_cookie, Sync_C
      * for me in the tests, but the sync repl tests now correctly work and reflect the behaviour
      * expected.
      */
-    filter = slapi_ch_smprintf("(&(changenumber>=%lu)(changenumber<=%lu))",
-                               client_cookie->cookie_change_info + 1,
-                               server_cookie->cookie_change_info);
+    if (server_cookie->openldap_compat) {
+        /* In openldap compat we only want items that have an entryuuid, else we can't sync them */
+        filter = slapi_ch_smprintf("(&(changenumber>=%lu)(changenumber<=%lu)(" CL_ATTR_ENTRYUUID "=*))",
+                                   client_cookie->cookie_change_info + 1,
+                                   server_cookie->cookie_change_info);
+    } else {
+        filter = slapi_ch_smprintf("(&(changenumber>=%lu)(changenumber<=%lu))",
+                                   client_cookie->cookie_change_info + 1,
+                                   server_cookie->cookie_change_info);
+    }
     slapi_search_internal_set_pb(
         seq_pb,
         CL_SRCH_BASE,
@@ -364,7 +386,7 @@ sync_refresh_update_content(Slapi_PBlock *pb, Sync_Cookie *client_cookie, Sync_C
      * and the modified entries as single entries
      */
     sync_send_deleted_entries(pb, cb_data.cb_updates, chg_count, server_cookie);
-    sync_send_modified_entries(pb, cb_data.cb_updates, chg_count);
+    sync_send_modified_entries(pb, cb_data.cb_updates, chg_count, server_cookie);
 
     sync_free_update_nodes(&cb_data.cb_updates, chg_count);
     slapi_ch_free((void **)&filter);
@@ -387,6 +409,28 @@ sync_refresh_initial_content(Slapi_PBlock *pb, int sync_persist, PRThread *tid, 
      *   pre_entry, pre_result and post_search plugins
      */
     SyncOpInfo *info;
+
+    if (sc->openldap_compat == PR_TRUE) {
+        /*
+         * If this is true we need to adjust the filter to
+         * include a wrapping entryuuid condition. This is
+         * because openldap demands entryuuid == syncuuid so
+         * we must only send entries with an entryuuid.
+         */
+        struct slapi_filter *filter = NULL;
+        slapi_pblock_get(pb, SLAPI_SEARCH_FILTER, (void *)&filter);
+        PR_ASSERT(filter);
+        /* We need to alloc this due to how str2filter manips the str. If it's
+         * static we cause a segfault because it's in a protected section.
+         */
+        char *buf = slapi_ch_strdup("(entryUUID=*)");
+        struct slapi_filter *euuid_filter = slapi_str2filter(buf);
+        PR_ASSERT(euuid_filter);
+        struct slapi_filter *wrapped_filter = slapi_filter_join(LDAP_FILTER_AND, filter, euuid_filter);
+        PR_ASSERT(wrapped_filter);
+        slapi_pblock_set(pb, SLAPI_SEARCH_FILTER, (void *)wrapped_filter);
+        slapi_ch_free_string(&buf);
+    }
 
     if (sync_persist) {
         info = new_SyncOpInfo(SYNC_FLAG_ADD_STATE_CTRL |
@@ -502,6 +546,7 @@ int
 sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
 {
     char *uniqueid = NULL;
+    char *entryuuid = NULL;
     char *chgtype = NULL;
     char *chgnr = NULL;
     int chg_req;
@@ -518,9 +563,21 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
     if (uniqueid == NULL) {
         slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM,
                       "sync_read_entry_from_changelog - Retro Changelog does not provide nsuniquedid."
-                      "Check RCL plugin configuration.\n");
+                      "Check 'cn=Retro Changelog Plugin,cn=plugins,cn=config' contains 'nsslapd-attribute: nsuniqueid:targetUniqueId'\n");
         return (1);
     }
+
+    /* If we were requested to do openldap mode, get the targetEntryUuid too */
+    if (cb->openldap_compat == PR_TRUE) {
+        entryuuid = sync_get_attr_value_from_entry(cl_entry, CL_ATTR_ENTRYUUID);
+        if (entryuuid == NULL) {
+            slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM,
+                          "sync_read_entry_from_changelog - Retro Changelog does not provide entryuuid."
+                          "Check 'cn=Retro Changelog Plugin,cn=plugins,cn=config' contains 'nsslapd-attribute: entryuuid:targetEntryUUID'\n");
+            return (1);
+        }
+    }
+
     chgnr = sync_get_attr_value_from_entry(cl_entry, CL_ATTR_CHANGENUMBER);
     chgnum = sync_number2ulong(chgnr);
     if (SYNC_INVALID_CHANGENUM == chgnum) {
@@ -528,6 +585,7 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
                       "sync_read_entry_from_changelog - Change number provided by Retro Changelog is invalid: %s\n", chgnr);
         slapi_ch_free_string(&chgnr);
         slapi_ch_free_string(&uniqueid);
+        slapi_ch_free_string(&entryuuid);
         return (1);
     }
     if (chgnum < cb->change_start) {
@@ -537,6 +595,7 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
                       chgnr, cb->change_start);
         slapi_ch_free_string(&chgnr);
         slapi_ch_free_string(&uniqueid);
+        slapi_ch_free_string(&entryuuid);
         return (1);
     }
     index = chgnum - cb->change_start;
@@ -544,21 +603,28 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
     chg_req = sync_str2chgreq(chgtype);
     switch (chg_req) {
     case LDAP_REQ_ADD:
+        slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_ADD\n", uniqueid);
         /* nsuniqueid cannot exist, just add reference */
         cb->cb_updates[index].upd_chgtype = LDAP_REQ_ADD;
         cb->cb_updates[index].upd_uuid = uniqueid;
+        cb->cb_updates[index].upd_euuid = entryuuid;
         break;
     case LDAP_REQ_MODIFY:
         /* check if we have seen this uuid already */
         prev = sync_find_ref_by_uuid(cb->cb_updates, index, uniqueid);
         if (prev == -1) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODIFY\n", uniqueid);
             cb->cb_updates[index].upd_chgtype = LDAP_REQ_MODIFY;
             cb->cb_updates[index].upd_uuid = uniqueid;
+            cb->cb_updates[index].upd_euuid = entryuuid;
         } else {
             /* was add or mod, keep it */
-            cb->cb_updates[index].upd_uuid = 0;
+            slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODIFY (already queued)\n", uniqueid);
+            cb->cb_updates[index].upd_uuid = NULL;
+            cb->cb_updates[index].upd_euuid = NULL;
             cb->cb_updates[index].upd_chgtype = 0;
             slapi_ch_free_string(&uniqueid);
+            slapi_ch_free_string(&entryuuid);
         }
         break;
     case LDAP_REQ_MODRDN: {
@@ -592,31 +658,43 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
         if (old_scope && new_scope) {
             /* nothing changed, it's just a MOD */
             if (prev == -1) {
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODRDN\n", uniqueid);
                 cb->cb_updates[index].upd_chgtype = LDAP_REQ_MODIFY;
                 cb->cb_updates[index].upd_uuid = uniqueid;
+                cb->cb_updates[index].upd_euuid = entryuuid;
             } else {
-                cb->cb_updates[index].upd_uuid = 0;
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODRDN (already queued)\n", uniqueid);
+                cb->cb_updates[index].upd_uuid = NULL;
+                cb->cb_updates[index].upd_euuid = NULL;
                 cb->cb_updates[index].upd_chgtype = 0;
                 slapi_ch_free_string(&uniqueid);
+                slapi_ch_free_string(&entryuuid);
             }
         } else if (old_scope) {
             /* it was moved out of scope, handle as DEL */
             if (prev == -1) {
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODRDN -> LDAP_REQ_DELETE\n", uniqueid);
                 cb->cb_updates[index].upd_chgtype = LDAP_REQ_DELETE;
                 cb->cb_updates[index].upd_uuid = uniqueid;
+                cb->cb_updates[index].upd_euuid = entryuuid;
                 cb->cb_updates[index].upd_e = sync_deleted_entry_from_changelog(cl_entry);
             } else {
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODRDN -> LDAP_REQ_DELETE (already queued)\n", uniqueid);
                 cb->cb_updates[prev].upd_chgtype = LDAP_REQ_DELETE;
                 cb->cb_updates[prev].upd_e = sync_deleted_entry_from_changelog(cl_entry);
                 slapi_ch_free_string(&uniqueid);
+                slapi_ch_free_string(&entryuuid);
             }
         } else if (new_scope) {
             /* moved into scope, handle as ADD */
+            slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_MODRDN -> LDAP_REQ_ADD\n", uniqueid);
             cb->cb_updates[index].upd_chgtype = LDAP_REQ_ADD;
             cb->cb_updates[index].upd_uuid = uniqueid;
+            cb->cb_updates[index].upd_euuid = entryuuid;
         } else {
             /* nothing to do */
             slapi_ch_free_string(&uniqueid);
+            slapi_ch_free_string(&entryuuid);
         }
         slapi_sdn_free(&original_dn);
         break;
@@ -625,27 +703,36 @@ sync_read_entry_from_changelog(Slapi_Entry *cl_entry, void *cb_data)
         /* check if we have seen this uuid already */
         prev = sync_find_ref_by_uuid(cb->cb_updates, index, uniqueid);
         if (prev == -1) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_DELETE\n", uniqueid);
             cb->cb_updates[index].upd_chgtype = LDAP_REQ_DELETE;
             cb->cb_updates[index].upd_uuid = uniqueid;
+            cb->cb_updates[index].upd_euuid = entryuuid;
             cb->cb_updates[index].upd_e = sync_deleted_entry_from_changelog(cl_entry);
         } else {
             /* if it was added since last cookie state, we
-                 * can ignoere it */
+             * can ignore it */
             if (cb->cb_updates[prev].upd_chgtype == LDAP_REQ_ADD) {
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_DELETE -> NO-OP\n", uniqueid);
                 slapi_ch_free_string(&(cb->cb_updates[prev].upd_uuid));
                 cb->cb_updates[prev].upd_uuid = NULL;
+                cb->cb_updates[prev].upd_euuid = NULL;
                 cb->cb_updates[index].upd_uuid = NULL;
+                cb->cb_updates[index].upd_euuid = NULL;
             } else {
                 /* ignore previous mod */
+                slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_read_entry_from_changelog - %s LDAP_REQ_DELETE (already queued, updating)\n", uniqueid);
                 cb->cb_updates[index].upd_uuid = NULL;
+                cb->cb_updates[index].upd_euuid = NULL;
                 cb->cb_updates[prev].upd_chgtype = LDAP_REQ_DELETE;
                 cb->cb_updates[prev].upd_e = sync_deleted_entry_from_changelog(cl_entry);
             }
             slapi_ch_free_string(&uniqueid);
+            slapi_ch_free_string(&entryuuid);
         }
         break;
     default:
         slapi_ch_free_string(&uniqueid);
+        slapi_ch_free_string(&entryuuid);
     }
     slapi_ch_free_string(&chgtype);
     slapi_ch_free_string(&chgnr);
@@ -660,12 +747,19 @@ sync_send_deleted_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count,
     char *syncUUIDs[SYNC_MAX_DELETED_UUID_BATCH + 1] = {0};
     size_t uuid_index = 0;
 
+    PR_ASSERT(cookie);
+
     syncUUIDs[0] = NULL;
     for (size_t index = 0; index < chg_count; index++) {
-        if (upd[index].upd_chgtype == LDAP_REQ_DELETE &&
-            upd[index].upd_uuid) {
+        if (upd[index].upd_chgtype == LDAP_REQ_DELETE && upd[index].upd_uuid) {
             if (uuid_index < SYNC_MAX_DELETED_UUID_BATCH) {
-                syncUUIDs[uuid_index] = sync_nsuniqueid2uuid(upd[index].upd_uuid);
+                if (upd[index].upd_euuid) {
+                    /* Only occurs in openldap mode, swap to the entryuuid */
+                    syncUUIDs[uuid_index] = sync_entryuuid2uuid(upd[index].upd_euuid);
+                } else {
+                    /* Normal mode */
+                    syncUUIDs[uuid_index] = sync_nsuniqueid2uuid(upd[index].upd_uuid);
+                }
                 uuid_index++;
             } else {
                 /* max number of uuids to be sent in one sync info message */
@@ -692,24 +786,21 @@ sync_send_deleted_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count,
 }
 
 void
-sync_send_modified_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count)
+sync_send_modified_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count, Sync_Cookie *cookie)
 {
-    int index;
-
-    for (index = 0; index < chg_count; index++) {
-        if (upd[index].upd_chgtype != LDAP_REQ_DELETE &&
-            upd[index].upd_uuid)
-
-            sync_send_entry_from_changelog(pb, upd[index].upd_chgtype, upd[index].upd_uuid);
+    for (size_t index = 0; index < chg_count; index++) {
+        if (upd[index].upd_chgtype != LDAP_REQ_DELETE && upd[index].upd_uuid) {
+            sync_send_entry_from_changelog(pb, upd[index].upd_chgtype, upd[index].upd_uuid, cookie);
+        }
     }
 }
 
 int
-sync_send_entry_from_changelog(Slapi_PBlock *pb, int chg_req __attribute__((unused)), char *uniqueid)
+sync_send_entry_from_changelog(Slapi_PBlock *pb, int chg_req __attribute__((unused)), char *uniqueid, Sync_Cookie *cookie)
 {
     Slapi_Entry *db_entry = NULL;
     int chg_type = LDAP_SYNC_ADD;
-    int rv;
+    int rv = LDAP_SUCCESS;
     Slapi_PBlock *search_pb = NULL;
     Slapi_Entry **entries = NULL;
     char *origbase;
@@ -724,20 +815,27 @@ sync_send_entry_from_changelog(Slapi_PBlock *pb, int chg_req __attribute__((unus
     slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_RESULT, &rv);
     if (rv == LDAP_SUCCESS) {
         slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
-        if (entries)
+        if (entries) {
             db_entry = *entries; /* there can only be one */
+        }
     }
 
     if (db_entry && sync_is_entry_in_scope(pb, db_entry)) {
         LDAPControl **ctrl = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
-        sync_create_state_control(db_entry, &ctrl[0], chg_type, NULL);
+        rv = sync_create_state_control(db_entry, &ctrl[0], chg_type, NULL, cookie->openldap_compat);
+        if (rv != LDAP_SUCCESS) {
+            ldap_controls_free(ctrl);
+            slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM, "Terminating sync_send_entry_from_changelog due to error code -> %d\n", rv);
+            goto senddone;
+        }
         slapi_send_ldap_search_entry(pb, db_entry, ctrl, NULL, 0);
         ldap_controls_free(ctrl);
     }
+senddone:
     slapi_free_search_results_internal(search_pb);
     slapi_pblock_destroy(search_pb);
     slapi_ch_free((void **)&filter);
-    return (0);
+    return rv;
 }
 
 static SyncOpInfo *
@@ -794,6 +892,13 @@ sync_set_operation_extension(Slapi_PBlock *pb, SyncOpInfo *spec)
     slapi_pblock_get(pb, SLAPI_OPERATION, &op);
     slapi_set_object_extension(sync_extension_type, op,
                                sync_extension_handle, (void *)spec);
+}
+
+void
+sync_register_allow_openldap_compat(PRBool allow)
+{
+    /* This is synced by virtue of the plugin locking/loading. */
+    allow_openldap_compat = allow;
 }
 
 int

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -418,6 +418,7 @@ PR_fprintf(struct PRFileDesc *fd, const char *fmt, ...)
 #define SLAPI_ATTR_DN                    "dn"
 #define SLAPI_ATTR_RDN                   "rdn"
 #define SLAPI_ATTR_PARENTID              "parentid"
+#define SLAPI_ATTR_ENTRYUUID             "entryuuid"
 #define SLAPI_ATTR_UNIQUEID_LENGTH              10
 #define SLAPI_ATTR_OBJECTCLASS_LENGTH           11
 #define SLAPI_ATTR_VALUE_TOMBSTONE_LENGTH       11

--- a/src/lib389/lib389/cli_conf/__init__.py
+++ b/src/lib389/lib389/cli_conf/__init__.py
@@ -52,8 +52,30 @@ def generic_object_add(dsldap_objects_class, inst, log, args, arg_to_attr, dn=No
     return new_object
 
 
+def generic_object_add_attr(dsldap_object, log, args, arg_to_attr):
+    """Add an attribute to the entry. This differs to 'edit' as edit uses replace,
+    and this allows multivalues to be added.
+
+    dsldap_object should be a single instance of DSLdapObject with a set dn
+    """
+    log = log.getChild('generic_object_add_attr')
+    # Gather the attributes
+    attrs = _args_to_attrs(args, arg_to_attr)
+
+    modlist = []
+    for attr, value in attrs.items():
+        if not isinstance(value, list):
+            value = [value]
+        modlist.append((ldap.MOD_ADD, attr, value))
+    if len(modlist) > 0:
+        dsldap_object.apply_mods(modlist)
+        log.info("Successfully changed the %s", dsldap_object.dn)
+    else:
+        raise ValueError("There is nothing to set in the %s plugin entry" % dsldap_object.dn)
+
+
 def generic_object_edit(dsldap_object, log, args, arg_to_attr):
-    """Create an entry using DSLdapObject interface
+    """Replace or delete an attribute on an entry.
 
     dsldap_object should be a single instance of DSLdapObject with a set dn
     """

--- a/src/lib389/lib389/cli_conf/plugins/contentsync.py
+++ b/src/lib389/lib389/cli_conf/plugins/contentsync.py
@@ -7,9 +7,37 @@
 # --- END COPYRIGHT BLOCK ---
 
 from lib389.plugins import ContentSyncPlugin
-from lib389.cli_conf import add_generic_plugin_parsers
+from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr
+
+arg_to_attr = {
+    'allow_openldap': 'syncrepl-allow-openldap',
+}
+
+def contentsync_edit(inst, basedn, log, args):
+    log = log.getChild('contentsync_edit')
+    plugin = ContentSyncPlugin(inst)
+    generic_object_edit(plugin, log, args, arg_to_attr)
+
+
+def contentsync_add(inst, basedn, log, args):
+    log = log.getChild('contentsync_add')
+    plugin = ContentSyncPlugin(inst)
+    generic_object_add_attr(plugin, log, args, arg_to_attr)
+
+
+def _add_parser_args(parser):
+    parser.add_argument('--allow-openldap', choices=['on', 'off'], type=str.lower,
+                        help='Allows openldap servers to act as read only consumers of this server via syncrepl')
 
 def create_parser(subparsers):
     contentsync_parser = subparsers.add_parser('contentsync', help='Manage and configure Content Sync Plugin (aka syncrepl)')
     subcommands = contentsync_parser.add_subparsers(help='action')
     add_generic_plugin_parsers(subcommands, ContentSyncPlugin)
+
+    edit = subcommands.add_parser('set', help='Edit the plugin')
+    edit.set_defaults(func=contentsync_edit)
+    _add_parser_args(edit)
+
+    addp = subcommands.add_parser('add', help='Add attributes to the plugin')
+    addp.set_defaults(func=contentsync_add)
+    _add_parser_args(addp)

--- a/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
+++ b/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
@@ -7,7 +7,7 @@
 # --- END COPYRIGHT BLOCK ---
 
 from lib389.plugins import RetroChangelogPlugin
-from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit
+from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr
 
 arg_to_attr = {
     'is_replicated': 'isReplicated',
@@ -22,6 +22,12 @@ def retrochangelog_edit(inst, basedn, log, args):
     log = log.getChild('retrochangelog_edit')
     plugin = RetroChangelogPlugin(inst)
     generic_object_edit(plugin, log, args, arg_to_attr)
+
+
+def retrochangelog_add(inst, basedn, log, args):
+    log = log.getChild('retrochangelog_add')
+    plugin = RetroChangelogPlugin(inst)
+    generic_object_add_attr(plugin, log, args, arg_to_attr)
 
 
 def _add_parser_args(parser):
@@ -51,4 +57,7 @@ def create_parser(subparsers):
     edit.set_defaults(func=retrochangelog_edit)
     _add_parser_args(edit)
 
+    addp = subcommands.add_parser('add', help='Add attributes to the plugin')
+    addp.set_defaults(func=retrochangelog_add)
+    _add_parser_args(addp)
 


### PR DESCRIPTION
    Bug Description: OpenLDAP server as a syncrepl consumed enforces
    the condition that syncUUID in ldap messages must match the entryuuid
    of the entry. This is not in the RFC but it affects this one situation.

    Fix Description: To resolve this, we enforce that entryuuid is a
    requirement to the openldap syncrepl mode. Only entries with an
    entryuuid can be sent to openldap. Additionally, this mode is disabled
    by default by a configuration parameter "syncrepl-allow-openldap" in
    the content sync plugin config.


NOTE: It looks like the commits from 51260 which were previously merged seem to be missing after the migration, so this branch includes those. 

Thanks! 

Fixes: #4313 #4224 