### PR TITLE
Issue 4379 - Allow more than 1 empty AttributeDescription for ldapsea…

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1314,6 +1314,33 @@ def test_critical_msg_on_empty_range_idl(topology_st):
     # Step 5
     assert not topology_st.standalone.searchErrorsLog('CRIT - list_candidates - NULL idl was recieved from filter_candidates_ext.')
 
+@pytest.mark.bz1870624
+@pytest.mark.ds4379
+@pytest.mark.parametrize("case,value", [('positive', ['cn','','']),
+                                        ("positive", ['cn', '', '', '', '', '', '', '', '', '', '']),
+                                        ("negative", ['cn', '', '', '', '', '', '', '', '', '', '', ''])])
+def test_attr_description_limit(topology_st, case, value):
+    """Test that up to 10 empty attributeDescription is allowed
+
+    :id: 5afd3dcd-1028-428d-822d-a489ecf4b67e
+    :customerscenario: True
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Check that 2 empty values are allowed
+        2. Check that 10 empty values are allowed
+        3. Check that more than 10 empty values are allowed
+    :expectedresults:
+        1. Should succeed
+        2. Should succeed
+        3. Should fail
+    """
+    if case == 'positive':
+        DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
+    else:
+        with pytest.raises(ldap.PROTOCOL_ERROR):
+            DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
+
 
 @pytest.mark.bz1647099
 @pytest.mark.ds50026
@@ -1635,34 +1662,6 @@ def test_dscreate_with_different_rdn(dscreate_test_rdn_value):
             assert False
         else:
             assert True
-
-
-@pytest.mark.bz1870624
-@pytest.mark.ds4379
-@pytest.mark.parametrize("case,value", [('positive', ['cn','','']),
-                                        ("positive", ['cn', '', '', '', '', '', '', '', '', '', '']),
-                                        ("negative", ['cn', '', '', '', '', '', '', '', '', '', '', ''])])
-def test_attr_description_limit(topology_st, case, value):
-    """Test that up to 10 empty attributeDescription is allowed
-
-    :id: 5afd3dcd-1028-428d-822d-a489ecf4b67e
-    :customerscenario: True
-    :parametrized: yes
-    :setup: Standalone instance
-    :steps:
-        1. Check that 2 empty values are allowed
-        2. Check that 10 empty values are allowed
-        3. Check that more than 10 empty values are allowed
-    :expectedresults:
-        1. Should succeeds
-        2. Should succeeds
-        3. Should fail
-    """
-    if case == 'positive':
-        DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
-    else:
-        with pytest.raises(ldap.PROTOCOL_ERROR):
-            DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -23,6 +23,7 @@ from lib389.config import LDBMConfig
 from lib389.dseldif import DSEldif
 from lib389.rootdse import RootDSE
 from ....conftest import get_rpm_version
+from lib389._mapped_object import DSLdapObjects
 
 
 pytestmark = pytest.mark.tier0
@@ -1634,6 +1635,34 @@ def test_dscreate_with_different_rdn(dscreate_test_rdn_value):
             assert False
         else:
             assert True
+
+
+@pytest.mark.bz1870624
+@pytest.mark.ds4379
+@pytest.mark.parametrize("case,value", [('positive', ['cn','','']),
+                                        ("positive", ['cn', '', '', '', '', '', '', '', '', '', '']),
+                                        ("negative", ['cn', '', '', '', '', '', '', '', '', '', '', ''])])
+def test_attr_description_limit(topology_st, case, value):
+    """Test that up to 10 empty attributeDescription is allowed
+
+    :id: 5afd3dcd-1028-428d-822d-a489ecf4b67e
+    :customerscenario: True
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Check that 2 empty values are allowed
+        2. Check that 10 empty values are allowed
+        3. Check that more than 10 empty values are allowed
+    :expectedresults:
+        1. Should succeeds
+        2. Should succeeds
+        3. Should fail
+    """
+    if case == 'positive':
+        DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
+    else:
+        with pytest.raises(ldap.PROTOCOL_ERROR):
+            DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -1236,7 +1236,7 @@ class DSLdapObjects(DSLogging, DSLints):
         # Now actually commit the creation req
         return co.ensure_state(rdn, properties, self._basedn)
 
-    def filter(self, search, scope=None, strict=False):
+    def filter(self, search, attrlist=None, scope=None, strict=False):
         # This will yield and & filter for objectClass with as many terms as needed.
         if search:
             search_filter = _gen_and([self._get_objectclass_filter(), search])
@@ -1244,7 +1244,9 @@ class DSLdapObjects(DSLogging, DSLints):
             search_filter = self._get_objectclass_filter()
         if scope is None:
             scope = self._scope
-        self._log.debug(f'list filter = {search_filter} with scope {scope}')
+        if attrlist:
+            self._list_attrlist = attrlist
+        self._log.debug(f'list filter = {search_filter} with scope {scope} and attribute list {attrlist}')
         try:
             results = self._instance.search_ext_s(
                 base=self._basedn,


### PR DESCRIPTION
…rch, without the risk of denial of service

Desciption: Added a test case to verify up to 10 empty values and a negetive
case to check max limit.

Relates: https://github.com/389ds/389-ds-base/issues/4379

Reviewed by: ???