### PR TITLE
Issue 4632 - dscontainer: SyntaxWarning: "is" with a literal.

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -432,7 +432,7 @@ container host.
     if args.runit:
         begin_magic()
     elif args.healthcheck:
-        if begin_healthcheck(None) is (False, True):
+        if begin_healthcheck(None) == (False, True):
             sys.exit(0)
         else:
             sys.exit(1)


### PR DESCRIPTION
Bug Description:
`dscontainer -H` always returns 1 because of incorrect comparison
(object instead of value).

Fix Description:
Use the euality operator `==` instead of identity operator `is`.

Relates: https://github.com/389ds/389-ds-base/issues/4300
Fixes: https://github.com/389ds/389-ds-base/issues/4632

Reviewed by: ???