### PR TITLE
Ticket 4351 - improve generated sssd.conf output

### DIFF
--- a/src/lib389/lib389/cli_idm/client_config.py
+++ b/src/lib389/lib389/cli_idm/client_config.py
@@ -50,7 +50,7 @@ ldap_tls_cacertdir = /etc/openldap/certs
 # Only users who match this filter can login and authorise to this machine. Note
 # that users who do NOT match, will still have their uid/gid resolve, but they
 # can't login.
-ldap_access_filter = {ldap_access_filter}
+{ldap_access_filter}
 
 enumerate = false
 access_provider = ldap
@@ -93,11 +93,14 @@ def sssd_conf(inst, basedn, log, args):
     except:
         schema_type = "unknown - likely access denied to memberof plugin config"
 
-    ldap_access_filter = None
+    ldap_access_filter = "# ldap_access_filter = (memberOf=<dn>)"
     if args.allowed_group:
         groups = Groups(inst, basedn)
         g_access = groups.get(args.allowed_group)
-        ldap_access_filter = '(memberOf=%s)' % g_access.dn
+        ldap_access_filter = 'ldap_access_filter = (memberOf=%s)' % g_access.dn
+
+    if inst.ldapuri.startswith("ldapi://"):
+        log.warning("WARNING: ldap_uri starts with ldapi:// - you should review this parameter in the sssd configuration")
 
     # Print a customised sssd.config.
     print(SSSD_CONF_TEMPLATE.format(


### PR DESCRIPTION
Bug Description: There were some subtle issues in the sssd.conf
generator. When no group was specified, we'd generate an invalid
config. When the config used ldapi, it may not work on remote
servers.

Fix Description: When the uri is ldapi, emit a warning for
this parameter to be reviewed. When ldap filter is none
provide the example as commented out.

fixes: #4351

Author: William Brown <william@blackhats.net.au>

Review by: ???