### PR TITLE
Issue 4678 - RFE automatique disable of virtual attribute checking

### DIFF
--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -355,7 +355,7 @@ def test_ignore_virtual_attrs(topo):
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
-         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF
+         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON
          3. Set the valid values i.e. on/ON and off/OFF for nsslapd-ignore-virtual-attrs
          4. Set invalid value for attribute nsslapd-ignore-virtual-attrs
          5. Set nsslapd-ignore-virtual-attrs=off
@@ -378,8 +378,8 @@ def test_ignore_virtual_attrs(topo):
     log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
     assert topo.standalone.config.present('nsslapd-ignore-virtual-attrs')
 
-    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF")
-    assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "off"
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON")
+    assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
 
     log.info("Set the valid values i.e. on/ON and off/OFF for nsslapd-ignore-virtual-attrs")
     for attribute_value in ['on', 'off', 'ON', 'OFF']:
@@ -419,6 +419,40 @@ def test_ignore_virtual_attrs(topo):
     log.info("Test if virtual attribute i.e. postal code not shown while nsslapd-ignore-virtual-attrs: on")
     assert not test_user.present('postalcode', '117')
 
+def test_ignore_virtual_attrs_after_restart(topo):
+    """Test nsslapd-ignore-virtual-attrs configuration attribute
+       The attribute is ON by default. If it set to OFF, it keeps
+       its value on restart
+
+    :id: ac368649-4fda-473c-9ef8-e0c728b162af
+    :setup: Standalone instance
+    :steps:
+         1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
+         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON
+         3. Set nsslapd-ignore-virtual-attrs=off
+         4. restart the instance
+         5. Check the attribute nsslapd-ignore-virtual-attrs is OFF
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+    """
+
+    log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
+    assert topo.standalone.config.present('nsslapd-ignore-virtual-attrs')
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON")
+    assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    log.info("Set nsslapd-ignore-virtual-attrs = off")
+    topo.standalone.config.set('nsslapd-ignore-virtual-attrs', 'off')
+
+    topo.standalone.restart()
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF")
+    assert topo.standalone.config.present('nsslapd-ignore-virtual-attrs', 'off')
 
 @pytest.mark.bz918694
 @pytest.mark.ds408

--- a/ldap/servers/plugins/roles/roles_cache.c
+++ b/ldap/servers/plugins/roles/roles_cache.c
@@ -530,6 +530,15 @@ roles_cache_trigger_update_role(char *dn, Slapi_Entry *roles_entry, Slapi_DN *be
     }
 
     slapi_rwlock_unlock(global_lock);
+    {
+        /* A role definition has been updated, enable vattr handling */
+        char errorbuf[SLAPI_DSE_RETURNTEXT_SIZE];
+        errorbuf[0] = '\0';
+        config_set_ignore_vattrs(CONFIG_IGNORE_VATTRS, "off", errorbuf, 1);
+        slapi_log_err(SLAPI_LOG_INFO,
+                      "roles_cache_trigger_update_role",
+                      "Because of virtual attribute definition (role), %s was set to 'off'\n", CONFIG_IGNORE_VATTRS);
+    }
 
     slapi_log_err(SLAPI_LOG_PLUGIN, ROLES_PLUGIN_SUBSYSTEM, "<-- roles_cache_trigger_update_role: %p \n", roles_list);
 }

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1807,7 +1807,7 @@ FrontendConfig_init(void)
     init_ndn_cache_enabled = cfg->ndn_cache_enabled = LDAP_ON;
     cfg->ndn_cache_max_size = SLAPD_DEFAULT_NDN_SIZE;
     init_sasl_mapping_fallback = cfg->sasl_mapping_fallback = LDAP_OFF;
-    init_ignore_vattrs = cfg->ignore_vattrs = LDAP_OFF;
+    init_ignore_vattrs = cfg->ignore_vattrs = LDAP_ON;
     cfg->sasl_max_bufsize = SLAPD_DEFAULT_SASL_MAXBUFSIZE;
     cfg->unhashed_pw_switch = SLAPD_DEFAULT_UNHASHED_PW_SWITCH;
     init_return_orig_type = cfg->return_orig_type = LDAP_OFF;

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -1062,6 +1062,8 @@ main(int argc, char **argv)
         eq_start(); /* must be done after plugins started - DEPRECATED */
         eq_start_rel(); /* must be done after plugins started */
 
+        vattr_check(); /* Check if it exists virtual attribute definitions */
+
 #ifdef HPUX10
         /* HPUX linker voodoo */
         if (collation_init == NULL) {

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1465,6 +1465,7 @@ void subentry_create_filter(Slapi_Filter **filter);
  */
 void vattr_init(void);
 void vattr_cleanup(void);
+void vattr_check(void);
 
 /*
  * slapd_plhash.c - supplement to NSPR plhash

--- a/src/lib389/lib389/idm/role.py
+++ b/src/lib389/lib389/idm/role.py
@@ -252,6 +252,8 @@ class FilteredRole(Role):
         self._rdn_attribute = 'cn'
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsFilteredRoleDefinition']
 
+        self._protected = False
+
 
 
 class FilteredRoles(Roles):
@@ -285,6 +287,7 @@ class ManagedRole(Role):
         self._rdn_attribute = 'cn'
         self._create_objectclasses = ['nsSimpleRoleDefinition', 'nsManagedRoleDefinition']
 
+        self._protected = False
 
 class ManagedRoles(Roles):
     """DSLdapObjects that represents all Managed Roles entries
@@ -320,6 +323,7 @@ class NestedRole(Role):
         self._rdn_attribute = 'cn'
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsNestedRoleDefinition']
 
+        self._protected = False
 
 class NestedRoles(Roles):
     """DSLdapObjects that represents all NestedRoles entries in suffix.


### PR DESCRIPTION
Bug description:
	Virtual attributes are configured via Roles or COS definitions
        and registered during initialization of those plugins.
	Virtual attributes are processed during search evaluation of
	filter and returned attributes. This processing is expensive
	and prone to create contention between searches.
	Use of virtual attribute is not frequent. So many of the
	deployement process virtual attribute even if there is none.

Fix description:
	The fix configure the server to ignore virtual attribute by
        default (nsslapd-ignore-virtual-attrs: on).
        At startup, if a new virtual attribute is registered or
        it exists Roles/COS definitions, then the server is
	configured to process the virtual attributes
        (nsslapd-ignore-virtual-attrs: off)
        design: https://www.port389.org/docs/389ds/design/vattr-automatic-toggle.html

relates: https://github.com/389ds/389-ds-base/issues/4678

Reviewed by: ?

Platforms tested: F34