### PR TITLE
Issue 4603 - Reindexing a single backend

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -470,6 +470,8 @@ def test_basic_db2index(topology_st):
 
     assert indexNum+1 == numIndexes
 
+    topology_st.standalone.start()
+
 
 def test_basic_acl(topology_st, import_example_ldif):
     """Run some basic access control (ACL) tests

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -401,8 +401,7 @@ def test_basic_backup(topology_st, import_example_ldif):
 
     log.info('test_basic_backup: PASSED')
 
-
-def test_basic_db2index(topology_st, import_example_ldif):
+def test_basic_db2index(topology_st):
     """Assert db2index can operate correctly.
 
     :id: 191fc0fd-9722-46b5-a7c3-e8760effe119
@@ -410,16 +409,66 @@ def test_basic_db2index(topology_st, import_example_ldif):
     :setup: Standalone instance
 
     :steps:
-        1: call db2index
+        1: Call db2index with a single index attribute
+        2: Call db2index with multiple index attributes
+        3: Call db2index with no index attributes
 
     :expectedresults:
-        1: Index succeeds.
+        1: Index succeeds for single index attribute
+        2: Index succeeds for multiple index attributes
+        3: Index succeeds for all backend indexes which have been obtained from dseldif
 
     """
-    topology_st.standalone.stop()
-    topology_st.standalone.db2index()
-    topology_st.standalone.db2index(suffixes=[DEFAULT_SUFFIX], attrs=['uid'])
+
+    indexes = []
+
+    # Error log message to confirm a reindex
+    info_message = 'INFO - bdb_db2index - ' + DEFAULT_BENAME + ':' + ' Indexing attribute: '
+
+    log.info('Start the server')
     topology_st.standalone.start()
+
+    log.info('Offline reindex, stopping the server')
+    topology_st.standalone.stop()
+
+    log.info('Reindex with a single index attribute')
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=['uid'])
+    assert topology_st.standalone.searchErrorsLog(info_message + 'uid')
+
+    log.info('Restart the server to clear the logs')
+    topology_st.standalone.start()
+    topology_st.standalone.stop()
+
+    log.info('Reindex with multiple attributes')
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=['cn','aci','givenname'])
+    assert topology_st.standalone.searchErrorsLog(info_message + 'cn')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'aci')
+    assert topology_st.standalone.searchErrorsLog(info_message + 'givenname')
+
+    log.info('Restart the server to clear the logs')
+    topology_st.standalone.start()
+    topology_st.standalone.stop()
+
+    log.info('Start the server and get all indexes for specified backend')
+    topology_st.standalone.start()
+    dse_ldif = DSEldif(topology_st.standalone)
+    indexes = dse_ldif.get_indexes(DEFAULT_BENAME)
+    numIndexes = len(indexes)
+    assert numIndexes > 0
+
+    log.info('Stop the server and reindex with all backend indexes')
+    topology_st.standalone.stop()
+    topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=indexes)
+    log.info('Checking the server logs for %d backend indexes' % numIndexes)
+    for indexNum, index in enumerate(indexes):
+        if index in "entryrdn":
+            assert topology_st.standalone.searchErrorsLog(
+                'INFO - bdb_db2index - ' + DEFAULT_BENAME + ':' + ' Indexing ' + index)
+        else:
+            assert topology_st.standalone.searchErrorsLog(
+                'INFO - bdb_db2index - ' + DEFAULT_BENAME + ':' + ' Indexing attribute: ' + index)
+    
+    assert indexNum+1 == numIndexes
 
 
 def test_basic_acl(topology_st, import_example_ldif):
@@ -906,7 +955,6 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
-pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="389-ds-base-snmp package is not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -459,7 +459,7 @@ def test_basic_db2index(topology_st):
     log.info('Stop the server and reindex with all backend indexes')
     topology_st.standalone.stop()
     topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=indexes)
-    log.info('Checking the server logs for %d backend indexes' % numIndexes)
+    log.info('Checking the server logs for %d backend indexes INFO' % numIndexes)
     for indexNum, index in enumerate(indexes):
         if index in "entryrdn":
             assert topology_st.standalone.searchErrorsLog(
@@ -467,7 +467,7 @@ def test_basic_db2index(topology_st):
         else:
             assert topology_st.standalone.searchErrorsLog(
                 'INFO - bdb_db2index - ' + DEFAULT_BENAME + ':' + ' Indexing attribute: ' + index)
-    
+
     assert indexNum+1 == numIndexes
 
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -2586,13 +2586,6 @@ bdb_rm_db_file(backend *be, struct attrinfo *a, PRBool use_lock, int no_force_ch
     if (NULL == pEnv) { /* db does not exist */
         return rc;
     }
-    /* Added for bug 600401. Somehow the checkpoint thread deadlocked on
-     index file with this function, index file couldn't be removed on win2k.
-     Force a checkpoint here to break deadlock.
-  */
-    if (0 == no_force_checkpoint) {
-        bdb_force_checkpoint(li);
-    }
 
     if (0 == dblayer_get_index_file(be, a, (dbi_db_t**)&db, 0 /* Don't create an index file
                                                    if it does not exist. */)) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -2586,7 +2586,10 @@ bdb_rm_db_file(backend *be, struct attrinfo *a, PRBool use_lock, int no_force_ch
     if (NULL == pEnv) { /* db does not exist */
         return rc;
     }
-
+    /* Added for bug 600401. Somehow the checkpoint thread deadlocked on
+     index file with this function, index file couldn't be removed on win2k.
+     Force a checkpoint here to break deadlock.
+    */
     if (0 == no_force_checkpoint) {
 	bdb_force_checkpoint(li);
     }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -2587,6 +2587,10 @@ bdb_rm_db_file(backend *be, struct attrinfo *a, PRBool use_lock, int no_force_ch
         return rc;
     }
 
+    if (0 == no_force_checkpoint) {
+	bdb_force_checkpoint(li);
+    }
+
     if (0 == dblayer_get_index_file(be, a, (dbi_db_t**)&db, 0 /* Don't create an index file
                                                    if it does not exist. */)) {
         if (use_lock)

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1408,7 +1408,7 @@ bdb_db2index(Slapi_PBlock *pb)
      */
     if (run_from_cmdline) {
         /* Turn off transactions */
-        ldbm_config_internal_set(li, CONFIG_DB_TRANSACTION_LOGGING, "off");
+        bdb_config_internal_set(li, CONFIG_DB_TRANSACTION_LOGGING, "off");
 
         if (0 != dblayer_start(li, DBLAYER_INDEX_MODE)) {
             slapi_task_log_notice(task, "Failed to init database: %s", instance_name);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1559,7 +1559,7 @@ bdb_db2index(Slapi_PBlock *pb)
                                   "bdb_db2index", "%s: Indexing attribute: %s\n",
                                   inst->inst_name, attrs[i] + 1);
                 }
-                dblayer_erase_index_file(be, ai, PR_TRUE, i /* chkpt; 1st time only */);
+                dblayer_erase_index_file(be, ai, PR_TRUE, i);
                 break;
             case 'T': /* VLV Search to index */
                 vlvip = vlv_find_searchname((attrs[i]) + 1, be);

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -2830,9 +2830,9 @@ class DirSrv(SimpleLDAPObject, object):
     def db2index(self, bename=None, suffixes=None, attrs=None, vlvTag=None):
         """
         @param bename - The backend name to reindex
