### PR TITLE
Issue 4379 - allow more than 1 empty AttributeDescription for ldapsea…

### DIFF
--- a/ldap/servers/slapd/search.c
+++ b/ldap/servers/slapd/search.c
@@ -259,7 +259,7 @@ do_search(Slapi_PBlock *pb)
 
             if ( attrs[i][0] == '\0') {
                 empty_attrs++;
-                if (empty_attrs > 1) {
+                if (empty_attrs > 10) {
                     log_search_access(pb, base, scope, fstr, "invalid attribute request");
                     send_ldap_result(pb, LDAP_PROTOCOL_ERROR, NULL, NULL, 0, NULL);
                     slapi_ch_free_string(&normaci);


### PR DESCRIPTION
…rch, without the risk of denial of service

Bug description:
	The fix #3028 enforces a strict limit of empty attributeDescription.
        The limit is low (1) and some application may failing.
        We can relax this limit to a higher value without reopening DOS risk

Fix description:
	Change the max authorized empty attributesDescription from 1 to 10

relates: https://github.com/389ds/389-ds-base/issues/4379

Reviewed by: ?

Platforms tested: F31