### PR TITLE
Issue 4875 - CLI - Add some verbosity to installer

### DIFF
--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -542,7 +542,7 @@ class SetupDs(object):
         return True
 
     def _prepare_ds(self, general, slapd, backends):
-
+        self.log.info("Validate installation settings ...")
         assert_c(general['defaults'] is not None, "Configuration defaults in section [general] not found")
         self.log.debug("PASSED: using config settings %s" % general['defaults'])
         # Validate our arguments.
@@ -655,9 +655,9 @@ class SetupDs(object):
         Actually does the setup. this is what you want to call as an api.
         """
 
-        self.log.debug("START: Starting installation...")
+        self.log.debug("START: Starting installation ...")
         if not self.verbose:
-            self.log.info("Starting installation...")
+            self.log.info("Starting installation ...")
 
         # Check we have privs to run
         self.log.debug("READY: Preparing installation for %s...", slapd['instance_name'])
@@ -683,9 +683,9 @@ class SetupDs(object):
 
             # Call the child api to do anything it needs.
             self._install(extra)
-        self.log.debug("FINISH: Completed installation for %s", slapd['instance_name'])
+        self.log.debug("FINISH: Completed installation for instance: slapd-%s", slapd['instance_name'])
         if not self.verbose:
-            self.log.info("Completed installation for %s", slapd['instance_name'])
+            self.log.info("Completed installation for instance: slapd-%s", slapd['instance_name'])
 
         return True
 
@@ -764,6 +764,7 @@ class SetupDs(object):
             )
             file_dse.write(dse_fmt)
 
+        self.log.info("Create file system structures ...")
         # Create all the needed paths
         # we should only need to make bak_dir, cert_dir, config_dir, db_dir, ldif_dir, lock_dir, log_dir, run_dir?
         for path in ('backup_dir', 'cert_dir', 'db_dir', 'ldif_dir', 'lock_dir', 'log_dir', 'run_dir'):
@@ -874,6 +875,7 @@ class SetupDs(object):
             tlsdb.reinit()
 
         if slapd['self_sign_cert']:
+            self.log.info("Create self-signed certificate database ...")
             etc_dirsrv_path = os.path.join(slapd['sysconf_dir'], 'dirsrv/')
             ssca_path = os.path.join(etc_dirsrv_path, 'ssca/')
             ssca = NssSsl(dbpath=ssca_path)
@@ -900,6 +902,7 @@ class SetupDs(object):
 
         # Do selinux fixups
         if general['selinux']:
+            self.log.info("Perform SELinux labeling ...")
             selinux_paths = ('backup_dir', 'cert_dir', 'config_dir', 'db_dir',
                              'ldif_dir', 'lock_dir', 'log_dir',
                              'run_dir', 'schema_dir', 'tmp_dir')
@@ -948,6 +951,7 @@ class SetupDs(object):
         # Create the backends as listed
         # Load example data if needed.
         for backend in backends:
+            self.log.info(f"Create database backend: {backend['nsslapd-suffix']} ...")
             is_sample_entries_in_props = "sample_entries" in backend
             create_suffix_entry_in_props = backend.pop('create_suffix_entry', False)
             ds_instance.backends.create(properties=backend)
@@ -1002,6 +1006,7 @@ class SetupDs(object):
         else:
             self.log.debug("Skipping default SASL maps - no backend found!")
 
+        self.log.info("Perform post-installation tasks ...")
         # Change the root password finally
         ds_instance.config.set('nsslapd-rootpw', slapd['root_password'])
 


### PR DESCRIPTION
Description:  

Previously the installer would basically say "Starting" and "Finished".  If a step would run into a problem it is difficult to narrow down what is going wrong.  So add a little more output during the installation.

relates: https://github.com/389ds/389-ds-base/issues/4875

