### PR TITLE
Issue 4373 - BUG - calloc of size 0 in MT build

### DIFF
--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -918,6 +918,14 @@ mapping_tree_node_build_tree()
      */
     int ent_count = 0;
     slapi_pblock_get(pb, SLAPI_NENTRIES, (void *)&ent_count);
+    if (ent_count == 0) {
+        /*
+         * It is invalid to do a calloc of 0, so if we have no entries. we just return.
+         */
+        result = 0;
+        goto build_tree_done;
+    }
+
     struct mt_suffix_ord *ordered_suffixes = (struct mt_suffix_ord *)slapi_ch_calloc(ent_count, sizeof(struct mt_suffix_ord));
     /* Assert the last value is null, and that we don't sigsegv */
     PR_ASSERT(entries[ent_count] == NULL);


### PR DESCRIPTION
Bug Description: In some cases it's possible for there to be
no mapping trees which causes a warning of a calloc of size
0.

Fix Description: In these cases, we can skip the attempt to calloc
and build.

fixes: https://github.com/389ds/389-ds-base/issues/4373

Author: William Brown <william@blackhats.net.au>

Review by: ???