### PR TITLE
Issue 4700 - Regression in winsync replication agreement

### DIFF
--- a/ldap/servers/slapd/backend.c
+++ b/ldap/servers/slapd/backend.c
@@ -173,7 +173,8 @@ void
 be_addsuffix(Slapi_Backend *be, const Slapi_DN *suffix)
 {
     if (be->be_state != BE_STATE_DELETED) {
-        be->be_suffix = slapi_sdn_dup(suffix);;
+        slapi_sdn_free(&be->be_suffix);
+        be->be_suffix = slapi_sdn_dup(suffix);
     }
 }
 

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -2900,6 +2900,7 @@ setup_internal_backends(char *configdir)
         Slapi_DN counters;
         Slapi_DN snmp;
         Slapi_DN root;
+        Slapi_Backend *be;
         Slapi_DN encryption;
         Slapi_DN saslmapping;
         Slapi_DN plugins;
@@ -2948,7 +2949,10 @@ setup_internal_backends(char *configdir)
         dse_register_callback(pfedse, SLAPI_OPERATION_ADD, DSE_FLAG_PREOP, &saslmapping, LDAP_SCOPE_SUBTREE, "(objectclass=nsSaslMapping)", sasl_map_config_add, NULL, NULL);
         dse_register_callback(pfedse, SLAPI_OPERATION_ADD, DSE_FLAG_PREOP, &plugins, LDAP_SCOPE_SUBTREE, "(objectclass=nsSlapdPlugin)", check_plugin_path, NULL, NULL);
 
-        be_new_internal(pfedse, "DSE", DSE_BACKEND, &fedse_plugin);
+        be = be_new_internal(pfedse, "DSE", DSE_BACKEND, &fedse_plugin);
+        be_addsuffix(be, &root);
+        be_addsuffix(be, &monitor);
+        be_addsuffix(be, &config);
 
         /*
          * Now that the be's are in place, we can setup the mapping tree.


### PR DESCRIPTION
Bug description:
	#4396 fixes a memory leak but did not set 'cn=config' as
	DSE backend.
	It had no signicant impact unless with sidgen IPA plugin

Fix description:
	revert the portion of the #4364 patch that set be_suffix

relates: https://github.com/389ds/389-ds-base/issues/4700

Reviewed by:

Platforms tested: F33