### PR TITLE
Issue 4480 - Unexpected info returned to ldap request

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1477,6 +1477,36 @@ def test_dscreate_with_different_rdn(dscreate_test_rdn_value):
         else:
             assert True
 
+def test_bind_invalid_entry(topology_st):
+    """Test the failing bind does not return information about the entry
+
+    :id: 5cd9b083-eea6-426b-84ca-83c26fc49a6f
+
+    :setup: Standalone instance
+
+    :steps:
+    1: bind as non existing entry
+    2: check that bind info does not report 'No such entry'
+
+    :expectedresults:
+    1: pass
+    2: pass
+    """
+
+    topology_st.standalone.restart()
+    INVALID_ENTRY="cn=foooo,%s" % DEFAULT_SUFFIX
+    try:
+        topology_st.standalone.simple_bind_s(INVALID_ENTRY, PASSWORD)
+    except ldap.LDAPError as e:
+        log.info('test_bind_invalid_entry: Failed to bind as %s (expected)' % INVALID_ENTRY)
+        log.info('exception description: ' + e.args[0]['desc'])
+        if 'info' in e.args[0]:
+            log.info('exception info: ' + e.args[0]['info'])
+        assert e.args[0]['desc'] == 'Invalid credentials'
+        assert 'info' not in e.args[0]
+        pass
+
+    log.info('test_bind_invalid_entry: PASSED')
 
 if __name__ == '__main__':
     # Run isolated

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.c
@@ -1243,7 +1243,7 @@ ldbm_config_search_entry_callback(Slapi_PBlock *pb __attribute__((unused)),
             if (attrs) {
                 for (size_t i = 0; attrs[i]; i++) {
                     if (ldbm_config_moved_attr(attrs[i])) {
-                        slapi_pblock_set(pb, SLAPI_PB_RESULT_TEXT, "at least one required attribute has been moved to the BDB scecific configuration entry");
+                        slapi_pblock_set(pb, SLAPI_RESULT_TEXT, "at least one required attribute has been moved to the BDB scecific configuration entry");
                         break;
                     }
                 }

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -355,7 +355,7 @@ send_ldap_result_ext(
     if (text) {
         pbtext = text;
     } else {
-        slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &pbtext);
+        slapi_pblock_get(pb, SLAPI_RESULT_TEXT, &pbtext);
     }
 
     if (operation == NULL) {


### PR DESCRIPTION
Bug description:
	If the bind entry does not exist, the bind result info
        reports that 'No such entry'. It should not give any
        information if the target entry exists or not

Fix description:
	Does not return any additional information during a bind

relates: https://github.com/389ds/389-ds-base/issues/4480

Reviewed by:

Platforms tested:  F31