### PR TITLE
Fix some man-page typo

### DIFF
--- a/man/man1/dbscan.1
+++ b/man/man1/dbscan.1
@@ -61,7 +61,7 @@ only display index entries with more than <n> ids
 display ID list lengths
 .TP
 .B \fB\-r\fR
-display the conents of ID list
+display the contents of ID list
 .TP
 .B \fB\-s\fR
 Summary of index counts

--- a/man/man1/ldclt.1
+++ b/man/man1/ldclt.1
@@ -17,7 +17,7 @@
 .\" for manpage-specific macros, see man(7)
 .SH NAME
 ldclt \- load test program for LDAP
-.SH SYNOPSYS
+.SH SYNOPSIS
 .B ldclt 
 [\fI\-qQvV\fR] [\fI\-E <max errors>\fR]
 [\fI\-b <base DN>\fR] [\fI\-h <host>\fR] [\fI\-p <port>\fR] [\fI\-t <timeout>\fR]

--- a/man/man1/rsearch.1
+++ b/man/man1/rsearch.1
@@ -67,16 +67,16 @@ quiet
 logging
 .TP
 .B \fB\-m\fR
-operaton: modify non\-indexed attr (description). \fB\-B\fR required
+operation: modify non\-indexed attr (description). \fB\-B\fR required
 .TP
 .B \fB\-M\fR
-operaton: modify indexed attr (telephonenumber). \fB\-B\fR required
+operation: modify indexed attr (telephonenumber). \fB\-B\fR required
 .TP
 .B \fB\-d\fR
-operaton: delete. \fB\-B\fR required
+operation: delete. \fB\-B\fR required
 .TP
 .B \fB\-c\fR
-operaton: compare. \fB\-B\fR required
+operation: compare. \fB\-B\fR required
 .TP
 .B \fB\-i\fR file
 name file; used for the search filter

--- a/man/man5/99user.ldif.5
+++ b/man/man5/99user.ldif.5
@@ -43,7 +43,7 @@ attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN
 'user-defined' )
 .br
 objectClasses: ( 1.1.1.1.1.1.1.2 NAME 'myNewObjectcass' DESC 'Custom defined 
-objectclass' SUP top MUST ( myNewAttrbiute ) MAY ( uid $ cn ) X-ORIGIN 'user-defined' )
+objectclass' SUP top MUST ( myNewAttribute ) MAY ( uid $ cn ) X-ORIGIN 'user-defined' )
 
 .SH AUTHOR
 99user.ldif was written by the 389 Project.

--- a/man/man5/dirsrv.systemd.5
+++ b/man/man5/dirsrv.systemd.5
@@ -25,10 +25,10 @@
 dirsrv.systemd
 
 This controls the resources to the direct child of systemd, in
-this case ns-slapd. Because we are type notify we recieve these
+this case ns-slapd. Because we are type notify we receive these
 limits correctly.
 
-For more inforation see man systemd.exec and man systemd.resource-control
+For more information see man systemd.exec and man systemd.resource-control
 
 .SH AUTHOR
 dirsrv.systemd was written by the 389 Project.


### PR DESCRIPTION
Fixed the following man-page typo.
- dbscan(1)
- ldclt(1)
- rsearch(1)
- 99user.ldif(5)
- dirsrv.systemd(5)