### PR TITLE
Issue 2526 - suffix management in backends incorrect

### DIFF
--- a/dirsrvtests/tests/suites/mapping_tree/acceptance_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/acceptance_test.py
@@ -1,0 +1,65 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import ldap
+import logging
+import pytest
+import os
+from lib389._constants import *
+from lib389.topologies import topology_st as topo
+from lib389.mappingTree import MappingTrees
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def test_invalid_mt(topo):
+    """Test that you can not add a new suffix/mapping tree
+    that does not already have the backend entry created.
+
+    :id: caabd407-f541-4695-b13f-8f92af1112a0
+    :setup: Standalone Instance
+    :steps:
+        1. Create a new suffix that specifies an existing backend which has a
+           different suffix.
+        2. Create a suffix that has no backend entry at all.
+    :expectedresults:
+        1. Should fail with UNWILLING_TO_PERFORM
+        1. Should fail with UNWILLING_TO_PERFORM
+    """
+
+    bad_suffix = 'dc=does,dc=not,dc=exist'
+    mts = MappingTrees(topo.standalone)
+    
+    properties = {
+        'cn': bad_suffix,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': 'userroot',
+    }
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        mts.create(properties=properties)
+
+    properties = {
+        'cn': bad_suffix,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': 'notCreatedRoot',
+    }
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        mts.create(properties=properties)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/plugins/acl/acllist.c
+++ b/ldap/servers/plugins/acl/acllist.c
@@ -129,7 +129,7 @@ acl_be_state_change_fnc(void *handle __attribute__((unused)), char *be_name, int
          * Just get the first suffix--if there are multiple XXX ?
         */
 
-        if ((sdn = slapi_be_getsuffix(be, 0)) == NULL) {
+        if ((sdn = slapi_be_getsuffix(be)) == NULL) {
             slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                           "acl_be_state_change_fnc - Failed to retrieve backend--NOT activating it's acis\n");
             return;
@@ -156,7 +156,7 @@ acl_be_state_change_fnc(void *handle __attribute__((unused)), char *be_name, int
          * In fact there can onlt be one sufffix here.
         */
 
-        if ((sdn = slapi_be_getsuffix(be, 0)) == NULL) {
+        if ((sdn = slapi_be_getsuffix(be)) == NULL) {
             slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                           "acl_be_state_change_fnc - Failed to retrieve backend--NOT activating it's acis\n");
             return;

--- a/ldap/servers/plugins/chainingdb/cb_instance.c
+++ b/ldap/servers/plugins/chainingdb/cb_instance.c
@@ -1662,9 +1662,9 @@ cb_instance_search_config_callback(Slapi_PBlock *pb __attribute__((unused)),
     char buf[CB_BUFSIZE];
     struct berval val;
     struct berval *vals[2];
-    int i = 0;
     cb_backend_instance *inst = (cb_backend_instance *)arg;
     cb_instance_config_info *config;
+    const Slapi_DN *aSuffix;
 
     vals[0] = &val;
     vals[1] = NULL;
@@ -1673,25 +1673,17 @@ cb_instance_search_config_callback(Slapi_PBlock *pb __attribute__((unused)),
 
     slapi_rwlock_rdlock(inst->rwl_config_lock);
 
-    {
-        const Slapi_DN *aSuffix;
-        i = 0;
-        if (inst->inst_be) {
-            while ((aSuffix = slapi_be_getsuffix(inst->inst_be, i))) {
-                val.bv_val = (char *)slapi_sdn_get_dn(aSuffix);
-                val.bv_len = strlen(val.bv_val);
-                if (val.bv_len) {
-                    if (i == 0)
-                        slapi_entry_attr_replace(e, CB_CONFIG_SUFFIX, (struct berval **)vals);
-                    else
-                        slapi_entry_attr_merge(e, CB_CONFIG_SUFFIX, (struct berval **)vals);
-                }
-                i++;
+    if (inst->inst_be) {
+        if ((aSuffix = slapi_be_getsuffix(inst->inst_be))) {
+            val.bv_val = (char *)slapi_sdn_get_dn(aSuffix);
+            val.bv_len = strlen(val.bv_val);
+            if (val.bv_len) {
+                slapi_entry_attr_replace(e, CB_CONFIG_SUFFIX, (struct berval **)vals);
             }
         }
     }
 
-    for (i = 0; inst->chaining_components && inst->chaining_components[i]; i++) {
+    for (size_t i = 0; inst->chaining_components && inst->chaining_components[i]; i++) {
         val.bv_val = inst->chaining_components[i];
         val.bv_len = strlen(val.bv_val);
         if (val.bv_len) {
@@ -1702,7 +1694,7 @@ cb_instance_search_config_callback(Slapi_PBlock *pb __attribute__((unused)),
         }
     }
 
-    for (i = 0; inst->illegal_attributes && inst->illegal_attributes[i]; i++) {
+    for (size_t i = 0; inst->illegal_attributes && inst->illegal_attributes[i]; i++) {
         val.bv_val = inst->illegal_attributes[i];
         val.bv_len = strlen(val.bv_val);
         if (val.bv_len) {

--- a/ldap/servers/plugins/chainingdb/cb_test.c
+++ b/ldap/servers/plugins/chainingdb/cb_test.c
@@ -42,7 +42,7 @@ cb_back_test(Slapi_PBlock *pb)
 
     printf("Begin test instance %s.\n", inst->inst_name);
 
-    aSuffix = slapi_be_getsuffix(be, 0);
+    aSuffix = slapi_be_getsuffix(be);
     /* Remove leading white spaces */
     for (aSuffixString = slapi_sdn_get_dn(aSuffix);
          *aSuffixString == ' '; aSuffixString++) {

--- a/ldap/servers/plugins/chainingdb/cb_utils.c
+++ b/ldap/servers/plugins/chainingdb/cb_utils.c
@@ -342,7 +342,7 @@ cb_be_state_change(void *handle __attribute__((unused)), char *be_name, int old_
     }
 
     /* get the suffix for the local backend */
-    tmpsdn = slapi_be_getsuffix(the_be, 0);
+    tmpsdn = slapi_be_getsuffix(the_be);
     if (!tmpsdn) {
         return;
     } else {
@@ -355,7 +355,7 @@ cb_be_state_change(void *handle __attribute__((unused)), char *be_name, int old_
         /* only look at chaining backends */
         if (slapi_be_is_flag_set(chainbe, SLAPI_BE_FLAG_REMOTE_DATA)) {
             /* get the suffix */
-            const Slapi_DN *tmpcbsuf = slapi_be_getsuffix(chainbe, 0);
+            const Slapi_DN *tmpcbsuf = slapi_be_getsuffix(chainbe);
             if (tmpcbsuf) {
                 /* make a copy - to be safe */
                 Slapi_DN *cbsuffix = slapi_sdn_dup(tmpcbsuf);

--- a/ldap/servers/plugins/dna/dna.c
+++ b/ldap/servers/plugins/dna/dna.c
@@ -2884,7 +2884,7 @@ dna_is_replica_bind_dn(char *range_dn, char *bind_dn)
     /* Find the backend suffix where the shared config is stored. */
     range_sdn = slapi_sdn_new_dn_byref(range_dn);
     if ((be = slapi_be_select(range_sdn)) != NULL) {
-        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be, 0));
+        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be));
     }
 
     /* Fetch the "cn=replica" entry for the backend that stores
@@ -2976,7 +2976,7 @@ dna_get_replica_bind_creds(char *range_dn, struct dnaServer *server, char **bind
     /* Find the backend suffix where the shared config is stored. */
     range_sdn = slapi_sdn_new_normdn_byref(range_dn);
     if ((be = slapi_be_select(range_sdn)) != NULL) {
-        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be, 0));
+        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be));
     }
 
     /* Fetch the replication agreement entry */

--- a/ldap/servers/plugins/linkedattrs/fixup_task.c
+++ b/ldap/servers/plugins/linkedattrs/fixup_task.c
@@ -430,7 +430,7 @@ linked_attrs_add_backlinks_callback(Slapi_Entry *e, void *callback_data)
             Slapi_DN *linksdn = slapi_sdn_new_normdn_byref(linkdn);
 
             if ((be = slapi_be_select(linksdn))) {
-                perform_update = slapi_sdn_issuffix(targetsdn, slapi_be_getsuffix(be, 0));
+                perform_update = slapi_sdn_issuffix(targetsdn, slapi_be_getsuffix(be));
             }
 
             slapi_sdn_free(&linksdn);

--- a/ldap/servers/plugins/linkedattrs/linked_attrs.c
+++ b/ldap/servers/plugins/linkedattrs/linked_attrs.c
@@ -1443,7 +1443,7 @@ linked_attrs_mod_backpointers(Slapi_PBlock *pb, char *linkdn, char *type, char *
             Slapi_DN *linksdn = slapi_sdn_new_normdn_byref(linkdn);
 
             if ((be = slapi_be_select(linksdn))) {
-                perform_update = slapi_sdn_issuffix(targetsdn, slapi_be_getsuffix(be, 0));
+                perform_update = slapi_sdn_issuffix(targetsdn, slapi_be_getsuffix(be));
             }
 
             slapi_sdn_free(&linksdn);

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -799,7 +799,7 @@ memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_DN *sdn
                 break;
             }
         }
-        if ((base_sdn = (Slapi_DN *)slapi_be_getsuffix(be, 0)) == NULL) {
+        if ((base_sdn = (Slapi_DN *)slapi_be_getsuffix(be)) == NULL) {
             if (!all_backends) {
                 break;
             } else {
@@ -1549,7 +1549,7 @@ memberof_modop_one_replace_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod_o
                         break;
                     }
                 }
-                if ((base_sdn = (Slapi_DN *)slapi_be_getsuffix(be, 0)) == NULL) {
+                if ((base_sdn = (Slapi_DN *)slapi_be_getsuffix(be)) == NULL) {
                     if (!all_backends) {
                         break;
                     } else {

--- a/ldap/servers/plugins/posix-winsync/posix-group-func.c
+++ b/ldap/servers/plugins/posix-winsync/posix-group-func.c
@@ -301,7 +301,7 @@ posix_winsync_foreach_parent(Slapi_Entry *entry, char **attrs, plugin_search_ent
 
     for (be = slapi_get_first_backend(&cookie); be;
          be = slapi_get_next_backend(cookie)) {
-        const Slapi_DN *base_sdn = slapi_be_getsuffix(be, 0);
+        const Slapi_DN *base_sdn = slapi_be_getsuffix(be);
         if (base_sdn == NULL) {
             continue;
         }

--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -4388,7 +4388,7 @@ cl5Export(Slapi_PBlock *pb)
     slapi_pblock_get(pb, SLAPI_BACKEND_INSTANCE_NAME, &instance_name);
     slapi_pblock_get(pb, SLAPI_DB2LDIF_FILE, &instance_ldif);
     slapi_pblock_get(pb, SLAPI_BACKEND, &be);
-    replica = replica_get_replica_from_dn(slapi_be_getsuffix(be, 0));
+    replica = replica_get_replica_from_dn(slapi_be_getsuffix(be));
     if (replica == NULL) {
         slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
                               "cl5Export - No replica defined for instance %s\n", instance_name);

--- a/ldap/servers/plugins/replication/repl5_mtnode_ext.c
+++ b/ldap/servers/plugins/replication/repl5_mtnode_ext.c
@@ -201,7 +201,7 @@ replica_get_for_backend(const char *be_name)
     if (NULL == be)
         return NULL;
 
-    suffix = slapi_be_getsuffix(be, 0);
+    suffix = slapi_be_getsuffix(be);
 
     return replica_get_replica_from_dn(suffix);
 

--- a/ldap/servers/plugins/roles/roles_cache.c
+++ b/ldap/servers/plugins/roles/roles_cache.c
@@ -459,7 +459,7 @@ roles_cache_trigger_update_suffix(void *handle __attribute__((unused)), char *be
     /* Backend back on line or new one created*/
     backend = slapi_be_select_by_instance_name(be_name);
     if (backend != NULL) {
-        be_suffix_dn = slapi_be_getsuffix(backend, 0);
+        be_suffix_dn = slapi_be_getsuffix(backend);
         top_suffix_dn = roles_cache_get_top_suffix((Slapi_DN *)be_suffix_dn);
     }
 
@@ -842,7 +842,7 @@ roles_cache_change_notify(Slapi_PBlock *pb)
             }
         }
 #endif
-        Slapi_DN *top_suffix = roles_cache_get_top_suffix((Slapi_DN *)slapi_be_getsuffix(be, 0));
+        Slapi_DN *top_suffix = roles_cache_get_top_suffix((Slapi_DN *)slapi_be_getsuffix(be));
 
         if (top_suffix != NULL) {
             dn = slapi_sdn_get_dn(sdn);
@@ -1679,7 +1679,7 @@ roles_cache_find_roles_in_suffix(Slapi_DN *target_entry_dn, roles_cache_def **li
     *list_of_roles = NULL;
     backend = slapi_mapping_tree_find_backend_for_sdn(target_entry_dn);
     if ((backend != NULL) && !slapi_be_is_flag_set(backend, SLAPI_BE_FLAG_REMOTE_DATA)) {
-        Slapi_DN *suffix = roles_cache_get_top_suffix((Slapi_DN *)slapi_be_getsuffix(backend, 0));
+        Slapi_DN *suffix = roles_cache_get_top_suffix((Slapi_DN *)slapi_be_getsuffix(backend));
         roles_cache_def *current_role = roles_list;
 
         /* Go through all the roles list and trigger the associated structure */

--- a/ldap/servers/plugins/usn/usn_cleanup.c
+++ b/ldap/servers/plugins/usn/usn_cleanup.c
@@ -279,7 +279,7 @@ usn_cleanup_add(Slapi_PBlock *pb,
     /* suffix is not given, but backend is; get the suffix */
     if (!suffix && backend) {
         be = slapi_be_select_by_instance_name(backend);
-        be_suffix = slapi_be_getsuffix(be, 0);
+        be_suffix = slapi_be_getsuffix(be);
         if (be_suffix) {
             suffix = slapi_ch_strdup(slapi_sdn_get_ndn(be_suffix));
         } else {

--- a/ldap/servers/slapd/back-ldbm/ancestorid.c
+++ b/ldap/servers/slapd/back-ldbm/ancestorid.c
@@ -218,7 +218,7 @@ ldbm_ancestorid_index_entry(
 
     ret = ldbm_ancestorid_index_update(be,
                                        slapi_entry_get_sdn_const(e->ep_entry),
-                                       slapi_be_getsuffix(be, 0),
+                                       slapi_be_getsuffix(be),
                                        0, 1, e->ep_id, NULL, flags, txn);
 
     return ret;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -422,7 +422,7 @@ bdb_fetch_subtrees(backend *be, char **include, int *err)
     /* for each subtree spec... */
     for (i = 0; include[i]; i++) {
         IDList *idl = NULL;
-        const char *suffix = slapi_sdn_get_ndn(slapi_be_getsuffix(be, 0));
+        const char *suffix = slapi_sdn_get_ndn(slapi_be_getsuffix(be));
         char *parentdn = slapi_ch_strdup(suffix);
         char *nextdn = NULL;
         int matched = 0;

--- a/ldap/servers/slapd/back-ldbm/ldbm_compare.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_compare.c
@@ -54,7 +54,7 @@ ldbm_back_compare(Slapi_PBlock *pb)
         return -1;
     }
     /* get the namespace dn */
-    namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+    namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be);
 
     if ((e = find_entry(pb, be, addr, &txn, NULL)) == NULL) {
         ret = -1; /* error result sent by find_entry() */

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -555,6 +555,8 @@ parse_ldbm_instance_config_entry(ldbm_instance *inst, Slapi_Entry *e, config_inf
     /* Read the attribute encryption entries */
     read_instance_attrcrypt_entries(inst);
 
+
+
     return 0;
 }
 
@@ -745,26 +747,20 @@ ldbm_instance_search_config_entry_callback(Slapi_PBlock *pb __attribute__((unuse
     struct ldbminfo *li = inst->inst_li;
     dblayer_private *priv = (dblayer_private *)li->li_dblayer_private;
     config_info *config;
-    int x;
     const Slapi_DN *suffix;
 
     vals[0] = &val;
     vals[1] = NULL;
-
     returntext[0] = '\0';
 
     /* show the suffixes */
     attrlist_delete(&e->e_attrs, CONFIG_INSTANCE_SUFFIX);
-    x = 0;
-    do {
-        suffix = slapi_be_getsuffix(inst->inst_be, x);
-        if (suffix != NULL) {
-            val.bv_val = (char *)slapi_sdn_get_dn(suffix);
-            val.bv_len = strlen(val.bv_val);
-            attrlist_merge(&e->e_attrs, CONFIG_INSTANCE_SUFFIX, vals);
-        }
-        x++;
-    } while (suffix != NULL);
+    suffix = slapi_be_getsuffix(inst->inst_be);
+    if (suffix != NULL) {
+        val.bv_val = (char *)slapi_sdn_get_dn(suffix);
+        val.bv_len = strlen(val.bv_val);
+        attrlist_merge(&e->e_attrs, CONFIG_INSTANCE_SUFFIX, vals);
+    }
 
     PR_Lock(inst->inst_config_mutex);
 

--- a/ldap/servers/slapd/configdse.c
+++ b/ldap/servers/slapd/configdse.c
@@ -200,19 +200,14 @@ read_config_dse(Slapi_PBlock *pb __attribute__((unused)),
     be = slapi_get_first_backend(&cookie);
     while (be) {
         if (be->be_private) {
-            int n = 0;
             const Slapi_DN *base = NULL;
-            do {
-                base = slapi_be_getsuffix(be, n);
-                if (base != NULL) {
-                    val.bv_val = (void *)slapi_sdn_get_dn(base); /* jcm: had to cast away const */
-                    val.bv_len = strlen(val.bv_val);
-                    attrlist_merge(&e->e_attrs, "nsslapd-privatenamespaces", vals);
-                }
-                n++;
-            } while (base != NULL);
+            base = slapi_be_getsuffix(be);
+            if (base != NULL) {
+                val.bv_val = (void *)slapi_sdn_get_dn(base); /* jcm: had to cast away const */
+                val.bv_len = strlen(val.bv_val);
+                attrlist_merge(&e->e_attrs, "nsslapd-privatenamespaces", vals);
+            }
         }
-
         be = slapi_get_next_backend(cookie);
     }
 

--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -569,7 +569,7 @@ free_mapping_tree_node_arrays(backend ***be_list, char ***be_names, int **be_sta
  * tree node (guaranteed to be non-NULL).
  */
 static int
-mapping_tree_entry_add(Slapi_Entry *entry, mapping_tree_node **newnodep)
+mapping_tree_entry_add(Slapi_Entry *entry, mapping_tree_node **newnodep, PRBool check_be)
 {
     Slapi_DN *subtree = NULL;
     const char *tmp_ndn;
@@ -588,7 +588,7 @@ mapping_tree_entry_add(Slapi_Entry *entry, mapping_tree_node **newnodep)
     Slapi_Attr *attr = NULL;
     mapping_tree_node *node = NULL;
     mapping_tree_node *parent_node = mapping_tree_root;
-    int rc;
+    int rc = 0;
     int lderr = LDAP_UNWILLING_TO_PERFORM; /* our default result code */
     char *tmp_backend_name;
     Slapi_Backend *be;
@@ -603,6 +603,37 @@ mapping_tree_entry_add(Slapi_Entry *entry, mapping_tree_node **newnodep)
                       "Unable to determine the subtree represented by the mapping tree node %s\n",
                       slapi_entry_get_dn(entry));
         return lderr;
+    }
+
+    /* Verify there is a matching backend for this suffix */
+    if (check_be) {
+        const char *mt_be_name;
+        char *cookie = NULL;
+        int32_t found_be = 0;
+
+        /* get the backend name for this mapping tree node */
+        mt_be_name = slapi_entry_attr_get_ref(entry, "nsslapd-backend");
+
+        be = slapi_get_first_backend(&cookie);
+        while (be) {
+            char *be_name = slapi_be_get_name(be);
+            if (mt_be_name && be_name &&
+                strcasecmp(be_name, mt_be_name) == 0 &&
+                slapi_sdn_compare(subtree, be->be_suffix) == 0)
+            {
+                found_be = 1;
+                break;
+            }
+            be = (backend *)slapi_get_next_backend(cookie);
+        }
+        slapi_ch_free((void **)&cookie);
+        if (!found_be) {
+            slapi_log_err(SLAPI_LOG_ERR, "mapping_tree_entry_add",
+                     "The subtree %s does not match any existing backends, and will not be created.\n",
+                     slapi_sdn_get_dn(subtree));
+            slapi_sdn_free(&subtree);
+            return LDAP_UNWILLING_TO_PERFORM;
+        }
     }
 
     tmp_ndn = slapi_sdn_get_ndn(subtree);
@@ -620,8 +651,8 @@ mapping_tree_entry_add(Slapi_Entry *entry, mapping_tree_node **newnodep)
     /* Make sure a node does not already exist for this subtree */
     if (parent_node != NULL && NULL != mtn_get_mapping_tree_node_by_entry(mapping_tree_root, subtree)) {
         slapi_log_err(SLAPI_LOG_WARNING, "mapping_tree_entry_add",
-                      "Mapping tree node for the subtree %s already exists; unable to add the node %s\n",
-                      slapi_sdn_get_dn(subtree), slapi_entry_get_dn(entry));
+					  "Mapping tree node for the subtree %s already exists; unable to add the node %s\n",
+					  slapi_sdn_get_dn(subtree), slapi_entry_get_dn(entry));
         slapi_sdn_free(&subtree);
         return LDAP_ALREADY_EXISTS;
     }
@@ -922,8 +953,7 @@ mapping_tree_node_get_children(mapping_tree_node *target, int is_root)
 
     for (x = 0; entries[x] != NULL; x++) {
         mapping_tree_node *child = NULL;
-
-        if (LDAP_SUCCESS != mapping_tree_entry_add(entries[x], &child)) {
+        if (LDAP_SUCCESS != mapping_tree_entry_add(entries[x], &child, PR_FALSE)) {
             slapi_log_err(SLAPI_LOG_ERR, "mapping_tree_node_get_children",
                           "Could not add mapping tree node %s\n",
                           slapi_entry_get_dn(entries[x]));
@@ -1332,7 +1362,7 @@ mapping_tree_entry_add_callback(Slapi_PBlock *pb __attribute__((unused)),
      * Should the mapping tree stucture change, this  would have to
      * be checked again
      */
-    *returncode = mapping_tree_entry_add(entryBefore, &node);
+    *returncode = mapping_tree_entry_add(entryBefore, &node, PR_TRUE /* Check be exists */);
     if (LDAP_SUCCESS != *returncode || !node) {
         return SLAPI_DSE_CALLBACK_ERROR;
     }

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -678,7 +678,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
          */
 
         /* that means we only support one suffix per backend */
-        be_suffix = slapi_be_getsuffix(be, 0);
+        be_suffix = slapi_be_getsuffix(be);
 
         if (be_list[0] == NULL) {
             next_be = NULL;

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1225,7 +1225,7 @@ send_all_attrs(Slapi_Entry *e, char **attrs, Slapi_Operation *op, Slapi_PBlock *
 
             /* get the namespace dn */
             slapi_pblock_get(pb, SLAPI_BACKEND, (void *)&be);
-            namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+            namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be);
 
             /* Get the attribute value from the vattr service */
             /* ctx will be freed by attr_context_ungrok() */
@@ -1379,7 +1379,7 @@ send_specific_attrs(Slapi_Entry *e, char **attrs, Slapi_Operation *op, Slapi_PBl
 
         /* get the namespace dn */
         slapi_pblock_get(pb, SLAPI_BACKEND, (void *)&be);
-        namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+        namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be);
 
         /* Get the attribute value from the vattr service */
         /* This call handles subtype, as well.

--- a/ldap/servers/slapd/rootdse.c
+++ b/ldap/servers/slapd/rootdse.c
@@ -149,7 +149,7 @@ read_root_dse(Slapi_PBlock *pb,
             continue;
 
         /* tolerate a backend under construction containing no suffix */
-        if ((be_suffix = slapi_be_getsuffix(be, 0)) == NULL)
+        if ((be_suffix = slapi_be_getsuffix(be)) == NULL)
             continue;
 
         if ((base = (char *)slapi_sdn_get_dn(be_suffix)) == NULL)

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1386,25 +1386,22 @@ struct suffixlist
  */
 typedef struct backend
 {
-    struct suffixlist *be_suffixlist; /* linked list of DN suffixes in this backend */
-    PRLock *be_suffixlock;
-    Slapi_Counter *be_suffixcounter;
+    Slapi_DN *be_suffix;                     /* Suffix for this backend */
     char *be_basedn;                         /* The base dn for the config & monitor dns */
-    char *be_configdn;                       /* The config dn for this backend          */
-    char *be_monitordn;                      /* The monitor dn for this backend          */
-    int be_readonly;                         /* 1 => db is in "read only" mode       */
-    int be_sizelimit;                        /* size limit for this backend          */
-    int be_timelimit;                        /* time limit for this backend              */
+    char *be_configdn;                       /* The config dn for this backend */
+    char *be_monitordn;                      /* The monitor dn for this backend */
+    int be_readonly;                         /* 1 => db is in "read only" mode */
+    int be_sizelimit;                        /* size limit for this backend */
+    int be_timelimit;                        /* time limit for this backend */
     int be_maxnestlevel;                     /* Max nest level for acl group evaluation */
-    int be_noacl;                            /* turn off front end acl for this be      */
-    int be_lastmod;                          /* keep track of lastmodified{by,time}       */
-    char *be_type;                           /* type of database               */
+    int be_noacl;                            /* turn off front end acl for this be */
+    int be_lastmod;                          /* keep track of lastmodified{by,time} */
+    char *be_type;                           /* type of database */
     char *be_backendconfig;                  /* backend config filename */
     char **be_include;                       /* include files within this db definition */
     int be_private;                          /* Internal backends use this to hide from the user */
     int be_logchanges;                       /* changes to this backend should be logged in the changelog */
-    int (*be_writeconfig)(Slapi_PBlock *pb); /* function to call to make this
-                                                backend write its conf file */
+    int (*be_writeconfig)(Slapi_PBlock *pb); /* function to call to make this backend write its conf file */
     /*
      * backend database api function ptrs and args (to do operations)
      */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6398,7 +6398,7 @@ int slapi_be_logchanges(Slapi_Backend *be);
 int slapi_be_issuffix(const Slapi_Backend *be, const Slapi_DN *suffix);
 void slapi_be_addsuffix(Slapi_Backend *be, const Slapi_DN *suffix);
 char *slapi_be_get_name(Slapi_Backend *be);
-const Slapi_DN *slapi_be_getsuffix(Slapi_Backend *be, int n);
+const Slapi_DN *slapi_be_getsuffix(Slapi_Backend *be);
 Slapi_Backend *slapi_get_first_backend(char **cookie);
 Slapi_Backend *slapi_get_next_backend(char *cookie);
 int slapi_be_private(Slapi_Backend *be);

--- a/ldap/servers/slapd/vattr.c
+++ b/ldap/servers/slapd/vattr.c
@@ -576,7 +576,7 @@ vattr_test_filter(Slapi_PBlock *pb,
     /* get the namespace this entry belongs to */
     sdn = slapi_entry_get_sdn(e);
     be = slapi_be_select(sdn);
-    namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+    namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be);
 
     /* Look for attribute in the map */
 
@@ -1784,7 +1784,7 @@ slapi_vattrspi_regattr(vattr_sp_handle *h, char *type_name_to_register, char *DN
 
         slapi_sdn_set_dn_byref(&original_dn, DN);
         be = slapi_be_select(&original_dn);
-        namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+        namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be);
 
         if (namespace_dn && be != defbackend_get_backend()) /* just in case someone thinks "" is a good namespace */
         {

--- a/src/rewriters/adfilter.c
+++ b/src/rewriters/adfilter.c
@@ -407,7 +407,7 @@ adfilter_rewrite_objectCategory(Slapi_PBlock *pb)
         return SEARCH_REWRITE_CALLBACK_CONTINUE;
     }
     if ((be = slapi_be_select(sdn)) != NULL) {
-        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be, 0));
+        be_suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be));
     }
 
     /* prepare the argument of filter apply callback: a format and


### PR DESCRIPTION
Description:  

Previously the server used to support multiple suffixes per backend and the server had to maintain and check a be list of suffixes.  However, this is no longer supported, so all of this code can be cleaned up to support a single suffix per backend.

Also added a check that when creating a mapping tree entry, that the backend entry must already exist and match the suffix.

Relates: https://github.com/389ds/389-ds-base/issues/2526
