### PR TITLE
Issue 4925 - Performance ACI: targetfilter evaluation result can be r…

### DIFF
--- a/ldap/servers/plugins/acl/acl.h
+++ b/ldap/servers/plugins/acl/acl.h
@@ -407,6 +407,17 @@ struct aci_container
 };
 typedef struct aci_container AciContainer;
 
+/* This structure is stored in the aclpb.
+ * It is a linked list containing the result of
+ * the filter matching against a specific entry.
+ *
+ * This list is free for each new entry in the aclpb*/
+struct targetfilter_cached_result {
+    char *filter;                            /* strdup of string representation of aci->targetFilter */
+    int matching_result;                     /* 0 does not match / 1 does match */
+    struct targetfilter_cached_result *next; /* next targetfilter already evaluated */
+};
+
 struct acl_pblock
 {
     int aclpb_state;
@@ -476,6 +487,8 @@ struct acl_pblock
 
     /* Current entry/dn/attr evaluation info */
     Slapi_Entry *aclpb_curr_entry; /* current Entry being processed */
+    int32_t targetfilter_cache_enabled;
+    struct targetfilter_cached_result *aclpb_curr_entry_targetfilters;
     int aclpb_num_entries;
     Slapi_DN *aclpb_curr_entry_sdn;    /* Entry's SDN */
     Slapi_DN *aclpb_authorization_sdn; /* dn used for authorization */
@@ -723,6 +736,7 @@ void acl_modified(Slapi_PBlock *pb, int optype, Slapi_DN *e_sdn, void *change);
 
 int acl_access_allowed_disjoint_resource(Slapi_PBlock *pb, Slapi_Entry *e, char *attr, struct berval *val, int access);
 int acl_access_allowed_main(Slapi_PBlock *pb, Slapi_Entry *e, char **attrs, struct berval *val, int access, int flags, char **errbuf);
+void targetfilter_cache_free(struct acl_pblock *aclpb);
 int acl_access_allowed(Slapi_PBlock *pb, Slapi_Entry *e, char *attr, struct berval *val, int access);
 aclUserGroup *acl_get_usersGroup(struct acl_pblock *aclpb, char *n_dn);
 void acl_print_acllib_err(NSErr_t *errp, char *str);

--- a/ldap/servers/plugins/acl/acl_ext.c
+++ b/ldap/servers/plugins/acl/acl_ext.c
@@ -187,6 +187,11 @@ acl_operation_ext_constructor(void *object __attribute__((unused)), void *parent
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "acl_operation_ext_constructor - Operation extension allocation Failed\n");
     }
+    /* targetfilter_cache toggle set during aclpb allocation
+     * to avoid accessing configuration during the evaluation
+     * of each aci
+     */
+    aclpb->targetfilter_cache_enabled = config_get_targetfilter_cache();
 
     TNF_PROBE_0_DEBUG(acl_operation_ext_constructor_end, "ACL", "");
 
@@ -711,6 +716,7 @@ acl__free_aclpb(Acl_PBlock **aclpb_ptr)
     slapi_ch_free((void **)&(aclpb->aclpb_curr_entryEval_context.acle_handles_matched_target));
     slapi_ch_free((void **)&(aclpb->aclpb_prev_entryEval_context.acle_handles_matched_target));
     slapi_ch_free((void **)&(aclpb->aclpb_prev_opEval_context.acle_handles_matched_target));
+    targetfilter_cache_free(aclpb);
     slapi_sdn_free(&aclpb->aclpb_authorization_sdn);
     slapi_sdn_free(&aclpb->aclpb_curr_entry_sdn);
     if (aclpb->aclpb_macro_ht) {
@@ -918,6 +924,12 @@ acl__done_aclpb(struct acl_pblock *aclpb)
                       aclpb->aclpb_proplist ? (char *)aclpb->aclpb_proplist : "NULL",
                       aclpb->aclpb_acleval ? (char *)aclpb->aclpb_acleval : "NULL");
     }
+
+    /* This aclpb return to the aclpb pool, make sure
+     * the cached evaluations are freed and that
+     * aclpb_curr_entry_targetfilters is NULL
+     */
+    targetfilter_cache_free(aclpb);
 
     /* Now Free the contents or clean it */
     slapi_sdn_done(aclpb->aclpb_curr_entry_sdn);

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -211,6 +211,7 @@ slapi_onoff_t init_return_exact_case;
 slapi_onoff_t init_result_tweak;
 slapi_onoff_t init_plugin_track;
 slapi_onoff_t init_moddn_aci;
+slapi_onoff_t init_targetfilter_cache;
 slapi_onoff_t init_lastmod;
 slapi_onoff_t init_readonly;
 slapi_onoff_t init_accesscontrol;
@@ -822,6 +823,11 @@ static struct config_get_and_set
      (void **)&global_slapdFrontendConfig.moddn_aci,
      CONFIG_ON_OFF, (ConfigGetFunc)config_get_moddn_aci,
      &init_moddn_aci},
+    {CONFIG_TARGETFILTER_CACHE_ATTRIBUTE, config_set_targetfilter_cache,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.targetfilter_cache,
+     CONFIG_ON_OFF, (ConfigGetFunc)config_get_targetfilter_cache,
+     &init_targetfilter_cache},
     {CONFIG_ATTRIBUTE_NAME_EXCEPTION_ATTRIBUTE, config_set_attrname_exceptions,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.attrname_exceptions,
@@ -1567,6 +1573,7 @@ FrontendConfig_init(void)
     init_syntaxcheck = cfg->syntaxcheck = LDAP_ON;
     init_plugin_track = cfg->plugin_track = LDAP_OFF;
     init_moddn_aci = cfg->moddn_aci = LDAP_ON;
+    init_targetfilter_cache = cfg->targetfilter_cache = LDAP_ON;
     init_syntaxlogging = cfg->syntaxlogging = LDAP_OFF;
     init_dn_validate_strict = cfg->dn_validate_strict = LDAP_OFF;
     init_ds4_compatible_schema = cfg->ds4_compatible_schema = LDAP_OFF;
@@ -3526,6 +3533,21 @@ config_set_moddn_aci(const char *attrname, char *value, char *errorbuf, int appl
 }
 
 int32_t
+config_set_targetfilter_cache(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int32_t retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    retVal = config_set_onoff(attrname,
+                              value,
+                              &(slapdFrontendConfig->targetfilter_cache),
+                              errorbuf,
+                              apply);
+
+    return retVal;
+}
+
+int32_t
 config_set_dynamic_plugins(const char *attrname, char *value, char *errorbuf, int apply)
 {
     int32_t retVal = LDAP_SUCCESS;
@@ -5332,6 +5354,13 @@ config_get_moddn_aci(void)
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     return slapi_atomic_load_32(&(slapdFrontendConfig->moddn_aci), __ATOMIC_ACQUIRE);
+}
+
+int32_t
+config_get_targetfilter_cache(void)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    return slapi_atomic_load_32(&(slapdFrontendConfig->targetfilter_cache), __ATOMIC_ACQUIRE);
 }
 
 int32_t

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -262,6 +262,7 @@ int config_set_lastmod(const char *attrname, char *value, char *errorbuf, int ap
 int config_set_nagle(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesscontrol(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_moddn_aci(const char *attrname, char *value, char *errorbuf, int apply);
+int32_t config_set_targetfilter_cache(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_security(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_readonly(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_schemacheck(const char *attrname, char *value, char *errorbuf, int apply);
@@ -450,6 +451,7 @@ int config_get_accesscontrol(void);
 int config_get_return_exact_case(void);
 int config_get_result_tweak(void);
 int config_get_moddn_aci(void);
+int32_t config_get_targetfilter_cache(void);
 int config_get_security(void);
 int config_get_schemacheck(void);
 int config_get_syntaxcheck(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2157,6 +2157,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_REWRITE_RFC1274_ATTRIBUTE "nsslapd-rewrite-rfc1274"
 #define CONFIG_PLUGIN_BINDDN_TRACKING_ATTRIBUTE "nsslapd-plugin-binddn-tracking"
 #define CONFIG_MODDN_ACI_ATTRIBUTE "nsslapd-moddn-aci"
+#define CONFIG_TARGETFILTER_CACHE_ATTRIBUTE "nsslapd-targetfilter-cache"
 #define CONFIG_GLOBAL_BACKEND_LOCK "nsslapd-global-backend-lock"
 #define CONFIG_ENABLE_NUNC_STANS "nsslapd-enable-nunc-stans"
 #define CONFIG_CONFIG_ATTRIBUTE "nsslapd-config"
@@ -2315,6 +2316,7 @@ typedef struct _slapdFrontendConfig
     char **plugin;
     slapi_onoff_t plugin_track;
     slapi_onoff_t moddn_aci;
+    slapi_onoff_t targetfilter_cache;
     struct pw_scheme *pw_storagescheme;
     slapi_onoff_t pwpolicy_local;
     slapi_onoff_t pw_is_global_policy;


### PR DESCRIPTION
…eused (#4926)

Bug description:
	An ACI may contain targetfilter. For a given returned entry, of a
        SRCH request, the same targetfilter is evaluated for each of the
        returned attributes.
        Once the filter has been evaluated, it is useless to reevaluate
        it for a next attribute.

Fix description:
	The fix implements a very simple cache (linked list) that keeps
        the results of the previously evaluated 'targetfilter'.
        This cache is per-entry. For an operation, a aclpb is allocated
        that is used to evaluate ACIs against each successive entry.
        Each time a candidate entry is added in the aclpb
        (acl_access_allowed), the cache (aclpb_curr_entry_targetfilters)
        is freed. Then for each 'targetfilter', the original targetfilter
        is lookup from the cache. If this is the first evaluation of it
        then the result of the evaluation is stored into the cache using
        the original targetfilter as the key in the cache

	The key to lookup/store the cache is the string representation
        of the targetfilter. The string contains a redzone to detect
        that the filter exceeds the maximum size (2K). If it exceeds
        then the key is invalid and the lookup/store is noop.

relates: #4925

Reviewed by: Mark Reynolds, William Brown (Thanks)

Platforms tested: F34