### PR TITLE
Issue 4093 - Fix MEP test case

### DIFF
--- a/ldap/servers/plugins/replication/repl5_plugins.c
+++ b/ldap/servers/plugins/replication/repl5_plugins.c
@@ -882,8 +882,6 @@ copy_operation_parameters(Slapi_PBlock *pb)
 
     /* we are only interested in the updates to replicas */
     if (NULL == replica) {
-        slapi_log_err(SLAPI_LOG_REPL, REPLICATION_SUBSYSTEM,
-                      "copy_operation_parameters - replica is null.\n");
         return;
     }
     /* we only save the original operation parameters for replicated operations

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -105,7 +105,10 @@ def _create_instances(topo_dict, suffix):
             if DEBUGGING:
                 instance.config.set('nsslapd-accesslog-logbuffering','off')
                 instance.config.set('nsslapd-errorlog-level','8192')
+                instance.config.set('nsslapd-accesslog-level','260')
                 instance.config.set('nsslapd-auditlog-logging-enabled','on')
+                instance.config.set('nsslapd-auditfaillog-logging-enabled','on')
+                instance.config.set('nsslapd-plugin-logging', 'on')
             log.info("Instance with parameters {} was created.".format(args_instance))
 
     if "standalone1" in instances and len(instances) == 1:


### PR DESCRIPTION
Bug Description:  

Once some compiler warnings were fixed it accidentally fixed the modrdn behavior.  Previously the modrdn code accidentally ignored errors that the test case was taking for granted.  Once these checks were properly enforced the test case started to fail.

Fix Description:  Revise test case to "properly" check modrdn operations by creating the Managed Entry before assigning it to an entry, and then check for the revise managed entry DN after the modrdn takes place.

Also, improved CI debugging logging settings

relates: https://github.com/389ds/389-ds-base/issues/4093

