### PR TITLE
Issue 4381 - RFE - LDAPI authentication DN rewritter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1111,6 +1111,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	ldap/servers/slapd/filterentry.c \
 	ldap/servers/slapd/generation.c \
 	ldap/servers/slapd/getfilelist.c \
+	ldap/servers/slapd/ldapi.c \
 	ldap/servers/slapd/ldaputil.c \
 	ldap/servers/slapd/lenstr.c \
 	ldap/servers/slapd/libglobs.c \
@@ -1171,6 +1172,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	ldap/servers/slapd/vattr.c \
 	ldap/servers/slapd/slapi_pal.c \
 	src/libsds/external/csiphash/csiphash.c \
+	$(GETSOCKETPEER) \
 	$(libavl_a_SOURCES)
 
 libslapd_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) @db_inc@ $(KERBEROS_CFLAGS) $(PCRE_CFLAGS) $(SVRCORE_INCLUDES)
@@ -1861,8 +1863,7 @@ ns_slapd_SOURCES = ldap/servers/slapd/abandon.c \
 	ldap/servers/slapd/strdup.c \
 	ldap/servers/slapd/stubs.c \
 	ldap/servers/slapd/tempnam.c  \
-	ldap/servers/slapd/unbind.c \
-	$(GETSOCKETPEER)
+	ldap/servers/slapd/unbind.c
 
 ns_slapd_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(SVRCORE_INCLUDES)
 ns_slapd_LDADD = libslapd.la libldaputil.la libsvrcore.la $(LDAPSDK_LINK) $(NSS_LINK) $(LIBADD_DL) \

--- a/dirsrvtests/tests/suites/ldapi/ldapi_test.py
+++ b/dirsrvtests/tests/suites/ldapi/ldapi_test.py
@@ -1,0 +1,154 @@
+import logging
+import pytest
+import os
+import subprocess
+from lib389._constants import DEFAULT_SUFFIX, DN_DM
+from lib389.idm.user import UserAccounts
+from lib389.ldapi import LDAPIMapping, LDAPIFixedMapping
+from lib389.topologies import topology_st as topo
+from lib389.tasks import LDAPIMappingReloadTask
+
+
+def test_ldapi_authdn_attr_rewrite(topo, request):
+    """Test LDAPI Authentication DN mapping feature
+
+    :id: e8d68979-4b3d-4e2d-89ed-f9bad827718c
+    :setup: Standalone Instance
+    :steps:
+        1. Set LDAPI configuration
+        2. Create LDAP user
+        3. Create OS user
+        4. Create entries under cn=config for auto bind subtree and mapping entry
+        5. Do an LDAPI ldapsearch as the OS user
+        6. OS user was mapped expected LDAP entry
+        7. Do search using root & LDAPI
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+    """
+
+    LINUX_USER = "ldapi_test_lib389_user"
+    LINUX_USER2 = "ldapi_test_lib389_user2"
+    LINUX_USER3 = "ldapi_test_lib389_user3"
+    LINUX_PWD = "5ecret_137"
+    LDAP_ENTRY_DN = "uid=test_ldapi,ou=people,dc=example,dc=com"
+    LDAP_ENTRY_DN2 = "uid=test_ldapi2,ou=people,dc=example,dc=com"
+    LDAP_ENTRY_DN3 = "uid=test_ldapi3,ou=people,dc=example,dc=com"
+    LDAPI_AUTH_CONTAINER = "cn=auto_bind,cn=config"
+
+    def fin():
+        # Remove the OS users
+        for user in [LINUX_USER, LINUX_USER2, LINUX_USER3]:
+            try:
+                subprocess.run(['userdel', '-r', user])
+            except:
+                pass
+    request.addfinalizer(fin)
+
+    # Must be root
+    if os.geteuid() != 0:
+        return
+
+    # Perform config tasks
+    topo.standalone.config.set('nsslapd-accesslog-logbuffering', 'off')
+    topo.standalone.config.set('nsslapd-ldapiDNMappingBase', 'cn=auto_bind,cn=config')
+    topo.standalone.config.set('nsslapd-ldapimaptoentries', 'on')
+    topo.standalone.config.set('nsslapd-ldapiuidnumbertype', 'uidNumber')
+    topo.standalone.config.set('nsslapd-ldapigidnumbertype', 'gidNumber')
+    ldapi_socket_raw = topo.standalone.config.get_attr_val_utf8('nsslapd-ldapifilepath')
+    ldapi_socket = ldapi_socket_raw.replace('/', '%2F')
+
+    # Create LDAP users
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    user_properties = {
+        'uid': 'test_ldapi',
+        'cn': 'test_ldapi',
+        'sn': 'test_ldapi',
+        'uidNumber': '2020',
+        'gidNumber': '2020',
+        'userpassword': 'password',
+        'description': 'userdesc',
+        'homeDirectory': '/home/test_ldapi'}
+    users.create(properties=user_properties)
+
+    user_properties = {
+        'uid': 'test_ldapi2',
+        'cn': 'test_ldapi2',
+        'sn': 'test_ldapi2',
+        'uidNumber': '2021',
+        'gidNumber': '2021',
+        'userpassword': 'password',
+        'description': 'userdesc',
+        'homeDirectory': '/home/test_ldapi2'}
+    users.create(properties=user_properties)
+
+    user_properties = {
+        'uid': 'test_ldapi3',
+        'cn': 'test_ldapi3',
+        'sn': 'test_ldapi3',
+        'uidNumber': '2023',
+        'gidNumber': '2023',
+        'userpassword': 'password',
+        'description': 'userdesc',
+        'homeDirectory': '/home/test_ldapi3'}
+    users.create(properties=user_properties)
+
+    # Create OS users
+    subprocess.run(['useradd', '-u', '5001', '-p', LINUX_PWD, LINUX_USER])
+    subprocess.run(['useradd', '-u', '5002', '-p', LINUX_PWD, LINUX_USER2])
+
+    # Create some mapping entries
+    ldapi_mapping = LDAPIMapping(topo.standalone, LDAPI_AUTH_CONTAINER)
+    ldapi_mapping.create_mapping(name='entry_map1', username='dummy1',
+                                 ldap_dn='uid=dummy1,dc=example,dc=com')
+    ldapi_mapping.create_mapping(name='entry_map2', username=LINUX_USER,
+                                 ldap_dn=LDAP_ENTRY_DN)
+    ldapi_mapping.create_mapping(name='entry_map3', username='dummy2',
+                                 ldap_dn='uid=dummy3,dc=example,dc=com')
+
+    # Restart server for config to take effect, and clear the access log
+    topo.standalone.deleteAccessLogs(restart=True)
+
+    # Bind as OS user using ldapsearch
+    ldapsearch_cmd = f'ldapsearch -b \'\' -s base -Y EXTERNAL -H ldapi://{ldapi_socket}'
+    os.system(f'su {LINUX_USER} -c "{ldapsearch_cmd}"')
+
+    # Check access log
+    assert topo.standalone.ds_access_log.match(f'.*AUTOBIND dn="{LDAP_ENTRY_DN}".*')
+
+    # Bind as Root DN just to make sure it still works
+    assert os.system(ldapsearch_cmd) == 0
+    assert topo.standalone.ds_access_log.match(f'.*AUTOBIND dn="{DN_DM}".*')
+
+    # Create some fixed mapping
+    ldapi_fixed_mapping = LDAPIFixedMapping(topo.standalone, LDAPI_AUTH_CONTAINER)
+    ldapi_fixed_mapping.create_mapping("fixed", "5002", "5002", ldap_dn=LDAP_ENTRY_DN2)
+    topo.standalone.deleteAccessLogs(restart=True)
+
+    # Bind as OS user using ldapsearch
+    os.system(f'su {LINUX_USER2} -c "{ldapsearch_cmd}"')
+
+    # Check access log
+    assert topo.standalone.ds_access_log.match(f'.*AUTOBIND dn="{LDAP_ENTRY_DN2}".*')
+
+    # Add 3rd user, and test reload task
+    subprocess.run(['useradd', '-u', '5003', '-p', LINUX_PWD, LINUX_USER3])
+    ldapi_fixed_mapping.create_mapping("reload", "5003", "5003", ldap_dn=LDAP_ENTRY_DN3)
+
+    reload_task = LDAPIMappingReloadTask(topo.standalone).create()
+    reload_task.wait(timeout=20)
+
+    os.system(f'su {LINUX_USER3} -c "{ldapsearch_cmd}"')
+    assert topo.standalone.ds_access_log.match(f'.*AUTOBIND dn="{LDAP_ENTRY_DN3}".*')
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -25,6 +25,11 @@ nsslapd-ldapifilepath: %ldapi%
 nsslapd-ldapiautobind: %ldapi_autobind%
 nsslapd-ldapimaprootdn: %rootdn%
 
+dn: cn=auto_bind,cn=config
+objectclass: top
+objectclass: nsContainer
+cn: auto_bind
+
 dn: cn=features,cn=config
 objectclass: top
 objectclass: nsContainer

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -40,6 +40,11 @@ nsSSLPersonalitySSL: Server-Cert
 nsSSLActivation: on
 nsSSLToken: internal (software)
 
+dn: cn=auto_bind,cn=config
+objectclass: top
+objectclass: nsContainer
+cn: auto_bind
+
 dn: cn=features,cn=config
 objectclass: top
 objectclass: nsContainer

--- a/ldap/schema/30ns-common.ldif
+++ b/ldap/schema/30ns-common.ldif
@@ -56,6 +56,8 @@ attributeTypes: ( nsClassname-oid NAME 'nsClassname' DESC 'Netscape defined attr
 attributeTypes: ( 2.16.840.1.113730.3.1.2337 NAME 'nsCertSubjectDN' DESC 'An x509 DN from a certificate used to map during a TLS bind process' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN '389 Directory Server Project' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2342 NAME 'nsSshPublicKey' DESC 'An nsSshPublicKey record' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN '389 Directory Server Project' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2343 NAME 'legalName' DESC 'An individuals legalName' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN '389 Directory Server Project' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2376 NAME 'nsslapd-authenticateAsDN' DESC 'LDAPI mapping DN' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2377 NAME 'nsslapd-ldapiUsername' DESC 'LDAPI mapping system username' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 objectClasses: ( nsAdminDomain-oid NAME 'nsAdminDomain' DESC 'Netscape defined objectclass' SUP organizationalUnit MAY ( nsAdminDomainName ) X-ORIGIN 'Netscape' )
 objectClasses: ( nsHost-oid NAME 'nsHost' DESC 'Netscape defined objectclass' SUP top MUST ( cn ) MAY ( serverHostName $ description $ l $ nsHostLocation $ nsHardwarePlatform $ nsOsVersion ) X-ORIGIN 'Netscape' )
 objectClasses: ( nsAdminGroup-oid NAME 'nsAdminGroup' DESC 'Netscape defined objectclass' SUP top MUST ( cn ) MAY ( nsAdminGroupName $ description $ nsConfigRoot $ nsAdminSIEDN ) X-ORIGIN 'Netscape' )
@@ -75,3 +77,5 @@ objectClasses: ( 2.16.840.1.113730.3.2.334 NAME 'nsOrgPerson' DESC 'A representa
   mobile $ o $ pager $ photo $ roomNumber $ uid $ userCertificate $ telephoneNumber $
   x500uniqueIdentifier $ userSMIMECertificate $ userPKCS12 )
   X-ORIGIN '389 Directory Server Project' )
+objectClasses: ( 2.16.840.1.113730.3.2.338 NAME 'nsLDAPIAuthMap' DESC 'LDAPI authentication DN mapping' SUP top MUST ( cn $ nsslapd-ldapiUsername $ nsslapd-authenticateAsDN ) MAY ( description ) X-ORIGIN '389 Directory Server' )
+objectClasses: ( 2.16.840.1.113730.3.2.339 NAME 'nsLDAPIFixedAuthMap' DESC 'LDAPI fixed authentication DN mapping' SUP top MUST ( cn $ uidNumber $ gidNumber $ nsslapd-authenticateAsDN ) MAY ( description ) X-ORIGIN '389 Directory Server' )

--- a/ldap/servers/slapd/ldapi.c
+++ b/ldap/servers/slapd/ldapi.c
@@ -1,0 +1,395 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2020 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <unistd.h>
+#include "slap.h"
+#include "getsocketpeer.h"
+
+#if defined(ENABLE_LDAPI)
+
+struct ldapi_mapping {
+    char *dn;
+    uid_t uid;
+    gid_t gid;
+    struct ldapi_mapping *next;
+};
+
+static struct ldapi_mapping *ldapi_mappings = NULL;
+static Slapi_RWLock *dn_mapping_lock = NULL;
+
+void
+initialize_ldapi_auth_dn_mappings(slapi_ldapi_state reload)
+{
+    Slapi_PBlock *search_pb = NULL;
+    Slapi_Entry **entries = NULL;
+    struct ldapi_mapping *mappings = NULL;
+    char *base_dn = config_get_ldapi_mapping_base_dn();
+    char *filter = "(|(objectclass=nsLDAPIAuthMap)(objectclass=nsLDAPIFixedAuthMap))";
+    int32_t result = 0;
+
+    if (base_dn == NULL) {
+        /* nothing to do */
+        return;
+    }
+
+    if (reload) {
+        /* Free the current mapping and rebuild it */
+        free_ldapi_auth_dn_mappings(LDAPI_RELOAD);
+    } else {
+        /* Server is starting up, init mutex */
+        if ((dn_mapping_lock = slapi_new_rwlock_prio(1 /* priority on writers */)) == NULL) {
+            slapi_log_err(SLAPI_LOG_ERR, "initialize_ldapi_auth_dn_mappings",
+                          "Cannot create new lock.  error %d (%s)\n",
+                          result, strerror(result));
+            exit(-1);
+        }
+    }
+
+    /* Get all the mapping entries */
+    search_pb = slapi_pblock_new();
+    slapi_search_internal_set_pb(search_pb, base_dn, LDAP_SCOPE_SUBTREE, filter,
+            NULL, 0, NULL, NULL, (void *)plugin_get_default_component_id(), 0);
+    slapi_search_internal_pb(search_pb);
+    slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_RESULT, &result);
+    if (result == LDAP_SUCCESS) {
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+        slapi_rwlock_wrlock(dn_mapping_lock);
+        for (size_t i = 0; entries && entries[i]; i++) {
+            const char *username = slapi_entry_attr_get_ref(entries[i], CONFIG_LDAPI_AUTH_USERNAME_ATTRIBUTE);
+            uid_t user_uid = slapi_entry_attr_get_uint(entries[i], "uidNumber");
+            gid_t user_gid = slapi_entry_attr_get_uint(entries[i], "gidNumber");
+
+            if (user_uid && user_gid) {
+                /* There is a fixed uid/gid use that */
+            	struct ldapi_mapping *new_mapping = (struct ldapi_mapping *)slapi_ch_calloc(1, sizeof(struct ldapi_mapping));
+                new_mapping->uid = user_uid;
+                new_mapping->gid = user_gid;
+                new_mapping->dn = slapi_entry_attr_get_charptr(entries[i], CONFIG_LDAPI_AUTH_DN_ATTRIBUTE);
+                if (mappings == NULL) {
+                    ldapi_mappings = new_mapping; /* Set the head */
+                    mappings = new_mapping;
+                } else {
+                    mappings->next = new_mapping;
+                    mappings = mappings->next;
+                }
+            } else {
+                /* Get the uid/gid from the system */
+                struct passwd *pws;
+                pws = getpwnam(username);
+                if (pws) {
+                    struct ldapi_mapping *new_mapping = (struct ldapi_mapping *)slapi_ch_calloc(1, sizeof(struct ldapi_mapping));
+                    new_mapping->uid = pws->pw_uid;
+                    new_mapping->gid = pws->pw_gid;
+                    new_mapping->dn = slapi_entry_attr_get_charptr(entries[i], CONFIG_LDAPI_AUTH_DN_ATTRIBUTE);
+                    if (mappings == NULL) {
+                        ldapi_mappings = new_mapping; /* Set the head */
+                        mappings = new_mapping;
+                    } else {
+                        mappings->next = new_mapping;
+                        mappings = mappings->next;
+                    }
+                } else {
+                    slapi_log_err(SLAPI_LOG_WARNING, "initialize_ldapi_auth_dn_mappings",
+                            "System username (%s) in entry (%s) was not found and will be ignored.\n",
+                            username, slapi_entry_get_dn(entries[i]));
+                }
+            }
+        }
+        slapi_rwlock_unlock(dn_mapping_lock);
+    }
+    slapi_free_search_results_internal(search_pb);
+    slapi_pblock_destroy(search_pb);;
+    slapi_ch_free_string(&base_dn);
+}
+
+void
+free_ldapi_auth_dn_mappings(int32_t shutdown)
+{
+    struct ldapi_mapping *mapping = ldapi_mappings;
+    struct ldapi_mapping *next_mapping = NULL;
+
+    slapi_rwlock_wrlock(dn_mapping_lock);
+
+    while (mapping) {
+        next_mapping = mapping->next;
+        slapi_ch_free_string(&mapping->dn);
+        slapi_ch_free((void **)&mapping);
+        mapping = next_mapping;
+    }
+
+    slapi_rwlock_unlock(dn_mapping_lock);
+
+    if (shutdown == LDAPI_SHUTDOWN) {
+        slapi_destroy_rwlock(dn_mapping_lock);
+    }
+}
+
+int32_t
+slapd_identify_local_user(Connection *conn)
+{
+    uid_t uid = 0;
+    gid_t gid = 0;
+    int32_t ret = -1;
+
+    conn->c_local_valid = 0;
+
+    if (0 == slapd_get_socket_peer(conn->c_prfd, &uid, &gid)) {
+        conn->c_local_uid = uid;
+        conn->c_local_gid = gid;
+        conn->c_local_valid = 1;
+
+        ret = 0;
+    }
+
+    return ret;
+}
+
+#if defined(ENABLE_AUTOBIND)
+int32_t
+slapd_bind_local_user(Connection *conn)
+{
+    uid_t uid = conn->c_local_uid;
+    gid_t gid = conn->c_local_gid;
+    char *auth_dn = NULL;
+    int32_t ret = -1;
+
+    uid_t proc_uid = geteuid();
+    gid_t proc_gid = getegid();
+
+    if (!conn->c_local_valid) {
+        goto done;
+    }
+
+    /* observe configuration for auto binding */
+    /* bind at all? */
+    if (config_get_ldapi_bind_switch()) {
+        /* map users to a dn root may also map to an entry */
+        /* require real entry? */
+        if (config_get_ldapi_map_entries()) {
+            /*
+             * First check if the uid/gid maps to one of our LDAPI auth mappings
+             */
+            slapi_rwlock_rdlock(dn_mapping_lock);
+            for (struct ldapi_mapping *mapping = ldapi_mappings; mapping; mapping = mapping->next) {
+                if (mapping->uid == uid && mapping->gid == gid) {
+                    /* We found this user in our mappings, make sure the entry
+                     * actually exists, and check if it's locked out before binding */
+                    Slapi_Entry *e = NULL;
+                    auth_dn = slapi_ch_strdup(mapping->dn);
+                    Slapi_DN sdn;
+
+                    slapi_sdn_init_dn_byref(&sdn, auth_dn);
+                    slapi_search_internal_get_entry(&sdn, NULL, &e, plugin_get_default_component_id());
+                    slapi_sdn_done(&sdn);
+                    if (e) {
+                        ret = slapi_check_account_lock(0, e, 0, 0, 0);
+                        if (ret == 0) {
+                            /* All looks good, now do the bind */
+                            bind_credentials_set_nolock(conn, SLAPD_AUTH_OS, auth_dn,
+                                                        NULL, NULL, NULL, NULL);
+                        }
+                        /* all done here */
+                        slapi_rwlock_unlock(dn_mapping_lock);
+                        goto done;
+                    } else {
+                        slapi_log_err(SLAPI_LOG_ERR, "slapd_bind_local_user",
+                                "LDAPI auth mapping for (%s) points to entry that does not exist\n",
+                                auth_dn);
+                        break;
+                    }
+                }
+            }
+            slapi_rwlock_unlock(dn_mapping_lock);
+
+            /* get uid type to map to (e.g. uidNumber) */
+            char *utype = config_get_ldapi_uidnumber_type();
+            /* get gid type to map to (e.g. gidNumber) */
+            char *gtype = config_get_ldapi_gidnumber_type();
+            /* get base dn for search */
+            char *base_dn = config_get_ldapi_search_base_dn();
+
+            /* search vars */
+            Slapi_PBlock *search_pb = NULL;
+            Slapi_Entry **entries = NULL;
+            int32_t result;
+
+            /* filter manipulation vars */
+            char *one_type = NULL;
+            char *filter_tpl = NULL;
+            char *filter = NULL;
+
+            /* create filter, matching whatever is given */
+            if (utype && gtype) {
+                filter_tpl = "(&(%s=%u)(%s=%u))";
+            } else {
+                if (utype || gtype) {
+                    filter_tpl = "(%s=%u)";
+                    if (utype) {
+                        one_type = utype;
+                    } else {
+                        one_type = gtype;
+                    }
+                } else {
+                    goto entry_map_free;
+                }
+            }
+
+            if (one_type) {
+                if (one_type == utype) {
+                    filter = slapi_ch_smprintf(filter_tpl, utype, uid);
+                } else {
+                    filter = slapi_ch_smprintf(filter_tpl, gtype, gid);
+                }
+            } else {
+                filter = slapi_ch_smprintf(filter_tpl, utype, uid, gtype, gid);
+            }
+
+            /* search for single entry matching types */
+            search_pb = slapi_pblock_new();
+            slapi_search_internal_set_pb(
+                search_pb,
+                base_dn,
+                LDAP_SCOPE_SUBTREE,
+                filter,
+                NULL, 0, NULL, NULL,
+                (void *)plugin_get_default_component_id(),
+                0);
+
+            slapi_search_internal_pb(search_pb);
+            slapi_pblock_get(
+                search_pb,
+                SLAPI_PLUGIN_INTOP_RESULT,
+                &result);
+            if (LDAP_SUCCESS == result)
+                slapi_pblock_get(
+                    search_pb,
+                    SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES,
+                    &entries);
+
+            if (entries) {
+                /* zero or multiple entries fail */
+                if (entries[0] && 0 == entries[1]) {
+                    /* observe account locking */
+                    ret = slapi_check_account_lock(
+                        0, /* pb not req */
+                        entries[0],
+                        0, /* no response control */
+                        0, /* don't check password policy */
+                        0  /* don't send ldap result */
+                        );
+
+                    if (0 == ret) {
+                        auth_dn = slapi_ch_strdup(slapi_entry_get_ndn(entries[0]));
+                        bind_credentials_set_nolock(
+                            conn,
+                            SLAPD_AUTH_OS,
+                            auth_dn,
+                            NULL, NULL,
+                            NULL, entries[0]);
+                    }
+                }
+            }
+
+        entry_map_free:
+            /* auth_dn consumed by bind creds set */
+            slapi_free_search_results_internal(search_pb);
+            slapi_pblock_destroy(search_pb);
+            slapi_ch_free_string(&filter);
+            slapi_ch_free_string(&utype);
+            slapi_ch_free_string(&gtype);
+            slapi_ch_free_string(&base_dn);
+        }
+
+        /*
+         * We map the current process uid also to directory manager.
+         * This is secure as it requires local machine OR same-container volume
+         * access and the correct uid access. If you have access to the uid/gid
+         * and are on the same machine you could always just reset the rootdn hashes
+         * anyway ... so this is no reduction in security.
+         */
+
+        if (ret && (0 == uid || proc_uid == uid || proc_gid == gid)) {
+            /* map unix root (uidNumber:0)? */
+            char *root_dn = config_get_ldapi_root_dn();
+
+            if (root_dn) {
+                Slapi_PBlock *entry_pb = NULL;
+                Slapi_DN *edn = slapi_sdn_new_dn_byref(slapi_dn_normalize(root_dn));
+                Slapi_Entry *e = NULL;
+
+                /* root might be locked too! :) */
+                ret = slapi_search_get_entry(&entry_pb, edn, 0, &e, (void *)plugin_get_default_component_id());
+                if (0 == ret && e) {
+                    ret = slapi_check_account_lock(
+                        0, /* pb not req */
+                        e,
+                        0, /* no response control */
+                        0, /* don't check password policy */
+                        0  /* don't send ldap result */
+                        );
+
+                    if (1 == ret)
+                        /* sorry root,
+                         * just not cool enough
+                         */
+                        goto root_map_free;
+                }
+
+                /* it's ok not to find the entry,
+                 * dn doesn't have to have an entry
+                 * e.g. cn=Directory Manager
+                 */
+                bind_credentials_set_nolock(
+                    conn, SLAPD_AUTH_OS, root_dn,
+                    NULL, NULL, NULL, e);
+
+            root_map_free:
+                /* root_dn consumed by bind creds set */
+                slapi_sdn_free(&edn);
+                slapi_search_get_entry_done(&entry_pb);
+                ret = 0;
+            }
+        }
+
+#if defined(ENABLE_AUTO_DN_SUFFIX)
+        if (ret) {
+            /* create phony auth dn? */
+            char *base = config_get_ldapi_auto_dn_suffix();
+            if (base) {
+                auth_dn = slapi_ch_smprintf("gidNumber=%u+uidNumber=%u,%s",
+                                            gid, uid, base);
+                auth_dn = slapi_dn_normalize(auth_dn);
+                bind_credentials_set_nolock(
+                    conn,
+                    SLAPD_AUTH_OS,
+                    auth_dn,
+                    NULL, NULL, NULL, NULL);
+
+                /* auth_dn consumed by bind creds set */
+                slapi_ch_free_string(&base);
+                ret = 0;
+            }
+        }
+#endif
+    }
+
+done:
+    /* if all fails, the peer is anonymous */
+    if (conn->c_dn) {
+        /* log the auto bind */
+        slapi_log_access(LDAP_DEBUG_STATS, "conn=%" PRIu64 " AUTOBIND dn=\"%s\"\n", conn->c_connid, conn->c_dn);
+    }
+
+    return ret;
+}
+#endif /* ENABLE_AUTOBIND */
+#endif /* ENABLE_LDAPI */

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -833,6 +833,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.ldapi_search_base_dn,
      CONFIG_STRING, NULL, SLAPD_DEFAULT_LDAPI_SEARCH_BASE, NULL},
+    {CONFIG_LDAPI_AUTH_MAP_BASE_ATTRIBUTE, config_set_ldapi_mapping_base_dn,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.ldapi_auto_mapping_base,
+     CONFIG_STRING, NULL, SLAPD_DEFAULT_LDAPI_MAPPING_DN, NULL},
 #if defined(ENABLE_AUTO_DN_SUFFIX)
     {CONFIG_LDAPI_AUTO_DN_SUFFIX_ATTRIBUTE, config_set_ldapi_auto_dn_suffix,
      NULL, 0,
@@ -1613,6 +1617,7 @@ FrontendConfig_init(void)
     cfg->ldapi_gidnumber_type = slapi_ch_strdup(SLAPD_DEFAULT_GIDNUM_TYPE);
     /* These DNs are no need to be normalized. */
     cfg->ldapi_search_base_dn = slapi_ch_strdup(SLAPD_DEFAULT_LDAPI_SEARCH_BASE);
+    cfg->ldapi_auto_mapping_base = slapi_ch_strdup(SLAPD_DEFAULT_LDAPI_MAPPING_DN);
 #if defined(ENABLE_AUTO_DN_SUFFIX)
     cfg->ldapi_auto_dn_suffix = slapi_ch_strdup(SLAPD_DEFAULT_LDAPI_AUTO_DN);
 #endif
@@ -2551,6 +2556,37 @@ config_set_ldapi_search_base_dn(const char *attrname, char *value, char *errorbu
         slapdFrontendConfig->ldapi_search_base_dn = slapi_ch_strdup(value);
         CFG_UNLOCK_WRITE(slapdFrontendConfig);
     }
+    return retVal;
+}
+
+int
+config_set_ldapi_mapping_base_dn(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    if (config_value_is_null(attrname, value, errorbuf, 0)) {
+        /* Make sure value is NULL in this case */
+        value = NULL;
+    }
+
+    if (apply) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        slapi_ch_free_string(&(slapdFrontendConfig->ldapi_auto_mapping_base));
+        slapdFrontendConfig->ldapi_auto_mapping_base = slapi_ch_strdup(value);
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+char *
+config_get_ldapi_mapping_base_dn(void)
+{
+    char *retVal;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapi_ch_strdup(slapdFrontendConfig->ldapi_auto_mapping_base);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
     return retVal;
 }
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -252,6 +252,7 @@ int config_set_ldapi_map_entries(const char *attrname, char *value, char *errorb
 int config_set_ldapi_uidnumber_type(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ldapi_gidnumber_type(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ldapi_search_base_dn(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_ldapi_mapping_base_dn(const char *attrname, char *value, char *errorbuf, int apply);
 #if defined(ENABLE_AUTO_DN_SUFFIX)
 int config_set_ldapi_auto_dn_suffix(const char *attrname, char *value, char *errorbuf, int apply);
 #endif
@@ -428,6 +429,7 @@ int config_get_ldapi_map_entries(void);
 char *config_get_ldapi_uidnumber_type(void);
 char *config_get_ldapi_gidnumber_type(void);
 char *config_get_ldapi_search_base_dn(void);
+char *config_get_ldapi_mapping_base_dn(void);
 #if defined(ENABLE_AUTO_DN_SUFFIX)
 char *config_get_ldapi_auto_dn_suffix(void);
 #endif

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -462,7 +462,6 @@ LDAPMod **copy_mods(LDAPMod **orig_mods);
  */
 #define LDAP_MOD_IGNORE 0x100
 
-
 /* dl.c */
 typedef struct datalist DataList;
 

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -785,7 +785,6 @@ modify_internal_entry(char *dn, LDAPMod **mods)
             }
             DS_Sleep(PR_SecondsToInterval(1));
         }
-
         slapi_pblock_destroy(pb);
     } while (ret != LDAP_SUCCESS);
 }
@@ -2589,6 +2588,58 @@ fixup_tombstone_task_destructor(Slapi_Task *task)
                   "fixup_tombstone_task_destructor <--\n");
 }
 
