### PR TITLE
Issue 4372 BUG - Chaining DB did not validate bind mech parameters

### DIFF
--- a/ldap/servers/plugins/chainingdb/cb_instance.c
+++ b/ldap/servers/plugins/chainingdb/cb_instance.c
@@ -1459,6 +1459,19 @@ cb_instance_bindmech_set(void *arg, void *value, char *errorbuf, int phase, int 
         }
     }
 
+    if (rc == LDAP_SUCCESS) {
+        /* Assert the value is a valid mechanism */
+        if (value && !(
+            PL_strcasecmp((char *)value, CB_SIMPLE_BINDMECH) == 0 ||
+            PL_strcasecmp((char *)value, "GSSAPI") == 0 ||
+            PL_strcasecmp((char *)value, "EXTERNAL") == 0 ||
+            PL_strcasecmp((char *)value, "DIGEST-MD5") == 0
+        )) {
+            PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "Invalid value for " CB_CONFIG_BINDMECH " . It must be one of \"SIMPLE\", \"EXTERNAL\", or \"GSSAPI\"");
+            rc = LDAP_UNWILLING_TO_PERFORM;
+        }
+    }
+
     if ((LDAP_SUCCESS == rc) && apply) {
         slapi_rwlock_wrlock(inst->rwl_config_lock);
         if ((phase != CB_CONFIG_PHASE_INITIALIZATION) &&

--- a/src/lib389/lib389/cli_conf/chaining.py
+++ b/src/lib389/lib389/cli_conf/chaining.py
@@ -259,7 +259,7 @@ def create_parser(subparsers):
     create_link_parser.add_argument('--suffix', required=True, help="The suffix managed by the database link.")
     create_link_parser.add_argument('--server-url', required=True, help="Gives the LDAP/LDAPS URL of the remote server.")
     create_link_parser.add_argument('--bind-mech', required=True,
-        help="Sets the authentication method to use to authenticate to the remote server: <leave empty for LDAP/LDAPS>, EXTERNAL, DIGEST-MD5, or GSSAPI")
+        help="Sets the authentication method to use to authenticate to the remote server: SIMPLE, EXTERNAL, DIGEST-MD5, or GSSAPI. Default if unset is SIMPLE.")
     create_link_parser.add_argument('--bind-dn', required=True, help="DN of the administrative entry used to communicate with the remote server")
     create_link_parser.add_argument('--bind-pw', required=True, help="Password for the administrative user.")
 
@@ -273,7 +273,8 @@ def create_parser(subparsers):
     edit_link_parser.add_argument('CHAIN_NAME', nargs=1, help='The name of the database link')
     edit_link_parser.add_argument('--suffix', help="The suffix managed by the database link.")
     edit_link_parser.add_argument('--server-url', help="Gives the LDAP/LDAPS URL of the remote server.")
-    edit_link_parser.add_argument('--bind-mech', help="Sets the authentication method to use to authenticate to the remote server: <leave empty for LDAP/LDAPS>, EXTERNAL, DIGEST-MD5, or GSSAPI")
+    edit_link_parser.add_argument('--bind-mech',
+        help="Sets the authentication method to use to authenticate to the remote server: SIMPLE, EXTERNAL, DIGEST-MD5, or GSSAPI. Default if unset is SIMPLE.")
     edit_link_parser.add_argument('--bind-dn', help="DN of the administrative entry used to communicate with the remote server")
     edit_link_parser.add_argument('--bind-pw', help="Password for the administrative user.")
 


### PR DESCRIPTION
Bug Description: Chaining DB did not validate the content of bind mech.
When combined with an ambiguous help string, this caused users to set
blank/empty strings into the chaining db config, that would not auth
correctly to the tarcet.

Fix Description: The chaining DB should strictly enforce the incoming
values that are set. The help in dsconf should be explicit about what
values are supported and how they are set.

fixes: #4372

Author: William Brown <william@blackhats.net.au>

Review by: ???