-        @param suffixes - List/tuple of suffixes to reindex
+        @param suffixes - List/tuple of suffixes to reindex, currently unused
         @param attrs - List/tuple of the attributes to index
-        @param vlvTag - The VLV index name to index
+        @param vlvTag - The VLV index name to index, currently unused
         @return - True if reindexing succeeded
         """
         prog = os.path.join(self.ds_paths.sbin_dir, 'ns-slapd')
@@ -2840,17 +2840,25 @@ class DirSrv(SimpleLDAPObject, object):
         if self.status():
             self.log.error("db2index: Can not operate while directory server is running")
             return False
-
-        if (not bename and not suffixes) and (attrs or vlvTag):
-            self.log.error("db2index: missing required backend name or suffix")
-            return False
-
         cmd = [prog, ]
-        if attrs or vlvTag:
+        # No backend specified, do an upgrade on all backends
+        # Backend and no attrs specified, reindex with all backend indexes
+        # Backend and attr/s specified, reindex backend with attr/s
+        if bename:
             cmd.append('db2index')
-            if bename:
-                cmd.append('-n')
-                cmd.append(bename)
+            cmd.append('-n')
+            cmd.append(bename)
+            if attrs:
+                 for attr in attrs:
+                        cmd.append('-t')
+                        cmd.append(attr)
+            else:
+                dse_ldif = DSEldif(self)
+                indexes = dse_ldif.get_indexes(bename)
+                if indexes:
+                    for idx in indexes:
+                        cmd.append('-t')
+                        cmd.append(idx)
         else:
             cmd.append('upgradedb')
             cmd.append('-a')
@@ -2860,21 +2868,6 @@ class DirSrv(SimpleLDAPObject, object):
 
         cmd.append('-D')
         cmd.append(self.get_config_dir())
-
-        # Can only use suffiix in attr only mode.
-        if suffixes and (attrs or vlvTag):
-            for suffix in suffixes:
-                cmd.append('-s')
-                cmd.append(suffix)
-
-        if attrs:
-            for attr in attrs:
-                cmd.append('-t')
-                cmd.append(attr)
-
-        if vlvTag:
-            cmd.append('-T')
-            cmd.append(vlvTag)
 
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -10,11 +10,29 @@
 from lib389._constants import TaskWarning
 
 def dbtasks_db2index(inst, log, args):
-    if not inst.db2index(bename=args.backend):
-        log.fatal("db2index failed")
-        return False
+    rtn = False
+    if not args.backend:
+        if not inst.db2index():
+            rtn = False
+        else:
+            rtn = True
+    elif args.backend and not args.attr:
+        if not inst.db2index(bename=args.backend):
+            rtn = False
+        else:
+            rtn = True
     else:
+        if not inst.db2index(bename=args.backend, attrs=args.attr):
+            rtn = False
+        else:
+            rtn = True
+    if rtn:
         log.info("db2index successful")
+        return rtn
+    else:
+        log.fatal("db2index failed")
+        return rtn
+
 
 
 def dbtasks_db2bak(inst, log, args):
@@ -95,7 +113,8 @@ def dbtasks_verify(inst, log, args):
 def create_parser(subcommands):
     db2index_parser = subcommands.add_parser('db2index', help="Initialise a reindex of the server database. The server must be stopped for this to proceed.")
     # db2index_parser.add_argument('suffix', help="The suffix to reindex. IE dc=example,dc=com.")
-    db2index_parser.add_argument('backend', help="The backend to reindex. IE userRoot")
+    db2index_parser.add_argument('backend', nargs="?", help="The backend to reindex. IE userRoot", default=False)
+    db2index_parser.add_argument('--attr', nargs="*", help="The attribute's to reindex. IE --attr aci cn givenname", default=False)
     db2index_parser.set_defaults(func=dbtasks_db2index)
 
     db2bak_parser = subcommands.add_parser('db2bak', help="Initialise a BDB backup of the database. The server must be stopped for this to proceed.")

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -54,8 +54,10 @@ class DSEldif(DSLint):
                 if not line.startswith(' '):
                     if processed_line:
                         self._contents.append(processed_line)
-
-                    processed_line = line
+                        if line.startswith('dn:'):
+                            processed_line = line.lower()
+                        else:
+                            processed_line = line
                 else:
                     processed_line = processed_line[:-1] + line[1:]
 
@@ -99,7 +101,7 @@ class DSEldif(DSLint):
         relative attribute indexes and the attribute value
         """
 
