### PR TITLE
Issue 1199 - Misleading message in access log for idle timeout

### DIFF
--- a/ldap/admin/src/logconv.pl
+++ b/ldap/admin/src/logconv.pl
@@ -2371,7 +2371,7 @@ sub parseLineNormal
 		elsif (m/- B3/){ $hashes->{rc}->{"B3"}++; }
 		elsif (m/- R1/){ $hashes->{rc}->{"R1"}++; }
 		elsif (m/- P1/){ $hashes->{rc}->{"P1"}++; }
-		elsif (m/- P1/){ $hashes->{rc}->{"P2"}++; }
+		elsif (m/- P2/){ $hashes->{rc}->{"P2"}++; }
 		elsif (m/- U1/){ $hashes->{rc}->{"U1"}++; }
 		else { $hashes->{rc}->{"other"}++; }
 	}

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2267,15 +2267,15 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
         }
         if(error) {
             slapi_log_access(LDAP_DEBUG_STATS,
-                    "conn=%" PRIu64 " op=%d fd=%d closed %s %d (%s) - %s\n",
-                    conn->c_connid, opid, conn->c_sd, str_reason, error,
-                    slapd_system_strerror(error),
-                    slapd_pr_strerror(reason));
+                            "conn=%" PRIu64 " op=%d fd=%d closed %s %d (%s) - %s\n",
+                            conn->c_connid, opid, conn->c_sd, str_reason, error,
+                            slapd_system_strerror(error),
+                            slapd_pr_strerror(reason));
         } else {
             slapi_log_access(LDAP_DEBUG_STATS,
-                    "conn=%" PRIu64 " op=%d fd=%d closed %s - %s\n",
-                    conn->c_connid, opid, conn->c_sd, str_reason,
-                    slapd_pr_strerror(reason));
+                            "conn=%" PRIu64 " op=%d fd=%d closed %s - %s\n",
+                            conn->c_connid, opid, conn->c_sd, str_reason,
+                            slapd_pr_strerror(reason));
         }
 
         if (!config_check_referral_mode()) {

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2226,6 +2226,8 @@ static ps_wakeup_all_fn_ptr ps_wakeup_all_fn = NULL;
 void
 disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRErrorCode reason, PRInt32 error, int schedule_closure_job)
 {
+	char * str_reason = NULL;
+
     if ((conn->c_sd != SLAPD_INVALID_SOCKET &&
          conn->c_connid == opconnid) &&
         !(conn->c_flags & CONN_FLAG_CLOSING)) {
@@ -2250,19 +2252,30 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
         g_decrement_current_conn_count();
 
         /*
-         * Print the error captured above.
+         * Provide info on the error captured above.
          */
-        if (error && (EPIPE != error)) {
+	    switch(reason) {
+            case SLAPD_DISCONNECT_IDLE_TIMEOUT:
+                str_reason = "Idle timeout (nsslapd-idletimeout)";
+                break;
+            case SLAPD_DISCONNECT_IO_TIMEOUT:
+                str_reason = "IO timeout (nsslapd-ioblocktimeout)";
+                break;
+            default:
+                str_reason = "error";
+                break;
+        }
+        if(error) {
             slapi_log_access(LDAP_DEBUG_STATS,
-                             "conn=%" PRIu64 " op=%d fd=%d closed error %d (%s) - %s\n",
-                             conn->c_connid, opid, conn->c_sd, error,
-                             slapd_system_strerror(error),
-                             slapd_pr_strerror(reason));
+                    "conn=%" PRIu64 " op=%d fd=%d closed %s %d (%s) - %s\n",
+                    conn->c_connid, opid, conn->c_sd, str_reason, error,
+                    slapd_system_strerror(error),
+                    slapd_pr_strerror(reason));
         } else {
             slapi_log_access(LDAP_DEBUG_STATS,
-                             "conn=%" PRIu64 " op=%d fd=%d closed - %s\n",
-                             conn->c_connid, opid, conn->c_sd,
-                             slapd_pr_strerror(reason));
+                    "conn=%" PRIu64 " op=%d fd=%d closed %s - %s\n",
+                    conn->c_connid, opid, conn->c_sd, str_reason,
+                    slapd_pr_strerror(reason));
         }
 
         if (!config_check_referral_mode()) {

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2226,7 +2226,7 @@ static ps_wakeup_all_fn_ptr ps_wakeup_all_fn = NULL;
 void
 disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRErrorCode reason, PRInt32 error, int schedule_closure_job)
 {
-	char * str_reason = NULL;
+    char * str_reason = NULL;
 
     if ((conn->c_sd != SLAPD_INVALID_SOCKET &&
          conn->c_connid == opconnid) &&
@@ -2254,7 +2254,7 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
         /*
          * Provide info on the error captured above.
          */
-	    switch(reason) {
+        switch(reason) {
             case SLAPD_DISCONNECT_IDLE_TIMEOUT:
                 str_reason = "Idle timeout (nsslapd-idletimeout)";
                 break;
@@ -2267,15 +2267,15 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
         }
         if(error) {
             slapi_log_access(LDAP_DEBUG_STATS,
-                    "conn=%" PRIu64 " op=%d fd=%d closed %s %d (%s) - %s\n",
-                    conn->c_connid, opid, conn->c_sd, str_reason, error,
-                    slapd_system_strerror(error),
-                    slapd_pr_strerror(reason));
+                             "conn=%" PRIu64 " op=%d fd=%d closed %s %d (%s) - %s\n",
+                             conn->c_connid, opid, conn->c_sd, str_reason, error,
+                             slapd_system_strerror(error),
+                             slapd_pr_strerror(reason));
         } else {
             slapi_log_access(LDAP_DEBUG_STATS,
-                    "conn=%" PRIu64 " op=%d fd=%d closed %s - %s\n",
-                    conn->c_connid, opid, conn->c_sd, str_reason,
-                    slapd_pr_strerror(reason));
+                             "conn=%" PRIu64 " op=%d fd=%d closed %s - %s\n",
+                             conn->c_connid, opid, conn->c_sd, str_reason,
+                             slapd_pr_strerror(reason));
         }
 
         if (!config_check_referral_mode()) {

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1567,7 +1567,7 @@ handle_pr_read_ready(Connection_Table *ct, PRIntn num_poll __attribute__((unused
                            NULL == c->c_ops) {
                     /* idle timeout */
                     disconnect_server_nomutex(c, c->c_connid, -1,
-                                              SLAPD_DISCONNECT_IDLE_TIMEOUT, EAGAIN);
+                                              SLAPD_DISCONNECT_IDLE_TIMEOUT, ETIMEDOUT);
                 }
             }
             pthread_mutex_unlock(&(c->c_mutex));


### PR DESCRIPTION
Description:
Update timeout error code in daemon.
Add extra detail to idle and IO timeout error messaging.
Typo in logconv.pl

Relates: #1199

Reviewed by: