### PR TITLE
Issue 4316 - performance search rate: useless poll on network send ca…

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1639,9 +1639,6 @@ write_function(int ignore __attribute__((unused)), void *buffer, int count, void
         PR_SetError(PR_NOT_SOCKET_ERROR, EBADF);
     } else {
         while (1) {
-            if (slapd_poll(handle, SLAPD_POLLOUT) < 0) { /* error */
-                break;
-            }
             bytes = PR_Write((PRFileDesc *)handle, (char *)buffer + sentbytes,
                              count - sentbytes);
             if (bytes > 0) {
@@ -1662,6 +1659,11 @@ write_function(int ignore __attribute__((unused)), void *buffer, int count, void
                                       fd, sentbytes, count);
                     }
                     break; /* fatal error */
+                } else {
+                    /* The purpose of that call is to manage ioblocktimeout */
+                    if (slapd_poll(handle, SLAPD_POLLOUT) < 0) {
+                        break; /* fatal error */
+                    }
                 }
             } else if (bytes == 0) { /* disconnect */
                 PRErrorCode prerr = PR_GetError();


### PR DESCRIPTION
…llback

Bug description:
	When sending back result/entries, DS first poll the connection to check
        it is able to write data on the socket. Then it writes the data.
	The purpose of the poll is to handle ioblocktimeout.
	The problem is that most of the time, the socket will process the write
	without any issue so it is useless to poll before the write.

Fix description:
	The fix is try write first. It polls for ioblocktimeout
        only if the write fails

relates: https://github.com/389ds/389-ds-base/issues/4316

Reviewed by:

Platforms tested: F31