### PR TITLE
Issue 4742 - UI - should always use LDAPI path when calling dsconf

### DIFF
--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -356,7 +356,7 @@ export class DSInstance extends React.Component {
                 rows.push([row[0], row[1], row[2]]);
             }
             // Get the server version from the monitor
-            cmd = ["dsconf", "-j", this.state.serverId, "monitor", "server"];
+            cmd = ["dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.state.serverId + ".socket", "monitor", "server"];
             log_cmd("loadBackups", "Get the server version", cmd);
             cockpit.spawn(cmd, { superuser: true, err: "message" }).done(content => {
                 let monitor = JSON.parse(content);

--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -1014,7 +1014,7 @@ export class ManageBackupsModal extends React.Component {
                         let cmd = [
                             "dsconf",
                             "-j",
-                            "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+                            "ldapi://%2fvar%2frun%2fslapd-" + "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket" + ".socket",
                             "backup",
                             "create"
                         ];
@@ -1094,7 +1094,7 @@ export class ManageBackupsModal extends React.Component {
                         const cmd = [
                             "dsconf",
                             "-j",
-                            "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+                            "ldapi://%2fvar%2frun%2fslapd-" + "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket" + ".socket",
                             "backup",
                             "restore",
                             this.state.backupName

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -293,7 +293,8 @@ export class Backups extends React.Component {
         this.showLDIFDeleteSpinningModal();
 
         let cmd = [
-            "dsctl", this.props.serverId, "ldifs", "--delete", this.state.ldifName
+            "dsctl", this.props.serverId,
+            "ldifs", "--delete", this.state.ldifName
         ];
         log_cmd("deleteLDIF", "Deleting LDIF", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -160,7 +160,8 @@ export class GlobalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of general_attrs) {
@@ -263,7 +264,8 @@ export class GlobalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of exp_attrs) {
@@ -339,7 +341,8 @@ export class GlobalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of lockout_attrs) {
@@ -440,7 +443,8 @@ export class GlobalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of syntax_attrs) {
@@ -488,7 +492,8 @@ export class GlobalPwPolicy extends React.Component {
             loading: true
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", "get"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
         ];
         log_cmd("loadGlobal", "Load global password policy", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -1030,7 +1030,8 @@ export class LocalPwPolicy extends React.Component {
             action = "addsubtree";
         }
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'localpwp', action, this.state.policyDN
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'localpwp', action, this.state.policyDN
         ];
 
         for (let attr of all_attrs) {
@@ -1111,7 +1112,8 @@ export class LocalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'localpwp', 'set', this.state.policyName
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'localpwp', 'set', this.state.policyName
         ];
 
         for (let attr of general_attrs) {
@@ -1187,7 +1189,8 @@ export class LocalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'localpwp', 'set', this.state.policyName
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'localpwp', 'set', this.state.policyName
         ];
 
         for (let attr of exp_attrs) {
@@ -1263,7 +1266,8 @@ export class LocalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'localpwp', 'set', this.state.policyName
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'localpwp', 'set', this.state.policyName
         ];
 
         for (let attr of lockout_attrs) {
@@ -1364,7 +1368,8 @@ export class LocalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'localpwp', 'set', this.state.policyName
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'localpwp', 'set', this.state.policyName
         ];
 
         for (let attr of syntax_attrs) {
@@ -1414,7 +1419,8 @@ export class LocalPwPolicy extends React.Component {
         });
 
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "localpwp", "remove", this.state.deleteName
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "localpwp", "remove", this.state.deleteName
         ];
         log_cmd("deletePolicy", "delete policy", cmd);
         cockpit
@@ -1437,7 +1443,8 @@ export class LocalPwPolicy extends React.Component {
             loading: true,
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "localpwp", "list"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "localpwp", "list"
         ];
         log_cmd("loadPolicies", "Load all the local password policies for the table", cmd);
         cockpit
@@ -1625,7 +1632,8 @@ export class LocalPwPolicy extends React.Component {
 
     loadLocal(name) {
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "localpwp", "get", name
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "localpwp", "get", name
         ];
         log_cmd("loadLocal", "Load a local password policy", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
@@ -134,7 +134,7 @@ export class ServerMonitor extends React.Component {
                     cockpit
                             .script(cpu_cmd, [], { superuser: true, err: "message" })
                             .done(top_output => {
-                                let top_parts = top_output.split(/\s+/);
+                                let top_parts = top_output.trim().split(/\s+/);
                                 virt_mem = top_parts[4];
                                 res_mem = top_parts[5];
                                 cpu = parseInt(top_parts[8]);

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -142,7 +142,8 @@ export class ServerAccessLog extends React.Component {
         }
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of config_attrs) {
@@ -203,7 +204,8 @@ export class ServerAccessLog extends React.Component {
             loading: true
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", "get"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
         ];
         log_cmd("reloadConfig", "load Access Log configuration", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -129,7 +129,8 @@ export class ServerAuditLog extends React.Component {
         }
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of config_attrs) {
@@ -221,7 +222,8 @@ export class ServerAuditLog extends React.Component {
             loading: true,
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", "get"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
         ];
         log_cmd("reloadConfig", "load Audit Log configuration", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -129,7 +129,8 @@ export class ServerAuditFailLog extends React.Component {
         }
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of config_attrs) {
@@ -177,7 +178,8 @@ export class ServerAuditFailLog extends React.Component {
             loading: true,
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", "get"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
         ];
         log_cmd("loadConfig", "load Audit Failure Log configuration", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -151,7 +151,8 @@ export class ServerErrorLog extends React.Component {
         }
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of config_attrs) {
@@ -295,7 +296,8 @@ export class ServerErrorLog extends React.Component {
             loading: true,
         });
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", "get"
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
         ];
         log_cmd("reloadConfig", "load Error Log configuration", cmd);
         cockpit

--- a/src/cockpit/389-console/src/lib/server/ldapi.jsx
+++ b/src/cockpit/389-console/src/lib/server/ldapi.jsx
@@ -112,7 +112,8 @@ export class ServerLDAPI extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
         ];
 
         for (let attr of ldapi_attrs) {

--- a/src/cockpit/389-console/src/lib/server/sasl.jsx
+++ b/src/cockpit/389-console/src/lib/server/sasl.jsx
@@ -274,7 +274,8 @@ export class ServerSASL extends React.Component {
 
     loadConfig() {
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "config", 'get'
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", 'get'
         ];
         log_cmd("loadConfig", "Get SASL settings", cmd);
         cockpit
@@ -314,7 +315,7 @@ export class ServerSASL extends React.Component {
 
     loadMechs() {
         let cmd = [
-            "dsconf", "-j", this.props.serverId, "sasl", 'get-mechs'
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket", "sasl", 'get-mechs'
         ];
         log_cmd("loadMechs", "Get supported SASL mechanisms", cmd);
         cockpit
@@ -328,7 +329,7 @@ export class ServerSASL extends React.Component {
     }
 
     loadSASLMappings() {
-        let cmd = ["dsconf", '-j', this.props.serverId, 'sasl', 'list', '--details'];
+        let cmd = ["dsconf", '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket", 'sasl', 'list', '--details'];
         log_cmd('get_and_set_sasl', 'Get SASL mappings', cmd);
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
@@ -419,7 +420,7 @@ export class ServerSASL extends React.Component {
             tableLoading: true,
         });
         let cmd = [
-            'dsconf', '-j', this.props.serverId,
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             'sasl', 'create',
             '--cn=' + this.state.saslMapName,
             '--nsSaslMapFilterTemplate=' + this.state.saslFilter,
@@ -467,11 +468,11 @@ export class ServerSASL extends React.Component {
 
         // Delete and create
         let delete_cmd = [
-            'dsconf', '-j', this.props.serverId,
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             'sasl', 'delete', this.state._saslMapName
         ];
         let create_cmd = [
-            'dsconf', '-j', this.props.serverId,
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             'sasl', 'create',
             '--cn=' + this.state.saslMapName,
             '--nsSaslMapFilterTemplate=' + this.state.saslFilter,
@@ -532,7 +533,7 @@ export class ServerSASL extends React.Component {
         });
 
         let cmd = [
-            'dsconf', '-j', this.props.serverId,
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             'sasl', 'delete', this.state.saslMapName
         ];
         log_cmd("deleteMapping", "Delete sasl mapping", cmd);
@@ -564,7 +565,7 @@ export class ServerSASL extends React.Component {
 
         // Build up the command list
         let cmd = [
-            'dsconf', '-j', this.props.serverId, 'config', 'replace'
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket", 'config', 'replace'
         ];
 
         let mech_str_new = this.state.allowedMechs.join(' ');

--- a/src/cockpit/389-console/src/lib/server/tuning.jsx
+++ b/src/cockpit/389-console/src/lib/server/tuning.jsx
@@ -118,7 +118,10 @@ export class ServerTuning extends React.Component {
             });
         }
 
-        let cmd = ["dsconf", "-j", this.props.serverId, "config", "get"];
+        let cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
+        ];
         log_cmd("loadConfig", "Load server configuration", cmd);
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })

--- a/src/cockpit/389-console/src/server.jsx
+++ b/src/cockpit/389-console/src/server.jsx
@@ -73,7 +73,10 @@ export class Server extends React.Component {
             loaded: false,
             firstLoad: false
         });
-        let cmd = ["dsconf", "-j", this.props.serverId, "config", "get"];
+        let cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
+        ];
         log_cmd("loadConfig", "Load server configuration", cmd);
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })


### PR DESCRIPTION
Bug Description:

In some places in the UI code we call dsconf like:

dsconf -j slapd-instance ...

Instead of:

dsconf -j "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket"

The problem is that if you setup the ".dsrc" file to use something other than LDAPI then the UI hangs.

Fix Description:

We need to always call dsconf using the LDAPI socket.

Relates: https://github.com/389ds/389-ds-base/issues/4742

