### PR TITLE
Issue 4446 RFE - openldap password hashers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -374,7 +374,8 @@ serverplugin_LTLIBRARIES = libacl-plugin.la \
 	$(LIBBITWISE_PLUGIN) $(LIBPRESENCE_PLUGIN) $(LIBPOSIX_WINSYNC_PLUGIN)
 
 if RUST_ENABLE
-serverplugin_LTLIBRARIES += libentryuuid-plugin.la libentryuuid-syntax-plugin.la
+serverplugin_LTLIBRARIES += libentryuuid-plugin.la libentryuuid-syntax-plugin.la \
+	libpwdchan-plugin.la
 endif
 
 
@@ -903,7 +904,8 @@ libsds_la_LDFLAGS = $(AM_LDFLAGS) $(SDS_LDFLAGS)
 
 if RUST_ENABLE
 
-noinst_LTLIBRARIES = librsds.la librslapd.la librnsslapd.la libentryuuid.la libentryuuid_syntax.la
+noinst_LTLIBRARIES = librsds.la librslapd.la librnsslapd.la libentryuuid.la libentryuuid_syntax.la \
+	libpwdchan.la
 
 ### Why does this exist?
 #
@@ -1031,10 +1033,33 @@ libentryuuid_syntax_la_EXTRA = src/plugin/entryuuid_syntax/Cargo.lock
 		$(CARGO_FLAGS) --verbose -- $(RUSTC_FLAGS)
 	cp $(ENTRYUUID_SYNTAX_LIB) @abs_top_builddir@/.libs/libentryuuid_syntax.a
 
+# == pwdchan
+
+PWDCHAN_LIB = @abs_top_builddir@/rs/@rust_target_dir@/libpwdchan.a
+
+libpwdchan_la_SOURCES = \
+	src/plugins/pwdchan/Cargo.toml \
+	src/plugins/pwdchan/src/lib.rs \
+	$(libslapi_r_plugin_SOURCES)
+
+libpwdchan_la_EXTRA = src/plugin/pwdchan/Cargo.lock
+
+@abs_top_builddir@/rs/@rust_target_dir@/libpwdchan.a: $(libpwdchan_la_SOURCES) libslapd.la libpwdchan.la
+	RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
+	CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
+	SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
+	SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
+		cargo rustc $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/plugins/pwdchan/Cargo.toml \
+		$(CARGO_FLAGS) --verbose -- $(RUSTC_FLAGS)
+	cp $(PWDCHAN_LIB) @abs_top_builddir@/.libs/libpwdchan.a
+
+# == pwdchan
+
 EXTRA_DIST = $(librsds_la_SOURCES) $(librsds_la_EXTRA) \
 			$(librslapd_la_SOURCES) $(librslapd_la_EXTRA) \
 			$(libentryuuid_la_SOURCES) $(libentryuuid_la_EXTRA) \
 			$(libentryuuid_syntax_la_SOURCES) $(libentryuuid_syntax_la_EXTRA) \
+			$(libpwdchan_la_SOURCES) $(libpwdchan_la_EXTRA) \
 			$(librnsslapd_la_SOURCES) $(librnsslapd_la_EXTRA)
 
 ## Run rust tests
@@ -1042,21 +1067,37 @@ EXTRA_DIST = $(librsds_la_SOURCES) $(librsds_la_EXTRA) \
 if RUST_ENABLE_OFFLINE
 else
 check-local:
-	RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
-	CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
-	SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
-	SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
-		cargo test $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/libsds/Cargo.toml
-	RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
-	CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
-	SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
-	SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
-		cargo test $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/librslapd/Cargo.toml
-	RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
-	CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
-	SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
-	SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
-		cargo test $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/librnsslapd/Cargo.toml
+	for thing in "libsds" "librslapd" "librnsslapd" ; do \
+		echo LD_LIBRARY_PATH=$(abs_top_builddir)/.libs \
+		RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
+		CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
+		SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
+		SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
+			cargo test $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/$${thing}/Cargo.toml ; \
+		LD_LIBRARY_PATH=$(abs_top_builddir)/.libs \
+		RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
+		CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
+		SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
+		SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
+			cargo test $(RUST_OFFLINE) --manifest-path=$(srcdir)/src/$${thing}/Cargo.toml ; \
+	done
+# Plugin tests are a little different
+	for thing in "plugins/pwdchan" ; do \
+		echo LD_LIBRARY_PATH=$(abs_top_builddir)/.libs \
+		RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
+		CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
+		SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
+		SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
+			cargo test $(RUST_OFFLINE) --features=slapi_r_plugin/test_log_direct \
+			--manifest-path=$(srcdir)/src/$${thing}/Cargo.toml -- --nocapture ; \
+		LD_LIBRARY_PATH=$(abs_top_builddir)/.libs \
+		RUST_BACKTRACE=1 RUSTC_BOOTSTRAP=1 \
+		CARGO_TARGET_DIR=$(abs_top_builddir)/rs \
+		SLAPD_DYLIB_DIR=$(abs_top_builddir)/ \
+		SLAPD_HEADER_DIR=$(abs_top_builddir)/ \
+			cargo test $(RUST_OFFLINE) --features=slapi_r_plugin/test_log_direct \
+			--manifest-path=$(srcdir)/src/$${thing}/Cargo.toml -- --nocapture ; \
+	done
 endif
 
 else
