### PR TITLE
Issue 4661 - RFE - allow importing openldap schemas

### DIFF
--- a/dirsrvtests/tests/suites/openldap_2_389/migrate_hdb_test.py
+++ b/dirsrvtests/tests/suites/openldap_2_389/migrate_hdb_test.py
@@ -39,7 +39,7 @@ def test_migrate_openldap_hdb(topology_st):
     config = olConfig(config_path)
     ldifs = {}
 
-    migration = Migration(config, inst, ldifs)
+    migration = Migration(inst, config.schema, config.databases, ldifs)
 
     print("==== migration plan ====")
     print(migration.__unicode__())

--- a/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
+++ b/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
@@ -67,7 +67,7 @@ def test_migrate_openldap_slapdd(topology_st):
         "dc=example,dc=net": os.path.join(DATADIR1, 'example_net.slapcat.ldif'),
     }
 
-    migration = Migration(config, inst, ldifs)
+    migration = Migration(inst, config.schema, config.databases, ldifs)
 
     print("==== migration plan ====")
     print(migration.__unicode__())
@@ -105,7 +105,7 @@ def test_migrate_openldap_slapdd_skip_elements(topology_st):
 
     # 1.3.6.1.4.1.5322.13.1.1 is namedObject, so check that isn't there
 
-    migration = Migration(config, inst, ldifs,
+    migration = Migration(inst, config.schema, config.databases, ldifs,
         skip_schema_oids=['1.3.6.1.4.1.5322.13.1.1'],
         skip_overlays=[olOverlayType.UNIQUE],
     )

--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -272,7 +272,8 @@ def begin_magic():
         # Create the marker to say we exist. This is also a good writable permissions
         # test for the volume.
         basedn = '# basedn = dc=example,dc=com'
-        if suffix := os.getenv("SUFFIX_NAME"):
+        suffix = os.getenv("SUFFIX_NAME")
+        if suffix is not None:
             basedn = f'basedn = {suffix}'
         config_file = """
 [localhost]

--- a/src/lib389/cli/openldap_to_ds
+++ b/src/lib389/cli/openldap_to_ds
@@ -181,7 +181,11 @@ def do_migration(inst, log, args, skip_overlays):
     ldifmeta = LdifMetadata(args.slapd_ldif, log)
 
     # Create the migration plan.
-    migration = Migration(config, inst, ldifmeta.get_suffixes(),
+    migration = Migration(
+        inst,
+        config.schema,
+        config.databases,
+        ldifmeta.get_suffixes(),
         skip_schema_oids,
         skip_overlays,
         skip_entry_attributes,

--- a/src/lib389/lib389/migrate/plan.py
+++ b/src/lib389/lib389/migrate/plan.py
@@ -411,7 +411,7 @@ class PluginUnknownManual(MigrationAction):
 
 
 class Migration(object):
-    def __init__(self, olconfig, inst, ldifs=None, skip_schema_oids=[], skip_overlays=[], skip_entry_attributes=[]):
+    def __init__(self, inst, olschema=None, oldatabases=None, ldifs=None, skip_schema_oids=[], skip_overlays=[], skip_entry_attributes=[]):
         """Generate a migration plan from an openldap config, the instance to migrate too
         and an optional dictionary of { suffix: ldif_path }.
 
@@ -420,7 +420,8 @@ class Migration(object):
         accepted. Plan modification is "out of scope", but possible as the array could
         be manipulated in place.
         """
-        self.olconfig = olconfig
+        self.olschema = olschema
+        self.oldatabases = oldatabases
         self.inst = inst
         self.plan = []
         self.ldifs = ldifs
@@ -497,6 +498,8 @@ class Migration(object):
         return buff
 
     def _gen_schema_plan(self):
+        if self.olschema is None:
+            return
         # Get the server schema so that we can query it repeatedly.
         schema = Schema(self.inst)
         schema_attrs = schema.get_attributetypes()
@@ -505,7 +508,7 @@ class Migration(object):
         resolver = Resolver(schema_attrs)
 
         # Examine schema attrs
-        for attr in self.olconfig.schema.attrs:
+        for attr in self.olschema.attrs:
             # If we have been instructed to ignore this oid, skip.
             if attr.oid in self._schema_oid_do_not_migrate:
                 continue
@@ -529,7 +532,7 @@ class Migration(object):
                 self.plan.append(SchemaAttributeAmbiguous(attr, overlaps))
 
         # Examine schema classes
-        for obj in self.olconfig.schema.classes:
+        for obj in self.olschema.classes:
             # If we have been instructed to ignore this oid, skip.
             if obj.oid in self._schema_oid_do_not_migrate:
                 continue
@@ -603,9 +606,12 @@ class Migration(object):
     def _gen_db_plan(self):
         # Create/Manage dbs
         # Get the set of current dbs.
+        if self.oldatabases is None:
+            return
+
         backends = Backends(self.inst)
 
-        for db in self.olconfig.databases:
+        for db in self.oldatabases:
             # Get the suffix
             suffix = db.suffix
             try:
@@ -637,6 +643,10 @@ class Migration(object):
         if log is None:
             log = logger
 
+        # Do we have anything to do?
+        if len(self.plan) == 0:
+            raise Exception("Migration has no actions to perform")
+
         count = 1
 
         # First apply everything
@@ -657,6 +667,8 @@ class Migration(object):
 
     def display_plan_review(self, log):
         """Given an output log sink, display the migration plan"""
+        if len(self.plan) == 0:
+            raise Exception("Migration has no actions to perform")
         for item in self.plan:
             item.display_plan(log)
 


### PR DESCRIPTION
Bug Description: Many applications only publish schemas in
openldap formats. We should be able to import them.

Fix Description: Add a dsconf tool that allows online
importing of these schemas. This uses the migration framework
underneath so that we avoid code duplication.

fixes: https://github.com/389ds/389-ds-base/issues/4661

Author: William Brown <william@blackhats.net.au>

Review by: ???