### PR TITLE
Issue 4506 - BUG -

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1334,7 +1334,7 @@ setup_pr_read_pds(Connection_Table *ct, PRFileDesc **n_tcps, PRFileDesc **s_tcps
      * is no longer in use, we should remove it from the linked
      * list. */
     c = connection_table_get_first_active_connection(ct);
-    while (c) {
+    while (c && count < ct->size) {
         next = connection_table_get_next_active_connection(ct, c);
         if (c->c_state == CONN_STATE_FREE) {
             connection_table_move_connection_out_of_active_list(ct, c);


### PR DESCRIPTION
Bug Description: While investigating 4506 it was noticed that
it was possible to exceed the capacity of the connection table
fd array if you had many listeners and a large number of
connections. The number of connections required and in the
correct state to cause this is in the thousands and would
be infeasible in reality, but it is still worth defending
from this.

Fix Description: Add the correct bound on the while loop
setting up the fd for polling.

relates: https://github.com/389ds/389-ds-base/issues/4506

Author: William Brown <william@blackhats.net.au>

Review by: ???