### PR TITLE
Issue 4384 - Use MONOTONIC clock for all timing events and conditions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1176,7 +1176,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	ldap/servers/slapd/security_wrappers.c \
 	ldap/servers/slapd/slapd_plhash.c \
 	ldap/servers/slapd/slapi_counter.c \
-	ldap/servers/slapd/slapi2nspr.c \
+	ldap/servers/slapd/slapi2runtime.c \
 	ldap/servers/slapd/snmp_collator.c \
 	ldap/servers/slapd/sort.c \
 	ldap/servers/slapd/ssl.c \

--- a/dirsrvtests/tests/suites/plugins/entryusn_test.py
+++ b/dirsrvtests/tests/suites/plugins/entryusn_test.py
@@ -6,9 +6,11 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import os
 import ldap
 import logging
 import pytest
+import time
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.config import Config
 from lib389.plugins import USNPlugin, MemberOfPlugin
@@ -211,6 +213,7 @@ def test_entryusn_after_repl_delete(topology_m2):
         user_usn = user_1.get_attr_val_int('entryusn')
 
         user_1.delete()
+        time.sleep(1)  # Gives a little time for tombstone creation to complete
 
         ts = tombstones.get(user_rdn)
         ts_usn = ts.get_attr_val_int('entryusn')

--- a/ldap/servers/plugins/chainingdb/cb_add.c
+++ b/ldap/servers/plugins/chainingdb/cb_add.c
@@ -130,7 +130,7 @@ chaining_back_add(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     /* Send LDAP operation to the remote host */

--- a/ldap/servers/plugins/chainingdb/cb_compare.c
+++ b/ldap/servers/plugins/chainingdb/cb_compare.c
@@ -126,7 +126,7 @@ chaining_back_compare(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     /*

--- a/ldap/servers/plugins/chainingdb/cb_delete.c
+++ b/ldap/servers/plugins/chainingdb/cb_delete.c
@@ -117,7 +117,7 @@ chaining_back_delete(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     /*

--- a/ldap/servers/plugins/chainingdb/cb_instance.c
+++ b/ldap/servers/plugins/chainingdb/cb_instance.c
@@ -1947,7 +1947,8 @@ cb_instance_add_config_callback(Slapi_PBlock *pb __attribute__((unused)),
          * we can't call recursively into the DSE to do more adds, they'll
          * silently fail.  instead, schedule the adds to happen in 1 second.
          */
-        inst->eq_ctx = slapi_eq_once(cb_instance_add_monitor_later, (void *)inst, time(NULL) + 1);
+        inst->eq_ctx = slapi_eq_once(cb_instance_add_monitor_later, (void *)inst,
+                                     slapi_current_rel_time_t() + 1);
     }
 
     /* Get the list of operational attrs defined in the schema */

--- a/ldap/servers/plugins/chainingdb/cb_modify.c
+++ b/ldap/servers/plugins/chainingdb/cb_modify.c
@@ -125,7 +125,7 @@ chaining_back_modify(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     /*

--- a/ldap/servers/plugins/chainingdb/cb_modrdn.c
+++ b/ldap/servers/plugins/chainingdb/cb_modrdn.c
@@ -129,7 +129,7 @@ chaining_back_modrdn(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     /*

--- a/ldap/servers/plugins/chainingdb/cb_search.c
+++ b/ldap/servers/plugins/chainingdb/cb_search.c
@@ -236,7 +236,7 @@ chainingdb_build_candidate_list(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     rc = ldap_search_ext(ld, target, scope, filter, attrs, attrsonly,
@@ -503,7 +503,7 @@ chainingdb_next_search_entry(Slapi_PBlock *pb)
 
     /* heart-beat management */
     if (cb->max_idle_time > 0) {
-        endtime = slapi_current_utc_time() + cb->max_idle_time;
+        endtime = slapi_current_rel_time_t() + cb->max_idle_time;
     }
 
     while (1) {
@@ -579,7 +579,7 @@ chainingdb_next_search_entry(Slapi_PBlock *pb)
 
             /* heart-beat management */
             if (cb->max_idle_time > 0) {
-                endtime = slapi_current_utc_time() + cb->max_idle_time;
+                endtime = slapi_current_rel_time_t() + cb->max_idle_time;
             }
 
             /* The server sent one of the entries found by the search */
@@ -611,7 +611,7 @@ chainingdb_next_search_entry(Slapi_PBlock *pb)
 
             /* heart-beat management */
             if (cb->max_idle_time > 0) {
-                endtime = slapi_current_utc_time() + cb->max_idle_time;
+                endtime = slapi_current_rel_time_t() + cb->max_idle_time;
             }
 
             parse_rc = ldap_parse_reference(ctx->ld, res, &referrals, NULL, 1);

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -346,7 +346,7 @@ cos_cache_init(void)
     if (ret == 0) {
         slapi_lock_mutex(start_lock);
         while (!started) {
-            while (slapi_wait_condvar(start_cond, NULL) == 0)
+            while (slapi_wait_condvar_pt(start_cond, start_lock, NULL) == 0)
                 ;
         }
         slapi_unlock_mutex(start_lock);
@@ -401,7 +401,7 @@ cos_cache_wait_on_change(void *arg __attribute__((unused)))
              * thread notifies our condvar, and so we will not miss any
              * notifications, including the shutdown notification.
              */
-            slapi_wait_condvar(something_changed, NULL);
+            slapi_wait_condvar_pt(something_changed, change_lock, NULL);
         } else {
             /* Something to do...do it below */
         }

--- a/ldap/servers/plugins/dna/dna.c
+++ b/ldap/servers/plugins/dna/dna.c
@@ -907,7 +907,7 @@ dna_load_plugin_config(Slapi_PBlock *pb, int use_eventq)
          * performing the operation at this point when
          * starting up  would cause the change to not
          * get changelogged. */
-        now = slapi_current_utc_time();
+        now = slapi_current_rel_time_t();
         eq_ctx = slapi_eq_once(dna_update_config_event, NULL, now + 30);
     } else {
         dna_update_config_event(0, NULL);

--- a/ldap/servers/plugins/passthru/ptconn.c
+++ b/ldap/servers/plugins/passthru/ptconn.c
@@ -233,7 +233,7 @@ passthru_get_connection(PassThruServer *srvr, LDAP **ldp)
         slapi_log_err(SLAPI_LOG_PLUGIN, PASSTHRU_PLUGIN_SUBSYSTEM,
                       "... passthru_get_connection waiting for conn to free up\n");
 #endif
-        slapi_wait_condvar(srvr->ptsrvr_connlist_cv, NULL);
+        slapi_wait_condvar_pt(srvr->ptsrvr_connlist_cv, srvr->ptsrvr_connlist_mutex, NULL);
 
 #ifdef PASSTHRU_VERBOSE_LOGGING
         slapi_log_err(SLAPI_LOG_PLUGIN, PASSTHRU_PLUGIN_SUBSYSTEM,

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * Copyright (C) 2009 Hewlett-Packard Development Company, L.P.
  * All rights reserved.
  *
@@ -28,6 +28,7 @@
 #include "llist.h"
 #include "repl5_ruv.h"
 #include "plstr.h"
+#include <pthread.h>
 
 #define START_UPDATE_DELAY                   2 /* 2 second */
 #define REPLICA_TYPE_WINDOWS                 1

--- a/ldap/servers/plugins/replication/repl5_backoff.c
+++ b/ldap/servers/plugins/replication/repl5_backoff.c
@@ -110,7 +110,7 @@ backoff_reset(Backoff_Timer *bt, slapi_eq_fn_t callback, void *callback_data)
         bt->next_interval = bt->initial_interval;
     }
     /* Schedule the callback */
-    bt->last_fire_time = slapi_current_utc_time();
+    bt->last_fire_time = slapi_current_rel_time_t();
     return_value = bt->last_fire_time + bt->next_interval;
     bt->pending_event = slapi_eq_once(bt->callback, bt->callback_arg,
                                       return_value);
@@ -177,7 +177,7 @@ backoff_expired(Backoff_Timer *bt, int margin)
 
     PR_ASSERT(NULL != bt);
     PR_Lock(bt->lock);
-    return_value = (slapi_current_utc_time() >= (bt->last_fire_time + bt->next_interval + margin));
+    return_value = (slapi_current_rel_time_t() >= (bt->last_fire_time + bt->next_interval + margin));
     PR_Unlock(bt->lock);
     return return_value;
 }

--- a/ldap/servers/plugins/replication/repl5_connection.c
+++ b/ldap/servers/plugins/replication/repl5_connection.c
@@ -402,7 +402,7 @@ conn_read_result_ex(Repl_Connection *conn, char **retoidp, struct berval **retda
         }
         if (block) {
             /* Did the connection's timeout expire ? */
-            time_now = slapi_current_utc_time();
+            time_now = slapi_current_rel_time_t();
             if (conn->timeout.tv_sec <= (time_now - start_time)) {
                 /* We timed out */
                 rc = 0;
@@ -676,7 +676,7 @@ conn_is_available(Repl_Connection *conn)
 {
     time_t poll_timeout_sec = 1;   /* Polling for 1sec */
     time_t yield_delay_msec = 100; /* Delay to wait */
-    time_t start_time = slapi_current_utc_time();
+    time_t start_time = slapi_current_rel_time_t();
     time_t time_now;
     ConnResult return_value = CONN_OPERATION_SUCCESS;
 
@@ -686,7 +686,7 @@ conn_is_available(Repl_Connection *conn)
             /* in case of timeout we return CONN_TIMEOUT only
              * if the RA.timeout is exceeded
              */
-            time_now = slapi_current_utc_time();
+            time_now = slapi_current_rel_time_t();
             if (conn->timeout.tv_sec <= (time_now - start_time)) {
                 break;
             } else {
@@ -1010,7 +1010,7 @@ linger_timeout(time_t event_time __attribute__((unused)), void *arg)
 void
 conn_start_linger(Repl_Connection *conn)
 {
-    time_t now;
+    time_t now = slapi_current_rel_time_t();
 
     PR_ASSERT(NULL != conn);
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
@@ -1022,7 +1022,7 @@ conn_start_linger(Repl_Connection *conn)
                       agmt_get_long_name(conn->agmt));
         return;
     }
-    now = slapi_current_utc_time();
+
     PR_Lock(conn->lock);
     if (conn->linger_active) {
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
@@ -1989,7 +1989,7 @@ repl5_start_debug_timeout(int *setlevel)
 {
     Slapi_Eq_Context eqctx = 0;
     if (s_debug_timeout && s_debug_level) {
-        time_t now = slapi_current_utc_time();
+        time_t now = slapi_current_rel_time_t();
         eqctx = slapi_eq_once(repl5_debug_timeout_callback, setlevel,
                               s_debug_timeout + now);
     }

--- a/ldap/servers/plugins/replication/repl5_inc_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_inc_protocol.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -129,7 +129,7 @@ typedef struct result_data
  * don't see any updates for a period equal to this interval,
  * we go ahead and start a replication session, just to be safe
  */
-#define MAX_WAIT_BETWEEN_SESSIONS PR_SecondsToInterval(60 * 5) /* 5 minutes */
+#define MAX_WAIT_BETWEEN_SESSIONS 300 /* 5 minutes */
 
 /*
  * tests if the protocol has been shutdown and we need to quit
@@ -145,7 +145,7 @@ typedef struct result_data
 /* Forward declarations */
 static PRUint32 event_occurred(Private_Repl_Protocol *prp, PRUint32 event);
 static void reset_events(Private_Repl_Protocol *prp);
-static void protocol_sleep(Private_Repl_Protocol *prp, PRIntervalTime duration);
+static void protocol_sleep(Private_Repl_Protocol *prp, int32_t duration);
 static int send_updates(Private_Repl_Protocol *prp, RUV *ruv, PRUint32 *num_changes_sent);
 static void repl5_inc_backoff_expired(time_t timer_fire_time, void *arg);
 static int examine_update_vector(Private_Repl_Protocol *prp, RUV *ruv);
@@ -253,7 +253,7 @@ repl5_inc_result_threadmain(void *param)
         char *uniqueid = NULL;
         char *ldap_error_string = NULL;
         time_t time_now = 0;
-        time_t start_time = slapi_current_utc_time();
+        time_t start_time = slapi_current_rel_time_t();
         int connection_error = 0;
         int operation_code = 0;
         int backoff_time = 1;
@@ -275,7 +275,7 @@ repl5_inc_result_threadmain(void *param)
                 /* We need to a) check that the 'real' timeout hasn't expired and
                  * b) implement a backoff sleep to avoid spinning */
                 /* Did the connection's timeout expire ? */
-                time_now = slapi_current_utc_time();
+                time_now = slapi_current_rel_time_t();
                 if (conn_get_timeout(conn) <= (time_now - start_time)) {
                     /* We timed out */
                     conres = CONN_TIMEOUT;
@@ -358,7 +358,7 @@ repl5_inc_result_threadmain(void *param)
         /* Should we stop ? */
         PR_Lock(rd->lock);
         if (!finished && yield_session && rd->abort != SESSION_ABORTED && rd->abort_time == 0) {
-            rd->abort_time = slapi_current_utc_time();
+            rd->abort_time = slapi_current_rel_time_t();
             rd->abort = SESSION_ABORTED; /* only set the abort time once */
             slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "repl5_inc_result_threadmain - "
                                                             "Abort control detected, setting abort time...(%s)\n",
@@ -532,13 +532,11 @@ repl5_inc_delete(Private_Repl_Protocol **prpp)
         (*prpp)->stop(*prpp);
     }
     /* Then, delete all resources used by the protocol */
-    if ((*prpp)->lock) {
-        PR_DestroyLock((*prpp)->lock);
-        (*prpp)->lock = NULL;
+    if (&((*prpp)->lock)) {
+        pthread_mutex_destroy(&((*prpp)->lock));
     }
-    if ((*prpp)->cvar) {
-        PR_DestroyCondVar((*prpp)->cvar);
-        (*prpp)->cvar = NULL;
+    if (&((*prpp)->cvar)) {
+        pthread_cond_destroy(&(*prpp)->cvar);
     }
     slapi_ch_free((void **)&(*prpp)->private);
     slapi_ch_free((void **)prpp);
@@ -712,7 +710,7 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                 conn_set_agmt_changed(prp->conn);
             } else if (event_occurred(prp, EVENT_TRIGGERING_CRITERIA_MET)) { /* change available */
                 /* just ignore it and go to sleep */
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             } else if ((e1 = event_occurred(prp, EVENT_WINDOW_CLOSED)) ||
                        event_occurred(prp, EVENT_BACKOFF_EXPIRED)) {
                 /* this events - should not occur - log a warning and go to sleep */
@@ -720,13 +718,13 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                               "repl5_inc_run - %s: "
                               "Event %s should not occur in state %s; going to sleep\n",
                               agmt_get_long_name(prp->agmt), e1 ? event2name(EVENT_WINDOW_CLOSED) : event2name(EVENT_BACKOFF_EXPIRED), state2name(current_state));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             } else {
                 /* wait until window opens or an event occurs */
                 slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                               "repl5_inc_run - %s: Waiting for update window to open\n",
                               agmt_get_long_name(prp->agmt));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             }
             break;
 
@@ -850,7 +848,7 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                 }
                 next_state = STATE_BACKOFF;
                 backoff_reset(prp_priv->backoff, repl5_inc_backoff_expired, (void *)prp);
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
                 use_busy_backoff_timer = PR_FALSE;
             }
             break;
@@ -899,13 +897,13 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                */
                 if (STATE_BACKOFF == next_state) {
                     /* Step the backoff timer */
-                    now = slapi_current_utc_time();
+                    now = slapi_current_rel_time_t();
                     next_fire_time = backoff_step(prp_priv->backoff);
                     /* And go back to sleep */
                     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                                   "repl5_inc_run - %s: Replication session backing off for %ld seconds\n",
                                   agmt_get_long_name(prp->agmt), next_fire_time - now);
-                    protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                    protocol_sleep(prp, 0);
                 } else {
                     /* Destroy the backoff timer, since we won't need it anymore */
                     backoff_delete(&prp_priv->backoff);
@@ -923,7 +921,7 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                     next_state = STATE_READY_TO_ACQUIRE;
                 } else {
                     /* ignore changes and go to sleep */
-                    protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                    protocol_sleep(prp, 0);
                 }
             } else if (event_occurred(prp, EVENT_WINDOW_OPENED)) {
                 /* this should never happen - log an error and go to sleep */
@@ -931,7 +929,7 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                                                                "Event %s should not occur in state %s; going to sleep\n",
                               agmt_get_long_name(prp->agmt), event2name(EVENT_WINDOW_OPENED),
                               state2name(current_state));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             }
             break;
 
@@ -1178,7 +1176,7 @@ repl5_inc_run(Private_Repl_Protocol *prp)
                 reset_events(prp);
             }
 
-            protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+            protocol_sleep(prp, 0);
             break;
 
         case STATE_STOP_NORMAL_TERMINATION:
@@ -1209,20 +1207,28 @@ repl5_inc_run(Private_Repl_Protocol *prp)
  * Go to sleep until awakened.
  */
 static void
-protocol_sleep(Private_Repl_Protocol *prp, PRIntervalTime duration)
+protocol_sleep(Private_Repl_Protocol *prp, int32_t duration)
 {
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     /* we should not go to sleep if there are events available to be processed.
        Otherwise, we can miss the event that suppose to wake us up */
-    if (prp->eventbits == 0)
-        PR_WaitCondVar(prp->cvar, duration);
-    else {
+    if (prp->eventbits == 0) {
+        if (duration > 0) {
+            struct timespec current_time = {0};
+            /* get the current monotonic time and add our interval */
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+            current_time.tv_sec += duration;
+            pthread_cond_timedwait(&(prp->cvar), &(prp->lock), &current_time);
+        } else {
+            pthread_cond_wait(&(prp->cvar), &(prp->lock));
+        }
+    } else {
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                       "protocol_sleep - %s: Can't go to sleep: event bits - %x\n",
                       agmt_get_long_name(prp->agmt), prp->eventbits);
     }
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
 }
 
 /*
@@ -1235,10 +1241,10 @@ static void
 event_notify(Private_Repl_Protocol *prp, PRUint32 event)
 {
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     prp->eventbits |= event;
-    PR_NotifyCondVar(prp->cvar);
-    PR_Unlock(prp->lock);
+    pthread_cond_signal(&(prp->cvar));
+    pthread_mutex_unlock(&(prp->lock));
 }
 
 /*
@@ -1250,10 +1256,10 @@ event_occurred(Private_Repl_Protocol *prp, PRUint32 event)
 {
     PRUint32 return_value;
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     return_value = (prp->eventbits & event);
     prp->eventbits &= ~event; /* Clear event */
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
     return return_value;
 }
 
