### PR TITLE
Issue 4667 - incorrect accounting of readers in vattr rwlock

### DIFF
--- a/ldap/servers/slapd/detach.c
+++ b/ldap/servers/slapd/detach.c
@@ -145,10 +145,6 @@ detach(int slapd_exemode, int importexport_encrypt, int s_port, daemon_ports_t *
             }
             break;
         }
-        /* The thread private counter needs to be allocated after the fork
-         * it is not inherited from parent process
-         */
-        vattr_global_lock_create();
 
         /* call this right after the fork, but before closing stdin */
         if (slapd_do_all_nss_ssl_init(slapd_exemode, importexport_encrypt, s_port, ports_info)) {
@@ -193,10 +189,6 @@ detach(int slapd_exemode, int importexport_encrypt, int s_port, daemon_ports_t *
 
         g_set_detached(1);
     } else { /* not detaching - call nss/ssl init */
-        /* The thread private counter needs to be allocated after the fork
-         * it is not inherited from parent process
-         */
-        vattr_global_lock_create();
 
         if (slapd_do_all_nss_ssl_init(slapd_exemode, importexport_encrypt, s_port, ports_info)) {
             return 1;

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -271,7 +271,6 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
     int pr_idx = -1;
     Slapi_DN *orig_sdn = NULL;
     int free_sdn = 0;
-    PRBool vattr_lock_acquired = PR_FALSE;
 
     be_list[0] = NULL;
     referral_list[0] = NULL;
@@ -565,8 +564,6 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
     }
 
     slapi_pblock_set(pb, SLAPI_BACKEND_COUNT, &index);
-    vattr_rdlock();
-    vattr_lock_acquired = PR_TRUE;
 
     if (be) {
         slapi_pblock_set(pb, SLAPI_BACKEND, be);
@@ -1042,9 +1039,6 @@ free_and_return:
         slapi_mapping_tree_free_all(be_list, referral_list);
     } else if (be_single) {
         slapi_be_Unlock(be_single);
-    }
-    if (vattr_lock_acquired) {
-        vattr_rd_unlock();
     }
 
 free_and_return_nolock:

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1458,11 +1458,6 @@ void subentry_create_filter(Slapi_Filter **filter);
  * vattr.c
  */
 void vattr_init(void);
-void vattr_global_lock_create(void);
-void vattr_rdlock(void);
-void vattr_rd_unlock(void);
-void vattr_wrlock(void);
-void vattr_wr_unlock(void);
 void vattr_cleanup(void);
 
 /*


### PR DESCRIPTION
Bug description:
	The fix #2932 (Contention on virtual attribute lookup) reduced
	contention on vattr acquiring vattr lock at the operation
	level rather than at the attribute level (filter and
        returned attr).
        The fix #2932 is invalid. it can lead to deadlock scenario
	(3 threads). A vattr writer (new cos/schema) blocks
        an update thread that hold DB pages and later needs vattr.
	Then if a reader (holding vattr) blocks vattr writer and later
        needs the same DB pages, there is a deadlock.
	The decisions are:
		- revert #2932 (this issue)
		- Skip contention if deployement has no vattr #4678
		- reduce contention with new approaches
                  (COW and/or cache vattr struct in each thread)
		  no issue opened

Fix description:
	The fix reverts #2932

relates: https://github.com/389ds/389-ds-base/issues/4667

Reviewed by:

Platforms tested:  F33