### PR TITLE
Issue 4901 - Add COPR integration

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,13 @@
+srpm:
+	# Generate spec file
+	make -f rpm.mk rpmroot
+	# Install build dependencies
+	dnf install -y dnf-plugins-core
+	dnf builddep -y --skip-broken --spec rpmbuild/SPECS/389-ds-base.spec --best --allowerasing --setopt=install_weak_deps=False
+	# Generate srpm
+	make -f rpm.mk srpms
+	
+	if [[ "${outdir}" != "" ]]; then \
+	        mv dist/srpms/* ${outdir}; \
+	fi
+


### PR DESCRIPTION
Description:
Fedora COPR supports automatic rebuilds from SCM:
https://docs.pagure.org/copr.copr/user_documentation.html#scm
And GitHub webhooks to automatically trigger builds:
https://docs.pagure.org/copr.copr/user_documentation.html#github-webhooks

Fixes: https://github.com/389ds/389-ds-base/issues/4901

Reviewed by: ???