@@ -1261,9 +1267,9 @@ static void
 reset_events(Private_Repl_Protocol *prp)
 {
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     prp->eventbits = 0;
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
 }
 
 /*
@@ -1882,7 +1888,7 @@ send_updates(Private_Repl_Protocol *prp, RUV *remote_update_vector, PRUint32 *nu
             /* See if the result thread has hit a problem */
 
             if (!finished && rd->abort_time) {
-                time_t current_time = slapi_current_utc_time();
+                time_t current_time = slapi_current_rel_time_t();
                 if ((current_time - rd->abort_time) >= release_timeout) {
                     rd->result = UPDATE_YIELD;
                     return_value = UPDATE_YIELD;
@@ -2088,7 +2094,9 @@ Private_Repl_Protocol *
 Repl_5_Inc_Protocol_new(Repl_Protocol *rp)
 {
     repl5_inc_private *rip = NULL;
-    Private_Repl_Protocol *prp = (Private_Repl_Protocol *)slapi_ch_malloc(sizeof(Private_Repl_Protocol));
+    pthread_condattr_t cattr; /* the pthread condition attr */
+    Private_Repl_Protocol *prp = (Private_Repl_Protocol *)slapi_ch_calloc(1, sizeof(Private_Repl_Protocol));
+
     prp->delete = repl5_inc_delete;
     prp->run = repl5_inc_run;
     prp->stop = repl5_inc_stop;
@@ -2099,12 +2107,19 @@ Repl_5_Inc_Protocol_new(Repl_Protocol *rp)
     prp->notify_window_closed = repl5_inc_notify_window_closed;
     prp->update_now = repl5_inc_update_now;
     prp->replica = prot_get_replica(rp);
-    if ((prp->lock = PR_NewLock()) == NULL) {
+    if (pthread_mutex_init(&(prp->lock), NULL) != 0) {
         goto loser;
     }
-    if ((prp->cvar = PR_NewCondVar(prp->lock)) == NULL) {
+    if (pthread_condattr_init(&cattr) != 0) {
         goto loser;
     }
+    if (pthread_condattr_setclock(&cattr, CLOCK_MONOTONIC) != 0) {
+        goto loser;
+    }
+    if (pthread_cond_init(&(prp->cvar), &cattr) != 0) {
+        goto loser;
+    }
+    pthread_condattr_destroy(&cattr);
     prp->stopped = 0;
     prp->terminate = 0;
     prp->eventbits = 0;

--- a/ldap/servers/plugins/replication/repl5_mtnode_ext.c
+++ b/ldap/servers/plugins/replication/repl5_mtnode_ext.c
@@ -82,7 +82,8 @@ multimaster_mtnode_construct_replicas()
                 }
             }
             /* Wait a few seconds for everything to startup before resuming any replication tasks */
-            slapi_eq_once(replica_check_for_tasks, (void *)replica_get_root(r), time(NULL) + 5);
+            slapi_eq_once(replica_check_for_tasks, (void *)replica_get_root(r),
+                          slapi_current_rel_time_t() + 5);
         }
     }
 }

