### PR TITLE
Issue 4778 - RFE - Allow setting TOD for db compaction and add task

### DIFF
--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -1,0 +1,80 @@
+import logging
+import pytest
+import os
+import time
+from lib389.tasks import DBCompactTask
+from lib389.backend import DatabaseConfig
+from lib389.topologies import topology_m1 as topo
+
+log = logging.getLogger(__name__)
+
+
+def test_compact_db_task(topo):
+    """Specify a test case purpose or name here
+
+    :id: 1b3222ef-a336-4259-be21-6a52f76e1859
+    :setup: Standalone Instance
+    :steps:
+        1. Create task
+        2. Check task was successful
+        3. Check errors log to show task was run
+        3. Create task just for replication
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+    inst = topo.ms["supplier1"]
+
+    task = DBCompactTask(inst)
+    task.create()
+    task.wait()
+    assert task.get_exit_code() == 0
+
+    # Check errors log to make sure task actually compacted db
+    assert inst.searchErrorsLog("Compacting databases")
+    inst.deleteErrorLogs()
+
+    # Create new task that only compacts changelog
+    task = DBCompactTask(inst)
+    task_properties = {'justChangelog': 'yes'}
+    task.create(properties=task_properties)
+    task.wait()
+    assert task.get_exit_code() == 0
+
+    # Check errors log to make sure task only performed changelog compaction
+    assert inst.searchErrorsLog("Compacting DB") == False
+    assert inst.searchErrorsLog("Compacting Replication Changelog")
+    inst.deleteErrorLogs(restart=False)
+
+
+def test_compaction_interval_and_time(topo):
+    """Specify a test case purpose or name here
+
+    :id: f361bee9-d7e7-4569-9255-d7b60dd9d92e
+    :setup: Supplier Instance
+    :steps:
+        1. Configure compact interval and time
+        2. Check compaction occurs as expected
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+
+    inst = topo.ms["supplier1"]
+    config = DatabaseConfig(inst)
+    config.set([('nsslapd-db-compactdb-interval', '2'), ('nsslapd-db-compactdb-time', '00:01')])
+    inst.deleteErrorLogs()
+
+    time.sleep(6)
+    assert inst.searchErrorsLog("Compacting databases")
+    inst.deleteErrorLogs(restart=False)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
@@ -718,6 +718,84 @@ bdb_config_db_compactdb_interval_set(void *arg,
 }
 
 static void *
