### PR TITLE
Issue 4837 - persistent search returns entries even when an error is …

### DIFF
--- a/ldap/servers/plugins/sync/sync_refresh.c
+++ b/ldap/servers/plugins/sync/sync_refresh.c
@@ -213,7 +213,7 @@ sync_srch_refresh_pre_entry(Slapi_PBlock *pb)
         Slapi_Entry *e;
         slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_ENTRY, &e);
         LDAPControl **ctrl = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
-        sync_create_state_control(e, &ctrl[0], LDAP_SYNC_ADD, NULL);
+        rc = sync_create_state_control(e, &ctrl[0], LDAP_SYNC_ADD, NULL);
         slapi_pblock_set(pb, SLAPI_SEARCH_CTRLS, ctrl);
     }
     return (rc);


### PR DESCRIPTION
…returned by content-sync-plugin

Bug description:
	When a ldap client sends a sync request control, the server response may contain a sync state control.
        If the server fails to create the control the search should fail.

Fix description:
	In case the server fails to create the response control
        logs the failure

relates: https://github.com/389ds/389-ds-base/issues/4837

Reviewed by:

Platforms tested: