### PR TITLE
Issue 4750 - Fix compiler warning in retrocl

### DIFF
--- a/dirsrvtests/tests/suites/retrocl/basic_test.py
+++ b/dirsrvtests/tests/suites/retrocl/basic_test.py
@@ -58,13 +58,6 @@ def test_retrocl_exclude_attr_add(topology_st):
 
     st = topology_st.standalone
 
-    log.info('Enable dynamic plugins')
-    try:
-        st.config.set('nsslapd-dynamic-plugins', 'on')
-    except ldap.LDAPError as e:
-        ldap.error('Failed to enable dynamic plugins ' + e.args[0]['desc'])
-        assert False
-
     log.info('Configure retrocl plugin')
     rcl = RetroChangelogPlugin(st)
     rcl.disable()
@@ -129,8 +122,12 @@ def test_retrocl_exclude_attr_add(topology_st):
     disconnect_instance(inst)
     assert result is None
 
-    log.info("5s delay for retrocl plugin to restart")
-    time.sleep(5)
+    log.info('Restarting instance')
+    try:
+        st.restart()
+    except ldap.LDAPError as e:
+        ldap.error('Failed to restart instance ' + e.args[0]['desc'])
+        assert False
 
     log.info('Adding user2')
     try:
@@ -190,13 +187,6 @@ def test_retrocl_exclude_attr_mod(topology_st):
     """
 
     st = topology_st.standalone
-
-    log.info('Enable dynamic plugins')
-    try:
-        st.config.set('nsslapd-dynamic-plugins', 'on')
-    except ldap.LDAPError as e:
-        ldap.error('Failed to enable dynamic plugins ' + e.args[0]['desc'])
-        assert False
 
     log.info('Configure retrocl plugin')
     rcl = RetroChangelogPlugin(st)
@@ -262,8 +252,12 @@ def test_retrocl_exclude_attr_mod(topology_st):
     disconnect_instance(inst)
     assert result is None
 
-    log.info("5s delay for retrocl plugin to restart")
-    time.sleep(5)
+    log.info('Restarting instance')
+    try:
+        st.restart()
+    except ldap.LDAPError as e:
+        ldap.error('Failed to restart instance ' + e.args[0]['desc'])
+        assert False
 
     log.info('Modify user1 carLicense attribute')
     try:

--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -399,8 +399,6 @@ retrocl_start(Slapi_PBlock *pb)
 
         for (size_t i = 0; i < num_vals; i++) {
             char *value = values[i];
-            size_t length = strlen(value);
-
             char *pos = strchr(value, ':');
             if (pos == NULL) {
                 retrocl_exclude_attrs[i] = slapi_ch_strdup(value);


### PR DESCRIPTION
Description: An unused variable generates a compiler warning.

Fix description: Remove unused variable.
		 Modify CI test to restart the test instance instead
		 of using dynamic plugins.

Fixes: https://github.com/389ds/389-ds-base/issues/4750

Relates: https://github.com/389ds/389-ds-base/issues/4701

Reviewed by: jchapma (One line commit rule)