### PR TITLE
Issue 4329 - Sync repl - if a serie of updates target the same entry …

### DIFF
--- a/ldap/servers/plugins/sync/sync_util.c
+++ b/ldap/servers/plugins/sync/sync_util.c
@@ -487,7 +487,7 @@ sync_cookie_get_change_number(int lastnr, const char *uniqueid)
     LDAPControl **ctrls = NULL;
     
     ctrls = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
-    char *filter = slapi_ch_smprintf("(&(changenumber>=%d)(targetuniqueid=%s))", lastnr, uniqueid);
+    char *filter = slapi_ch_smprintf("(&(changenumber>=%d)(targetuniqueid=%s))", lastnr + 1, uniqueid);
     ctrls[0] = sync_build_sort_control("changenumber");
 
     srch_pb = slapi_pblock_new();


### PR DESCRIPTION
…then the cookie get wrong changenumber

Bug description:
            In persist mode, sync_repl sends a matching updated entry with a sync state control
            containing a cookie. The cookie contains the changenumber related to the updated entry.
	    If several consecutive updates targets the same entry, sync_repl will send for each
            update the same changenumber (the first of the set of updates).
            changenumber will resync as soon as another entry is sent.
            The reason why sync_repl sends several time the same entry is that the internal
            search looks for '(changenumber >= cookie_changenumber)' rather than
            '(changenumber > cookie_changenumber)'.

Fix description:
            Change the filter to look for the next changenumber

Fixes: #4329

Reviewed by:  ?

Platforms tested: F31, F33