### PR TITLE
Issue 4506 - BUG - fix oob alloc for fds

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1301,9 +1301,7 @@ setup_pr_accept_pds(PRFileDesc **n_tcps, PRFileDesc **s_tcps, PRFileDesc **i_uni
     LBER_SOCKET socketdesc = SLAPD_INVALID_SOCKET;
     PRIntn count = 0;
     size_t n_listeners = 0;
-    struct POLL_STRUCT *myfds = (struct POLL_STRUCT *)slapi_ch_calloc(1, (count + 1) * sizeof(struct POLL_STRUCT));
-    /* Setup the return ptr */
-    *fds = myfds;
+    struct POLL_STRUCT *myfds = NULL;
 
     /* How many fds do we have? */
     if (n_tcps != NULL) {
@@ -1320,6 +1318,10 @@ setup_pr_accept_pds(PRFileDesc **n_tcps, PRFileDesc **s_tcps, PRFileDesc **i_uni
         for (fdesc = i_unix; fdesc && *fdesc; fdesc++, count++) { }
     }
 #endif
+
+    /* Setup the return ptr and alloc the struct */
+    myfds = (struct POLL_STRUCT *)slapi_ch_calloc(1, (count + 1) * sizeof(struct POLL_STRUCT));
+    *fds = myfds;
 
     /* Reset count. */
     count = 0;


### PR DESCRIPTION
Bug Description: during review it was requested that a piece
of code be changed which seemed quite innocent. The code was
moved but the logic around the code wasn't considered
causing the fd array for the accept thread to be allocated with
a size of zero, causing the values to be lost.

Fix Description: Move the allocation to the correct location.

fixes: https://github.com/389ds/389-ds-base/issues/4506

Author: William Brown <william@blackhats.net.au>

Review by: ???