### PR TITLE
Issue 4820 - RFE - control flow integrity

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,16 @@ MSAN_CFLAGS = @msan_cflags@
 TSAN_CFLAGS = @tsan_cflags@
 UBSAN_CFLAGS = @ubsan_cflags@
 
+if CFI_ENABLE
+# https://clang.llvm.org/docs/ControlFlowIntegrity.html#available-schemes
+# vcall is "forward edge" cfi which is what gives a lot of benefit security wise.
+CFI_CFLAGS = -flto=thin -fsanitize=cfi-cast-strict,cfi-vcall -fvisibility=hidden
+# Settings we could use in the future
+# -fsanitize=cfi-icall,cfi-nvcall,cfi-derived-cast,cfi-unrelated-cast,cfi-mfcall
+else
+CFI_CFLAGS =
+endif
+
 SYSTEMD_DEFINES = @systemd_defs@
 
 CMOCKA_INCLUDES = $(CMOCKA_CFLAGS)
@@ -52,7 +62,7 @@ RUST_ON = 1
 CARGO_FLAGS = @cargo_defs@
 
 if CLANG_ENABLE
-RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@ 
+RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@
 RUSTC_LINK_FLAGS = -C link-arg=-fuse-ld=lld
 else
 RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@
@@ -1868,7 +1878,7 @@ ns_slapd_SOURCES = ldap/servers/slapd/abandon.c \
 	ldap/servers/slapd/tempnam.c  \
 	ldap/servers/slapd/unbind.c
 
-ns_slapd_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(SVRCORE_INCLUDES)
+ns_slapd_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(SVRCORE_INCLUDES) $(CFI_CFLAGS)
 # We need our libraries to come first, then our externals libraries second.
 ns_slapd_LDADD = libslapd.la libldaputil.la libsvrcore.la
 if RUST_ENABLE

--- a/configure.ac
+++ b/configure.ac
@@ -225,6 +225,11 @@ AC_ARG_ENABLE(clang, AS_HELP_STRING([--enable-clang], [Enable clang (default: no
 AC_MSG_RESULT($enable_clang)
 AM_CONDITIONAL(CLANG_ENABLE,test "$enable_clang" = "yes")
 
+AC_MSG_CHECKING(for --enable-cfi)
+AC_ARG_ENABLE(cfi, AS_HELP_STRING([--enable-cfi], [Enable control flow integrity - requires --enable-clang (default: no)]),
+              [], [ enable_cfi=no ])
+AC_MSG_RESULT($enable_cfi)
+AM_CONDITIONAL(CFI_ENABLE,test "$enable_cfi" = "yes" -a "$enable_clang" = "yes")
 
 AM_CONDITIONAL([RPM_HARDEND_CC], [test -f /usr/lib/rpm/redhat/redhat-hardened-cc1])
 AC_MSG_CHECKING(for --enable-gcc-security)


### PR DESCRIPTION
Bug Description: Many attacks involved hijacking the
control flow of an executable to change it's behaviour.
While we can do many things to prevent this at development
time, we need to be ready for unexpected situations in
run time.

Fix Description: Enabling control flow integrity allows
enforcing that our projects logic flow only goes in certain,
known valid locations at compile time. This means a program
that violates these behaviours will be terminated to prevent
exploitation.

fixes: https://github.com/389ds/389-ds-base/issues/4820

Author: William Brown <william@blackhats.net.au>

Review by: ???