### PR TITLE
Issue 4432 - After a failed online import the next imports are very slow

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -2474,14 +2474,14 @@ error:
             cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
         }
         /* initialize the entry cache */
-        if (!cache_init(&(inst->inst_cache), DEFAULT_CACHE_SIZE,
+        if (!cache_init(&(inst->inst_cache), inst->inst_cache.c_maxsize,
                         DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
             slapi_log_err(SLAPI_LOG_ERR, "bdb_import_main",
                           "cache_init failed.  Server should be restarted.\n");
         }
 
         /* initialize the dn cache */
-        if (!cache_init(&(inst->inst_dncache), DEFAULT_DNCACHE_SIZE,
+        if (!cache_init(&(inst->inst_dncache), inst->inst_dncache.c_maxsize,
                         DEFAULT_DNCACHE_MAXCOUNT, CACHE_TYPE_DN)) {
             slapi_log_err(SLAPI_LOG_ERR, "bdb_import_main",
                           "dn cache_init failed.  Server should be restarted.\n");


### PR DESCRIPTION
Bug Description:  

When an online import fails the entry and DN caches are "reset", but we use the wrong "new maxsize" which was setting the entry cache maxsize to zero which killed the import performance.

Fix Description:  When resetting the caches use the previous cache maxsize.

Relates: https://github.com/389ds/389-ds-base/issues/4432