@@ -1500,6 +1541,14 @@ libentryuuid_plugin_la_SOURCES = src/slapi_r_plugin/src/init.c
 libentryuuid_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSPR_LINK) -lentryuuid
 libentryuuid_plugin_la_DEPENDENCIES = libslapd.la $(ENTRYUUID_LIB)
 libentryuuid_plugin_la_LDFLAGS = -avoid-version
+
+#------------------------
+# libpwdchan-plugin
+#-----------------------
+libpwdchan_plugin_la_SOURCES = src/slapi_r_plugin/src/init.c
+libpwdchan_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSPR_LINK) -lpwdchan
+libpwdchan_plugin_la_DEPENDENCIES = libslapd.la $(PWDCHAN_LIB)
+libpwdchan_plugin_la_LDFLAGS = -avoid-version
 endif
 
 #------------------------

--- a/dirsrvtests/tests/suites/openldap_2_389/password_migrate_test.py
+++ b/dirsrvtests/tests/suites/openldap_2_389/password_migrate_test.py
@@ -50,10 +50,10 @@ def test_migrate_openldap_password_hash(topology_st):
         '{SHA512}sQnzu7wkTrgkQZF+0G1hi5AI3Qmzvv0bXgc5THBqi7mAsdd4Xll27ASbRt9fEyavWi6m0QP9B8lThf+rDKy8hg==',
         '{SSHA512}+7A8kA32q4mCBao4Cbatdyzl5imVwJ62ZAE7UOTP4pfrF90E9R2LabOfJFzx6guaYhTmUEVK2wRKC8bToqspdeTluX2d1BX2',
         # Need to check --
-        # '{PBKDF2}10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w',
-        # '{PBKDF2-SHA1}10000$ZBEH6B07rgQpJSikyvMU2w$TAA03a5IYkz1QlPsbJKvUsTqNV',
-        # '{PBKDF2-SHA256}10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw',
-        # '{PBKDF2-SHA512}10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA',
+        '{PBKDF2}10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w',
+        '{PBKDF2-SHA1}10000$ZBEH6B07rgQpJSikyvMU2w$TAA03a5IYkz1QlPsbJKvUsTqNV',
+        '{PBKDF2-SHA256}10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw',
+        '{PBKDF2-SHA512}10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA',
         # '{ARGON2}$argon2id$v=19$m=65536,t=2,p=1$IyTQMsvzB2JHDiWx8fq7Ew$VhYOA7AL0kbRXI5g2kOyyp8St1epkNj7WZyUY4pAIQQ',
     ]
 

--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -12,6 +12,9 @@ from lib389.utils import *
 from lib389.topologies import topology_st
 from lib389._constants import DEFAULT_SUFFIX, HOST_STANDALONE, PORT_STANDALONE
 from lib389.idm.user import UserAccounts, TEST_USER_PROPERTIES
+from lib389.paths import Paths
+
+default_paths = Paths()
 
 pytestmark = pytest.mark.tier1
 
@@ -120,10 +123,17 @@ def _test_algo_for_pbkdf2(inst, algo_name):
     inst.delete_s(USER_DN)
 
 
-@pytest.mark.parametrize("algo",
-    ('CLEAR', 'CRYPT', 'CRYPT-MD5', 'CRYPT-SHA256', 'CRYPT-SHA512',
+ALGO_SET = ('CLEAR', 'CRYPT', 'CRYPT-MD5', 'CRYPT-SHA256', 'CRYPT-SHA512',
      'MD5', 'SHA', 'SHA256', 'SHA384', 'SHA512', 'SMD5', 'SSHA',
-     'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',))
+     'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',)
+
+if default_paths.rust_enabled and ds_is_newer('1.4.3.0'):
+    ALGO_SET = ('CLEAR', 'CRYPT', 'CRYPT-MD5', 'CRYPT-SHA256', 'CRYPT-SHA512',
+         'MD5', 'SHA', 'SHA256', 'SHA384', 'SHA512', 'SMD5', 'SSHA',
+         'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',
+         'PBKDF2-SHA1', 'PBKDF2-SHA256', 'PBKDF2-SHA512',)
+
+@pytest.mark.parametrize("algo", ALGO_SET)
 def test_pwd_algo_test(topology_st, algo):
     """Assert that all of our password algorithms correctly PASS and FAIL varying
     password conditions.

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -203,6 +203,60 @@ static const char *internal_entries[] =
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
         "nsslapd-pluginDescription: CRYPT-SHA512\n",
+
+#ifdef RUST_ENABLE
+        "dn: cn=PBKDF2,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "cn: PBKDF2\n"
+        "nsslapd-pluginpath: libpwdchan-plugin\n"
+        "nsslapd-plugininitfunc: pwdchan_pbkdf2_plugin_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: PBKDF2\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: PBKDF2\n",
+
+        "dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "cn: PBKDF2-SHA1\n"
+        "nsslapd-pluginpath: libpwdchan-plugin\n"
+        "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha1_plugin_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: PBKDF2-SHA1\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: PBKDF2-SHA1\n",
+
+        "dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "cn: PBKDF2-SHA256\n"
+        "nsslapd-pluginpath: libpwdchan-plugin\n"
+        "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha256_plugin_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: PBKDF2-SHA256\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: PBKDF2-SHA256\n",
+
+        "dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "cn: PBKDF2-SHA512\n"
+        "nsslapd-pluginpath: libpwdchan-plugin\n"
+        "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: PBKDF2-SHA512\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: PBKDF2-SHA512\n",
+#endif
 };
 
 static int NUM_INTERNAL_ENTRIES = sizeof(internal_entries) / sizeof(internal_entries[0]);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6872,6 +6872,10 @@ slapi_timer_result slapi_timespec_expire_check(struct timespec *expire);
 /*
  * Plugin version.  Note that the Directory Server will load version 01
  * and 02 plugins, but some server features require 03 plugins.
+ *
+ * 2020-11-20 wbrown - The features in question for v03 only are related to
+ * backend features - otherwise it doesn't matter. But for your peace of mind
+ * just make everything version 3.
  */
 #define SLAPI_PLUGIN_VERSION_01 "01"
 #define SLAPI_PLUGIN_VERSION_02 "02"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -40,6 +40,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,9 +120,9 @@ dependencies = [
  "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -208,7 +213,7 @@ dependencies = [
 name = "entryuuid"
 version = "0.1.0"
 dependencies = [
- "cc 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "slapi_r_plugin 0.1.0",
@@ -219,7 +224,7 @@ dependencies = [
 name = "entryuuid_syntax"
 version = "0.1.0"
 dependencies = [
- "cc 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "slapi_r_plugin 0.1.0",
@@ -280,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -323,14 +328,14 @@ name = "librslapd"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "concread 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concread 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "slapd 0.1.0",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -445,7 +450,7 @@ version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,11 +458,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "instant 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lock_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -468,10 +473,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "instant 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -513,6 +518,19 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pwdchan"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slapi_r_plugin 0.1.0",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -626,7 +644,6 @@ dependencies = [
 name = "slapi_r_plugin"
 version = "0.1.0"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -634,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -739,15 +756,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9daec6140ab4dcd38c3dd57e580b59a621172a526ac79f1527af760a55afeafd"
-"checksum cc 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)" = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+"checksum cc 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)" = "ad9c6140b5a2c7db40ea56eb1821245e5362b44385c05b76288b1a599934ac87"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 "checksum cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-"checksum concread 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d2242b1bac936b6a156d2056e3d98d2424d044dbf7bbdaa856c4e6d629cc5aa5"
+"checksum concread 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "14fe52c39ed4e846fb3e6ad4bfe46224ef24db64ff7c5f496d2501c88c270b14"
 "checksum const-random 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
 "checksum const-random-macro 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
 "checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
@@ -762,12 +780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getrandom 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 "checksum getrandom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 "checksum hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
-"checksum instant 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+"checksum instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-"checksum lock_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+"checksum lock_api 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memoffset 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
@@ -780,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 "checksum openssl 0.10.30 (registry+https://github.com/rust-lang/crates.io-index)" = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 "checksum openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)" = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
-"checksum parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+"checksum parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 "checksum parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 "checksum paste 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
 "checksum paste-impl 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
@@ -800,7 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 "checksum serde_derive 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 "checksum serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
-"checksum smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+"checksum smallvec 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "slapi_r_plugin",
     "plugins/entryuuid",
     "plugins/entryuuid_syntax",
+    "plugins/pwdchan",
 ]
 
 [profile.release]

--- a/src/librnsslapd/src/lib.rs
+++ b/src/librnsslapd/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 // It's important that symbol names here are *unique* and do no conflict with symbol
 // names in ../../librslapd/src/lib.rs
 //

--- a/src/librslapd/src/lib.rs
+++ b/src/librslapd/src/lib.rs
@@ -1,10 +1,11 @@
+#![deny(warnings)]
 // It's important that symbol names here are *unique* and do no conflict with symbol
 // names in ../../librnsslapd/src/lib.rs
 //
 // Remember this is just a c-bindgen stub, all logic should come from slapd!
 
-extern crate libc;
 extern crate concread;
+extern crate libc;
 
 use slapd;
 

--- a/src/plugins/pwdchan/Cargo.toml
+++ b/src/plugins/pwdchan/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
-name = "slapi_r_plugin"
+name = "pwdchan"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2018"
-build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-test_log_direct = []
-
 [lib]
 path = "src/lib.rs"
-name = "slapi_r_plugin"
+name = "pwdchan"
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
 libc = "0.2"
 paste = "0.1"
-# lazy_static = "1.4"
+slapi_r_plugin = { path="../../slapi_r_plugin" }
 uuid = { version = "0.8", features = [ "v4" ] }
+openssl = { version = "0.10" }
+base64 = "0.13"
+
+[build-dependencies]
+cc = { version = "1.0", features = ["parallel"] }

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -1,0 +1,264 @@
+#![deny(warnings)]
+#[macro_use]
+extern crate slapi_r_plugin;
+use base64;
+use openssl::{hash::MessageDigest, pkcs5::pbkdf2_hmac, rand::rand_bytes};
+use slapi_r_plugin::prelude::*;
+use std::fmt;
+
+const PBKDF2_ROUNDS: usize = 10_000;
+const PBKDF2_SALT_LEN: usize = 24;
+const PBKDF2_SHA1_EXTRACT: usize = 20;
+const PBKDF2_SHA256_EXTRACT: usize = 32;
+const PBKDF2_SHA512_EXTRACT: usize = 64;
+
+pub mod pbkdf2;
+pub mod pbkdf2_sha1;
+pub mod pbkdf2_sha256;
+pub mod pbkdf2_sha512;
+
+struct PwdChanCrypto;
+
+// OpenLDAP based their PBKDF2 implementation on passlib from python, that uses a
+// non-standard base64 altchar set and padding that is not supported by
+// anything else in the world. To manage this, we only ever encode to base64 with
+// no pad but we have to remap ab64 to b64. This function allows b64 standard with
+// padding to pass, and remaps ab64 to b64 standard with padding.
+macro_rules! ab64_to_b64 {
+    ($ab64:expr) => {{
+        let mut s = $ab64.replace(".", "+");
+        match s.len() & 3 {
+            0 => {
+                // Do nothing
+            }
+            1 => {
+                // One is invalid, do nothing, we'll error in base64
+            }
+            2 => s.push_str("=="),
+            3 => s.push_str("="),
+            _ => unreachable!(),
+        }
+        s
+    }};
+}
+
+impl PwdChanCrypto {
+    #[inline(always)]
+    fn pbkdf2_decompose(encrypted: &str) -> Result<(usize, Vec<u8>, Vec<u8>), PluginError> {
+        let mut part_iter = encrypted.split('$');
+
+        let iter = part_iter
+            .next()
+            .ok_or(PluginError::MissingValue)
+            .and_then(|iter_str| {
+                usize::from_str_radix(iter_str, 10).map_err(|e| {
+                    log_error!(ErrorLevel::Error, "Invalid Integer {} -> {:?}", iter_str, e);
+                    PluginError::InvalidStrToInt
+                })
+            })?;
+
+        let salt = part_iter
+            .next()
+            .ok_or(PluginError::MissingValue)
+            .and_then(|ab64| {
+                let s = ab64_to_b64!(ab64);
+                base64::decode_config(&s, base64::STANDARD.decode_allow_trailing_bits(true))
+                    .map_err(|e| {
+                        log_error!(ErrorLevel::Error, "Invalid Base 64 {} -> {:?}", s, e);
+                        PluginError::InvalidBase64
+                    })
+            })?;
+
+        let hash = part_iter
+            .next()
+            .ok_or(PluginError::MissingValue)
+            .and_then(|ab64| {
+                let s = ab64_to_b64!(ab64);
+                base64::decode_config(&s, base64::STANDARD.decode_allow_trailing_bits(true))
+                    .map_err(|e| {
+                        log_error!(ErrorLevel::Error, "Invalid Base 64 {} -> {:?}", s, e);
+                        PluginError::InvalidBase64
+                    })
+            })?;
+
+        Ok((iter, salt, hash))
+    }
+
+    fn pbkdf2_compare(
+        cleartext: &str,
+        encrypted: &str,
+        digest: MessageDigest,
+    ) -> Result<bool, PluginError> {
+        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted).map_err(|e| {
+            // This means our DB content is flawed.
+            log_error!(ErrorLevel::Error, "invalid hashed pw -> {:?}", e);
+            e
+        })?;
+        // Need to pre-alloc the space as as_mut_slice can't resize.
+        let mut hash_input: Vec<u8> = (0..hash_expected.len()).map(|_| 0).collect();
+
+        pbkdf2_hmac(
+            cleartext.as_bytes(),
+            &salt,
+            iter,
+            digest,
+            hash_input.as_mut_slice(),
+        )
+        .map_err(|e| {
+            log_error!(ErrorLevel::Error, "OpenSSL Error -> {:?}", e);
+            PluginError::OpenSSL
+        })
+        .map(|()| hash_input == hash_expected)
+    }
+
+    fn pbkdf2_encrypt(cleartext: &str, digest: MessageDigest) -> Result<String, PluginError> {
+        let (hash_length, str_length, header) = if digest == MessageDigest::sha1() {
+            (PBKDF2_SHA1_EXTRACT, 80, "{PBKDF2-SHA1}")
+        } else if digest == MessageDigest::sha256() {
+            (PBKDF2_SHA256_EXTRACT, 100, "{PBKDF2-SHA256}")
+        } else if digest == MessageDigest::sha512() {
+            (PBKDF2_SHA512_EXTRACT, 140, "{PBKDF2-SHA512}")
+        } else {
+            return Err(PluginError::Unknown);
+        };
+
+        // generate salt
+        let mut salt: Vec<u8> = (0..PBKDF2_SALT_LEN).map(|_| 0).collect();
+        rand_bytes(salt.as_mut_slice()).map_err(|e| {
+            log_error!(ErrorLevel::Error, "OpenSSL Error -> {:?}", e);
+            PluginError::OpenSSL
+        })?;
+
+        let mut hash_input: Vec<u8> = (0..hash_length).map(|_| 0).collect();
+
+        pbkdf2_hmac(
+            cleartext.as_bytes(),
+            &salt,
+            PBKDF2_ROUNDS,
+            digest,
+            hash_input.as_mut_slice(),
+        )
+        .map_err(|e| {
+            log_error!(ErrorLevel::Error, "OpenSSL Error -> {:?}", e);
+            PluginError::OpenSSL
+        })?;
+
+        let mut output = String::with_capacity(str_length);
+        // Write the header
+        output.push_str(header);
+        // The iter + delim
+        fmt::write(&mut output, format_args!("{}$", PBKDF2_ROUNDS)).map_err(|e| {
+            log_error!(ErrorLevel::Error, "Format Error -> {:?}", e);
+            PluginError::Format
+        })?;
+        // the base64 salt
+        base64::encode_config_buf(&salt, base64::STANDARD, &mut output);
+        // Push the delim
+        output.push_str("$");
+        // Finally the base64 hash
+        base64::encode_config_buf(&hash_input, base64::STANDARD, &mut output);
+        // Return it
+        Ok(output)
+    }
+
+    // Remember, encrypted does *not* have the scheme prepended.
+    #[inline(always)]
+    fn pbkdf2_sha1_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        Self::pbkdf2_compare(cleartext, encrypted, MessageDigest::sha1())
+    }
+
+    #[inline(always)]
+    fn pbkdf2_sha256_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        Self::pbkdf2_compare(cleartext, encrypted, MessageDigest::sha256())
+    }
+
+    #[inline(always)]
+    fn pbkdf2_sha512_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        Self::pbkdf2_compare(cleartext, encrypted, MessageDigest::sha512())
+    }
+
+    #[inline(always)]
+    fn pbkdf2_sha1_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        Self::pbkdf2_encrypt(cleartext, MessageDigest::sha1())
+    }
+
+    #[inline(always)]
+    fn pbkdf2_sha256_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        Self::pbkdf2_encrypt(cleartext, MessageDigest::sha256())
+    }
+
+    #[inline(always)]
+    fn pbkdf2_sha512_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        Self::pbkdf2_encrypt(cleartext, MessageDigest::sha512())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::PwdChanCrypto;
+    /*
+     * '{PBKDF2}10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w'
+     * '{PBKDF2-SHA1}10000$ZBEH6B07rgQpJSikyvMU2w$TAA03a5IYkz1QlPsbJKvUsTqNV'
+     * '{PBKDF2-SHA256}10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw'
+     * '{PBKDF2-SHA512}10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA'
+     * '{ARGON2}$argon2id$v=19$m=65536,t=2,p=1$IyTQMsvzB2JHDiWx8fq7Ew$VhYOA7AL0kbRXI5g2kOyyp8St1epkNj7WZyUY4pAIQQ'
+     */
+
+    #[test]
+    fn pwdchan_pbkdf2_sha1_basic() {
+        let encrypted = "10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w";
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password", encrypted) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password!", encrypted) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("incorrect", encrypted) == Ok(false));
+
+        // this value gave some invalid b64 errors due to trailing bits and padding.
+        let encrypted = "10000$ZBEH6B07rgQpJSikyvMU2w$TAA03a5IYkz1QlPsbJKvUsTqNV";
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password", encrypted) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password!", encrypted) == Ok(false));
+
+        let test_enc = PwdChanCrypto::pbkdf2_sha1_encrypt("password").expect("Failed to hash");
+        // Remove the header and check.
+        let test_enc = test_enc.replace("{PBKDF2-SHA1}", "");
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password", &test_enc) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha1_compare("password!", &test_enc) == Ok(false));
+    }
+
+    #[test]
+    fn pwdchan_pbkdf2_sha256_basic() {
+        let encrypted = "10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("password", encrypted) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("password!", encrypted) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("incorrect", encrypted) == Ok(false));
+
+        // This is a django password with their pbkdf2_sha256$ type.
+        // "pbkdf2_sha256$36000$xIEozuZVAoYm$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w="
+        //            salt -->  xIEozuZVAoYm
+        // django doesn't base64 it's salt, so you need to base64 it to:
+        //                      eElFb3p1WlZBb1lt
+        let encrypted = "36000$eElFb3p1WlZBb1lt$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";
+        assert!(
+            PwdChanCrypto::pbkdf2_sha256_compare("eicieY7ahchaoCh0eeTa", encrypted) == Ok(true)
+        );
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("password!", encrypted) == Ok(false));
+
+        let test_enc = PwdChanCrypto::pbkdf2_sha256_encrypt("password").expect("Failed to hash");
+        // Remove the header and check.
+        let test_enc = test_enc.replace("{PBKDF2-SHA256}", "");
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("password", &test_enc) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha256_compare("password!", &test_enc) == Ok(false));
+    }
+
+    #[test]
+    fn pwdchan_pbkdf2_sha512_basic() {
+        let encrypted = "10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA";
+        assert!(PwdChanCrypto::pbkdf2_sha512_compare("password", encrypted) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha512_compare("password!", encrypted) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_sha512_compare("incorrect", encrypted) == Ok(false));
+
+        let test_enc = PwdChanCrypto::pbkdf2_sha512_encrypt("password").expect("Failed to hash");
+        // Remove the header and check.
+        let test_enc = test_enc.replace("{PBKDF2-SHA512}", "");
+        assert!(PwdChanCrypto::pbkdf2_sha512_compare("password", &test_enc) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_sha512_compare("password!", &test_enc) == Ok(false));
+    }
+}

--- a/src/plugins/pwdchan/src/pbkdf2.rs
+++ b/src/plugins/pwdchan/src/pbkdf2.rs
@@ -1,0 +1,44 @@
+use crate::PwdChanCrypto;
+use slapi_r_plugin::prelude::*;
+use std::os::raw::c_char;
+
+/*
+ *                    /---- plugin ident
+ *                    |          /---- Struct name.
+ *                    V          V
+ */
+slapi_r_plugin_hooks!(pwdchan_pbkdf2, PwdChanPbkdf2);
+
+// PBKDF2 == PBKDF2-SHA1
+struct PwdChanPbkdf2;
+
+impl SlapiPlugin3 for PwdChanPbkdf2 {
+    // We require a newer rust for default associated types.
+    type TaskData = ();
+
+    fn start(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin start");
+        Ok(())
+    }
+
+    fn close(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin close");
+        Ok(())
+    }
+
+    fn has_pwd_storage() -> bool {
+        true
+    }
+
+    fn pwd_scheme_name() -> &'static str {
+        "PBKDF2"
+    }
+
+    fn pwd_storage_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        PwdChanCrypto::pbkdf2_sha1_encrypt(cleartext)
+    }
+
+    fn pwd_storage_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        PwdChanCrypto::pbkdf2_sha1_compare(cleartext, encrypted)
+    }
+}

--- a/src/plugins/pwdchan/src/pbkdf2_sha1.rs
+++ b/src/plugins/pwdchan/src/pbkdf2_sha1.rs
@@ -1,0 +1,44 @@
+use crate::PwdChanCrypto;
+use slapi_r_plugin::prelude::*;
+use std::os::raw::c_char;
+
+/*
+ *                    /---- plugin ident
+ *                    |          /---- Struct name.
+ *                    V          V
+ */
+slapi_r_plugin_hooks!(pwdchan_pbkdf2_sha1, PwdChanPbkdf2Sha1);
+
+// PBKDF2 == PBKDF2-SHA1
+struct PwdChanPbkdf2Sha1;
+
+impl SlapiPlugin3 for PwdChanPbkdf2Sha1 {
+    // We require a newer rust for default associated types.
+    type TaskData = ();
+
+    fn start(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin start");
+        Ok(())
+    }
+
+    fn close(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin close");
+        Ok(())
+    }
+
+    fn has_pwd_storage() -> bool {
+        true
+    }
+
+    fn pwd_scheme_name() -> &'static str {
+        "PBKDF2-SHA1"
+    }
+
+    fn pwd_storage_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        PwdChanCrypto::pbkdf2_sha1_encrypt(cleartext)
+    }
+
+    fn pwd_storage_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        PwdChanCrypto::pbkdf2_sha1_compare(cleartext, encrypted)
+    }
+}

--- a/src/plugins/pwdchan/src/pbkdf2_sha256.rs
+++ b/src/plugins/pwdchan/src/pbkdf2_sha256.rs
@@ -1,0 +1,43 @@
+use crate::PwdChanCrypto;
+use slapi_r_plugin::prelude::*;
+use std::os::raw::c_char;
+
+/*
+ *                    /---- plugin ident
+ *                    |          /---- Struct name.
+ *                    V          V
+ */
+slapi_r_plugin_hooks!(pwdchan_pbkdf2_sha256, PwdChanPbkdf2Sha256);
+
+struct PwdChanPbkdf2Sha256;
+
+impl SlapiPlugin3 for PwdChanPbkdf2Sha256 {
+    // We require a newer rust for default associated types.
+    type TaskData = ();
+
+    fn start(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin start");
+        Ok(())
+    }
+
+    fn close(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin close");
+        Ok(())
+    }
+
+    fn has_pwd_storage() -> bool {
+        true
+    }
+
+    fn pwd_scheme_name() -> &'static str {
+        "PBKDF2-SHA256"
+    }
+
+    fn pwd_storage_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        PwdChanCrypto::pbkdf2_sha256_encrypt(cleartext)
+    }
+
+    fn pwd_storage_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        PwdChanCrypto::pbkdf2_sha256_compare(cleartext, encrypted)
+    }
+}

--- a/src/plugins/pwdchan/src/pbkdf2_sha512.rs
+++ b/src/plugins/pwdchan/src/pbkdf2_sha512.rs
@@ -1,0 +1,43 @@
+use crate::PwdChanCrypto;
+use slapi_r_plugin::prelude::*;
+use std::os::raw::c_char;
+
+/*
+ *                    /---- plugin ident
+ *                    |          /---- Struct name.
+ *                    V          V
+ */
+slapi_r_plugin_hooks!(pwdchan_pbkdf2_sha512, PwdChanPbkdf2Sha512);
+
+struct PwdChanPbkdf2Sha512;
+
+impl SlapiPlugin3 for PwdChanPbkdf2Sha512 {
+    // We require a newer rust for default associated types.
+    type TaskData = ();
+
+    fn start(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin start");
+        Ok(())
+    }
+
+    fn close(_pb: &mut PblockRef) -> Result<(), PluginError> {
+        log_error!(ErrorLevel::Trace, "plugin close");
+        Ok(())
+    }
+
+    fn has_pwd_storage() -> bool {
+        true
+    }
+
+    fn pwd_scheme_name() -> &'static str {
+        "PBKDF2-SHA512"
+    }
+
+    fn pwd_storage_encrypt(cleartext: &str) -> Result<String, PluginError> {
+        PwdChanCrypto::pbkdf2_sha512_encrypt(cleartext)
+    }
+
+    fn pwd_storage_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
+        PwdChanCrypto::pbkdf2_sha512_compare(cleartext, encrypted)
+    }
+}

--- a/src/slapi_r_plugin/build.rs
+++ b/src/slapi_r_plugin/build.rs
@@ -4,5 +4,6 @@ fn main() {
     if let Ok(lib_dir) = env::var("SLAPD_DYLIB_DIR") {
         println!("cargo:rustc-link-lib=dylib=slapd");
         println!("cargo:rustc-link-search=native={}", lib_dir);
+        println!("cargo:rustc-link-search=native={}/.libs", lib_dir);
     }
 }

--- a/src/slapi_r_plugin/src/backend.rs
+++ b/src/slapi_r_plugin/src/backend.rs
@@ -38,7 +38,7 @@ impl BackendRef {
         } else {
             Ok(BackendRefTxn {
                 pb,
-                be: self,
+                _be: self,
                 committed: false,
             })
         }
@@ -47,7 +47,8 @@ impl BackendRef {
 
 pub struct BackendRefTxn {
     pb: Pblock,
-    be: BackendRef,
+    // Used to keep lifetimes in check.
+    _be: BackendRef,
     committed: bool,
 }
 

--- a/src/slapi_r_plugin/src/ber.rs
+++ b/src/slapi_r_plugin/src/ber.rs
@@ -1,4 +1,6 @@
+#[cfg(not(feature = "test_log_direct"))]
 use crate::log::{log_error, ErrorLevel};
+
 use libc;
 use std::ffi::CString;
 // use std::ptr;

--- a/src/slapi_r_plugin/src/charray.rs
+++ b/src/slapi_r_plugin/src/charray.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 use std::ptr;
 
 pub struct Charray {
-    pin: Vec<CString>,
+    _pin: Vec<CString>,
     charray: Vec<*const c_char>,
 }
 
@@ -23,7 +23,7 @@ impl Charray {
             .chain(once(ptr::null()))
             .collect();
 
-        Ok(Charray { pin, charray })
+        Ok(Charray { _pin: pin, charray })
     }
 
     pub fn as_ptr(&self) -> *const *const c_char {

--- a/src/slapi_r_plugin/src/constants.rs
+++ b/src/slapi_r_plugin/src/constants.rs
@@ -104,6 +104,11 @@ pub enum PluginFnType {
     SyntaxValidate = 710,
     /// SLAPI_PLUGIN_SYNTAX_NORMALIZE
     SyntaxNormalize = 711,
+
+    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_ENC_FN
+    PwdStorageEncrypt = 800,
+    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_CMP_FN
+    PwdStorageCompare = 802,
 }
 
 static SV01: [u8; 3] = [b'0', b'1', b'\0'];
@@ -170,6 +175,8 @@ pub(crate) enum PblockType {
     SyntaxNames = 705,
     /// SLAPI_PLUGIN_SYNTAX_OID
     SyntaxOid = 706,
+    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_NAME
+    PwdStorageSchemeName = 810,
 }
 
 /// See ./ldap/include/ldaprot.h

--- a/src/slapi_r_plugin/src/error.rs
+++ b/src/slapi_r_plugin/src/error.rs
@@ -1,6 +1,6 @@
 // use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(i32)]
 pub enum RPluginError {
     Unknown = 500,
@@ -8,7 +8,7 @@ pub enum RPluginError {
     FilterType = 502,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PluginError {
     GenericFailure = -1,
@@ -19,6 +19,11 @@ pub enum PluginError {
     InvalidSyntax = 1004,
     InvalidFilter = 1005,
     TxnFailure = 1006,
+    MissingValue = 1007,
+    InvalidStrToInt = 1008,
+    InvalidBase64 = 1009,
+    OpenSSL = 1010,
+    Format = 1011,
 }
 
 #[derive(Debug)]

--- a/src/slapi_r_plugin/src/lib.rs
+++ b/src/slapi_r_plugin/src/lib.rs
@@ -1,5 +1,6 @@
-#[macro_use]
-extern crate lazy_static;
+#![deny(warnings)]
+// #[macro_use]
+// extern crate lazy_static;
 
 #[macro_use]
 pub mod macros;

--- a/src/slapi_r_plugin/src/modify.rs
+++ b/src/slapi_r_plugin/src/modify.rs
@@ -6,7 +6,7 @@ use crate::plugin::PluginIdRef;
 use crate::value::{slapi_value, ValueArray};
 
 use std::ffi::CString;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::os::raw::c_char;
 
 extern "C" {
@@ -78,7 +78,7 @@ pub struct Modify {
 }
 
 pub struct ModifyResult {
-    pb: Pblock,
+    _pb: Pblock,
 }
 
 impl Modify {
@@ -111,7 +111,7 @@ impl Modify {
         let result = pb.get_op_result();
 
         match result {
-            0 => Ok(ModifyResult { pb }),
+            0 => Ok(ModifyResult { _pb: pb }),
             _e => Err(LDAPError::from(result)),
         }
     }

--- a/src/slapi_r_plugin/src/pblock.rs
+++ b/src/slapi_r_plugin/src/pblock.rs
@@ -258,6 +258,38 @@ impl PblockRef {
         self.set_pb_char_arr_ptr(PblockType::MRNames, arr_ptr)
     }
 
+    pub fn register_pwd_storage_encrypt_fn(
+        &mut self,
+        ptr: extern "C" fn(*const c_char) -> *const c_char,
+    ) -> i32 {
+        let value_ptr: *const libc::c_void = ptr as *const libc::c_void;
+        unsafe {
+            slapi_pblock_set(
+                self.raw_pb,
+                PluginFnType::PwdStorageEncrypt as i32,
+                value_ptr,
+            )
+        }
+    }
+
+    pub fn register_pwd_storage_compare_fn(
+        &mut self,
+        ptr: extern "C" fn(*const c_char, *const c_char) -> i32,
+    ) -> i32 {
+        let value_ptr: *const libc::c_void = ptr as *const libc::c_void;
+        unsafe {
+            slapi_pblock_set(
+                self.raw_pb,
+                PluginFnType::PwdStorageCompare as i32,
+                value_ptr,
+            )
+        }
+    }
+
+    pub fn register_pwd_storage_scheme_name(&mut self, ptr: *const c_char) -> i32 {
+        self.set_pb_char_ptr(PblockType::PwdStorageSchemeName, ptr)
+    }
+
     pub fn get_op_add_entryref(&mut self) -> Result<EntryRef, ()> {
         self.get_value_ptr(PblockType::AddEntry)
             .map(|ptr| EntryRef::new(ptr))

--- a/src/slapi_r_plugin/src/plugin.rs
+++ b/src/slapi_r_plugin/src/plugin.rs
@@ -91,6 +91,10 @@ pub trait SlapiPlugin3 {
         None
     }
 
+    fn has_pwd_storage() -> bool {
+        false
+    }
+
     fn start(_pb: &mut PblockRef) -> Result<(), PluginError>;
 
     fn close(_pb: &mut PblockRef) -> Result<(), PluginError>;
@@ -112,6 +116,18 @@ pub trait SlapiPlugin3 {
     }
 
     fn task_handler(_task: &Task, _data: Self::TaskData) -> Result<Self::TaskData, PluginError> {
+        Err(PluginError::Unimplemented)
+    }
+
+    fn pwd_scheme_name() -> &'static str {
+        panic!("Unimplemented pwd_scheme_name for password storage plugin")
+    }
+
+    fn pwd_storage_encrypt(_cleartext: &str) -> Result<String, PluginError> {
+        Err(PluginError::Unimplemented)
+    }
+
+    fn pwd_storage_compare(_cleartext: &str, _encrypted: &str) -> Result<bool, PluginError> {
         Err(PluginError::Unimplemented)
     }
 }

--- a/src/slapi_r_plugin/src/search.rs
+++ b/src/slapi_r_plugin/src/search.rs
@@ -53,7 +53,7 @@ pub struct Search {
 }
 
 pub struct SearchResult {
-    pb: Pblock,
+    _pb: Pblock,
 }
 
 impl Search {
@@ -120,7 +120,7 @@ impl Search {
         let result = pb.get_op_result();
 
         match result {
-            0 => Ok(SearchResult { pb }),
+            0 => Ok(SearchResult { _pb: pb }),
             _e => Err(LDAPError::from(result)),
         }
     }


### PR DESCRIPTION
Bug Description: To allow easier migrations, we need to support
some password types that OpenLDAP has that we do not. This
is mainly PBKDF2 types. OpenLDAP's hashers are
based on python passlib, so they also store the values in
a different way than our PBDKF2 module.

Fix Description: This adds passlib style PBKDF2 support, written
in Rust. It extends the slapi_r_plugin shim to support password
extensions for Rust plugins, as well as providing a number of
small improvements to the build system and testing for rust
plugins.

fixes: #4446 

Author: William Brown <william@blackhats.net.au>

Review by: ???