### PR TITLE
Issue 4486 - Remove random ldif file generation from import test

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -35,7 +35,10 @@ def _generate_ldif(topo, no_no):
     """
     ldif_dir = topo.standalone.get_ldif_dir()
     import_ldif = ldif_dir + '/basic_import.ldif'
-    dbgen_users(topo.standalone, no_no, import_ldif, DEFAULT_SUFFIX)
+    if os.path.isfile(import_ldif):
+        pass
+    else:
+        dbgen_users(topo.standalone, no_no, import_ldif, DEFAULT_SUFFIX)
 
 
 def _check_users_before_test(topo, no_no):


### PR DESCRIPTION
Bug Description: The test_fast_slow_import() test validates the performance
                 impact of the nsslapd-db-private-import-mem config attribute
                 over multiple ldif file offline imports. For each import, a
                 random ldif file is generated which can differ in size,
                 effecting the duration of the import.

Fix Description: Check if the ldif file exists before creating a new one, so we
                 have the same ldif file for each import comparison.

Fixes: https://github.com/389ds/389-ds-base/issues/4486

Reviewed by: ?