--- a/ldap/servers/plugins/replication/repl5_prot_private.h
+++ b/ldap/servers/plugins/replication/repl5_prot_private.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -32,8 +32,6 @@ typedef struct private_repl_protocol
     void (*notify_window_opened)(struct private_repl_protocol *);
     void (*notify_window_closed)(struct private_repl_protocol *);
     void (*update_now)(struct private_repl_protocol *);
-    PRLock *lock;
-    PRCondVar *cvar;
     int stopped;
     int terminate;
     PRUint32 eventbits;
@@ -46,6 +44,8 @@ typedef struct private_repl_protocol
     int repl50consumer; /* Flag to tell us if this is a 5.0-style consumer we're talking to */
     int repl71consumer; /* Flag to tell us if this is a 7.1-style consumer we're talking to */
     int repl90consumer; /* Flag to tell us if this is a 9.0-style consumer we're talking to */
+    pthread_mutex_t lock;
+    pthread_cond_t cvar;
 } Private_Repl_Protocol;
 
 extern Private_Repl_Protocol *Repl_5_Inc_Protocol_new(Repl_Protocol *rp);

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -245,7 +245,7 @@ replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation,
        In that case the updated would fail but nothing bad would happen. The next
        scheduled update would save the state */
     r->repl_eqcxt_rs = slapi_eq_repeat(replica_update_state, r->repl_name,
-                                       slapi_current_utc_time() + START_UPDATE_DELAY, RUV_SAVE_INTERVAL);
+                                       slapi_current_rel_time_t() + START_UPDATE_DELAY, RUV_SAVE_INTERVAL);
 
     if (r->tombstone_reap_interval > 0) {
         /*
@@ -253,7 +253,7 @@ replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation,
          * This will allow the server to fully start before consuming resources.
          */
         r->repl_eqcxt_tr = slapi_eq_repeat(eq_cb_reap_tombstones, r->repl_name,
-                                           slapi_current_utc_time() + r->tombstone_reap_interval,
+                                           slapi_current_rel_time_t() + r->tombstone_reap_interval,
                                            1000 * r->tombstone_reap_interval);
     }
 
