### PR TITLE
Ticket 4788

### DIFF
--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -255,6 +255,9 @@ def create_parser(subparsers):
     set_parser.add_argument('--pwpinheritglobal', help="Set to \"on\" to allow local policies to inherit the global policy")
     set_parser.add_argument('--pwddictcheck', help="Set to \"on\" to enforce CrackLib dictionary checking")
     set_parser.add_argument('--pwddictpath', help="Filesystem path to specific/custom CrackLib dictionary files")
+    set_parser.add_argument('--pwptprmaxuse', help="Number of times a reset password can be used for authentication")
+    set_parser.add_argument('--pwptprdelayexpireat', help="Number of seconds after which a reset password expires")
+    set_parser.add_argument('--pwptprdelayvalidfrom', help="Number of seconds to wait before using a reset password to authenticated")
     # delete local password policy
     del_parser = local_subcommands.add_parser('remove', help='Remove a local password policy')
     del_parser.set_defaults(func=del_local_policy)

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -66,7 +66,10 @@ class PwPolicyManager(object):
             'pwddictcheck': 'passworddictcheck',
             'pwddictpath': 'passworddictpath',
             'pwdallowhash': 'nsslapd-allow-hashed-passwords',
-            'pwpinheritglobal': 'nsslapd-pwpolicy-inherit-global'
+            'pwpinheritglobal': 'nsslapd-pwpolicy-inherit-global',
+            'pwptprmaxuse': 'passwordTPRMaxUse',
+            'pwptprdelayexpireat': 'passwordTPRDelayExpireAt',
+            'pwptprdelayvalidfrom': 'passwordTPRDelayValidFrom'
         }
 
     def is_subtree_policy(self, dn):


### PR DESCRIPTION
Issue 4788 - CLI should support Temporary Password Rules attributes
    
Bug description:

     Since #4725, password policy support temporary password rules.
     CLI (dsconf) does not support this RFE and only direct ldap
     operation can configure global/local password policy

    
Fix description:

    Update dsconf to support this new RFE.
    To run successfully the testcase it relies on #4788
    
relates: #4788
    
Reviewed by: 
    
Platforms tested: F34