### PR TITLE
Ticket 4334 - Task timeout may cause larger dataset imports to fail

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -241,7 +241,7 @@ def backend_import(inst, basedn, log, args):
     task = mc.import_ldif(ldifs=args.ldifs, chunk_size=args.chunks_size, encrypted=args.encrypted,
                           gen_uniq_id=args.gen_uniq_id, only_core=args.only_core, include_suffixes=args.include_suffixes,
                           exclude_suffixes=args.exclude_suffixes)
-    task.wait()
+    task.wait(timeout=None)
     result = task.get_exit_code()
 
     if task.is_complete() and result == 0:
@@ -269,7 +269,7 @@ def backend_export(inst, basedn, log, args):
                           encrypted=args.encrypted, min_base64=args.min_base64, no_dump_uniq_id=args.no_dump_uniq_id,
                           replication=args.replication, not_folded=args.not_folded, no_seq_num=args.no_seq_num,
                           include_suffixes=args.include_suffixes, exclude_suffixes=args.exclude_suffixes)
-    task.wait()
+    task.wait(timeout=None)
     result = task.get_exit_code()
 
     if task.is_complete() and result == 0:

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -81,7 +81,10 @@ class Task(DSLdapObject):
         """Wait until task is complete."""
 
         count = 0
-        while count < timeout:
+        if timeout is None:
+            self._log.debug("No timeout is set, this may take a long time ...")
+
+        while timeout is None or count < timeout:
             if self.is_complete():
                 break
             count = count + 1


### PR DESCRIPTION
Bug Description: The task.wait() function had a hardcoded timeout
and no method to "disable" that check. This could cause very large
databases to fail to import.

Fix Description: Support timeout=None, which allows the task to
take 'infinite' time. Additionally, this provides a warning that
this is occuring.

fixes: #4334

Author: William Brown <william@blackhats.net.au>

Review by: ???