### PR TITLE
Issue 4608 - performance modify rate: prefetch target entry before ho…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -46,7 +46,7 @@ static int id2idl_same_key(const void *ididl, const void *k);
 typedef Hashtable id2idl_hash;
 
 #define id2idl_new_hash(size) new_hash(size, HASHLOC(id2idl, next), NULL, id2idl_same_key)
-#define id2idl_hash_lookup(ht, key, he) find_hash(ht, key, sizeof(ID), (void **)(he))
+#define id2idl_hash_lookup(ht, key, he) find_hash_move_front(ht, key, sizeof(ID), (void **)(he))
 #define id2idl_hash_add(ht, key, he, alt) add_hash(ht, key, sizeof(ID), he, (void **)(alt))
 #define id2idl_hash_remove(ht, key) remove_hash(ht, key, sizeof(ID))
 

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -66,6 +66,7 @@ void check_entry_cache(struct cache *cache, struct backentry *e);
 Hashtable *new_hash(u_long size, u_long offset, HashFn hfn, HashTestFn tfn);
 int add_hash(Hashtable *ht, void *key, uint32_t keylen, void *entry, void **alt);
 int find_hash(Hashtable *ht, const void *key, uint32_t keylen, void **entry);
+int find_hash_move_front(Hashtable *ht, const void *key, uint32_t keylen, void **entry);
 int remove_hash(Hashtable *ht, const void *key, uint32_t keylen);
 
 struct backdn *dncache_find_id(struct cache *cache, ID id);


### PR DESCRIPTION
…lding backend lock

Bug description:
	During a MOD, the target entry is fetch from the entry cache
	while holding the backend lock.
	If the entry needs to be upload from the DB it increase
	the duration of the critical section.

Fix description:
	Before holding the backend lock, pre-fetch the entry in the
	entry cache. In addition the pre-fetch move the entry
	at the beginning of the hash slot, that reduce the
	number of tests when the entry will be fetch in the critical
	section.

relates: https://github.com/389ds/389-ds-base/issues/4608

Reviewed by:

Platforms tested: RHEL 8.3, F31