### PR TITLE
Backport healthcheck changes to branch 1.4.3 and fix failing tests

### DIFF
--- a/dirsrvtests/requirements.txt
+++ b/dirsrvtests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-libfaketime

--- a/dirsrvtests/tests/suites/clu/dsidm_account_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_test.py
@@ -26,7 +26,7 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
-def check_value_and_reset(topology, content_list=None, content_list2=None, check_value=None, check_value_not=None):
+def check_value_in_log_and_reset(topology, content_list=None, content_list2=None, check_value=None, check_value_not=None):
         if content_list2 is not None:
             log.info('Check if content is present in output')
             for item in content_list + content_list2:

--- a/dirsrvtests/tests/suites/healthcheck/__init__.py
+++ b/dirsrvtests/tests/suites/healthcheck/__init__.py
@@ -1,0 +1,3 @@
+"""
+   :Requirement: 389-ds-base: HealthCheck
+"""

--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -1,0 +1,441 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+import subprocess
+
+from lib389.backend import Backends
+from lib389.cos import CosTemplates, CosPointerDefinitions
+from lib389.dbgen import dbgen_users
+from lib389.idm.account import Accounts
+from lib389.index import Index
+from lib389.plugins import ReferentialIntegrityPlugin
+from lib389.utils import *
+from lib389._constants import *
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_st
+from lib389.cli_ctl.health import health_check_run
+from lib389.paths import Paths
+
+
+CMD_OUTPUT = 'No issues found.'
+JSON_OUTPUT = '[]'
+
+ds_paths = Paths()
+pytestmark = [pytest.mark.skipif(ds_paths.perl_enabled and (os.getenv('PYINSTALL') is None),
+                                reason="These tests need to use python installer"),  pytest.mark.tier1]
+
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = None
+    args.dry_run = False
+
+    if json:
+        log.info('Use healthcheck with --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+    else:
+        log.info('Use healthcheck without --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+
+    log.info('Clear the log')
+    topology.logcap.flush()
+
+
+@pytest.fixture(scope="function")
+def setup_ldif(topology_st, request):
+    log.info("Generating LDIF...")
+    ldif_dir = topology_st.standalone.get_ldif_dir()
+    global import_ldif
+    import_ldif = ldif_dir + '/basic_import.ldif'
+    dbgen_users(topology_st.standalone, 5000, import_ldif, DEFAULT_SUFFIX)
+
+    def fin():
+        log.info('Delete file')
+        os.remove(import_ldif)
+
+    request.addfinalizer(fin)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_logging_format_should_be_revised(topology_st):
+    """Check if HealthCheck returns DSCLE0001 code
+
+    :id: 277d7980-123b-481b-acba-d90921b9f5ac
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set nsslapd-logging-hr-timestamps-enabled to 'off'
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. Set nsslapd-logging-hr-timestamps-enabled to 'on'
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCLE0001 code and related details
+        4. Healthcheck reports DSCLE0001 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSCLE0001'
+
+    standalone = topology_st.standalone
+
+    log.info('Set nsslapd-logging-hr-timestamps-enabled to off')
+    standalone.config.set('nsslapd-logging-hr-timestamps-enabled', 'off')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info('Set nsslapd-logging-hr-timestamps-enabled to off')
+    standalone.config.set('nsslapd-logging-hr-timestamps-enabled', 'on')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_RI_plugin_is_misconfigured(topology_st):
+    """Check if HealthCheck returns DSRILE0001 code
+
+    :id: de2e90a2-89fe-472c-acdb-e13cbca5178d
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Configure the instance with Integrity Plugin
+        3. Set the referint-update-delay attribute of the RI plugin, to a value upper than 0
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+        6. Set the referint-update-delay attribute to 0
+        7. Use HealthCheck without --json option
+        8. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports DSRILE0001 code and related details
+        5. Healthcheck reports DSRILE0001 code and related details
+        6. Success
+        7. Healthcheck reports no issue found
+        8. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSRILE0001'
+
+    standalone = topology_st.standalone
+
+    plugin = ReferentialIntegrityPlugin(standalone)
+    plugin.disable()
+    plugin.enable()
+
+    log.info('Set the referint-update-delay attribute to a value upper than 0')
+    plugin.replace('referint-update-delay', '5')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info('Set the referint-update-delay attribute back to 0')
+    plugin.replace('referint-update-delay', '0')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_RI_plugin_missing_indexes(topology_st):
+    """Check if HealthCheck returns DSRILE0002 code
+
+    :id: 05c55e37-bb3e-48d1-bbe8-29c980f94f10
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Configure the instance with Integrity Plugin
+        3. Change the index type of the member attribute index to ‘approx’
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+        6. Set the index type of the member attribute index to ‘eq’
+        7. Use HealthCheck without --json option
+        8. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports DSRILE0002 code and related details
+        5. Healthcheck reports DSRILE0002 code and related details
+        6. Success
+        7. Healthcheck reports no issue found
+        8. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSRILE0002'
+    MEMBER_DN = 'cn=member,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config'
+
+    standalone = topology_st.standalone
+
+    log.info('Enable RI plugin')
+    plugin = ReferentialIntegrityPlugin(standalone)
+    plugin.disable()
+    plugin.enable()
+
+    log.info('Change the index type of the member attribute index to approx')
+    index = Index(topology_st.standalone, MEMBER_DN)
+    index.replace('nsIndexType', 'approx')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info('Set the index type of the member attribute index back to eq')
+    index.replace('nsIndexType', 'eq')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_virtual_attr_incorrectly_indexed(topology_st):
+    """Check if HealthCheck returns DSVIRTLE0001 code
+
+    :id: 1055173b-21aa-4aaa-9e91-4dc6c5e0c01f
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Create a CoS definition entry
+        3. Create the matching CoS template entry, with postalcode as virtual attribute
+        4. Create an index for postalcode
+        5. Use HealthCheck without --json option
+        6. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Healthcheck reports DSVIRTLE0001 code and related details
+        6. Healthcheck reports DSVIRTLE0001 code and related details
+    """
+
+    RET_CODE = 'DSVIRTLE0001'
+
+    standalone = topology_st.standalone
+    postal_index_properties = {
+        'cn': 'postalcode',
+        'nsSystemIndex': 'False',
+        'nsIndexType': ['eq', 'sub', 'pres'],
+    }
+
+    log.info('Add cosPointer, cosTemplate and test entry to default suffix, where virtual attribute is postal code')
+    cos_pointer_properties = {
+        'cn': 'cosPointer',
+        'description': 'cosPointer example',
+        'cosTemplateDn': 'cn=cosTemplateExample,ou=People,dc=example,dc=com',
+        'cosAttribute': 'postalcode',
+    }
+    cos_pointer_definitions = CosPointerDefinitions(standalone, DEFAULT_SUFFIX, 'ou=People')
+    cos_pointer_definitions.create(properties=cos_pointer_properties)
+
+    log.info('Create CoS template')
+    cos_template_properties = {
+        'cn': 'cosTemplateExample',
+        'postalcode': '117'
+    }
+    cos_templates = CosTemplates(standalone, DEFAULT_SUFFIX, 'ou=People')
+    cos_templates.create(properties=cos_template_properties)
+
+    log.info('Create an index for postalcode')
+    backends = Backends(topology_st.standalone)
+    ur_indexes = backends.get('userRoot').get_indexes()
+    ur_indexes.create(properties=postal_index_properties)
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+@pytest.mark.xfail(ds_is_older("1.4.2.4"), reason="May fail because of bug 1796050")
+def test_healthcheck_low_disk_space(topology_st):
+    """Check if HealthCheck returns DSDSLE0001 code
+
+    :id: 144b335d-077e-430c-9c0e-cd6b0f2f73c1
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Get the free disk space for /
+        3. Use fallocate to create a file large enough for the use % be up 90%
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports DSDSLE0001 code and related details
+        5. Healthcheck reports DSDSLE0001 code and related details
+    """
+
+    RET_CODE = 'DSDSLE0001'
+
+    standalone = topology_st.standalone
+    file = '{}/foo'.format(standalone.ds_paths.log_dir)
+
+    log.info('Count the disk space to allocate')
+    total_size = int(re.findall(r'\d+', str(os.statvfs(standalone.ds_paths.log_dir)))[2]) * 4096
+    avail_size = round(int(re.findall(r'\d+', str(os.statvfs(standalone.ds_paths.log_dir)))[3]) * 4096)
+    used_size = total_size - avail_size
+    count_total_percent = total_size * 0.92
+    final_value = count_total_percent - used_size
+
+    log.info('Create a file large enough for the use % be up 90%')
+    subprocess.call(['fallocate', '-l', str(round(final_value)), file])
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    log.info('Remove created file')
+    os.remove(file)
+
+
+@pytest.mark.ds50791
+@pytest.mark.bz1843567
+@pytest.mark.xfail(ds_is_older("1.4.3.8"), reason="Not implemented")
+def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
+    """Check if HealthCheck returns DSLOGNOTES0001 code
+
+    :id: b25f7027-d43f-4ec2-ac49-9c9bb285df1d
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set nsslapd-accesslog-logbuffering to off
+        3. Import users from created ldif file
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports DSLOGNOTES0001
+        5. Healthcheck reports DSLOGNOTES0001
+    """
+
+    RET_CODE = 'DSLOGNOTES0001'
+
+    standalone = topology_st.standalone
+
+    log.info('Delete the previous access logs')
+    topology_st.standalone.deleteAccessLogs()
+
+    log.info('Set nsslapd-accesslog-logbuffering to off')
+    standalone.config.set("nsslapd-accesslog-logbuffering", "off")
+
+    log.info('Stopping the server and running offline import...')
+    standalone.stop()
+    assert standalone.ldif2db(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX], encrypt=None, excludeSuffixes=None,
+                              import_file=import_ldif)
+    standalone.start()
+
+    log.info('Use filters to reproduce "notes=A" in access log')
+    accounts = Accounts(standalone, DEFAULT_SUFFIX)
+    accounts.filter('(uid=test*)')
+
+    log.info('Check that access log contains "notes=A"')
+    assert standalone.ds_access_log.match(r'.*notes=A.*')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+
+@pytest.mark.ds50791
+@pytest.mark.bz1843567
+@pytest.mark.xfail(ds_is_older("1.4.3.8"), reason="Not implemented")
+def test_healthcheck_notes_unknown_attribute(topology_st, setup_ldif):
+    """Check if HealthCheck returns DSLOGNOTES0002 code
+
+    :id: 71ccd1d7-3c71-416b-9d2a-27f9f6633101
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set nsslapd-accesslog-logbuffering to off
+        3. Import users from created ldif file
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports DSLOGNOTES0002
+        5. Healthcheck reports DSLOGNOTES0002
+    """
+
+    RET_CODE = 'DSLOGNOTES0002'
+
+    standalone = topology_st.standalone
+
+    log.info('Delete the previous access logs')
+    topology_st.standalone.deleteAccessLogs()
+
+    log.info('Set nsslapd-accesslog-logbuffering to off')
+    standalone.config.set("nsslapd-accesslog-logbuffering", "off")
+
+    log.info('Stopping the server and running offline import...')
+    standalone.stop()
+    assert standalone.ldif2db(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX], encrypt=None, excludeSuffixes=None,
+                              import_file=import_ldif)
+    standalone.start()
+
+    log.info('Use filters to reproduce "notes=F" in access log')
+    accounts = Accounts(standalone, DEFAULT_SUFFIX)
+    accounts.filter('(unknown=test)')
+
+    log.info('Check that access log contains "notes=F"')
+    assert standalone.ds_access_log.match(r'.*notes=F.*')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -1,0 +1,270 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+import subprocess
+import distro
+
+from lib389.idm.user import UserAccounts
+from lib389.replica import Changelog5, ReplicationManager, Replicas
+from lib389.utils import *
+from lib389._constants import *
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_m2, topology_m3
+from lib389.cli_ctl.health import health_check_run
+from lib389.paths import Paths
+
+CMD_OUTPUT = 'No issues found.'
+JSON_OUTPUT = '[]'
+
+ds_paths = Paths()
+pytestmark = [pytest.mark.skipif(ds_paths.perl_enabled and (os.getenv('PYINSTALL') is None),
+                                reason="These tests need to use python installer"),  pytest.mark.tier1]
+
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = None
+    args.dry_run = False
+
+    if json:
+        log.info('Use healthcheck with --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+    else:
+        log.info('Use healthcheck without --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+
+    log.info('Clear the log')
+    topology.logcap.flush()
+
+
+def set_changelog_trimming(instance):
+    log.info('Get the changelog enteries')
+    inst_changelog = Changelog5(instance)
+
+    log.info('Set nsslapd-changelogmaxage to 30d')
+    inst_changelog.add('nsslapd-changelogmaxage', '30')
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication_replica_not_reachable(topology_m2):
+    """Check if HealthCheck returns DSREPLLE0005 code
+
+    :id: d452a564-7b82-4c1a-b331-a71abbd82a10
+    :setup: Replicated topology
+    :steps:
+        1. Create a replicated topology
+        2. On M1, set nsds5replicaport for the replication agreement to an unreachable port on the replica
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. On M1, set nsds5replicaport for the replication agreement to a reachable port number
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSREPLLE0005 code and related details
+        4. Healthcheck reports DSREPLLE0005 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSREPLLE0005'
+
+    M1 = topology_m2.ms['master1']
+    M2 = topology_m2.ms['master2']
+
+    set_changelog_trimming(M1)
+
+    log.info('Set nsds5replicaport for the replication agreement to an unreachable port')
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.wait_for_replication(M1, M2)
+
+    replica_m1 = Replicas(M1).get(DEFAULT_SUFFIX)
+    agmt_m1 = replica_m1.get_agreements().list()[0]
+    agmt_m1.replace('nsds5replicaport', '4389')
+
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=True)
+
+    log.info('Set nsds5replicaport for the replication agreement to a reachable port')
+    agmt_m1.replace('nsDS5ReplicaPort', '{}'.format(M2.port))
+    repl.wait_for_replication(M1, M2)
+
+    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_changelog_trimming_not_configured(topology_m2):
+    """Check if HealthCheck returns DSCLLE0001 code
+
+    :id: c2165032-88ba-4978-a4ca-2fecfd8c35d8
+    :setup: Replicated topology
+    :steps:
+        1. Create a replicated topology
+        2. On M1, check that value of nsslapd-changelogmaxage from cn=changelog5,cn=config is None
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. On M1, set nsslapd-changelogmaxage to 30d
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCLLE0001 code and related details
+        4. Healthcheck reports DSCLLE0001 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    M1 = topology_m2.ms['master1']
+    M2 = topology_m2.ms['master2']
+
+    RET_CODE = 'DSCLLE0001'
+
+    log.info('Get the changelog entries for M1')
+    changelog_m1 = Changelog5(M1)
+
+    log.info('Check nsslapd-changelogmaxage value')
+    if changelog_m1.get_attr_val('nsslapd-changelogmaxage') is not None:
+        changelog_m1.remove_all('nsslapd-changelogmaxage')
+
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=True)
+
+    set_changelog_trimming(M1)
+
+    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication_presence_of_conflict_entries(topology_m2):
+    """Check if HealthCheck returns DSREPLLE0002 code
+
+    :id: 43abc6c6-2075-42eb-8fa3-aa092ff64cba
+    :setup: Replicated topology
+    :steps:
+        1. Create a replicated topology
+        2. Create conflict entries : different entries renamed to the same dn
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSREPLLE0002 code and related details
+        4. Healthcheck reports DSREPLLE0002 code and related details
+    """
+
+    RET_CODE = 'DSREPLLE0002'
+
+    M1 = topology_m2.ms['master1']
+    M2 = topology_m2.ms['master2']
+
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.wait_for_replication(M1, M2)
+
+    topology_m2.pause_all_replicas()
+
+    log.info("Create conflict entries")
+    test_users_m1 = UserAccounts(M1, DEFAULT_SUFFIX)
+    test_users_m2 = UserAccounts(M2, DEFAULT_SUFFIX)
+    user_num = 1000
+    test_users_m1.create_test_user(user_num, 2000)
+    test_users_m2.create_test_user(user_num, 2000)
+
+    topology_m2.resume_all_replicas()
+
+    repl.test_replication_topology(topology_m2)
+
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, RET_CODE, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication_out_of_sync_broken(topology_m3):
+    """Check if HealthCheck returns DSREPLLE0001 code
+
+    :id: b5ae7cae-de0f-4206-95a4-f81538764bea
+    :setup: 3 MMR topology
+    :steps:
+        1. Create a 3 masters full-mesh topology, on M2 and M3 don’t set nsds5BeginReplicaRefresh:start
+        2. Perform modifications on M1
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSREPLLE0001 code and related details
+        4. Healthcheck reports DSREPLLE0001 code and related details
+    """
+
+    RET_CODE = 'DSREPLLE0001'
+
+    M1 = topology_m3.ms['master1']
+    M2 = topology_m3.ms['master2']
+    M3 = topology_m3.ms['master3']
+
+    log.info('Break master2 and master3')
+    replicas = Replicas(M2)
+    replica = replicas.list()[0]
+    replica.replace('nsds5ReplicaBindDNGroup', 'cn=repl')
+
+    replicas = Replicas(M3)
+    replica = replicas.list()[0]
+    replica.replace('nsds5ReplicaBindDNGroup', 'cn=repl')
+
+    log.info('Perform update on master1')
+    test_users_m1 = UserAccounts(M1, DEFAULT_SUFFIX)
+    test_users_m1.create_test_user(1005, 2000)
+
+    run_healthcheck_and_flush_log(topology_m3, M1, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_m3, M1, RET_CODE, json=True)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -1,0 +1,361 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+import subprocess
+import distro
+
+
+from datetime import *
+from lib389.config import Encryption
+from lib389.utils import *
+from lib389._constants import *
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_st
+from lib389.cli_ctl.health import health_check_run
+from lib389.paths import Paths
+
+CMD_OUTPUT = 'No issues found.'
+JSON_OUTPUT = '[]'
+
+ds_paths = Paths()
+pytestmark = [pytest.mark.skipif(ds_paths.asan_enabled or ds_paths.perl_enabled and (os.getenv('PYINSTALL') is None),
+                                reason="These tests can only be run with python installer and disabled ASAN"),
+              pytest.mark.tier1]
+
+libfaketime = pytest.importorskip('libfaketime')
+libfaketime.reexec_if_needed()
+
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def is_fips():
+    if os.path.exists('/proc/sys/crypto/fips_enabled'):
+        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
+            state = f.readline().strip()
+            if state == '1':
+                return True
+            else:
+                return False
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = None
+    args.dry_run = False
+
+    if json:
+        log.info('Use healthcheck with --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+    else:
+        log.info('Use healthcheck without --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+
+    log.info('Clear the log')
+    topology.logcap.flush()
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_insecure_pwd_hash_configured(topology_st):
+    """Check if HealthCheck returns DSCLE0002 code
+
+    :id: 6baf949c-a5eb-4f4e-83b4-8302e677758a
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Configure an insecure passwordStorageScheme (as SHA) for the instance
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCLE0002 code and related details
+        4. Healthcheck reports DSCLE0002 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSCLE0002'
+
+    standalone = topology_st.standalone
+
+    log.info('Configure an insecure passwordStorageScheme (SHA)')
+    standalone.config.set('passwordStorageScheme', 'SHA')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    if is_fips():
+        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to SSHA512 in FIPS mode')
+        standalone.config.set('passwordStorageScheme', 'SSHA512')
+        standalone.config.set('nsslapd-rootpwstoragescheme', 'SSHA512')
+    else:
+        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256')
+        standalone.config.set('passwordStorageScheme', 'PBKDF2_SHA256')
+        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2_SHA256')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_min_allowed_tls_version_too_low(topology_st):
+    """Check if HealthCheck returns DSELE0001 code
+
+    :id: a4be3390-9508-4827-8f82-e4e21081caab
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set the TLS minimum version to TLS1.0
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. Set the TLS minimum version to TLS1.2
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSELE0001 code and related details
+        4. Healthcheck reports DSELE0001 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSELE0001'
+    HIGHER_VS = 'TLS1.2'
+    SMALL_VS = 'TLS1.0'
+    RHEL = 'Red Hat Enterprise Linux'
+
+    standalone = topology_st.standalone
+
+    standalone.enable_tls()
+
+    # We have to update-crypto-policies to LEGACY, otherwise we can't set TLS1.0
+    log.info('Updating crypto policies')
+    assert subprocess.check_call(['update-crypto-policies', '--set', 'LEGACY']) == 0
+
+    log.info('Set the TLS minimum version to TLS1.0')
+    enc = Encryption(standalone)
+    enc.replace('sslVersionMin', SMALL_VS)
+    standalone.restart()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info('Set the TLS minimum version to TLS1.2')
+    enc.replace('sslVersionMin', HIGHER_VS)
+    standalone.restart()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+    if RHEL in distro.linux_distribution():
+        log.info('Set crypto-policies back to DEFAULT')
+        assert subprocess.check_call(['update-crypto-policies', '--set', 'DEFAULT']) == 0
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_resolvconf_bad_file_perm(topology_st):
+    """Check if HealthCheck returns DSPERMLE0001 code
+
+    :id: 8572b9e9-70e7-49e9-b745-864f6f2468a8
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Change the /etc/resolv.conf file permissions to 444
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. set /etc/resolv.conf permissions to 644
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSPERMLE0001 code and related details
+        4. Healthcheck reports DSPERMLE0001 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSPERMLE0001'
+
+    standalone = topology_st.standalone
+
+    log.info('Change the /etc/resolv.conf file permissions to 444')
+    os.chmod('/etc/resolv.conf', 0o444)
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    log.info('Change the /etc/resolv.conf file permissions to 644')
+    os.chmod('/etc/resolv.conf', 0o644)
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_pwdfile_bad_file_perm(topology_st):
+    """Check if HealthCheck returns DSPERMLE0002 code
+
+    :id: ec137d66-bad6-4eed-90bd-fc1d572bbe1f
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Change the /etc/dirsrv/slapd-xxx/pwdfile.txt permissions to 000
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. Change the /etc/dirsrv/slapd-xxx/pwdfile.txt permissions to 400
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSPERMLE0002 code and related details
+        4. Healthcheck reports DSPERMLE0002 code and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE = 'DSPERMLE0002'
+
+    standalone = topology_st.standalone
+    cert_dir = standalone.ds_paths.cert_dir
+
+    log.info('Change the /etc/dirsrv/slapd-{}/pwdfile.txt permissions to 000'.format(standalone.serverid))
+    os.chmod('{}/pwdfile.txt'.format(cert_dir), 0o000)
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    log.info('Change the /etc/dirsrv/slapd-{}/pwdfile.txt permissions to 400'.format(standalone.serverid))
+    os.chmod('{}/pwdfile.txt'.format(cert_dir), 0o400)
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_certif_expiring_within_30d(topology_st):
+    """Check if HealthCheck returns DSCERTLE0001 code
+
+    :id: c2165032-88ba-4978-a4ca-2fecfd8c35d8
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Use libfaketime to tell the process the date is within 30 days before certificate expiration
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCERTLE0001 code and related details
+        4. Healthcheck reports DSCERTLE0001 code and related details
+    """
+
+    RET_CODE = 'DSCERTLE0001'
+
+    standalone = topology_st.standalone
+
+    standalone.enable_tls()
+
+    # Cert is valid two years from today, so we count the date that is within 30 days before certificate expiration
+    date_future = datetime.now() + timedelta(days=701)
+
+    with libfaketime.fake_time(date_future):
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    # Try again with real time just to make sure no issues were found
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_certif_expired(topology_st):
+    """Check if HealthCheck returns DSCERTLE0002 code
+
+    :id: ceff2c22-62c0-4fd9-b737-930a88458d68
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Use libfaketime to tell the process the date is after certificate expiration
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCERTLE0002 code and related details
+        4. Healthcheck reports DSCERTLE0002 code and related details
+    """
+
+    RET_CODE = 'DSCERTLE0002'
+
+    standalone = topology_st.standalone
+
+    standalone.enable_tls()
+
+    # Cert is valid two years from today, so we count the date that is after expiration
+    date_future = datetime.now() + timedelta(days=731)
+
+    with libfaketime.fake_time(date_future):
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    # Try again with real time just to make sure no issues were found
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/healthcheck/health_sync_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_sync_test.py
@@ -1,0 +1,137 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+
+from datetime import *
+from lib389.agreement import Agreements
+from lib389.idm.user import UserAccounts
+from lib389.utils import *
+from lib389._constants import *
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_m3
+from lib389.cli_ctl.health import health_check_run
+from lib389.paths import Paths
+
+
+ds_paths = Paths()
+pytestmark = [pytest.mark.skipif(ds_paths.perl_enabled and (os.getenv('PYINSTALL') is None),
+                                reason="These tests need to use python installer"), pytest.mark.tier1]
+
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = None
+    args.dry_run = False
+
+    if json:
+        log.info('Use healthcheck with --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+    else:
+        log.info('Use healthcheck without --json option')
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info('Healthcheck returned searched code: %s' % searched_code2)
+
+    log.info('Clear the log')
+    topology.logcap.flush()
+
+
+# This test is in separate file because it is timeout specific
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication_out_of_sync_not_broken(topology_m3):
+    """Check if HealthCheck returns DSREPLLE0003 code
+
+    :id: 8305000d-ba4d-4c00-8331-be0e8bd92150
+    :setup: 3 MMR topology
+    :steps:
+        1. Create a 3 masters full-mesh topology, all replicas being synchronized
+        2. Stop M1
+        3. Perform an update on M2 and M3.
+        4. Check M2 and M3 are synchronized.
+        5. From M2, reinitialize the M3 agreement
+        6. Stop M2 and M3
+        7. Restart M1
+        8. Start M3
+        9. Use HealthCheck without --json option
+        10. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Healthcheck reports DSREPLLE0003 code and related details
+        10. Healthcheck reports DSREPLLE0003 code and related details
+    """
+
+    RET_CODE = 'DSREPLLE0003'
+
+    M1 = topology_m3.ms['master1']
+    M2 = topology_m3.ms['master2']
+    M3 = topology_m3.ms['master3']
+
+    log.info('Stop master1')
+    M1.stop()
+
+    log.info('Perform update on master2 and master3')
+    test_users_m2 = UserAccounts(M2, DEFAULT_SUFFIX)
+    test_users_m3 = UserAccounts(M3, DEFAULT_SUFFIX)
+    test_users_m2.create_test_user(1000, 2000)
+    test_users_m3.create_test_user(1001, 2000)
+
+    log.info('Init M2->M3 agreement')
+    agmt = Agreements(M2).list()[1]
+    agmt.begin_reinit()
+    agmt.wait_reinit()
+
+    log.info('Stop M2 and M3')
+    M2.stop()
+    M3.stop()
+
+    log.info('Start M1 first, then M3')
+    M1.start()
+    M3.start()
+
+    run_healthcheck_and_flush_log(topology_m3, M3, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_m3, M3, RET_CODE, json=True)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -1,0 +1,492 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+
+from lib389.backend import Backends
+from lib389.mappingTree import MappingTrees
+from lib389.replica import Changelog5
+from lib389.utils import *
+from lib389._constants import *
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_st, topology_no_sample, topology_m2
+from lib389.cli_ctl.health import health_check_run
+from lib389.paths import Paths
+
+CMD_OUTPUT = 'No issues found.'
+JSON_OUTPUT = '[]'
+
+ds_paths = Paths()
+pytestmark = [pytest.mark.skipif(ds_paths.perl_enabled and (os.getenv('PYINSTALL') is None),
+                                reason="These tests need to use python installer"), pytest.mark.tier1]
+
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=False, searched_code2=None,
+                                  list_checks=False, list_errors=False, check=None, searched_list=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = list_errors
+    args.list_checks = list_checks
+    args.check = check
+    args.dry_run = False
+    args.json = json
+
+    log.info('Use healthcheck with --json == {} option'.format(json))
+    health_check_run(instance, topology.logcap.log, args)
+
+    if searched_list is not None:
+        for item in searched_list:
+            assert topology.logcap.contains(item)
+            log.info('Healthcheck returned searched item: %s' % item)
+    else:
+        assert topology.logcap.contains(searched_code)
+        log.info('Healthcheck returned searched code: %s' % searched_code)
+
+    if searched_code2 is not None:
+        assert topology.logcap.contains(searched_code2)
+        log.info('Healthcheck returned searched code: %s' % searched_code2)
+
+    log.info('Clear the log')
+    topology.logcap.flush()
+
+
+def set_changelog_trimming(instance):
+    log.info('Get the changelog enteries')
+    inst_changelog = Changelog5(instance)
+
+    log.info('Set nsslapd-changelogmaxage to 30d')
+    inst_changelog.add('nsslapd-changelogmaxage', '30')
+
+
+def test_healthcheck_disabled_suffix(topology_st):
+    """Test that we report when a suffix is disabled
+
+    :id: 49ebce72-7e7b-4eff-8bd9-8384d12251b4
+    :setup: Standalone Instance
+    :steps:
+        1. Disable suffix
+        2. Use HealthCheck without --json option
+        3. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. HealthCheck should return code DSBLE0002
+        3. HealthCheck should return code DSBLE0002
+    """
+
+    RET_CODE = 'DSBLE0002'
+
+    mts = MappingTrees(topology_st.standalone)
+    mt = mts.get(DEFAULT_SUFFIX)
+    mt.replace("nsslapd-state", "disabled")
+
+    run_healthcheck_and_flush_log(topology_st, topology_st.standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, topology_st.standalone, RET_CODE, json=True)
+
+    # reset the suffix state
+    mt.replace("nsslapd-state", "backend")
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_standalone(topology_st):
+    """Check functionality of HealthCheck Tool on standalone instance with no errors
+
+    :id: 4844b446-3939-4fbd-b14b-293b20bb8be0
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Use HealthCheck without --json option
+        3. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    standalone = topology_st.standalone
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT,json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50746
+@pytest.mark.bz1816851
+@pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
+def test_healthcheck_list_checks(topology_st):
+    """Check functionality of HealthCheck Tool with --list-checks option
+
+    :id: 44b1d8d3-b94a-4c2d-9233-ebe876802803
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set list_checks to True
+        3. Run HealthCheck
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    output_list = ['config:hr_timestamp',
+                   'config:passwordscheme',
+                   'backends:userroot:mappingtree',
+                   'backends:userroot:search',
+                   'backends:userroot:virt_attrs',
+                   'encryption:check_tls_version',
+                   'fschecks:file_perms',
+                   'refint:attr_indexes',
+                   'refint:update_delay',
+                   'monitor-disk-space:disk_space',
+                   'replication:agmts_status',
+                   'replication:conflicts',
+                   'changelog:cl_trimming',
+                   'dseldif:nsstate',
+                   'tls:certificate_expiration',
+                   'logs:notes']
+
+    standalone = topology_st.standalone
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_checks=True, searched_list=output_list)
+
+
+@pytest.mark.ds50746
+@pytest.mark.bz1816851
+@pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
+def test_healthcheck_list_errors(topology_st):
+    """Check functionality of HealthCheck Tool with --list-errors option
+
+    :id: 295c07c0-a939-4d5e-b3a6-b4c9d0da3897
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set list_errors to True
+        3. Run HealthCheck
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    output_list = ['DSBLE0001 :: Possibly incorrect mapping tree',
+                   'DSBLE0002 :: Unable to query backend',
+                   'DSBLE0003 :: Uninitialized backend database',
+                   'DSCERTLE0001 :: Certificate about to expire',
+                   'DSCERTLE0002 :: Certificate expired',
+                   'DSCLE0001 :: Different log timestamp format',
+                   'DSCLE0002 :: Weak passwordStorageScheme',
+                   'DSCLLE0001 :: Changelog trimming not configured',
+                   'DSDSLE0001 :: Low disk space',
+                   'DSELE0001 :: Weak TLS protocol version',
+                   'DSLOGNOTES0001 :: Unindexed Search',
+                   'DSLOGNOTES0002 :: Unknown Attribute In Filter',
+                   'DSPERMLE0001 :: Incorrect file permissions',
+                   'DSPERMLE0002 :: Incorrect security database file permissions',
+                   'DSREPLLE0001 :: Replication agreement not set to be synchronized',
+                   'DSREPLLE0002 :: Replication conflict entries found',
+                   'DSREPLLE0003 :: Unsynchronized replication agreement',
+                   'DSREPLLE0004 :: Unable to get replication agreement status',
+                   'DSREPLLE0005 :: Replication consumer not reachable',
+                   'DSRILE0001 :: Referential integrity plugin may be slower',
+                   'DSRILE0002 :: Referential integrity plugin configured with unindexed attribute',
+                   'DSSKEWLE0001 :: Medium time skew',
+                   'DSSKEWLE0002 :: Major time skew',
+                   'DSSKEWLE0003 :: Extensive time skew',
+                   'DSVIRTLE0001 :: Virtual attribute indexed']
+
+    standalone = topology_st.standalone
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_errors=True, searched_list=output_list)
+
+
+@pytest.mark.ds50746
+@pytest.mark.bz1816851
+@pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
+def test_healthcheck_check_option(topology_st):
+    """Check functionality of HealthCheck Tool with --check option
+
+    :id: ee382d6f-8bec-4236-ace4-4700d19dc9fd
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set check to value from list
+        3. Run HealthCheck
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    output_list = ['config:hr_timestamp',
+                   'config:passwordscheme',
+                   'backends:userroot:mappingtree',
+                   'backends:userroot:search',
+                   'backends:userroot:virt_attrs',
+                   'encryption:check_tls_version',
+                   'fschecks:file_perms',
+                   'refint:attr_indexes',
+                   'refint:update_delay',
+                   'monitor-disk-space:disk_space',
+                   'replication:agmts_status',
+                   'replication:conflicts',
+                   'changelog:cl_trimming',
+                   'dseldif:nsstate',
+                   'tls:certificate_expiration',
+                   'logs:notes']
+
+    standalone = topology_st.standalone
+
+    for item in output_list:
+        pattern = 'Checking ' + item
+        log.info('Check {}'.format(item))
+        run_healthcheck_and_flush_log(topology_st, standalone, searched_code=pattern, json=False, check=[item],
+                                      searched_code2=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, searched_code=JSON_OUTPUT, json=True, check=[item])
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_standalone_tls(topology_st):
+    """Check functionality of HealthCheck Tool on TLS enabled standalone instance with no errors
+
+    :id: 4844b446-3939-4fbd-b14b-293b20bb8be0
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Enable TLS
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    standalone = topology_st.standalone
+    standalone.enable_tls()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT,json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication(topology_m2):
+    """Check functionality of HealthCheck Tool on replication instance with no errors
+
+    :id: 9ee6d491-d6d7-4c2c-ac78-70d08f054166
+    :setup: 2 MM topology
+    :steps:
+        1. Create a two masters replication topology
+        2. Set nsslapd-changelogmaxage to 30d
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    M1 = topology_m2.ms['master1']
+    M2 = topology_m2.ms['master2']
+
+    # If we don't set changelog trimming, we will get error DSCLLE0001
+    set_changelog_trimming(M1)
+    set_changelog_trimming(M2)
+
+    log.info('Run healthcheck for master1')
+    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+
+    log.info('Run healthcheck for master2')
+    run_healthcheck_and_flush_log(topology_m2, M2, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_replication_tls(topology_m2):
+    """Check functionality of HealthCheck Tool on replication instance with no errors
+
+    :id: 9ee6d491-d6d7-4c2c-ac78-70d08f054166
+    :setup: 2 MM topology
+    :steps:
+        1. Create a two masters replication topology
+        2. Enable TLS
+        3. Set nsslapd-changelogmaxage to 30d
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+
+    M1 = topology_m2.ms['master1']
+    M2 = topology_m2.ms['master2']
+
+    M1.enable_tls()
+    M2.enable_tls()
+
+    log.info('Run healthcheck for master1')
+    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+
+    log.info('Run healthcheck for master2')
+    run_healthcheck_and_flush_log(topology_m2, M2, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1685160
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+@pytest.mark.xfail(ds_is_older("1.4.3"),reason="Might fail because of bz1835619")
+def test_healthcheck_backend_missing_mapping_tree(topology_st):
+    """Check if HealthCheck returns DSBLE0001 and DSBLE0003 code
+
+    :id: 4c83ffcf-01a4-4ec8-a3d2-01022b566225
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Disable the dc=example,dc=com backend suffix entry in the mapping tree
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+        5. Enable the dc=example,dc=com backend suffix entry in the mapping tree
+        6. Use HealthCheck without --json option
+        7. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSBLE0001 and DSBLE0003 codes and related details
+        4. Healthcheck reports DSBLE0001 and DSBLE0003 codes and related details
+        5. Success
+        6. Healthcheck reports no issue found
+        7. Healthcheck reports no issue found
+    """
+
+    RET_CODE1 = 'DSBLE0001'
+    RET_CODE2 = 'DSBLE0003'
+
+    standalone = topology_st.standalone
+
+    log.info('Delete the dc=example,dc=com backend suffix entry in the mapping tree')
+    mts = MappingTrees(standalone)
+    mt = mts.get(DEFAULT_SUFFIX)
+    mt.delete()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE1, json=False, searched_code2=RET_CODE2)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE1, json=True, searched_code2=RET_CODE2)
+
+    log.info('Create the dc=example,dc=com backend suffix entry')
+    mts.create(properties={
+        'cn': DEFAULT_SUFFIX,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': 'userRoot',
+    })
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1796343
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+@pytest.mark.skipif(ds_is_older("1.4.3.16"), reason="Might fail because of bz1837315")
+def test_healthcheck_unable_to_query_backend(topology_st):
+    """Check if HealthCheck returns DSBLE0002 code
+
+    :id: 716b1ff1-94bd-4780-98b8-96ff8ef21e30
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Create a new root suffix and database
+        3. Disable new suffix
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. HealthCheck should return code DSBLE0002
+        5. HealthCheck should return code DSBLE0002
+    """
+
+    RET_CODE = 'DSBLE0002'
+    RET_CODE_ENABLED = 'DSBLE0003'
+    NEW_SUFFIX = 'dc=test,dc=com'
+    NEW_BACKEND = 'userData'
+
+    standalone = topology_st.standalone
+
+    log.info('Create new suffix')
+    backends = Backends(standalone)
+    backends.create(properties={
+        'cn': NEW_BACKEND,
+        'nsslapd-suffix': NEW_SUFFIX,
+    })
+
+    log.info('Disable the newly created suffix')
+    mts = MappingTrees(standalone)
+    mt_new = mts.get(NEW_SUFFIX)
+    mt_new.replace('nsslapd-state', 'disabled')
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    log.info('Enable the suffix again and check if nothing is broken. '
+             'Will return DSBLE0003, because database is not initialized for the new suffix')
+    mt_new.replace('nsslapd-state', 'backend')
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE_ENABLED, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE_ENABLED, json=True)
+
+
+@pytest.mark.ds50873
+@pytest.mark.bz1796343
+@pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
+def test_healthcheck_database_not_initialized(topology_no_sample):
+    """Check if HealthCheck returns DSBLE0003 code
+
+    :id: 716b1ff1-94bd-4780-98b8-96ff8ef21e30
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance without example entries
+        2. Use HealthCheck without --json option
+        3. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. HealthCheck should return code DSBLE0003
+        3. HealthCheck should return code DSBLE0003
+    """
+
+    RET_CODE = 'DSBLE0003'
+    standalone = topology_no_sample.standalone
+
+    run_healthcheck_and_flush_log(topology_no_sample, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_no_sample, standalone, RET_CODE, json=True)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -86,9 +86,9 @@ def _list_checks(inst, specs: Iterable[str]):
             raise ValueError('No such object specifier')
 
 