@@ -1105,7 +1105,7 @@ replica_is_updatedn(Replica *r, const Slapi_DN *sdn)
     if (r->groupdn_list) {
         /* check and rebuild groupdns */
         if (r->updatedn_group_check_interval > -1) {
-            time_t now = slapi_current_utc_time();
+            time_t now = slapi_current_rel_time_t();
             if (now - r->updatedn_group_last_check > r->updatedn_group_check_interval) {
                 Slapi_ValueSet *updatedn_groups_copy = NULL;
                 ReplicaUpdateDNList groupdn_list = replica_updatedn_list_new(NULL);
@@ -1529,7 +1529,7 @@ replica_set_enabled(Replica *r, PRBool enable)
         if (r->repl_eqcxt_rs == NULL) /* event is not already registered */
         {
             r->repl_eqcxt_rs = slapi_eq_repeat(replica_update_state, r->repl_name,
-                                               slapi_current_utc_time() + START_UPDATE_DELAY, RUV_SAVE_INTERVAL);
+                                               slapi_current_rel_time_t() + START_UPDATE_DELAY, RUV_SAVE_INTERVAL);
         }
     } else /* disable */
     {
@@ -3665,7 +3665,7 @@ replica_set_tombstone_reap_interval(Replica *r, long interval)
     r->tombstone_reap_interval = interval;
     if (interval > 0 && r->repl_eqcxt_tr == NULL) {
         r->repl_eqcxt_tr = slapi_eq_repeat(eq_cb_reap_tombstones, r->repl_name,
-                                           slapi_current_utc_time() + r->tombstone_reap_interval,
+                                           slapi_current_rel_time_t() + r->tombstone_reap_interval,
                                            1000 * r->tombstone_reap_interval);
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                       "replica_set_tombstone_reap_interval - tombstone_reap event (interval=%" PRId64 ") was %s\n",

--- a/ldap/servers/plugins/replication/repl_extop.c
+++ b/ldap/servers/plugins/replication/repl_extop.c
@@ -1178,7 +1178,7 @@ multimaster_extop_EndNSDS50ReplicationRequest(Slapi_PBlock *pb)
                     /* now that the changelog is open and started, we can alos cretae the
                      * keep alive entry without risk that db and cl will not match
                      */
-                    replica_subentry_check(replica_get_root(r), replica_get_rid(r));
+                    replica_subentry_check((Slapi_DN *)replica_get_root(r), replica_get_rid(r));
                 }
 
                 /* ONREPL code that dealt with new RUV, etc was moved into the code
@@ -1476,7 +1476,7 @@ multimaster_extop_cleanruv(Slapi_PBlock *pb)
          *  Launch the cleanruv monitoring thread.  Once all the replicas are cleaned it will release the rid
          */
 
-        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "Launching cleanAllRUV thread...\n");
+        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "Launching cleanAllRUV thread...");
         data = (cleanruv_data *)slapi_ch_calloc(1, sizeof(cleanruv_data));
         if (data == NULL) {
             slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "multimaster_extop_cleanruv - CleanAllRUV Task - Failed to allocate "

--- a/ldap/servers/plugins/replication/windows_connection.c
+++ b/ldap/servers/plugins/replication/windows_connection.c
@@ -1121,7 +1121,7 @@ windows_conn_start_linger(Repl_Connection *conn)
                       agmt_get_long_name(conn->agmt));
         return;
     }
-    now = slapi_current_utc_time();
+    now = slapi_current_rel_time_t();
     PR_Lock(conn->lock);
     if (conn->linger_active) {
         slapi_log_err(SLAPI_LOG_REPL, windows_repl_plugin_name,

--- a/ldap/servers/plugins/replication/windows_inc_protocol.c
+++ b/ldap/servers/plugins/replication/windows_inc_protocol.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -48,7 +48,7 @@ typedef struct windows_inc_private
     char *ruv; /* RUV on remote replica (use diff type for this? - ggood */
     Backoff_Timer *backoff;
     Repl_Protocol *rp;
-    PRLock *lock;
+    pthread_mutex_t *lock;
     PRUint32 eventbits;
 } windows_inc_private;
 
@@ -96,7 +96,7 @@ typedef struct windows_inc_private
  * don't see any updates for a period equal to this interval,
  * we go ahead and start a replication session, just to be safe
  */
-#define MAX_WAIT_BETWEEN_SESSIONS PR_SecondsToInterval(60 * 5) /* 5 minutes */
+#define MAX_WAIT_BETWEEN_SESSIONS 300 /* 5 minutes */
 /*
  * tests if the protocol has been shutdown and we need to quit
  * event_occurred resets the bits in the bit flag, so whoever tests for shutdown
@@ -108,7 +108,7 @@ typedef struct windows_inc_private
 /* Forward declarations */
 static PRUint32 event_occurred(Private_Repl_Protocol *prp, PRUint32 event);
 static void reset_events(Private_Repl_Protocol *prp);
-static void protocol_sleep(Private_Repl_Protocol *prp, PRIntervalTime duration);
+static void protocol_sleep(Private_Repl_Protocol *prp, int32_t duration);
 static int send_updates(Private_Repl_Protocol *prp, RUV *ruv, PRUint32 *num_changes_sent, int do_send);
 static void windows_inc_backoff_expired(time_t timer_fire_time, void *arg);
 static int windows_examine_update_vector(Private_Repl_Protocol *prp, RUV *ruv);
@@ -143,13 +143,11 @@ windows_inc_delete(Private_Repl_Protocol **prpp)
         (*prpp)->stopped = 1;
         (*prpp)->stop(*prpp);
     }
-    if ((*prpp)->lock) {
-        PR_DestroyLock((*prpp)->lock);
-        (*prpp)->lock = NULL;
+    if (&((*prpp)->lock)) {
+        pthread_mutex_destroy(&((*prpp)->lock));
     }
-    if ((*prpp)->cvar) {
-        PR_DestroyCondVar((*prpp)->cvar);
-        (*prpp)->cvar = NULL;
+    if (&((*prpp)->cvar)) {
+        pthread_cond_destroy(&(*prpp)->cvar);
     }
     slapi_ch_free((void **)&(*prpp)->private);
     slapi_ch_free((void **)prpp);
@@ -360,7 +358,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
             } else if (event_occurred(prp, EVENT_TRIGGERING_CRITERIA_MET)) /* change available */
             {
                 /* just ignore it and go to sleep */
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             } else if ((e1 = event_occurred(prp, EVENT_WINDOW_CLOSED)) ||
                        event_occurred(prp, EVENT_BACKOFF_EXPIRED)) {
                 /* this events - should not occur - log a warning and go to sleep */
@@ -370,18 +368,18 @@ windows_inc_run(Private_Repl_Protocol *prp)
                               agmt_get_long_name(prp->agmt),
                               e1 ? event2name(EVENT_WINDOW_CLOSED) : event2name(EVENT_BACKOFF_EXPIRED),
                               state2name(current_state));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             } else if (event_occurred(prp, EVENT_RUN_DIRSYNC)) /* periodic_dirsync */
             {
                 /* just ignore it and go to sleep */
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             } else {
                 /* wait until window opens or an event occurs */
                 slapi_log_err(SLAPI_LOG_REPL, windows_repl_plugin_name,
                               "windows_inc_run - %s: "
                               "Waiting for update window to open\n",
                               agmt_get_long_name(prp->agmt));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             }
             break;
 
@@ -536,7 +534,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
                 }
                 next_state = STATE_BACKOFF;
                 backoff_reset(prp_priv->backoff, windows_inc_backoff_expired, (void *)prp);
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
                 use_busy_backoff_timer = PR_FALSE;
             }
             break;
@@ -605,7 +603,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
                                   agmt_get_long_name(prp->agmt),
                                   next_fire_time - now);
 
-                    protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                    protocol_sleep(prp, 0);
                 } else {
                     /* Destroy the backoff timer, since we won't need it anymore */
                     backoff_delete(&prp_priv->backoff);
@@ -624,7 +622,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
                     next_state = STATE_READY_TO_ACQUIRE;
                 } else {
                     /* ignore changes and go to sleep */
-                    protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                    protocol_sleep(prp, 0);
                 }
             } else if (event_occurred(prp, EVENT_WINDOW_OPENED)) {
                 /* this should never happen - log an error and go to sleep */
@@ -632,7 +630,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
                                                                        "event %s should not occur in state %s; going to sleep\n",
                               agmt_get_long_name(prp->agmt),
                               event2name(EVENT_WINDOW_OPENED), state2name(current_state));
