### PR TITLE
Issue 4753 - Adjust our tests to 389-ds-base-snmp missing in RHEL 9 A…

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -22,6 +22,7 @@ from lib389.idm.directorymanager import DirectoryManager
 from lib389.config import LDBMConfig
 from lib389.dseldif import DSEldif
 from lib389.rootdse import RootDSE
+from ....conftest import get_rpm_version
 
 
 pytestmark = pytest.mark.tier0
@@ -904,7 +905,7 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
-pytestmark = pytest.mark.skipif(not snmp_present(), reason="Not present")
+pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="Not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -905,7 +905,7 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
-pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="Not present")
+pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="389-ds-base-snmp package is not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -904,6 +904,7 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
+pytestmark = pytest.mark.skipif(not snmp_present(), reason="Not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1431,12 +1431,3 @@ def is_valid_hostname(hostname):
         hostname = hostname[:-1] # strip exactly one dot from the right, if present
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))
-
-
-def snmp_present():
-    rpm_handle = os.popen('rpm -qa --qf "%{NAME}\n"')
-    rpm_list = rpm_handle.read().splitlines()
-    if '389-ds-base-snmp' in rpm_list:
-        return True
-    else:
-        return False

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1431,3 +1431,12 @@ def is_valid_hostname(hostname):
         hostname = hostname[:-1] # strip exactly one dot from the right, if present
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))
+
+
+def snmp_present():
+    rpm_handle = os.popen('rpm -qa --qf "%{NAME}\n"')
+    rpm_list = rpm_handle.read().splitlines()
+    if '389-ds-base-snmp' in rpm_list:
+        return True
+    else:
+        return False


### PR DESCRIPTION
…ppstream

Description: With RHEL 9, 389-ds-base-snmp is no longer delivered in AppStream.
We need to adapt our tests which rely on 389-ds-base-snmp, so that they are skipped if it is missing.

Fix Description: Added skipif to tests which rely on 389-ds-base-snmp

Fixes: https://github.com/389ds/389-ds-base/issues/4753

Reviewed by: ???