### PR TITLE
Issue 4560 - Enable additional python_files '*_test_*' discovery

### DIFF
--- a/dirsrvtests/pytest.ini
+++ b/dirsrvtests/pytest.ini
@@ -4,3 +4,4 @@ markers =
     tier1: mark a test as part of tier1
     tier2: mark a test as part of tier2
     tier3: mark a test as part of tier3
+python_files = test_*.py *_test.py *_test_*.py


### PR DESCRIPTION
Bug Description: We have tests that currently are not discovered
with 'pytest' - dbgen_test_usan.py
Also, it will be nice to have an option to name the test suites
accordingly to the topology they use.
(i.e. repl/regression_test_m2.py, repl/regression_test_m3.py, etc.)

Fix Description: Add a new rule for py.test discovery - 'test'.

Fixes: #4560

Reviewed by: ?