### PR TITLE
Issue 4916 - Memory leak in ldap-agent

### DIFF
--- a/ldap/servers/snmp/main.c
+++ b/ldap/servers/snmp/main.c
@@ -101,6 +101,7 @@ main(int argc, char *argv[])
     }
 
     load_config(config_file);
+    free(config_file);
 
     /* check if we're already running as another process */
     if ((pid_fp = fopen(pidfile, "r")) != NULL) {


### PR DESCRIPTION
Description:
Fix minor memory leak in ldap-agent to make AddressSanitizer happy.

Fixes: https://github.com/389ds/389-ds-base/issues/4916

Reviewed by: ???