### PR TITLE
Issue 4454 - RFE - fix version numbers to allow object caching

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,12 @@ QUOTE := $(NULLSTRING)"# a double quote"
 #
 
 PYTHON := python3
+if DEBUG
+# This allows sccache to work correctly with C files.
+BUILDNUM := "\"0000.000.0000\""
+else
 BUILDNUM := $(shell $(srcdir)/buildnum.py)
+endif
 NQBUILDNUM := $(subst \,,$(subst $(QUOTE),,$(BUILDNUM)))
 DEBUG_DEFINES = @debug_defs@
 DEBUG_CFLAGS = @debug_cflags@

--- a/VERSION.sh
+++ b/VERSION.sh
@@ -47,7 +47,7 @@ PACKAGE_VERSION=$VERSION_MAJOR.$VERSION_MINOR.${VERSION_MAINT}${VERSION_PREREL}
 PACKAGE_TARNAME=${brand}-ds-base
 # url for bug reports
 PACKAGE_BUGREPORT="${PACKAGE_BUGREPORT}enter_bug.cgi?product=$brand"
-PACKAGE_STRING="$PACKAGE_TARNAME $PACKAGE_VERSION"
+# PACKAGE_STRING="$PACKAGE_TARNAME $PACKAGE_VERSION"
 # the version of the ds console package that this directory server
 # is compatible with
 # console .2 is still compatible with 389 .3 for now

--- a/configure.ac
+++ b/configure.ac
@@ -7,16 +7,7 @@ AC_CONFIG_HEADERS([config.h])
 # include the version information
 . $srcdir/VERSION.sh
 AC_MSG_NOTICE(This is configure for $PACKAGE_TARNAME $PACKAGE_VERSION)
-AC_DEFINE_UNQUOTED([DS_PACKAGE_VERSION], "$PACKAGE_VERSION", [package version])
-AC_DEFINE_UNQUOTED([DS_PACKAGE_TARNAME], "$PACKAGE_TARNAME", [package tarball name])
-AC_DEFINE_UNQUOTED([DS_PACKAGE_BUGREPORT], "$PACKAGE_BUGREPORT", [package bug report url])
-AC_DEFINE_UNQUOTED([DS_PACKAGE_STRING], "$PACKAGE_STRING", [package string])
 AM_INIT_AUTOMAKE([1.9 foreign subdir-objects dist-bzip2 no-dist-gzip no-define tar-pax])
-# define these for automake distdir
-VERSION=$PACKAGE_VERSION
-PACKAGE=$PACKAGE_TARNAME
-AC_DEFINE_UNQUOTED([VERSION], "$VERSION", [package version])
-AC_DEFINE_UNQUOTED([PACKAGE], "$PACKAGE", [package tar name])
 AC_SUBST([RPM_VERSION])
 AC_SUBST([RPM_RELEASE])
 AC_SUBST([VERSION_PREREL])
@@ -122,6 +113,11 @@ AC_SUBST([enable_cockpit])
 AC_SUBST(ENABLE_COCKPIT)
 AM_CONDITIONAL([ENABLE_COCKPIT],[test "$enable_cockpit" = yes])
 
+AC_DEFINE_UNQUOTED([DS_PACKAGE_TARNAME], "$PACKAGE_TARNAME", [package tarball name])
+AC_DEFINE_UNQUOTED([DS_PACKAGE_BUGREPORT], "$PACKAGE_BUGREPORT", [package bug report url])
+# define these for automake distdir
+PACKAGE=$PACKAGE_TARNAME
+AC_DEFINE_UNQUOTED([PACKAGE], "$PACKAGE", [package tar name])
 
 AC_MSG_CHECKING(for --enable-debug)
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug], [Enable debug features (default: no)]),
@@ -134,6 +130,11 @@ if test "$enable_debug" = yes ; then
   debug_rust_defs="-C debuginfo=2 -Z macro-backtrace"
   cargo_defs=""
   rust_target_dir="debug"
+  AC_DEFINE_UNQUOTED([DS_PACKAGE_VERSION], "$VERSION_MAJOR.$VERSION_MINOR.$VERSION_MAINT DEVELOPER BUILD", [package version])
+  AC_DEFINE_UNQUOTED([DS_PACKAGE_STRING], "$PACKAGE_TARNAME DEVELOPER BUILD", [package string])
+  # define these for automake distdir
+  VERSION="DEBUG"
+  AC_DEFINE_UNQUOTED([VERSION], "$VERSION", [package version])
 else
   debug_defs=""
   # set the default safe CFLAGS that would be set by AC_PROG_CC otherwise
@@ -142,6 +143,11 @@ else
   debug_rust_defs="-C debuginfo=2"
   cargo_defs="--release"
   rust_target_dir="release"
+  AC_DEFINE_UNQUOTED([DS_PACKAGE_VERSION], "$PACKAGE_VERSION", [package version])
+  AC_DEFINE_UNQUOTED([DS_PACKAGE_STRING], "$PACKAGE_TARNAME $PACKAGE_VERSION", [package string])
+  # define these for automake distdir
+  VERSION=$PACKAGE_VERSION
+  AC_DEFINE_UNQUOTED([VERSION], "$VERSION", [package version])
 fi
 AC_SUBST([debug_defs])
 AC_SUBST([debug_cflags])


### PR DESCRIPTION
Bug Description: ccache and sccache are unable to cache object
files in 389-ds due to the use of BUILDNUM that takes a current
time including minutes, and VERSION.sh using the current
date and git commit which can change between branches.

Fix Description: When using --enable-debug, BUILDNUM and VERSION
are set to 0 or "DEVELOPER BUILD". Since this is now static
object caching can now occuring, reducing developer recompile
times and allowing incremental compilation to work correctly.

fixes: #4454

Author: William Brown <william@blackhats.net.au>

Review by: ???