### PR TITLE
Issue 4734 - import of entry with no parent warning

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -2767,7 +2767,13 @@ import_foreman(void *param)
         if (job->flags & FLAG_ABORT) {
             goto error;
         }
+
+        /* capture skipped entry warnings for this task */
+        if((job) && (job->skipped)) {
+            slapi_task_set_warning(job->task, WARN_SKIPPED_IMPORT_ENTRY);
+        }
     }
+
 
     slapi_pblock_destroy(pb);
     info->state = FINISHED;


### PR DESCRIPTION
Description:    Online import of ldif file that contains an entry with
                no parent doesnt generate a task warning.

Fixes:          https://github.com/389ds/389-ds-base/issues/4734

Author: vashirov@redhat.com (Thanks)

Reviewed by: jchapma