### PR TITLE
Issue 4284 - dsidm fails to delete an organizationalUnit entry

### DIFF
--- a/dirsrvtests/tests/suites/clu/__init__.py
+++ b/dirsrvtests/tests/suites/clu/__init__.py
@@ -1,3 +1,31 @@
 """
    :Requirement: 389-ds-base: Command Line Utility
 """
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+def check_value_in_log_and_reset(topology, content_list=None, content_list2=None, check_value=None,
+                                 check_value_not=None):
+    if content_list2 is not None:
+        log.info('Check if content is present in output')
+        for item in content_list + content_list2:
+            assert topology.logcap.contains(item)
+
+    if content_list is not None:
+        log.info('Check if content is present in output')
+        for item in content_list:
+            assert topology.logcap.contains(item)
+
+    if check_value is not None:
+        log.info('Check if value is present in output')
+        assert topology.logcap.contains(check_value)
+
+    if check_value_not is not None:
+        log.info('Check if value is not present in output')
+        assert not topology.logcap.contains(check_value_not)
+
+    log.info('Reset the log for next test')
+    topology.logcap.flush()

--- a/dirsrvtests/tests/suites/clu/dsidm_account_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_test.py
@@ -19,34 +19,12 @@ from lib389.topologies import topology_st
 from lib389.cli_base import FakeArgs
 from lib389.utils import ds_is_older
 from lib389.idm.user import nsUserAccounts
+from . import check_value_in_log_and_reset
 
 pytestmark = pytest.mark.tier0
 
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
-
-
-def check_value_and_reset(topology, content_list=None, content_list2=None, check_value=None, check_value_not=None):
-        if content_list2 is not None:
-            log.info('Check if content is present in output')
-            for item in content_list + content_list2:
-                assert topology.logcap.contains(item)
-
-        if content_list is not None:
-            log.info('Check if content is present in output')
-            for item in content_list:
-                assert topology.logcap.contains(item)
-
-        if check_value is not None:
-            log.info('Check if value is present in output')
-            assert topology.logcap.contains(check_value)
-
-        if check_value_not is not None:
-            log.info('Check if value is not present in output')
-            assert not topology.logcap.contains(check_value_not)
-
-        log.info('Reset the log for next test')
-        topology.logcap.flush()
 
 
 @pytest.fixture(scope="function")

--- a/dirsrvtests/tests/suites/clu/dsidm_organizational_unit_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_organizational_unit_test.py
@@ -1,0 +1,83 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import time
+import subprocess
+import pytest
+import logging
+import os
+
+from lib389 import DEFAULT_SUFFIX
+from lib389.cli_idm.organizationalunit import get, get_dn, create, modify, delete, list, rename
+from lib389.topologies import topology_st
+from lib389.cli_base import FakeArgs
+from lib389.utils import ds_is_older
+from lib389.idm.organizationalunit import OrganizationalUnits
+from . import check_value_in_log_and_reset
+
+pytestmark = pytest.mark.tier0
+
+logging.getLogger(__name__).setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def create_test_ou(topology_st, request):
+    log.info('Create organizational unit')
+    ous = OrganizationalUnits(topology_st.standalone, DEFAULT_SUFFIX)
+    test_ou = ous.create(properties={
+        'ou': 'toDelete',
+        'description': 'Test OU',
+    })
+
+    def fin():
+        log.info('Delete organizational unit')
+        if test_ou.exists():
+            test_ou.delete()
+
+    request.addfinalizer(fin)
+
+
+@pytest.mark.bz1866294
+@pytest.mark.ds4284
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+@pytest.mark.xfail(ds_is_older("1.4.3.16"), reason="Might fail because of bz1866294")
+def test_dsidm_organizational_unit_delete(topology_st, create_test_ou):
+    """ Test dsidm organizationalunit delete
+
+    :id: 5d35a5ee-85c2-4b83-9101-938ba7732ccd
+    :setup: Standalone instance
+    :steps:
+         1. Run dsidm organizationalunit delete
+         2. Check the ou is deleted
+    :expectedresults:
+         1. Success
+         2. Entry is deleted
+    """
+
+    standalone = topology_st.standalone
+    ous = OrganizationalUnits(standalone, DEFAULT_SUFFIX)
+    test_ou = ous.get('toDelete')
+    delete_value = 'Successfully deleted {}'.format(test_ou.dn)
+
+    args = FakeArgs()
+    args.dn = test_ou.dn
+
+    log.info('Test dsidm organizationalunit delete')
+    delete(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args, warn=False)
+    check_value_in_log_and_reset(topology_st, check_value=delete_value)
+
+    log.info('Check the entry is deleted')
+    assert not test_ou.exists()
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/src/lib389/lib389/cli_idm/organizationalunit.py
+++ b/src/lib389/lib389/cli_idm/organizationalunit.py
@@ -41,9 +41,10 @@ def create(inst, basedn, log, args):
     kwargs = _get_attributes(args, MUST_ATTRIBUTES)
     _generic_create(inst, basedn, log.getChild('_generic_create'), MANY, kwargs, args)
 
-def delete(inst, basedn, log, args):
+def delete(inst, basedn, log, args, warn=True):
     dn = _get_arg(args.dn, msg="Enter dn to delete")
-    _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
+    if warn:
+        _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
     _generic_delete(inst, basedn, log.getChild('_generic_delete'), SINGULAR, dn, args)
 
 def modify(inst, basedn, log, args, warn=True):


### PR DESCRIPTION
Description:
Created test for dsidm organizationalunit delete and moved the function
check_value_in_log_and_reset() to __init__.py, because it will be used for
other dsidm tests.
Also modified the delete() function in lib389 to be able to delete the entry
without warning message for test purposes.

Relates: https://github.com/389ds/389-ds-base/issues/4284

Reviewed by: ???