### PR TITLE
Issue 4534 - libasan read buffer overflow in filtercmp - fix warning

### DIFF
--- a/ldap/servers/slapd/filtercmp.c
+++ b/ldap/servers/slapd/filtercmp.c
@@ -344,7 +344,6 @@ slapi_filter_compare(struct slapi_filter *f1, struct slapi_filter *f2)
     struct berval *inval1[2], *inval2[2], **outval1, **outval2;
     int ret;
     Slapi_Attr sattr;
-    int cmplen;
 
     slapi_log_err(SLAPI_LOG_TRACE, "slapi_filter_compare", "=>\n");
 
@@ -377,13 +376,13 @@ slapi_filter_compare(struct slapi_filter *f1, struct slapi_filter *f2)
         key2 = get_normalized_value(&sattr, &f2->f_ava);
         ret = 1;
         if (key1 && key2) {
-            struct berval bvkey1 = {
+            const struct berval bvkey1 = {
                 slapi_value_get_length(key1[0]),
-                slapi_value_get_string(key1[0])
+                (void*) slapi_value_get_string(key1[0])
             };
-            struct berval bvkey2 = {
+            const struct berval bvkey2 = {
                 slapi_value_get_length(key2[0]),
-                slapi_value_get_string(key2[0])
+                (void*) slapi_value_get_string(key2[0])
             };
             ret = slapi_berval_cmp(&bvkey1, &bvkey2);
         }


### PR DESCRIPTION
Fix the compiler warnings generated by PR:  [#4541](https://github.com/389ds/389-ds-base/pull/4541)

Issue [#4534 ](https://github.com/389ds/389-ds-base/issues/4534)

Thanks to @mreynolds389  for having seen that problem !