### PR TITLE
Issue 4419 - Warn users of skipped entries during ldif2db online import

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -65,6 +65,9 @@ def _import_clean(request, topo):
         import_ldif = ldif_dir + '/basic_import.ldif'
         if os.path.exists(import_ldif):
             os.remove(import_ldif)
+        syntax_err_ldif = ldif_dir + '/syntax_err.dif'
+        if os.path.exists(syntax_err_ldif):
+            os.remove(syntax_err_ldif)
 
     request.addfinalizer(finofaci)
 
@@ -141,17 +144,19 @@ def _create_bogus_ldif(topo):
 
 def _create_syntax_err_ldif(topo):
     """
-    Create an incorrect ldif entry that violates syntax check
+    Create an ldif file, which contains an entry that violates syntax check
     """
     ldif_dir = topo.standalone.get_ldif_dir()
     line1 = """dn: dc=example,dc=com
 objectClass: top
 objectClass: domain
 dc: example
+
 dn: ou=groups,dc=example,dc=com
 objectClass: top
 objectClass: organizationalUnit
 ou: groups
+
 dn: uid=JHunt,ou=groups,dc=example,dc=com
 objectClass: top
 objectClass: person
@@ -201,6 +206,34 @@ def test_import_with_index(topo, _import_clean):
     assert f'{place}/userRoot/roomNumber.db' in glob.glob(f'{place}/userRoot/*.db', recursive=True)
 
 
+def test_online_import_with_warning(topo, _import_clean):
+    """
+    Import an ldif file with syntax errors, verify skipped entry warning code
+
+    :id: 5bf75c47-a283-430e-a65c-3c5fd8dbadb8
+    :setup: Standalone Instance
+    :steps:
+        1. Create standalone Instance
+        2. Create an ldif file with an entry that violates syntax check (empty givenname)
+        3. Online import of troublesome ldif file
+    :expected results:
+        1. Successful import with skipped entry warning
+        """
+    topo.standalone.restart()
+
+    import_task = ImportTask(topo.standalone)
+    import_ldif1 = _create_syntax_err_ldif(topo)
+
+    # Importing  the offending ldif file - online
+    import_task.import_suffix_from_ldif(ldiffile=import_ldif1, suffix=DEFAULT_SUFFIX)
+
+    # There is just  a single entry in this ldif
+    import_task.wait(5)
+
+    # Check for the task nsTaskWarning attr, make sure its set to skipped entry code
+    assert import_task.present('nstaskwarning')
+    assert TaskWarning.WARN_SKIPPED_IMPORT_ENTRY == import_task.get_task_warn()
+
 def test_crash_on_ldif2db(topo, _import_clean):
     """
     Delete the cn=monitor entry for an LDBM backend instance. Doing this will
