### PR TITLE
Issue 4563 - Failure on s390x: 'Fails to split RDN  "o=pki-tomcat-CA"…

### DIFF
--- a/ldap/servers/plugins/acl/acl.h
+++ b/ldap/servers/plugins/acl/acl.h
@@ -472,7 +472,7 @@ struct acl_pblock
 
     Slapi_Entry *aclpb_client_entry; /* A copy of client's entry */
     Slapi_PBlock *aclpb_pblock;      /* back to LDAP PBlock */
-    int aclpb_optype;                /* current optype from pb */
+    unsigned long aclpb_optype;                /* current optype from pb */
 
     /* Current entry/dn/attr evaluation info */
     Slapi_Entry *aclpb_curr_entry; /* current Entry being processed */

--- a/ldap/servers/plugins/acl/acl_ext.c
+++ b/ldap/servers/plugins/acl/acl_ext.c
@@ -737,7 +737,7 @@ acl_init_aclpb(Slapi_PBlock *pb, Acl_PBlock *aclpb, const char *ndn, int copy_fr
     struct acl_cblock *aclcb = NULL;
     char *authType;
     void *conn;
-    int op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     intptr_t ssf = 0;
 
 

--- a/ldap/servers/plugins/acl/aclplugin.c
+++ b/ldap/servers/plugins/acl/aclplugin.c
@@ -98,7 +98,7 @@ aclplugin_preop_search(Slapi_PBlock *pb)
     int scope;
     const char *base = NULL;
     Slapi_DN *sdn = NULL;
-    int optype;
+    unsigned long optype = SLAPI_OPERATION_NONE;
     int isRoot;
     int isProxy = 0;
     int rc = 0;

--- a/ldap/servers/plugins/chainingdb/cb_controls.c
+++ b/ldap/servers/plugins/chainingdb/cb_controls.c
@@ -127,7 +127,7 @@ cb_update_controls(Slapi_PBlock *pb,
     int useloop = 0;
     int addauth = (ctrl_flags & CB_UPDATE_CONTROLS_ADDAUTH);
     int isabandon = (ctrl_flags & CB_UPDATE_CONTROLS_ISABANDON);
-    int op_type = 0;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     size_t i;
 
     *controls = NULL;

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -3170,7 +3170,7 @@ cos_cache_change_notify(Slapi_PBlock *pb)
     struct slapi_entry *e;
     Slapi_Backend *be = NULL;
     int rc = 0;
-    int optype = -1;
+    unsigned long optype = SLAPI_OPERATION_NONE;
 
     slapi_log_err(SLAPI_LOG_TRACE, COS_PLUGIN_SUBSYSTEM, "--> cos_cache_change_notify\n");
 

--- a/ldap/servers/plugins/pam_passthru/pam_ptpreop.c
+++ b/ldap/servers/plugins/pam_passthru/pam_ptpreop.c
@@ -635,7 +635,7 @@ pam_passthru_postop(Slapi_PBlock *pb)
     Slapi_DN *sdn = NULL;
     Slapi_DN *new_sdn = NULL;
     Slapi_Entry *e = NULL;
-    int optype = SLAPI_OPERATION_NONE;
+    unsigned long optype = SLAPI_OPERATION_NONE;
     int oprc = -1;
 
     slapi_log_err(SLAPI_LOG_TRACE, PAM_PASSTHRU_PLUGIN_SUBSYSTEM,

--- a/ldap/servers/plugins/replication/repl5_agmt.c
+++ b/ldap/servers/plugins/replication/repl5_agmt.c
@@ -2314,7 +2314,7 @@ agmt_notify_change(Repl_Agmt *agmt, Slapi_PBlock *pb)
                  * tossed because it doesn't affect any of the replicated
                  * attributes.
                  */
-                int optype;
+                unsigned long optype = SLAPI_OPERATION_NONE;
                 int affects_non_fractional_attribute = 0;
 
                 slapi_pblock_get(pb, SLAPI_OPERATION_TYPE, &optype);

--- a/ldap/servers/plugins/replication/repl5_plugins.c
+++ b/ldap/servers/plugins/replication/repl5_plugins.c
@@ -536,7 +536,7 @@ purge_entry_state_information(Slapi_PBlock *pb)
     }
     if (NULL != purge_csn) {
         Slapi_Entry *e;
-        int optype;
+        unsigned long optype = SLAPI_OPERATION_NONE;
 
         slapi_pblock_get(pb, SLAPI_OPERATION_TYPE, &optype);
         switch (optype) {

--- a/ldap/servers/slapd/back-ldbm/findentry.c
+++ b/ldap/servers/slapd/back-ldbm/findentry.c
@@ -92,7 +92,7 @@ find_entry_internal_dn(
     ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
     size_t tries = 0;
     int isroot = 0;
-    int op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
 
     /* get the managedsait ldap message control */
     slapi_pblock_get(pb, SLAPI_MANAGEDSAIT, &managedsait);

--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -216,7 +216,7 @@ error:
 int32_t
 entry_get_rdn_mods(Slapi_PBlock *pb, Slapi_Entry *entry, CSN *csn, int repl_op, Slapi_Mods **smods_ret)
 {
-    int op_type = SLAPI_OPERATION_NONE;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     char *new_rdn = NULL;
     char **dns = NULL;
     char **rdns = NULL;

--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -2075,7 +2075,7 @@ slapi_mapping_tree_select(Slapi_PBlock *pb, Slapi_Backend **be, Slapi_Entry **re
     int index;
     int ret;
     int scope = LDAP_SCOPE_BASE;
-    int op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     int fixup = 0;
 
     if (slapi_atomic_load_32(&mapping_tree_freed, __ATOMIC_RELAXED)) {
@@ -2180,7 +2180,7 @@ slapi_mapping_tree_select_all(Slapi_PBlock *pb, Slapi_Backend **be_list, Slapi_E
     int scope = LDAP_SCOPE_BASE;
     Slapi_DN *sdn = NULL;
     int flag_partial_result = 0;
-    int op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
 
     if (slapi_atomic_load_32(&mapping_tree_freed, __ATOMIC_RELAXED)) {
         return LDAP_OPERATIONS_ERROR;
@@ -2507,7 +2507,7 @@ mtn_get_be(mapping_tree_node *target_node, Slapi_PBlock *pb, Slapi_Backend **be,
     Slapi_Operation *op;
     int result = LDAP_SUCCESS;
     int override_referral = 0;
-    unsigned long op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     int flag_stop = 0;
     struct slapi_componentid *cid = NULL;
 
@@ -3029,7 +3029,7 @@ slapi_op_reserved(Slapi_PBlock *pb)
 {
     int scope = LDAP_SCOPE_BASE;
     int reservedOp = 0;
-    int op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
     Slapi_Operation *op = NULL;
     Slapi_DN *target_sdn = NULL;
 

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -617,7 +617,7 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Operation is NULL and hence cannot access SLAPI_OPERATION_TYPE \n");
             return (-1);
         }
-        (*(int *)value) = pblock->pb_op->o_params.operation_type;
+        (*(unsigned long *)value) = pblock->pb_op->o_params.operation_type;
         break;
     case SLAPI_OPINITIATED_TIME:
         if (pblock->pb_op == NULL) {

--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -720,7 +720,7 @@ slapi_send_ldap_result(Slapi_PBlock *pb, int err, char *matched, char *text, int
 {
     IFP fn = NULL;
     Slapi_Operation *operation;
-    long op_type;
+    unsigned long op_type = SLAPI_OPERATION_NONE;
 
     /* GB : for spanning requests over multiple backends */
     if (err == LDAP_NO_SUCH_OBJECT) {

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -1992,7 +1992,7 @@ new_passwdPolicy(Slapi_PBlock *pb, const char *dn)
     int type_name_disposition = 0;
     int attr_free_flags = 0;
     int rc = 0;
-    int optype = -1;
+    unsigned long optype = SLAPI_OPERATION_NONE;
     int free_e = 1; /* reset if e is taken from pb */
     if (pb) {
         slapi_pblock_get(pb, SLAPI_OPERATION_TYPE, &optype);

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2134,7 +2134,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 slapi_ch_free_string(&ext_str);
             }
         } else {
-            int optype;
+            unsigned long optype = SLAPI_OPERATION_NONE;
 #define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s\n"
             slapi_log_access(LDAP_DEBUG_ARGS,
                              connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_MSG_FMT :


### PR DESCRIPTION
… into components'

Bug Description:
SLAPI_OPERATION_TYPE is defined as unsigned long. In various places we
use int instead. This works fine on little-endian platforms, but fails
on big-endian, s390x in particular.

Fix Description:
Update all places where we use slapi_pblock_get with
SLAPI_OPERATION_TYPE to use unsigned long.

Fixes: https://github.com/389ds/389-ds-base/issues/4563

Reviewed by: ???