### PR TITLE
Issue 4127 - With Accounts/Account module delete fuction is not working

### DIFF
--- a/dirsrvtests/tests/suites/lib389/idm/account_test.py
+++ b/dirsrvtests/tests/suites/lib389/idm/account_test.py
@@ -1,0 +1,42 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import pytest
+from lib389.idm.user import UserAccounts, Account
+from lib389.topologies import topology_st as topo
+from lib389._constants import DEFAULT_SUFFIX
+
+
+def test_account_delete(topo):
+    """
+    Test that delete function is working with Accounts/Account
+
+    :id: 9b036f14-5144-4862-b18c-a6d91b7a1620
+
+    :setup: Standalone instance
+
+    :steps:
+        1. Create a test user.
+        2. Delete the test user using Account class object.
+
+    :expectedresults:
+        1. Operation should be successful
+        2. Operation should be successful
+    """
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    users.create_test_user(uid=1001)
+    account = Account(topo.standalone, f'uid=test_user_1001,ou=People,{DEFAULT_SUFFIX}')
+    account.delete()
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/src/lib389/lib389/tests/idm/account_test.py
+++ b/src/lib389/lib389/tests/idm/account_test.py
@@ -13,7 +13,7 @@ import os
 import pytest
 import ldap
 
-from lib389.idm.user import UserAccounts, nsUserAccounts
+from lib389.idm.user import UserAccounts, nsUserAccounts, Account
 from lib389.topologies import topology_st as topology
 from lib389._constants import DEFAULT_SUFFIX
 
@@ -80,3 +80,13 @@ def test_account_change_pw(topology):
     # Assert we can bind as the new PW
     c = testuser.bind('test_password')
     c.unbind_s()
+
+
+def test_account_delete(topology):
+    #This test requires a test user and account object
+
+    users = UserAccounts(topology.standalone, DEFAULT_SUFFIX)
+    users.create_test_user(uid=1003)
+
+    account = Account(topology.standalone, f'uid=test_user_1003,ou=People,{DEFAULT_SUFFIX}')
+    account.delete()

--- a/src/lib389/lib389/tests/idm/account_test.py
+++ b/src/lib389/lib389/tests/idm/account_test.py
@@ -13,7 +13,7 @@ import os
 import pytest
 import ldap
 
-from lib389.idm.user import UserAccounts, nsUserAccounts, Account
+from lib389.idm.user import UserAccounts, nsUserAccounts
 from lib389.topologies import topology_st as topology
 from lib389._constants import DEFAULT_SUFFIX
 
@@ -80,13 +80,3 @@ def test_account_change_pw(topology):
     # Assert we can bind as the new PW
     c = testuser.bind('test_password')
     c.unbind_s()
-
-
-def test_account_delete(topology):
-    #This test requires a test user and account object
-
-    users = UserAccounts(topology.standalone, DEFAULT_SUFFIX)
-    users.create_test_user(uid=1003)
-
-    account = Account(topology.standalone, f'uid=test_user_1003,ou=People,{DEFAULT_SUFFIX}')
-    account.delete()


### PR DESCRIPTION
Desciption: Added a test to verify delete function is working with Accounts/Account

Relates: https://github.com/389ds/389-ds-base/issues/4127

Reviewed by: @droideck