### PR TITLE
Issue - 4696 - Password hash upgrade on bind

### DIFF
--- a/dirsrvtests/tests/suites/password/pwd_upgrade_on_bind_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_upgrade_on_bind_test.py
@@ -8,32 +8,111 @@
 #
 import ldap
 import pytest
+from lib389.utils import *
 from lib389.topologies import topology_st
 from lib389.idm.user import UserAccounts
-from lib389._constants import (DEFAULT_SUFFIX, PASSWORD)
+from lib389._constants import (DEFAULT_SUFFIX, DN_CONFIG, PASSWORD, DN_DM)
 
 pytestmark = pytest.mark.tier1
 
-def test_password_hash_on_upgrade(topology_st):
+CONFIG_ATTR = 'passwordSendExpiringTime'
+USER_DN = 'uid=tuser,ou=people,{}'.format(DEFAULT_SUFFIX)
+USER_RDN = 'tuser'
+USER_PASSWD = 'secret123'
+USER_ACI = '(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)'
+
+@pytest.fixture
+def add_user(topology_st, request):
+    """Adds a user for binding"""
+
+    log.info('Add the user')
+
+    users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
+    user = users.create(properties={
+        'uid': USER_RDN,
+        'cn': USER_RDN,
+        'sn': USER_RDN,
+        'uidNumber': '3000',
+        'gidNumber': '4000',
+        'homeDirectory': '/home/user',
+        'description': 'd_e_s_c',
+        'userPassword': USER_PASSWD
+    })
+
+    def fin():
+        """Removes the user entry"""
+
+        log.info('Remove the user entry')
+        topology_st.standalone.simple_bind_s(DN_DM, PASSWORD)
+        user.delete()
+
+    request.addfinalizer(fin)
+
+@pytest.fixture
+def global_policy(topology_st, request):
+    """Sets the required global
+    password policy attributes under
+    cn=config entry
+    """
+
+    attrs = {'passwordExp': '',
+             'passwordMaxAge': '',
+             'passwordWarning': '',
+             CONFIG_ATTR: ''}
+
+    log.info('Get the default values')
+    entry = topology_st.standalone.getEntry(DN_CONFIG, ldap.SCOPE_BASE,
+                                            '(objectClass=*)', attrs.keys())
+
+    for key in attrs.keys():
+        attrs[key] = entry.getValue(key)
+
+    log.info('Set the new values')
+    topology_st.standalone.config.replace_many(('passwordExp', 'on'),
+                                               ('passwordMaxAge', '172800'),
+                                               ('passwordWarning', '86400'),
+                                               (CONFIG_ATTR, 'on'))
+
+    def fin():
+        """Resets the defaults"""
+
+        log.info('Reset the defaults')
+        topology_st.standalone.simple_bind_s(DN_DM, PASSWORD)
+        for key in attrs.keys():
+            topology_st.standalone.config.replace(key, attrs[key])
+
+    request.addfinalizer(fin)
+    # A short sleep is required after the modifying password policy or cn=config
+    time.sleep(0.5)
+
+def test_password_hash_on_upgrade(topology_st, global_policy, add_user):
     """If a legacy password hash is present, assert that on a correct bind
     the hash is "upgraded" to the latest-and-greatest hash format on the
     server.
-
+    
     Assert also that password FAILURE does not alter the password.
+    Assert that the password expiration date, history, etc is not modified
+    as password hash upgrade on bind should be invisible to the user.
+
 
     :id: 42cf99e6-454d-46f5-8f1c-8bb699864a07
     :setup: Single instance
     :steps: 1. Set a password hash in SSHA256, and hash to pbkdf2 statically
-            2. Test a faulty bind
-            3. Assert the PW is SSHA256
-            4. Test a correct bind
-            5. Assert the PW is PBKDF2
+            2. Get initial passwordExpirationtime
+            3. Test a faulty bind
+            4. Assert the PW is SSHA256
+            5. Test a correct bind
+            6. Assert the PW is PBKDF2
+            7. Assert the passwordExpirationtime hasnt changed after upgrade on bind
     :expectedresults:
             1. Successfully set the values
-            2. The bind fails
-            3. The PW is SSHA256
-            4. The bind succeeds
-            5. The PW is PBKDF2
+            2. Successfully get the passwordExpirationtime
+            3. The bind fails
+            4. The PW is SSHA256
+            5. The bind succeeds
+            6. The PW is PBKDF2udo
+            7. pwd expiration time hasnt been modifed
+
     """
     # Make sure the server is set to pkbdf
     topology_st.standalone.config.set('passwordStorageScheme', 'PBKDF2_SHA256')
