### PR TITLE
Issue 4889 - bdb lock deadlock while reindex/import vlv index

### DIFF
--- a/dirsrvtests/tests/suites/basic/vlv.py
+++ b/dirsrvtests/tests/suites/basic/vlv.py
@@ -61,7 +61,7 @@ def check_vlv_search(conn):
         assert i <= imax
         expected_dn = f'uid=testuser{i},ou=People,dc=example,dc=com'
         print(f'found {repr(dn)} expected {expected_dn}')
-        assert dn == expected_dn
+        assert dn.lower() == expected_dn.lower()
         i=i+1
 
 

--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -3149,7 +3149,7 @@ _cl5GetEntryCount(cldb_Handle *cldb)
     case DBI_RC_NOTFOUND:
         cldb->entryCount = 0;
 
-        rc = dblayer_get_entries_count(cldb->be, cldb->db, &cldb->entryCount);
+        rc = dblayer_get_entries_count(cldb->be, cldb->db, NULL, &cldb->entryCount);
         if (rc != 0) {
             slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
                           "_cl5GetEntryCount - Failed to get changelog statistics");

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6853,7 +6853,7 @@ bdb_get_entries_count(dbi_db_t *db, dbi_txn_t *txn, int *count)
     DB_BTREE_STAT *stats = NULL;
     int rc;
 
