### PR TITLE
Issue 4747 - Remove unstable/unstatus tests (followup)

### DIFF
--- a/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
@@ -110,6 +110,9 @@ def init_sync_repl_plugins(topology, request):
                 pass
     request.addfinalizer(fin)
 
+#unstable or unstatus tests, skipped for now
+#it fails, let's say 1 time out of 10, while decoding asn1 response
+@pytest.mark.flaky(max_runs=2, min_passes=1)
 @pytest.mark.skipif(ldap.__version__ < '3.3.1',
     reason="python ldap versions less that 3.3.1 have bugs in sync repl that will cause this to fail!")
 def test_syncrepl_basic(topology):


### PR DESCRIPTION
Bug description:
	test_syncrepl_basic test is unstable (1 fail out of 10 run)
	with a error.PyAsn1Error exception.

Fix description:
	flag this tests as flaky

relates: https://github.com/389ds/389-ds-base/issues/4747

Reviewed by:

Platforms tested: F33