+#if defined(ENABLE_LDAPI)
+static void
+task_ldapi_reload_thread(void *arg)
+{
+	Slapi_Task *task = (Slapi_Task *)arg;
+
+	initialize_ldapi_auth_dn_mappings(LDAPI_RELOAD);
+	slapi_task_log_notice(task, "Finished LDAPI DN Mapping Reload task.\n");
+	slapi_task_log_status(task, "Finished LDAPI DN Mapping Reload task.\n");
+	slapi_task_finish(task, 0);
+}
+
+/*
+ *  dn: cn=reload,cn=reload ldapi mappings,cn=tasks,cn=config
+ *  objectclass: top
+ *  objectclass: extensibleObject
+ *  cn: reload
+ */
+static int
+task_ldapi_dn_mapping_reload_add(Slapi_PBlock *pb __attribute__((unused)),
+                                 Slapi_Entry *e,
+                                 Slapi_Entry *eAfter __attribute__((unused)),
+                                 int *returncode,
+                                 char *returntext,
+                                 void *arg __attribute__((unused)))
+{
+    Slapi_Task *task = NULL;
+    PRThread *thread = NULL;
+    int32_t rc = 0;
+
+    /* allocate new task now */
+    task = slapi_new_task(slapi_entry_get_ndn(e));
+    slapi_task_begin(task, 1);
+    slapi_task_log_notice(task, "Beginning LDAPI DN Mapping Reload task...\n");
+    slapi_task_log_status(task, "Beginning LDAPI DN Mapping Reload task...\n");
+
+    /* start the reload as a separate thread */
+    thread = PR_CreateThread(PR_USER_THREAD, task_ldapi_reload_thread,
+                             (void *)task, PR_PRIORITY_NORMAL, PR_GLOBAL_THREAD,
+                             PR_UNJOINABLE_THREAD, SLAPD_DEFAULT_THREAD_STACKSIZE);
+    if (thread == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR,
+                      "task_backup_add", "Unable to create backup thread!\n");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        rc = SLAPI_DSE_CALLBACK_ERROR;
+        slapi_task_finish(task, rc);
+    }
+
+    return SLAPI_DSE_CALLBACK_OK;
+}
+#endif
+
 /* cleanup old tasks that may still be in the DSE from a previous session
  * (this can happen if the server crashes [no matter how unlikely we like
  * to think that is].)
@@ -2670,6 +2721,9 @@ task_init(void)
     slapi_task_register_handler("upgradedb", task_upgradedb_add);
     slapi_task_register_handler("sysconfig reload", task_sysconfig_reload_add);
     slapi_task_register_handler("fixup tombstones", task_fixup_tombstones_add);
+#if defined(ENABLE_LDAPI)
+    slapi_task_register_handler("reload ldapi mappings", task_ldapi_dn_mapping_reload_add);
+#endif
 }
 
 /* called when the server is shutting down -- abort all existing tasks */

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 dependencies = [
  "const-random",
 ]
