### PR TITLE
Issue 4383 - Do not normalize escaped spaces in a DN

### DIFF
--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -894,8 +894,7 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                             s++;
                         }
                     }
-                } else if (s + 2 < ends &&
-                           isxdigit(*(s + 1)) && isxdigit(*(s + 2))) {
+                } else if (s + 2 < ends && isxdigit(*(s + 1)) && isxdigit(*(s + 2))) {
                     /* esc hexpair ==> real character */
                     int n = slapi_hexchar2int(*(s + 1));
                     int n2 = slapi_hexchar2int(*(s + 2));
@@ -903,6 +902,11 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                     if (n == 0) { /* don't change \00 */
                         *d++ = *++s;
                         *d++ = *++s;
+                    } else if (n == 32) { /* leave \20 (space) intact */
+                        *d++ = *s;
+                        *d++ = *++s;
+                        *d++ = *++s;
+                        s++;
                     } else {
                         *d++ = n;
                         s += 3;


### PR DESCRIPTION
Bug Description:  

Adding an entry with an escaped leading space leads to many problems.  Mainly id2entry can get corrupted during an import of such an entry, and the entryrdn index is not updated correctly

Fix Description:  In slapi_dn_normalize_ext() leave an escaped space intact.

Relates: https://github.com/389ds/389-ds-base/issues/4383

