### PR TITLE
Issue 4758 - Add tests for WebUI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,7 +66,12 @@ jobs:
         set -x
         CID=$(sudo docker run -d -h server.example.com --privileged --rm --shm-size=4gb -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
         sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
-        sudo docker exec $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html -v dirsrvtests/tests/suites/${{ matrix.suite }}
+        export PASSWD=$(openssl rand -base64 32)
+        sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"
+        sudo docker exec $CID sh -c "systemctl start dbus.service"
+        sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
+        sudo docker exec -e WEBUI=1 -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+
     - name: Make the results file readable by all
       if: always()
       run: |

--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -9,6 +9,8 @@ import os
 from .report import getReport
 from lib389.paths import Paths
 from enum import Enum
+from slugify import slugify
+from pathlib import Path
 
 
 pkgs = ['389-ds-base', 'nss', 'nspr', 'openldap', 'cyrus-sasl']
@@ -118,6 +120,14 @@ def pytest_runtest_makereport(item, call):
                     instance_name = os.path.basename(os.path.dirname(f)).split("slapd-",1)[1]
                     extra.append(pytest_html.extras.text(text, name=f"{instance_name}-{log_name}"))
         report.extra = extra
+
+    # Make a screenshot if WebUI test fails
+    if call.when == "call":
+        if call.excinfo is not None and "page" in item.funcargs:
+            page = item.funcargs["page"]
+            screenshot_dir = Path(".playwright-screenshots")
+            screenshot_dir.mkdir(exist_ok=True)
+            page.screenshot(path=str(screenshot_dir / f"{slugify(item.nodeid)}.png"))
 
 
 def pytest_exception_interact(node, call, report):

--- a/dirsrvtests/tests/suites/webui/__init__.py
+++ b/dirsrvtests/tests/suites/webui/__init__.py
@@ -1,0 +1,110 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import distro
+import os
+
+from lib389.utils import *
+from lib389.topologies import topology_st
+
+pytest.importorskip('playwright')
+
+RHEL = 'Red Hat Enterprise Linux'
+
+
+# in cockpit-250 some selectors got renamed so this function returns True if cockpit version is 250 or higher
+def check_cockpit_version_is_higher():
+    f = os.popen('rpm -q cockpit')
+    arq = f.readline()
+    version = arq.split("-")[1]
+
+    return int(version) >= 250
+
+
+# the iframe selection differs for chromium and firefox browser
+def determine_frame_selection(page, browser_name):
+    if browser_name == 'firefox':
+        frame = page.query_selector('iframe[name=\"cockpit1:localhost/389-console\"]').content_frame()
+    else:
+        frame = page.frame('cockpit1:localhost/389-console')
+
+    return frame
+
+
+# sometimes on a slow machine the iframe is not loaded yet, so we check for it until
+# it is available or the timeout is exhausted
+def check_frame_assignment(page, browser_name):
+    timeout = 80
+    count = 0
+    frame = determine_frame_selection(page, browser_name)
+
+    while (frame is None) and (count != timeout):
+        log.info('Waiting 0.5 seconds for iframe availability')
+        time.sleep(0.5)
+        count += 0.5
+        frame = determine_frame_selection(page, browser_name)
+
+    return frame
+
+
+def remove_instance_through_lib(topology):
+    log.info('Check and remove instance before starting tests')
+    if topology.standalone.exists():
+        topology.standalone.delete()
+
+
+def remove_instance_through_webui(topology, page):
+    frame = page.frame('cockpit1:localhost/389-console')
+
+    log.info('Check if instance exist')
+    if topology.standalone.exists():
+        log.info('Delete instance')
+        frame.wait_for_selector('#ds-action')
+        frame.click('#ds-action')
+        frame.click('#remove-ds')
+        frame.check('#modalChecked')
+        frame.click('//button[normalize-space(.)=\'Remove Instance\']')
+        frame.wait_for_selector("#no-inst-create-btn")
+        log.info('Instance deleted')
+
+
+def setup_login(page):
+    password = ensure_str(os.getenv('PASSWD'))
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    # increase default timeout to wait enough time on a slow machine for selector availability
+    # (it will wait just enough time for the selector to be available,
+    # it won't stop for 80 000 miliseconds each time it is called)
+    page.set_default_timeout(65000)
+
+    page.goto("http://localhost:9090/")
+
+    # We are at login page
+    page.fill('#login-user-input', 'root')
+    page.fill('#login-password-input', password)
+    page.click("#login-button")
+    if RHEL in distro.linux_distribution():
+        page.wait_for_selector('text=Red Hat Directory Server')
+        page.click('text=Red Hat Directory Server')
+    else:
+        page.wait_for_selector('text=389 Directory Server')
+        page.click('text=389 Directory Server')
+
+
+@pytest.fixture(scope="function")
+def setup_page(topology_st, page, request):
+    # remove instance if it exists before starting tests
+    remove_instance_through_lib(topology_st)
+    setup_login(page)
+
+    def fin():
+        remove_instance_through_webui(topology_st, page)
+
+    request.addfinalizer(fin)

--- a/dirsrvtests/tests/suites/webui/create/__init__.py
+++ b/dirsrvtests/tests/suites/webui/create/__init__.py
@@ -1,0 +1,3 @@
+"""
+   :Requirement: WebUI: Create instance
+"""

--- a/dirsrvtests/tests/suites/webui/create/create_instance_test.py
+++ b/dirsrvtests/tests/suites/webui/create/create_instance_test.py
@@ -1,0 +1,223 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import time
+import subprocess
+import pytest
+
+from lib389.cli_idm.account import *
+from lib389.tasks import *
+from lib389.utils import *
+from lib389.topologies import topology_st
+from .. import setup_page, check_frame_assignment
+
+pytestmark = pytest.mark.skipif(os.getenv('WEBUI') is None, reason="These tests are only for WebUI environment")
+pytest.importorskip('playwright')
+
+SERVER_ID = 'standalone1'
+
+
+def test_no_instance(topology_st, page, browser_name, setup_page):
+    """ Test page of Red Hat Directory Server when no instance is created
+
+    :id: 04c962b1-df5e-470d-8e19-aa6b77988c75
+    :setup: Standalone instance
+    :steps:
+         1. Go to Red Hat Directory server side tab page
+         2. Check there is Create New Instance button when no instance exists
+    :expectedresults:
+         1. Success
+         2. Button is visible
+    """
+
+    frame = check_frame_assignment(page, browser_name)
+    log.info('Check the Create New instance button is present')
+    frame.wait_for_selector('#noInsts')
+    assert frame.is_visible('#noInsts')
+
+
+def test_instance_button_disabled_passwd_short(topology_st, page, browser_name, setup_page):
+    """ Test Create Instance button is disabled when password is too short
+
+    :id: 9d413b70-7746-45ef-b389-9b67fcbc945a
+    :setup: Standalone instance
+    :steps:
+         1. Click on Create New Instance button
+         2. Fill serverID
+         3. Fill password shorter than eight characters
+         4. Fill passwordConfirm shorter than eight character
+         5. Check the Create Instance button is disabled when password is too short
+    :expectedresults:
+         1. A pop-up window should appear with create instance details
+         2. Success
+         3. Success
+         4. Success
+         5. Button is disabled
+    """
+
+    frame = check_frame_assignment(page, browser_name)
+
+    log.info('Click on Create New Instance button')
+    frame.click("#no-inst-create-btn")
+    frame.wait_for_selector('#createServerId')
+
+    log.info('Fill serverID and short password')
+    frame.fill('#createServerId', SERVER_ID)
+    frame.fill('#createDMPassword', 'redhat')
+    frame.fill('#createDMPasswordConfirm', 'redhat')
+
+    log.info('Check Create Instance button is disabled')
+    assert frame.is_disabled("text=Create Instance")
+
+
+def test_create_instance_without_database(topology_st, page, browser_name, setup_page):
+    """ Test create instance without database
+
+    :id: 7390c009-cb0d-406a-962a-4a1f0f02cfe6
+    :setup: Standalone instance
+    :steps:
+         1. Click on Create New Instance button
+         2. Fill serverID
+         3. Fill password longer than eight characters
+         4. Fill passwordConfirm longer than eight character
+         5. Click on the Create Instance button
+    :expectedresults:
+         1. A pop-up window should appear with create instance details
+         2. Success
+         3. Success
+         4. Success
+         5. Page redirection successful and instance is created
+    """
+
+    frame = check_frame_assignment(page, browser_name)
+
+    log.info('Click on Create New Instance button')
+    frame.click("#no-inst-create-btn")
+    frame.wait_for_selector('#createServerId')
+
+    log.info('Fill serverID and password longer than eight characters')
+    frame.fill('#createServerId', SERVER_ID)
+    frame.fill('#createDMPassword', 'password')
+    frame.fill('#createDMPasswordConfirm', 'password')
+
+    log.info('Click Create Instance button')
+    frame.click("text=Create Instance")
+    frame.wait_for_selector("#serverId")
+
+    log.info('Check that created serverID is present')
+    assert frame.is_visible("#serverId")
+
+
+def test_create_instance_database_suffix_entry(topology_st, page, browser_name, setup_page):
+    """ Test create instance with database and suffix entry
+
+    :id: 52703fc9-2f5b-49f9-b80b-bd0703008118
+    :setup: Standalone instance
+    :steps:
+         1. Click on Create New Instance button
+         2. Fill serverID, user and password
+         3. Check Create Database checkbox
+         4. Fill database suffix and name
+         5. Select Create Suffix Entry from drop-down list
+         6. Click on the Create Instance button
+    :expectedresults:
+         1. A pop-up window should appear with create instance details
+         2. Success
+         3. Success
+         4. Success
+         5. Success
+         6. Page redirection successful and instance is created
+    """
+
+    frame = check_frame_assignment(page, browser_name)
+
+    log.info('Click on Create New Instance button')
+    frame.click("#no-inst-create-btn")
+    frame.wait_for_selector('#createServerId')
+
+    log.info('Fill serverID and password longer than eight characters')
+    frame.fill('#createServerId', SERVER_ID)
+    frame.fill('#createDMPassword', 'password')
+    frame.fill('#createDMPasswordConfirm', 'password')
+
+    log.info('Choose to create database with suffix entry')
+    if ds_is_older('2.0.10'):
+        frame.check('text="Create Database" >> input[type="checkbox"]')
+        frame.fill('input[placeholder="e.g. dc=example,dc=com"]', 'dc=example,dc=com')
+        frame.fill('input[placeholder="e.g. userRoot"]', 'userRoot')
+    else:
+        frame.check('#createDBCheckbox')
+        frame.fill('#createDBSuffix','dc=example,dc=com')
+        frame.fill('#createDBName','userRoot')
+
+    frame.select_option('#createInitDB', 'createSuffix')
+
+    frame.click("text=Create Instance")
+    frame.wait_for_selector("#serverId")
+
+    log.info('Check that created serverID is present')
+    assert frame.is_visible("#serverId")
+
+
+def test_create_instance_database_sample_entries(topology_st, page, browser_name, setup_page):
+    """ Test create instance with database and sample entries
+
+    :id: d6d8cb10-8a5f-428d-b9a7-1c65b85986b7
+    :setup: Standalone instance
+    :steps:
+         1. Click on Create New Instance button
+         2. Fill serverID, user and password
+         3. Check Create Database checkbox
+         4. Fill database suffix and name
+         5. Select Create Sample Entries from drop-down list
+         6. Click on the Create Instance button
+    :expectedresults:
+         1. A pop-up window should appear with create instance details
+         2. Success
+         3. Success
+         4. Success
+         5. Success
+         6. Page redirection successful and instance is created
+    """
+
+    frame = check_frame_assignment(page, browser_name)
+
+    log.info('Click on Create New Instance button')
+    frame.click("#no-inst-create-btn")
+    frame.wait_for_selector('#createServerId')
+
+    log.info('Fill serverID and password longer than eight characters')
+    frame.fill('#createServerId', SERVER_ID)
+    frame.fill('#createDMPassword', 'password')
+    frame.fill('#createDMPasswordConfirm', 'password')
+
+    log.info('Choose to create database with sample entries')
+    if ds_is_older('2.0.10'):
+        frame.check('text="Create Database" >> input[type="checkbox"]')
+        frame.fill('input[placeholder="e.g. dc=example,dc=com"]', 'dc=example,dc=com')
+        frame.fill('input[placeholder="e.g. userRoot"]', 'userRoot')
+    else:
+        frame.check('#createDBCheckbox')
+        frame.fill('#createDBSuffix','dc=example,dc=com')
+        frame.fill('#createDBName','userRoot')
+
+    frame.select_option('#createInitDB', 'createSample')
+
+    log.info('Click Create Instance button')
+    frame.click("text=Create Instance")
+    frame.wait_for_selector("#serverId")
+
+    log.info('Check that created serverID is present')
+    assert frame.is_visible("#serverId")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/dirsrvtests/tests/suites/webui/login/__init__.py
+++ b/dirsrvtests/tests/suites/webui/login/__init__.py
@@ -1,0 +1,3 @@
+"""
+   :Requirement: WebUI: Login
+"""

--- a/dirsrvtests/tests/suites/webui/login/login_test.py
+++ b/dirsrvtests/tests/suites/webui/login/login_test.py
@@ -1,0 +1,122 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import time
+import subprocess
+import pytest
+import distro
+
+from lib389.cli_idm.account import *
+from lib389.tasks import *
+from lib389.utils import *
+from lib389.topologies import topology_st
+from .. import setup_page, remove_instance_through_lib, check_cockpit_version_is_higher, check_frame_assignment
+
+pytestmark = pytest.mark.skipif(os.getenv('WEBUI') is None, reason="These tests are only for WebUI environment")
+pytest.importorskip('playwright')
+
+RHEL = 'Red Hat Enterprise Linux'
+
+
+def test_login_no_instance(topology_st, page, browser_name):
+    """ Test login to WebUI is successful
+
+    :id: 0a85c1ec-20f3-41ae-8203-3951e74f34e7
+    :setup: Standalone instance
+    :steps:
+         1. Go to cockpit login page
+         2. Fill user and password
+         3. Click on login button
+         4. Go to Red Hat Directory server side tab page
+         5. Check there is Create New Instance button when no instance exists
+    :expectedresults:
+         1. Page redirection to login page successful
+         2. Success
+         3. Login successful
+         4. Page redirection successful
+         5. Button is visible
+    """
+
+    remove_instance_through_lib(topology_st)
+    password = ensure_str(os.getenv('PASSWD'))
+
+    # if we use setup_page from __init__.py we would be logged in already
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    # increase default timeout to wait enough time on a slow machine for selector availability
+    # (it will wait just enough time for the selector to be available,
+    # it won't stop for 60 000 miliseconds each time it is called)
+    page.set_default_timeout(60000)
+
+    page.goto("http://localhost:9090/")
+    assert page.url == 'http://localhost:9090/'
+    page.wait_for_selector('#login-user-input')
+
+    # We are at login page
+    log.info('Let us log in')
+    page.fill('#login-user-input', 'root')
+    page.fill('#login-password-input', password)
+    page.click('#login-button')
+
+    if RHEL in distro.linux_distribution():
+        page.wait_for_selector('text=Red Hat Directory Server')
+        assert page.is_visible('text=Red Hat Directory Server')
+        log.info('Let us go to RHDS side tab page')
+        page.click('text=Red Hat Directory Server')
+    else:
+        page.wait_for_selector('text=389 Directory Server')
+        assert page.is_visible('text=389 Directory Server')
+        log.info('Let us go to RHDS side tab page')
+        page.click('text=389 Directory Server')
+
+    log.info('Login successful')
+    assert page.url == 'http://localhost:9090/389-console'
+
+    log.info('Check there is Create New Instance button')
+    frame = check_frame_assignment(page, browser_name)
+    frame.wait_for_selector('#no-inst-create-btn')
+    assert frame.is_visible("#no-inst-create-btn")
+
+
+def test_logout(topology_st, page, setup_page):
+    """ Test logout from WebUI is successful
+
+    :id: a7e71179-3ef0-4e4e-baca-a36beeef71b6
+    :setup: Standalone instance
+    :steps:
+         1. Go to cockpit login page
+         2. Fill user and password
+         3. Click on login button
+         4. Click on root user and choose Log Out option
+         5. Check we have been redirected to the login page
+    :expectedresults:
+         1. Page redirection to login page successful
+         2. Success
+         3. Login successful
+         4. Page redirection successful
+         5. We are at login page
+    """
+
+    assert page.url == "http://localhost:9090/389-console"
+
+    log.info('Let us log out')
+    if check_cockpit_version_is_higher():
+        page.click('#navbar-dropdown')
+    else:
+        page.click('#content-user-name')
+    page.click('#go-logout')
+    page.wait_for_selector('#login-user-input')
+    assert page.is_visible('#login-user-input')
+    log.info('Log out successful')
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)


### PR DESCRIPTION
Description:
Added some basic tests for WebUI (login, create instance etc.). These tests need
specific environment to be run so they will be skipped in normal conditions.
Playwright for Python was used to develop the tests and they pass in latest
RHDS version with Firefox and Chromium.

Relates: https://github.com/389ds/389-ds-base/issues/4758

Reviewed by: ???