-    rc = ((DB*)db)->stat(db, (DB_TXN*)txn, (void *)&stats, DB_FAST_STAT);
+    rc = ((DB*)db)->stat(db, (DB_TXN*)txn, (void *)&stats, 0);
     if (rc != 0) {
         slapi_log_err(SLAPI_LOG_ERR, "bdb_get_entries_count",
                       "Failed to get bd statistics: db error - %d %s\n",

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6848,12 +6848,12 @@ bdb_dbi_txn_abort(dbi_txn_t *txn)
 }
 
 int
-bdb_get_entries_count(dbi_db_t *db, int *count)
+bdb_get_entries_count(dbi_db_t *db, dbi_txn_t *txn, int *count)
 {
     DB_BTREE_STAT *stats = NULL;
     int rc;
 
-    rc = ((DB*)db)->stat(db, NULL, (void *)&stats, 0);
+    rc = ((DB*)db)->stat(db, (DB_TXN*)txn, (void *)&stats, DB_FAST_STAT);
     if (rc != 0) {
         slapi_log_err(SLAPI_LOG_ERR, "bdb_get_entries_count",
                       "Failed to get bd statistics: db error - %d %s\n",

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
@@ -137,7 +137,7 @@ void dbmdb_format_dbslist_info(char *info, dbmdb_dbi_t *dbi)
 {
     int nbentries = -1;
     int len = 0;
-    dbmdb_get_entries_count(dbi, &nbentries);
+    dbmdb_get_entries_count(dbi, NULL, &nbentries);
     len = append_flags(info, PATH_MAX, len, "flags", dbi->state.flags, mdb_dbi_flags_desc);
     len = append_flags(info, PATH_MAX, len, " state", dbi->state.state, mdb_state_desc);
     PR_snprintf(info+len, PATH_MAX-len, " dataversion: %d nb_entries=%d", dbi->state.dataversion, nbentries);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2544,14 +2544,13 @@ dbmdb_dbi_txn_abort(dbi_txn_t *txn)
 }
 
 int
-dbmdb_get_entries_count(dbi_db_t *db, int *count)
+dbmdb_get_entries_count(dbi_db_t *db, dbi_txn_t *txn, int *count)
 {
     dbmdb_dbi_t *dbmdb_db = (dbmdb_dbi_t*)db;
-    dbi_txn_t *txn = NULL;
     MDB_stat stats = {0};
     int rc = 0;
 
-    rc = START_TXN(&txn, NULL, MDB_RDONLY);
+    rc = START_TXN(&txn, txn, MDB_RDONLY);
     if (rc == 0)
         rc = mdb_stat(TXN(txn), dbmdb_db->dbi, &stats);
     if (rc == 0)

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -355,10 +355,10 @@ int dblayer_dbi_txn_abort(Slapi_Backend *be, dbi_txn_t *txn)
     return priv->dblayer_dbi_txn_abort_fn(txn);
 }
 
-int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, int *count)
+int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, dbi_txn_t *txn, int *count)
 {
     dblayer_private *priv = dblayer_get_priv(be);
-    return priv->dblayer_get_entries_count_fn(db, count);
+    return priv->dblayer_get_entries_count_fn(db, txn, count);
 }
 
 const char *dblayer_op2str(dbi_op_t op)

--- a/ldap/servers/slapd/back-ldbm/dbimpl.h
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.h
@@ -151,7 +151,7 @@ int dblayer_set_dup_cmp_fn(Slapi_Backend *be, struct attrinfo *a, dbi_dup_cmp_t 
 int dblayer_dbi_txn_begin(Slapi_Backend *be, dbi_env_t *dbenv, int flags, dbi_txn_t *parent_txn, dbi_txn_t **txn);
 int dblayer_dbi_txn_commit(Slapi_Backend *be, dbi_txn_t *txn);
 int dblayer_dbi_txn_abort(Slapi_Backend *be, dbi_txn_t *txn);
-int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, int *count);
+int dblayer_get_entries_count(Slapi_Backend *be, dbi_db_t *db, dbi_txn_t *txn, int *count);
 int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count);
 char *dblayer_get_db_filename(Slapi_Backend *be, dbi_db_t *db);
 const char *dblayer_strerror(int error);

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -108,7 +108,7 @@ typedef int dblayer_set_dup_cmp_fn_t(struct attrinfo *a, dbi_dup_cmp_t idx);
 typedef int dblayer_dbi_txn_begin_fn_t(dbi_env_t *dbenv, PRBool readonly, dbi_txn_t *parent_txn, dbi_txn_t **txn);
 typedef int dblayer_dbi_txn_commit_fn_t(dbi_txn_t *txn);
 typedef int dblayer_dbi_txn_abort_fn_t(dbi_txn_t *txn);
-typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, int *count);
+typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, dbi_txn_t *txn, int *count);
 typedef int dblayer_cursor_get_count_fn_t(dbi_cursor_t *cursor, dbi_recno_t *count);
 typedef int dblayer_private_open_fn_t(backend *be, const char *db_filename, dbi_env_t **env, dbi_db_t **db);
 typedef int dblayer_private_close_fn_t(dbi_env_t **env, dbi_db_t **db);

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -580,7 +580,7 @@ vlvIndex_get_indexlength(backend *be, struct vlvIndex *p, dbi_db_t *db, back_txn
 
     if (!p->vlv_indexlength_cached) {
         PR_Lock(p->vlv_indexlength_lock);
-        err = dblayer_get_entries_count(be, db, &nbentries);
+        err = dblayer_get_entries_count(be, db, txn->back_txn_txn, &nbentries);
         if (err == 0) {
             p->vlv_indexlength_cached = 1;
             p->vlv_indexlength = nbentries;

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -580,7 +580,7 @@ vlvIndex_get_indexlength(backend *be, struct vlvIndex *p, dbi_db_t *db, back_txn
 
     if (!p->vlv_indexlength_cached) {
         PR_Lock(p->vlv_indexlength_lock);
-        err = dblayer_get_entries_count(be, db, txn->back_txn_txn, &nbentries);
+        err = dblayer_get_entries_count(be, db, (txn ? txn->back_txn_txn : NULL), &nbentries);
         if (err == 0) {
             p->vlv_indexlength_cached = 1;
             p->vlv_indexlength = nbentries;


### PR DESCRIPTION
Description:
   suites/basic test_vlv  hangs in bdb locks while calling _db_stat because thread start a write txn and perform some operation then call db_stat without txn (trying to get a lock it already own)

Solution:
Propagate the txn up to the db->stat call

FYI :mdb had a generic way to handle that case ( a thread only open a single txn (or a sub txn) but there are never two non related txn) 

Issue: 4889 

Reviewed by:   ???