@@ -246,7 +279,7 @@ def test_ldif2db_allows_entries_without_a_parent_to_be_imported(topo, _import_cl
     topo.standalone.start()
 
 
-def test_ldif2db_syntax_check(topo):
+def test_ldif2db_syntax_check(topo, _import_clean):
     """ldif2db should return a warning when a skipped entry has occured.
     :id: 85e75670-42c5-4062-9edc-7f117c97a06f
     :setup:

--- a/ldap/schema/02common.ldif
+++ b/ldap/schema/02common.ldif
@@ -146,6 +146,7 @@ attributeTypes: ( 2.16.840.1.113730.3.1.2356 NAME 'nsTaskExitCode' DESC 'Slapi T
 attributeTypes: ( 2.16.840.1.113730.3.1.2357 NAME 'nsTaskCurrentItem' DESC 'Slapi Task item' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2358 NAME 'nsTaskTotalItems' DESC 'Slapi Task total items' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2359 NAME 'nsTaskCreated' DESC 'Slapi Task creation date' SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2375 NAME 'nsTaskWarning' DESC 'Slapi Task warning code' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 #
 # objectclasses:
 #
@@ -178,5 +179,5 @@ objectClasses: ( 2.16.840.1.113730.3.2.503 NAME 'nsDSWindowsReplicationAgreement
 objectClasses: ( 2.16.840.1.113730.3.2.128 NAME 'costemplate' DESC 'Netscape defined objectclass' SUP top MAY ( cn $ cospriority ) X-ORIGIN 'Netscape Directory Server' )
 objectClasses: ( 2.16.840.1.113730.3.2.304 NAME 'nsView' DESC 'Netscape defined objectclass' SUP top AUXILIARY MAY ( nsViewFilter $ description ) X-ORIGIN 'Netscape Directory Server' )
 objectClasses: ( 2.16.840.1.113730.3.2.316 NAME 'nsAttributeEncryption' DESC 'Netscape defined objectclass' SUP top MUST ( cn $ nsEncryptionAlgorithm ) X-ORIGIN 'Netscape Directory Server' )
-objectClasses: ( 2.16.840.1.113730.3.2.335 NAME 'nsSlapiTask' DESC 'Slapi_Task objectclass' SUP top MUST ( cn ) MAY ( ttl $ nsTaskLog $ nsTaskStatus $ nsTaskExitCode $ nsTaskCurrentItem $ nsTaskTotalItems $ nsTaskCreated ) X-ORIGIN '389 Directory Server' )
+objectClasses: ( 2.16.840.1.113730.3.2.335 NAME 'nsSlapiTask' DESC 'Slapi_Task objectclass' SUP top MUST ( cn ) MAY ( ttl $ nsTaskLog $ nsTaskStatus $ nsTaskExitCode $ nsTaskCurrentItem $ nsTaskTotalItems $ nsTaskCreated $ nsTaskWarning ) X-ORIGIN '389 Directory Server' )
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -747,6 +747,11 @@ import_producer(void *param)
         }
     }
 
+    /* capture skipped entry warnings for this task */
+    if((job) && (job->skipped)) {
+        slapi_task_set_warning(job->task, WARN_SKIPPED_IMPORT_ENTRY);
+    }
+
     slapi_value_free(&(job->usn_value));
     import_free_ldif(&c);
     info->state = FINISHED;

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1755,6 +1755,7 @@ typedef struct slapi_task
     int task_progress;         /* number between 0 and task_work */
     int task_work;             /* "units" of work to be done */
     int task_flags;            /* (see above) */
+    task_warning task_warn;    /* task warning */
     char *task_status;         /* transient status info */
     char *task_log;            /* appended warnings, etc */
     char task_date[SLAPI_TIMESTAMP_BUFSIZE]; /* Date/time when task was created */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6641,6 +6641,15 @@ int slapi_config_remove_callback(int operation, int flags, const char *base, int
 /* task flags (set by the task-control code) */
 #define SLAPI_TASK_DESTROYING 0x01 /* queued event for destruction */
 
+/* task warnings */
+typedef enum task_warning_t{
+    WARN_UPGARDE_DN_FORMAT_ALL    = (1 << 0),
+    WARN_UPGRADE_DN_FORMAT        = (1 << 1),
+    WARN_UPGRADE_DN_FORMAT_SPACE  = (1 << 2),
+    WARN_SKIPPED_IMPORT_ENTRY     = (1 << 3)
+} task_warning;
+
+
 int slapi_task_register_handler(const char *name, dseCallbackFn func);
 int slapi_plugin_task_register_handler(const char *name, dseCallbackFn func, Slapi_PBlock *plugin_pb);
 int slapi_plugin_task_unregister_handler(const char *name, dseCallbackFn func);
@@ -6657,6 +6666,8 @@ int slapi_task_get_refcount(Slapi_Task *task);
 void slapi_task_set_destructor_fn(Slapi_Task *task, TaskCallbackFn func);
 void slapi_task_set_cancel_fn(Slapi_Task *task, TaskCallbackFn func);
 void slapi_task_status_changed(Slapi_Task *task);
+void slapi_task_set_warning(Slapi_Task *task, task_warning warn);
+int slapi_task_get_warning(Slapi_Task *task);
 void slapi_task_log_status(Slapi_Task *task, char *format, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 2, 3)));

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1464,17 +1464,8 @@ void slapi_pblock_set_operation_notes(Slapi_PBlock *pb, uint32_t opnotes);
 void slapi_pblock_set_flag_operation_notes(Slapi_PBlock *pb, uint32_t opflag);
 void slapi_pblock_set_result_text_if_empty(Slapi_PBlock *pb, char *text);
 
-/* task warnings */
-typedef enum task_warning_t{
-    WARN_UPGARDE_DN_FORMAT_ALL    = (1 << 0),
-    WARN_UPGRADE_DN_FORMAT        = (1 << 1),
-    WARN_UPGRADE_DN_FORMAT_SPACE  = (1 << 2),
-    WARN_SKIPPED_IMPORT_ENTRY     = (1 << 3)
-} task_warning;
-
 int32_t slapi_pblock_get_task_warning(Slapi_PBlock *pb);
 void slapi_pblock_set_task_warning(Slapi_PBlock *pb, task_warning warn);
-
 
 int slapi_exists_or_add_internal(Slapi_DN *dn, const char *filter, const char *entry, const char *modifier_name);
 

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -46,6 +46,7 @@ static uint64_t shutting_down = 0;
 #define TASK_PROGRESS_NAME "nsTaskCurrentItem"
 #define TASK_WORK_NAME "nsTaskTotalItems"
 #define TASK_DATE_NAME "nsTaskCreated"
+#define TASK_WARNING_NAME "nsTaskWarning"
 
 #define DEFAULT_TTL "3600"                        /* seconds */
 #define TASK_SYSCONFIG_FILE_ATTR "sysconfigfile" /* sysconfig reload task file attr */
@@ -332,7 +333,7 @@ slapi_task_status_changed(Slapi_Task *task)
     LDAPMod modlist[20];
     LDAPMod *mod[20];
     int cur = 0, i;
-    char s1[20], s2[20], s3[20];
+    char s1[20], s2[20], s3[20], s4[20];
 
     if (shutting_down) {
         /* don't care about task status updates anymore */
@@ -346,9 +347,11 @@ slapi_task_status_changed(Slapi_Task *task)
     sprintf(s1, "%d", task->task_exitcode);
     sprintf(s2, "%d", task->task_progress);
     sprintf(s3, "%d", task->task_work);
+    sprintf(s4, "%d", task->task_warn);
     NEXTMOD(TASK_PROGRESS_NAME, s2);
     NEXTMOD(TASK_WORK_NAME, s3);
     NEXTMOD(TASK_DATE_NAME, task->task_date);
+    NEXTMOD(TASK_WARNING_NAME, s4);
     /* only add the exit code when the job is done */
     if ((task->task_state == SLAPI_TASK_FINISHED) ||
         (task->task_state == SLAPI_TASK_CANCELLED)) {
@@ -448,6 +451,30 @@ slapi_task_get_refcount(Slapi_Task *task)
     }
 
     return 0; /* return value not currently used */
+}
+
+/*
+ * Return task warning
+ */
+int
+slapi_task_get_warning(Slapi_Task *task)
+{
+    if (task) {
+        return task->task_warn;
+    }
+
+    return 0; /* return value not currently used */
+}
+
+/*
+ * Set task warning
+ */
+void
+slapi_task_set_warning(Slapi_Task *task, task_warning warn)
+{
+    if (task) {
+        return task->task_warn |= warn;
+    }
 }
 
 int

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -243,9 +243,13 @@ def backend_import(inst, basedn, log, args):
                           exclude_suffixes=args.exclude_suffixes)
     task.wait(timeout=None)
     result = task.get_exit_code()
+    warning = task.get_task_warn()
 
     if task.is_complete() and result == 0:
-        log.info("The import task has finished successfully")
+        if warning is None or (warning == 0):
+            log.info("The import task has finished successfully")
+        else:
+            log.info("The import task has finished successfully, with warning code {}, check the logs for more detail".format(warning))
     else:
         raise ValueError("Import task failed\n-------------------------\n{}".format(ensure_str(task.get_task_log())))
 


### PR DESCRIPTION
Bug Description:  During an online ldif2db import entries that do not
                  conform to various constraints will be skipped and
                  not imported. On completition of an import with skipped
                  entries, the server responds with a success message
                  and logs the skipped entry detail to the error logs.
                  The success messgae could lead the user to believe
                  that all entries were successfully imported.

Fix Description:  If a skipped entry occurs during import, the import
                  will continue and a warning message will be displayed.
                  The schema is extended with a nsTaskWarning attribute
                  which is used to capture and retrieve any task
                  warnings.

                  CLI tools for online import updated.

                  Test added to generate an incorrect ldif entry and perform an
                  online import.

Fixes: https://github.com/389ds/389-ds-base/issues/4419

Reviewed by: tbordaz, mreynolds389  (Thanks)