-def _print_checks(inst, specs: Iterable[str]) -> None:
+def _print_checks(inst, log, specs: Iterable[str]) -> None:
     for o, s in _list_checks(inst, specs):
-        print(f'{o.lint_uid()}:{s[0]}')
+        log.info(f'{o.lint_uid()}:{s[0]}')
 
 
 def _run(inst, log, args, checks):
@@ -153,7 +153,7 @@ def health_check_run(inst, log, args):
     checks = args.check or dict(_list_targets(inst)).keys()
 
     if args.list_checks or args.dry_run:
-        _print_checks(inst, checks)
+        _print_checks(inst, log, checks)
         return
 
     _run(inst, log, args, _list_checks(inst, checks))

--- a/src/lib389/lib389/tests/cli/__init__.py
+++ b/src/lib389/lib389/tests/cli/__init__.py
@@ -35,7 +35,7 @@ def topology_be_latest(request):
     topology = create_topology({ReplicaRole.STANDALONE: 1}, None)
     topology.standalone.backends.create(properties={
         'cn': 'userRoot',
-        'suffix': DEFAULT_SUFFIX,
+        'nsslapd-suffix': DEFAULT_SUFFIX,
     })
     # Now apply sample entries
     centries = get_sample_entries(INSTALL_LATEST_CONFIG)
@@ -58,7 +58,7 @@ def topology_be_001003006(request):
     topology = create_topology({ReplicaRole.STANDALONE: 1}, None)
     topology.standalone.backends.create(properties={
         'cn': 'userRoot',
-        'suffix': DEFAULT_SUFFIX,
+        'nsslapd-suffix': DEFAULT_SUFFIX,
     })
     # Now apply sample entries
     centries = get_sample_entries('001003006')


### PR DESCRIPTION
Description:
Backport changes for healthcheck issues to branch 1.4.3 for healthcheck files only,
fix print list_checks to log in lib389 and minor change to tests for dsidm and healthcheck
to prevent failing.

Relates: https://github.com/389ds/389-ds-base/issues/3926
Relates: https://github.com/389ds/389-ds-base/issues/3894
Relates: https://github.com/389ds/389-ds-base/issues/3894
Relates: https://github.com/389ds/389-ds-base/issues/3801
Relates: https://github.com/389ds/389-ds-base/issues/4144
Relates: https://github.com/389ds/389-ds-base/issues/4159