### PR TITLE
Issue 4759 - Fix coverity issue

### DIFF
--- a/ldap/servers/slapd/extendop.c
+++ b/ldap/servers/slapd/extendop.c
@@ -279,15 +279,15 @@ do_extended(Slapi_PBlock *pb)
     slapi_pblock_get(pb, SLAPI_OPERATION, &pb_op);
     slapi_pblock_get(pb, SLAPI_CONNECTION, &pb_conn);
 
-    /* Set the time we actually started the operation */
-    slapi_operation_set_time_started(pb_op);
-
     if (pb_conn == NULL || pb_op == NULL) {
         send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "param error", 0, NULL);
         slapi_log_err(SLAPI_LOG_ERR, "do_extended",
                       "NULL param error: conn (0x%p) op (0x%p)\n", pb_conn, pb_op);
         goto free_and_return;
     }
+
+    /* Set the time we actually started the operation */
+    slapi_operation_set_time_started(pb_op);
 
     /*
      * Parse the extended request. It looks like this:

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -284,9 +284,6 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
     slapi_pblock_get(pb, SLAPI_SEARCH_TARGET_SDN, &sdn);
     slapi_pblock_get(pb, SLAPI_OPERATION, &operation);
 
-    /* Set the time we actually started the operation */
-    slapi_operation_set_time_started(operation);
-
     if (NULL == sdn) {
         sdn = slapi_sdn_new_dn_byval(base);
         slapi_pblock_set(pb, SLAPI_SEARCH_TARGET_SDN, sdn);
@@ -317,6 +314,9 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
         rc = -1;
         goto free_and_return_nolock;
     }
+    
+    /* Set the time we actually started the operation */
+    slapi_operation_set_time_started(operation);
 
     internal_op = operation_is_flag_set(operation, OP_FLAG_INTERNAL);
     flag_psearch = operation_is_flag_set(operation, OP_FLAG_PS);


### PR DESCRIPTION
Bug description:
	with #4218 (wtime, optime in access log), hrtime is set in the
	operation. But it is done before checking if the operation is
	set. covscan fails

Fix description:
	move the setting after verification that operation != NULL

relates: https://github.com/389ds/389-ds-base/issues/4759

Reviewed by:

Platforms tested: