### PR TITLE
Issue 4884 - server crashes when dnaInterval attribute is set to zero

### DIFF
--- a/ldap/servers/plugins/dna/dna.c
+++ b/ldap/servers/plugins/dna/dna.c
@@ -1025,7 +1025,14 @@ dna_parse_config_entry(Slapi_PBlock *pb, Slapi_Entry *e, int apply)
 
     value = slapi_entry_attr_get_charptr(e, DNA_INTERVAL);
     if (value) {
+        errno = 0;
         entry->interval = strtoull(value, 0, 0);
+        if (entry->interval == 0 || errno == ERANGE) {
+            slapi_log_err(SLAPI_LOG_WARNING, DNA_PLUGIN_SUBSYSTEM,
+                          "dna_parse_config_entry - Invalid value for dnaInterval (%s), "
+                          "Using default value of 1\n", value);
+            entry->interval = 1;
+        }
         slapi_ch_free_string(&value);
     }
 


### PR DESCRIPTION
Bug Description:

A division by zero crash occurs if the dnaInterval is set to zero

Fix Description:

Validate the config value of dnaInterval and adjust it to the
default/safe value of "1" if needed.

CI test already exists in QE 

relates: https://github.com/389ds/389-ds-base/issues/4884

Reviewed by: ?