### PR TITLE
Issue 4159 - Healthcheck code DSBLE0002 not returned on disabled suffix

### DIFF
--- a/src/lib389/lib389/_mapped_object_lint.py
+++ b/src/lib389/lib389/_mapped_object_lint.py
@@ -26,7 +26,7 @@ class DSLint():
     then be available to the `lint()` method of the class.
 
     `lint_list`: takes a spec and yields available lints, recursively
-    `lint`:      takes a spac and runs lints according to it, yielding results if any
+    `lint`:      takes a spec and runs lints according to it, yielding results if any
 
     `spec`: is a colon-separated string, with prefix matching a method name and suffix
             being passed down to the method.
@@ -153,5 +153,10 @@ class DSLints():
         if spec == List:
             yield from self.lint_list()
         else:
+            if ":" in spec:
+                # Skip over any decorators, and get the actual function name
+                check_name = spec.split(":")[-1]
+            else:
+                check_name = spec
             for obj in self.list():
-                yield from obj.lint()
+                yield from obj.lint(check_name)

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -388,6 +388,10 @@ class LogCapture(logging.Handler):
                 result = True
         return result
 
+    def print(self):
+        for rec in self.outputs:
+            print(str(rec))
+
     def flush(self):
         self.outputs = []
 

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -43,17 +43,19 @@ CHECK_OBJECTS = [
 
 
 def _format_check_output(log, result, idx):
-    log.info("\n\n[{}] DS Lint Error: {}".format(idx, result['dsle']))
+    log.info(f"\n\n[{idx}] DS Lint Error: {result['dsle']}")
     log.info("-" * 80)
-    log.info("Severity: %s " % result['severity'])
+    log.info(f"Severity: {result['severity']}")
+    if 'check' in result:
+        log.info(f"Check: {result['check']}")
     log.info("Affects:")
     for item in result['items']:
-        log.info(" -- %s" % item)
+        log.info(f" -- {item}")
     log.info("\nDetails:")
-    log.info('-----------')
+    log.info("-----------")
     log.info(result['detail'])
     log.info("\nResolution:")
-    log.info('-----------')
+    log.info("-----------")
     log.info(result['fix'])
 
 
@@ -97,7 +99,10 @@ def _run(inst, log, args, checks):
     for o, s in checks:
         if not args.json:
             log.info(f"Checking {o.lint_uid()}:{s[0]} ...")
-        report += o.lint(s[0]) or []
+        try:
+            report += o.lint(s[0]) or []
+        except:
+            continue
 
     if not args.json:
         log.info("Healthcheck complete.")

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -205,6 +205,7 @@ class Config(DSLdapObject):
         if ensure_bytes('on') != hr_timestamp:
             report = copy.deepcopy(DSCLE0001)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['check'] = "config:hr_timestamp"
             yield report
 
     def _lint_passwordscheme(self):
@@ -214,6 +215,7 @@ class Config(DSLdapObject):
         if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:
             report = copy.deepcopy(DSCLE0002)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['check'] = "config:passwordscheme"
             yield report
 
     def disable_plaintext_port(self):
@@ -260,6 +262,7 @@ class Encryption(DSLdapObject):
         if tls_min is not None and tls_min < ensure_bytes('TLS1.1'):
             report = copy.deepcopy(DSELE0001)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['check'] = "encryption:check_tls_version"
             yield report
 
     @property

--- a/src/lib389/lib389/dirsrv_log.py
+++ b/src/lib389/lib389/dirsrv_log.py
@@ -253,6 +253,7 @@ class DirsrvAccessLog(DirsrvLog):
                     report['detail'] = report['detail'].replace('NUMBER', str(count))
                     for srch in searches:
                         report['detail'] += srch
+                    report['check'] = f'logs:notes'
                     yield report
 
 

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -85,6 +85,7 @@ class DSEldif(DSLint):
                 report['items'].append('Time Skew')
                 report['items'].append('Skew: ' + suffix['time_skew_str'])
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                report['check'] = f'dseldif:nsstate'
                 yield report
 
     def _update(self):
@@ -360,6 +361,7 @@ class FSChecks(DSLint):
                     report['detail'] = report['detail'].replace('PERMS', perms)
                     report['fix'] = report['fix'].replace('FILE', ds_file['name'])
                     report['fix'] = report['fix'].replace('PERMS', perms)
+                    report['check'] = f'fschecks:file_perms'
                     yield report
             except FileNotFoundError:
                 pass

--- a/src/lib389/lib389/monitor.py
+++ b/src/lib389/lib389/monitor.py
@@ -373,6 +373,7 @@ class MonitorDiskSpace(DSLdapObject):
                 report = copy.deepcopy(DSDSLE0001)
                 report['detail'] = report['detail'].replace('PARTITION', parts[0].split('=')[1].strip('"'))
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                report['check'] = f'monitor-disk-space:disk_space'
                 yield report
 
     def get_disks(self):

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -71,7 +71,7 @@ class NssSsl(DSLint):
 
     @classmethod
     def lint_uid(cls):
-        return 'ssl'
+        return 'tls'
 
     def _lint_certificate_expiration(self):
         """Check all the certificates in the db if they will expire within 30 days
@@ -89,11 +89,13 @@ class NssSsl(DSLint):
                 # Expired
                 report = copy.deepcopy(DSCERTLE0002)
                 report['detail'] = report['detail'].replace('CERT', cert[0])
+                report['check'] = f'tls:certificate_expiration'
                 yield report
             elif diff_date < timedelta(days=30):
                 # Expiring within 30 days
                 report = copy.deepcopy(DSCERTLE0001)
                 report['detail'] = report['detail'].replace('CERT', cert[0])
+                report['check'] = f'tls:certificate_expiration'
                 yield report
 
     def detect_alt_names(self, alt_names=[]):

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -452,6 +452,7 @@ class ReferentialIntegrityPlugin(Plugin):
             if delay is not None and delay != 0:
                 report = copy.deepcopy(DSRILE0001)
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                report['check'] = f'refint:update_delay'
                 yield report
 
     def _lint_attr_indexes(self):
@@ -488,6 +489,7 @@ class ReferentialIntegrityPlugin(Plugin):
                             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
                             report['items'].append(suffix)
                             report['items'].append(attr)
+                            report['check'] = f'refint:attr_indexes'
                             yield report
                     except:
                         # No index at all, bad
@@ -498,6 +500,7 @@ class ReferentialIntegrityPlugin(Plugin):
                         report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
                         report['items'].append(suffix)
                         report['items'].append(attr)
+                        report['check'] = f'refint:attr_indexes'
                         yield report
 
     def get_update_delay(self):


### PR DESCRIPTION
Bug Description:  

The healthcheck tool was actually crashing when a suffix was disabled.  We also were not correctly processing DSLdapObjects, where we would run all the lint tests even though we only asked to run one specific lint test.

Fix Description:  

Make healthcheck more robust to handle exceptions.  Fix the processing of DSLdapObjects by passing in the lint function name to DSLint().

Also added the health "check" that triggered the issue to the final report so you know which exact test to rerun.

Fixes: https://github.com/389ds/389-ds-base/issues/4159
