### PR TITLE
issue 4552 - Backup Redesign phase 3b - use dbimpl in replicatin plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1665,8 +1665,8 @@ libreplication_plugin_la_SOURCES = ldap/servers/plugins/replication/cl5_api.c \
 	ldap/servers/plugins/replication/windows_tot_protocol.c
 
 libreplication_plugin_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(ICU_CFLAGS) @db_inc@
-libreplication_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSS_LINK) $(NSPR_LINK) $(ICU_LIBS) $(DB_LINK)
-libreplication_plugin_la_DEPENDENCIES = libslapd.la
+libreplication_plugin_la_LIBADD = libslapd.la libback-ldbm.la $(LDAPSDK_LINK) $(NSS_LINK) $(NSPR_LINK) $(ICU_LIBS) $(DB_LINK)
+libreplication_plugin_la_DEPENDENCIES = libslapd.la libback-ldbm.la
 libreplication_plugin_la_LDFLAGS = -avoid-version
 
 #------------------------

--- a/ldap/servers/plugins/replication/cl5_api.h
+++ b/ldap/servers/plugins/replication/cl5_api.h
@@ -20,10 +20,6 @@
 #include "repl5_prot_private.h"
 #include <errno.h>
 
-#define BDB_IMPL "bdb"                         /* changelog type */
-#define BDB_REPLPLUGIN "libreplication-plugin" /* This backend plugin */
-
-
 #define CL5_TYPE "Changelog5" /* changelog type */
 #define VERSION_SIZE 127      /* size of the buffer to hold changelog version */
 #define CL5_DEFAULT_CONFIG -1 /* value that indicates to changelog to use default */

--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -243,9 +243,9 @@ clcache_get_buffer(Replica *replica, CLC_Buffer **buf, dbi_db_t *db, ReplicaId c
                 Slapi_Backend *be = (*buf)->buf_busy_list->bl_be;
                 /* buf_busy_list is now set, and we can get the backend. So lets initialize the dbimpl buffers */
                 
-                 dblayer_bulk_set_buffer(be, &(*buf)->buf_bulk, &(*buf)->buf_bulkdata,
-                         WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
-                 dblayer_value_set_buffer(be, &(*buf)->buf_key, (*buf)->buf_keydata, CSN_STRSIZE +1);
+                dblayer_bulk_set_buffer(be, &(*buf)->buf_bulk, &(*buf)->buf_bulkdata,
+                        WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
+                dblayer_value_set_buffer(be, &(*buf)->buf_key, (*buf)->buf_keydata, CSN_STRSIZE +1);
                 (*buf)->buf_key.size = CSN_STRSIZE;
                 set_thread_private_cache((void *)(*buf));
             } else {

--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -358,7 +358,9 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
             }
             csn_as_string(buf->buf_current_csn, 0, curr);
             slapi_log_err(loglevel, buf->buf_agmt_name,
-                      "clcache_load_buffer - bulk load cursor (%s) is lower than starting csn %s.\n", curr, initial_starting_csn);
+                      "clcache_load_buffer - bulk load cursor (%s) is lower than starting csn %s. Ending session.\n", curr, initial_starting_csn);
+            /* it just end the session with UPDATE_NO_MORE_UPDATES */
+            rc = CLC_STATE_DONE;
         }
     }
 

--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -17,15 +17,6 @@
 #include "slap.h"
 #include "proto-slap.h"
 
-/* newer bdb uses DBI_RC_BUFFER_SMALL instead of ENOMEM as the
-   error return if the given buffer in which to load a
-   key or value is too small - if it is not defined, define
-   it here to ENOMEM
-*/
-#ifndef DBI_RC_BUFFER_SMALL
-#define DBI_RC_BUFFER_SMALL ENOMEM
-#endif
-
 /*
  * Constants for the buffer pool:
  *

--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -12,19 +12,18 @@
 
 
 #include "errno.h" /* ENOMEM, EVAL used by Berkeley DB */
-#include "db.h"    /* Berkeley DB */
 #include "cl5.h"   /* changelog5Config */
 #include "cl5_clcache.h"
 #include "slap.h"
 #include "proto-slap.h"
 
-/* newer bdb uses DB_BUFFER_SMALL instead of ENOMEM as the
+/* newer bdb uses DBI_RC_BUFFER_SMALL instead of ENOMEM as the
    error return if the given buffer in which to load a
    key or value is too small - if it is not defined, define
    it here to ENOMEM
 */
-#ifndef DB_BUFFER_SMALL
-#define DB_BUFFER_SMALL ENOMEM
+#ifndef DBI_RC_BUFFER_SMALL
+#define DBI_RC_BUFFER_SMALL ENOMEM
 #endif
 
 /*
@@ -85,13 +84,13 @@ struct clc_buffer
      */
     int buf_state;
     CSN *buf_current_csn;
-    int buf_load_flag; /* db flag DB_MULTIPLE_KEY, DB_SET, DB_NEXT */
-    DBC *buf_cursor;
-    DBT buf_key;               /* current csn string */
-    DBT buf_data;              /* data retrived from db */
-    void *buf_record_ptr;      /* ptr to the current record in data */
+    dbi_cursor_t buf_cursor;
+    dbi_val_t buf_key;         /* current csn string */
+    dbi_bulk_t buf_bulk;       /* bulk operation buffer */
     CSN *buf_missing_csn;      /* used to detect persistent missing of CSN */
     CSN *buf_prev_missing_csn; /* used to surpress the repeated messages */
+    char buf_bulkdata[WORK_CLC_BUFFER_PAGE_SIZE];  /* default buf_bulk storage */
+    char buf_keydata[CSN_STRSIZE+1];               /* buf_key storage */
 
     /* fields for control the CSN sequence sent to the consumer */
     struct csn_seq_ctrl_block **buf_cscbs;
@@ -120,9 +119,10 @@ struct clc_buffer
 struct clc_busy_list
 {
     PRLock *bl_lock;
-    DB *bl_db;              /* changelog db handle */
+    dbi_db_t *bl_db;        /* changelog db handle */
     CLC_Buffer *bl_buffers; /* busy buffers of this list */
     CLC_Busy_List *bl_next; /* next busy list in the pool */
+    Slapi_Backend *bl_be;   /* backend (to use dbimpl API) */
 };
 
 /*
@@ -142,21 +142,21 @@ struct clc_pool
 static struct clc_pool *_pool = NULL; /* process's buffer pool */
 
 /* static prototypes */
-static int clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag);
-static int clcache_adjust_anchorcsn(CLC_Buffer *buf, int *flag);
+static int clcache_initial_anchorcsn(CLC_Buffer *buf, dbi_op_t *dbop);
+static int clcache_adjust_anchorcsn(CLC_Buffer *buf, dbi_op_t *dbop);
 static void clcache_refresh_consumer_maxcsns(CLC_Buffer *buf);
 static int clcache_refresh_local_maxcsns(CLC_Buffer *buf);
 static int clcache_skip_change(CLC_Buffer *buf);
-static int clcache_load_buffer_bulk(CLC_Buffer *buf, int flag);
-static int clcache_open_cursor(DB_TXN *txn, CLC_Buffer *buf, DBC **cursor);
-static int clcache_cursor_get(DBC *cursor, CLC_Buffer *buf, int flag);
+static int clcache_load_buffer_bulk(CLC_Buffer *buf, dbi_op_t dbop);
+static int clcache_open_cursor(dbi_txn_t *txn, CLC_Buffer *buf, dbi_cursor_t *cursor);
+static int clcache_cursor_get(dbi_cursor_t *cursor, CLC_Buffer *buf, dbi_op_t dbop);
 static struct csn_seq_ctrl_block *clcache_new_cscb(void);
 static void clcache_free_cscb(struct csn_seq_ctrl_block **cscb);
 static CLC_Buffer *clcache_new_buffer(ReplicaId consumer_rid);
 static void clcache_delete_buffer(CLC_Buffer **buf);
 static CLC_Busy_List *clcache_new_busy_list(void);
 static void clcache_delete_busy_list(CLC_Busy_List **bl);
-static int clcache_enqueue_busy_list(DB *db, CLC_Buffer *buf);
+static int clcache_enqueue_busy_list(Replica *replica, dbi_db_t *db, CLC_Buffer *buf);
 static void csn_dup_or_init_by_csn(CSN **csn1, CSN *csn2);
 
 /*
@@ -189,7 +189,7 @@ clcache_set_config()
     _pool->pl_buffer_cnt_max = CL5_DEFAULT_CONFIG_CACHESIZE;
 
     /*
-     * According to http://www.sleepycat.com/docs/api_c/dbc_get.html,
+     * Berkeley database: According to http://www.sleepycat.com/docs/api_c/dbc_get.html,
      * data buffer should be a multiple of 1024 bytes in size
      * for DB_MULTIPLE_KEY operation.
      */
@@ -209,10 +209,11 @@ clcache_set_config()
  * a replication session.
  */
 int
-clcache_get_buffer(CLC_Buffer **buf, DB *db, ReplicaId consumer_rid, const RUV *consumer_ruv, const RUV *local_ruv)
+clcache_get_buffer(Replica *replica, CLC_Buffer **buf, dbi_db_t *db, ReplicaId consumer_rid, const RUV *consumer_ruv, const RUV *local_ruv)
 {
     int rc = 0;
     int need_new;
+    static const dbi_cursor_t cursor0 = {0};
 
     if (buf == NULL)
         return CL5_BAD_DATA;
@@ -234,7 +235,7 @@ clcache_get_buffer(CLC_Buffer **buf, DB *db, ReplicaId consumer_rid, const RUV *
         (*buf)->buf_load_cnt = 0;
         (*buf)->buf_record_cnt = 0;
         (*buf)->buf_record_skipped = 0;
-        (*buf)->buf_cursor = NULL;
+        (*buf)->buf_cursor = cursor0;
         (*buf)->buf_skipped_new_rid = 0;
         (*buf)->buf_skipped_csn_gt_cons_maxcsn = 0;
         (*buf)->buf_skipped_up_to_date = 0;
@@ -247,7 +248,14 @@ clcache_get_buffer(CLC_Buffer **buf, DB *db, ReplicaId consumer_rid, const RUV *
     } else {
         *buf = clcache_new_buffer(consumer_rid);
         if (*buf) {
-            if (0 == clcache_enqueue_busy_list(db, *buf)) {
+            if (0 == clcache_enqueue_busy_list(replica, db, *buf)) {
+                Slapi_Backend *be = (*buf)->buf_busy_list->bl_be;
+                /* buf_busy_list is now set, and we can get the backend. So lets initialize the dbimpl buffers */
+                
+                 dblayer_bulk_set_buffer(be, &(*buf)->buf_bulk, &(*buf)->buf_bulkdata,
+                         WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
+                 dblayer_value_set_buffer(be, &(*buf)->buf_key, (*buf)->buf_keydata, CSN_STRSIZE +1);
+                (*buf)->buf_key.size = CSN_STRSIZE;
                 set_thread_private_cache((void *)(*buf));
             } else {
                 clcache_delete_buffer(buf);
@@ -260,7 +268,6 @@ clcache_get_buffer(CLC_Buffer **buf, DB *db, ReplicaId consumer_rid, const RUV *
         CSN *l_csn = NULL;
         (*buf)->buf_consumer_ruv = consumer_ruv;
         (*buf)->buf_local_ruv = local_ruv;
-        (*buf)->buf_load_flag = DB_MULTIPLE_KEY;
         ruv_get_largest_csn_for_replica(consumer_ruv, consumer_rid, &c_csn);
         ruv_get_largest_csn_for_replica(local_ruv, consumer_rid, &l_csn);
         if (l_csn && csn_compare(l_csn, c_csn) > 0) {
@@ -307,19 +314,14 @@ clcache_return_buffer(CLC_Buffer **buf)
     }
     slapi_ch_free((void **)&(*buf)->buf_cscbs);
 
-    if ((*buf)->buf_cursor) {
-
-        (*buf)->buf_cursor->c_close((*buf)->buf_cursor);
-        (*buf)->buf_cursor = NULL;
-    }
+    dblayer_cursor_op(&(*buf)->buf_cursor, DBI_OP_CLOSE, NULL, NULL);
 }
 
 /*
  * Loads a buffer from DB.
  *
  * anchorcsn - passed in for the first load of a replication session;
- * flag         - DB_SET to load in the key CSN record.
- *                DB_NEXT to load in the records greater than key CSN.
+ * continue_on_miss - tells whether session continue if a csn is missing
  * initial_starting_csn
  *              This is the starting_csn computed at the beginning of
  *              the replication session. It never change during a session
@@ -333,7 +335,7 @@ int
 clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, char *initial_starting_csn)
 {
     int rc = 0;
-    int flag = DB_NEXT;
+    dbi_op_t dbop = DBI_OP_NEXT;
     CSN limit_csn = {0};
 
     if (anchorCSN)
@@ -342,9 +344,9 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
 
     if (buf->buf_load_cnt == 0) {
         clcache_refresh_consumer_maxcsns(buf);
-        rc = clcache_initial_anchorcsn(buf, &flag);
+        rc = clcache_initial_anchorcsn(buf, &dbop);
     } else {
-        rc = clcache_adjust_anchorcsn(buf, &flag);
+        rc = clcache_adjust_anchorcsn(buf, &dbop);
     }
 
     /* safety checking, we do not want to (re)start replication before
@@ -374,16 +376,16 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
         buf->buf_state = CLC_STATE_READY;
         if (anchorCSN)
             *anchorCSN = buf->buf_current_csn;
-        rc = clcache_load_buffer_bulk(buf, flag);
+        rc = clcache_load_buffer_bulk(buf, dbop);
 
-        if (rc == DB_NOTFOUND && continue_on_miss && *continue_on_miss) {
+        if (rc == DBI_RC_NOTFOUND && continue_on_miss && *continue_on_miss) {
             /* make replication going using next best startcsn */
             slapi_log_err(SLAPI_LOG_ERR, buf->buf_agmt_name,
-                          "clcache_load_buffer - Can't load changelog buffer starting at CSN %s with flag(%s). "
+                          "clcache_load_buffer - Can't load changelog buffer starting at CSN %s with operation(%s). "
                           "Trying to use an alterantive start CSN.\n",
                           (char *)buf->buf_key.data,
-                          flag == DB_NEXT ? "DB_NEXT" : "DB_SET");
-            rc = clcache_load_buffer_bulk(buf, DB_SET_RANGE);
+                          dblayer_op2str(dbop));
+            rc = clcache_load_buffer_bulk(buf, DBI_OP_MOVE_NEAR_KEY);
             if (rc == 0) {
                 slapi_log_err(SLAPI_LOG_ERR, buf->buf_agmt_name,
                               "clcache_load_buffer - Using alternative start iteration csn: %s \n",
@@ -406,7 +408,7 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
                     }
                     csn_as_string(buf->buf_current_csn, 0, curr);
                     slapi_log_err(loglevel, buf->buf_agmt_name,
-                            "clcache_load_buffer - (DB_SET_RANGE) bulk load cursor (%s) is lower than starting csn %s.\n", curr, initial_starting_csn);
+                            "clcache_load_buffer - (DBI_OP_MOVE_NEAR_KEY) bulk load cursor (%s) is lower than starting csn %s.\n", curr, initial_starting_csn);
                 }
             }
         }
@@ -423,7 +425,7 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
                           (char *)buf->buf_key.data, rc);
         }
     } else if (rc == CLC_STATE_DONE) {
-        rc = DB_NOTFOUND;
+        rc = DBI_RC_NOTFOUND;
     }
 
     if (rc != 0) {
@@ -434,50 +436,22 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
     return rc;
 }
 
-/* Set a cursor to a specific key (buf->buf_key)
- * In case buf_data is too small to receive the value, DB_SET fails
- * (DB_BUFFER_SMALL). This let the cursor uninitialized that is
- * problematic because further cursor DB_NEXT will reset the cursor
- * to the beginning of the CL.
- * If buf_data is too small, this function reallocates enough space
+/* Set a cursor to a specific key (buf->buf_key) then load the buffer
+ * This function handles the following error case:
+ *  DBI_RC_BUFFER_SMALL: (realloc the buffer and retry the operation)
+ *  DBI_RC_RETRY: close the index and retry the opeartion:
  *
- * It returns the return code of cursor->c_get
+ * The function returns the dbimpl API return code.
  */
 static int
-clcache_cursor_set(DBC *cursor, CLC_Buffer *buf)
+clcache_load_buffer_bulk(CLC_Buffer *buf, dbi_op_t dbop)
 {
-    int rc;
-    uint32_t ulen;
-    uint32_t dlen;
-    uint32_t size;
-
-    rc = cursor->c_get(cursor, &buf->buf_key, &buf->buf_data, DB_SET);
-    if (rc == DB_BUFFER_SMALL) {
-        uint32_t ulen;
-
-        /* Fortunately, buf->buf_data.size has been set by
-         * c_get() to the actual data size needed. So we can
-         * reallocate the data buffer and try to set again.
-         */
-        ulen = buf->buf_data.ulen;
-        buf->buf_data.ulen = (buf->buf_data.size / DEFAULT_CLC_BUFFER_PAGE_SIZE + 1) * DEFAULT_CLC_BUFFER_PAGE_SIZE;
-        buf->buf_data.data = slapi_ch_realloc(buf->buf_data.data, buf->buf_data.ulen);
-        slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name,
-                      "clcache_cursor_set - buf data len reallocated %d -> %d bytes (DB_BUFFER_SMALL)\n",
-                      ulen, buf->buf_data.ulen);
-        rc = cursor->c_get(cursor, &buf->buf_key, &buf->buf_data, DB_SET);
-    }
-    return rc;
-}
-
-static int
-clcache_load_buffer_bulk(CLC_Buffer *buf, int flag)
-{
-    DB_TXN *txn = NULL;
-    DBC *cursor = NULL;
-    int rc = 0;
+    dbi_op_t use_dbop = dbop;
+    dbi_cursor_t cursor = {0};
+    dbi_val_t data = {0};
+    dbi_txn_t *txn = NULL;
     int tries = 0;
-    int use_flag = flag;
+    int rc = 0;
 
     if (NULL == buf) {
         slapi_log_err(SLAPI_LOG_ERR, get_thread_private_agmtname(),
@@ -496,39 +470,31 @@ clcache_load_buffer_bulk(CLC_Buffer *buf, int flag)
 retry:
     if (0 == (rc = clcache_open_cursor(txn, buf, &cursor))) {
 
-        if (use_flag == DB_NEXT) {
+        if (use_dbop == DBI_OP_NEXT) {
             /* For bulk read, position the cursor before read the next block */
-            rc = clcache_cursor_set(cursor, buf);
+            /* As data is not used afterwards lets try to avoid alloc buffer and reuse the bulk data buffer first */
+            dblayer_value_set_buffer(cursor.be, &data, buf->buf_bulkdata, WORK_CLC_BUFFER_PAGE_SIZE);
+            rc = dblayer_cursor_op(&cursor, DBI_OP_MOVE_TO_KEY, &buf->buf_key, &data);
+            if (DBI_RC_BUFFER_SMALL == rc) {
+                /* Not enough space in buffer ==> Lets retry but this time alloc a new buffer and free it afterwards */
+                dblayer_value_init(cursor.be, &data);
+                rc = dblayer_cursor_op(&cursor, DBI_OP_MOVE_TO_KEY, &buf->buf_key, &data);
+                dblayer_value_free(cursor.be, &data);
+            }
         }
 
-        if (0 == rc || DB_BUFFER_SMALL == rc) {
-           /*
-            * It should not have failed  with DB_BUFFER_SMALL as we tried
-            * to adjust buf_data in clcache_cursor_set.
-            * But if it failed with DB_BUFFER_SMALL, there is a risk in clcache_cursor_get
-            * that the cursor will be reset to the beginning of the changelog.
-            * Returning an error at this point will stop replication that is
-            * a risk. So just accept the risk of a reset to the beginning of the CL
-            * and log an alarming message.
-            */
-           if (rc == DB_BUFFER_SMALL) {
-               slapi_log_err(SLAPI_LOG_WARNING, buf->buf_agmt_name,
-                             "clcache_load_buffer_bulk - Fail to position on csn=%s from the changelog (too large update ?). Risk of full CL evaluation.\n",
-                             (char *)buf->buf_key.data);
-           }
-            rc = clcache_cursor_get(cursor, buf, use_flag);
+        if (0 == rc) {
+            rc = clcache_cursor_get(&cursor, buf, use_dbop);
         }
+        dblayer_bulk_start(&buf->buf_bulk);
     }
 
     /*
      * Don't keep a cursor open across the whole replication session.
      * That had caused noticeable DB resource contention.
      */
-    if (cursor) {
-        cursor->c_close(cursor);
-        cursor = NULL;
-    }
-    if ((rc == DB_LOCK_DEADLOCK) && (tries < MAX_TRIALS)) {
+    dblayer_cursor_op(&cursor, DBI_OP_CLOSE, NULL, NULL);
+    if ((rc == DBI_RC_RETRY) && (tries < MAX_TRIALS)) {
         PRIntervalTime interval;
 
         tries++;
@@ -538,10 +504,10 @@ retry:
         /* back off */
         interval = PR_MillisecondsToInterval(slapi_rand() % 100);
         DS_Sleep(interval);
-        use_flag = flag;
+        use_dbop = dbop;
         goto retry;
     }
-    if ((rc == DB_LOCK_DEADLOCK) && (tries >= MAX_TRIALS)) {
+    if ((rc == DBI_RC_RETRY) && (tries >= MAX_TRIALS)) {
         slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name, "clcache_load_buffer_bulk - "
                                                           "could not load buffer from changelog after %d tries\n",
                       tries);
@@ -549,13 +515,8 @@ retry:
 
     PR_Unlock(buf->buf_busy_list->bl_lock);
 
-    buf->buf_record_ptr = NULL;
     if (0 == rc) {
-        DB_MULTIPLE_INIT(buf->buf_record_ptr, &buf->buf_data);
-        if (NULL == buf->buf_record_ptr)
-            rc = DB_NOTFOUND;
-        else
-            buf->buf_load_cnt++;
+        buf->buf_load_cnt++;
     }
 
     return rc;
@@ -569,28 +530,25 @@ retry:
 int
 clcache_get_next_change(CLC_Buffer *buf, void **key, size_t *keylen, void **data, size_t *datalen, CSN **csn, char *initial_starting_csn)
 {
+    dbi_val_t dbi_key = { 0 };
+    dbi_val_t dbi_data = { 0 };
     int skip = 1;
     int rc = 0;
 
     do {
-        *key = *data = NULL;
-        *keylen = *datalen = 0;
-
-        if (buf->buf_record_ptr) {
-            DB_MULTIPLE_KEY_NEXT(buf->buf_record_ptr, &buf->buf_data,
-                                 *key, *keylen, *data, *datalen);
-        }
-
-        /*
-         * We're done with the current buffer. Now load the next chunk.
-         */
-        if (NULL == *key && CLC_STATE_READY == buf->buf_state) {
+        rc = dblayer_bulk_nextrecord(&buf->buf_bulk, &dbi_key, &dbi_data);
+        if (rc == DBI_RC_NOTFOUND && CLC_STATE_READY == buf->buf_state) {
+            /*
+             * We're done with the current buffer. Now load the next chunk.
+             */
             rc = clcache_load_buffer(buf, NULL, NULL, initial_starting_csn);
-            if (0 == rc && buf->buf_record_ptr) {
-                DB_MULTIPLE_KEY_NEXT(buf->buf_record_ptr, &buf->buf_data,
-                                     *key, *keylen, *data, *datalen);
+            if (0 == rc) {
+                rc = dblayer_bulk_nextrecord(&buf->buf_bulk, &dbi_key, &dbi_data);
             }
         }
+
+        *key = dbi_key.data;
+        *data = dbi_data.data;
 
         /* Compare the new change to the local and remote RUVs */
         if (NULL != *key) {
@@ -605,7 +563,7 @@ clcache_get_next_change(CLC_Buffer *buf, void **key, size_t *keylen, void **data
     if (NULL == *key) {
         *key = NULL;
         *csn = NULL;
-        rc = DB_NOTFOUND;
+        rc = DBI_RC_NOTFOUND;
     } else {
         *csn = buf->buf_current_csn;
         slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name,
@@ -701,7 +659,7 @@ clcache_refresh_local_maxcsns(CLC_Buffer *buf)
  *       Anchor-CSN = min { all Next-Anchor-CSN, Buffer-MaxCSN }
  */
 static int
-clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag)
+clcache_initial_anchorcsn(CLC_Buffer *buf, dbi_op_t *dbop)
 {
     PRBool hasChange = PR_FALSE;
     struct csn_seq_ctrl_block *cscb;
@@ -711,7 +669,7 @@ clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag)
     if (buf->buf_state == CLC_STATE_READY) {
         for (i = 0; i < buf->buf_num_cscbs; i++) {
             CSN *rid_anchor = NULL;
-            int rid_flag = DB_NEXT;
+            dbi_op_t rid_dbop = DBI_OP_NEXT;
             cscb = buf->buf_cscbs[i];
 
             if (slapi_is_loglevel_set(SLAPI_LOG_REPL)) {
@@ -734,7 +692,7 @@ clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag)
             if (cscb->consumer_maxcsn == NULL) {
                 /* the consumer hasn't seen changes for this RID */
                 rid_anchor = cscb->local_mincsn;
-                rid_flag = DB_SET;
+                rid_dbop = DBI_OP_MOVE_TO_KEY;
             } else if (csn_compare(cscb->local_maxcsn, cscb->consumer_maxcsn) > 0) {
                 rid_anchor = cscb->consumer_maxcsn;
             }
@@ -742,7 +700,7 @@ clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag)
             if (rid_anchor && (anchorcsn == NULL ||
                                (csn_compare(rid_anchor, anchorcsn) < 0))) {
                 anchorcsn = rid_anchor;
-                *flag = rid_flag;
+                *dbop = rid_dbop;
                 hasChange = PR_TRUE;
             }
         }
@@ -761,7 +719,7 @@ clcache_initial_anchorcsn(CLC_Buffer *buf, int *flag)
 }
 
 static int
-clcache_adjust_anchorcsn(CLC_Buffer *buf, int *flag)
+clcache_adjust_anchorcsn(CLC_Buffer *buf, dbi_op_t *dbop)
 {
     PRBool hasChange = PR_FALSE;
     struct csn_seq_ctrl_block *cscb;
@@ -771,7 +729,7 @@ clcache_adjust_anchorcsn(CLC_Buffer *buf, int *flag)
     if (buf->buf_state == CLC_STATE_READY) {
         for (i = 0; i < buf->buf_num_cscbs; i++) {
             CSN *rid_anchor = NULL;
-            int rid_flag = DB_NEXT;
+            int rid_dbop = DBI_OP_NEXT;
             cscb = buf->buf_cscbs[i];
 
             if (slapi_is_loglevel_set(SLAPI_LOG_REPL)) {
@@ -802,7 +760,7 @@ clcache_adjust_anchorcsn(CLC_Buffer *buf, int *flag)
                     if (cscb->consumer_maxcsn == NULL) {
                         /* the consumer hasn't seen changes for this RID */
                         rid_anchor = cscb->local_mincsn;
-                        rid_flag = DB_SET;
+                        rid_dbop = DBI_OP_MOVE_TO_KEY;
                     } else {
                         rid_anchor = cscb->consumer_maxcsn;
                     }
@@ -812,7 +770,7 @@ clcache_adjust_anchorcsn(CLC_Buffer *buf, int *flag)
             if (rid_anchor && (anchorcsn == NULL ||
                                (csn_compare(rid_anchor, anchorcsn) < 0))) {
                 anchorcsn = rid_anchor;
-                *flag = rid_flag;
+                *dbop = rid_dbop;
                 hasChange = PR_TRUE;
             }
         }
@@ -992,19 +950,6 @@ clcache_new_buffer(ReplicaId consumer_rid)
         if (NULL == buf)
             break;
 
-        buf->buf_key.flags = DB_DBT_USERMEM;
-        buf->buf_key.ulen = CSN_STRSIZE + 1;
-        buf->buf_key.size = CSN_STRSIZE;
-        buf->buf_key.data = slapi_ch_calloc(1, buf->buf_key.ulen);
-        if (NULL == buf->buf_key.data)
-            break;
-
-        buf->buf_data.flags = DB_DBT_USERMEM;
-        buf->buf_data.ulen = _pool->pl_buffer_default_pages * DEFAULT_CLC_BUFFER_PAGE_SIZE;
-        buf->buf_data.data = slapi_ch_malloc(buf->buf_data.ulen);
-        if (NULL == buf->buf_data.data)
-            break;
-
         if (NULL == (buf->buf_current_csn = csn_new()))
             break;
 
@@ -1036,8 +981,11 @@ static void
 clcache_delete_buffer(CLC_Buffer **buf)
 {
     if (buf && *buf) {
-        slapi_ch_free(&((*buf)->buf_key.data));
-        slapi_ch_free(&((*buf)->buf_data.data));
+        dbi_val_t *bulkdata = &(*buf)->buf_bulk.v;
+
+        if (bulkdata->data != (*buf)->buf_bulkdata) {
+            slapi_ch_free(&bulkdata->data);
+        }
         csn_free(&((*buf)->buf_current_csn));
         csn_free(&((*buf)->buf_missing_csn));
         csn_free(&((*buf)->buf_prev_missing_csn));
@@ -1100,7 +1048,7 @@ clcache_delete_busy_list(CLC_Busy_List **bl)
 }
 
 static int
-clcache_enqueue_busy_list(DB *db, CLC_Buffer *buf)
+clcache_enqueue_busy_list(Replica *replica, dbi_db_t *db, CLC_Buffer *buf)
 {
     CLC_Busy_List *bl;
     int rc = 0;
@@ -1116,6 +1064,7 @@ clcache_enqueue_busy_list(DB *db, CLC_Buffer *buf)
         } else {
             slapi_rwlock_wrlock(_pool->pl_lock);
             bl->bl_db = db;
+            bl->bl_be = slapi_be_select(replica_get_root(replica));
             bl->bl_next = _pool->pl_busy_lists;
             _pool->pl_busy_lists = bl;
             slapi_rwlock_unlock(_pool->pl_lock);
@@ -1134,55 +1083,53 @@ clcache_enqueue_busy_list(DB *db, CLC_Buffer *buf)
 }
 
 static int
-clcache_open_cursor(DB_TXN *txn, CLC_Buffer *buf, DBC **cursor)
+clcache_open_cursor(dbi_txn_t *txn, CLC_Buffer *buf, dbi_cursor_t *cursor)
 {
     int rc;
 
-    rc = buf->buf_busy_list->bl_db->cursor(buf->buf_busy_list->bl_db, txn, cursor, 0);
+    rc = dblayer_new_cursor(buf->buf_busy_list->bl_be, buf->buf_busy_list->bl_db, txn, cursor);
     if (rc != 0) {
         slapi_log_err(SLAPI_LOG_ERR, get_thread_private_agmtname(),
                       "clcache: failed to open cursor; db error - %d %s\n",
-                      rc, db_strerror(rc));
+                      rc, dblayer_strerror(rc));
     }
 
     return rc;
 }
 
 static int
-clcache_cursor_get(DBC *cursor, CLC_Buffer *buf, int flag)
+clcache_cursor_get(dbi_cursor_t *cursor, CLC_Buffer *buf, dbi_op_t dbop)
 {
+    dbi_val_t *bulkdata = &buf->buf_bulk.v;
     int rc;
 
-    if (buf->buf_data.ulen > WORK_CLC_BUFFER_PAGE_SIZE) {
+    if (bulkdata->data != buf->buf_bulkdata) {
         /*
-         * The buffer size had to be increased,
+         * The buffer size had been increased,
          * reset it to a smaller working size,
          * if not sufficient it will be increased again
          */
-        buf->buf_data.ulen = WORK_CLC_BUFFER_PAGE_SIZE;
+        slapi_ch_free(&bulkdata->data);
+        dblayer_bulk_set_buffer(cursor->be, &buf->buf_bulk, buf, WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
     }
 
-    rc = cursor->c_get(cursor,
-                       &buf->buf_key,
-                       &buf->buf_data,
-                       buf->buf_load_flag | flag);
-    if (DB_BUFFER_SMALL == rc) {
+    rc = dblayer_cursor_bulkop(cursor, dbop, &buf->buf_key, &buf->buf_bulk);
+    if (DBI_RC_BUFFER_SMALL == rc) {
         /*
          * The record takes more space than the current size of the
-         * buffer. Fortunately, buf->buf_data.size has been set by
-         * c_get() to the actual data size needed. So we can
+         * buffer. Fortunately, buf->buf_bulk.v.size has been set by
+         * dblayer_bulk_set_buffer() to the actual data size needed. So we can
          * reallocate the data buffer and try to read again.
          */
-        buf->buf_data.ulen = (buf->buf_data.size / DEFAULT_CLC_BUFFER_PAGE_SIZE + 1) * DEFAULT_CLC_BUFFER_PAGE_SIZE;
-        buf->buf_data.data = slapi_ch_realloc(buf->buf_data.data, buf->buf_data.ulen);
-        if (buf->buf_data.data != NULL) {
-            rc = cursor->c_get(cursor,
-                               &(buf->buf_key),
-                               &(buf->buf_data),
-                               buf->buf_load_flag | flag);
-            slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name,
-                          "clcache_cursor_get - clcache: (%d | %d) buf key len %d reallocated and retry returns %d\n", buf->buf_load_flag, flag, buf->buf_key.size, rc);
+        bulkdata->ulen = (bulkdata->size / DEFAULT_CLC_BUFFER_PAGE_SIZE + 1) * DEFAULT_CLC_BUFFER_PAGE_SIZE;
+        if (bulkdata->data != buf->buf_bulkdata) {
+            bulkdata->data = slapi_ch_realloc(bulkdata->data, bulkdata->ulen);
+        } else {
+            bulkdata->data = slapi_ch_malloc(bulkdata->ulen);
         }
+        rc = dblayer_cursor_bulkop(cursor, dbop, &buf->buf_key, &buf->buf_bulk);
+        slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name,
+                      "clcache_cursor_get - clcache: (%s) buf key len %lu reallocated and retry returns %d\n", dblayer_op2str(dbop), buf->buf_key.size, rc);
     }
 
     switch (rc) {
@@ -1191,9 +1138,9 @@ clcache_cursor_get(DBC *cursor, CLC_Buffer *buf, int flag)
                       "clcache_cursor_get - invalid parameter\n");
         break;
 
-    case DB_BUFFER_SMALL:
+    case DBI_RC_BUFFER_SMALL:
         slapi_log_err(SLAPI_LOG_ERR, buf->buf_agmt_name,
-                      "clcache_cursor_get - can't allocate %u bytes\n", buf->buf_data.ulen);
+                      "clcache_cursor_get - can't allocate %lu bytes\n", bulkdata->ulen);
         break;
 
     default:

--- a/ldap/servers/plugins/replication/cl5_clcache.h
+++ b/ldap/servers/plugins/replication/cl5_clcache.h
@@ -15,14 +15,14 @@
 #endif
 
 
-#include "db.h"
 #include "slapi-private.h"
+#include "../../slapd/back-ldbm/dbimpl.h"          /* DB Access API */
 
 typedef struct clc_buffer CLC_Buffer;
 
 int clcache_init(void);
 void clcache_set_config(void);
-int clcache_get_buffer(CLC_Buffer **buf, DB *db, ReplicaId consumer_rid, const RUV *consumer_ruv, const RUV *local_ruv);
+int clcache_get_buffer(Replica *replica, CLC_Buffer **buf, dbi_db_t *db, ReplicaId consumer_rid, const RUV *consumer_ruv, const RUV *local_ruv);
 int clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, char *initial_starting_csn);
 void clcache_return_buffer(CLC_Buffer **buf);
 int clcache_get_next_change(CLC_Buffer *buf, void **key, size_t *keylen, void **data, size_t *datalen, CSN **csn, char *initial_starting_csn);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
@@ -107,7 +107,6 @@ int bdb_init(struct ldbminfo *li, config_info *config_array)
     priv->instance_register_monitor_fn = &bdb_instance_register_monitor;
     priv->instance_search_callback_fn = &bdb_instance_search_callback;
     priv->dblayer_auto_tune_fn = &bdb_start_autotune;
-
     priv->dblayer_get_db_filename_fn = &bdb_public_get_db_filename;
     priv->dblayer_bulk_free_fn = &bdb_public_bulk_free;
     priv->dblayer_bulk_nextdata_fn = &bdb_public_bulk_nextdata;
@@ -121,6 +120,10 @@ int bdb_init(struct ldbminfo *li, config_info *config_array)
     priv->dblayer_value_free_fn = &bdb_public_value_free;
     priv->dblayer_value_init_fn = &bdb_public_value_init;
     priv->dblayer_set_dup_cmp_fn = &bdb_public_set_dup_cmp_fn;
+    priv->dblayer_dbi_txn_begin_fn = &bdb_dbi_txn_begin;
+    priv->dblayer_dbi_txn_commit_fn = &bdb_dbi_txn_commit;
+    priv->dblayer_dbi_txn_abort_fn = &bdb_dbi_txn_abort;
+    priv->dblayer_get_entries_count_fn = &bdb_get_entries_count;
     priv->dblayer_cursor_get_count_fn = &bdb_public_cursor_get_count;
 
     bdb_fake_priv = *priv; /* Copy the callbaks for bdb_be() */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6404,7 +6404,7 @@ int bdb_public_bulk_nextrecord(dbi_bulk_t *bulkdata, dbi_val_t *key, dbi_val_t *
     if (retdata == NULL || bulkdata->be == NULL) {
         return DBI_RC_NOTFOUND;
     }
-   return DBI_RC_SUCCESS;
+    return DBI_RC_SUCCESS;
 }
 
 int bdb_public_bulk_init(dbi_bulk_t *bulkdata)
@@ -6673,19 +6673,19 @@ bdb_public_set_dup_cmp_fn(struct attrinfo *a, dbi_dup_cmp_t idx)
 int
 bdb_dbi_txn_begin(dbi_env_t *env, PRBool readonly, dbi_txn_t *parent_txn, dbi_txn_t **txn)
 {
-   return TXN_BEGIN(env, parent_txn, txn, 0);
+    return TXN_BEGIN(env, parent_txn, txn, 0);
 }
 
 int
 bdb_dbi_txn_commit(dbi_txn_t *txn)
 {
-   return TXN_COMMIT(txn, 0);
+    return TXN_COMMIT(txn, 0);
 }
 
 int
 bdb_dbi_txn_abort(dbi_txn_t *txn)
 {
-   return TXN_ABORT(txn);
+    return TXN_ABORT(txn);
 }
 
 int

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -28,9 +28,9 @@
     }
 
 #define TXN_BEGIN(env, parent_txn, tid, flags) \
-    (env)->txn_begin((env), (parent_txn), (tid), (flags))
-#define TXN_COMMIT(txn, flags) (txn)->commit((txn), (flags))
-#define TXN_ABORT(txn) (txn)->abort(txn)
+    ((DB_ENV*)(env))->txn_begin((env), (parent_txn), (DB_TXN **)(tid), (flags))
+#define TXN_COMMIT(txn, flags) ((DB_TXN*)(txn))->commit((txn), (flags))
+#define TXN_ABORT(txn) ((DB_TXN*)(txn))->abort(txn)
 #define TXN_CHECKPOINT(env, kbyte, min, flags) \
     (env)->txn_checkpoint((env), (kbyte), (min), (flags))
 #define MEMP_STAT(env, gsp, fsp, flags, malloc) \
@@ -3831,7 +3831,7 @@ checkpoint_threadmain(void *param)
                 }
 
                 /* compact changelog db */
-                /* NOTE (LK) this is now done along regular compaction, 
+                /* NOTE (LK) this is now done along regular compaction,
                  * if it should be configurable add a switch to changelog config
                  */
                 dblayer_get_changelog(inst->inst_be, (dbi_db_t **)&db, 0);
@@ -6223,7 +6223,7 @@ bdb_back_ctrl(Slapi_Backend *be, int cmd, void *info)
 dbi_error_t bdb_map_error(const char *funcname, int err)
 {
     char *msg = NULL;
-    
+
     switch (err) {
         case 0:
             return DBI_RC_SUCCESS;
@@ -6252,7 +6252,7 @@ dbi_error_t bdb_map_error(const char *funcname, int err)
 void bdb_dbival2dbt(dbi_val_t *dbi, DBT *dbt, PRBool isresponse)
 {
 /*
- * isresponse is true means that bdb_dbt2dbival(dbt, dbi, PR_FALSE) 
+ * isresponse is true means that bdb_dbt2dbival(dbt, dbi, PR_FALSE)
  *  is called a few lines before bdb_dbival2dbt call
  * This means that if data pointer differs then the buffer has been
  * re alloced ==> should beware not to free it twice
@@ -6263,7 +6263,7 @@ void bdb_dbival2dbt(dbi_val_t *dbi, DBT *dbt, PRBool isresponse)
     dbt->data = dbi->data;
     dbt->size = dbi->size;
     dbt->ulen = dbi->ulen;
-    
+
     if (dbi->flags & DBI_VF_DONTGROW) {
         /* Should not change the buffer */
         dbt->flags = DB_DBT_USERMEM;
@@ -6280,7 +6280,7 @@ void bdb_dbival2dbt(dbi_val_t *dbi, DBT *dbt, PRBool isresponse)
 void bdb_dbt2dbival(DBT *dbt, dbi_val_t *dbi, PRBool isresponse)
 {
 /*
- * isresponse is true means that bdb_dbival2dbt(dbt, dbi, PR_FALSE) 
+ * isresponse is true means that bdb_dbival2dbt(dbt, dbi, PR_FALSE)
  *  is called a few lines before bdb_dbt2dbival call
  * This means that if data pointer differs then the buffer has been
  * re alloced ==> should beware not to free it twice
@@ -6288,18 +6288,18 @@ void bdb_dbt2dbival(DBT *dbt, dbi_val_t *dbi, PRBool isresponse)
     if (!dbi || !dbt) {
         return;
     }
-    /* 
+    /*
      * if dbi is read only
      *  return NOMEM
-     * if dbt and dbi do not have same data address 
+     * if dbt and dbi do not have same data address
      *     if dbt is not growable return NOMEM
      *     free dbi
-     *     set dbi to dbt values 
+     *     set dbi to dbt values
      *     if dbt is MALLOC or REALLOC set its value to NULL.
-     * update the size 
+     * update the size
      * and the flags
      */
-     
+
     if (dbi->flags & DBI_VF_READONLY) {
         /* trying to modify read only data */
         PR_ASSERT(0);
@@ -6307,7 +6307,7 @@ void bdb_dbt2dbival(DBT *dbt, dbi_val_t *dbi, PRBool isresponse)
         return;
     }
     /*
-     * Note: as dblayer_value_set/dblayer_value_set_buffer is used 
+     * Note: as dblayer_value_set/dblayer_value_set_buffer is used
      * typical usage:
      *    bdb_dbival2dbt(dbikey, &dbtkey, PR_FALSE);
      *    some bdb operation(...,&dbtkey,...);
@@ -6315,7 +6315,7 @@ void bdb_dbt2dbival(DBT *dbt, dbi_val_t *dbi, PRBool isresponse)
      * does free the original value if its address changes
      * So at backend level the dbi needs to be freed once before
      *  exiting the function (no more need to free the
-     *  value if its address change as it is the case with 
+     *  value if its address change as it is the case with
      *  when using DB_DBT_MALLOC )
      */
     if (dbt->data != dbi->data) {
@@ -6401,7 +6401,10 @@ int bdb_public_bulk_nextrecord(dbi_bulk_t *bulkdata, dbi_val_t *key, dbi_val_t *
         PR_ASSERT(0);
         return DBI_RC_INVALID;
     }
-    return DBI_RC_SUCCESS;
+    if (retdata == NULL || bulkdata->be == NULL) {
+        return DBI_RC_NOTFOUND;
+    }
+   return DBI_RC_SUCCESS;
 }
 
 int bdb_public_bulk_init(dbi_bulk_t *bulkdata)
@@ -6420,6 +6423,7 @@ int bdb_public_bulk_start(dbi_bulk_t *bulkdata)
 
 int bdb_public_cursor_bulkop(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key, dbi_bulk_t *bulkdata)
 {
+    int mflag = (bulkdata->v.flags & DBI_VF_BULK_RECORD) ? DB_MULTIPLE_KEY : DB_MULTIPLE;
     DBC *bdb_cur = (DBC*)cursor->cur;
     DBT bdb_key = {0};
     DBT bdb_data = {0};
@@ -6433,17 +6437,17 @@ int bdb_public_cursor_bulkop(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key,
     switch (op)
     {
         case DBI_OP_MOVE_TO_KEY:
-            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_SET | DB_MULTIPLE);
+            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_SET | mflag);
             break;
         case DBI_OP_NEXT_KEY:
-            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT_NODUP | DB_MULTIPLE);
+            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT_NODUP | mflag);
             break;
         case DBI_OP_NEXT:
             PR_ASSERT(bulkdata->v.flags & DBI_VF_BULK_RECORD);
-            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT | DB_MULTIPLE);
+            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT | mflag);
             break;
         case DBI_OP_NEXT_DATA:
-            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT_DUP | DB_MULTIPLE);
+            rc = bdb_cur->c_get(bdb_cur, &bdb_key, &bdb_data, DB_NEXT_DUP | mflag);
             break;
         default:
             /* Unknown bulk operation */
@@ -6664,6 +6668,42 @@ bdb_public_set_dup_cmp_fn(struct attrinfo *a, dbi_dup_cmp_t idx)
             return DBI_RC_UNSUPPORTED;
     }
     return DBI_RC_SUCCESS;
+}
+
+int
+bdb_dbi_txn_begin(dbi_env_t *env, PRBool readonly, dbi_txn_t *parent_txn, dbi_txn_t **txn)
+{
+   return TXN_BEGIN(env, parent_txn, txn, 0);
+}
+
+int
+bdb_dbi_txn_commit(dbi_txn_t *txn)
+{
+   return TXN_COMMIT(txn, 0);
+}
+
+int
+bdb_dbi_txn_abort(dbi_txn_t *txn)
+{
+   return TXN_ABORT(txn);
+}
+
+int
+bdb_get_entries_count(dbi_db_t *db, int *count)
+{
+    DB_BTREE_STAT *stats = NULL;
+    int rc;
+
+    rc = ((DB*)db)->stat(db, NULL, (void *)&stats, 0);
+    if (rc != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "bdb_get_entries_count",
+                      "Failed to get bd statistics: db error - %d %s\n",
+                      rc, db_strerror(rc));
+        rc = DBI_RC_OTHER;
+    }
+    *count = rc ? 0 : stats->bt_ndata;
+    slapi_ch_free((void **)&stats);
+    return rc;
 }
 
 int

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -128,8 +128,11 @@ dblayer_new_cursor_fn_t bdb_public_new_cursor;
 dblayer_value_free_fn_t bdb_public_value_free;
 dblayer_value_init_fn_t bdb_public_value_init;
 dblayer_set_dup_cmp_fn_t bdb_public_set_dup_cmp_fn;
+dblayer_dbi_txn_begin_fn_t bdb_dbi_txn_begin;
+dblayer_dbi_txn_commit_fn_t bdb_dbi_txn_commit;
+dblayer_dbi_txn_abort_fn_t bdb_dbi_txn_abort;
+dblayer_get_entries_count_fn_t bdb_get_entries_count;
 dblayer_cursor_get_count_fn_t bdb_public_cursor_get_count;
-
 
 /* instance functions */
 int bdb_instance_cleanup(struct ldbm_instance *inst);

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -362,32 +362,32 @@ int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, int *count)
 const char *dblayer_op2str(dbi_op_t op)
 {
     static const char *str[] = {
-        DBI_OP_MOVE_TO_KEY,         /* move cursor to specified key and data
+        "DBI_OP_MOVE_TO_KEY",         /* move cursor to specified key and data
                                      * then get the record.
                                      */
-        DBI_OP_MOVE_NEAR_KEY,       /* move cursor to smallest key greater or equal
+        "DBI_OP_MOVE_NEAR_KEY",       /* move cursor to smallest key greater or equal
                                      * than specified key then get the record.
                                      */
-        DBI_OP_MOVE_TO_DATA,        /* move cursor to specified key and data
+        "DBI_OP_MOVE_TO_DATA",        /* move cursor to specified key and data
                                      * then get the record.
                                      */
-        DBI_OP_MOVE_NEAR_DATA,      /* move cursor to specified key and smallest
+        "DBI_OP_MOVE_NEAR_DATA",      /* move cursor to specified key and smallest
                                      * data greater or equal than specified data
                                      * then get the record.
                                      */
-        DBI_OP_MOVE_TO_RECNO,       /* move cursor to specified record number */
-        DBI_OP_MOVE_TO_LAST,
-        DBI_OP_GET,                 /* db operation: get record associated with key */
-        DBI_OP_GET_RECNO,           /* Get current record number */
-        DBI_OP_NEXT,                /* move to next record */
-        DBI_OP_NEXT_DATA,           /* Move to next record having same key */
-        DBI_OP_NEXT_KEY,            /* move to next record having different key */
-        DBI_OP_PREV,
-        DBI_OP_PUT,                 /* db operation */
-        DBI_OP_REPLACE,             /* Replace value at cursor position (key is ignored) */
-        DBI_OP_ADD,                 /* Add record if it does not exists */
-        DBI_OP_DEL,
-        DBI_OP_CLOSE
+        "DBI_OP_MOVE_TO_RECNO",       /* move cursor to specified record number */
+        "DBI_OP_MOVE_TO_LAST",
+        "DBI_OP_GET",                 /* db operation: get record associated with key */
+        "DBI_OP_GET_RECNO",           /* Get current record number */
+        "DBI_OP_NEXT",                /* move to next record */
+        "DBI_OP_NEXT_DATA",           /* Move to next record having same key */
+        "DBI_OP_NEXT_KEY",            /* move to next record having different key */
+        "DBI_OP_PREV",
+        "DBI_OP_PUT",                 /* db operation */
+        "DBI_OP_REPLACE",             /* Replace value at cursor position (key is ignored) */
+        "DBI_OP_ADD",                 /* Add record if it does not exists */
+        "DBI_OP_DEL",
+        "DBI_OP_CLOSE"
     };
     int idx = op - DBI_OP_MOVE_TO_KEY;
     if (idx <0 || idx >= (sizeof str)/(sizeof str[0])) {

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -363,18 +363,18 @@ const char *dblayer_op2str(dbi_op_t op)
 {
     static const char *str[] = {
         "DBI_OP_MOVE_TO_KEY",         /* move cursor to specified key and data
-                                     * then get the record.
-                                     */
+                                       * then get the record.
+                                       */
         "DBI_OP_MOVE_NEAR_KEY",       /* move cursor to smallest key greater or equal
-                                     * than specified key then get the record.
-                                     */
+                                       * than specified key then get the record.
+                                       */
         "DBI_OP_MOVE_TO_DATA",        /* move cursor to specified key and data
-                                     * then get the record.
-                                     */
+                                       * then get the record.
+                                       */
         "DBI_OP_MOVE_NEAR_DATA",      /* move cursor to specified key and smallest
-                                     * data greater or equal than specified data
-                                     * then get the record.
-                                     */
+                                       * data greater or equal than specified data
+                                       * then get the record.
+                                       */
         "DBI_OP_MOVE_TO_RECNO",       /* move cursor to specified record number */
         "DBI_OP_MOVE_TO_LAST",
         "DBI_OP_GET",                 /* db operation: get record associated with key */

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -142,6 +142,7 @@ int dblayer_cursor_bulkop(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key, db
 
 int dblayer_cursor_op(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key, dbi_val_t *data)
 {
+    static const dbi_cursor_t cursor0 = {0};
     dblayer_private *priv;
     int rc = DBI_RC_UNSUPPORTED;
     if (op == DBI_OP_CLOSE && cursor->be == NULL) {
@@ -163,8 +164,11 @@ int dblayer_cursor_op(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key, dbi_va
         case DBI_OP_REPLACE:
         case DBI_OP_ADD:
         case DBI_OP_DEL:
+            rc = priv->dblayer_cursor_op_fn(cursor, op, key, data);
+            break;
         case DBI_OP_CLOSE:
             rc = priv->dblayer_cursor_op_fn(cursor, op, key, data);
+            *cursor = cursor0;
             break;
         default:
             PR_ASSERT(0);
@@ -243,6 +247,7 @@ int dblayer_value_strdup(Slapi_Backend *be, dbi_val_t *data, char *str)
 
 /* Concat all data/size pairs into a dbi_val_t
  * value is either set from buffer (if it is large enough) or it is alloced
+ * (Cannot use varargs here because it leads to a crash on Suze)
  */
 void dblayer_value_concat(Slapi_Backend *be, dbi_val_t *data,
     void *buf, size_t buflen, const char *str1, size_t len1,
@@ -253,8 +258,8 @@ void dblayer_value_concat(Slapi_Backend *be, dbi_val_t *data,
     char lastc = '?';
 
     /* add space for \0 if it is missing */
-    lastc = ((len3 > 0) ? str3[len3 -1] : 
-            ((len2 > 0) ? str2[len2 -1] : 
+    lastc = ((len3 > 0) ? str3[len3 -1] :
+            ((len2 > 0) ? str2[len2 -1] :
             ((len1 > 0) ? str1[len1 -1] : '?')));
     len = len1 + len2 + len3 + (lastc ? 1 : 0);
 
@@ -293,6 +298,33 @@ int dblayer_set_dup_cmp_fn(Slapi_Backend *be, struct attrinfo *a, dbi_dup_cmp_t 
     return priv->dblayer_set_dup_cmp_fn(a, idx);
 }
 
+char *
+dblayer_strerror(int error)
+{
+    switch (error)
+    {
+        case DBI_RC_SUCCESS:
+            return "No error.";
+        case DBI_RC_UNSUPPORTED:
+            return "Database operation error: Operation not supported.";
+        case DBI_RC_BUFFER_SMALL:
+            return "Database operation error: Buffer is too small to store the result.";
+        case DBI_RC_KEYEXIST:
+            return "Database operation error: Key already exists.";
+        case DBI_RC_NOTFOUND:
+            return "Database operation error: Key not found (or no more keys).";
+        case DBI_RC_RUNRECOVERY:
+            return "Database operation error: Database recovery is needed.";
+        case DBI_RC_RETRY:
+            return "Database operation error: Transient error. transaction should be retried.";
+        case DBI_RC_OTHER:
+           return "Database operation error: Unhandled code. See details in previous error messages.";
+        default:
+           return "Unexpected error code.";
+   }
+}
+
+
 int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count)
 {
     dblayer_private *priv;
@@ -302,3 +334,65 @@ int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count)
     priv = dblayer_get_priv(cursor->be);
     return priv->dblayer_cursor_get_count_fn(cursor, count);
 }
+
+int dblayer_dbi_txn_begin(Slapi_Backend *be, dbi_env_t *dbenv, PRBool readonly, dbi_txn_t *parent_txn, dbi_txn_t **txn)
+{
+    dblayer_private *priv = dblayer_get_priv(be);
+    return priv->dblayer_dbi_txn_begin_fn(dbenv, readonly, parent_txn, txn);
+}
+
+int dblayer_dbi_txn_commit(Slapi_Backend *be, dbi_txn_t *txn)
+{
+    dblayer_private *priv = dblayer_get_priv(be);
+    return priv->dblayer_dbi_txn_commit_fn(txn);
+}
+
+int dblayer_dbi_txn_abort(Slapi_Backend *be, dbi_txn_t *txn)
+{
+    dblayer_private *priv = dblayer_get_priv(be);
+    return priv->dblayer_dbi_txn_abort_fn(txn);
+}
+
+int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, int *count)
+{
+    dblayer_private *priv = dblayer_get_priv(be);
+    return priv->dblayer_get_entries_count_fn(db, count);
+}
+
+const char *dblayer_op2str(dbi_op_t op)
+{
+    static const char *str[] = {
+        DBI_OP_MOVE_TO_KEY,         /* move cursor to specified key and data
+                                     * then get the record.
+                                     */
+        DBI_OP_MOVE_NEAR_KEY,       /* move cursor to smallest key greater or equal
+                                     * than specified key then get the record.
+                                     */
+        DBI_OP_MOVE_TO_DATA,        /* move cursor to specified key and data
+                                     * then get the record.
+                                     */
+        DBI_OP_MOVE_NEAR_DATA,      /* move cursor to specified key and smallest
+                                     * data greater or equal than specified data
+                                     * then get the record.
+                                     */
+        DBI_OP_MOVE_TO_RECNO,       /* move cursor to specified record number */
+        DBI_OP_MOVE_TO_LAST,
+        DBI_OP_GET,                 /* db operation: get record associated with key */
+        DBI_OP_GET_RECNO,           /* Get current record number */
+        DBI_OP_NEXT,                /* move to next record */
+        DBI_OP_NEXT_DATA,           /* Move to next record having same key */
+        DBI_OP_NEXT_KEY,            /* move to next record having different key */
+        DBI_OP_PREV,
+        DBI_OP_PUT,                 /* db operation */
+        DBI_OP_REPLACE,             /* Replace value at cursor position (key is ignored) */
+        DBI_OP_ADD,                 /* Add record if it does not exists */
+        DBI_OP_DEL,
+        DBI_OP_CLOSE
+    };
+    int idx = op - DBI_OP_MOVE_TO_KEY;
+    if (idx <0 || idx >= (sizeof str)/(sizeof str[0])) {
+        return "INVALID DBI_OP";
+    }
+    return str[idx];
+}
+

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -318,9 +318,9 @@ dblayer_strerror(int error)
         case DBI_RC_RETRY:
             return "Database operation error: Transient error. transaction should be retried.";
         case DBI_RC_OTHER:
-           return "Database operation error: Unhandled code. See details in previous error messages.";
+            return "Database operation error: Unhandled code. See details in previous error messages.";
         default:
-           return "Unexpected error code.";
+            return "Unexpected error code.";
    }
 }
 

--- a/ldap/servers/slapd/back-ldbm/dbimpl.h
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.h
@@ -38,6 +38,7 @@ typedef enum {
     DBI_VF_BULK_RECORD = 0x10,  /* Bulk operation on key+data */
 } dbi_valflags_t;               /* Should not be used in backend except within dbimpl.c */
 
+/* Warning! any change in dbi_op_t should also be reported in dblayer_op2str() */
 typedef enum {
     DBI_OP_MOVE_TO_KEY = 1001,  /* move cursor to specified key and data
                                  * then get the record.
@@ -66,11 +67,6 @@ typedef enum {
     DBI_OP_DEL,
     DBI_OP_CLOSE,
 } dbi_op_t;
-
-typedef enum {
-    DBI_BULK_DATA,
-    DBI_BULK_RECORDS
-} dbi_bulk_mode_t;
 
 typedef enum {
     DBI_DUP_CMP_NONE,
@@ -142,9 +138,10 @@ int dblayer_dbi_txn_begin(Slapi_Backend *be, dbi_env_t *dbenv, int flags, dbi_tx
 int dblayer_dbi_txn_commit(Slapi_Backend *be, dbi_txn_t *txn);
 int dblayer_dbi_txn_abort(Slapi_Backend *be, dbi_txn_t *txn);
 int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, int *count);
+int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count);
 char *dblayer_get_db_filename(Slapi_Backend *be, dbi_db_t *db);
+char *dblayer_strerror(int error);
 const char *dblayer_op2str(dbi_op_t op);
-char * dblayer_strerror(int error);
 int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count);
 
 #endif /* _DBIMPL_H */

--- a/ldap/servers/slapd/back-ldbm/dblayer.c
+++ b/ldap/servers/slapd/back-ldbm/dblayer.c
@@ -1212,34 +1212,6 @@ dblayer_get_instance_data_dir(backend *be)
     return ret;
 }
 
-char *
-dblayer_strerror(int error)
-{
-    switch (error)
-    {
-        case DBI_RC_SUCCESS:
-            return "No error.";
-        case DBI_RC_UNSUPPORTED:
-            return "Database operation error: Operation not supported.";
-        case DBI_RC_BUFFER_SMALL:
-            return "Database operation error: Buffer is too small to store the result.";
-        case DBI_RC_KEYEXIST:
-            return "Database operation error: Key already exists.";
-        case DBI_RC_NOTFOUND:
-            return "Database operation error: Key not found (or no more keys).";
-        case DBI_RC_RUNRECOVERY:
-            return "Database operation error: Database recovery is needed.";
-        case DBI_RC_RETRY:
-            return "Database operation error: Transient error. transaction should be retried.";
-        case DBI_RC_INVALID:
-            return "Database operation error: Invalid parameter or invalid state.";
-        case DBI_RC_OTHER:
-            return "Database operation error: Unhandled code. See details in previous error messages.";
-        default:
-            return "Unexpected error code.";
-    }
-}
-
 /* [605974] check a db region file's existence to know whether import is executed by other process or not */
 int
 dblayer_in_import(ldbm_instance *inst)

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -115,6 +115,10 @@ typedef int dblayer_value_alloc_fn_t(dbi_val_t *data, size_t size);
 typedef int dblayer_value_free_fn_t(dbi_val_t *data);
 typedef int dblayer_value_init_fn_t(dbi_val_t *data);
 typedef int dblayer_set_dup_cmp_fn_t(struct attrinfo *a, dbi_dup_cmp_t idx);
+typedef int dblayer_dbi_txn_begin_fn_t(dbi_env_t *dbenv, PRBool readonly, dbi_txn_t *parent_txn, dbi_txn_t **txn);
+typedef int dblayer_dbi_txn_commit_fn_t(dbi_txn_t *txn);
+typedef int dblayer_dbi_txn_abort_fn_t(dbi_txn_t *txn);
+typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, int *count);
 typedef int dblayer_cursor_get_count_fn_t(dbi_cursor_t *cursor, dbi_recno_t *count);
 
 struct dblayer_private
@@ -180,6 +184,10 @@ struct dblayer_private
     dblayer_value_free_fn_t *dblayer_value_free_fn;
     dblayer_value_init_fn_t *dblayer_value_init_fn;
     dblayer_set_dup_cmp_fn_t *dblayer_set_dup_cmp_fn;
+    dblayer_dbi_txn_begin_fn_t *dblayer_dbi_txn_begin_fn;
+    dblayer_dbi_txn_commit_fn_t *dblayer_dbi_txn_commit_fn;
+    dblayer_dbi_txn_abort_fn_t *dblayer_dbi_txn_abort_fn;
+    dblayer_get_entries_count_fn_t *dblayer_get_entries_count_fn;
     dblayer_cursor_get_count_fn_t *dblayer_cursor_get_count_fn;
 };
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -1556,7 +1556,7 @@ _entryrdn_get_tombstone_elem(dbi_cursor_t *cursor,
                              dbi_txn_t *db_txn)
 {
     int rc = 0;
-    dbi_bulk_t data;
+    dbi_bulk_t data = {0};
     rdn_elem *childelem = NULL;
     char buffer[RDN_BULK_FETCH_BUFFER_SIZE];
     backend *be = cursor->be;
@@ -2628,7 +2628,7 @@ _entryrdn_delete_key(backend *be,
         dblayer_value_set(be, &key, keybuf, strlen(keybuf) + 1);
         dblayer_value_protect_data(be, &key);
         dblayer_value_set(be, &data, elem, len);
-        dblayer_value_protect_data(be, &data);
+        elem = NULL;
 
         /* Position cursor at the matching key */
         rc = _entryrdn_get_elem(cursor, &key, &data,
@@ -2740,6 +2740,7 @@ _entryrdn_delete_key(backend *be,
 bail:
     slapi_ch_free_string(&parentnrdn);
     dblayer_value_free(be, &key);
+    dblayer_value_free(be, &data);
     slapi_ch_free((void **)&elem);
     slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_delete_key",
                   "<-- _entryrdn_delete_key\n");

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -115,7 +115,6 @@ void dblayer_remember_disk_filled(struct ldbminfo *li);
 int dblayer_instance_start(backend *be, int normal_mode);
 int dblayer_make_new_instance_data_dir(backend *be);
 int dblayer_get_instance_data_dir(backend *be);
-char *dblayer_strerror(int error);
 PRInt64 db_atol(char *str, int *err);
 PRInt64 db_atoi(char *str, int *err);
 uint32_t db_strtoul(const char *str, int *err);
@@ -136,7 +135,6 @@ int ldbm_back_get_info(Slapi_Backend *be, int cmd, void **info);
 int ldbm_back_set_info(Slapi_Backend *be, int cmd, void *info);
 int ldbm_back_ctrl_info(Slapi_Backend *be, int cmd, void *info);
 
-
 int dblayer_is_restored(void);
 void dblayer_set_restored(void);
 int dblayer_restore_file_init(struct ldbminfo *li);
@@ -144,7 +142,6 @@ void dblayer_restore_file_update(struct ldbminfo *li, char *directory);
 int dblayer_import_file_init(ldbm_instance *inst);
 void dblayer_import_file_update(ldbm_instance *inst);
 int dblayer_import_file_check(ldbm_instance *inst);
-char *dblayer_get_db_filename(Slapi_Backend *be, dbi_db_t *db);
 
 /*
  * dn2entry.c


### PR DESCRIPTION
Change description:
This replace Berkeley database dependencies in replication plugin
dbimpl API (as defined in https://directory.fedoraproject.org/docs/389ds/design/backend-redesign-phase3.html )
 is now used.
 
 Code impacted  is:
- the changelog and changelog cache (to use dbimp) 
- dbimpl and bdb (to add a few missing callbacks (txn handling) )
- dblayer (needed to move dblayer_strerror in dbimp to avoid getting in trouble with backend include in replication plugin ) 

relates: 
   #4469 - Backend redesign phase 3a - (dbimpl API implementation + bdb dependencies removal in back-ldbm)
   #4552 -  Backend redesign phase 3b - bdb dependencies removal in replication plugins 

Reviewed by: @Firstyear  @mreynolds389 

Platforms tested: F32