-        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn))
+        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn.lower()))
         attr_data = {}
 
         # Find where the entry ends
@@ -150,7 +152,7 @@ class DSEldif(DSLint):
         """
         indexes = []
         for entry in self._contents:
-            if fnmatch.fnmatch(entry, "*,cn=index,cn={}*".format(backend)):
+            if fnmatch.fnmatch(entry, "*,cn=index,cn={}*".format(backend.lower())):
                 start = entry.find("cn=")
                 end = entry.find(",")
                 indexes.append(entry[start+len('cn='):end])
@@ -168,7 +170,7 @@ class DSEldif(DSLint):
         :type value: str
         """
 
-        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn))
+        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn.lower()))
         self._contents.insert(entry_dn_i+1, "{}: {}\n".format(attr, value))
         self._update()
 
@@ -197,7 +199,7 @@ class DSEldif(DSLint):
         self.add(entry_dn, new_rdn_attr, new_rdn_val)
 
         # Rename the entry
-        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn))
+        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn.lower()))
         self._contents[entry_dn_i] = f"dn: {new_dn}\n"
         self._update()
 

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -54,10 +54,10 @@ class DSEldif(DSLint):
                 if not line.startswith(' '):
                     if processed_line:
                         self._contents.append(processed_line)
-                        if line.startswith('dn:'):
-                            processed_line = line.lower()
-                        else:
-                            processed_line = line
+                    if line.startswith('dn:'):
+                        processed_line = line.lower()
+                    else:
+                        processed_line = line
                 else:
                     processed_line = processed_line[:-1] + line[1:]
 


### PR DESCRIPTION
Bug description:
	While trying to offline reindex a single backend, all backends
	are reindexed. This can introduce un-wanted latencies if one wants to reindex a
	single backend rather than reindexing all backends.

Fix description:
	DB checkpoint disabled for offline reindex
	CLI modified to provide extra reindex options
	DSELidf extended to get backend index attributes

Relates: https://github.com/389ds/389-ds-base/issues/4603

Reviewed by: