### PR TITLE
Issue 4489 - Remove return statement from a void function

### DIFF
--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -473,7 +473,7 @@ void
 slapi_task_set_warning(Slapi_Task *task, task_warning warn)
 {
     if (task) {
-        return task->task_warn |= warn;
+        task->task_warn |= warn;
     }
 }
 


### PR DESCRIPTION
Bug  Description: void function returns a value, causing compiler warnings.

Fix Description: Remove return statement.

Relates: https://github.com/389ds/389-ds-base/issues/4419

Reviewed by: One line rule