@@ -147,7 +147,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.1",
  "lazy_static",
  "proc-macro-hack",
  "tiny-keccak",
@@ -261,7 +261,7 @@ checksum = "e7ac567fd75ce6bc28b68e63b5beaa3ce34f56bafd1122f64f8647c822e38a8b"
 dependencies = [
  "base64 0.10.1",
  "byteorder",
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "openssl",
 ]
 
@@ -282,24 +282,24 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
@@ -343,9 +343,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "librnsslapd"
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -601,7 +601,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -624,7 +624,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
 
 [[package]]
 name = "strsim"
@@ -724,9 +724,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"
@@ -812,6 +812,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -1259,3 +1259,23 @@ class DSLdapObjects(DSLogging, DSLints):
             # There are no objects to select from, se we return an empty array
             insts = []
         return insts
+
+
+class DSContainer(DSLdapObject):
+    """Just a basic container entry
+
+    :param instance: DirSrv instance
+    :type instance: DirSrv
+    :param dn: The dn of the entry
+    :type dn: str
+    """
+
+    def __init__(self, instance, dn):
+        super(DSContainer, self).__init__(instance, dn)
+        self._rdn_attribute = 'cn'
+        self._must_attributes = ['cn']
+        self._create_objectclasses = [
+            'top',
+            'nsContainer',
+        ]
+        self._protected = True

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -604,7 +604,7 @@ class SetupDs(object):
 
         # Right now, the way that rootpw works on ns-slapd works, it force hashes the pw
         # see https://fedorahosted.org/389/ticket/48859
