### PR TITLE
Issue 4412 - Fix CLI repl-agmt requirement for parameters

### DIFF
--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -756,8 +756,8 @@ def add_agmt(inst, basedn, log, args):
             raise ValueError('Bootstrap connection protocol can only be "LDAP", "LDAPS", or "STARTTLS"')
         properties['nsDS5ReplicaBootstrapTransportInfo'] = args.bootstrap_conn_protocol
 
-    # We do need the bind dn and credentials for none-sasl bind methods
-    if (bind_method in ('simple', 'sslclientauth')) and (args.bind_dn is None or args.bind_passwd is None):
+    # We do need the bind dn and credentials for 'simple' bind method
+    if (bind_method == 'simple') and (args.bind_dn is None or args.bind_passwd is None):
         raise ValueError("You need to set the bind dn (--bind-dn) and the password (--bind-passwd) for bind method ({})".format(bind_method))
 
     # Create the agmt


### PR DESCRIPTION
Description: In dsconf CLI, make it possible to create SSLCLIENTAUTH
bind method agreement without specifying bind dn (--bind-dn) and
the password (--bind-passwd).

Fixes: #4412

Reviewed by: ?