### PR TITLE
Ticket 4345 - import self sign cert doc comment

### DIFF
--- a/src/lib389/lib389/instance/options.py
+++ b/src/lib389/lib389/instance/options.py
@@ -184,7 +184,7 @@ class Slapd2Base(Options2):
 
         self._options['self_sign_cert'] = True
         self._type['self_sign_cert'] = bool
-        self._helptext['self_sign_cert'] = "Sets whether the setup creates a self-signed certificate and enables TLS encryption during the installation. This is not suitable for production, but it enables administrators to use TLS right after the installation. You can replace the self-signed certificate with a certificate issued by a Certificate Authority."
+        self._helptext['self_sign_cert'] = "Sets whether the setup creates a self-signed certificate and enables TLS encryption during the installation. The certificate is not suitable for production, but it enables administrators to use TLS right after the installation. You can replace the self-signed certificate with a certificate issued by a Certificate Authority. If set to False, you can enable TLS later by importing a CA/Certificate and enabling 'dsconf <instance_name> config replace nsslapd-security=on'"
 
         self._options['self_sign_cert_valid_months'] = 24
         self._type['self_sign_cert_valid_months'] = int


### PR DESCRIPTION
Bug Description: It was raised that the doc comment with TLS
and self sign cert could be confusing and if disabled it was
not clear how to enable TLS later.

Fix Description: Improve the doc comment with examples.

fixes: #4345

Author: William Brown <william@blackhats.net.au>

Review by: ???