-        if not re.match('^\{[A-Z0-9]+\}.*$', slapd['root_password']):
+        if not re.match('^([A-Z0-9]+).*$', slapd['root_password']):
             # We need to hash it. Call pwdhash-bin.
             # slapd['root_password'] = password_hash(slapd['root_password'], prefix=slapd['prefix'])
             pass

--- a/src/lib389/lib389/ldap_objs.py
+++ b/src/lib389/lib389/ldap_objs.py
@@ -1,0 +1,30 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+from lib389._mapped_object import DSLdapObject
+
+# Collection of generic LDAP objects/entries
+
+class DSContainer(DSLdapObject):
+    """Just a basic container entry
+
+    :param instance: DirSrv instance
+    :type instance: DirSrv
+    :param dn: The dn of the entry
+    :type dn: str
+    """
+
+    def __init__(self, instance, dn):
+        super(DSContainer, self).__init__(instance, dn)
+        self._rdn_attribute = 'cn'
+        self._must_attributes = ['cn']
+        self._create_objectclasses = [
+            'top',
+            'nsContainer',
+        ]
+        self._protected = True

--- a/src/lib389/lib389/ldapi.py
+++ b/src/lib389/lib389/ldapi.py
@@ -1,0 +1,70 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2020 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+from lib389._mapped_object import DSLdapObject
+
+class LDAPIMapping(DSLdapObject):
+    """
+    Manage LDAPI mapping entries
+    """
+    def __init__(self, instance, container_dn, dn=None):
+        """
+        @param instance - a DirSrv instance
+        @param container_dn - the subtree where the mapping entries are located
+        """
+        super(LDAPIMapping, self).__init__(instance, dn)
+        #self._dn = dn
+        self._rdn_attribute = 'cn'
+        self._filterattrs = ['cn']
+        self._must_attributes = ['nsslapd-ldapiusername', 'nsslapd-authenticateasdn']
+        self._create_objectclasses = ['top', 'nsLDAPIAuthMap']
+        self._container_dn = container_dn
+
+    def create_mapping(self, name, username, ldap_dn):
+        """
+        @param name - name for the container entry.  This will be the RDN value.
+        @param username - the system username
+        @param ldap_dn - the LDAP DN that the system user should be mapped to
+        """
+        self._dn = None  # clear the DN before creating a new mapping
+        self.create(basedn=self._container_dn,
+                    properties={'cn': name,
+                                'nsslapd-ldapiusername': username,
+                                'nsslapd-authenticateasdn': ldap_dn})
+
+
+class LDAPIFixedMapping(DSLdapObject):
+    """
+    Manage LDAPI mapping entries
+    """
+    def __init__(self, instance, container_dn, dn=None):
+        """
+        @param instance - a DirSrv instance
+        @param container_dn - the subtree where the mapping entries are located
+        """
+        super(LDAPIFixedMapping, self).__init__(instance, dn)
+        self._dn = dn
+        self._rdn_attribute = 'cn'
+        self._filterattrs = ['cn']
+        self._must_attributes = ['uidNumber', 'gidNumber', 'nsslapd-authenticateasdn']
+        self._create_objectclasses = ['top', 'nsLDAPIFixedAuthMap']
+        self._container_dn = container_dn
+
+    def create_mapping(self, name, uid, gid, ldap_dn):
+        """
+        @param name - name for the container entry.  This will be the RDN value.
+        @param uid - the system user's uid
+        @param gid - the system user's gid
+        @param ldap_dn - the LDAP DN that the system user should be mapped to
+        """
+        self._dn = None  # clear the DN before creating a new mapping
+        self.create(basedn=self._container_dn,
+                    properties={'cn': name,
+                                'uidNumber': uid,
+                                'gidNumber': gid,
+                                'nsslapd-authenticateasdn': ldap_dn})

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -1385,7 +1385,7 @@ class Tasks(object):
             raise ValueError("Missing required paramter: configfile")
 
         cn = 'task-' + time.strftime("%m%d%Y_%H%M%S", time.localtime())
-        dn = ('cn=%s,cn=cn=sysconfig reload,cn=tasks,cn=config' % cn)
+        dn = ('cn=%s,cn=sysconfig reload,cn=tasks,cn=config' % cn)
         entry = Entry(dn)
         entry.setValues('objectclass', 'top', 'extensibleObject')
         entry.setValues('cn', cn)
@@ -1577,3 +1577,16 @@ class Tasks(object):
         self.entry = entry
 
         return exitCode
+
+
+class LDAPIMappingReloadTask(Task):
+    """LDAPI DN Mapping task entry
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    """
+
+    def __init__(self, instance, dn=None):
+        self.cn = 'reload-' + Task._get_task_date()
+        dn = f'cn={self.cn},cn=reload ldapi mappings,cn=tasks,cn=config'
+        super(LDAPIMappingReloadTask, self).__init__(instance, dn)


### PR DESCRIPTION
Description:  

Create a new LDAPI configuration attribute to specify a DN syntax attribute that can be added to an LDAP entry that will cause the BIND to use the DN set in that attribute.

For more information see:

https://www.port389.org/docs/389ds/design/ldapi-auto-auth-dn-design.html

Relates: https://github.com/389ds/389-ds-base/issues/4381

