### PR TITLE
Issue 4593 - Log an additional message if the server certificate nick…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -350,6 +350,9 @@ attrcrypt_fetch_public_key(SECKEYPublicKey **public_key)
         errorCode = PR_GetError();
         slapi_log_err(SLAPI_LOG_ERR, "attrcrypt_fetch_public_key", "Can't find certificate %s: %d - %s\n",
                       cert_name, errorCode, slapd_pr_strerror(errorCode));
+        if (PR_FILE_NOT_FOUND_ERROR == errorCode) {
+            slapd_cert_not_found_error_help(cert_name);
+        }
     }
     if (cert != NULL) {
         key = slapd_CERT_ExtractPublicKey(cert);
@@ -397,6 +400,9 @@ attrcrypt_fetch_private_key(SECKEYPrivateKey **private_key)
         errorCode = PR_GetError();
         slapi_log_err(SLAPI_LOG_ERR, "attrcrypt_fetch_private_key", "Can't find certificate %s: %d - %s\n",
                       cert_name, errorCode, slapd_pr_strerror(errorCode));
+        if (PR_FILE_NOT_FOUND_ERROR == errorCode) {
+            slapd_cert_not_found_error_help(cert_name);
+        }
     }
     if (cert != NULL) {
         key = slapd_get_unlocked_key_for_cert(cert, NULL);


### PR DESCRIPTION
…name doesn't match nsSSLPersonalitySSL value

Description:
Added a test to check if additional message is present in the error log
if nsSSLPersonalitySSL value does not match the certificate nickname.

Relates: https://github.com/389ds/389-ds-base/issues/4593

Reviewed by: ???