### PR TITLE
Issue 4656 - replication name change upgrade code causes crash with d…

### DIFF
--- a/dirsrvtests/tests/suites/upgrade/upgrade_repl_plugin_test.py
+++ b/dirsrvtests/tests/suites/upgrade/upgrade_repl_plugin_test.py
@@ -68,11 +68,13 @@ def test_repl_plugin_name_change(topo):
         plugin = Plugins(topo.standalone).get(REPL_PLUGIN_NAME)
         assert plugin is not None
         assert plugin.get_attr_val_utf8_l(REPL_PLUGIN_INIT_ATTR) == REPL_PLUGIN_INIT_FUNC
+        assert len(plugin.get_attr_vals_utf8_l(REPL_PLUGIN_INIT_ATTR)) == 1
 
         # Verify dependency was updated in retro changelog plugin
         plugin = Plugins(topo.standalone).get(RETROCL_PLUGIN_NAME)
         assert plugin is not None
         assert plugin.get_attr_val_utf8_l(REPL_DEPENDS_ATTR) == REPL_PLUGIN_NAME.lower()
+        assert len(plugin.get_attr_vals_utf8_l(REPL_DEPENDS_ATTR)) == 1
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -3366,11 +3366,9 @@ plugin_remove_plugins(struct slapdplugin *plugin_entry, char *plugin_type __attr
                      */
                     return PLUGIN_BUSY;
                 }
-                if (plugin->plg_started) {
-                    Slapi_PBlock *pb = slapi_pblock_new();
-                    plugin_call_one(plugin, SLAPI_PLUGIN_CLOSE_FN, pb);
-                    slapi_pblock_destroy(pb);
-                }
+                Slapi_PBlock *pb = slapi_pblock_new();
+                plugin_call_one(plugin, SLAPI_PLUGIN_CLOSE_FN, pb);
+                slapi_pblock_destroy(pb);
 
                 if (plugin_prev) {
                     plugin_prev->plg_next = plugin_next;

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -190,15 +190,14 @@ upgrade_205_fixup_repl_dep(void)
             mods[1] = &mod_add;
             mods[2] = 0;
             for (; *entries; entries++) {
-                slapi_log_err(SLAPI_LOG_CONFIG,
-                        "upgrade_205_fixup_repl_dep",
-                        "Found plugin to update (%s)\n",
-						slapi_entry_get_dn(*entries));
+                slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_205_fixup_repl_dep",
+                              "Upgrade task: updating the Replication Plugin dependency for (%s)\n",
+                              slapi_entry_get_dn(*entries));
                 /* clean the plugin */
                 struct slapi_pblock *mod_pb = slapi_pblock_new();
                 slapi_modify_internal_set_pb(mod_pb, slapi_entry_get_dn(*entries),
                                              mods, 0, 0, plugin_get_default_component_id(),
-											 SLAPI_OP_FLAG_FIXUP);
+                                             SLAPI_OP_FLAG_FIXUP);
                 slapi_modify_internal_pb(mod_pb);
                 slapi_pblock_destroy(mod_pb);
             }
@@ -280,8 +279,8 @@ upgrade_repl_plugin_name(Slapi_Entry *plugin_entry, struct slapdplugin *plugin)
                                          "replication_multisupplier_plugin_init");
             slapi_entry_attr_set_charptr(plugin_entry, "cn", "Multisupplier Replication Plugin");
 
-            slapi_log_err(SLAPI_LOG_CONFIG, "upgrade_repl_plugin_name",
-                          "Changed replication plugin name to: %s\n",
+            slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_repl_plugin_name",
+                          "Upgrade task: changed the replication plugin name to: %s\n",
                           slapi_entry_get_dn(plugin_entry));
         }
     }


### PR DESCRIPTION
…ynamic plugins

Bug Description:  

If dynamic plugins is enabled, the server will crash after restarting several plugins.  The global plugin list became corrupted, and an invalid plugin entry was read.

Fix Description:  

Always call the close function of a plugin even if its not started (this undoes a change from the previous patch that was not needed afterall).

Updated the replication plugin upgrade code logging to be more clear, and to be logged by default.

ASAN tested and approved

relates: https://github.com/389ds/389-ds-base/issues/4656

