### PR TITLE
Issue #4534 - libasan read buffer overflow in filtercmp

### DIFF
--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -84,8 +84,8 @@ def test_bulk_import_when_the_backend_with_vlv_was_recreated(topology_m2):
     MappingTrees(M2).list()[0].delete()
     Backends(M2).list()[0].delete()
     # Recreate the backend and the VLV index on Master 2.
-    M2.mappingtree.create(DEFAULT_SUFFIX, "userRoot")
     M2.backend.create(DEFAULT_SUFFIX, {BACKEND_NAME: "userRoot"})
+    M2.mappingtree.create(DEFAULT_SUFFIX, "userRoot")
     # Recreating vlvSrchDn and vlvIndexDn on Master 2.
     vlv_searches.create(
         basedn="cn=userRoot,cn=ldbm database,cn=plugins,cn=config",
@@ -101,6 +101,8 @@ def test_bulk_import_when_the_backend_with_vlv_was_recreated(topology_m2):
     repl.test_replication(M2, M1, 30)
     entries = M2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(cn=*)")
     assert len(entries) > 0
+    entries = M2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(objectclass=*)")
+    entries = M2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(objectclass=*)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bug Description:
    slapi_filter_compare function calls memcmp using first key length which may be longer than second key length.
    
 Bug Fix:
     Use slapi_berval_cmp that check both value sizes instead of memcmp

Issue: [#4534](https://github.com/389ds/389-ds-base/issues/4534) 
     
Reviewed by: [droideck](https://github.com/droideck)  