### PR TITLE
Issue 4680 - 389ds coredump (@389ds/389-ds-base-nightly) in replica install with CA

### DIFF
--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -1103,7 +1103,7 @@ clcache_cursor_get(dbi_cursor_t *cursor, CLC_Buffer *buf, dbi_op_t dbop)
          * if not sufficient it will be increased again
          */
         slapi_ch_free(&bulkdata->data);
-        dblayer_bulk_set_buffer(cursor->be, &buf->buf_bulk, buf, WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
+        dblayer_bulk_set_buffer(cursor->be, &buf->buf_bulk, buf->buf_bulkdata, WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
     }
 
     rc = dblayer_cursor_bulkop(cursor, dbop, &buf->buf_key, &buf->buf_bulk);

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -51,7 +51,9 @@ static inline dblayer_private *dblayer_get_priv(Slapi_Backend *be)
 static int dblayer_value_set_int(Slapi_Backend *be __attribute__((unused)), dbi_val_t *data,
     void *ptr, size_t size, size_t ulen, int flags)
 {
-    dblayer_value_free(be, data);
+    if (ptr != data->data) {
+        dblayer_value_free(be, data);
+    }
     data->flags = flags;
     data->data = ptr;
     data->size = size;


### PR DESCRIPTION
Symptoms: 389ds coredump while running ipa-ca-install (during IPA nightly test) 

Cause: The changelog cache context (a CLC_Buffer named buf) get overwritten while reading the next block of changes after a large update (Because the read buffer was reset to wrong pointer (i.e the CLC_Buffer pointer rather than to the data buffer contained in that CLC_Buffer)

Fix:  reset the bulk data buffer to the right pointer.

Reviewer: tbordaz

relates to: [#4680](https://github.com/389ds/389-ds-base/issues/4680)

Tested on: F32