### PR TITLE
Issue 4295 - Fix a closing quote issue

### DIFF
--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1958,7 +1958,7 @@ notes2str(unsigned int notes, char *buf, size_t buflen)
              * Put in the end quote. If another snp_detail is append a comma
              * will overwrite the quote.
              */
-            *(p + 1) = '"';
+            *p = '"';
         }
     }
 


### PR DESCRIPTION
Description: The "details" keyword in access log does not have
a closing quote.
The issue happens because the quote was set in the wrong place.

Fixes: #4295

Reviewed by: ?