### PR TITLE
Issue 4391 - DSE config modify does not call be_postop

### DIFF
--- a/ldap/servers/plugins/chainingdb/cb_instance.c
+++ b/ldap/servers/plugins/chainingdb/cb_instance.c
@@ -329,7 +329,7 @@ cb_instance_modify_config_check_callback(Slapi_PBlock *pb,
         }
     }
     *returncode = rc;
-    return ((LDAP_SUCCESS == rc) ? 1 : -1);
+    return ((LDAP_SUCCESS == rc) ? SLAPI_DSE_CALLBACK_OK : SLAPI_DSE_CALLBACK_ERROR);
 }
 
 

--- a/ldap/servers/slapd/configdse.c
+++ b/ldap/servers/slapd/configdse.c
@@ -536,7 +536,7 @@ postop_modify_config_dse(Slapi_PBlock *pb,
     }
 
     *returncode = LDAP_SUCCESS;
-    return *returncode;
+    return SLAPI_DSE_CALLBACK_OK;
 }
 
 static int


### PR DESCRIPTION
Bug description:
	During a DSE modify, be_preop callback are called. But be_postop callback are called at the condition
	dse_call_callback is different that SLAPI_DSE_CALLBACK_DO_NOT_APPLY.

	This should systematically call be_postop if be_preop were called.
	In addition postop_modify_config_dse returning an invalid rc, systematically prevents DSE modify to call be_postop

Fix description:
        The required bug fix is that dse_callback need to return SLAPI_DSE_CALLBACK* not ldap rc.
	Also in case of vlv config (SLAPI_DSE_CALLBACK_DO_NOT_APPLY) if preop were called
        it requires to call the postop.

	In dse_modify, rc is used for dse_call_callback() (returns SLAPI_DSE_CALLBACK*)
        but also for plugin_call_plugin (returns SLAPI_PLUGIN_*). Those rc are not compatible
	and although the code works to help maintenance use 'plugin_rc' instead of 'rc'.

relates: https://github.com/389ds/389-ds-base/issues/4391

Reviewed by:

Platforms tested: F31