+bdb_config_db_compactdb_time_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    return (void *)slapi_ch_strdup(BDB_CONFIG(li)->bdb_compactdb_time);
+}
+
+static int
+bdb_config_db_compactdb_time_set(void *arg,
+                                 void *value,
+                                 char *errorbuf __attribute__((unused)),
+                                 int phase __attribute__((unused)),
+                                 int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    char *val = slapi_ch_strdup((char *)value);
+    char *endp = NULL;
+    char *hour_str = NULL;
+    char *min_str = NULL;
+    char *default_time = "23:59";
+    int32_t hour, min;
+    int retval = LDAP_SUCCESS;
+    errno = 0;
+
+    if (strstr(val, ":")) {
+        /* Get the hour and minute */
+        hour_str = ldap_utf8strtok_r(val, ":", &min_str);
+
+        /* Validate hour */
+        hour = strtoll(hour_str, &endp, 10);
+        if (*endp != '\0' || errno == ERANGE || hour < 0 || hour > 23 || strlen(hour_str) != 2) {
+            slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Invalid hour set (%s), must be a two digit number between 00 and 23",
+                    hour_str);
+            slapi_log_err(SLAPI_LOG_ERR, "bdb_config_db_compactdb_interval_set",
+                    "Invalid minute set (%s), must be a two digit number between 00 and 59.  "
+                    "Using default of 23:59\n", hour_str);
+            retval = LDAP_OPERATIONS_ERROR;
+            goto done;
+        }
+
+        /* Validate minute */
+        min = strtoll(min_str, &endp, 10);
+        if (*endp != '\0' || errno == ERANGE || min < 0 || min > 59 || strlen(min_str) != 2) {
+            slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Invalid minute set (%s), must be a two digit number between 00 and 59",
+                    hour_str);
+            slapi_log_err(SLAPI_LOG_ERR, "bdb_config_db_compactdb_interval_set",
+                    "Invalid minute set (%s), must be a two digit number between 00 and 59.  "
+                    "Using default of 23:59\n", min_str);
+            retval = LDAP_OPERATIONS_ERROR;
+            goto done;
+        }
+    } else {
+        /* Wrong format */
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                "Invalid setting (%s), must have a time format of HH:MM", val);
+        slapi_log_err(SLAPI_LOG_ERR, "bdb_config_db_compactdb_interval_set",
+                "Invalid setting (%s), must have a time format of HH:MM\n", val);
+        retval = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+
+done:
+    if (apply) {
+        slapi_ch_free((void **)&(BDB_CONFIG(li)->bdb_compactdb_time));
+        if (retval) {
+            /* Something went wrong, use the default */
+            BDB_CONFIG(li)->bdb_compactdb_time = slapi_ch_strdup(default_time);
+        } else {
+            BDB_CONFIG(li)->bdb_compactdb_time = slapi_ch_strdup((char *)value);
+        }
+    }
+    slapi_ch_free_string(&val);
+
+    return retval;
+}
+
+static void *
 bdb_config_db_page_size_get(void *arg)
 {
     struct ldbminfo *li = (struct ldbminfo *)arg;
@@ -1512,6 +1590,7 @@ static config_info bdb_config_param[] = {
     {CONFIG_DB_TRANSACTION_WAIT, CONFIG_TYPE_ONOFF, "off", &bdb_config_db_transaction_wait_get, &bdb_config_db_transaction_wait_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_CHECKPOINT_INTERVAL, CONFIG_TYPE_INT, "60", &bdb_config_db_checkpoint_interval_get, &bdb_config_db_checkpoint_interval_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_COMPACTDB_INTERVAL, CONFIG_TYPE_INT, "2592000" /*30days*/, &bdb_config_db_compactdb_interval_get, &bdb_config_db_compactdb_interval_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_DB_COMPACTDB_TIME, CONFIG_TYPE_STRING, "23:59", &bdb_config_db_compactdb_time_get, &bdb_config_db_compactdb_time_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH, CONFIG_TYPE_INT, "0", &bdb_get_batch_transactions, &bdb_set_batch_transactions, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH_MIN_SLEEP, CONFIG_TYPE_INT, "50", &bdb_get_batch_txn_min_sleep, &bdb_set_batch_txn_min_sleep, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH_MAX_SLEEP, CONFIG_TYPE_INT, "50", &bdb_get_batch_txn_max_sleep, &bdb_set_batch_txn_max_sleep, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -2128,6 +2128,7 @@ bdb_post_close(struct ldbminfo *li, int dbmode)
          */
         slapi_ch_free_string(&conf->bdb_dbhome_directory);
         slapi_ch_free_string(&conf->bdb_home_directory);
+        slapi_ch_free_string(&conf->bdb_compactdb_time);
     }
 
     return return_value;
@@ -3723,6 +3724,39 @@ log_flush_threadmain(void *param)
 }
 
 /*
+ * This refreshes the TOD expiration.  So live changes to the configuration
+ * will take effect immediately.
+ */
+static time_t
+bdb_get_tod_expiration(char *expire_time)
+{
+    time_t start_time, todays_elapsed_time, now = time(NULL);
+    struct tm *tm_struct = localtime(&now);
+    char hour_str[3] = {0};
+    char min_str[3] = {0};
+    char *s = expire_time;
+    char *endp = NULL;
+    int32_t hour, min, expiring_time;
+
+    /* Get today's start time */
+    todays_elapsed_time = (tm_struct->tm_hour * 3600) + (tm_struct->tm_min * 60) + (tm_struct->tm_sec);
+    start_time = slapi_current_utc_time() - todays_elapsed_time;
+
+    /* Get the hour and minute and calculate the expiring time.  The time was
+     * already validated in bdb_config.c:  HH:MM */
+    hour_str[0] = *s++;
+    hour_str[1] = *s++;
+    s++;  /* skip colon */
+    min_str[0] = *s++;
+    min_str[1] = *s++;
+    hour = strtoll(hour_str, &endp, 10);
+    min = strtoll(min_str, &endp, 10);
+    expiring_time = (hour * 60 * 60) + (min * 60);
+
+    return start_time + expiring_time;
+}
+
+/*
  * create a thread for checkpoint_threadmain
  */
 static int
@@ -3763,6 +3797,8 @@ checkpoint_threadmain(void *param)
     time_t checkpoint_interval_update = 0;
     time_t compactdb_interval = 0;
     time_t checkpoint_interval = 0;
+    int32_t compactdb_time = 0;
+    PRBool compacting = PR_FALSE;
 
     PR_ASSERT(NULL != param);
     li = (struct ldbminfo *)param;
@@ -3801,21 +3837,34 @@ checkpoint_threadmain(void *param)
     slapi_timespec_expire_at(checkpoint_interval, &checkpoint_expire);
 
     while (!BDB_CONFIG(li)->bdb_stop_threads) {
-        /* sleep for a while */
-        /* why aren't we sleeping exactly the right amount of time ? */
-        /* answer---because the interval might be changed after the server
-         * starts up */
+        PR_Lock(li->li_config_mutex);
+        checkpoint_interval_update = (time_t)BDB_CONFIG(li)->bdb_checkpoint_interval;
+        compactdb_interval_update = (time_t)BDB_CONFIG(li)->bdb_compactdb_interval;
+        if (!compacting) {
+            /* Once we know we want to compact we need to stop refreshing the
+             * TOD expiration. Otherwise if the compact time is close to
+             * midnight we could roll over past midnight during the checkpoint
+             * sleep interval, and we'd never actually compact the databases.
+             * We also need to get this value before the sleep.
+             */
+            compactdb_time = bdb_get_tod_expiration((char *)BDB_CONFIG(li)->bdb_compactdb_time);
+        }
+        PR_Unlock(li->li_config_mutex);
 
+        if (compactdb_interval_update != compactdb_interval) {
+            /* Compact interval was changed, so reset the timer */
+            slapi_timespec_expire_at(compactdb_interval_update, &compactdb_expire);
+        }
+
+        /* Sleep for a while ...
+         * Why aren't we sleeping exactly the right amount of time ?
+         * Answer---because the interval might be changed after the server
+         * starts up */
         DS_Sleep(interval);
 
         if (0 == BDB_CONFIG(li)->bdb_enable_transactions) {
             continue;
         }
-
-        PR_Lock(li->li_config_mutex);
-        checkpoint_interval_update = (time_t)BDB_CONFIG(li)->bdb_checkpoint_interval;
-        compactdb_interval_update = (time_t)BDB_CONFIG(li)->bdb_compactdb_interval;
-        PR_Unlock(li->li_config_mutex);
 
         /* If the checkpoint has been updated OR we have expired */
         if (checkpoint_interval != checkpoint_interval_update ||
@@ -3884,61 +3933,36 @@ checkpoint_threadmain(void *param)
 
         /*
          * Remember that if compactdb_interval is 0, timer_expired can
-         * never occur unless the value in compctdb_interval changes.
+         * never occur unless the value in compactdb_interval changes.
          *
-         * this could have been a bug infact, where compactdb_interval
+         * this could have been a bug in fact, where compactdb_interval
          * was 0, if you change while running it would never take effect ....
          */
-        if (compactdb_interval_update != compactdb_interval ||
-            slapi_timespec_expire_check(&compactdb_expire) == TIMER_EXPIRED) {
-            int rc = 0;
-            Object *inst_obj;
-            ldbm_instance *inst;
-            DB *db = NULL;
-
-            for (inst_obj = objset_first_obj(li->li_instance_set);
-                 inst_obj;
-                 inst_obj = objset_next_obj(li->li_instance_set, inst_obj)) {
-                inst = (ldbm_instance *)object_get_data(inst_obj);
-                rc = dblayer_get_id2entry(inst->inst_be, (dbi_db_t **)&db);
-                if (!db || rc) {
-                    continue;
-                }
-                slapi_log_err(SLAPI_LOG_NOTICE, "checkpoint_threadmain", "Compacting DB start: %s\n",
-                              inst->inst_name);
-
-                rc = bdb_db_compact_one_db(db, inst);
-                if (rc) {
-                    slapi_log_err(SLAPI_LOG_ERR, "checkpoint_threadmain",
-                                  "compactdb: failed to compact id2entry for %s; db error - %d %s\n",
-                                   inst->inst_name, rc, db_strerror(rc));
-                    break;
-                }
-
-                /* compact changelog db */
-                /* NOTE (LK) this is now done along regular compaction,
-                 * if it should be configurable add a switch to changelog config
-                 */
-                dblayer_get_changelog(inst->inst_be, (dbi_db_t **)&db, 0);
-
-                rc = bdb_db_compact_one_db(db, inst);
-                if (rc) {
-                    slapi_log_err(SLAPI_LOG_ERR, "checkpoint_threadmain",
-                                  "compactdb: failed to compact changelog for %s; db error - %d %s\n",
-                                   inst->inst_name, rc, db_strerror(rc));
-                    break;
-                }
+        if (slapi_timespec_expire_check(&compactdb_expire) == TIMER_EXPIRED) {
+            compacting = PR_TRUE;
+            if (slapi_current_utc_time() < compactdb_time) {
+                /* We have passed the interval, but we need to wait for a
+                 * particular TOD to pass before compacting */
+                continue;
             }
+
+            /* Time to compact the DB's */
+            bdb_force_checkpoint(li);
+            bdb_compact(li, PR_FALSE);
+            bdb_force_checkpoint(li);
+
+            /* Now reset the timer and compacting flag */
             compactdb_interval = compactdb_interval_update;
             slapi_timespec_expire_at(compactdb_interval, &compactdb_expire);
+            compacting = PR_FALSE;
         }
     }
-    slapi_log_err(SLAPI_LOG_TRACE, "checkpoint_threadmain", "Check point before leaving\n");
+    slapi_log_err(SLAPI_LOG_HOUSE, "checkpoint_threadmain", "Check point before leaving\n");
     rval = bdb_force_checkpoint(li);
 error_return:
 
     DECR_THREAD_COUNT(pEnv);
-    slapi_log_err(SLAPI_LOG_TRACE, "checkpoint_threadmain", "Leaving checkpoint_threadmain\n");
+    slapi_log_err(SLAPI_LOG_HOUSE, "checkpoint_threadmain", "Leaving checkpoint_threadmain\n");
     return rval;
 }
 
@@ -6845,7 +6869,72 @@ bdb_public_private_close(dbi_env_t **env, dbi_db_t **db)
     return bdb_map_error(__FUNCTION__, rc);
 }
 
-const char *bdb_public_get_db_suffix(void)
+const char *
+bdb_public_get_db_suffix(void)
 {
     return LDBM_FILENAME_SUFFIX;
+}
+
+int32_t
+ldbm_back_compact(Slapi_Backend *be, PRBool just_changelog)
+{
+    struct ldbminfo *li = NULL;
+    int32_t rc = -1;
+
+    li = (struct ldbminfo *)be->be_database->plg_private;
+    bdb_force_checkpoint(li);
+    rc = bdb_compact(li, just_changelog);
+    bdb_force_checkpoint(li);
+    return rc;
+}
+
+int32_t
+bdb_compact(struct ldbminfo *li, PRBool just_changelog)
+{
+    Object *inst_obj;
+    ldbm_instance *inst;
+    DB *db = NULL;
+    int rc = 0;
+
+    slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact",
+                  "Compacting databases ...\n");
+    for (inst_obj = objset_first_obj(li->li_instance_set);
+        inst_obj;
+        inst_obj = objset_next_obj(li->li_instance_set, inst_obj))
+    {
+        inst = (ldbm_instance *)object_get_data(inst_obj);
+        if (!just_changelog) {
+            rc = dblayer_get_id2entry(inst->inst_be, (dbi_db_t **)&db);
+            if (!db || rc) {
+                continue;
+            }
+            slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact",
+                    "Compacting DB: %s\n", inst->inst_name);
+            rc = bdb_db_compact_one_db(db, inst);
+            if (rc) {
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_compact",
+                        "failed to compact id2entry for %s; db error - %d %s\n",
+                        inst->inst_name, rc, db_strerror(rc));
+                break;
+            }
+        }
+
+        /* Compact changelog db */
+        slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact",
+                "Compacting Replication Changelog: %s\n", inst->inst_name);
+        dblayer_get_changelog(inst->inst_be, (dbi_db_t **)&db, 0);
+        if (db) {
+            rc = bdb_db_compact_one_db(db, inst);
+            if (rc) {
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_compact",
+                        "failed to compact changelog for %s; db error - %d %s\n",
+                        inst->inst_name, rc, db_strerror(rc));
+                break;
+            }
+        }
+    }
+
+    slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact", "Compacting databases finished.\n");
+
+    return rc;
 }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -90,7 +90,8 @@ typedef struct bdb_config
     int bdb_previous_lock_config;  /* Max lock count when we last shut down--
                                       * used to determine if we delete the mpool */
     u_int32_t bdb_deadlock_policy; /* i.e. the atype to DB_ENV->lock_detect in deadlock_threadmain */
