### PR TITLE
Issue 2526 - retrocl backend created out of order

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -222,15 +222,11 @@ retrocl_select_backend(void)
     slapi_entry_free(referral);
 
     if (err != LDAP_SUCCESS || be == NULL || be == defbackend_get_backend()) {
-        slapi_log_err(SLAPI_LOG_ERR, RETROCL_PLUGIN_NAME,
+        /* Could not find the backend for cn=changelog, either because
+         * it doesn't exist mapping tree not registered. */
+        slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME,
                       "retrocl_select_backend - Mapping tree select failed (%d) %s.\n", err, errbuf);
-
-        /* could not find the backend for cn=changelog, either because
-         * it doesn't exist
-         * mapping tree not registered.
-         */
         err = retrocl_create_config();
-
         if (err != LDAP_SUCCESS)
             return err;
     } else {

--- a/ldap/servers/plugins/retrocl/retrocl_create.c
+++ b/ldap/servers/plugins/retrocl/retrocl_create.c
@@ -192,6 +192,25 @@ retrocl_create_config(void)
     vals[0] = &val;
     vals[1] = NULL;
 
+    retrocl_be_changelog = slapi_be_select_by_instance_name("changelog");
+
+    if (retrocl_be_changelog == NULL) {
+        /* This is not the nsslapd-changelogdir from cn=changelog4,cn=config */
+        char *bedir;
+
+        bedir = retrocl_get_config_str(CONFIG_CHANGELOG_DIRECTORY_ATTRIBUTE);
+        if (bedir == NULL) {
+            /* none specified */
+        }
+
+        rc = retrocl_create_be(bedir);
+        slapi_ch_free_string(&bedir);
+        if (rc != LDAP_SUCCESS && rc != LDAP_ALREADY_EXISTS) {
+            return rc;
+        }
+        retrocl_be_changelog = slapi_be_select_by_instance_name("changelog");
+    }
+
     /* Assume the mapping tree node is missing.  It doesn't hurt to
      * attempt to add it if it already exists.  You will see a warning
      * in the errors file when the referenced backend does not exist.
@@ -254,25 +273,6 @@ retrocl_create_config(void)
         slapi_log_err(SLAPI_LOG_ERR, RETROCL_PLUGIN_NAME,
                       "cn=\"cn=changelog\",cn=mapping tree,cn=config could not be created (%d)\n", rc);
         return rc;
-    }
-
-    retrocl_be_changelog = slapi_be_select_by_instance_name("changelog");
-
-    if (retrocl_be_changelog == NULL) {
-        /* This is not the nsslapd-changelogdir from cn=changelog4,cn=config */
-        char *bedir;
-
-        bedir = retrocl_get_config_str(CONFIG_CHANGELOG_DIRECTORY_ATTRIBUTE);
-        if (bedir == NULL) {
-            /* none specified */
-        }
-
-        rc = retrocl_create_be(bedir);
-        slapi_ch_free_string(&bedir);
-        if (rc != LDAP_SUCCESS && rc != LDAP_ALREADY_EXISTS) {
-            return rc;
-        }
-        retrocl_be_changelog = slapi_be_select_by_instance_name("changelog");
     }
 
     return LDAP_SUCCESS;


### PR DESCRIPTION
Bug Description:  

A recent change verified that you do not create a mapping tree entry before the backend entry was created.  The server created the retrocl backend in the opposite order which broke the retrocl.

Fix Description:  

Create the retrocl backend entry before creating the mapping tree entry.

Relates: https://github.com/389ds/389-ds-base/issues/2526

Reviewed by: ?