### PR TITLE
Issue 4764 - replicated operation sometime checks ACI

### DIFF
--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1772,6 +1772,14 @@ connection_threadmain()
         }
 
         /*
+         * Fix bz 1931820 issue (the check to set OP_FLAG_REPLICATED may be done
+         * before replication session is properly set).
+         */
+        if (replication_connection) {
+            operation_set_flag(op, OP_FLAG_REPLICATED);
+        }
+
+        /*
          * Call the do_<operation> function to process this request.
          */
         connection_dispatch_operation(conn, op, pb);


### PR DESCRIPTION
Bug Description: Replication operation sometime fails with err=50, 
   it occurs the failing operation is not flagged as replicated although its connection is flagged as a replication connection.
   The operation is flagged as  replicated by the replication factory constructor but this is done before reading the data so it is possible that op struct for first operation after setting up the replication session get built before receiving the operation
   (while replication session is not yet fully set up.
   
 Fix description:  Adding a second test (to set the operation as replicated  if done on a replicated connection) after having read the operation but before dispatching it does fix this risk of race condition                     

Relates: #4764

Reviewed by: 