### PR TITLE
Issue 4460 - Fix isLocal and TLS paths discovery

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -942,7 +942,13 @@ class DirSrv(SimpleLDAPObject, object):
 
         if certdir is None and self.isLocal:
             certdir = self.get_cert_dir()
-            self.log.debug("Using dirsrv ca certificate %s", certdir)
+            # If we are trying to manage local instance and admin doesn't have access
+            # to the instance certdir we shouldn't use it.
+            # If we don't set it the python-ldap will pick up the policy from /etc/openldap/ldap.conf
+            if not os.access(ensure_str(certdir), os.R_OK):
+                certdir = None
+            else:
+                self.log.debug("Using dirsrv ca certificate %s", certdir)
 
         if certdir is not None:
             # Note this sets LDAP.OPT not SELF. Because once self has opened


### PR DESCRIPTION
Description: Fix isLocal inconsistency in the 'allocate' code.
And make sure that the certdir (and other TLS paths) are accessible
(has read right) before setting ldap.OPT_X_TLS_*.

Relates: https://github.com/389ds/389-ds-base/issues/4460

Reviewed by: ?