### PR TITLE
Fix a poential deadlock bug due to re-acquisition

### DIFF
--- a/ldap/servers/plugins/replication/repl5_replica_config.c
+++ b/ldap/servers/plugins/replication/repl5_replica_config.c
@@ -2196,7 +2196,7 @@ check_replicas_are_done_cleaning(cleanruv_data *data)
             current_time.tv_sec += interval;
             pthread_mutex_lock(&notify_lock);
             pthread_cond_timedwait(&notify_cvar, &notify_lock, &current_time);
-            pthread_mutex_lock(&notify_lock);
+            pthread_mutex_unlock(&notify_lock);
         }
 
         interval *= 2;


### PR DESCRIPTION
Fix a potential deadlock bug due to the re-acquisition on the lock notify_lock. This patch is for issue #4836.