-    int bdb_compactdb_interval;    /* interval to execute compact id2entry dbs */
+    int32_t bdb_compactdb_interval; /* interval to execute compact id2entry dbs */
+    char *bdb_compactdb_time;       /* time of day to execute compact id2entry dbs */
 } bdb_config;
 
 int bdb_init(struct ldbminfo *li, config_info *config_array);
@@ -107,6 +108,7 @@ int bdb_db_size(Slapi_PBlock *pb);
 int bdb_upgradedb(Slapi_PBlock *pb);
 int bdb_upgradednformat(Slapi_PBlock *pb);
 int bdb_upgradeddformat(Slapi_PBlock *pb);
+int32_t bdb_compact(struct ldbminfo *li, PRBool just_changelog);
 int bdb_restore(struct ldbminfo *li, char *src_dir, Slapi_Task *task);
 int bdb_cleanup(struct ldbminfo *li);
 int bdb_txn_begin(struct ldbminfo *li, back_txnid parent_txn, back_txn *txn, PRBool use_lock);

--- a/ldap/servers/slapd/back-ldbm/init.c
+++ b/ldap/servers/slapd/back-ldbm/init.c
@@ -145,6 +145,8 @@ ldbm_back_init(Slapi_PBlock *pb)
                            (void *)ldbm_back_set_info);
     rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_DB_CTRL_INFO_FN,
                            (void *)ldbm_back_ctrl_info);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_DB_COMPACT_FN,
+                           (void *)ldbm_back_compact);
 
     if (rc != 0) {
         slapi_log_err(SLAPI_LOG_CRIT, "ldbm_back_init", "Failed %d\n", rc);

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -84,6 +84,7 @@ struct config_info
 #define CONFIG_DB_TRANSACTION_WAIT "nsslapd-db-transaction-wait"
 #define CONFIG_DB_CHECKPOINT_INTERVAL "nsslapd-db-checkpoint-interval"
 #define CONFIG_DB_COMPACTDB_INTERVAL "nsslapd-db-compactdb-interval"
+#define CONFIG_DB_COMPACTDB_TIME "nsslapd-db-compactdb-time"
 #define CONFIG_DB_TRANSACTION_BATCH "nsslapd-db-transaction-batch-val"
 #define CONFIG_DB_TRANSACTION_BATCH_MIN_SLEEP "nsslapd-db-transaction-batch-min-wait"
 #define CONFIG_DB_TRANSACTION_BATCH_MAX_SLEEP "nsslapd-db-transaction-batch-max-wait"

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -469,6 +469,7 @@ void ldbm_back_search_results_release(void **search_results);
 int ldbm_back_init(Slapi_PBlock *pb);
 void ldbm_back_prev_search_results(Slapi_PBlock *pb);
 int ldbm_back_isinitialized(void);
+int32_t ldbm_back_compact(Slapi_Backend *be, PRBool just_changelog);
 
 /*
  * vlv.c

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -910,6 +910,12 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
         }
         (*(IFP *)value) = pblock->pb_plugin->plg_db2ldif;
         break;
+    case SLAPI_PLUGIN_DB_COMPACT_FN:
+        if (pblock->pb_plugin->plg_type != SLAPI_PLUGIN_DATABASE) {
+            return (-1);
+        }
+        (*(IFP *)value) = pblock->pb_plugin->plg_dbcompact;
+        break;
     case SLAPI_PLUGIN_DB_DB2INDEX_FN:
         if (pblock->pb_plugin->plg_type != SLAPI_PLUGIN_DATABASE) {
             return (-1);
@@ -2891,7 +2897,12 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
         }
         pblock->pb_backend->be_noacl = *((int *)value);
         break;
-
+    case SLAPI_PLUGIN_DB_COMPACT_FN:
+        if (pblock->pb_plugin->plg_type != SLAPI_PLUGIN_DATABASE) {
+            return (-1);
+        }
+        pblock->pb_plugin->plg_dbcompact = (IFP)value;
+        break;
 
     /* extendedop plugin functions */
     case SLAPI_PLUGIN_EXT_OP_FN:
@@ -4108,8 +4119,8 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
         break;
 
     case SLAPI_URP_TOMBSTONE_CONFLICT_DN:
-	pblock->pb_intop->pb_urp_tombstone_conflict_dn = (char *)value;
-	break;
+        pblock->pb_intop->pb_urp_tombstone_conflict_dn = (char *)value;
+        break;
 
     case SLAPI_URP_TOMBSTONE_UNIQUEID:
         _pblock_assert_pb_intop(pblock);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1044,6 +1044,7 @@ struct slapdplugin
             IFP plg_un_db_ldif2db;              /* ldif 2 database */
             IFP plg_un_db_db2ldif;              /* database 2 ldif */
             IFP plg_un_db_db2index;             /* database 2 index */
+            IFP plg_un_db_dbcompact;            /* compact database */
             IFP plg_un_db_archive2db;           /* ldif 2 database */
             IFP plg_un_db_db2archive;           /* database 2 ldif */
             IFP plg_un_db_upgradedb;            /* convert old idl to new */
@@ -1085,6 +1086,7 @@ struct slapdplugin
 #define plg_result plg_un.plg_un_db.plg_un_db_result
 #define plg_ldif2db plg_un.plg_un_db.plg_un_db_ldif2db
 #define plg_db2ldif plg_un.plg_un_db.plg_un_db_db2ldif
+#define plg_dbcompact plg_un.plg_un_db.plg_un_db_dbcompact
 #define plg_db2index plg_un.plg_un_db.plg_un_db_db2index
 #define plg_archive2db plg_un.plg_un_db.plg_un_db_archive2db
 #define plg_db2archive plg_un.plg_un_db.plg_un_db_db2archive

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -926,6 +926,7 @@ int proxyauth_get_dn(Slapi_PBlock *pb, char **proxydnp, char **errtextp);
 #define SLAPI_PLUGIN_DB_GET_INFO_FN               290
 #define SLAPI_PLUGIN_DB_SET_INFO_FN               291
 #define SLAPI_PLUGIN_DB_CTRL_INFO_FN              292
+#define SLAPI_PLUGIN_DB_COMPACT_FN                294
 
 /**** End of database plugin interface. **************************************/
 

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -215,6 +215,7 @@ export class Database extends React.Component {
                                     dblocksMonitoringPause: attrs['nsslapd-db-locks-monitoring-pause'],
                                     chxpoint: attrs['nsslapd-db-checkpoint-interval'],
                                     compactinterval: attrs['nsslapd-db-compactdb-interval'],
+                                    compacttime: attrs['nsslapd-db-compactdb-time'],
                                     importcacheauto: attrs['nsslapd-import-cache-autosize'],
                                     importcachesize: attrs['nsslapd-import-cachesize'],
                                 },

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -40,6 +40,7 @@ export class GlobalDatabaseConfig extends React.Component {
             dblocksMonitoringPause: this.props.data.dblocksMonitoringPause,
             chxpoint: this.props.data.chxpoint,
             compactinterval: this.props.data.compactinterval,
+            compacttime: this.props.data.compacttime,
             importcachesize: this.props.data.importcachesize,
             importcacheauto: this.props.data.importcacheauto,
             // These variables store the original value (used for saving config)
@@ -59,6 +60,7 @@ export class GlobalDatabaseConfig extends React.Component {
             _dblocksMonitoringPause: this.props.data.dblocksMonitoringPause,
             _chxpoint: this.props.data.chxpoint,
             _compactinterval: this.props.data.compactinterval,
+            _compacttime: this.props.data.compacttime,
             _importcachesize: this.props.data.importcachesize,
             _importcacheauto: this.props.data.importcacheauto,
             _db_cache_auto: this.props.data.db_cache_auto,
@@ -195,6 +197,10 @@ export class GlobalDatabaseConfig extends React.Component {
         }
         if (this.state._compactinterval != this.state.compactinterval) {
             cmd.push("--compactdb-interval=" + this.state.compactinterval);
+            requireRestart = true;
+        }
+        if (this.state._compacttime != this.state.compacttime) {
+            cmd.push("--compactdb-time=" + this.state.compacttime);
             requireRestart = true;
         }
         if (this.state.import_cache_auto) {
@@ -571,14 +577,28 @@ export class GlobalDatabaseConfig extends React.Component {
                             <FormGroup
                                 label="Database Compact Interval"
                                 fieldId="compactinterval"
-                                title="The interval in seconds when the database is compacted (nsslapd-db-compactdb-interval).  The default is 30 days."
+                                title="The interval in seconds when the database is compacted (nsslapd-db-compactdb-interval).  The default is 30 days at midnight."
                             >
                                 <TextInput
                                     value={this.state.compactinterval}
-                                    type="text"
+                                    type="number"
                                     id="compactinterval"
                                     aria-describedby="compactinterval"
                                     name="compactinterval"
+                                    onChange={this.handleChange}
+                                />
+                            </FormGroup>
+                            <FormGroup
+                                label="Database Compact Time"
+                                fieldId="compacttime"
+                                title="The Time Of Day to perform the database compaction after the compact interval has been met.  Uses the format: 'HH:MM' and defaults to '23:59'. (nsslapd-db-compactdb-time)"
+                            >
+                                <TextInput
+                                    value={this.state.compacttime}
+                                    type="text"
+                                    id="compacttime"
+                                    aria-describedby="compacttime"
+                                    name="compacttime"
                                     onChange={this.handleChange}
                                 />
                             </FormGroup>

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -157,6 +157,7 @@ DN_EUUID_TASK = "cn=entryuuid task,%s" % DN_TASKS
 DN_TOMB_FIXUP_TASK = "cn=fixup tombstones,%s" % DN_TASKS
 DN_FIXUP_LINKED_ATTIBUTES = "cn=fixup linked attributes,%s" % DN_TASKS
 DN_AUTOMEMBER_REBUILD_TASK = "cn=automember rebuild membership,%s" % DN_TASKS
+DN_COMPACTDB_TASK = "cn=compact db,%s" % DN_TASKS
 
 # Script Constants
 LDIF2DB = 'ldif2db'

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -1026,6 +1026,7 @@ class DatabaseConfig(DSLdapObject):
                     'nsslapd-db-transaction-wait',
                     'nsslapd-db-checkpoint-interval',
                     'nsslapd-db-compactdb-interval',
+                    'nsslapd-db-compactdb-time',
                     'nsslapd-db-page-size',
                     'nsslapd-db-transaction-batch-val',
                     'nsslapd-db-transaction-batch-min-wait',

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -230,6 +230,19 @@ class EntryUUIDFixupTask(Task):
         self._must_attributes.extend(['basedn'])
 
 
+class DBCompactTask(Task):
+    """A single instance of compactdb task entry
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    """
+
+    def __init__(self, instance, dn=None):
+        self.cn = 'compact_db_' + Task._get_task_date()
+        dn = "cn=" + self.cn + "," + DN_COMPACTDB_TASK
+        super(DBCompactTask, self).__init__(instance, dn)
+
+
 class SchemaReloadTask(Task):
     """A single instance of schema reload task entry
 
@@ -240,7 +253,6 @@ class SchemaReloadTask(Task):
     def __init__(self, instance, dn=None):
         self.cn = 'schema_reload_' + Task._get_task_date()
         dn = "cn=" + self.cn + ",cn=schema reload task," + DN_TASKS
-
         super(SchemaReloadTask, self).__init__(instance, dn)
 
 


### PR DESCRIPTION
Description:  

Since database compaction can be costly it should be allowed to set a time to execute it during offpeak hours.  Once the compaction interval has been met, it will wait for the configured time of day to do the compaction.  The default is just before midnight: 23:59

A task was also created that can run compaction on demand, and can also just target the replication changelog.  This could be used in conjunction with a cronjob for more complex execution patterns.

ASAN tested and approved.

relates: https://github.com/389ds/389-ds-base/issues/4778

