### PR TITLE
Issue 4765 - database suffix unexpectdly changed from .db to .db4

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -66,14 +66,6 @@ typedef unsigned short u_int16_t;
 
 #define ID2ENTRY "id2entry" /* main db file name: ID2ENTRY+LDBM_SUFFIX */
 
-#if 1000 * DB_VERSION_MAJOR + 100 * DB_VERSION_MINOR >= 5000
-#define LDBM_SUFFIX_OLD ".db4"
-#define LDBM_SUFFIX     ".db"
-#else
-#define LDBM_SUFFIX_OLD ".db3"
-#define LDBM_SUFFIX     ".db4"
-#endif
-
 #define MEGABYTE (1024 * 1024)
 #define GIGABYTE (1024 * MEGABYTE)
 
@@ -143,7 +135,6 @@ typedef unsigned short u_int16_t;
 #define LDBM_VERSION_40   "Netscape-ldbm/4.0"
 #define LDBM_VERSION_30   "Netscape-ldbm/3.0"
 #define LDBM_VERSION_31   "Netscape-ldbm/3.1"
-#define LDBM_FILENAME_SUFFIX LDBM_SUFFIX
 #define DBVERSION_FILENAME "DBVERSION"
 /* 0 here means to let the autotuning reset the value on first run */
 /* cache can't get any smaller than this (in bytes) */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
@@ -127,6 +127,7 @@ int bdb_init(struct ldbminfo *li, config_info *config_array)
     priv->dblayer_cursor_get_count_fn = &bdb_public_cursor_get_count;
     priv->dblayer_private_open_fn = &bdb_public_private_open;
     priv->dblayer_private_close_fn = &bdb_public_private_close;
+    priv->dblayer_get_db_suffix_fn = &bdb_public_get_db_suffix;
 
     bdb_fake_priv = *priv; /* Copy the callbaks for bdb_be() */
     return 0;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6759,3 +6759,8 @@ bdb_public_private_close(dbi_env_t **env, dbi_db_t **db)
     *env = NULL;
     return bdb_map_error(__FUNCTION__, rc);
 }
+
+const char *bdb_public_get_db_suffix(void)
+{
+    return LDBM_FILENAME_SUFFIX;
+}

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -13,6 +13,16 @@
 
 #define BDB_CONFIG(li) ((bdb_config *)(li)->li_dblayer_config)
 
+#if 1000 * DB_VERSION_MAJOR + 100 * DB_VERSION_MINOR >= 5000
+#define LDBM_SUFFIX_OLD ".db4"
+#define LDBM_SUFFIX     ".db"
+#else
+#define LDBM_SUFFIX_OLD ".db3"
+#define LDBM_SUFFIX     ".db4"
+#endif
+
+#define LDBM_FILENAME_SUFFIX LDBM_SUFFIX
+
 typedef struct bdb_db_env
 {
     DB_ENV *bdb_DB_ENV;
@@ -135,6 +145,7 @@ dblayer_get_entries_count_fn_t bdb_get_entries_count;
 dblayer_cursor_get_count_fn_t bdb_public_cursor_get_count;
 dblayer_private_open_fn_t bdb_public_private_open;
 dblayer_private_close_fn_t bdb_public_private_close;
+dblayer_get_db_suffix_fn_t bdb_public_get_db_suffix;
 
 /* instance functions */
 int bdb_instance_cleanup(struct ldbm_instance *inst);

--- a/ldap/servers/slapd/back-ldbm/dblayer.c
+++ b/ldap/servers/slapd/back-ldbm/dblayer.c
@@ -1381,3 +1381,12 @@ dblayer_pop_pvt_txn(void)
     }
     return;
 }
+
+const char *
+dblayer_get_db_suffix(Slapi_Backend *be)
+{
+    struct ldbminfo *li = be ? (struct ldbminfo *)be->be_database->plg_private : NULL;
+    dblayer_private *prv = li ? (dblayer_private *)li->li_dblayer_private : NULL;
+
+    return  prv ? prv->dblayer_get_db_suffix_fn() : NULL;
+}

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -111,6 +111,7 @@ typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, int *count);
 typedef int dblayer_cursor_get_count_fn_t(dbi_cursor_t *cursor, dbi_recno_t *count);
 typedef int dblayer_private_open_fn_t(const char *db_filename, dbi_env_t **env, dbi_db_t **db);
 typedef int dblayer_private_close_fn_t(dbi_env_t **env, dbi_db_t **db);
+typedef const char *dblayer_get_db_suffix_fn_t(void);
 
 struct dblayer_private
 {
@@ -182,6 +183,7 @@ struct dblayer_private
     dblayer_cursor_get_count_fn_t *dblayer_cursor_get_count_fn;
     dblayer_private_open_fn_t *dblayer_private_open_fn;
     dblayer_private_close_fn_t *dblayer_private_close_fn;
+    dblayer_get_db_suffix_fn_t *dblayer_get_db_suffix_fn;
 };
 
 #define DBLAYER_PRIV_SET_DATA_DIR 0x1
@@ -193,6 +195,7 @@ void dblayer_pop_pvt_txn(void);
 
 int dblayer_delete_indices(ldbm_instance *inst);
 int dbimpl_setup(struct ldbminfo *li, const char *plgname);
+const char *dblayer_get_db_suffix(Slapi_Backend *be);
 
 
 /* Return the last four characters of a string; used for comparing extensions. */

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -142,6 +142,8 @@ void dblayer_restore_file_update(struct ldbminfo *li, char *directory);
 int dblayer_import_file_init(ldbm_instance *inst);
 void dblayer_import_file_update(ldbm_instance *inst);
 int dblayer_import_file_check(ldbm_instance *inst);
+const char *dblayer_get_db_suffix(Slapi_Backend *be);
+
 
 /*
  * dn2entry.c

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -514,7 +514,6 @@ vlvIndex_init(struct vlvIndex *p, backend *be, struct vlvSearch *pSearch, const 
 {
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
     const char *file_suffix = dblayer_get_db_suffix(be);
-    dblayer_private *prv = NULL;
     char *filename = NULL;
 
     if (NULL == p)

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -30,7 +30,6 @@ char *const type_vlvEnabled = "vlvEnabled";
 char *const type_vlvUses = "vlvUses";
 
 static const char *file_prefix = "vlv#"; /* '#' used to avoid collision with real attributes */
-static const char *file_suffix = LDBM_FILENAME_SUFFIX;
 
 static int vlvIndex_createfilename(struct vlvIndex *pIndex, char **ppc);
 
@@ -514,6 +513,8 @@ void
 vlvIndex_init(struct vlvIndex *p, backend *be, struct vlvSearch *pSearch, const Slapi_Entry *e)
 {
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
+    const char *file_suffix = dblayer_get_db_suffix(be);
+    dblayer_private *prv = NULL;
     char *filename = NULL;
 
     if (NULL == p)


### PR DESCRIPTION
Description: when removing the bdb dependency from the backend
 include <db.h> was removed from back-ldbm.h 
 because of that the #if used to check bdb version and define the suffix become false and the db suffix reverted to old values
  so we got .db4 suffix instead of .db

The solution is:
   to move the bdb version test inside db-bdb plugin (where bdb version defines are available)
   to add a callback to get the db suffix from db-pdb plugin

Fixes: #4765

Reviewed by: @tbordaz @jchapma 