### PR TITLE
Issue 4615 - log message when psearch first exceeds max threads per conn

### DIFF
--- a/dirsrvtests/tests/suites/psearch/psearch_test.py
+++ b/dirsrvtests/tests/suites/psearch/psearch_test.py
@@ -1,16 +1,17 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2021 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import ldap
+import os
 import pytest
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.topologies import topology_st
 from lib389.idm.group import Groups
-import ldap
 from ldap.controls.psearch import PersistentSearchControl,EntryChangeNotificationControl
 
 pytestmark = pytest.mark.tier1

--- a/ldap/servers/plugins/sync/sync.h
+++ b/ldap/servers/plugins/sync/sync.h
@@ -111,7 +111,7 @@ typedef struct OPERATION_PL_CTX
 
 OPERATION_PL_CTX_T * get_thread_primary_op(void);
 void set_thread_primary_op(OPERATION_PL_CTX_T *op);
-const op_ext_ident_t * sync_persist_get_operation_extension(Slapi_PBlock *pb);
+op_ext_ident_t * sync_persist_get_operation_extension(Slapi_PBlock *pb);
 void sync_persist_set_operation_extension(Slapi_PBlock *pb, op_ext_ident_t *op_ident);
 
 void sync_register_allow_openldap_compat(PRBool allow);

--- a/ldap/servers/plugins/sync/sync_init.c
+++ b/ldap/servers/plugins/sync/sync_init.c
@@ -278,7 +278,7 @@ set_thread_primary_op(OPERATION_PL_CTX_T *op)
 static int sync_persist_extension_type;   /* initialized in sync_persist_register_operation_extension */
 static int sync_persist_extension_handle; /* initialized in sync_persist_register_operation_extension */
 
-const op_ext_ident_t *
+op_ext_ident_t *
 sync_persist_get_operation_extension(Slapi_PBlock *pb)
 {
     Slapi_Operation *op;
@@ -289,7 +289,7 @@ sync_persist_get_operation_extension(Slapi_PBlock *pb)
                                        sync_persist_extension_handle);
     slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM, "sync_persist_get_operation_extension operation (op=0x%lx) -> %d\n",
                     (ulong) op, ident ? ident->idx_pl : -1);
-    return (const op_ext_ident_t *) ident;
+    return (op_ext_ident_t *) ident;
 
 }
 

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2020 Red Hat, Inc.
+ * Copyright (C) 2021 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1459,6 +1459,13 @@ setup_pr_read_pds(Connection_Table *ct)
                 } else {
                     if (c->c_threadnumber >= c->c_max_threads_per_conn) {
                         c->c_maxthreadsblocked++;
+                        if (c->c_maxthreadsblocked == 1 && connection_has_psearch(c)) {
+                            slapi_log_err(SLAPI_LOG_NOTICE, "connection_threadmain",
+                                    "Connection (conn=%" PRIu64 ") has a running persistent search "
+                                    "that has exceeded the maximum allowed threads per connection. "
+                                    "New operations will be blocked.\n",
+                                    c->c_connid);
+                        }
                     }
                     c->c_fdi = SLAPD_INVALID_SOCKET_INDEX;
                 }

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1489,6 +1489,7 @@ int connection_release_nolock_ext(Connection *conn, int release_only);
 int connection_is_free(Connection *conn, int user_lock);
 int connection_is_active_nolock(Connection *conn);
 ber_slen_t openldap_read_function(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len);
+int32_t connection_has_psearch(Connection *c);
 
 /*
  * saslbind.c


### PR DESCRIPTION
Desciption:  When a connection hits max threads per conn for the first time
             log a message in the error.  This will help customers diagnosis
             misbehaving clients.

Also fixed some compiler warnings

Fixes: https://github.com/389ds/389-ds-base/issues/4615