-                protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+                protocol_sleep(prp, 0);
             }
             break;
         case STATE_SENDING_UPDATES:
@@ -856,7 +854,7 @@ windows_inc_run(Private_Repl_Protocol *prp)
                 reset_events(prp);
             }
 
-            protocol_sleep(prp, PR_INTERVAL_NO_TIMEOUT);
+            protocol_sleep(prp, 0);
             break;
 
         case STATE_STOP_NORMAL_TERMINATION:
@@ -891,21 +889,29 @@ windows_inc_run(Private_Repl_Protocol *prp)
  * Go to sleep until awakened.
  */
 static void
-protocol_sleep(Private_Repl_Protocol *prp, PRIntervalTime duration)
+protocol_sleep(Private_Repl_Protocol *prp, int32_t duration)
 {
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "=> protocol_sleep\n");
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     /* we should not go to sleep if there are events available to be processed.
        Otherwise, we can miss the event that suppose to wake us up */
-    if (prp->eventbits == 0)
-        PR_WaitCondVar(prp->cvar, duration);
-    else {
+    if (prp->eventbits == 0) {
+        if (duration > 0) {
+            struct timespec current_time = {0};
+            /* get the current monotonic time and add our interval */
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+            current_time.tv_sec += duration;
+            pthread_cond_timedwait(&(prp->cvar), &(prp->lock), &current_time);
+        } else {
+            pthread_cond_wait(&(prp->cvar), &(prp->lock));
+        }
+    } else {
         slapi_log_err(SLAPI_LOG_REPL, windows_repl_plugin_name,
                       "protocol_sleep - %s: Can't go to sleep: event bits - %x\n",
                       agmt_get_long_name(prp->agmt), prp->eventbits);
     }
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "<= protocol_sleep\n");
 }
 
@@ -921,10 +927,10 @@ event_notify(Private_Repl_Protocol *prp, PRUint32 event)
 {
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "=> event_notify\n");
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     prp->eventbits |= event;
-    PR_NotifyCondVar(prp->cvar);
-    PR_Unlock(prp->lock);
+    pthread_cond_signal(&(prp->cvar));
+    pthread_mutex_unlock(&(prp->lock));
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "<= event_notify\n");
 }
 
@@ -941,10 +947,10 @@ event_occurred(Private_Repl_Protocol *prp, PRUint32 event)
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "=> event_occurred\n");
 
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     return_value = (prp->eventbits & event);
     prp->eventbits &= ~event; /* Clear event */
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "<= event_occurred\n");
     return return_value;
 }
@@ -954,9 +960,9 @@ reset_events(Private_Repl_Protocol *prp)
 {
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "=> reset_events\n");
     PR_ASSERT(NULL != prp);
-    PR_Lock(prp->lock);
+    pthread_mutex_lock(&(prp->lock));
     prp->eventbits = 0;
-    PR_Unlock(prp->lock);
+    pthread_mutex_unlock(&(prp->lock));
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "<= reset_events\n");
 }
 
@@ -1417,6 +1423,7 @@ Windows_Inc_Protocol_new(Repl_Protocol *rp)
 {
     windows_inc_private *rip = NULL;
     Private_Repl_Protocol *prp = (Private_Repl_Protocol *)slapi_ch_calloc(1, sizeof(Private_Repl_Protocol));
+    pthread_condattr_t cattr;
 
     slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "=> Windows_Inc_Protocol_new\n");
 
@@ -1430,12 +1437,19 @@ Windows_Inc_Protocol_new(Repl_Protocol *rp)
     prp->notify_window_closed = windows_inc_notify_window_closed;
     prp->update_now = windows_inc_update_now;
     prp->replica = prot_get_replica(rp);
-    if ((prp->lock = PR_NewLock()) == NULL) {
+    if (pthread_mutex_init(&(prp->lock), NULL) != 0) {
         goto loser;
     }
-    if ((prp->cvar = PR_NewCondVar(prp->lock)) == NULL) {
+    if (pthread_condattr_init(&cattr) != 0) {
         goto loser;
     }
+    if (pthread_condattr_setclock(&cattr, CLOCK_MONOTONIC) != 0) {
+        goto loser;
+    }
+    if (pthread_cond_init(&(prp->cvar), &cattr) != 0) {
+        goto loser;
+    }
+    pthread_condattr_destroy(&cattr); /* no longer needed */
     prp->stopped = 0;
     prp->terminate = 0;
     prp->eventbits = 0;

--- a/ldap/servers/plugins/retrocl/retrocl_trim.c
+++ b/ldap/servers/plugins/retrocl/retrocl_trim.c
@@ -241,7 +241,7 @@ trim_changelog(void)
     int me, lt;
 
 
-    now = slapi_current_utc_time();
+    now = slapi_current_rel_time_t();
 
     PR_Lock(ts.ts_s_trim_mutex);
     me = ts.ts_c_max_age;

--- a/ldap/servers/plugins/roles/roles_cache.c
+++ b/ldap/servers/plugins/roles/roles_cache.c
@@ -343,7 +343,7 @@ roles_cache_create_suffix(Slapi_DN *sdn)
 
     slapi_lock_mutex(new_suffix->create_lock);
     if (new_suffix->is_ready != 1) {
-        slapi_wait_condvar(new_suffix->suffix_created, NULL);
+        slapi_wait_condvar_pt(new_suffix->suffix_created, new_suffix->create_lock, NULL);
     }
     slapi_unlock_mutex(new_suffix->create_lock);
 
@@ -384,7 +384,7 @@ roles_cache_wait_on_change(void *arg)
             test roles_def->keeprunning before
             going to sleep.
         */
-        slapi_wait_condvar(roles_def->something_changed, NULL);
+        slapi_wait_condvar_pt(roles_def->something_changed, roles_def->change_lock, NULL);
 
         slapi_log_err(SLAPI_LOG_PLUGIN, ROLES_PLUGIN_SUBSYSTEM, "roles_cache_wait_on_change - notified\n");
 

--- a/ldap/servers/plugins/sync/sync.h
+++ b/ldap/servers/plugins/sync/sync.h
@@ -202,8 +202,8 @@ typedef struct sync_request_list
 {
     Slapi_RWLock *sync_req_rwlock; /* R/W lock struct to serialize access */
     SyncRequest *sync_req_head;    /* Head of list */
-    PRLock *sync_req_cvarlock;     /* Lock for cvar */
-    PRCondVar *sync_req_cvar;      /* ps threads sleep on this */
+    pthread_mutex_t sync_req_cvarlock;    /* Lock for cvar */
+    pthread_cond_t sync_req_cvar;         /* ps threads sleep on this */
     int sync_req_max_persist;
     int sync_req_cur_persist;
 } SyncRequestList;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_instance_config.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -270,10 +270,8 @@ bdb_instance_cleanup(struct ldbm_instance *inst)
             slapi_ch_free_string(&inst_dirp);
     }
     slapi_destroy_rwlock(inst_env->bdb_env_lock);
-    PR_DestroyCondVar(inst_env->bdb_thread_count_cv);
-    inst_env->bdb_thread_count_cv = NULL;
-    PR_DestroyLock(inst_env->bdb_thread_count_lock);
-    inst_env->bdb_thread_count_lock = NULL;
+    pthread_mutex_destroy(&(inst_env->bdb_thread_count_lock));
+    pthread_cond_destroy(&(inst_env->bdb_thread_count_cv));
     slapi_ch_free((void **)&inst->inst_db);
     /* 
     slapi_destroy_rwlock(((bdb_db_env *)inst->inst_db)->bdb_env_lock);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -52,16 +52,16 @@
    return.
 */
 #define INCR_THREAD_COUNT(pEnv)       \
-    PR_Lock(pEnv->bdb_thread_count_lock); \
+    pthread_mutex_lock(&pEnv->bdb_thread_count_lock); \
     ++pEnv->bdb_thread_count;     \
-    PR_Unlock(pEnv->bdb_thread_count_lock)
+    pthread_mutex_unlock(&pEnv->bdb_thread_count_lock)
 
 #define DECR_THREAD_COUNT(pEnv)                  \
-    PR_Lock(pEnv->bdb_thread_count_lock);            \
+    pthread_mutex_lock(&pEnv->bdb_thread_count_lock);            \
     if (--pEnv->bdb_thread_count == 0) {     \
-        PR_NotifyCondVar(pEnv->bdb_thread_count_cv); \
+        pthread_cond_broadcast(&pEnv->bdb_thread_count_cv); \
     }                                            \
-    PR_Unlock(pEnv->bdb_thread_count_lock)
+    pthread_mutex_unlock(&pEnv->bdb_thread_count_lock)
 
 #define NEWDIR_MODE 0755
 #define DB_REGION_PREFIX "__db."
@@ -92,9 +92,12 @@ static int trans_batch_txn_max_sleep = 50;
 static PRBool log_flush_thread = PR_FALSE;
 static int txn_in_progress_count = 0;
 static int *txn_log_flush_pending = NULL;
-static PRLock *sync_txn_log_flush = NULL;
-static PRCondVar *sync_txn_log_flush_done = NULL;
-static PRCondVar *sync_txn_log_do_flush = NULL;
+
+static pthread_mutex_t sync_txn_log_flush;
+static pthread_cond_t sync_txn_log_flush_done;
+static pthread_cond_t sync_txn_log_do_flush;
+
+
 static int bdb_db_remove_ex(bdb_db_env *env, char const path[], char const dbName[], PRBool use_lock);
 static int bdb_db_compact_one_db(DB *db, ldbm_instance *inst);
 static int bdb_restore_file_check(struct ldbminfo *li);
@@ -183,12 +186,12 @@ bdb_set_batch_transactions(void *arg __attribute__((unused)), void *value, char 
         } else {
             if (val == 0) {
                 if (log_flush_thread) {
-                    PR_Lock(sync_txn_log_flush);
+                    pthread_mutex_lock(&sync_txn_log_flush);
                 }
                 trans_batch_limit = FLUSH_REMOTEOFF;
                 if (log_flush_thread) {
                     log_flush_thread = PR_FALSE;
-                    PR_Unlock(sync_txn_log_flush);
+                    pthread_mutex_unlock(&sync_txn_log_flush);
                 }
             } else if (val > 0) {
                 if (trans_batch_limit == FLUSH_REMOTEOFF) {
@@ -219,12 +222,12 @@ bdb_set_batch_txn_min_sleep(void *arg __attribute__((unused)), void *value, char
         } else {
             if (val == 0) {
                 if (log_flush_thread) {
-                    PR_Lock(sync_txn_log_flush);
+                    pthread_mutex_lock(&sync_txn_log_flush);
                 }
                 trans_batch_txn_min_sleep = FLUSH_REMOTEOFF;
                 if (log_flush_thread) {
                     log_flush_thread = PR_FALSE;
-                    PR_Unlock(sync_txn_log_flush);
+                    pthread_mutex_unlock(&sync_txn_log_flush);
                 }
             } else if (val > 0) {
                 if (trans_batch_txn_min_sleep == FLUSH_REMOTEOFF || !log_flush_thread) {
@@ -251,12 +254,12 @@ bdb_set_batch_txn_max_sleep(void *arg __attribute__((unused)), void *value, char
         } else {
             if (val == 0) {
                 if (log_flush_thread) {
-                    PR_Lock(sync_txn_log_flush);
+                    pthread_mutex_lock(&sync_txn_log_flush);
                 }
                 trans_batch_txn_max_sleep = FLUSH_REMOTEOFF;
                 if (log_flush_thread) {
                     log_flush_thread = PR_FALSE;
-                    PR_Unlock(sync_txn_log_flush);
+                    pthread_mutex_unlock(&sync_txn_log_flush);
                 }
             } else if (val > 0) {
                 if (trans_batch_txn_max_sleep == FLUSH_REMOTEOFF || !log_flush_thread) {
@@ -727,10 +730,9 @@ bdb_free_env(void **arg)
         slapi_destroy_rwlock((*env)->bdb_env_lock);
         (*env)->bdb_env_lock = NULL;
     }
-    PR_DestroyCondVar((*env)->bdb_thread_count_cv);
-    (*env)->bdb_thread_count_cv = NULL;
-    PR_DestroyLock((*env)->bdb_thread_count_lock);
-    (*env)->bdb_thread_count_lock = NULL;
+    pthread_mutex_destroy(&((*env)->bdb_thread_count_lock));
+    pthread_cond_destroy(&((*env)->bdb_thread_count_cv));
+
     slapi_ch_free((void **)env);
     return;
 }
@@ -748,11 +750,15 @@ bdb_make_env(bdb_db_env **env, struct ldbminfo *li)
     int ret;
     Object *inst_obj;
     ldbm_instance *inst = NULL;
+    pthread_condattr_t condAttr;
 
     pEnv = (bdb_db_env *)slapi_ch_calloc(1, sizeof(bdb_db_env));
 
-    pEnv->bdb_thread_count_lock = PR_NewLock();
-    pEnv->bdb_thread_count_cv = PR_NewCondVar(pEnv->bdb_thread_count_lock);
+    pthread_mutex_init(&pEnv->bdb_thread_count_lock, NULL);
+    pthread_condattr_init(&condAttr);
+    pthread_condattr_setclock(&condAttr, CLOCK_MONOTONIC);
+    pthread_cond_init(&pEnv->bdb_thread_count_cv, &condAttr);
+    pthread_condattr_destroy(&condAttr); /* no longer needed */
 
     if ((ret = db_env_create(&pEnv->bdb_DB_ENV, 0)) != 0) {
         slapi_log_err(SLAPI_LOG_ERR,
@@ -2015,9 +2021,9 @@ bdb_pre_close(struct ldbminfo *li)
         return;
 
     /* first, see if there are any housekeeping threads running */
-    PR_Lock(pEnv->bdb_thread_count_lock);
+    pthread_mutex_lock(&pEnv->bdb_thread_count_lock);
     threadcount = pEnv->bdb_thread_count;
-    PR_Unlock(pEnv->bdb_thread_count_lock);
+    pthread_mutex_unlock(&pEnv->bdb_thread_count_lock);
 
     if (threadcount) {
         PRIntervalTime cvwaittime = PR_MillisecondsToInterval(DBLAYER_SLEEP_INTERVAL * 100);
@@ -2025,7 +2031,7 @@ bdb_pre_close(struct ldbminfo *li)
         /* Print handy-dandy log message */
         slapi_log_err(SLAPI_LOG_INFO, "bdb_pre_close", "Waiting for %d database threads to stop\n",
                       threadcount);
-        PR_Lock(pEnv->bdb_thread_count_lock);
+        pthread_mutex_lock(&pEnv->bdb_thread_count_lock);
         /* Tell them to stop - we wait until the last possible moment to invoke
            this.  If we do this much sooner than this, we could find ourselves
            in a situation where the threads see the stop_threads and exit before
@@ -2036,6 +2042,7 @@ bdb_pre_close(struct ldbminfo *li)
         conf->bdb_stop_threads = 1;
         /* Wait for them to exit */
         while (pEnv->bdb_thread_count > 0) {
+            struct timespec current_time = {0};
             PRIntervalTime before = PR_IntervalNow();
             /* There are 3 ways to wake up from this WaitCondVar:
                1) The last database thread exits and calls NotifyCondVar - thread_count
@@ -2043,7 +2050,9 @@ bdb_pre_close(struct ldbminfo *li)
                2) Timeout - in this case, thread_count will be > 0 - bad
                3) A bad error occurs - bad - will be reported as a timeout
             */
-            PR_WaitCondVar(pEnv->bdb_thread_count_cv, cvwaittime);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+            current_time.tv_sec += DBLAYER_SLEEP_INTERVAL / 10; /* cvwaittime but in seconds */
+            pthread_cond_timedwait(&pEnv->bdb_thread_count_cv, &pEnv->bdb_thread_count_lock, &current_time);
             if (pEnv->bdb_thread_count > 0) {
                 /* still at least 1 thread running - see if this is a timeout */
                 if ((PR_IntervalNow() - before) >= cvwaittime) {
@@ -2054,7 +2063,7 @@ bdb_pre_close(struct ldbminfo *li)
                 /* else just a spurious interrupt */
             }
         }
-        PR_Unlock(pEnv->bdb_thread_count_lock);
+        pthread_mutex_unlock(&pEnv->bdb_thread_count_lock);
         if (timedout) {
             slapi_log_err(SLAPI_LOG_ERR,
                           "bdb_pre_close", "Timeout after [%d] milliseconds; leave %d database thread(s)...\n",
@@ -2709,12 +2718,12 @@ bdb_txn_begin(struct ldbminfo *li, back_txnid parent_txn, back_txn *txn, PRBool 
                and new parent for any nested transactions created */
             if (use_lock && log_flush_thread) {
                 int txn_id = new_txn.back_txn_txn->id(new_txn.back_txn_txn);
-                PR_Lock(sync_txn_log_flush);
+                pthread_mutex_lock(&sync_txn_log_flush);
                 txn_in_progress_count++;
                 slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_begin_ext",
                               "Batchcount: %d, txn_in_progress: %d, curr_txn: %x\n",
                               trans_batch_count, txn_in_progress_count, txn_id);
-                PR_Unlock(sync_txn_log_flush);
+                pthread_mutex_unlock(&sync_txn_log_flush);
             }
             dblayer_push_pvt_txn(&new_txn);
             if (txn) {
@@ -2781,11 +2790,11 @@ bdb_txn_commit(struct ldbminfo *li, back_txn *txn, PRBool use_lock)
         if ((conf->bdb_durable_transactions) && use_lock) {
             if (trans_batch_limit > 0 && log_flush_thread) {
                 /* let log_flush thread do the flushing */
-                PR_Lock(sync_txn_log_flush);
+                pthread_mutex_lock(&sync_txn_log_flush);
                 txn_batch_slot = trans_batch_count++;
                 txn_log_flush_pending[txn_batch_slot] = txn_id;
-                slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_commit_ext", "(before notify): batchcount: %d, "
-                                                                            "txn_in_progress: %d, curr_txn: %x\n",
+                slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_commit_ext",
+                              "(before notify): batchcount: %d, txn_in_progress: %d, curr_txn: %x\n",
                               trans_batch_count,
                               txn_in_progress_count, txn_id);
                 /*
@@ -2795,8 +2804,9 @@ bdb_txn_commit(struct ldbminfo *li, back_txn *txn, PRBool use_lock)
                  * - there is no other outstanding txn
                  */
                 if (trans_batch_count > trans_batch_limit ||
-                    trans_batch_count == txn_in_progress_count) {
-                    PR_NotifyCondVar(sync_txn_log_do_flush);
+                    trans_batch_count == txn_in_progress_count)
+                {
+                    pthread_cond_signal(&sync_txn_log_do_flush);
                 }
                 /*
                  * We need to wait until the txn has been flushed before continuing
@@ -2804,14 +2814,14 @@ bdb_txn_commit(struct ldbminfo *li, back_txn *txn, PRBool use_lock)
                  * PR_WaitCondvar releases and reaquires the lock
                  */
                 while (txn_log_flush_pending[txn_batch_slot] == txn_id) {
-                    PR_WaitCondVar(sync_txn_log_flush_done, PR_INTERVAL_NO_TIMEOUT);
+                    pthread_cond_wait(&sync_txn_log_flush_done, &sync_txn_log_flush);
                 }
                 txn_in_progress_count--;
-                slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_commit_ext", "(before unlock): batchcount: %d, "
-                                                                            "txn_in_progress: %d, curr_txn %x\n",
+                slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_commit_ext",
+                              "(before unlock): batchcount: %d, txn_in_progress: %d, curr_txn %x\n",
                               trans_batch_count,
                               txn_in_progress_count, txn_id);
-                PR_Unlock(sync_txn_log_flush);
+                pthread_mutex_unlock(&sync_txn_log_flush);
             } else if (trans_batch_limit == FLUSH_REMOTEOFF) { /* user remotely turned batching off */
                 LOG_FLUSH(pEnv->bdb_DB_ENV, 0);
             }
@@ -2863,9 +2873,9 @@ bdb_txn_abort(struct ldbminfo *li, back_txn *txn, PRBool use_lock)
         int txn_id = db_txn->id(db_txn);
         bdb_db_env *pEnv = (bdb_db_env *)priv->dblayer_env;
         if (use_lock && log_flush_thread) {
-            PR_Lock(sync_txn_log_flush);
+            pthread_mutex_lock(&sync_txn_log_flush);
             txn_in_progress_count--;
-            PR_Unlock(sync_txn_log_flush);
+            pthread_mutex_unlock(&sync_txn_log_flush);
             slapi_log_err(SLAPI_LOG_BACKLDBM, "dblayer_txn_abort_ext",
                           "Batchcount: %d, txn_in_progress: %d, curr_txn: %x\n",
                           trans_batch_count, txn_in_progress_count, txn_id);
@@ -3484,11 +3494,18 @@ bdb_start_log_flush_thread(struct ldbminfo *li)
     int max_threads = config_get_threadnumber();
 
     if ((BDB_CONFIG(li)->bdb_durable_transactions) &&
-        (BDB_CONFIG(li)->bdb_enable_transactions) && (trans_batch_limit > 0)) {
+        (BDB_CONFIG(li)->bdb_enable_transactions) && (trans_batch_limit > 0))
+    {
         /* initialize the synchronization objects for the log_flush and worker threads */
-        sync_txn_log_flush = PR_NewLock();
-        sync_txn_log_flush_done = PR_NewCondVar(sync_txn_log_flush);
-        sync_txn_log_do_flush = PR_NewCondVar(sync_txn_log_flush);
+        pthread_condattr_t condAttr;
+
+        pthread_mutex_init(&sync_txn_log_flush, NULL);
+        pthread_condattr_init(&condAttr);
+        pthread_condattr_setclock(&condAttr, CLOCK_MONOTONIC);
+        pthread_cond_init(&sync_txn_log_do_flush, &condAttr);
+        pthread_cond_init(&sync_txn_log_flush_done, NULL);
+        pthread_condattr_destroy(&condAttr); /* no longer needed */
+
         txn_log_flush_pending = (int *)slapi_ch_malloc(max_threads * sizeof(int));
         log_flush_thread = PR_TRUE;
         if (NULL == PR_CreateThread(PR_USER_THREAD,
@@ -3515,7 +3532,7 @@ bdb_start_log_flush_thread(struct ldbminfo *li)
 static int
 log_flush_threadmain(void *param)
 {
-    PRIntervalTime interval_wait, interval_flush, interval_def;
+    PRIntervalTime interval_flush, interval_def;
     PRIntervalTime last_flush = 0;
     int i;
     int do_flush = 0;
@@ -3528,7 +3545,6 @@ log_flush_threadmain(void *param)
     INCR_THREAD_COUNT(pEnv);
 
     interval_flush = PR_MillisecondsToInterval(trans_batch_txn_min_sleep);
-    interval_wait = PR_MillisecondsToInterval(trans_batch_txn_max_sleep);
     interval_def = PR_MillisecondsToInterval(300); /*used while no txn or txn batching */
     /* LK this is only needed if online change of
      * of txn config is supported ???
@@ -3537,10 +3553,10 @@ log_flush_threadmain(void *param)
         if (BDB_CONFIG(li)->bdb_enable_transactions) {
             if (trans_batch_limit > 0) {
                 /* synchronize flushing thread with workers */
-                PR_Lock(sync_txn_log_flush);
+                pthread_mutex_lock(&sync_txn_log_flush);
                 if (!log_flush_thread) {
                     /* batch transactions was disabled while waiting for the lock */
-                    PR_Unlock(sync_txn_log_flush);
+                    pthread_mutex_unlock(&sync_txn_log_flush);
                     break;
                 }
                 slapi_log_err(SLAPI_LOG_BACKLDBM, "log_flush_threadmain", "(in loop): batchcount: %d, "
@@ -3566,20 +3582,31 @@ log_flush_threadmain(void *param)
                     slapi_log_err(SLAPI_LOG_BACKLDBM, "log_flush_threadmain", "(before notify): batchcount: %d, "
                                                                               "txn_in_progress: %d\n",
                                   trans_batch_count, txn_in_progress_count);
-                    PR_NotifyAllCondVar(sync_txn_log_flush_done);
+                    pthread_cond_broadcast(&sync_txn_log_flush_done);
                 }
                 /* wait until flushing conditions are met */
                 while ((trans_batch_count == 0) ||
-                       (trans_batch_count < trans_batch_limit && trans_batch_count < txn_in_progress_count)) {
+                       (trans_batch_count < trans_batch_limit && trans_batch_count < txn_in_progress_count))
+                {
+                    struct timespec current_time = {0};
+                    /* convert milliseconds to nano seconds */
+                    int32_t nano_sec_sleep = trans_batch_txn_max_sleep * 1000000;
                     if (BDB_CONFIG(li)->bdb_stop_threads)
                         break;
                     if (PR_IntervalNow() - last_flush > interval_flush) {
                         do_flush = 1;
                         break;
                     }
-                    PR_WaitCondVar(sync_txn_log_do_flush, interval_wait);
+                    clock_gettime(CLOCK_MONOTONIC, &current_time);
+                    if (current_time.tv_nsec + nano_sec_sleep > 1000000000) {
+                        /* nano sec will overflow, just bump the seconds */
+                        current_time.tv_sec++;
+                    } else {
+                        current_time.tv_nsec += nano_sec_sleep;
+                    }
+                    pthread_cond_timedwait(&sync_txn_log_do_flush, &sync_txn_log_flush, &current_time);
                 }
-                PR_Unlock(sync_txn_log_flush);
+                pthread_mutex_unlock(&sync_txn_log_flush);
                 slapi_log_err(SLAPI_LOG_BACKLDBM, "log_flush_threadmain", "(wakeup): batchcount: %d, "
                                                                           "txn_in_progress: %d\n",
                               trans_batch_count, txn_in_progress_count);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -18,10 +18,10 @@ typedef struct bdb_db_env
     Slapi_RWLock *bdb_env_lock;
     int bdb_openflags;
     int bdb_priv_flags;
-    PRLock *bdb_thread_count_lock;      /* lock for thread_count_cv */
-    PRCondVar *bdb_thread_count_cv;     /* condition variable for housekeeping thread shutdown */
-    PRInt32 bdb_thread_count;           /* Tells us how many threads are running,
-                                         * used to figure out when they're all stopped */
+    pthread_mutex_t bdb_thread_count_lock; /* lock for thread_count_cv */
+    pthread_cond_t bdb_thread_count_cv;    /* condition variable for housekeeping thread shutdown */
+    PRInt32 bdb_thread_count;              /* Tells us how many threads are running,
+                                            * used to figure out when they're all stopped */
 } bdb_db_env;
 
 /* structure which holds our stuff */

--- a/ldap/servers/slapd/back-ldbm/import.h
+++ b/ldap/servers/slapd/back-ldbm/import.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2020 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -130,8 +130,8 @@ typedef struct
     char **exclude_subtrees;            /* list of subtrees to NOT import */
     Fifo fifo;                          /* entry fifo for indexing */
     char *task_status;                  /* transient state info for the end-user */
-    PRLock *wire_lock;                  /* lock for serializing wire imports */
-    PRCondVar *wire_cv;                 /* ... and ordering the startup */
+    pthread_mutex_t wire_lock;          /* lock for serializing wire imports */
+    pthread_cond_t wire_cv;             /* ... and ordering the startup */
     PRThread *main_thread;              /* for FRI: import_main() thread id */
     int encrypt;
     Slapi_Value *usn_value; /* entryusn for import */

--- a/ldap/servers/slapd/libmakefile
+++ b/ldap/servers/slapd/libmakefile
@@ -46,7 +46,7 @@ LIBSLAPD_OBJS=plugin_role.o getfilelist.o libglobs.o log.o ch_malloc.o entry.o p
 	filter.o filtercmp.o filterentry.o operation.o schemaparse.o pw.o \
 	backend.o defbackend.o ava.o charray.o regex.o \
 	str2filter.o dynalib.o plugin.o plugin_syntax.o plugin_mr.o \
-	slapi2nspr.o rwlock.o control.o plugin_internal_op.o \
+	slapi2runtime.o rwlock.o control.o plugin_internal_op.o \
 	result.o pw_retry.o agtmmap.o referral.o snmp_collator.o util.o \
 	dse.o errormap.o computed.o match.o fileio.o \
 	generation.o localhost.o ssl.o factory.o auditlog.o \

--- a/ldap/servers/slapd/regex.c
+++ b/ldap/servers/slapd/regex.c
@@ -72,7 +72,7 @@ int
 slapi_re_exec(Slapi_Regex *re_handle, const char *subject, time_t time_up)
 {
     int rc;
-    time_t curtime = slapi_current_utc_time();
+    time_t curtime = slapi_current_rel_time_t();
 
     if (NULL == re_handle || NULL == re_handle->re_pcre || NULL == subject) {
         return LDAP_PARAM_ERROR;

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6088,6 +6088,7 @@ Slapi_CondVar *slapi_new_condvar(Slapi_Mutex *mutex);
 void slapi_destroy_condvar(Slapi_CondVar *cvar);
 int slapi_wait_condvar(Slapi_CondVar *cvar, struct timeval *timeout);
 int slapi_notify_condvar(Slapi_CondVar *cvar, int notify_all);
+int slapi_wait_condvar_pt(Slapi_CondVar *cvar, Slapi_Mutex *mutex, struct timeval *timeout);
 
 /**
  * Creates a new read/write lock
@@ -6769,6 +6770,12 @@ struct timespec slapi_current_time_hr(void);
  * \return timespec of the current monotonic time.
  */
 struct timespec slapi_current_rel_time_hr(void);
+/**
+ * Returns the current system time as a hr clock
+ *
+ * \return time_t of the current monotonic time.
+ */
+time_t slapi_current_rel_time_t(void);
 /**
  * Returns the current system time as a hr clock in UTC timezone.
  * This clock adjusts with ntp steps, and should NOT be

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -377,16 +377,14 @@ slapi_task_status_changed(Slapi_Task *task)
         Slapi_PBlock *pb = slapi_pblock_new();
         Slapi_Entry *e;
         int ttl;
-        time_t expire;
 
         if ((e = get_internal_entry(pb, task->task_dn))) {
             ttl = atoi(slapi_fetch_attr(e, "ttl", DEFAULT_TTL));
             if (ttl > (24*3600))
                 ttl = (24*3600); /* be reasonable, allow to check task status not longer than one day  */
-            expire = time(NULL) + ttl;
             task->task_flags |= SLAPI_TASK_DESTROYING;
             /* queue an event to destroy the state info */
-            slapi_eq_once(destroy_task, (void *)task, expire);
+            slapi_eq_once(destroy_task, (void *)task, slapi_current_rel_time_t() + ttl);
         }
         slapi_free_search_results_internal(pb);
         slapi_pblock_destroy(pb);

--- a/ldap/servers/slapd/time.c
+++ b/ldap/servers/slapd/time.c
@@ -107,6 +107,14 @@ slapi_current_rel_time_hr(void)
     return now;
 }
 
+time_t
+slapi_current_rel_time_t(void)
+{
+    struct timespec now = {0};
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return now.tv_sec;
+}
+
 struct timespec
 slapi_current_utc_time_hr(void)
 {
@@ -292,7 +300,7 @@ slapi_timer_result
 slapi_timespec_expire_check(struct timespec *expire)
 {
     /*
-     * Check this first, as it makes no timeout virutally free.
+     * Check this first, as it makes no timeout virtually free.
      */
     if (expire->tv_sec == 0 && expire->tv_nsec == 0) {
         return TIMER_CONTINUE;


### PR DESCRIPTION
Bug Description:  

All of the server's event handling and replication were based on REALTIME clocks, which can be influenced by the system time changing.  This could causes massive delays, and simply cause unexpected behavior.

Fix Description:  

Move all condition variables to use pthread instead of NSPR functions.  Also make sure we use MONOTONIC clocks when we get the current time when checking for timeouts and other timed events.

All CI tests that could be affected by this code pass.

Relates: https://github.com/389ds/389-ds-base/issues/4384

