### PR TITLE
Issue 4460 - BUG - add machine name to subject alt names in SSCA

### DIFF
--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -888,7 +888,7 @@ class SetupDs(object):
                         tlsdb_inst = NssSsl(dbpath=os.path.join(etc_dirsrv_path, dir))
                         tlsdb_inst.import_rsa_crt(ca)
 
-            csr = tlsdb.create_rsa_key_and_csr()
+            csr = tlsdb.create_rsa_key_and_csr(alt_names=[general['full_machine_name']])
             (ca, crt) = ssca.rsa_ca_sign_csr(csr)
             tlsdb.import_rsa_crt(ca, crt)
             if general['selinux']:


### PR DESCRIPTION
Bug Description: During SSCA creation, the server cert did not have
the machine name, which meant that the cert would not work without
reqcert = never.

Fix Description: Add the machine name as an alt name during SSCA
creation. It is not guaranteed this value is correct, but it
is better than nothing.

relates: https://github.com/389ds/389-ds-base/issues/4460

Author: William Brown <william@blackhats.net.au>

Review by: ???