### PR TITLE
Issue 4646 - CLI/UI - revise DNA plugin management

### DIFF
--- a/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
@@ -104,7 +104,7 @@ class AutoMembership extends React.Component {
                 .done(content => {
                     let myObject = JSON.parse(content);
                     this.setState({
-                        definitionRows: myObject.items.map(item => JSON.parse(item).attrs)
+                        definitionRows: myObject.items.map(item => item.attrs)
                     });
                 })
                 .fail(err => {
@@ -133,7 +133,7 @@ class AutoMembership extends React.Component {
                 .done(content => {
                     let myObject = JSON.parse(content);
                     this.setState({
-                        regexRows: myObject.items.map(item => JSON.parse(item).attrs)
+                        regexRows: myObject.items.map(item => item.attrs)
                     });
                     this.props.toggleLoadingHandler();
                 })

--- a/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
@@ -82,7 +82,7 @@ class LinkedAttributes extends React.Component {
                 .done(content => {
                     let myObject = JSON.parse(content);
                     this.setState({
-                        configRows: myObject.items.map(item => JSON.parse(item).attrs)
+                        configRows: myObject.items.map(item => item.attrs)
                     });
                 })
                 .fail(err => {

--- a/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
@@ -98,7 +98,7 @@ class ManagedEntries extends React.Component {
                 .done(content => {
                     let myObject = JSON.parse(content);
                     this.setState({
-                        configRows: myObject.items.map(item => JSON.parse(item).attrs)
+                        configRows: myObject.items.map(item => item.attrs)
                     });
                 })
                 .fail(err => {

--- a/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
@@ -123,7 +123,7 @@ class PassthroughAuthentication extends React.Component {
                 .done(content => {
                     let myObject = JSON.parse(content);
                     this.setState({
-                        pamConfigRows: myObject.items.map(item => JSON.parse(item).attrs)
+                        pamConfigRows: myObject.items.map(item => item.attrs)
                     });
                 })
                 .fail(err => {

--- a/src/lib389/lib389/cli_conf/plugins/automember.py
+++ b/src/lib389/lib389/cli_conf/plugins/automember.py
@@ -33,7 +33,7 @@ def definition_list(inst, basedn, log, args):
     result_json = []
     for definition in automembers.list():
         if args.json:
-            result_json.append(definition.get_all_attrs_json())
+            result_json.append(json.loads(definition.get_all_attrs_json()))
         else:
             result.append(definition.rdn)
     if args.json:

--- a/src/lib389/lib389/cli_conf/plugins/linkedattr.py
+++ b/src/lib389/lib389/cli_conf/plugins/linkedattr.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2021 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -26,7 +26,7 @@ def linkedattr_list(inst, basedn, log, args):
     result_json = []
     for config in configs.list():
         if args.json:
-            result_json.append(config.get_all_attrs_json())
+            result_json.append(json.loads(config.get_all_attrs_json()))
         else:
             result.append(config.rdn)
     if args.json:

--- a/src/lib389/lib389/cli_conf/plugins/managedentries.py
+++ b/src/lib389/lib389/cli_conf/plugins/managedentries.py
@@ -44,7 +44,7 @@ def mep_config_list(inst, basedn, log, args):
     result_json = []
     for config in configs.list():
         if args.json:
-            result_json.append(config.get_all_attrs_json())
+            result_json.append(json.loads(config.get_all_attrs_json()))
         else:
             result.append(config.rdn)
     if args.json:
@@ -109,7 +109,7 @@ def mep_template_list(inst, basedn, log, args):
     result_json = []
     for template in templates.list():
         if args.json:
-            result_json.append(template.get_all_attrs_json())
+            result_json.append(json.loads(template.get_all_attrs_json()))
         else:
             result.append(template.rdn)
     if args.json:

--- a/src/lib389/lib389/cli_conf/plugins/passthroughauth.py
+++ b/src/lib389/lib389/cli_conf/plugins/passthroughauth.py
@@ -73,7 +73,7 @@ def pta_list(inst, basedn, log, args):
     urls = plugin.get_urls()
     if args.json:
         log.info(json.dumps({"type": "list",
-                             "items": [{"id": id, "url": value} for id, value in urls.items()]}, 
+                             "items": [{"id": id, "url": value} for id, value in urls.items()]},
                             indent=4))
     else:
         if len(urls) > 0:
@@ -135,7 +135,7 @@ def pam_pta_list(inst, basedn, log, args):
     result_json = []
     for config in configs.list():
         if args.json:
-            result_json.append(config.get_all_attrs_json())
+            result_json.append(json.loads(config.get_all_attrs_json()))
         else:
             result.append(config.rdn)
     if args.json:


### PR DESCRIPTION
Bug Description:

There was a false assumption that you have to create the shared DNA
server configuration entry, but in fact the server creates and manages
this entry.  The only thing you should edit in this entry are the
remote Bind Method and Connection Protocol.

Fix Description:

Remove the options to create the shared config entry, and edit the
core/reserved attributes.

Also fixed some issues where we were not showing CLI plugin output in
proper JSON.  This required some changes to the UI as well.

Relates: https://github.com/389ds/389-ds-base/issues/4646
