### PR TITLE
Issue 4872 - Move entryuuid plugin to subpackage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,13 @@ fi
 AC_SUBST([enable_rust])
 AM_CONDITIONAL([RUST_ENABLE],[test "$enable_rust" = yes -o "$enable_rust_offline" = yes])
 
+# Check is we should add the entryuuid plugin by default
+AC_MSG_CHECKING(for --enable-entryuuid)
+AC_ARG_ENABLE(entryuuid, AS_HELP_STRING([--enable-entryuuid], [Enable the entryuuid plugin (default: no)]),
+              [], [ enable_entryuuid=no ])
+AC_MSG_RESULT($enable_entryuuid)
+AM_CONDITIONAL([ENTRYUUID_AUTOMATIC],[test "$enable_entryuuid" = yes])
+
 # Optional cockpit support (enabled by default)
 AC_MSG_CHECKING(for --enable-cockpit)
 AC_ARG_ENABLE(cockpit, AS_HELP_STRING([--enable-cockpit], [Enable cockpit plugin (default: yes)]),

--- a/dirsrvtests/tests/suites/entryuuid/basic_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/basic_test.py
@@ -8,9 +8,8 @@
 
 import ldap
 import pytest
-import time
 import shutil
-from lib389.idm.user import nsUserAccounts, UserAccounts
+from lib389.idm.user import nsUserAccounts
 from lib389.idm.account import Accounts
 from lib389.idm.domain import Domain
 from lib389.topologies import topology_st as topology
@@ -30,6 +29,13 @@ UUID_BETWEEN = "eeeeeeee-0000-0000-0000-000000000000"
 IMPORT_UUID_B = "f6df8fe9-6b30-46aa-aa13-f0bf755371e8"
 UUID_MIN = "00000000-0000-0000-0000-000000000000"
 UUID_MAX = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+@pytest.fixture(scope="module")
+def _plugin_setup(topology):
+    entryuuid_plugin = EntryUUIDPlugin(topology.standalone)
+    entryuuid_plugin.install()
+    topology.standalone.restart()
 
 def _entryuuid_import_and_search(topology):
     # 1
@@ -72,7 +78,7 @@ def _entryuuid_import_and_search(topology):
 
 
 @pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
-def test_entryuuid_indexed_import_and_search(topology):
+def test_entryuuid_indexed_import_and_search(topology, _plugin_setup):
     """ Test that an ldif of entries containing entryUUID's can be indexed and searched
     correctly. As https://tools.ietf.org/html/rfc4530 states, the MR's are equality and
     ordering, so we check these are correct.
@@ -112,7 +118,7 @@ def test_entryuuid_indexed_import_and_search(topology):
     _entryuuid_import_and_search(topology)
 
 @pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
-def test_entryuuid_unindexed_import_and_search(topology):
+def test_entryuuid_unindexed_import_and_search(topology, _plugin_setup):
     """ Test that an ldif of entries containing entryUUID's can be UNindexed searched
     correctly. As https://tools.ietf.org/html/rfc4530 states, the MR's are equality and
     ordering, so we check these are correct.
@@ -154,7 +160,7 @@ def test_entryuuid_unindexed_import_and_search(topology):
 
 # Test entryUUID generation
 @pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
-def test_entryuuid_generation_on_add(topology):
+def test_entryuuid_generation_on_add(topology, _plugin_setup):
     """ Test that when an entry is added, the entryuuid is added.
 
     :id: a7439b0a-dcee-4cd6-b8ef-771476c0b4f6
@@ -178,7 +184,7 @@ def test_entryuuid_generation_on_add(topology):
 
 # Test fixup task
 @pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
-def test_entryuuid_fixup_task(topology):
+def test_entryuuid_fixup_task(topology, _plugin_setup):
     """Test that when an entries without UUID's can have one generated via
     the fixup process.
 

--- a/dirsrvtests/tests/suites/entryuuid/replicated_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/replicated_test.py
@@ -8,21 +8,30 @@
 
 import ldap
 import pytest
-import logging
 from lib389.topologies import topology_m2 as topo_m2
 from lib389.idm.user import nsUserAccounts
 from lib389.paths import Paths
 from lib389.utils import ds_is_older
 from lib389._constants import *
 from lib389.replica import ReplicationManager
+from lib389.plugins import EntryUUIDPlugin, EntryUUIDSyntaxPlugin
 
 default_paths = Paths()
 
 pytestmark = pytest.mark.tier1
 
-@pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
+@pytest.fixture(scope="module")
+def _plugin_setup(topo_m2):
+    for inst in [topo_m2.ms["supplier1"], topo_m2.ms["supplier2"]]:
+        entryuuid_plugin = EntryUUIDPlugin(inst)
+        entryuuid_plugin.install()
+        entryuuid_syntax_plugin = EntryUUIDSyntaxPlugin(inst)
+        entryuuid_syntax_plugin.install()
+        inst.restart()
 
-def test_entryuuid_with_replication(topo_m2):
+
+@pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
+def test_entryuuid_with_replication(topo_m2, _plugin_setup):
     """ Check that entryuuid works with replication
 
     :id: a5f15bf9-7f63-473a-840c-b9037b787024

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -119,34 +119,6 @@ static const char *internal_entries[] =
         "cn:SNMP\n"
         "nsSNMPEnabled: on\n",
 
-#ifdef RUST_ENABLE
-        "dn: cn=entryuuid_syntax,cn=plugins,cn=config\n"
-        "objectclass: top\n"
-        "objectclass: nsSlapdPlugin\n"
-        "cn: entryuuid_syntax\n"
-        "nsslapd-pluginpath: libentryuuid-syntax-plugin\n"
-        "nsslapd-plugininitfunc: entryuuid_syntax_plugin_init\n"
-        "nsslapd-plugintype: syntax\n"
-        "nsslapd-pluginenabled: on\n"
-        "nsslapd-pluginId: entryuuid_syntax\n"
-        "nsslapd-pluginVersion: none\n"
-        "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: entryuuid_syntax\n",
-
-        "dn: cn=entryuuid,cn=plugins,cn=config\n"
-        "objectclass: top\n"
-        "objectclass: nsSlapdPlugin\n"
-        "cn: entryuuid\n"
-        "nsslapd-pluginpath: libentryuuid-plugin\n"
-        "nsslapd-plugininitfunc: entryuuid_plugin_init\n"
-        "nsslapd-plugintype: betxnpreoperation\n"
-        "nsslapd-pluginenabled: on\n"
-        "nsslapd-pluginId: entryuuid\n"
-        "nsslapd-pluginVersion: none\n"
-        "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: entryuuid\n",
-#endif
-
         "dn: cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"
         "objectclass: nsContainer\n"
@@ -2667,8 +2639,7 @@ void
 add_internal_entries(void)
 {
     /* add the internal only entries */
-    int i;
-    for (i = 0; i < NUM_INTERNAL_ENTRIES; i++) {
+    for (size_t i = 0; i < NUM_INTERNAL_ENTRIES; i++) {
         Slapi_Entry *e;
         char *p;
         p = slapi_ch_strdup(internal_entries[i]);

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -98,7 +98,9 @@ upgrade_AES_reverpwd_plugin(void)
     return uresult;
 }
 
-#ifdef RUST_ENABLE
+
+
+#if defined(RUST_ENABLE) && defined(ENTRYUUID_AUTOMATIC)
 static upgrade_status
 upgrade_143_entryuuid_exists(void)
 {
@@ -109,11 +111,13 @@ upgrade_143_entryuuid_exists(void)
                   "nsslapd-pluginpath: libentryuuid-plugin\n"
                   "nsslapd-plugininitfunc: entryuuid_plugin_init\n"
                   "nsslapd-plugintype: betxnpreoperation\n"
-                  "nsslapd-pluginenabled: on\n"
+                  "nsslapd-pluginenabled: off\n"
                   "nsslapd-pluginId: entryuuid\n"
                   "nsslapd-pluginVersion: none\n"
                   "nsslapd-pluginVendor: 389 Project\n"
                   "nsslapd-pluginDescription: entryuuid\n";
+
+    slapi_log_err(SLAPI_LOG_ALERT, "MARK", "okay adding plugin\n");
 
     return upgrade_entry_exists_or_create(
         "upgrade_143_entryuuid_exists",
@@ -123,6 +127,7 @@ upgrade_143_entryuuid_exists(void)
     );
 }
 #endif
+
 
 static upgrade_status
 upgrade_144_remove_http_client_presence(void)
@@ -229,12 +234,15 @@ upgrade_205_fixup_repl_dep(void)
 upgrade_status
 upgrade_server(void)
 {
-#ifdef RUST_ENABLE
+#if defined(RUST_ENABLE) && defined(ENTRYUUID_AUTOMATIC)
+
     if (upgrade_143_entryuuid_exists() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
 #endif
-
+#ifdef ENTRYUUID_AUTOMATIC
+    slapi_log_err(SLAPI_LOG_ALERT, "MARK", "Ok automatic is set!\n");
+#endif
     if (upgrade_AES_reverpwd_plugin() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -259,6 +259,15 @@ Requires:         systemd-libs
 %description      devel
 Development Libraries and headers for the 389 Directory Server base package.
 
+%if %{use_rust}
+%package          entryuuid
+Summary:          EntryUUID plugin for 389 Directory Server
+Group:            Development/Libraries
+Requires:         %{name} = %{version}-%{release}
+
+%description      entryuuid
+EntryUUID Plugin and Schema for the 389 Directory Server base package.
+%endif
 
 %package          snmp
 Summary:          SNMP Agent for 389 Directory Server
@@ -558,6 +567,29 @@ fi
 %postun snmp
 %systemd_postun_with_restart %{pkgname}-snmp.service
 
+%if %{use_rust}
+%post entryuuid
+# Add the entryuuid plugins
+instbase="%{_sysconfdir}/%{pkgname}"
+ninst=0
+for dir in $instbase/slapd-* ; do
+    if [ ! -d "$dir" ] ; then continue ; fi
+    case "$dir" in *.removed) continue ;; esac
+    basename=`basename $dir`
+    dsctl $basename entryuuid install > /dev/null 2>&1
+done
+
+%postun entryuuid
+# Remove the entryuuid config entries
+instbase="%{_sysconfdir}/%{pkgname}"
+ninst=0
+for dir in $instbase/slapd-* ; do
+    if [ ! -d "$dir" ] ; then continue ; fi
+    case "$dir" in *.removed) continue ;; esac
+    basename=`basename $dir`
+    dsctl $basename entryuuid uninstall > /dev/null 2>&1
+done
+%endif
 
 %files
 %if %{bundle_jemalloc}
@@ -574,6 +606,7 @@ fi
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/slapd-collations.conf
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/certmap.conf
 %{_datadir}/%{pkgname}
+%exclude %{_datadir}/%{pkgname}/schema/03entryuuid.ldif
 %{_datadir}/gdb/auto-load/*
 %{_unitdir}
 %{_bindir}/dbscan
@@ -603,6 +636,7 @@ fi
 %{_libdir}/%{pkgname}/python
 %dir %{_libdir}/%{pkgname}/plugins
 %{_libdir}/%{pkgname}/plugins/*.so
+%exclude %{_libdir}/%{pkgname}/plugins/libentryuuid-plugin*
 # This has to be hardcoded to /lib - $libdir changes between lib/lib64, but
 # sysctl.d is always in /lib.
 %{_prefix}/lib/sysctl.d/*
@@ -645,6 +679,13 @@ fi
 %{_libdir}/%{pkgname}/librewriters.so*
 %if %{bundle_jemalloc}
 %{_libdir}/%{pkgname}/lib/libjemalloc.so.2
+%endif
+
+%if %{use_rust}
+%files entryuuid
+%doc LICENSE LICENSE.GPLv3+
+%{_libdir}/%{pkgname}/plugins/libentryuuid-plugin.so
+%{_datadir}/%{pkgname}/schema/03entryuuid.ldif
 %endif
 
 %files snmp

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -25,6 +25,7 @@ from lib389.cli_ctl import nsstate as cli_nsstate
 from lib389.cli_ctl import dbgen as cli_dbgen
 from lib389.cli_ctl import dsrc as cli_dsrc
 from lib389.cli_ctl import cockpit as cli_cockpit
+from lib389.cli_ctl import entryuuid as cli_entryuuid
 from lib389.cli_ctl.instance import instance_remove_all
 from lib389.cli_base import (
     disconnect_instance,
@@ -63,6 +64,7 @@ cli_health.create_parser(subparsers)
 cli_nsstate.create_parser(subparsers)
 cli_dbgen.create_parser(subparsers)
 cli_dsrc.create_parser(subparsers)
+cli_entryuuid.create_parser(subparsers)
 cli_cockpit.create_parser(subparsers)
 
 argcomplete.autocomplete(parser)

--- a/src/lib389/lib389/cli_ctl/entryuuid.py
+++ b/src/lib389/lib389/cli_ctl/entryuuid.py
@@ -1,0 +1,78 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import os
+from lib389.plugins import EntryUUIDPlugin
+from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
+from lib389._constants import DSRC_HOME
+from lib389.cli_base import connect_instance, disconnect_instance
+
+
+def get_connected_inst(inst, log, args):
+    # update the args for connect_instance()
+    args.basedn = None
+    args.binddn = None
+    args.bindpw = None
+    args.starttls = None
+    args.pwdfile = None
+    args.prompt = False
+    new_inst = inst
+    dsrc_inst = dsrc_to_ldap(DSRC_HOME, args.instance, log.getChild('dsrc'))
+    dsrc_inst = dsrc_arg_concat(args, dsrc_inst)
+    try:
+        new_inst = connect_instance(dsrc_inst=dsrc_inst, verbose=args.verbose, args=args)
+    except Exception:
+        # just assume offline
+        pass
+    return new_inst
+
+def install_plugin(inst, log, args):
+    """Add the plugin entries to cn=config"""
+
+    # This can only be done if the plugin package is installed
+    plugin_dir = inst.get_plugin_dir()
+    if not os.path.exists(plugin_dir + "/libentryuuid-plugin.so"):
+        # Not found
+        raise ValueError("The '389-ds-base-entryuuid' package must be installed before the plugin configuration can be added to the server.")
+
+    inst = get_connected_inst(inst, log, args)
+    entryuuid_plugin = EntryUUIDPlugin(inst)
+    entryuuid_plugin.install()
+
+    disconnect_instance(inst)
+
+    if args.restart:
+        inst.restart()
+
+    log.info("Successfully added the Entry UUID plugin to the configuration.")
+
+
+def uninstall_plugin(inst, log, args):
+    """Remove the entryuuid plugin entries"""
+    inst = get_connected_inst(inst, log, args)
+    entryuuid_plugin = EntryUUIDPlugin(inst)
+    entryuuid_plugin.uninstall()
+    if args.restart:
+        inst.restart()
+
+    log.info("Successfully removed the Entry UUID plugin from the configuration.")
+
+
+def create_parser(subparsers):
+    entryuuid_parser = subparsers.add_parser('entryuuid', help="Manage the EntryUUID plugins")
+    subcommands = entryuuid_parser.add_subparsers(help="action")
+
+    entryuuid_install = subcommands.add_parser('install', help="Create the EntryUUID plugin entry under cn=plugins,cn=config")
+    entryuuid_install.add_argument('--restart', help="Restart the server after adding the Entry UUID plugin",
+                                   default=False, action='store_true')
+    entryuuid_install.set_defaults(func=install_plugin)
+
+    entryuuid_uninstall = subcommands.add_parser('uninstall', help="Remove the EntryUUID plugin entry under cn=plugins,cn=config")
+    entryuuid_uninstall.add_argument('--restart', help="Restart the server after removing the Entry UUID plugin",
+                                     default=False, action='store_true')
+    entryuuid_uninstall.set_defaults(func=uninstall_plugin)

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -8,7 +8,6 @@
 
 import json
 import re
-from lib389._mapped_object import DSLdapObjects
 from lib389._mapped_object_lint import DSLint
 from lib389.cli_base import connect_instance, disconnect_instance
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -667,7 +667,8 @@ def isLocalHost(host_name):
     # first see if this is a "well known" local hostname
     if host_name == 'localhost' or \
        host_name == 'localhost.localdomain' or \
-       host_name == socket.gethostname():
+       host_name == socket.gethostname() or \
+       host_name is None:
         return True
 
     # first lookup ip addr


### PR DESCRIPTION
Bug Description:  

The new EntryUUID Plugin comes with its own schema and syntax plugin, but this does not work with replication and consumer that do not have the entryUUID plugins installed.

Fix Description:  

Move Entry UUID plugins to a subpackage that contains the libraries and the schema file.  Then the admin can choose to install this subpackage once the deployment is all on the required version.

Also fixed a a bug in dseldif.py, where we always stripped the last line of the dse.ldif with every update to the file (from update()).

relates: https://github.com/389ds/389-ds-base/issues/4872
