### PR TITLE
Issue 4794 - BUG - don't capture container output

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -310,7 +310,7 @@ binddn = cn=Directory Manager
         # "-i", "/data/run/slapd-localhost.pid",
         # See /ldap/servers/slapd/slap.h SLAPD_DEFAULT_ERRORLOG_LEVEL
         "-d", "266354688",
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ.copy())
+        ], stdout=None, stderr=None, env=os.environ.copy())
 
     # Setup the process and shutdown handler in an init-esque fashion.
     def kill_ds():


### PR DESCRIPTION
Bug Description: It was noticed that capturing the container
output with PIPE may cause the buffer to fill up, resulting
in some tasks hanging.

Fix Description: Do not capture the process output.

fixes: https://github.com/389ds/389-ds-base/issues/4794

Author: William Brown <william@blackhats.net.au>

Review by: ???
