### PR TITLE
Issue 4872 - BUG - entryuuid enabled by default causes replication issues

### DIFF
--- a/ldap/schema/03entryuuid.ldif
+++ b/ldap/schema/03entryuuid.ldif
@@ -13,4 +13,5 @@ dn: cn=schema
 #
 # attributes
 #
-attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'UUID of the entry' EQUALITY UUIDMatch ORDERING UUIDOrderingMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
+# attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'UUID of the entry' EQUALITY UUIDMatch ORDERING UUIDOrderingMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
+attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'UUID of the entry' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )

--- a/src/lib389/lib389/migrate/plan.py
+++ b/src/lib389/lib389/migrate/plan.py
@@ -443,6 +443,8 @@ class Migration(object):
             '2.5.6.13', # dsa
             '2.5.6.17', # groupOfUniqueNames
             '2.5.6.20', # dmd
+            # This has to be excluded as 389 syntax had an issue in 4872
+            '1.3.6.1.1.16.4',
             # We ignore all of the conflicts/changes from rfc2307 and rfc2307bis
             # as we provide rfc2307compat, which allows both to coexist.
             '1.3.6.1.1.1.1.16', # ipServiceProtocol


### PR DESCRIPTION
Bug Description: Due to older servers missing the syntax
plugin this breaks schema replication and causes cascading
errors.

Fix Description: This changes the syntax to be a case
insensitive string, while leaving the plugins in place
for other usage.

fixes: https://github.com/389ds/389-ds-base/issues/4872

Author: William Brown <william@blackhats.net.au>

Review by: ???