### PR TITLE
Issue 4526 - sync_repl: when completing an operation in the pending l…

### DIFF
--- a/ldap/servers/plugins/sync/sync.h
+++ b/ldap/servers/plugins/sync/sync.h
@@ -87,6 +87,12 @@ typedef enum _pl_flags {
     OPERATION_PL_IGNORED = 5
 } pl_flags_t;
 
+typedef struct op_ext_ident
+{
+    uint32_t idx_pl;   /* To uniquely identify an operation in PL, the operation extension
+                        * contains the index of that operation in the pending list
+                        */
+} op_ext_ident_t;
 /* Pending list operations.
  * it contains a list ('next') of nested operations. The
  * order the same order that the server applied the operation
@@ -95,6 +101,7 @@ typedef enum _pl_flags {
 typedef struct OPERATION_PL_CTX
 {
     Operation *op;      /* Pending operation, should not be freed as it belongs to the pblock */
+    uint32_t idx_pl;    /* index of the operation in the pending list */
     pl_flags_t flags;  /* operation is completed (set to TRUE in POST) */
     Slapi_Entry *entry; /* entry to be store in the enqueued node. 1st arg sync_queue_change */
     Slapi_Entry *eprev; /* pre-entry to be stored in the enqueued node. 2nd arg sync_queue_change */
@@ -104,6 +111,8 @@ typedef struct OPERATION_PL_CTX
 
 OPERATION_PL_CTX_T * get_thread_primary_op(void);
 void set_thread_primary_op(OPERATION_PL_CTX_T *op);
+const op_ext_ident_t * sync_persist_get_operation_extension(Slapi_PBlock *pb);
+void sync_persist_set_operation_extension(Slapi_PBlock *pb, op_ext_ident_t *op_ident);
 
 void sync_register_allow_openldap_compat(PRBool allow);
 int sync_register_operation_extension(void);

--- a/ldap/servers/plugins/sync/sync_init.c
+++ b/ldap/servers/plugins/sync/sync_init.c
@@ -16,6 +16,7 @@ static int sync_preop_init(Slapi_PBlock *pb);
 static int sync_postop_init(Slapi_PBlock *pb);
 static int sync_be_postop_init(Slapi_PBlock *pb);
 static int sync_betxn_preop_init(Slapi_PBlock *pb);
+static int sync_persist_register_operation_extension(void);
 
 static PRUintn thread_primary_op;
 
@@ -43,7 +44,8 @@ sync_init(Slapi_PBlock *pb)
         slapi_pblock_set(pb, SLAPI_PLUGIN_CLOSE_FN,
                          (void *)sync_close) != 0 ||
         slapi_pblock_set(pb, SLAPI_PLUGIN_DESCRIPTION,
-                         (void *)&pdesc) != 0) {
+                         (void *)&pdesc) != 0 ||
+        sync_persist_register_operation_extension()) {
         slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM,
                       "sync_init - Failed to register plugin\n");
         rc = 1;
@@ -266,4 +268,64 @@ set_thread_primary_op(OPERATION_PL_CTX_T *op)
         PR_SetThreadPrivate(thread_primary_op, (void *) head);
     }
     head->next = op;
+}
+
+/* The following definitions are used for the operation pending list
+ * (used by sync_repl). To retrieve a specific operation in the pending
+ * list, the operation extension contains the index of the operation in
+ * the pending list
+ */
+static int sync_persist_extension_type;   /* initialized in sync_persist_register_operation_extension */
+static int sync_persist_extension_handle; /* initialized in sync_persist_register_operation_extension */
+
+const op_ext_ident_t *
+sync_persist_get_operation_extension(Slapi_PBlock *pb)
+{
+    Slapi_Operation *op;
+    op_ext_ident_t *ident;
+
+    slapi_pblock_get(pb, SLAPI_OPERATION, &op);
+    ident = slapi_get_object_extension(sync_persist_extension_type, op,
+                                       sync_persist_extension_handle);
+    slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_persist_get_operation_extension operation (op=0x%lx) -> %d\n",
+                    (ulong) op, ident ? ident->idx_pl : -1);
+    return (const op_ext_ident_t *) ident;
+
+}
+
+void
+sync_persist_set_operation_extension(Slapi_PBlock *pb, op_ext_ident_t *op_ident)
+{
+    Slapi_Operation *op;
+
+    slapi_pblock_get(pb, SLAPI_OPERATION, &op);
+    slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_persist_set_operation_extension operation (op=0x%lx) -> %d\n",
+                    (ulong) op, op_ident ? op_ident->idx_pl : -1);
+    slapi_set_object_extension(sync_persist_extension_type, op,
+                               sync_persist_extension_handle, (void *)op_ident);
+}
+/* operation extension constructor */
+static void *
+sync_persist_operation_extension_constructor(void *object __attribute__((unused)), void *parent __attribute__((unused)))
+{
+    /* we only set the extension value explicitly in sync_update_persist_betxn_pre_op */
+    return NULL; /* we don't set anything in the ctor */
+}
+
+/* consumer operation extension destructor */
+static void
+sync_persist_operation_extension_destructor(void *ext, void *object __attribute__((unused)), void *parent __attribute__((unused)))
+{
+    op_ext_ident_t *op_ident = (op_ext_ident_t *)ext;
+    slapi_ch_free((void **)&op_ident);
+}
+static int
+sync_persist_register_operation_extension(void)
+{
+    return slapi_register_object_extension(SYNC_PLUGIN_SUBSYSTEM,
+                                           SLAPI_EXT_OPERATION,
+                                           sync_persist_operation_extension_constructor,
+                                           sync_persist_operation_extension_destructor,
+                                           &sync_persist_extension_type,
+                                           &sync_persist_extension_handle);
 }


### PR DESCRIPTION
…ist, it can select the wrong operation

Bug description:
	When an operation complete, it was retrieved in the pending list with
	the address of the Operation structure. In case of POST OP nested operations
	the same address can be reused. So when completing an operation there could be
	a confusion which operation actually completed.

Fix description:
	The fix defines a new operation extension (sync_persist_extension_type).
	This operation extension contains an index (idx_pl) of the op_pl in the
	the pending list.
	And additional safety fix is to dump the pending list in case it becomes large (>10).
	The pending list is dumped with SLAPI_LOG_PLUGIN.

relates: https://github.com/389ds/389-ds-base/issues/4526

Reviewed by:

Platforms tested: F31