### PR TITLE
Issue 4363 - Sync repl: per thread structure was incorrectly initialized

### DIFF
--- a/ldap/servers/plugins/sync/sync.h
+++ b/ldap/servers/plugins/sync/sync.h
@@ -76,10 +76,11 @@ typedef struct sync_callback
  * OPERATION_PL_IGNORED: operation completed but with an undefine status
  */
 typedef enum _pl_flags {
-    OPERATION_PL_PENDING = 1,
-    OPERATION_PL_SUCCEEDED = 2,
-    OPERATION_PL_FAILED = 3,
-    OPERATION_PL_IGNORED = 4
+    OPERATION_PL_HEAD = 1,
+    OPERATION_PL_PENDING = 2,
+    OPERATION_PL_SUCCEEDED = 3,
+    OPERATION_PL_FAILED = 4,
+    OPERATION_PL_IGNORED = 5
 } pl_flags_t;
 
 /* Pending list operations.


### PR DESCRIPTION
Bug description:
	A per thread structure should be allocated once, either on get/set.
        Currently it is allocated on the primary operation and free when
        the primary operation is completed.

Fix description:
	The per thread structure is now a HEAD structure.
        The HEAD is the where the primary operation is referenced when
        the operation starts and where it is reset when the primary operation ends
	(pushed to the sync_repl thread)

relates: https://github.com/389ds/389-ds-base/issues/4363

Reviewed by:

Platforms tested: F31, F33