### PR TITLE
Issue 4581 - A failed re-indexing leaves the database in broken state

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -468,18 +468,30 @@ bdb_get_nonleaf_ids(backend *be, DB_TXN *txn, IDList **idl, ImportJob *job)
         }
         key_count++;
         if (!(key_count % PROGRESS_INTERVAL)) {
-            import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
-                              "Gathering ancestorid non-leaf IDs: processed %d%% (ID count %d)",
-                              (key_count * 100 / job->numsubordinates), key_count);
+            if (job->numsubordinates) {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
+                                  "Gathering ancestorid non-leaf IDs: processed %d%% (ID count %d)",
+                                  (key_count * 100 / job->numsubordinates), key_count);
+            } else {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
+                                  "Gathering ancestorid non-leaf IDs: processed %d ancestors...",
+                                  key_count);
+            }
             started_progress_logging = 1;
         }
     } while (ret == 0 && !(job->flags & FLAG_ABORT));
 
     if (started_progress_logging) {
         /* finish what we started logging */
-        import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
-                          "Gathering ancestorid non-leaf IDs: processed %d%% (ID count %d)",
-                          (key_count * 100 / job->numsubordinates), key_count);
+        if (job->numsubordinates) {
+            import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
+                              "Gathering ancestorid non-leaf IDs: processed %d%% (ID count %d)",
+                              (key_count * 100 / job->numsubordinates), key_count);
+        } else {
+            import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
+                              "Gathering ancestorid non-leaf IDs: processed %d ancestors",
+                              key_count);
+        }
     }
     import_log_notice(job, SLAPI_LOG_INFO, "bdb_get_nonleaf_ids",
                       "Finished gathering ancestorid non-leaf IDs.");
@@ -660,9 +672,15 @@ bdb_ancestorid_default_create_index(backend *be, ImportJob *job)
 
         key_count++;
         if (!(key_count % PROGRESS_INTERVAL)) {
-            import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
-                              "Creating ancestorid index: processed %d%% (ID count %d)",
-                              (key_count * 100 / job->numsubordinates), key_count);
+            if (job->numsubordinates) {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
+                                  "Creating ancestorid index: processed %d%% (ID count %d)",
+                                  (key_count * 100 / job->numsubordinates), key_count);
+            } else {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
+                                  "Creating ancestorid index: processed %d ancestors...",
+                                  key_count);
+            }
             started_progress_logging = 1;
         }
 
@@ -743,9 +761,15 @@ out:
     if (ret == 0) {
         if (started_progress_logging) {
             /* finish what we started logging */
-            import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
-                              "Creating ancestorid index: processed %d%% (ID count %d)",
-                              (key_count * 100 / job->numsubordinates), key_count);
+            if (job->numsubordinates) {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
+                                  "Creating ancestorid index: processed %d%% (ID count %d)",
+                                  (key_count * 100 / job->numsubordinates), key_count);
+            } else {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
+                                  "Creating ancestorid index: processed %d ancestors",
+                                  key_count);
+            }
         }
         import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_default_create_index",
                           "Created ancestorid index (old idl).");
@@ -869,9 +893,15 @@ bdb_ancestorid_new_idl_create_index(backend *be, ImportJob *job)
 
         key_count++;
         if (!(key_count % PROGRESS_INTERVAL)) {
-            import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
-                              "Creating ancestorid index: progress %d%% (ID count %d)",
-                              (key_count * 100 / job->numsubordinates), key_count);
+            if (job->numsubordinates) {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
+                                  "Creating ancestorid index: progress %d%% (ID count %d)",
+                                  (key_count * 100 / job->numsubordinates), key_count);
+            } else {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
+                                  "Creating ancestorid index: progress %d ancestors...",
+                                  key_count);
+            }
             started_progress_logging = 1;
         }
 
@@ -932,9 +962,15 @@ out:
     if (ret == 0) {
         if (started_progress_logging) {
             /* finish what we started logging */
-            import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
-                              "Creating ancestorid index: processed %d%% (ID count %d)",
-                              (key_count * 100 / job->numsubordinates), key_count);
+            if (job->numsubordinates) {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
+                                  "Creating ancestorid index: processed %d%% (ID count %d)",
+                                  (key_count * 100 / job->numsubordinates), key_count);
+            } else {
+                import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
+                                  "Creating ancestorid index: processed %d ancestors",
+                                  key_count);
+            }
         }
         import_log_notice(job, SLAPI_LOG_INFO, "bdb_ancestorid_new_idl_create_index",
                           "Created ancestorid index (new idl).");


### PR DESCRIPTION
Bug description:
	During reindex the numsubordinates attribute is not updated in parent entry.
	The consequence is that the internal counter job->numsubordinates==0.
	Later when indexing the ancestorid, the server can show the progression of this
	indexing with a ratio using job->numsubordinates==0.
	Division with 0 -> SIGFPE

Fix description:
	if the numsubordinates is NULL, log a message without a division.

relates: https://github.com/389ds/389-ds-base/issues/4581

Reviewed by:

Platforms tested: F31