### PR TITLE
Client keytab fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -839,8 +839,6 @@ if test "$krb5_vendor" = "MIT"; then
     LIBS="$KERBEROS_LIBS"
     AC_CHECK_FUNCS([krb5_cc_new_unique])
     LIBS="$save_LIBS"
-elif test "$krb5_vendor" = "Heimdal"; then
-    AC_DEFINE(HAVE_HEIMDAL_KERBEROS, 1, [Define if you have Heimdal Kerberos])
 fi
 
 if $PKG_CONFIG --exists pcre; then


### PR DESCRIPTION
The impetus for these changes is an unintended behavior being used in `set_krb5_creds()`.  Basically, the function creates a principal with realm "" (i.e., an empty string), and expects this to function as a kind of wildcard.  However, this was not the intent of krb5, and depending on the DNS canonicalization settings, it may or may not work.

I present two approaches to fixing the problem.  My preferred approach is to eliminate `set_krb5_creds()` entirely in favor of krb5's [client keytab](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html#default-client-keytab) support.  However, if this is undesirable, I've also included a commit that preserves the current behavior while just fixing the bug.

Finally, regarding Heimdal, I want to emphasize that 389ds's Kerberos manipulations haven't been built for against Heimdal in almost two years, so nothing is being lost here; it's just code simplification.  Heimdal lacks `krb5_get_init_creds_opt_set_out_ccache()` which makes the behavior-preserving fix impossible; however, if/when Heimdal has a new feature release, Heimdal will support client keytabs with similar semantics to MIT krb5 (which is part of why I prefer that approach).