### PR TITLE
Issue 4373 - BUG - one line cleanup, free results in mt if ent 0

### DIFF
--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -967,8 +967,8 @@ mapping_tree_node_build_tree()
     }
     slapi_ch_free((void **)&ordered_suffixes);
 
-    slapi_free_search_results_internal(pb);
 build_tree_done:
+    slapi_free_search_results_internal(pb);
     slapi_pblock_destroy(pb);
     slapi_ch_free((void **)&filter);
     return result;


### PR DESCRIPTION
Bug Description: We had a free on the wrong line which could
lead to a memory leak during server setup.

Fix Description: Free results if ent count is 0

fixes: https://github.com/389ds/389-ds-base/issues/4373

Author: William Brown <william@blackhats.net.au>

Review by: ???