### PR TITLE
Issue 4169 - UI - port charts to PF4

### DIFF
--- a/src/cockpit/389-console/package-lock.json
+++ b/src/cockpit/389-console/package-lock.json
@@ -2792,6 +2792,59 @@
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.71.7.tgz",
       "integrity": "sha512-JjgBJcPOiZhEyixc6mY781eMmVL+qm5gs/h7IipVfps3IoadEZVlvOjffBCfqOVWug0DJbv6APqrZqOQmzISMA=="
     },
+    "@patternfly/react-charts": {
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.13.8.tgz",
+      "integrity": "sha512-IEQBtUCNMAA6JnLBcWj4RUQ5a80n/uBw3a8FzeL5x90Fp6pR6nc5wVjVH8WcO7minw3QMRwxtcu5itW/v+Ga0g==",
+      "requires": {
+        "@patternfly/patternfly": "4.80.3",
+        "@patternfly/react-styles": "^4.7.29",
+        "@patternfly/react-tokens": "^4.9.26",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.19",
+        "tslib": "1.13.0",
+        "victory-area": "^35.4.4",
+        "victory-axis": "^35.4.4",
+        "victory-bar": "^35.4.4",
+        "victory-chart": "^35.4.4",
+        "victory-core": "^35.4.4",
+        "victory-create-container": "^35.4.4",
+        "victory-group": "^35.4.4",
+        "victory-legend": "^35.4.4",
+        "victory-line": "^35.4.4",
+        "victory-pie": "^35.4.4",
+        "victory-scatter": "^35.4.4",
+        "victory-stack": "^35.4.4",
+        "victory-tooltip": "^35.4.4",
+        "victory-voronoi-container": "^35.4.4",
+        "victory-zoom-container": "^35.4.4"
+      },
+      "dependencies": {
+        "@patternfly/patternfly": {
+          "version": "4.80.3",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.80.3.tgz",
+          "integrity": "sha512-YLUk4L6iCBXql92YP6zHg0FdlnEkd5/3V+uz/A3UoBuuDdEoyDpx4M/Tf56R7IXmYiRaHE1mToJHPDYypIlnmw=="
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
     "@patternfly/react-core": {
       "version": "4.90.2",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.90.2.tgz",
@@ -6349,6 +6402,84 @@
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6523,6 +6654,19 @@
             "kind-of": "^6.0.2"
           }
         }
+      }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "delaunay-find": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+      "requires": {
+        "delaunator": "^4.0.0"
       }
     },
     "delayed-stream": {
@@ -15688,6 +15832,11 @@
         "uuid": "^3.1.0"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-fontawesome": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.7.1.tgz",
@@ -18577,6 +18726,233 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "victory-area": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.4.8.tgz",
+      "integrity": "sha512-eNr6ZFonAhCHoCetA9g5fJxFn+g+5YpgBmlbxwzE7kgKg+jH7+ViD/R2aNcY6aoljiRyE6DbSVAxDiksPp0q1A==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-axis": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.4.8.tgz",
+      "integrity": "sha512-+DcevVoIL6tjbTHwGZ2DzZiRl+Pwwowuf99mL10ECRzY+Iuc+s+x4o3gpw/HWJ/dGOyD+kPKPcwilmaQLnEOhQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-bar": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.4.8.tgz",
+      "integrity": "sha512-9EUxHoX2R7t/iOZEWDtpypX13V2+Pngo2V3I9uW7lHtg+SCKTjGjHP1sJSbwLP3WxHl7dHg3Jg+ok04cych6XQ==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-brush-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.4.8.tgz",
+      "integrity": "sha512-/nTpCijvLfCr86M5P3sr8umLsRJM7GaYODqagRChcPIS5O4oEzRZsgEVhOYmWZZiS56PIjMoLAzMBvgsiwBsDg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-chart": {
+      "version": "35.4.9",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.4.9.tgz",
+      "integrity": "sha512-OM8LFjBdzc2iujPlNj7WuwygMdCFjKLGWPN9dxzkpPhGaqQnH+k1rQaEz/DQC42x83QRlU93VwVcRTl9h3MzeA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^35.4.8",
+        "victory-core": "^35.4.8",
+        "victory-polar-axis": "^35.4.8",
+        "victory-shared-events": "^35.4.9"
+      }
+    },
+    "victory-core": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.4.8.tgz",
+      "integrity": "sha512-4yhNeeyttEe24mAG4DUPP3RvditQU+364WTnUS05ZHPrACyDWYTOfN5+L0GzmvkJ3kbteQkfX3UJgpHwwqVmug==",
+      "requires": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "victory-create-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.4.8.tgz",
+      "integrity": "sha512-1qYRi+npvvWurDjdrC2IthxvTWeKcP1nw8bw2OpL+oG21k/mQBrPGT2GtAmUBGp3e8LDr6BwrCx32FGd01PWYw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^35.4.8",
+        "victory-core": "^35.4.8",
+        "victory-cursor-container": "^35.4.8",
+        "victory-selection-container": "^35.4.8",
+        "victory-voronoi-container": "^35.4.8",
+        "victory-zoom-container": "^35.4.8"
+      }
+    },
+    "victory-cursor-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.4.8.tgz",
+      "integrity": "sha512-KLQug3j4dY8nkcL5CrPqO/pz48hH9chLS86eFiN56gUzLCHx81lEujc01YrsFxQat1cOyC3LghyM+pnexLMWEQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-group": {
+      "version": "35.4.9",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.4.9.tgz",
+      "integrity": "sha512-JhJYD/ykPVKFq8ZATTpj8zA1Y8f6pXVoD9o/qBcRMggyfjPglV4rGdg6NnFCTV5bK/YMV5jYiSvZpdJlBtQpPQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.8",
+        "victory-shared-events": "^35.4.9"
+      }
+    },
+    "victory-legend": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.4.8.tgz",
+      "integrity": "sha512-QI8zZLm8JipzzlAfJjpJm1MHl6FVcXWJOqU2XMl18RCkwDesukIiBO4dU8UAvNRkqxLRmkJzywFXSp3LFEah0Q==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-line": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.4.8.tgz",
+      "integrity": "sha512-RJ/Wqon7PS07NRZnlku2C8+cJ48ruunizvKtl7HVv15e1hybo/dCg3dD2IizrO6vF/ja8Iv/RZ2YBDe/nWywrg==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-pie": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.4.8.tgz",
+      "integrity": "sha512-1+FnHdlqYqQzuiA/Psa77dsXcK1sKbXEUjNgnwfEZSUY2HX5v3fQ0sk4AiZhnVVsz6Rp+Wl4We/cca1PHp7i/w==",
+      "requires": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-polar-axis": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.4.8.tgz",
+      "integrity": "sha512-rhNGYUj7A70ZoHyta0ma3WD12Kv162Mf0AmFLvfxC6W+4eh2uwgGE8j+CJBW+/HbzLhFoeDY+aTe0FqJPLiO4A==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-scatter": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.4.8.tgz",
+      "integrity": "sha512-UWyYgUhvdMFBkzBrgvN5WFCFX1E7tG6EjLNvAhsMoGK2eVH69QzC7Aiun+hLeXUXcssg2Gi1+f/w4rrxpdpZzw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-selection-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.4.8.tgz",
+      "integrity": "sha512-2I2pEoUwjEltm0hJO+EwTlcrVhfvchph3OlcGp3N/Kw9q5veS/gfvcQMwur0FjS2GNwwCSjW/Gbv8zv31B/xFg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-shared-events": {
+      "version": "35.4.9",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.4.9.tgz",
+      "integrity": "sha512-AW6iYsZn+2kmRNb+RKzAze6z8/u5uQakBpkKsVl/AI43uzlWNEQELIfJOcFfTbM2Qo1vkwJCSz0S9mrbt2meAw==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-stack": {
+      "version": "35.4.9",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.4.9.tgz",
+      "integrity": "sha512-fePjKUM5zfp3+5lJPtow/6HAglwcVb1JBDNIsrpChn78G3NvbpTZUlMlNdbSmE1+xDLFEWBGJ9oUI/gjjWynGA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.8",
+        "victory-shared-events": "^35.4.9"
+      }
+    },
+    "victory-tooltip": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.4.8.tgz",
+      "integrity": "sha512-CZLsLgfxUA6PdaIxUgIk4DJfoo5DRM70OLTZFekctQkvwt2S6Fc7DSv47ZvFw7nL6SEVaNjwsDmTZnabUJb+4Q==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
+      }
+    },
+    "victory-voronoi-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.4.8.tgz",
+      "integrity": "sha512-+rQRr2SwdixwxvUSF4NUsPj7yWpkeQcQZWcPz8NNNpaCBxN1HNVQ41W7DmAZ98Spta2gkrk6888Q31zQeiGDXw==",
+      "requires": {
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.8",
+        "victory-tooltip": "^35.4.8"
+      }
+    },
+    "victory-zoom-container": {
+      "version": "35.4.8",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.4.8.tgz",
+      "integrity": "sha512-jLHm0/wttiRIzCEdxK3SL/emNUkfc9Rt64I2Yp+9OuP+YJP+5/MkuavjjnYaVowBD3sbn6ByGBMkJ8e+Q/U7dA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.8"
       }
     },
     "vm-browserify": {

--- a/src/cockpit/389-console/package.json
+++ b/src/cockpit/389-console/package.json
@@ -46,6 +46,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@patternfly/patternfly": "^2.71.7",
+    "@patternfly/react-charts": "^6.13.8",
     "@patternfly/react-core": "^4.90.2",
     "@patternfly/react-icons": "^4.8.4",
     "@restart/hooks": "^0.3.26",

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -474,10 +474,6 @@ textarea {
     margin-left: 40px !important;
 }
 
-.ds-margin-left-piechart {
-    margin-left: 140px !important;
-}
-
 .ds-margin-right-sm {
     margin-left: 5px !important;
 }
@@ -698,6 +694,12 @@ h4 {
     padding-left: 0px !important;
 }
 
-.pf-c-form__group-label {
-    text-align: right !important;
+.chart-container {
+  height: 100px;
+  width: 400px;
+}
+.chart-label-container {
+  margin-left: 50px;
+  margin-top: 50px;
+  height: 135px;
 }

--- a/src/cockpit/389-console/src/lib/monitor/dbMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/dbMonitor.jsx
@@ -1,330 +1,465 @@
+import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
+import { log_cmd } from "../tools.jsx";
 import {
-    DonutChart,
-    PieChart,
-    Nav,
-    NavItem,
-    TabContent,
-    TabPane,
-    TabContainer,
-    Row,
-    Col,
-    ControlLabel,
-    Form,
-    Icon,
-    noop,
-} from "patternfly-react";
-import d3 from "d3";
+    Card,
+    CardBody,
+    Grid,
+    GridItem,
+    Spinner,
+    Tab,
+    Tabs,
+    TabTitleText,
+    noop
+} from "@patternfly/react-core";
+import {
+    Chart,
+    ChartArea,
+    ChartAxis,
+    ChartGroup,
+    ChartThemeColor,
+    ChartVoronoiContainer
+} from '@patternfly/react-charts';
 
 export class DatabaseMonitor extends React.Component {
     constructor (props) {
         super(props);
         this.state = {
-            activeKey: 1,
-            disableTabs: false,
+            activeTabKey: 0,
+            data: {},
+            loading: true,
+            // refresh charts
+            cache_refresh: "",
+            count: 10,
+            dbCacheList: [],
+            ndnCacheList: [],
+            ndnCacheUtilList: []
         };
-        this.handleNavSelect = this.handleNavSelect.bind(this);
+
+        // Toggle currently active tab
+        this.handleNavSelect = (event, tabIndex) => {
+            this.setState({
+                activeTabKey: tabIndex
+            });
+        };
+
+        this.startCacheRefresh = this.startCacheRefresh.bind(this);
+        this.refreshCache = this.refreshCache.bind(this);
     }
 
     componentDidMount() {
+        this.resetChartData();
+        this.refreshCache();
+        this.startCacheRefresh();
         this.props.enableTree();
     }
 
-    handleNavSelect(key) {
-        this.setState({ activeKey: key });
+    componentWillUnmount() {
+        this.stopCacheRefresh();
+    }
+
+    resetChartData() {
+        this.setState({
+            data: {
+                dbcachehitratio: [0],
+                dbcachetries: [0],
+                dbcachehits: [0],
+                dbcachepagein: [0],
+                dbcachepageout: [0],
+                dbcacheroevict: [0],
+                dbcacherwevict: [0],
+                normalizeddncachehitratio: [0],
+                maxnormalizeddncachesize: [0],
+                currentnormalizeddncachesize: [0],
+                normalizeddncachetries: [0],
+                normalizeddncachehits: [0],
+                normalizeddncacheevictions: [0],
+                currentnormalizeddncachecount: [0],
+                normalizeddncachethreadsize: [0],
+                normalizeddncachethreadslots: [0],
+            },
+            dbCacheList: [
+                {name: "", x: "1", y: 0},
+                {name: "", x: "2", y: 0},
+                {name: "", x: "3", y: 0},
+                {name: "", x: "4", y: 0},
+                {name: "", x: "5", y: 0},
+                {name: "", x: "6", y: 0},
+                {name: "", x: "7", y: 0},
+                {name: "", x: "8", y: 0},
+                {name: "", x: "9", y: 0},
+                {name: "", x: "10", y: 0},
+            ],
+            ndnCacheList: [
+                {name: "", x: "1", y: 0},
+                {name: "", x: "2", y: 0},
+                {name: "", x: "3", y: 0},
+                {name: "", x: "4", y: 0},
+                {name: "", x: "5", y: 0},
+            ],
+            ndnCacheUtilList: [
+                {name: "", x: "1", y: 0},
+                {name: "", x: "2", y: 0},
+                {name: "", x: "3", y: 0},
+                {name: "", x: "4", y: 0},
+                {name: "", x: "5", y: 0},
+            ],
+        });
+    }
+
+    refreshCache() {
+        // Search for db cache stat and update state
+        let cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "monitor", "ldbm"
+        ];
+        log_cmd("refreshCache", "Load database monitor", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    let config = JSON.parse(content);
+                    let count = this.state.count + 1; // This is used by all the charts
+                    if (count > 100) {
+                        // Keep progress count in check
+                        count = 1;
+                    }
+
+                    // Build up the DB Cache chart data
+                    let dbratio = config.attrs.dbcachehitratio[0];
+                    let chart_data = this.state.dbCacheList;
+                    chart_data.shift();
+                    chart_data.push({name: "Cache Hit Ratio", x: count.toString(), y: parseInt(dbratio)});
+
+                    // Build up the NDN Cache chart data
+                    let ndnratio = config.attrs.normalizeddncachehitratio[0];
+                    let ndn_chart_data = this.state.ndnCacheList;
+                    ndn_chart_data.shift();
+                    ndn_chart_data.push({name: "Cache Hit Ratio", x: count.toString(), y: parseInt(ndnratio)});
+
+                    // Build up the DB Cache Util chart data
+                    let ndn_util_chart_data = this.state.ndnCacheUtilList;
+                    let currNDNSize = parseInt(config.attrs.currentnormalizeddncachesize[0]);
+                    let maxNDNSize = parseInt(config.attrs.maxnormalizeddncachesize[0]);
+                    let ndn_utilization = (currNDNSize / maxNDNSize) * 100;
+                    ndn_util_chart_data.shift();
+                    ndn_util_chart_data.push({name: "Cache Utilization", x: count.toString(), y: parseInt(ndn_utilization)});
+
+                    this.setState({
+                        data: config.attrs,
+                        loading: false,
+                        dbCacheList: chart_data,
+                        ndnCacheList: ndn_chart_data,
+                        ndnCacheUtilList: ndn_util_chart_data,
+                        count: count
+                    });
+                })
+                .fail(() => {
+                    this.resetChartData();
+                });
+    }
+
+    startCacheRefresh() {
+        this.state.cache_refresh = setInterval(this.refreshCache, 2000);
+    }
+
+    stopCacheRefresh() {
+        clearInterval(this.state.cache_refresh);
     }
 
     render() {
-        let badColor = "#d01c8b";
-        let warningColor = "#ffc107";
-        let goodColor = "#4dac26";
-        let emptyColor = "#d3d3d3";
-        let donutColorDB = goodColor;
-        let donutColorNDN = goodColor;
-        let donutColorNDNUtil = goodColor;
-        let donutColorNDNMiss = emptyColor;
-        let donutColorDBMiss = emptyColor;
-        let dbcachehit = parseInt(this.props.data.dbcachehitratio[0]);
-        let ndncachehit = parseInt(this.props.data.normalizeddncachehitratio[0]);
-        let ndncachemax = parseInt(this.props.data.maxnormalizeddncachesize[0]);
-        let ndncachecurr = parseInt(this.props.data.currentnormalizeddncachesize[0]);
-        let utilratio = Math.round((ndncachecurr / ndncachemax) * 100);
+        let chartColor = ChartThemeColor.green;
+        let ndnChartColor = ChartThemeColor.green;
+        let ndnUtilColor = ChartThemeColor.green;
+        let dbcachehit = 0;
+        let ndncachehit = 0;
+        let ndncachemax = 0;
+        let ndncachecurr = 0;
+        let utilratio = 0;
+        let content =
+            <div className="ds-margin-top-xlg ds-center">
+                <h4>Loading database monitor information ...</h4>
+                <Spinner className="ds-margin-top-lg" size="xl" />
+            </div>;
 
-        // Database cache
-        if (dbcachehit > 89) {
-            donutColorDB = goodColor;
-        } else if (dbcachehit > 74) {
-            donutColorDB = warningColor;
-        } else {
-            if (dbcachehit < 50) {
-                // Pie chart shows higher catagory, so we need to highlight the misses
-                donutColorDBMiss = badColor;
-            } else {
-                donutColorDB = badColor;
+        if (!this.state.loading) {
+            dbcachehit = parseInt(this.state.data.dbcachehitratio[0]);
+            ndncachehit = parseInt(this.state.data.normalizeddncachehitratio[0]);
+            ndncachemax = parseInt(this.state.data.maxnormalizeddncachesize[0]);
+            ndncachecurr = parseInt(this.state.data.currentnormalizeddncachesize[0]);
+            utilratio = Math.round((ndncachecurr / ndncachemax) * 100);
+            if (utilratio == 0) {
+                // Just round up to 1
+                utilratio = 1;
             }
-        }
-        // NDN cache ratio
-        if (ndncachehit > 89) {
-            donutColorNDN = goodColor;
-        } else if (ndncachehit > 74) {
-            donutColorNDN = warningColor;
-        } else {
-            if (ndncachehit < 50) {
-                // Pie chart shows higher catagory, so we need to highlight the misses
-                donutColorNDNMiss = badColor;
+
+            // Database cache
+            if (dbcachehit > 89) {
+                chartColor = ChartThemeColor.green;
+            } else if (dbcachehit > 74) {
+                chartColor = ChartThemeColor.orange;
             } else {
-                donutColorNDN = badColor;
+                chartColor = ChartThemeColor.purple;
             }
-        }
-        // NDN cache utilization
-        if (ndncachehit < 90) {
+            // NDN cache ratio
+            if (ndncachehit > 89) {
+                ndnChartColor = ChartThemeColor.green;
+            } else if (ndncachehit > 74) {
+                ndnChartColor = ChartThemeColor.orange;
+            } else {
+                ndnChartColor = ChartThemeColor.purple;
+            }
+            // NDN cache utilization
             if (utilratio > 95) {
-                donutColorNDNUtil = badColor;
+                ndnUtilColor = ChartThemeColor.purple;
             } else if (utilratio > 90) {
-                donutColorNDNUtil = warningColor;
+                ndnUtilColor = ChartThemeColor.orange;
+            } else {
+                ndnUtilColor = ChartThemeColor.green;
             }
+
+            content =
+                <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
+                    <Tab eventKey={0} title={<TabTitleText><b>Database Cache</b></TabTitleText>}>
+                        <div className="ds-margin-top">
+                            <Card>
+                                <CardBody>
+                                    <div className="ds-container">
+                                        <div className="ds-center">
+                                            <h4 className="ds-margin-top-xlg">Cache Hit Ratio</h4>
+                                            <h3><b>{dbcachehit}%</b></h3>
+                                        </div>
+                                        <div className="ds-margin-left" style={{ height: '200px', width: '500px' }}>
+                                            <Chart
+                                                ariaDesc="Database Cache"
+                                                ariaTitle="Live Database Cache Statistics"
+                                                containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+                                                height={200}
+                                                maxDomain={{y: 100}}
+                                                minDomain={{y: 0}}
+                                                padding={{
+                                                    bottom: 30,
+                                                    left: 40,
+                                                    top: 10,
+                                                    right: 10,
+                                                }}
+                                                width={500}
+                                                themeColor={chartColor}
+                                            >
+                                                <ChartAxis />
+                                                <ChartAxis dependentAxis showGrid tickValues={[25, 50, 75, 100]} />
+                                                <ChartGroup>
+                                                    <ChartArea
+                                                        data={this.state.dbCacheList}
+                                                    />
+                                                </ChartGroup>
+                                            </Chart>
+                                        </div>
+                                    </div>
+                                </CardBody>
+                            </Card>
+                        </div>
+
+                        <Grid hasGutter className="ds-margin-top-xlg">
+                            <GridItem span={3}>
+                                Database Cache Hit Ratio:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcachehitratio}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Database Cache Tries:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcachetries}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Database Cache Hits:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcachehits}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Cache Pages Read:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcachepagein}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Cache Pages Written:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcachepageout}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Read-Only Page Evictions:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcacheroevict}</b>
+                            </GridItem>
+                            <GridItem span={3}>
+                                Read-Write Page Evictions:
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{this.state.data.dbcacherwevict}</b>
+                            </GridItem>
+                        </Grid>
+                    </Tab>
+
+                    <Tab eventKey={1} title={<TabTitleText><b>Normalized DN Cache</b></TabTitleText>}>
+                        <div className="ds-margin-top-lg">
+                            <Grid hasGutter>
+                                <GridItem span={6}>
+                                    <Card>
+                                        <CardBody>
+                                            <div className="ds-container">
+                                                <div className="ds-center">
+                                                    <h4 className="ds-margin-top-lg">Cache Hit Ratio</h4>
+                                                    <h3><b>{ndncachehit}%</b></h3>
+                                                </div>
+                                                <div className="ds-margin-left" style={{ height: '200px', width: '350px' }}>
+                                                    <Chart
+                                                        ariaDesc="NDN Cache"
+                                                        ariaTitle="Live Normalized DN Cache Statistics"
+                                                        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+                                                        height={200}
+                                                        maxDomain={{y: 100}}
+                                                        minDomain={{y: 0}}
+                                                        padding={{
+                                                            bottom: 40,
+                                                            left: 60,
+                                                            top: 10,
+                                                            right: 15,
+                                                        }}
+                                                        width={350}
+                                                        themeColor={ndnChartColor}
+                                                    >
+                                                        <ChartAxis />
+                                                        <ChartAxis dependentAxis showGrid tickValues={[25, 50, 75, 100]} />
+                                                        <ChartGroup>
+                                                            <ChartArea
+                                                                data={this.state.ndnCacheList}
+                                                            />
+                                                        </ChartGroup>
+                                                    </Chart>
+                                                </div>
+                                            </div>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                                <GridItem span={6}>
+                                    <Card>
+                                        <CardBody>
+                                            <div className="ds-container">
+                                                <div className="ds-center">
+                                                    <h4 className="ds-margin-top-lg">Cache Utilization</h4>
+                                                    <h3><b>{utilratio}%</b></h3>
+                                                    <h6 className="ds-margin-top-xlg">Cached DN's</h6>
+                                                    <b>{this.state.data.currentnormalizeddncachecount[0]}</b>
+                                                </div>
+                                                <div className="ds-margin-left" style={{ height: '200px', width: '350px' }}>
+                                                    <Chart
+                                                        ariaDesc="NDN Cache Utilization"
+                                                        ariaTitle="Live Normalized DN Cache Utilization Statistics"
+                                                        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+                                                        height={200}
+                                                        maxDomain={{y: 100}}
+                                                        minDomain={{y: 0}}
+                                                        padding={{
+                                                            bottom: 40,
+                                                            left: 60,
+                                                            top: 10,
+                                                            right: 15,
+                                                        }}
+                                                        width={350}
+                                                        themeColor={ndnUtilColor}
+                                                    >
+                                                        <ChartAxis />
+                                                        <ChartAxis dependentAxis showGrid tickValues={[25, 50, 75, 100]} />
+                                                        <ChartGroup>
+                                                            <ChartArea
+                                                                data={this.state.ndnCacheUtilList}
+                                                            />
+                                                        </ChartGroup>
+                                                    </Chart>
+                                                </div>
+                                            </div>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                            </Grid>
+
+                            <Grid hasGutter className="ds-margin-top-xlg">
+                                <GridItem span={3}>
+                                    NDN Cache Hit Ratio:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachehitratio}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache Max Size:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.maxnormalizeddncachesize}</b>
+                                </GridItem>
+
+                                <GridItem span={3}>
+                                    NDN Cache Tries:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachetries}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Current Cache Size:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.currentnormalizeddncachesize}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache Hits:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachehits}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache DN Count:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.currentnormalizeddncachecount}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache Evictions:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncacheevictions}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache Thread Size:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachethreadsize}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    NDN Cache Thread Slots:
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachethreadslots}</b>
+                                </GridItem>
+                            </Grid>
+                        </div>
+                    </Tab>
+                </Tabs>;
         }
 
         return (
             <div id="db-content">
-                <Row>
-                    <Col sm={12} className="ds-word-wrap">
-                        <ControlLabel className="ds-suffix-header">
-                            Database Performance Statistics
-                            <Icon className="ds-left-margin ds-refresh"
-                                type="fa" name="refresh" title="Refresh database monitor"
-                                onClick={this.props.reload}
-                            />
-                        </ControlLabel>
-                    </Col>
-                </Row>
-                <TabContainer className="ds-margin-top-lg" id="basic-tabs-pf" onSelect={this.handleNavSelect} activeKey={this.state.activeKey}>
-                    <div>
-                        <Nav bsClass="nav nav-tabs nav-tabs-pf">
-                            <NavItem eventKey={1}>
-                                <div dangerouslySetInnerHTML={{__html: 'Database Cache'}} />
-                            </NavItem>
-                            <NavItem eventKey={2}>
-                                <div dangerouslySetInnerHTML={{__html: 'Normalized DN Cache'}} />
-                            </NavItem>
-                        </Nav>
-                        <TabContent>
+                <h3>
+                    Database Performance Statistics
+                </h3>
+                <div className="ds-margin-top-xlg">
+                    {content}
+                </div>
 
-                            <TabPane eventKey={1}>
-                                <div className="ds-margin-top-lg ds-margin-left-piechart">
-                                    <DonutChart
-                                        id="monitor-db-cache-hitratio-chart"
-                                        size={{width: 180, height: 120}}
-                                        data={{
-                                            columns: [['miss', 100 - dbcachehit], ['hit', dbcachehit]],
-                                            colors: {
-                                                'hit': donutColorDB,
-                                                'miss': donutColorDBMiss,
-                                            },
-                                            order: null,
-                                        }}
-                                        title={{type: 'percent'}}
-                                        legend={{show: true, position: 'right'}}
-                                    />
-                                    <b className="ds-left-margin">DB Cache Hit Ratio</b>
-                                </div>
-                                <hr />
-                                <Form horizontal>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Database Cache Hit Ratio
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcachehitratio} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Database Cache Tries
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcachetries} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Database Cache Hits
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcachehits} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Cache Pages Read
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcachepagein} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Cache Pages Written
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcachepageout} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Read-Only Page Evictions
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcacheroevict} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                    <Row className="ds-margin-top">
-                                        <Col componentClass={ControlLabel} sm={3}>
-                                            Read-Write Page Evictions
-                                        </Col>
-                                        <Col sm={3}>
-                                            <input type="text" value={this.props.data.dbcacherwevict} size="28" readOnly />
-                                        </Col>
-                                    </Row>
-                                </Form>
-                            </TabPane>
-
-                            <TabPane eventKey={2}>
-                                <div className="ds-margin-top-lg">
-                                    <div className="ds-container">
-                                        <div className="ds-divider" />
-                                        <div className="ds-left-margin">
-                                            <DonutChart
-                                                id="monitor-db-cache-ndn-hitratio-chart"
-                                                size={{width: 180, height: 120}}
-                                                data={{
-                                                    columns: [['miss', 100 - ndncachehit], ['hit', ndncachehit]],
-                                                    colors: {
-                                                        'hit': donutColorNDN,
-                                                        'miss': donutColorNDNMiss,
-                                                    },
-                                                    order: null,
-                                                }}
-                                                title={{type: 'percent'}}
-                                                legend={{show: true, position: 'right'}}
-                                            />
-                                            <b>NDN Cache Hit Ratio</b>
-                                        </div>
-                                        <div className="ds-divider" />
-                                        <div className="ds-divider" />
-                                        <div className="ds-chart-right">
-                                            <PieChart
-                                                id="monitor-db-cache-ndn-util-chart"
-                                                size={{width: 180, height: 120}}
-                                                data={{
-                                                    columns: [
-                                                        ['Used', utilratio],
-                                                        ['Unused', 100 - utilratio],
-                                                    ],
-                                                    colors: {
-                                                        'Used': donutColorNDNUtil,
-                                                        'Unused': emptyColor,
-                                                    },
-                                                    order: null,
-                                                }}
-                                                pie={{
-                                                    label: {
-                                                        format: function (value, ratio, id) {
-                                                            return d3.format(',%')(value / 100);
-                                                        }
-                                                    }
-                                                }}
-                                                title={{type: 'pie'}}
-                                                legend={{show: true, position: 'right'}}
-                                                unloadBeforeLoad
-                                            />
-                                            <b>NDN Cache Utilization</b>
-                                            <div>
-                                                (DN's in cache: <b>{this.props.data.currentnormalizeddncachecount}</b>)
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <hr />
-                                    <Form horizontal>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Hit Ratio
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncachehitratio} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Tries
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncachetries} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Hits
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncachehits} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Evictions
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncacheevictions} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Max Size
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.maxnormalizeddncachesize} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Current Cache Size
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.currentnormalizeddncachesize} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache DN Count
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.currentnormalizeddncachecount} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Thread Size
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncachethreadsize} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                        <Row className="ds-margin-top">
-                                            <Col componentClass={ControlLabel} sm={3}>
-                                                NDN Cache Thread Slots
-                                            </Col>
-                                            <Col sm={3}>
-                                                <input type="text" value={this.props.data.normalizeddncachethreadslots} size="28" readOnly />
-                                            </Col>
-                                        </Row>
-                                    </Form>
-                                </div>
-                            </TabPane>
-                        </TabContent>
-                    </div>
-                </TabContainer>
             </div>
         );
     }
@@ -333,14 +468,12 @@ export class DatabaseMonitor extends React.Component {
 // Prop types and defaults
 
 DatabaseMonitor.propTypes = {
-    data: PropTypes.object,
-    reload: PropTypes.func,
+    serverId: PropTypes.string,
     enableTree: PropTypes.func,
 };
 
 DatabaseMonitor.defaultProps = {
-    data: {},
-    reload: noop,
+    serverId: "",
     enableTree: noop,
 };
 

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -75,7 +75,7 @@ export function get_date_string(timestamp) {
         parseInt(minute),
         parseInt(sec)
     );
-    return date.toLocaleString();
+    return date.toLocaleString('en-ZA');
 }
 
 // Take two directory server tiemstamps and get the elapsed time


### PR DESCRIPTION
Description:  

Ported the charts under the monitor tab to use PF4 sparkline charts and provide realtime stats on the caches.

Relates: https://github.com/389ds/389-ds-base/issues/4169

