### PR TITLE
Issue 4262 - Fix Index out of bound in fractional test

### DIFF
--- a/dirsrvtests/tests/suites/fractional/fractional_test.py
+++ b/dirsrvtests/tests/suites/fractional/fractional_test.py
@@ -311,7 +311,8 @@ def test_newly_added_attribute_nsds5replicatedattributelisttotal(_create_entries
     check_all_replicated()
     user = f'uid=test_user_1000,ou=People,{DEFAULT_SUFFIX}'
     for instance in (SUPPLIER1, SUPPLIER2, CONSUMER1, CONSUMER2):
-        assert Groups(instance, DEFAULT_SUFFIX).list()[1].get_attr_val_utf8("member") == user
+        g = Groups(instance, DEFAULT_SUFFIX).get('bug739172_01group')
+        assert g.get_attr_val_utf8("member") == user
         assert UserAccount(instance, user).get_attr_val_utf8("sn") == "test_user_1000"
     # The attributes mentioned in the nsds5replicatedattributelist
     # excluded from incremental updates.


### PR DESCRIPTION
Bug description:
	The index '1' becomes invalid after an external
        change. The list containing only one member.

Fix description:
	Revert the index to '0'

relates: https://github.com/389ds/389-ds-base/issues/4262

Reviewed by:

Platforms tested:  8.5, fedora