### PR TITLE
Issue 4773 - Extend CI tests for DNA interval assignment

### DIFF
--- a/dirsrvtests/tests/suites/plugins/dna_interval_test.py
+++ b/dirsrvtests/tests/suites/plugins/dna_interval_test.py
@@ -15,15 +15,50 @@ from lib389.plugins import DNAPlugin, DNAPluginConfigs
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.idm.user import UserAccounts
 from lib389.topologies import topology_st
+from lib389.utils import *
 
 pytestmark = pytest.mark.tier1
 
 log = logging.getLogger(__name__)
 
-def test_dna_interval(topology_st):
+
+@pytest.fixture(scope="function")
+def dna_plugin(topology_st, request):
+    inst = topology_st.standalone
+    plugin = DNAPlugin(inst)
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    ou_people = ous.get("People")
+
+    log.info("Add dna plugin config entry...")
+    configs = DNAPluginConfigs(inst, plugin.dn)
+    dna_config = configs.create(properties={'cn': 'dna config',
+                                            'dnaType': 'uidNumber',
+                                            'dnaMaxValue': '1000',
+                                            'dnaMagicRegen': '-1',
+                                            'dnaFilter': '(objectclass=top)',
+                                            'dnaScope': ou_people.dn,
+                                            'dnaNextValue': '10',
+                                            'dnaInterval': '10'})
+
+    log.info("Enable the DNA plugin and restart...")
+    plugin.enable()
+    inst.restart()
+
+    def fin():
+        inst.stop()
+        dse_ldif = DSEldif(inst)
+        dse_ldif.delete_dn(f'cn=dna config,{plugin.dn}')
+        inst.start()
+    request.addfinalizer(fin)
+
+    return dna_config
+
+
+def test_dna_interval(topology_st, dna_plugin):
     """Test the dna interval works
 
     :id: 3982d698-e16b-4945-9eb4-eecaa4bac5f7
+    :customerscenario: True
     :setup: Standalone Instance
     :steps:
         1. Set DNAZZ interval to 10
@@ -39,26 +74,6 @@ def test_dna_interval(topology_st):
         5. Success
     """
 
-    inst = topology_st.standalone
-    plugin = DNAPlugin(inst)
-    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
-    ou_people = ous.get("People")
-
-    log.info("Add dna plugin config entry...")
-    configs = DNAPluginConfigs(inst, plugin.dn)
-    configs.create(properties={'cn': 'dna config',
-                               'dnaType': 'uidNumber',
-                               'dnaMaxValue': '1000',
-                               'dnaMagicRegen': '-1',
-                               'dnaFilter': '(objectclass=top)',
-                               'dnaScope': ou_people.dn,
-                               'dnaNextValue': '10',
-                               'dnaInterval': '10'})
-
-    log.info("Enable the DNA plugin and restart...")
-    plugin.enable()
-    inst.restart()
-
     # Create user and check interval
     log.info("Test DNA is working...")
     users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
@@ -72,7 +87,7 @@ def test_dna_interval(topology_st):
         'givenname': 'interval',
         'homePhone': '0861234567',
         'carLicense': '131D16674',
-        'mail': 'interval@whereever.com',
+        'mail': 'interval@example.com',
         'homeDirectory': '/home/interval'})
 
     # Verify DNA works
@@ -82,3 +97,95 @@ def test_dna_interval(topology_st):
     log.info("Test DNA interval assignment is working...")
     user.replace('uidNumber', '-1')
     assert user.get_attr_val_utf8_l('uidNumber') == '20'
