### PR TITLE
Issue 4847 - BUG - potential deadlock in replica

### DIFF
--- a/ldap/servers/plugins/replication/repl5_replica_config.c
+++ b/ldap/servers/plugins/replication/repl5_replica_config.c
@@ -2196,7 +2196,7 @@ check_replicas_are_done_cleaning(cleanruv_data *data)
             current_time.tv_sec += interval;
             pthread_mutex_lock(&notify_lock);
             pthread_cond_timedwait(&notify_cvar, &notify_lock, &current_time);
-            pthread_mutex_lock(&notify_lock);
+            pthread_mutex_unlock(&notify_lock);
         }
 
         interval *= 2;


### PR DESCRIPTION
Bug Description: There was an incorrect double lock in
repl5_replica_config.c

Fix Description: Replace the incorrect lock with and unlock.

fixes: https://github.com/389ds/389-ds-base/issues/4847

Author: jenny <@jenny-cheung>

Review by: @firstyear @droideck