### PR TITLE
Issue 4859 - Don't version libns-dshttpd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1077,8 +1077,7 @@ libns_dshttpd_la_SOURCES = lib/libaccess/access_plhash.cpp \
 
 libns_dshttpd_la_CPPFLAGS = -I$(srcdir)/include/base $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) -I$(srcdir)/lib/ldaputil
 libns_dshttpd_la_LIBADD = libslapd.la libldaputil.la $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK)
-# Mark that this is a per version library.
-libns_dshttpd_la_LDFLAGS = -release @PACKAGE_VERSION@
+libns_dshttpd_la_LDFLAGS = $(AM_LDFLAGS)
 
 #------------------------
 # libslapd

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -638,7 +638,7 @@ fi
 %dir %{_libdir}/%{pkgname}
 %{_libdir}/libsvrcore.so.*
 %{_libdir}/%{pkgname}/libslapd.so.*
-%{_libdir}/%{pkgname}/libns-dshttpd-*.so
+%{_libdir}/%{pkgname}/libns-dshttpd.so.*
 %{_libdir}/%{pkgname}/libldaputil.so.*
 %{_libdir}/%{pkgname}/librewriters.so*
 %if %{bundle_jemalloc}


### PR DESCRIPTION
Description:
On every build libns-dshttpd has a version corresponding
to the package version, e.g. libns-dshttpd-2.0.7.so.
It's unnecessary, as we are the only consumers of this library
and we don't change its ABI on every build.
It also triggers rpmdiff test failures that have to be waived on
each build.

Fixes: https://github.com/389ds/389-ds-base/issues/4859

Reviewed by: ???