### PR TITLE
Issue 4096 - Missing perl dependencies for logconv.pl

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -180,6 +180,8 @@ Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $ver
 # Needed by logconv.pl
 Requires:         perl-DB_File
 Requires:         perl-Archive-Tar
+Requires:         perl-debugger
+Requires:         perl-sigtrap
 # Needed for password dictionary checks
 Requires:         cracklib-dicts
 # Picks up our systemd deps.


### PR DESCRIPTION
Bug Description:
On a minimal Fedora install logconv.pl fails to run because of the
missing perl dependencies. These were part of the perl package but in
perl-5.32 they were split into smaller packages.
See https://fedoraproject.org/wiki/Changes/perl5.32

Fix Description:
Add explicit Requires for perl-sigtrap and perl-debugger.

Fixes: https://github.com/389ds/389-ds-base/issues/4096

Reviewed by: ???