### PR TITLE
Issue 2820 - Fix CI test suite issues

### DIFF
--- a/dirsrvtests/tests/suites/retrocl/__init__.py
+++ b/dirsrvtests/tests/suites/retrocl/__init__.py
@@ -1,0 +1,3 @@
+"""
+   :Requirement: 389-ds-base: Retro Changelog plugin
+"""


### PR DESCRIPTION
Bug Description:
Test collection fails due to file name clash - basic_test.py is present
in other suites too.

Fix Description:
Add a missing a __init__.py file.

Relates: https://github.com/389ds/389-ds-base/issues/2820