### PR TITLE
Issue 4593 - RFE - Print help when nsSSLPersonalitySSL is not found

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -350,6 +350,9 @@ attrcrypt_fetch_public_key(SECKEYPublicKey **public_key)
         errorCode = PR_GetError();
         slapi_log_err(SLAPI_LOG_ERR, "attrcrypt_fetch_public_key", "Can't find certificate %s: %d - %s\n",
                       cert_name, errorCode, slapd_pr_strerror(errorCode));
+        if (PR_FILE_NOT_FOUND_ERROR == errorCode) {
+            slapd_cert_not_found_error_help(cert_name);
+        }
     }
     if (cert != NULL) {
         key = slapd_CERT_ExtractPublicKey(cert);
@@ -397,6 +400,9 @@ attrcrypt_fetch_private_key(SECKEYPrivateKey **private_key)
         errorCode = PR_GetError();
         slapi_log_err(SLAPI_LOG_ERR, "attrcrypt_fetch_private_key", "Can't find certificate %s: %d - %s\n",
                       cert_name, errorCode, slapd_pr_strerror(errorCode));
+        if (PR_FILE_NOT_FOUND_ERROR == errorCode) {
+            slapd_cert_not_found_error_help(cert_name);
+        }
     }
     if (cert != NULL) {
         key = slapd_get_unlocked_key_for_cert(cert, NULL);

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -871,6 +871,7 @@ int strarray2str(char **a, char *buf, size_t buflen, int include_quotes);
 int slapd_chown_if_not_owner(const char *filename, uid_t uid, gid_t gid);
 int slapd_comp_path(char *p0, char *p1);
 void replace_char(char *name, char c, char c2);
+void slapd_cert_not_found_error_help(char *cert_name);
 
 
 /*

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1681,6 +1681,9 @@ slapd_ssl_init2(PRFileDesc **fd, int startTLS)
                                "certificate (%s) for family %s (" SLAPI_COMPONENT_NAME_NSPR " error %d - %s)",
                                cert_name, *family,
                                errorCode, slapd_pr_strerror(errorCode));
+                if (PR_FILE_NOT_FOUND_ERROR == errorCode) {
+                    slapd_cert_not_found_error_help(cert_name);
+                }
             }
             /* Step Five -- Get the private key from cert  */
             if (cert != NULL)

--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -969,6 +969,21 @@ slapi_berval_get_string_copy(const struct berval *bval)
     return return_value;
 }
 
+/* Prints an advice to errors log when cert is not found.
+   It may happen when nsSSLPersonalitySSL value is different from actual NSS DB content*/
+void
+slapd_cert_not_found_error_help(char *cert_name)
+{
+    char *certdir = config_get_certdir();
+    slapi_log_err(SLAPI_LOG_ERR, "slapd_cert_not_found_error_help",
+                  "Please, make sure that nsSSLPersonalitySSL value is correctly set to the certificate from"
+                  " NSS database (currently, nsSSLPersonalitySSL attribute is set to '%1$s'). You can get the certificate list"
+                  " for your NSS DB by running 'certutil -L -d \"%2$s\"' command. Then, you can either set nsSSLPersonalitySSL attribute"
+                  " to the correct certificate from the list, either you can change the certificate Nickname in your NSS DB"
+                  " by running 'certutil -d \"%2$s\" --rename -n \"OLD_NICKNAME\" --new-n \"%1$s\" '\n",
+                  cert_name, certdir);
+    slapi_ch_free_string(&certdir);
+}
 
 /* Takes a return code supposed to be errno or from a plugin
    which we don't expect to see and prints a handy log message */


### PR DESCRIPTION
Description: RHDS instance will fail to start if the TLS server certificate
nickname doesn't match the value of the configuration parameter "nsSSLPersonalitySSL".

The mismatch typically happens when customers copy the NSS DB from a previous instance
or export the certificates data but forget to set the "nsSSLPersonalitySSL" value accordingly.

Log an additional message which should help a user to set up nsSSLPersonalitySSL correctly.

Fixes: #4593

Reviewed by: ?