@@ -41,21 +120,31 @@ def test_password_hash_on_upgrade(topology_st):
     topology_st.standalone.config.set('nsslapd-enable-upgrade-hash', 'on')
 
     users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
-    user = users.create_test_user()
+    user = users.get(USER_RDN)
+
     # Static version of "password" in SSHA256.
     user.set('userPassword', "{SSHA256}9eliEQgjfc4Fcj1IXZtc/ne1GRF+OIjz/NfSTX4f7HByGMQrWHLMLA==")
+    ts1 = user.get_attr_val_utf8('passwordExpirationTime')
+
     # Attempt to bind with incorrect password.
     with pytest.raises(ldap.INVALID_CREDENTIALS):
         badconn = user.bind('badpassword')
+
     # Check the pw is SSHA256
     up = user.get_attr_val_utf8('userPassword')
     assert up.startswith('{SSHA256}')
 
-    # Bind with correct.
+    # Bind with correct, trigger update on bind
+    time.sleep(1)
     conn = user.bind(PASSWORD)
+
     # Check the pw is now PBKDF2!
     up = user.get_attr_val_utf8('userPassword')
     assert up.startswith('{PBKDF2_SHA256}')
+
+    # Verify passwordExpirationtime has not been reset ater hash upgrade
+    ts2 = user.get_attr_val_utf8('passwordExpirationTime')
+    assert ts1 == ts2
 
 def test_password_hash_on_upgrade_clearcrypt(topology_st):
     """In some deploymentes, some passwords MAY be in clear or crypt which have

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -1029,7 +1029,7 @@ op_shared_modify(Slapi_PBlock *pb, int pw_change, char *old_pw)
 
                 if (operation_is_flag_set(operation, OP_FLAG_ACTION_LOG_AUDIT))
                     write_audit_log_entry(pb); /* Record the operation in the audit log */
-                
+
                 if (pw_change && (!slapi_be_is_flag_set(be, SLAPI_BE_FLAG_REMOTE_DATA))) {
                     /* update the password info */
                     update_pw_info(pb, old_pw);
@@ -1435,7 +1435,7 @@ optimize_mods(Slapi_Mods *smods)
             (SLAPI_IS_MOD_ADD(prev_mod->mod_op) || SLAPI_IS_MOD_DELETE(prev_mod->mod_op)) &&
             (prev_mod->mod_op == mod->mod_op) &&
             (!strcasecmp(prev_mod->mod_type, mod->mod_type)))
-            {
+        {
             /* Get the current number of mod values from the previous mod.  Do it once per attr */
             if (mod_count == 0) {
                 for (; prev_mod->mod_bvalues != NULL && prev_mod->mod_bvalues[mod_count] != NULL; mod_count++)

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -3568,7 +3568,7 @@ int32_t update_pw_encoding(Slapi_PBlock *orig_pb, Slapi_Entry *e, Slapi_DN *sdn,
                                      NULL,                         /* Controls */
                                      NULL,                         /* UniqueID */
                                      pw_get_componentID(),         /* PluginID */
-                                     OP_FLAG_SKIP_MODIFIED_ATTRS &
+                                     OP_FLAG_SKIP_MODIFIED_ATTRS |
                                      OP_FLAG_ACTION_SKIP_PWDPOLICY);          /* Flags */
     slapi_modify_internal_pb(pb);
 


### PR DESCRIPTION
Description:
	There is an unintended side effect of the "upgrade password
	on bind" feature. It causes the password policy code to be
	engaged and it resets the passwordExpirationtime in the entry.

Fix description:
	Only allow an external password modify operation or an extended
	password modify operation update the password info.

Relates: https://github.com/389ds/389-ds-base/issues/4696

Reviewed by: