### PR TITLE
Issue 4648 - Fix some issues and improvement around CI tests

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -195,7 +195,7 @@ def test_import_with_index(topo, _import_clean):
         3. Operation successful
     """
     place = topo.standalone.dbdir
-    assert f'{place}/userRoot/roomNumber.db' not in glob.glob(f'{place}/userRoot/*.db', recursive=True)
+    assert not glob.glob(f'{place}/userRoot/roomNumber.db*', recursive=True)
     # Creating the room number index
     indexes = Indexes(topo.standalone)
     indexes.create(properties={
@@ -206,7 +206,8 @@ def test_import_with_index(topo, _import_clean):
     # Importing online
     _import_online(topo, 5)
     # Import is done -- verifying that it worked
-    assert f'{place}/userRoot/roomNumber.db' in glob.glob(f'{place}/userRoot/*.db', recursive=True)
+    assert glob.glob(f'{place}/userRoot/roomNumber.db*', recursive=True)
+
 
 
 def test_online_import_with_warning(topo, _import_clean):

--- a/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
@@ -140,7 +140,7 @@ def local_policy(topology_st, add_user):
 
     log.info("Setting fine grained policy for user ({})".format(USER_DN))
 
-    subprocess.call(['%s/dsconf' % topology_st.standalone.get_sbin_dir(),
+    subprocess.call(['%s/dsconf' % topology_st.standalone.get_bin_dir(),
                      'slapd-standalone1',
                      'localpwp',
                      'adduser',

--- a/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
@@ -140,7 +140,7 @@ def local_policy(topology_st, add_user):
 
     log.info("Setting fine grained policy for user ({})".format(USER_DN))
 
-    subprocess.call(['%s/dsconf' % topology_st.standalone.get_bin_dir(),
+    subprocess.call(['%s/dsconf' % topology_st.standalone.get_sbin_dir(),
                      'slapd-standalone1',
                      'localpwp',
                      'adduser',

--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -7,6 +7,7 @@
 #
 import pytest
 import time
+import glob
 from lib389._constants import PASSWORD, DN_DM, DEFAULT_SUFFIX
 from lib389._constants import SUFFIX, PASSWORD, DN_DM, DN_CONFIG, PLUGIN_RETRO_CHANGELOG, DEFAULT_SUFFIX, DEFAULT_CHANGELOG_DB, DEFAULT_BENAME
 from lib389 import Entry
@@ -47,12 +48,9 @@ def _check_unhashed_userpw(inst, user_dn, is_present=False):
         dbscanOut = inst.dbscan(DEFAULT_BENAME, 'replication_changelog')
     else:
         changelog_dbdir = os.path.join(os.path.dirname(inst.dbdir), DEFAULT_CHANGELOG_DB)
-        for dbfile in os.listdir(changelog_dbdir):
-            if dbfile.endswith('.db'):
-                changelog_dbfile = os.path.join(changelog_dbdir, dbfile)
-                log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
-        log.info('Running dbscan -f to check {} attr'.format(unhashed_pwd_attribute))
-        dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
+        for changelog_dbfile in glob.glob(f'{changelog_dbdir}*/*.db*'):
+            log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
+            dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
 
     for entry in dbscanOut.split(b'dbid: '):
         if ensure_bytes('operation: modify') in entry and ensure_bytes(user_dn) in entry and ensure_bytes('userPassword') in entry:

--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -13,6 +13,7 @@ import ldif
 import pytest
 import time
 import subprocess
+import glob
 from lib389.properties import TASK_WAIT
 from lib389.replica import Replicas
 from lib389.idm.user import UserAccounts
@@ -489,10 +490,10 @@ def test_verify_changelog_online_backup(topo):
         backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, BDB_CL_FILENAME)
     else:
         backup_checkdir = os.path.join(backup_dir, '.repl_changelog_backup', DEFAULT_CHANGELOG_DB)
-    if os.path.exists(backup_checkdir):
+    if glob.glob(f'{backup_checkdir}*'):
         log.info('Database backup is created successfully')
     else:
-        log.fatal('test_changelog5: backup directory does not exist : {}'.format(backup_checkdir))
+        log.fatal('test_changelog5: backup directory does not exist : {}*'.format(backup_checkdir))
         assert False
 
     log.info('Run bak2db to restore directory server')
@@ -550,10 +551,10 @@ def test_verify_changelog_offline_backup(topo):
         backup_checkdir = os.path.join(backup_dir, DEFAULT_BENAME, BDB_CL_FILENAME)
     else:
         backup_checkdir = os.path.join(backup_dir, '.repl_changelog_backup', DEFAULT_CHANGELOG_DB)
-    if os.path.exists(backup_checkdir):
+    if glob.glob(f'{backup_checkdir}*'):
         log.info('Database backup is created successfully')
     else:
-        log.fatal('test_changelog5: backup directory does not exist : {}'.format(backup_checkdir))
+        log.fatal('test_changelog5: backup directory does not exist : {}*'.format(backup_checkdir))
         assert False
 
     log.info('LDAP operations add, modify, modrdn and delete')

--- a/dirsrvtests/tests/suites/replication/encryption_cl5_test.py
+++ b/dirsrvtests/tests/suites/replication/encryption_cl5_test.py
@@ -65,12 +65,10 @@ def _check_unhashed_userpw_encrypted(inst, change_type, user_dn, user_pw, is_enc
         dbscanOut = inst.dbscan(DEFAULT_BENAME, 'replication_changelog')
     else:
         changelog_dbdir = os.path.join(os.path.dirname(inst.dbdir), DEFAULT_CHANGELOG_DB)
-        for dbfile in os.listdir(changelog_dbdir):
-            if dbfile.endswith('.db'):
-                changelog_dbfile = os.path.join(changelog_dbdir, dbfile)
-                log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
-        log.info('Running dbscan -f to check {} attr'.format(ATTRIBUTE))
-        dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
+        for changelog_dbfile in glob.glob(f'{changelog_dbdir}*/*.db*'):
+            log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
+            log.info('Running dbscan -f to check {} attr'.format(ATTRIBUTE))
+            dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
 
     count = 0
     for entry in dbscanOut.split(b'dbid: '):

--- a/ldap/servers/slapd/detach.c
+++ b/ldap/servers/slapd/detach.c
@@ -169,16 +169,17 @@ detach(int slapd_exemode, int importexport_encrypt, int s_port, daemon_ports_t *
         (void)dup2(sd, 2);
         close(sd);
 #ifdef DEBUG
-        /* But preserve other errors like loader undefined symbols */
-		sprintf(buf, "/tmp/ns-slapd-%d-XXXXXX.stderr", getpid());
-        if ((sd = mkstemps(buf, 7)) >= 0) {
+        /* But lets try to preserve other errors like loader undefined symbols */
+		sprintf(buf, "/var/dirsrv/ns-slapd-%d-XXXXXX.stderr", getpid());
+        if ((sd = mkstemps(buf, 7)) < 0) {
+            /* Lets try /tmp (so that non root users may keep the stderr */
+		    sprintf(buf, "/tmp/ns-slapd-%d-XXXXXX.stderr", getpid());
+            sd = mkstemps(buf, 7);
+        }
+        if (sd >= 0) {
             (void)dup2(sd, 2);
             close(sd);
-        } else {
-            (void)dup2(1, 2);
         }
-#else
-        (void)dup2(1, 2);
 #endif
 
 #ifdef USE_SETSID

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -1055,7 +1055,7 @@ is_changelog(char *filename)
         ptr++;
     }
 
-    if (0 == strcmp(ptr, "replication_changelog.db")) return 1;
+    if (strstr(ptr, "replication_changelog.db")) return 1;
 
     for (; ptr && *ptr; ptr++) {
         if ('.' == *ptr) {

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -2989,6 +2989,9 @@ class DirSrv(SimpleLDAPObject, object):
             indexfile = os.path.join(self.dbdir, bename, index)
         else:
             indexfile = os.path.join(self.dbdir, bename, index + '.db')
+        # (we should also accept a version number for .db suffix)
+        for f in glob.glob(f'{indexfile}*'):
+            indexfile = f
 
         cmd = [prog, '-f', indexfile]
 

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -195,8 +195,12 @@ def selinux_present():
     try:
         import selinux
         if selinux.is_selinux_enabled():
-            # We have selinux, continue.
-            status = True
+            # We have selinux, lets see if we are allowed to configure it.
+            # (just checking the uid for now - we may rather check if semanage command success)
+            if os.geteuid() != 0:
+                log.error('Non priviledged user cannot use semanage, will not relabel ports or files.' )
+            else:
+                status = True
         else:
             # We have the module, but it's disabled.
             log.error('selinux is disabled, will not relabel ports or files.' )
@@ -271,7 +275,7 @@ def selinux_label_port(port, remove_label=False):
         log.debug('selinux python module not found, skipping port labeling.')
         return
 
-    if not selinux.is_selinux_enabled():
+    if not selinux_present():
         log.debug('selinux is disabled, skipping port relabel')
         return
 


### PR DESCRIPTION
Description: 
  Some pytests fails:
      - because database file suffix moved from .db to .db4 some time ago.
      - because semanage fails if ci test are run by non root user
  And it would be useful to keep the ns-slapd stderr for debug build 

Solution:
     - use wildcard when checking the path
     - fix dbscan to recognize changelog whatever is the db version.
     - when detaching ns-slapd process, redirect stderr into a tmp file rather than into /dev/null
     - to not try to relabel the ports if user is not root     
     
  Reviewers: @mreynolds389 @vashirov @droideck  