### PR TITLE
Issue 4324 - Performance search rate: change entry cache monitor to r…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -381,7 +381,7 @@ struct cache
     Slapi_Counter *c_tries;
     struct backcommon *c_lruhead; /* add entries here */
     struct backcommon *c_lrutail; /* remove entries here */
-    PRMonitor *c_mutex;           /* lock for cache operations */
+    pthread_mutex_t *c_mutex __attribute__((__aligned__(64)));           /* lock for cache operations */
     PRLock *c_emutexalloc_mutex;
 };
 

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6090,6 +6090,8 @@ void slapi_destroy_condvar(Slapi_CondVar *cvar);
 int slapi_wait_condvar(Slapi_CondVar *cvar, struct timeval *timeout) __attribute__((deprecated));
 int slapi_notify_condvar(Slapi_CondVar *cvar, int notify_all);
 int slapi_wait_condvar_pt(Slapi_CondVar *cvar, Slapi_Mutex *mutex, struct timeval *timeout);
+pthread_mutex_t *slapi_pthread_mutex_alloc(int type);
+void slapi_pthread_mutex_free(pthread_mutex_t **mutex);
 
 /**
  * Creates a new read/write lock


### PR DESCRIPTION
…ecursive pthread mutex

Bug description:
	The entry cache is protected with recursive mutex. Currently it is
	implemented using PR_Monitor (NSPR). When the entry cache mutex
	becomes the bottleneck (for example base search searchrate on
	the same entry), using pthread recursive mutex gives 8% benefit.

Fix description:
	Changing the c_mutex from PR_Monitor to pthread recursive mutex

relates: https://github.com/389ds/389-ds-base/issues/4324

Reviewed by:

Platforms tested: