### PR TITLE
Issue 4880: Revert removed_config_49298_test.py wrongly modified by issue 4699

### DIFF
--- a/dirsrvtests/tests/suites/config/removed_config_49298_test.py
+++ b/dirsrvtests/tests/suites/config/removed_config_49298_test.py
@@ -79,8 +79,7 @@ def test_removed_config(topo):
     # We actually can't check the log output, because it can't read dse.ldif,
     # don't know where to write it yet! All we want is the server fail to
     # start here, rather than infinite run + segfault.
-    #with pytest.raises(subprocess.CalledProcessError):
-    with pytest.raises(ValueError):
+    with pytest.raises(subprocess.CalledProcessError):
         topo.standalone.start()
 
     # Restore the files so that setup-ds.l can work


### PR DESCRIPTION
The error that I saw in the PR test was not normal and impacted the gating test this night
git diff showed that test was somehow unwillingly modified.
 I just reverted it out:
  git checkout HEAD~1 removed_config_49298_test.py
  git commit -m "Issue 4880: Revert removed_config_49298_test.py wrongly modified by issue 4699" 
  
 Note: that is a bit worrisome meaning that there was probably a merge issue I will check if there is some other 
  CI tests unexpectedly modified but if we have the same kind of issue on the slapd code it will be hell to find it (due to the amount of changes) 