### PR TITLE
Issue 4464 - RFE - clang with ds+asan+rust

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,15 @@ DEBUG_DEFINES = @debug_defs@
 DEBUG_CFLAGS = @debug_cflags@
 DEBUG_CXXFLAGS = @debug_cxxflags@
 GCCSEC_CFLAGS = @gccsec_cflags@
+if CLANG_ENABLE
 ASAN_CFLAGS = @asan_cflags@
+else
+if enable_asan
+ASAN_CFLAGS = @asan_cflags@ -lasan
+else
+ASAN_CFLAGS = @asan_cflags@
+endif
+endif
 MSAN_CFLAGS = @msan_cflags@
 TSAN_CFLAGS = @tsan_cflags@
 UBSAN_CFLAGS = @ubsan_cflags@
@@ -42,8 +50,12 @@ if RUST_ENABLE
 # Rust enabled
 RUST_ON = 1
 CARGO_FLAGS = @cargo_defs@
+
+if CLANG_ENABLE
+RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@ -C link-arg=-fuse-ld=lld
+else
 RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@
-# -L@abs_top_builddir@/rs/@rust_target_dir@
+endif
 RUST_LDFLAGS = -ldl -lpthread -lgcc_s -lc -lm -lrt -lutil
 RUST_DEFINES = -DRUST_ENABLE
 if RUST_ENABLE_OFFLINE
@@ -62,10 +74,14 @@ endif
 
 if CLANG_ENABLE
 CLANG_ON = 1
-CLANG_LDFLAGS = -latomic
+CLANG_LDFLAGS = -latomic -fuse-ld=lld
+EXPORT_LDFLAGS =
 else
 CLANG_ON = 0
 CLANG_LDFLAGS =
+if DEBUG
+EXPORT_LDFLAGS = -rdynamic
+endif
 endif
 
 # We can't add the lfds includes all the time as they have a "bomb" in them that
@@ -80,9 +96,14 @@ REWRITERS_INCLUDES = -I$(srcdir)/src/rewriters/
 
 SVRCORE_INCLUDES = -I$(srcdir)/src/svrcore/src/
 
+if CLANG_ENABLE
+# clang complains about the -U.
+DS_DEFINES = -DBUILD_NUM=$(BUILDNUM) -DVENDOR="\"$(vendor)\"" -DBRAND="\"$(brand)\"" -DCAPBRAND="\"$(capbrand)\""
+else
 # the -U undefines these symbols - should use the corresponding DS_ ones instead - see configure.ac
 DS_DEFINES = -DBUILD_NUM=$(BUILDNUM) -DVENDOR="\"$(vendor)\"" -DBRAND="\"$(brand)\"" -DCAPBRAND="\"$(capbrand)\"" \
 	-UPACKAGE_VERSION -UPACKAGE_TARNAME -UPACKAGE_STRING -UPACKAGE_BUGREPORT
+endif
 DS_INCLUDES = -I$(srcdir)/ldap/include -I$(srcdir)/ldap/servers/slapd -I$(srcdir)/include -I.
 
 
@@ -186,7 +207,7 @@ if HPUX
 AM_LDFLAGS = -lpthread
 else
 #AM_LDFLAGS = -Wl,-z,defs
-AM_LDFLAGS = $(PW_CRACK_LINK) $(RUST_LDFLAGS) $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS) $(UBSAN_CFLAGS) $(PROFILING_LINKS) $(CLANG_LDFLAGS)
+AM_LDFLAGS = $(PW_CRACK_LINK) $(RUST_LDFLAGS) $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS) $(UBSAN_CFLAGS) $(PROFILING_LINKS) $(CLANG_LDFLAGS) $(EXPORT_LDFLAGS)
 endif #end hpux
 
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info

--- a/configure.ac
+++ b/configure.ac
@@ -125,8 +125,8 @@ AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug], [Enable debug features (de
 AC_MSG_RESULT($enable_debug)
 if test "$enable_debug" = yes ; then
   debug_defs="-DDEBUG -DMCC_DEBUG"
-  debug_cflags="-g3 -O0 -rdynamic"
-  debug_cxxflags="-g3 -O0 -rdynamic"
+  debug_cflags="-g3 -O0"
+  debug_cxxflags="-g3 -O0"
   debug_rust_defs="-C debuginfo=2 -Z macro-backtrace"
   cargo_defs=""
   rust_target_dir="debug"
@@ -162,7 +162,7 @@ AC_ARG_ENABLE(asan, AS_HELP_STRING([--enable-asan], [Enable gcc/clang address sa
               [], [ enable_asan=no ])
 AC_MSG_RESULT($enable_asan)
 if test "$enable_asan" = yes ; then
-  asan_cflags="-fsanitize=address -fno-omit-frame-pointer -lasan"
+  asan_cflags="-fsanitize=address -fno-omit-frame-pointer"
   asan_rust_defs="-Z sanitizer=address"
 else
   asan_cflags=""

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -38,6 +38,11 @@
 # Use Clang instead of GCC
 %global use_clang __CLANG_ON__
 
+%if %{use_clang}
+%global toolchain clang
+%global _missing_build_ids_terminate_build 0
+%endif
+
 # Build cockpit plugin
 %global use_cockpit __COCKPIT_ON__
 
@@ -79,6 +84,7 @@ BuildRequires:    cracklib-devel
 BuildRequires:    libatomic
 BuildRequires:    clang
 BuildRequires:    compiler-rt
+BuildRequires:    lld
 %else
 BuildRequires:    gcc
 BuildRequires:    gcc-c++
@@ -309,8 +315,6 @@ cp %{SOURCE2} README.devel
 %build
 
 %if %{use_clang}
-export CC=clang
-export CXX=clang++
 CLANG_FLAGS="--enable-clang"
 %endif
 


### PR DESCRIPTION
Bug Description: Some subtle issues existed when using clang with
ds for builds, emiting warnings or not working (asan).

Fix Description: Remove some compiler flags that caused warnings,
and clean up how to emit certain linking related parts for asan
and dynamic libs for clang.

fixes: #4464

Author: William Brown <william@blackhats.net.au>

Review by: ???