### PR TITLE
Issue 4603 - Offline backend reindexing processes all backends

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -408,15 +408,74 @@ def test_basic_db2index(topology_st, import_example_ldif):
     :setup: Standalone instance
 
     :steps:
-        1: call db2index
+        1: call db2index with single attr arg
+        2: call db2index with multiple attr args
+        3: call db2index with no attr args, all be attrs will be used
 
     :expectedresults:
-        1: Index succeeds.
+        1: Index succeeds, search error logs for confirmation
+        2: Index succeeds, search error logs for confirmation
+        3: Index succeeds, search error logs for confirmation
 
     """
+    # Info messgage to search error logs
+    info_message = 'INFO - bdb_db2index - ' + DEFAULT_BENAME + ':' + ' Indexing attribute: '
+
+    log.info('Stopping the server...')
     topology_st.standalone.stop()
-    topology_st.standalone.db2index()
-    topology_st.standalone.db2index(suffixes=[DEFAULT_SUFFIX], attrs=['uid'])
+
+    log.info('Reindexing default backend with single attr...')
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=['uid'])
+    assert topology_st.standalone.searchErrorsLog(info_message + 'uid')
+
+    log.info('Starting the server...')
+    topology_st.standalone.start()
+
+    log.info('Stopping the server...')
+    topology_st.standalone.stop()
+
+    log.info('Reindexing default backend with multiple attrs...')
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=['cn','aci','uid'])
+    assert topology_st.standalone.searchErrorsLog(info_message + 'cn')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'aci')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'uid')
+
+    log.info('Starting the server...')
+    topology_st.standalone.start()
+
+    log.info('Stopping the server...')
+    topology_st.standalone.stop()
+
+    log.info('Reindexing default backend with all index attrs...')
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME)
+    assert topology_st.standalone.searchErrorsLog(info_message + 'aci')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'cn')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'entryusn')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'givenName')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'mail')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'mailAlternateAddress')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'mailHost')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'member')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'memberOf')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'nsCertSubjectDN')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'nscpEntryDN')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'nsds5ReplConflict')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'nsTombstoneCSN')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'nsuniqueid')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'ntUniqueId')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'ntUserDomainId')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'numsubordinates')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'objectclass')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'owner')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'parentid')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'seeAlso')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'sn')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'targetuniqueid')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'telephoneNumber')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'uid')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'uniquemember')
+
+    log.info('Starting the server...')
     topology_st.standalone.start()
 
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1410,7 +1410,7 @@ bdb_db2index(Slapi_PBlock *pb)
         /* Turn off transactions */
         ldbm_config_internal_set(li, CONFIG_DB_TRANSACTION_LOGGING, "off");
 
-        if (0 != dblayer_start(li, DBLAYER_INDEX_MODE)) {
+        if (0 != dblayer_start(li, DBLAYER_NORMAL_MODE)) {
             slapi_task_log_notice(task, "Failed to init database: %s", instance_name);
             slapi_log_err(SLAPI_LOG_ERR,
                           "ldbm2index", "Failed to init database: %s\n", instance_name);
@@ -2190,7 +2190,7 @@ err_min:
 
     if (run_from_cmdline) {
         dblayer_instance_close(be);
-        if (0 != dblayer_close(li, DBLAYER_INDEX_MODE)) {
+        if (0 != dblayer_close(li, DBLAYER_NORMAL_MODE)) {
             slapi_log_err(SLAPI_LOG_ERR,
                           "bdb_db2index", "%s: Failed to close database\n", inst->inst_name);
         }

--- a/ldap/servers/slapd/back-ldbm/ldif2ldbm.c
+++ b/ldap/servers/slapd/back-ldbm/ldif2ldbm.c
@@ -225,7 +225,7 @@ ldbm_back_ldbm2index(Slapi_PBlock *pb)
 
     dblayer_private *priv = (dblayer_private *)li->li_dblayer_private;
 
-    return priv->dblayer_db2index_fn(pb);;
+    return priv->dblayer_db2index_fn(pb);
 }
 
 /*

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -90,6 +90,7 @@ DN_MONITOR_SNMP = "cn=snmp,cn=monitor"
 DN_MONITOR_LDBM = "cn=monitor,cn=ldbm database,cn=plugins,cn=config"
 DN_MONITOR_DATABASE = "cn=database,cn=monitor,cn=ldbm database,cn=plugins,cn=config"
 DN_PWDSTORAGE_SCHEMES = "cn=Password Storage Schemes,cn=plugins,cn=config"
+DN_INDEX_GLOB = "cn=index,cn="
 
 CMD_PATH_SETUP_DS = "setup-ds.pl"
 CMD_PATH_REMOVE_DS = "remove-ds.pl"

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -10,7 +10,7 @@
 from lib389._constants import TaskWarning
 
 def dbtasks_db2index(inst, log, args):
-    if not inst.db2index(bename=args.backend):
+    if not inst.db2index(bename=args.backend,attrs=args.attr):
         log.fatal("db2index failed")
         return False
     else:
@@ -96,6 +96,7 @@ def create_parser(subcommands):
     db2index_parser = subcommands.add_parser('db2index', help="Initialise a reindex of the server database. The server must be stopped for this to proceed.")
     # db2index_parser.add_argument('suffix', help="The suffix to reindex. IE dc=example,dc=com.")
     db2index_parser.add_argument('backend', help="The backend to reindex. IE userRoot")
+    db2index_parser.add_argument('--attr', help="The index attribute's to reindex. Skip this argument to reindex all attributes. IE --attr aci --attr uid --attr cn", action='append')
     db2index_parser.set_defaults(func=dbtasks_db2index)
 
     db2bak_parser = subcommands.add_parser('db2bak', help="Initialise a BDB backup of the database. The server must be stopped for this to proceed.")


### PR DESCRIPTION
Bug description:
While trying to index a given backend, the command output shows that
all configured backends are being processed. This can be problematic 
if one wants to reindex a small database and the command takes time 
because it runs also on existing larger backends.

Fix description:
ns-slapd - dblayer start mode changed
dsctl - modifed to use db2index instead of upgradedb.
dsctl - attribute arg parsing
dsctl - query dseldif for all attrs for a be, when none is specified
dseldif - added index searching
dseldif - trivial bug where dse.ldif entries changed to lower case which broke my tests
CI - extended basic_tests with extra db2index tests

Fixes: https://github.com/389ds/389-ds-base/issues/4603

Reviewed by: ????