### PR TITLE
Issue 4714 - dscontainer fails with rootless podman

### DIFF
--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -793,14 +793,14 @@ class SetupDs(object):
         # Copy in the collation
         srcfile = os.path.join(slapd['sysconf_dir'], 'dirsrv/config/slapd-collations.conf')
         dstfile = os.path.join(slapd['config_dir'], 'slapd-collations.conf')
-        shutil.copy2(srcfile, dstfile)
+        shutil.copy(srcfile, dstfile)
         os.chown(dstfile, slapd['user_uid'], slapd['group_gid'])
         os.chmod(dstfile, 0o440)
 
         # Copy in the certmap configuration
         srcfile = os.path.join(slapd['sysconf_dir'], 'dirsrv/config/certmap.conf')
         dstfile = os.path.join(slapd['config_dir'], 'certmap.conf')
-        shutil.copy2(srcfile, dstfile)
+        shutil.copy(srcfile, dstfile)
         os.chown(dstfile, slapd['user_uid'], slapd['group_gid'])
         os.chmod(dstfile, 0o440)
 


### PR DESCRIPTION
Bug Description:
shutil.copy2 attempts to preserve metadata, but in a container without
privileges we don't have access to set xattrs. With rootless podman this
triggers an AVC denial and causes dscontainer to fail when a shared
data volume is reused.

Fix Description:
Use shutil.copy instead.

Reviewed by:

Fixes: https://github.com/389ds/389-ds-base/issues/4714