### PR TITLE
Issue 4348 - Add tests for dsidm

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_user_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_test.py
@@ -186,7 +186,7 @@ def test_dsidm_user_get_rdn(topology_st, create_test_user):
 
 
 @pytest.mark.bz1893667
-@pytest.mark.xfail("Will fail because of bz1893667")
+@pytest.mark.xfail(reason="Will fail because of bz1893667")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_user_get_dn(topology_st, create_test_user):
     """ Test dsidm user get_dn option

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -334,8 +334,6 @@ def _generic_modify_inner(log, o, changes):
     log.debug("Requested mods: %s" % mods)
     # Now push them to dsldapobject to modify
     o.apply_mods(mods)
-    print('Successfully modified %s' % o.dn)
-    # Print to log for test purposes
     log.info('Successfully modified %s' % o.dn)
 
 

--- a/src/lib389/lib389/cli_idm/__init__.py
+++ b/src/lib389/lib389/cli_idm/__init__.py
@@ -67,8 +67,6 @@ def _generic_list(inst, basedn, log, manager_class, args=None):
     ol = mc.list()
     if len(ol) == 0:
         if args and args.json:
-            print(json.dumps({"type": "list", "items": []}, indent=4))
-            # Print to log for test purposes
             log.info(json.dumps({"type": "list", "items": []}, indent=4))
         else:
             log.info("No objects to display")
@@ -83,8 +81,6 @@ def _generic_list(inst, basedn, log, manager_class, args=None):
             else:
                 log.info(o_str)
         if args and args.json:
-            print(json.dumps(json_result, indent=4))
-            # Print to log for test purposes
             log.info(json.dumps(json_result, indent=4))
 
 
@@ -93,8 +89,6 @@ def _generic_get(inst, basedn, log, manager_class, selector, args=None):
     mc = manager_class(inst, basedn)
     if args and args.json:
         o = mc.get(selector, json=True)
-        print(o)
-        # Print to log for test purposes
         log.info(o)
     else:
         o = mc.get(selector)
@@ -106,8 +100,6 @@ def _generic_get_dn(inst, basedn, log, manager_class, dn, args=None):
     mc = manager_class(inst, basedn)
     o = mc.get(dn=dn)
     o_str = o.__unicode__()
-    print(o_str)
-    # Print to log for test purposes
     log.info(o_str)
 
 
@@ -133,8 +125,6 @@ def _generic_rename_inner(log, o, new_rdn, newsuperior=None, deloldrdn=None):
     if deloldrdn is not None:
         arguments['deloldrdn'] = deloldrdn
     o.rename(**arguments)
-    print('Successfully renamed to %s' % o.dn)
-    # Print to log for test purposes
     log.info('Successfully renamed to %s' % o.dn)
 
 


### PR DESCRIPTION
Description:
Fixed missing reason for xfail mark in test_dsidm_user_get_dn.
Replaced print() statements with log.info() in cli_base and cli_idm init files.

Relates: https://github.com/389ds/389-ds-base/issues/4348

Reviewed by: ???