### PR TITLE
Issue 4414 - disk monitoring - prevent division by zero crash

### DIFF
--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def test_compact_db_task(topo):
-    """Specify a test case purpose or name here
+    """Test creation of dbcompact task is successful
 
     :id: 1b3222ef-a336-4259-be21-6a52f76e1859
     :setup: Standalone Instance
@@ -18,7 +18,7 @@ def test_compact_db_task(topo):
         1. Create task
         2. Check task was successful
         3. Check errors log to show task was run
-        3. Create task just for replication
+        4. Create task just for replication
     :expectedresults:
         1. Success
         2. Success
@@ -50,7 +50,7 @@ def test_compact_db_task(topo):
 
 
 def test_compaction_interval_and_time(topo):
-    """Specify a test case purpose or name here
+    """Test dbcompact is successful when nsslapd-db-compactdb-interval and nsslapd-db-compactdb-time is set
 
     :id: f361bee9-d7e7-4569-9255-d7b60dd9d92e
     :setup: Supplier Instance

--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
@@ -1,0 +1,102 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import time
+import subprocess
+import pytest
+from lib389.tasks import *
+from lib389.utils import *
+from lib389.topologies import topology_st
+from lib389._mapped_object import DSLdapObjects
+
+pytestmark = pytest.mark.tier2
+
+logging.getLogger(__name__).setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def create_dummy_mount(topology_st, request):
+    cmds = ['setenforce 0',
+            'mkdir /var/log/dirsrv/slapd-{}/tmp'.format(topology_st.standalone.serverid),
+            'mount -t tmpfs tmpfs /var/log/dirsrv/slapd-{}/tmp -o size=0'.format(topology_st.standalone.serverid),
+            'chown dirsrv: /var/log/dirsrv/slapd-{}/tmp'.format(topology_st.standalone.serverid)]
+
+    log.info('Create dummy mount')
+    for cmd in cmds:
+        log.info('Command used : %s' % cmd)
+        subprocess.Popen(cmd, shell=True)
+
+    def fin():
+        cmds = ['umount /var/log/dirsrv/slapd-{}/tmp'.format(topology_st.standalone.serverid),
+                'setenforce 1']
+
+        for cmd in cmds:
+            log.info('Command used : %s' % cmds)
+            subprocess.Popen(cmd, shell=True)
+
+    request.addfinalizer(fin)
+
+
+@pytest.fixture(scope="function")
+def change_config(topology_st):
+    topology_st.standalone.config.set('nsslapd-disk-monitoring', 'on')
+    topology_st.standalone.config.set('nsslapd-disk-monitoring-readonly-on-threshold', 'on')
+
+
+@pytest.mark.ds4414
+@pytest.mark.bz1890118
+@pytest.mark.skipif(ds_is_older("1.4.3.16"), reason="Might fail because of bz1890118")
+def test_produce_division_by_zero(topology_st, create_dummy_mount, change_config):
+    """Test dirsrv will not crash when division by zero occurs
+
+    :id: 51b11093-8851-41bd-86cb-217b1a3339c7
+    :customerscenario: True
+    :setup: Standalone
+    :steps:
+        1. Turn on disk monitoring
+        2. Go below the threshold
+        3. Check DS is up and not entering shutdown mode
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    standalone = topology_st.standalone
+
+    log.info('Check search works before changing the nsslapd-auditlog attribute')
+    try:
+        DSLdapObjects(topology_st.standalone, basedn='cn=disk space,cn=monitor').filter("(objectclass=*)", scope=0)
+    except ldap.SERVER_DOWN as e:
+        log.info('Test failed - dirsrv crashed')
+        assert False
+
+    log.info('Change location of nsslapd-auditlog')
+    standalone.config.set('nsslapd-auditlog', '/var/log/dirsrv/slapd-{}/tmp/audit'.format(standalone.serverid))
+
+    log.info('Check search will not fail')
+    try:
+        DSLdapObjects(topology_st.standalone, basedn='cn=disk space,cn=monitor').filter("(objectclass=*)", scope=0)
+    except ldap.SERVER_DOWN as e:
+        log.info('Test failed - dirsrv crashed')
+        assert False
+
+    log.info('If passed, run search again just in case')
+    try:
+        DSLdapObjects(topology_st.standalone, basedn='cn=disk space,cn=monitor').filter("(objectclass=*)", scope=0)
+    except ldap.SERVER_DOWN as e:
+        log.info('Test failed - dirsrv crashed')
+        assert False
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)


### PR DESCRIPTION
Description:
Added a test to check DS will not crash when division by zero
occurs in disk monitoring. Also fixed a description in compact_test.py
because it was causing errors in Polarion.

Relates: https://github.com/389ds/389-ds-base/issues/4414

Reviewed by: ???