### PR TITLE
Issue 1795 - RFE - Enable logging for libldap and libber in error log

### DIFF
--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
@@ -138,6 +138,40 @@ def test_verify_operation_when_disk_monitoring_is_off(topo, setup, reset_logs):
 
 
 @disk_monitoring_ack
+def test_enable_external_libs_debug_log(topo, setup, reset_logs):
+    """Check that OpenLDAP logs are successfully enabled and disabled when
+    disk threshold is reached
+
+    :id: 121b2b24-ecba-48e2-9ee2-312d929dc8c6
+    :setup: Standalone instance
+    :steps: 1. Set nsslapd-external-libs-debug-enabled to "on"
+            2. Go straight below 1/2 of the threshold
+            3. Verify that the external libs debug setting is disabled
+            4. Go back above 1/2 of the threshold
+            5. Verify that the external libs debug setting is enabled back
+    :expectedresults: 1. Success
+                      2. Success
+                      3. Success
+                      4. Success
+                      5. Success
+    """
+    try:
+        # Verify that verbose logging was set to default level
+        assert topo.standalone.config.set('nsslapd-disk-monitoring', 'on')
+        assert topo.standalone.config.set('nsslapd-disk-monitoring-logging-critical', 'off')
+        assert topo.standalone.config.set('nsslapd-external-libs-debug-enabled', 'on')
+        assert topo.standalone.config.set('nsslapd-errorlog-level', '8')
+        topo.standalone.restart()
+        subprocess.call(['dd', 'if=/dev/zero', 'of={}/foo'.format(topo.standalone.ds_paths.log_dir), 'bs=1M', 'count={}'.format(HALF_THR_FILL_SIZE)])
+        # Verify that logging is disabled
+        _withouterrorlog(topo, "topo.standalone.config.get_attr_val_utf8('nsslapd-external-libs-debug-enabled') != 'off'", 31)
+    finally:
+        os.remove('{}/foo'.format(topo.standalone.ds_paths.log_dir))
+        _withouterrorlog(topo, "topo.standalone.config.get_attr_val_utf8('nsslapd-external-libs-debug-enabled') != 'on'", 31)
+        assert topo.standalone.config.set('nsslapd-external-libs-debug-enabled', 'off')
+
+
+@disk_monitoring_ack
 def test_free_up_the_disk_space_and_change_ds_config(topo, setup, reset_logs):
     """Free up the disk space and change DS config
 
@@ -734,3 +768,4 @@ def test_valid_operations_are_permitted(topo, setup, reset_logs):
 if __name__ == '__main__':
     CURRENT_FILE = os.path.realpath(__file__)
     pytest.main("-s -v %s" % CURRENT_FILE)
+

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -409,6 +409,7 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
     int using_accesslog = 0;
     int using_auditlog = 0;
     int using_auditfaillog = 0;
+    int using_external_libs_debug = 0;
     int logs_disabled = 0;
     int grace_period = 0;
     int first_pass = 1;
@@ -421,6 +422,8 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
     Slapi_Backend *be_list[BE_LIST_SIZE + 1] = {0};
 
     while (!g_get_shutdown()) {
+        char errorbuf[SLAPI_DSE_RETURNTEXT_SIZE];
+
         if (!first_pass) {
             struct timespec current_time = {0};
 
@@ -458,6 +461,9 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
         if (config_get_accesslog_logging_enabled()) {
             using_accesslog = 1;
         }
+        if (config_get_external_libs_debug_enabled()) {
+            using_external_libs_debug = 1;
+        }
         /*
          *  Check the disk space.  Always refresh the list, as backends can be added
          */
@@ -492,6 +498,13 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
                     }
                     if (using_auditfaillog) {
                         config_set_auditfaillog_enabled(LOGGING_ON);
+                    }
+                    if (using_external_libs_debug) {
+                        if (config_set_external_libs_debug_enabled(CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED,
+                                "on", errorbuf, CONFIG_APPLY) != LDAP_SUCCESS) {
+                            slapi_log_err(SLAPI_LOG_ERR, "disk_monitoring_thread - setting on: %s: %s\n",
+                                          CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED, errorbuf);
+                        }
                     }
                 } else {
                     slapi_log_err(SLAPI_LOG_INFO, "disk_monitoring_thread", "Disk space is now within acceptable levels.\n");
@@ -573,6 +586,12 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
             config_set_accesslog_enabled(LOGGING_OFF);
             config_set_auditlog_enabled(LOGGING_OFF);
             config_set_auditfaillog_enabled(LOGGING_OFF);
+            if (config_set_external_libs_debug_enabled(CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED,
+                    "off", errorbuf, CONFIG_APPLY) != LDAP_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_ERR, "disk_monitoring_thread - setting off: %s: %s\n",
+                              CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED, errorbuf);
+            }
+
             logs_disabled = 1;
             continue;
         }
@@ -656,6 +675,13 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
                     }
                     if (logs_disabled && using_auditfaillog) {
                         config_set_auditfaillog_enabled(LOGGING_ON);
+                    }
+                    if (logs_disabled && using_external_libs_debug) {
+                        if (config_set_external_libs_debug_enabled(CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED,
+                                "on", errorbuf, CONFIG_APPLY) != LDAP_SUCCESS) {
+                            slapi_log_err(SLAPI_LOG_ERR, "disk_monitoring_thread - setting on: %s: %s\n",
+                                          CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED, errorbuf);
+                        }
                     }
                     deleted_rotated_logs = 0;
                     passed_threshold = 0;

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -183,6 +183,7 @@ slapi_onoff_t init_auditlog_rotationsync_enabled;
 slapi_onoff_t init_auditfaillog_rotationsync_enabled;
 slapi_onoff_t init_accesslog_logging_enabled;
 slapi_onoff_t init_accesslogbuffering;
+slapi_onoff_t init_external_libs_debug_enabled;
 slapi_onoff_t init_errorlog_logging_enabled;
 slapi_onoff_t init_auditlog_logging_enabled;
 slapi_onoff_t init_auditlog_logging_hide_unhashed_pw;
@@ -561,6 +562,11 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.errorlog,
      CONFIG_STRING_OR_EMPTY, NULL, NULL, NULL /* deletion is not allowed */},
+    {CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED, config_set_external_libs_debug_enabled,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.external_libs_debug_enabled,
+     CONFIG_ON_OFF, (ConfigGetFunc)config_get_external_libs_debug_enabled,
+     &init_external_libs_debug_enabled, NULL},
     {CONFIG_AUDITLOG_LOGEXPIRATIONTIME_ATTRIBUTE, NULL,
      log_set_expirationtime, SLAPD_AUDIT_LOG,
      (void **)&global_slapdFrontendConfig.auditlog_exptime,
@@ -1712,6 +1718,7 @@ FrontendConfig_init(void)
     init_csnlogging = cfg->csnlogging = LDAP_ON;
 
     init_errorlog_logging_enabled = cfg->errorlog_logging_enabled = LDAP_ON;
+    init_external_libs_debug_enabled = cfg->external_libs_debug_enabled = LDAP_OFF;
     cfg->errorlog_mode = slapi_ch_strdup(SLAPD_INIT_LOG_MODE);
     cfg->errorlog_maxnumlogs = SLAPD_DEFAULT_LOG_MAXNUMLOGS;
     cfg->errorlog_maxlogsize = SLAPD_DEFAULT_LOG_MAXLOGSIZE;
@@ -6108,6 +6115,13 @@ config_get_errorlog()
     return retVal;
 }
 
+int32_t
+config_get_external_libs_debug_enabled()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    return slapi_atomic_load_32(&(slapdFrontendConfig->external_libs_debug_enabled), __ATOMIC_ACQUIRE);
+}
+
 char *
 config_get_auditlog()
 {
@@ -8435,6 +8449,28 @@ config_set_entry(Slapi_Entry *e)
     }
 
     return 1;
+}
+
+
+int
+config_set_external_libs_debug_enabled(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int32_t retVal = LDAP_SUCCESS;
+    int32_t dbglvl = 0; /* no debugging */
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    retVal = config_set_onoff(attrname, value, &(slapdFrontendConfig->external_libs_debug_enabled),
+                              errorbuf, apply);
+    if (retVal == LDAP_SUCCESS && strcasecmp(value, "on") == 0) {
+        dbglvl = -1; /* all debug levels */
+    } else if (retVal == LDAP_SUCCESS && strcasecmp(value, "off") == 0) {
+        dbglvl = 0;
+    } else {
+        return retVal;
+    }
+    ber_set_option(NULL, LBER_OPT_DEBUG_LEVEL, &dbglvl);
+    ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, &dbglvl);
+    return retVal;
 }
 
 void

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -119,6 +119,7 @@ static void log_write_title(LOGFD fp);
 static void log__error_emergency(const char *errstr, int reopen, int locked);
 static void vslapd_log_emergency_error(LOGFD fp, const char *msg, int locked);
 static int get_syslog_loglevel(int loglevel);
+static void log_external_libs_debug_openldap_print(char *buffer);
 
 static int
 get_syslog_loglevel(int loglevel)
@@ -439,6 +440,23 @@ log_set_logging(const char *attrname, char *value, int logtype, char *errorbuf, 
     }
 
     return LDAP_SUCCESS;
+}
+
+static void
+log_external_libs_debug_openldap_print(char *buffer)
+{
+    slapi_log_error(SLAPI_LOG_WARNING, "libldap/libber", "%s", buffer);
+}
+
+int
+log_external_libs_debug_set_log_fn(void)
+{
+    int rc = ber_set_option(NULL, LBER_OPT_LOG_PRINT_FN, log_external_libs_debug_openldap_print);
+    if (rc != LBER_OPT_SUCCESS) {
+        slapi_log_error(SLAPI_LOG_WARNING, "libldap/libber",
+              "Failed to init Log Function, err = %d\n", rc);
+    }
+    return rc;
 }
 
 int

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -542,6 +542,9 @@ main(int argc, char **argv)
 #endif
 #endif
 
+    /* Set third party libs function before we init config so we see the logs earlier */
+    log_external_libs_debug_set_log_fn();
+
     /*
      * Initialize NSPR very early. NSPR supports implicit initialization,
      * but it is not bulletproof -- so it is better to be explicit.

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -385,6 +385,7 @@ int config_set_disk_grace_period(const char *attrname, char *value, char *errorb
 int config_set_disk_logging_critical(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditlog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditfaillog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_external_libs_debug_enabled(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ndn_cache_enabled(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ndn_cache_max_size(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_unhashed_pw_switch(const char *attrname, char *value, char *errorbuf, int apply);
@@ -403,6 +404,7 @@ int config_set_localuser(const char *attrname, char *value, char *errorbuf, int 
 
 int config_set_maxsimplepaged_per_conn(const char *attrname, char *value, char *errorbuf, int apply);
 
+int log_external_libs_debug_set_log_fn(void);
 int log_set_backend(const char *attrname, char *value, int logtype, char *errorbuf, int apply);
 
 #ifdef HAVE_CLOCK_GETTIME
@@ -544,6 +546,7 @@ void config_set_accesslog_enabled(int value);
 void config_set_auditlog_enabled(int value);
 void config_set_auditfaillog_enabled(int value);
 int config_get_accesslog_logging_enabled(void);
+int config_get_external_libs_debug_enabled(void);
 int config_get_disk_monitoring(void);
 int config_get_disk_threshold_readonly(void);
 uint64_t config_get_disk_threshold(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2098,6 +2098,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_AUDITFAILLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-auditfaillog-logexpirationtimeunit"
 #define CONFIG_ACCESSLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-accesslog-logging-enabled"
 #define CONFIG_ERRORLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-errorlog-logging-enabled"
+#define CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED "nsslapd-external-libs-debug-enabled"
 #define CONFIG_AUDITLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-auditlog-logging-enabled"
 #define CONFIG_AUDITFAILLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-auditfaillog-logging-enabled"
 #define CONFIG_AUDITLOG_LOGGING_HIDE_UNHASHED_PW "nsslapd-auditlog-logging-hide-unhashed-pw"
@@ -2428,6 +2429,7 @@ typedef struct _slapdFrontendConfig
     int errorlog_exptime;
     char *errorlog_exptimeunit;
     int errorloglevel;
+    slapi_onoff_t external_libs_debug_enabled;
 
     /* AUDIT LOG */
     char *auditlog; /* replication audit file */


### PR DESCRIPTION
Description: Libraries like libldap, libber do error and debug
logging, but it is not available in the DS logs.

Provide a way to enable the third party logging in DS.
Add nsslapd-external-libs-debug-enabled attribute to 'cn=config'
which will enable all of the levels abailable in libldap and libber.
The setting should be used only for debugging purposes as
it prints all of the operataions with a great verbosity.

The code for log_external_libs_debug_print() and
log_external_libs_debug_set_log_fn() functions are provided
by a former Red Hat employee - Ludwig Krispenz.

Fixes: #1795

Reviewed by: ?