### PR TITLE
Issue 4894 - IPA failure in ipa user-del --preserve

### DIFF
--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1330,7 +1330,7 @@ preop_modrdn(Slapi_PBlock *pb)
      * determining which managed tree this belongs to
      */
     if (!destinationSDN)
-        destinationSDN = sourceSDN;
+        slapi_sdn_get_parent(sourceSDN, destinationSDN);
 
     /* Get the new RDN - this has the attribute values */
     err = slapi_pblock_get(pb, SLAPI_MODRDN_NEWRDN, &rdn);


### PR DESCRIPTION
Bug Description: Starting with 389-ds 2.0.8 on rawhide,
any call to ipa user-del --preserve fails with
This entry already exists.

Fix Description: We should split 'dn' parameter in searchAllSubtrees
into parent and target. As one of them is used for excluding the
subtree checks and another one for searching.

Fixes: https://github.com/389ds/389-ds-base/issues/4763

Reviewed by: ?