### PR TITLE
Issue 4563 - Failure on s390x: 'Fails to split RDN "o=pki-tomcat-CA" …

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -216,7 +216,7 @@ error:
 int32_t
 entry_get_rdn_mods(Slapi_PBlock *pb, Slapi_Entry *entry, CSN *csn, int repl_op, Slapi_Mods **smods_ret)
 {
-    unsigned long op_type = SLAPI_OPERATION_NONE;
+    int op_type = SLAPI_OPERATION_NONE;
     char *new_rdn = NULL;
     char **dns = NULL;
     char **rdns = NULL;


### PR DESCRIPTION
…into components'

Bug description:
	SLAPI_OPERATION_TYPE is a stored/read as an int (slapi_pblock_get/set).
	This although the storage field is an unsigned long.
	Calling slapi_pblock_get with an long (8 btyes) destination creates
	a problem on big-endian (s390x).

Fix description:
	Define destination op_type as an int (4 bytes)

relates: https://github.com/389ds/389-ds-base/issues/4563

Reviewed by:

Platforms tested: F31 (little endian)