### PR TITLE
Issue 4272 RFE - add support for gost-yescrypt for hashing passwords

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1582,7 +1582,9 @@ libpwdstorage_plugin_la_SOURCES = ldap/servers/plugins/pwdstorage/clear_pwd.c \
 	ldap/servers/plugins/pwdstorage/sha_pwd.c \
 	ldap/servers/plugins/pwdstorage/smd5_pwd.c \
 	ldap/servers/plugins/pwdstorage/ssha_pwd.c \
-	ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c
+	ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c \
+	ldap/servers/plugins/pwdstorage/gost_yescrypt.c \
+	$(NULLSTRING)
 
 libpwdstorage_plugin_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS)
 libpwdstorage_plugin_la_LIBADD = libslapd.la $(NSS_LINK) $(NSPR_LINK) $(LIBCRYPT)

--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -125,13 +125,16 @@ def _test_algo_for_pbkdf2(inst, algo_name):
 
 ALGO_SET = ('CLEAR', 'CRYPT', 'CRYPT-MD5', 'CRYPT-SHA256', 'CRYPT-SHA512',
      'MD5', 'SHA', 'SHA256', 'SHA384', 'SHA512', 'SMD5', 'SSHA',
-     'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',)
+     'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',
+     'GOST_YESCRYPT',
+)
 
 if default_paths.rust_enabled and ds_is_newer('1.4.3.0'):
     ALGO_SET = ('CLEAR', 'CRYPT', 'CRYPT-MD5', 'CRYPT-SHA256', 'CRYPT-SHA512',
          'MD5', 'SHA', 'SHA256', 'SHA384', 'SHA512', 'SMD5', 'SSHA',
          'SSHA256', 'SSHA384', 'SSHA512', 'PBKDF2_SHA256', 'DEFAULT',
-         'PBKDF2-SHA1', 'PBKDF2-SHA256', 'PBKDF2-SHA512',)
+         'PBKDF2-SHA1', 'PBKDF2-SHA256', 'PBKDF2-SHA512', 'GOST_YESCRYPT',
+    )
 
 @pytest.mark.parametrize("algo", ALGO_SET)
 def test_pwd_algo_test(topology_st, algo):

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -194,6 +194,15 @@ nsslapd-pluginarg1: nsds5ReplicaCredentials
 nsslapd-pluginid: aes-storage-scheme
 nsslapd-pluginprecedence: 1
 
+dn: cn=GOST_YESCRYPT,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: GOST_YESCRYPT
+nsslapd-pluginpath: libpwdstorage-plugin
+nsslapd-plugininitfunc: gost_yescrypt_pwd_storage_scheme_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+
 dn: cn=Syntax Validation Task,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -242,6 +242,15 @@ nsslapd-pluginarg2: nsds5ReplicaBootstrapCredentials
 nsslapd-pluginid: aes-storage-scheme
 nsslapd-pluginprecedence: 1
 
+dn: cn=GOST_YESCRYPT,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: GOST_YESCRYPT
+nsslapd-pluginpath: libpwdstorage-plugin
+nsslapd-plugininitfunc: gost_yescrypt_pwd_storage_scheme_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+
 dn: cn=Syntax Validation Task,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin

--- a/ldap/servers/plugins/pwdstorage/gost_yescrypt.c
+++ b/ldap/servers/plugins/pwdstorage/gost_yescrypt.c
@@ -1,0 +1,64 @@
+/** BEGIN COPYRIGHT BLOCK
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <crypt.h>
+#include <errno.h>
+
+#include "pwdstorage.h"
+
+int
+gost_yescrypt_pw_cmp(const char *userpwd, const char *dbpwd)
+{
+    /* return 0 If the passwords match, return 1 if passwords do not match. */
+    int rc = 1;
+    char *hash;
+    struct crypt_data output = {0};
+
+    hash = crypt_rn(userpwd, dbpwd, &output, (int) sizeof(output));
+    if (!hash) {
+        slapi_log_err(SLAPI_LOG_ERR, GOST_YESCRYPT_SCHEME_NAME,
+                      "Unable to hash userpwd value: %d\n", errno);
+        return rc;
+    }
+
+    if (slapi_ct_memcmp(hash, dbpwd, strlen(dbpwd)) == 0) {
+        rc = 0;
+    }
+
+    return rc;
+}
+
+char *
+gost_yescrypt_pw_enc(const char *pwd)
+{
+    const char *prefix = "$gy$";
+    char salt[CRYPT_GENSALT_OUTPUT_SIZE];
+    char *hash;
+    char *enc = NULL;
+    struct crypt_data output = {0};
+
+    /* 0 - means default, in Y2020 it defaults to 5 */
+    if (!crypt_gensalt_rn(prefix, 0, NULL, 0, salt, (int) sizeof(salt))) {
+        slapi_log_err(SLAPI_LOG_ERR, GOST_YESCRYPT_SCHEME_NAME,
+                      "Unable to generate salt: %d\n", errno);
+        return NULL;
+    }
+
+    hash = crypt_rn(pwd, salt, &output, (int) sizeof(output));
+    if (!hash) {
+        slapi_log_err(SLAPI_LOG_ERR, GOST_YESCRYPT_SCHEME_NAME,
+                      "Unable to hash pwd value: %d\n", errno);
+        return NULL;
+    }
+    enc = slapi_ch_smprintf("%c%s%c%s", PWD_HASH_PREFIX_START,
+                            GOST_YESCRYPT_SCHEME_NAME, PWD_HASH_PREFIX_END,
+                            hash);
+
+    return enc;
+}

--- a/ldap/servers/plugins/pwdstorage/pwd_init.c
+++ b/ldap/servers/plugins/pwdstorage/pwd_init.c
@@ -52,6 +52,8 @@ static Slapi_PluginDesc smd5_pdesc = {"smd5-password-storage-scheme", VENDOR, DS
 
 static Slapi_PluginDesc pbkdf2_sha256_pdesc = {"pbkdf2-sha256-password-storage-scheme", VENDOR, DS_PACKAGE_VERSION, "Salted PBKDF2 SHA256 hash algorithm (PBKDF2_SHA256)"};
 
+static Slapi_PluginDesc gost_yescrypt_pdesc = {"gost-yescrypt-password-storage-scheme", VENDOR, DS_PACKAGE_VERSION, "Yescrypt KDF algorithm (Streebog256)"};
+
 static char *plugin_name = "NSPwdStoragePlugin";
 
 int
@@ -426,5 +428,22 @@ pbkdf2_sha256_pwd_storage_scheme_init(Slapi_PBlock *pb)
     rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_PWD_STORAGE_SCHEME_NAME, PBKDF2_SHA256_SCHEME_NAME);
 
     slapi_log_err(SLAPI_LOG_PLUGIN, plugin_name, "<= pbkdf2_sha256_pwd_storage_scheme_init %d\n", rc);
+    return rc;
+}
+
+int
+gost_yescrypt_pwd_storage_scheme_init(Slapi_PBlock *pb)
+{
+    int rc;
+
+    slapi_log_err(SLAPI_LOG_PLUGIN, plugin_name, "=> gost_yescrypt_pwd_storage_scheme_init\n");
+
+    rc = slapi_pblock_set(pb, SLAPI_PLUGIN_VERSION, (void *)SLAPI_PLUGIN_VERSION_01);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_DESCRIPTION, (void *)&gost_yescrypt_pdesc);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_PWD_STORAGE_SCHEME_ENC_FN, (void *)gost_yescrypt_pw_enc);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_PWD_STORAGE_SCHEME_CMP_FN, (void *)gost_yescrypt_pw_cmp);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_PWD_STORAGE_SCHEME_NAME, GOST_YESCRYPT_SCHEME_NAME);
+
+    slapi_log_err(SLAPI_LOG_PLUGIN, plugin_name, "<= gost_yescrypt_pwd_storage_scheme_init %d\n", rc);
     return rc;
 }

--- a/ldap/servers/plugins/pwdstorage/pwdstorage.h
+++ b/ldap/servers/plugins/pwdstorage/pwdstorage.h
@@ -54,6 +54,7 @@
 #define SALTED_MD5_NAME_LEN       4
 #define PBKDF2_SHA256_SCHEME_NAME "PBKDF2_SHA256"
 #define PBKDF2_SHA256_NAME_LEN    13
+#define GOST_YESCRYPT_SCHEME_NAME "GOST_YESCRYPT"
 
 
 SECStatus sha_salted_hash(char *hash_out, const char *pwd, struct berval *salt, unsigned int secOID);
@@ -84,6 +85,8 @@ int md5_pw_cmp(const char *userpwd, const char *dbpwd);
 char *md5_pw_enc(const char *pwd);
 int smd5_pw_cmp(const char *userpwd, const char *dbpwd);
 char *smd5_pw_enc(const char *pwd);
+int gost_yescrypt_pw_cmp(const char *userpwd, const char *dbpwd);
+char *gost_yescrypt_pw_enc(const char *pwd);
 
 int pbkdf2_sha256_start(Slapi_PBlock *pb);
 int pbkdf2_sha256_close(Slapi_PBlock *pb);

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -204,6 +204,19 @@ static const char *internal_entries[] =
         "nsslapd-pluginVendor: 389 Project\n"
         "nsslapd-pluginDescription: CRYPT-SHA512\n",
 
+        "dn: cn=GOST_YESCRYPT,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "cn: GOST_YESCRYPT\n"
+        "nsslapd-pluginpath: libpwdstorage-plugin\n"
+        "nsslapd-plugininitfunc: gost_yescrypt_pwd_storage_scheme_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: GOST_YESCRYPT\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: GOST_YESCRYPT\n",
+
 #ifdef RUST_ENABLE
         "dn: cn=PBKDF2,cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1085,6 +1085,7 @@ export class GlobalPwPolicy extends React.Component {
                                                         <option>CRYPT-SHA512</option>
                                                         <option>CRYPT-SHA256</option>
                                                         <option>CRYPT</option>
+                                                        <option>GOST_YESCRYPT</option>
                                                         <option>CLEAR</option>
                                                     </select>
                                                 </Col>

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -128,6 +128,7 @@ class CreatePolicy extends React.Component {
                                         <option>CRYPT-SHA512</option>
                                         <option>CRYPT-SHA256</option>
                                         <option>CRYPT</option>
+                                        <option>GOST_YESCRYPT</option>
                                         <option>CLEAR</option>
                                     </select>
                                 </Col>
@@ -2103,6 +2104,7 @@ export class LocalPwPolicy extends React.Component {
                                                     <option>CRYPT-SHA512</option>
                                                     <option>CRYPT-SHA256</option>
                                                     <option>CRYPT</option>
+                                                    <option>GOST_YESCRYPT</option>
                                                     <option>CLEAR</option>
                                                 </select>
                                             </Col>

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -1103,6 +1103,7 @@ export class ServerSettings extends React.Component {
                                                         <option>CRYPT-SHA512</option>
                                                         <option>CRYPT-SHA256</option>
                                                         <option>CRYPT</option>
+                                                        <option>GOST_YESCRYPT</option>
                                                         <option>CLEAR</option>
                                                     </select>
                                                 </Col>

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -209,7 +209,7 @@ class Config(DSLdapObject):
             yield report
 
     def _lint_passwordscheme(self):
-        allowed_schemes = ['SSHA512', 'PBKDF2_SHA256']
+        allowed_schemes = ['SSHA512', 'PBKDF2_SHA256', 'GOST_YESCRYPT']
         u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
         u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
         if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:


### PR DESCRIPTION
Bug Description: The state standard of Russian Federation requires
strong password hashes relied on GOST R 34.11-2012 (also known as
Streebog\[0\]) hash function.

Fix Description: One of the implementations of Streebog hash function
was made by libxcrypt, which has come as the replacement of glibc's
libcrypt. This means that several of the pwdstorage plugins have already
linked against libxcrypt.

From libxcrypt docs:
```
    gost-yescrypt uses the output from the yescrypt hashing method in
    place of a hmac message.  Thus, the yescrypt crypto properties
    are superseeded by the GOST R 34.11-2012 (Streebog) hash function
    with a 256 bit digest.
```

\[0\]: https://tools.ietf.org/html/rfc6986

fixes: #4272