### PR TITLE
Issue 4418 - ldif2db - offline. Warn the user of skipped entries

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -2104,6 +2104,14 @@ slapd_exemode_ldif2db(struct main_config *mcfg)
                       plugin->plg_name);
         return_value = -1;
     }
+
+    /* check for task warnings */
+    if(!return_value) {
+        if((return_value = slapi_pblock_get_task_warning(pb))) {
+            slapi_log_err(SLAPI_LOG_INFO, "slapd_exemode_ldif2db","returning task warning: %d\n", return_value);
+        }
+    }
+
     slapi_pblock_destroy(pb);
     charray_free(instances);
     charray_free(mcfg->cmd_line_instance_names);

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -28,11 +28,13 @@
 #define SLAPI_LDIF_DUMP_REPLICA 2003
 #define SLAPI_PWDPOLICY 2004
 #define SLAPI_PW_ENTRY 2005
+#define SLAPI_TASK_WARNING 2006
 
 /* Used for checking assertions about pblocks in some cases. */
 #define SLAPI_HINT 9999
 
 static PRLock *pblock_analytics_lock = NULL;
+
 
 static PLHashNumber
 hash_int_func(const void *key)
@@ -4287,6 +4289,28 @@ slapi_pblock_set_ldif_dump_replica(Slapi_PBlock *pb, int32_t dump_replica)
 #endif
     _pblock_assert_pb_task(pb);
     pb->pb_task->ldif_dump_replica = dump_replica;
+}
+
+int32_t
+slapi_pblock_get_task_warning(Slapi_PBlock *pb)
+{
+#ifdef PBLOCK_ANALYTICS
+    pblock_analytics_record(pb, SLAPI_TASK_WARNING);
+#endif
+    if (pb->pb_task != NULL) {
+        return pb->pb_task->task_warning;
+    }
+    return 0;
+}
+
+void
+slapi_pblock_set_task_warning(Slapi_PBlock *pb, task_warning warning)
+{
+#ifdef PBLOCK_ANALYTICS
+    pblock_analytics_record(pb, SLAPI_TASK_WARNING);
+#endif
+    _pblock_assert_pb_task(pb);
+    pb->pb_task->task_warning = warning;
 }
 
 void *

--- a/ldap/servers/slapd/pblock_v3.h
+++ b/ldap/servers/slapd/pblock_v3.h
@@ -68,6 +68,7 @@ typedef struct _slapi_pblock_task
     int ldif2db_noattrindexes;
     int ldif_printkey;
     int task_flags;
+    int32_t task_warning;
     int import_state;
 
     int server_running; /* indicate that server is running */

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1464,6 +1464,17 @@ void slapi_pblock_set_operation_notes(Slapi_PBlock *pb, uint32_t opnotes);
 void slapi_pblock_set_flag_operation_notes(Slapi_PBlock *pb, uint32_t opflag);
 void slapi_pblock_set_result_text_if_empty(Slapi_PBlock *pb, char *text);
 
+/* task warnings */
+typedef enum task_warning_t{
+    WARN_UPGARDE_DN_FORMAT_ALL    = (1 << 0),
+    WARN_UPGRADE_DN_FORMAT        = (1 << 1),
+    WARN_UPGRADE_DN_FORMAT_SPACE  = (1 << 2),
+    WARN_SKIPPED_IMPORT_ENTRY     = (1 << 3)
+} task_warning;
+
+int32_t slapi_pblock_get_task_warning(Slapi_PBlock *pb);
+void slapi_pblock_set_task_warning(Slapi_PBlock *pb, task_warning warn);
+
 
 int slapi_exists_or_add_internal(Slapi_DN *dn, const char *filter, const char *entry, const char *modifier_name);
 

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -2673,14 +2673,14 @@ class DirSrv(SimpleLDAPObject, object):
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:
-            self.log.debug("Command: %s failed with the return code %s and the error %s",
-                           format_cmd_list(cmd), e.returncode, e.output)
-            return False
-
-        self.log.debug("ldif2db output: BEGIN")
-        for line in result.split("\n"):
-            self.log.debug(line)
-        self.log.debug("ldif2db output: END")
+            if e.returncode == TaskWarning.WARN_SKIPPED_IMPORT_ENTRY:
+                self.log.debug("Command: %s skipped import entry warning %s",
+                               format_cmd_list(cmd), e.returncode)
+                return e.returncode
+            else:
+                self.log.debug("Command: %s failed with the return code %s and the error %s",
+                               format_cmd_list(cmd), e.returncode, e.output)
+                return False
 
         return True
 

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -166,6 +166,13 @@ DB2BAK = 'db2bak'
 DB2INDEX = 'db2index'
 DBSCAN = 'dbscan'
 
+# Task warnings
+class TaskWarning(IntEnum):
+    WARN_UPGARDE_DN_FORMAT_ALL      = (1 << 0)
+    WARN_UPGRADE_DN_FORMAT          = (1 << 1)
+    WARN_UPGRADE_DN_FORMAT_SPACE    = (1 << 2)
+    WARN_SKIPPED_IMPORT_ENTRY       = (1 << 3)
+
 RDN_REPLICA = "cn=replica"
 
 RETROCL_SUFFIX = "cn=changelog"

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -7,6 +7,7 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+from lib389._constants import TaskWarning
 
 def dbtasks_db2index(inst, log, args):
     if not inst.db2index(bename=args.backend):
@@ -44,10 +45,13 @@ def dbtasks_db2ldif(inst, log, args):
 
 
 def dbtasks_ldif2db(inst, log, args):
-    if not inst.ldif2db(bename=args.backend, encrypt=args.encrypted, import_file=args.ldif,
-                        suffixes=None, excludeSuffixes=None, import_cl=False):
+    ret = inst.ldif2db(bename=args.backend, encrypt=args.encrypted, import_file=args.ldif,
+                        suffixes=None, excludeSuffixes=None, import_cl=False)
+    if not ret:
         log.fatal("ldif2db failed")
         return False
+    elif ret == TaskWarning.WARN_SKIPPED_IMPORT_ENTRY:
+        log.warn("ldif2db successful with skipped entries")
     else:
         log.info("ldif2db successful")
 


### PR DESCRIPTION
Bug Description: During an ldif2db import entries that do not
conform to various constraints will be skipped and not imported.
On completition of an import with skipped entries, the server
returns a success exit code and logs the skipped entry detail to
the error logs. The success exit code could lead the user to
believe that all entries were successfully imported.

Fix Description: If a skipped entry occurs during import, the
import will continue and a warning will be returned to the user.

CLI tools for offline import updated to handle warning code.

Test added to generate an incorrect ldif entry and perform an
import.

Fixes: #4418

Reviewed by: ?