### PR TITLE
Issue 4789 - Temporary password rules are not enforce with local pass…

### DIFF
--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -2356,6 +2356,18 @@ new_passwdPolicy(Slapi_PBlock *pb, const char *dn)
                     if ((sval = attr_get_present_values(attr))) {
                         pwdpolicy->pw_dict_path = (char *)slapi_value_get_string(*sval);
                     }
+                } else if (!strcasecmp(attr_name, CONFIG_PW_TPR_MAXUSE)) {
+                    if ((sval = attr_get_present_values(attr))) {
+                        pwdpolicy->pw_tpr_maxuse = slapi_value_get_int(*sval);
+                    }
+                } else if (!strcasecmp(attr_name, CONFIG_PW_TPR_DELAY_EXPIRE_AT)) {
+                    if ((sval = attr_get_present_values(attr))) {
+                        pwdpolicy->pw_tpr_delay_expire_at = slapi_value_get_int(*sval);
+                    }
+                } else if (!strcasecmp(attr_name, CONFIG_PW_TPR_DELAY_VALID_FROM)) {
+                    if ((sval = attr_get_present_values(attr))) {
+                        pwdpolicy->pw_tpr_delay_valid_from = slapi_value_get_int(*sval);
+                    }
                 }
             } /* end of for() loop */
             if (pw_entry) {


### PR DESCRIPTION
…word policy

Bug description:
	When allocating a password policy structure (new_passwdPolicy)
        it is initialized with the local policy definition or
	the global one. If it exists a local policy entry, the TPR
        attributes (passwordTPRMaxUse, passwordTPRDelayValidFrom and
        passwordTPRDelayExpireAt) are not taken into account.

Fix description:
	Take into account TPR attributes to initialize the policy

relates: https://github.com/389ds/389-ds-base/issues/4789

Reviewed by:

Platforms tested: F34