### PR TITLE
Ticket 4350 - One line, fix invalid type error in tls_cacertdir check

### DIFF
--- a/src/lib389/lib389/cli_base/dsrc.py
+++ b/src/lib389/lib389/cli_base/dsrc.py
@@ -139,7 +139,7 @@ def dsrc_to_ldap(path, instance_name, log):
     dsrc_inst['tls_cacertdir'] = config.get(instance_name, 'tls_cacertdir', fallback=None)
     # At this point, we should check if the provided cacertdir is indeed, a dir. This can be a cause
     # of basic failures and confusion.
-    if os.path.exists(dsrc_inst['tls_cacertdir']) == False or os.path.isdir(dsrc_inst['tls_cacertdir']) == False:
+    if dsrc_inst['tls_cacertdir'] is not None and (os.path.exists(dsrc_inst['tls_cacertdir']) == False or os.path.isdir(dsrc_inst['tls_cacertdir']) == False):
         log.warning("Warning: dsrc tls_cacertdir path may not exist, or is not a directory")
         log.warning("Warning: This should be a directory, and you must run '/usr/bin/c_rehash path' for it to be a valid CA store")
 


### PR DESCRIPTION
Bug Description: When the tls_cacertdir parameter was not
present os.path fails with None not a str.

Fix Description: Check if the path is None

fixes: #4350

Author: William Brown <william@blackhats.net.au>

Review by: