### PR TITLE
Issue 4797 - ACL IP ADDRESS evaluation may corrupt c_isreplication_se…

### DIFF
--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -2583,7 +2583,7 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
         pblock->pb_conn->c_authtype = slapi_ch_strdup((char *)value);
         pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
-	case SLAPI_CONN_CLIENTNETADDR_ACLIP:
+    case SLAPI_CONN_CLIENTNETADDR_ACLIP:
         if (pblock->pb_conn == NULL) {
             break;
         }
@@ -2591,6 +2591,7 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
         slapi_ch_free((void **)&pblock->pb_conn->cin_addr_aclip);
         pblock->pb_conn->cin_addr_aclip = (PRNetAddr *)value;
         pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
+        break;
     case SLAPI_CONN_IS_REPLICATION_SESSION:
         if (pblock->pb_conn == NULL) {
             slapi_log_err(SLAPI_LOG_ERR,


### PR DESCRIPTION
…ssion connection flags

Bug description:
	The fix for ticket #3764 was broken with a missing break in a
	switch. The consequence is that while setting the client IP
	address in the pblock (SLAPI_CONN_CLIENTNETADDR_ACLIP), the
	connection is erroneously set as replication connection.
        This can lead to crash or failure of testcase
        test_access_from_certain_network_only_ip.
        This bug was quite hidden until the fix for #4764 is
        showing it more frequently

Fix description:
	Add the missing break

relates: https://github.com/389ds/389-ds-base/issues/4797

Reviewed by:

Platforms tested: F33