### PR TITLE
Issue 4265 - UI - Make the secondary plugins read-only

### DIFF
--- a/src/cockpit/389-console/src/lib/plugins/pluginModal.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pluginModal.jsx
@@ -13,14 +13,13 @@ import {
 } from "patternfly-react";
 import PropTypes from "prop-types";
 
-class PluginEditModal extends React.Component {
+class PluginViewModal extends React.Component {
     render() {
         const {
             showModal,
             closeHandler,
             handleChange,
             handleSwitchChange,
-            savePluginHandler
         } = this.props;
         const {
             currentPluginName,
@@ -59,14 +58,13 @@ class PluginEditModal extends React.Component {
                         >
                             <Icon type="pf" name="close" />
                         </button>
-                        <Modal.Title>Edit Plugin - {currentPluginName}</Modal.Title>
+                        <Modal.Title>View Plugin - {currentPluginName}</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
                         <Form horizontal>
                             <FormGroup
                                 key="currentPluginEnabled"
                                 controlId="currentPluginEnabled"
-                                disabled={false}
                             >
                                 <Col componentClass={ControlLabel} sm={5}>
                                     Plugin Status
@@ -79,11 +77,12 @@ class PluginEditModal extends React.Component {
                                         value={currentPluginEnabled}
                                         onChange={() => handleSwitchChange(currentPluginEnabled)}
                                         animate={false}
+                                        disabled
                                     />
                                 </Col>
                             </FormGroup>
                             {Object.entries(modalFields).map(([id, value]) => (
-                                <FormGroup key={id} controlId={id} disabled={false}>
+                                <FormGroup key={id} controlId={id} disabled>
                                     <Col componentClass={ControlLabel} sm={5}>
                                         Plugin {id.replace("currentPlugin", "")}
                                     </Col>
@@ -92,6 +91,7 @@ class PluginEditModal extends React.Component {
                                             type="text"
                                             value={value}
                                             onChange={handleChange}
+                                            disabled
                                         />
                                     </Col>
                                 </FormGroup>
@@ -99,7 +99,7 @@ class PluginEditModal extends React.Component {
                             <FormGroup
                                 key="currentPluginDependsOnType"
                                 controlId="currentPluginDependsOnType"
-                                disabled={false}
+                                disabled
                             >
                                 <Col componentClass={ControlLabel} sm={5}>
                                     Plugin Depends On Type
@@ -109,13 +109,14 @@ class PluginEditModal extends React.Component {
                                         type="text"
                                         value={currentPluginDependsOnType}
                                         onChange={handleChange}
+                                        disabled
                                     />
                                 </Col>
                             </FormGroup>
                             <FormGroup
                                 key="currentPluginDependsOnNamed"
                                 controlId="currentPluginDependsOnNamed"
-                                disabled={false}
+                                disabled
                             >
                                 <Col componentClass={ControlLabel} sm={5}>
                                     Plugin Depends On Named
@@ -125,6 +126,7 @@ class PluginEditModal extends React.Component {
                                         type="text"
                                         value={currentPluginDependsOnNamed}
                                         onChange={handleChange}
+                                        disabled
                                     />
                                 </Col>
                             </FormGroup>
@@ -132,28 +134,7 @@ class PluginEditModal extends React.Component {
                     </Modal.Body>
                     <Modal.Footer>
                         <Button bsStyle="default" className="btn-cancel" onClick={closeHandler}>
-                            Cancel
-                        </Button>
-                        <Button
-                            bsStyle="primary"
-                            onClick={() =>
-                                savePluginHandler({
-                                    name: currentPluginName,
-                                    enabled: currentPluginEnabled,
-                                    type: currentPluginType,
-                                    path: currentPluginPath,
-                                    initfunc: currentPluginInitfunc,
-                                    id: currentPluginId,
-                                    vendor: currentPluginVendor,
-                                    version: currentPluginVersion,
-                                    description: currentPluginDescription,
-                                    dependsOnType: currentPluginDependsOnType,
-                                    dependsOnNamed: currentPluginDependsOnNamed,
-                                    precedence: currentPluginPrecedence
-                                })
-                            }
-                        >
-                            Save
+                            Close
                         </Button>
                     </Modal.Footer>
                 </div>
@@ -162,7 +143,7 @@ class PluginEditModal extends React.Component {
     }
 }
 
-PluginEditModal.propTypes = {
+PluginViewModal.propTypes = {
     handleChange: PropTypes.func,
     handleSwitchChange: PropTypes.func,
     pluginData: PropTypes.exact({
@@ -180,11 +161,10 @@ PluginEditModal.propTypes = {
         currentPluginPrecedence: PropTypes.string
     }),
     closeHandler: PropTypes.func,
-    savePluginHandler: PropTypes.func,
     showModal: PropTypes.bool
 };
 
-PluginEditModal.defaultProps = {
+PluginViewModal.defaultProps = {
     handleChange: noop,
     handleSwitchChange: noop,
     pluginData: {
@@ -202,8 +182,7 @@ PluginEditModal.defaultProps = {
         currentPluginPrecedence: ""
     },
     closeHandler: noop,
-    savePluginHandler: noop,
     showModal: false
 };
 
-export default PluginEditModal;
+export default PluginViewModal;

--- a/src/cockpit/389-console/src/lib/plugins/pluginTables.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pluginTables.jsx
@@ -106,7 +106,7 @@ class PluginTable extends React.Component {
                                                 this.props.loadModalHandler(rowData);
                                             }}
                                         >
-                                            Edit Plugin
+                                            View Plugin
                                         </Button>
                                     </td>
                                 ];

--- a/src/cockpit/389-console/src/plugins.jsx
+++ b/src/cockpit/389-console/src/plugins.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { log_cmd } from "./lib/tools.jsx";
 import { Col, Row, Tab, Nav, NavItem, noop, Spinner } from "patternfly-react";
-import PluginEditModal from "./lib/plugins/pluginModal.jsx";
+import PluginViewModal from "./lib/plugins/pluginModal.jsx";
 import { PluginTable } from "./lib/plugins/pluginTables.jsx";
 import AccountPolicy from "./lib/plugins/accountPolicy.jsx";
 import AttributeUniqueness from "./lib/plugins/attributeUniqueness.jsx";
@@ -528,7 +528,7 @@ export class Plugins extends React.Component {
                             </Col>
                         </Row>
                     </Tab.Container>
-                    <PluginEditModal
+                    <PluginViewModal
                         handleChange={this.handleFieldChange}
                         handleSwitchChange={this.handleSwitchChange}
                         pluginData={{
@@ -547,7 +547,6 @@ export class Plugins extends React.Component {
                         }}
                         closeHandler={this.closePluginModal}
                         showModal={this.state.showPluginModal}
-                        savePluginHandler={this.savePlugin}
                     />
                 </div>
             </div>


### PR DESCRIPTION
Description: As some of the changes may break the server.
We should make all the plugins in the UI Plugins table read-only.
Only the ones in the left column should editable.
The change is only for UI.

Fixes: #4265

Reviewed by: ?