+
+
+def test_dna_max_value(topology_st, dna_plugin):
+    """Test the dna max value works with dna interval
+
+    :id: cc979ea8-3cd0-4d52-af35-9cea7cf8cb5f
+    :customerscenario: True
+    :setup: Standalone Instance
+    :steps:
+        1. Set dnaMaxValue, dnaNextValue, dnaInterval values to 100, 90, 50 respectively
+        2. Create user that trigger DNA to assign a value
+        3. Try to make an update to entry that triggers DNA again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Operation should fail with OPERATIONS_ERROR
+    """
+    log.info("Make the config changes needed to test dnaMaxValue")
+    dna_plugin.replace_many(('dnaMaxValue', '100'), ('dnaNextValue', '90'), ('dnaInterval', '50'))
+    # Create user2
+    users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
+    log.info('Adding user2')
+    user = users.create(properties={
+        'sn': 'interval2',
+        'cn': 'interval2',
+        'uid': 'interval2',
+        'uidNumber': '-1',  # Magic regen value
+        'gidNumber': '222',
+        'givenname': 'interval2',
+        'homePhone': '0861234567',
+        'carLicense': '131D16674',
+        'mail': 'interval2@example.com',
+        'homeDirectory': '/home/interval2'})
+
+    # Verify DNA works
+    assert user.get_attr_val_utf8_l('uidNumber') == '90'
+
+    log.info("Make an update and verify it raises error as the new interval value is more than dnaMaxValue")
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        user.replace('uidNumber', '-1')
+
+
+@pytest.mark.parametrize('attr_value', ('0', 'abc', '2000'))
+def test_dna_interval_with_different_values(topology_st, dna_plugin, attr_value):
+    """Test the dna interval with different values
+
+    :id: 1a3f69fd-1d8d-4046-ba68-b6aa7cafbd37
+    :customerscenario: True
+    :parametrized: yes
+    :setup: Standalone Instance
+    :steps:
+        1. Set dnaInterval value to 0
+        2. Set dnaInterval value to 'abc'
+        3. Set dnaInterval value to 2000 and dnaMaxValue to 1000
+        4. Create user that trigger DNA to assign a value
+        5. Try to make an update to entry that triggers DNA again when dnaInerval is greater than dnaMaxValue
+    :expectedresults:
+        1. Success
+        2. Operation should fail with INVALID_SYNTAX
+        3. Success
+        4. Success
+        5. Operation should fail with OPERATIONS_ERROR
+    """
+    log.info("Make the config changes needed to test dnaInterval")
+    if attr_value == '0':
+        dna_plugin.replace('dnaInterval', attr_value)
+    elif attr_value == 'abc':
+        with pytest.raises(ldap.INVALID_SYNTAX):
+            dna_plugin.replace('dnaInterval', attr_value)
+    else:
+        dna_plugin.replace_many(('dnaInterval', attr_value), ('dnaMaxValue', '1000'))
+    # Create user3
+        users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
+        log.info('Adding user3')
+        user = users.create(properties={
+            'sn': 'interval3',
+            'cn': 'interval3',
+            'uid': 'interval3',
+            'uidNumber': '-1',  # Magic regen value
+            'gidNumber': '333',
+            'givenname': 'interval3',
+            'homePhone': '0861234567',
+            'carLicense': '131D16674',
+            'mail': 'interval3@example.com',
+            'homeDirectory': '/home/interval3'})
+
+        # Verify DNA works
+        assert user.get_attr_val_utf8_l('uidNumber') == '10'
+
+        log.info("Make an update and verify it raises error as the new interval value is more than dnaMaxValue")
+        with pytest.raises(ldap.OPERATIONS_ERROR):
+            user.replace('uidNumber', '-1')

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -203,6 +203,25 @@ class DSEldif(DSLint):
         self._contents[entry_dn_i] = f"dn: {new_dn}\n"
         self._update()
 
+    def delete_dn(self, entry_dn):
+        """Delete the whole entry by DN
+
+        :param entry_dn: a DN of an entry we want to delete
+        :type entry_dn: str
+        """
+
+        entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn.lower()))
+
+        # Find where the entry ends
+        try:
+            dn_end_i = self._contents[entry_dn_i:].index("\n")
+        except ValueError:
+            # We are in the end of the list
+            dn_end_i = len(self._contents)
+
+        del self._contents[entry_dn_i:entry_dn_i+dn_end_i+1]
+        self._update()
+
     def delete(self, entry_dn, attr, value=None):
         """Delete attributes under a given entry
 


### PR DESCRIPTION
Description: Extend CI tests for DNA interval assignment

Relates: https://github.com/389ds/389-ds-base/issues/4773

Reviewed by: ???