### PR TITLE
Issue 4312 - performance search rate: contention on global monitoring…

### DIFF
--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -77,7 +77,7 @@ do_add(Slapi_PBlock *pb)
     ber = operation->o_ber;
 
     /* count the add request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsAddEntryOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsAddEntryOps);
 
     /*
      * Parse the add request.  It looks like this:

--- a/ldap/servers/slapd/compare.c
+++ b/ldap/servers/slapd/compare.c
@@ -67,7 +67,7 @@ do_compare(Slapi_PBlock *pb)
     ber = pb_op->o_ber;
 
     /* count the compare request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsCompareOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsCompareOps);
 
     /*
      * Parse the compare request.  It looks like this:

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -28,7 +28,7 @@
 #endif
 
 typedef Connection work_q_item;
-static void connection_threadmain(void);
+static void connection_threadmain(void *arg);
 static void connection_add_operation(Connection *conn, Operation *op);
 static void connection_free_private_buffer(Connection *conn);
 static void op_copy_identity(Connection *conn, Operation *op);
@@ -277,8 +277,8 @@ connection_reset(Connection *conn, int ns, PRNetAddr *from, int fromLen __attrib
     conn->c_connid = slapi_counter_increment(num_conns);
 
     if (!in_referral_mode) {
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsConnectionSeq);
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsConnections);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsConnectionSeq);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsConnections);
     }
 
     /*
@@ -429,6 +429,7 @@ init_op_threads()
     pthread_condattr_t condAttr;
     int32_t max_threads = config_get_threadnumber();
     int32_t rc;
+    int32_t *threads_indexes;
 
     /* Initialize the locks and cv */
     if ((rc = pthread_mutex_init(&work_q_lock, NULL)) != 0) {
@@ -457,12 +458,20 @@ init_op_threads()
 
     work_q_stack = PR_CreateStack("connection_work_q");
     op_stack = PR_CreateStack("connection_operation");
+    alloc_per_thread_snmp_vars(max_threads);
+    init_thread_private_snmp_vars();
+    
 
+    threads_indexes = (int32_t *) slapi_ch_calloc(max_threads, sizeof(int32_t));
+    for (size_t i = 0; i < max_threads; i++) {
+        threads_indexes[i] = i + 1; /* idx 0 is reserved for global snmp_vars */
+    }
+    
     /* start the operation threads */
     for (size_t i = 0; i < max_threads; i++) {
         PR_SetConcurrency(4);
         if (PR_CreateThread(PR_USER_THREAD,
-                            (VFP)(void *)connection_threadmain, NULL,
+                            (VFP)(void *)connection_threadmain, (void *) &threads_indexes[i],
                             PR_PRIORITY_NORMAL, PR_GLOBAL_THREAD,
                             PR_UNJOINABLE_THREAD,
                             SLAPD_DEFAULT_THREAD_STACKSIZE) == NULL) {
@@ -474,6 +483,10 @@ init_op_threads()
             g_incr_active_threadcnt();
         }
     }
+    /* Here we should free thread_indexes, but because of the dynamic of the new
+     * threads (connection_threadmain) we are not sure when it can be freed.
+     * Let's accept that unique initialization leak (typically 32 to 64 bytes)
+     */
 }
 
 static void
@@ -1477,9 +1490,10 @@ connection_enter_leave_turbo(Connection *conn, int current_turbo_flag, int *new_
 }
 
 static void
-connection_threadmain()
+connection_threadmain(void *arg)
 {
     Slapi_PBlock *pb = slapi_pblock_new();
+    int32_t *snmp_vars_idx = (int32_t *) arg;
     /* wait forever for new pb until one is available or shutdown */
     int32_t interval = 0; /* used be  10 seconds */
     Connection *conn = NULL;
@@ -1497,6 +1511,7 @@ connection_threadmain()
     /* Arrange to ignore SIGPIPE signals. */
     SIGNAL(SIGPIPE, SIG_IGN);
 #endif
+    thread_private_snmp_vars_set_idx(*snmp_vars_idx);
 
     while (1) {
         int is_timedout = 0;
@@ -1598,8 +1613,8 @@ connection_threadmain()
             }
             pthread_mutex_unlock(&(conn->c_mutex));
             if (!config_check_referral_mode()) {
-                slapi_counter_increment(ops_initiated);
-                slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsInOps);
+                slapi_counter_increment(g_get_per_thread_snmp_vars()->server_tbl.dsOpInitiated);
+                slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsInOps);
             }
         }
         /* Once we're here we have a pb */
@@ -1791,7 +1806,7 @@ connection_threadmain()
             connection_make_readable_nolock(conn);
             conn->c_threadnumber--;
             slapi_counter_decrement(conns_in_maxthreads);
-            slapi_counter_decrement(g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
+            slapi_counter_decrement(g_get_per_thread_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
             connection_release_nolock(conn);
             pthread_mutex_unlock(&(conn->c_mutex));
             signal_listner();
@@ -1808,7 +1823,7 @@ connection_threadmain()
         /* number of ops on this connection */
         PR_AtomicIncrement(&conn->c_opscompleted);
         /* total number of ops for the server */
-        slapi_counter_increment(ops_completed);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->server_tbl.dsOpCompleted);
         /* If this op isn't a persistent search, remove it */
         if (op->o_flags & OP_FLAG_PS) {
             /* Release the connection (i.e. decrease refcnt) at the condition
@@ -1870,7 +1885,7 @@ connection_threadmain()
                     if (conn->c_threadnumber == maxthreads) {
                         conn->c_flags &= ~CONN_FLAG_MAX_THREADS;
                         slapi_counter_decrement(conns_in_maxthreads);
-                        slapi_counter_decrement(g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
+                        slapi_counter_decrement(g_get_per_thread_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
                     }
                     conn->c_threadnumber--;
                     connection_release_nolock(conn);
@@ -1916,8 +1931,8 @@ connection_activity(Connection *conn, int maxthreads)
         conn->c_maxthreadscount++;
         slapi_counter_increment(max_threads_count);
         slapi_counter_increment(conns_in_maxthreads);
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsMaxThreadsHits);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsMaxThreadsHits);
     }
     op_stack_obj = connection_get_operation();
     connection_add_operation(conn, op_stack_obj->op);
@@ -1926,8 +1941,8 @@ connection_activity(Connection *conn, int maxthreads)
     add_work_q((work_q_item *)conn, op_stack_obj);
 
     if (!config_check_referral_mode()) {
-        slapi_counter_increment(ops_initiated);
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsInOps);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->server_tbl.dsOpInitiated);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsInOps);
     }
     return 0;
 }
@@ -2298,7 +2313,7 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
         }
 
         if (!config_check_referral_mode()) {
-            slapi_counter_decrement(g_get_global_snmp_vars()->ops_tbl.dsConnections);
+            slapi_counter_decrement(g_get_per_thread_snmp_vars()->ops_tbl.dsConnections);
         }
 
         conn->c_gettingber = 0;

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -972,6 +972,11 @@ slapd_daemon(daemon_ports_t *ports)
 
     init_op_threads();
 
+    /* Start the SNMP collator if counters are enabled. */
+    if (config_get_slapi_counters()) {
+        snmp_collator_start();
+    }
+
     /*
      *  If we are monitoring disk space, then create the mutex, the cvar,
      *  and the monitoring thread.

--- a/ldap/servers/slapd/defbackend.c
+++ b/ldap/servers/slapd/defbackend.c
@@ -185,7 +185,7 @@ defbackend_bind(Slapi_PBlock *pb)
     slapi_pblock_get(pb, SLAPI_BIND_METHOD, &method);
     slapi_pblock_get(pb, SLAPI_BIND_CREDENTIALS, &cred);
     if (method == LDAP_AUTH_SIMPLE && cred->bv_len == 0) {
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsAnonymousBinds);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsAnonymousBinds);
         rc = SLAPI_BIND_ANONYMOUS;
     } else {
         slapi_pblock_set(pb, SLAPI_PB_RESULT_TEXT, DEFBE_NO_SUCH_SUFFIX);

--- a/ldap/servers/slapd/delete.c
+++ b/ldap/servers/slapd/delete.c
@@ -49,7 +49,7 @@ do_delete(Slapi_PBlock *pb)
     ber = operation->o_ber;
 
     /* count the delete request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsRemoveEntryOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsRemoveEntryOps);
 
     /*
      * Parse the delete request.  It looks like this:

--- a/ldap/servers/slapd/globals.c
+++ b/ldap/servers/slapd/globals.c
@@ -46,8 +46,6 @@ Slapi_PBlock *repl_pb = NULL;
 /*
  * global variables that need mutex protection
  */
-Slapi_Counter *ops_initiated;
-Slapi_Counter *ops_completed;
 Slapi_Counter *num_conns;
 Slapi_Counter *max_threads_count;
 Slapi_Counter *conns_in_maxthreads;
@@ -75,18 +73,10 @@ set_entry_points()
     /* To apply the nsslapd-counters config value properly,
        these values are initialized here after config file is read */
     if (config_get_slapi_counters()) {
-        ops_initiated = slapi_counter_new();
-        ops_completed = slapi_counter_new();
         max_threads_count = slapi_counter_new();
         conns_in_maxthreads = slapi_counter_new();
-        g_set_num_entries_sent(slapi_counter_new());
-        g_set_num_bytes_sent(slapi_counter_new());
     } else {
-        ops_initiated = NULL;
-        ops_completed = NULL;
         max_threads_count = NULL;
         conns_in_maxthreads = NULL;
-        g_set_num_entries_sent(NULL);
-        g_set_num_bytes_sent(NULL);
     }
 }

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1877,6 +1877,124 @@ g_get_slapd_security_on(void)
 }
 
 static struct snmp_vars_t global_snmp_vars;
+static PRUintn thread_private_snmp_vars_idx;
+/*
+ * https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR/Reference/PR_NewThreadPrivateIndex
+ * It is called each time:
+ *  - PR_SetThreadPrivate is called with a not NULL private value
+ *  - on thread exit
+ */
+static void
+snmp_vars_idx_free(void *ptr)
+{
+    int *idx = ptr;
+    if (idx) {
+        slapi_ch_free((void **)&idx);
+    }
+}
+/* Define a per thread private area that is used to store
+ * in the (workers) thread the index in per_thread_snmp_vars
+ * of the set of counters
+ */
+void
+init_thread_private_snmp_vars()
+{
+    if (PR_NewThreadPrivateIndex(&thread_private_snmp_vars_idx, snmp_vars_idx_free) != PR_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_ALERT,
+              "init_thread_private_snmp_vars", "Failure to per thread snmp counters !\n");
+        PR_ASSERT(0);
+    }
+}
+int
+thread_private_snmp_vars_get_idx(void)
+{
+    int *idx;
+    idx = (int *) PR_GetThreadPrivate(thread_private_snmp_vars_idx);
+    if (idx == NULL) {
+        /* if it was not initialized set it to zero */
+        return 0;
+    }
+    return *idx;
+}
+void
+thread_private_snmp_vars_set_idx(int32_t idx)
+{
+    int *val;
+    val = (int32_t *) PR_GetThreadPrivate(thread_private_snmp_vars_idx);
+    if (val == NULL) {
+        /* if it was not initialized set it to zero */
+        val = (int *) slapi_ch_calloc(1, sizeof(int32_t));
+        PR_SetThreadPrivate(thread_private_snmp_vars_idx, (void *) val);
+    }
+    *val = idx;
+}
+
+static struct snmp_vars_t *per_thread_snmp_vars = NULL; /* array of counters */
+static int max_slots_snmp_vars = 0;                     /* no slots array of counters */
+struct snmp_vars_t *
+g_get_per_thread_snmp_vars(void)
+{
+    int thread_vars = thread_private_snmp_vars_get_idx();
+    if (thread_vars < 0 || thread_vars >= max_slots_snmp_vars) {
+        /* fallback to the global one */
+        thread_vars = 0;
+    }
+    return &per_thread_snmp_vars[thread_vars];
+}
+
+
+struct snmp_vars_t *
+g_get_first_thread_snmp_vars(int *cookie)
+{
+    *cookie = 0;
+    if (max_slots_snmp_vars == 0) {
+        /* not yet initialized */
+        return NULL;
+    }
+    return &per_thread_snmp_vars[0];
+}
+
+struct snmp_vars_t *
+g_get_next_thread_snmp_vars(int *cookie)
+{
+    int index = *cookie;
+    if (index < 0 || index >= (max_slots_snmp_vars - 1)) {
+        return NULL;
+    }
+    *cookie = index + 1;
+    return &per_thread_snmp_vars[index + 1];
+}
+
+/* Allocated the first slot of arrays of counters
+ * The first slot contains counters that are not specific to counters
+ */
+struct snmp_vars_t *
+alloc_global_snmp_vars()
+{
+    PR_ASSERT(max_slots_snmp_vars == 0);
+    if (max_slots_snmp_vars == 0) {
+        max_slots_snmp_vars = 1;
+        per_thread_snmp_vars = (struct snmp_vars_t *) slapi_ch_calloc(max_slots_snmp_vars, sizeof(struct snmp_vars_t));
+    }
+
+}
+
+/* Allocated the next slots of the arrays of counters
+ * with a slot per worker thread
+ */
+struct snmp_vars_t *
+alloc_per_thread_snmp_vars(int32_t maxthread)
+{
+    PR_ASSERT(max_slots_snmp_vars == 1);
+    if (max_slots_snmp_vars == 1) {
+        max_slots_snmp_vars += maxthread; /* one extra slot for the global counters */
+        per_thread_snmp_vars = (struct snmp_vars_t *) slapi_ch_realloc((char *) per_thread_snmp_vars,
+                                                                       max_slots_snmp_vars * sizeof (struct snmp_vars_t));
+
+        /* make sure to zeroed the new alloacted counters */
+        memset(&per_thread_snmp_vars[1], 0, (max_slots_snmp_vars - 1) * sizeof (struct snmp_vars_t));
+    }
+}
 
 struct snmp_vars_t *
 g_get_global_snmp_vars(void)

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -635,6 +635,9 @@ main(int argc, char **argv)
      * consideration of rust etc)
      */
     slapi_td_init();
+    
+    /* Init the global counters */
+    alloc_global_snmp_vars();
 
     if (mcfg.slapd_exemode == SLAPD_EXEMODE_REFERRAL) {
         slapdFrontendConfig = getFrontendConfig();
@@ -1002,11 +1005,6 @@ main(int argc, char **argv)
 
         eq_init(); /* DEPRECATED */
         eq_init_rel(); /* must be done before plugins started */
-
-        /* Start the SNMP collator if counters are enabled. */
-        if (config_get_slapi_counters()) {
-            snmp_collator_start();
-        }
 
         ps_init_psearch_system(); /* must come before plugin_startall() */
 

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -131,7 +131,7 @@ do_modify(Slapi_PBlock *pb)
     ber = operation->o_ber;
 
     /* count the modify request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsModifyEntryOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsModifyEntryOps);
 
     /*
      * Parse the modify request.  It looks like this:

--- a/ldap/servers/slapd/modrdn.c
+++ b/ldap/servers/slapd/modrdn.c
@@ -56,7 +56,7 @@ do_modrdn(Slapi_PBlock *pb)
     slapi_log_err(SLAPI_LOG_TRACE, "do_modrdn", "=>\n");
 
     /* count the modrdn request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsModifyRDNOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsModifyRDNOps);
 
     slapi_pblock_get(pb, SLAPI_OPERATION, &operation);
     ber = operation->o_ber;

--- a/ldap/servers/slapd/monitor.c
+++ b/ldap/servers/slapd/monitor.c
@@ -62,11 +62,11 @@ monitor_info(Slapi_PBlock *pb __attribute__((unused)),
 
     connection_table_as_entry(the_connection_table, e);
 
-    val.bv_len = snprintf(buf, sizeof(buf), "%" PRIu64, slapi_counter_get_value(ops_initiated));
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRIu64, g_get_num_ops_initiated());
     val.bv_val = buf;
     attrlist_replace(&e->e_attrs, "opsinitiated", vals);
 
-    val.bv_len = snprintf(buf, sizeof(buf), "%" PRIu64, slapi_counter_get_value(ops_completed));
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRIu64, g_get_num_ops_completed());
     val.bv_val = buf;
     attrlist_replace(&e->e_attrs, "opscompleted", vals);
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1041,9 +1041,9 @@ void reslimit_cleanup(void);
 /*
  * result.c
  */
-void g_set_num_entries_sent(Slapi_Counter *counter);
+PRUint64 g_get_num_ops_initiated(void);
+PRUint64 g_get_num_ops_completed(void);
 PRUint64 g_get_num_entries_sent(void);
-void g_set_num_bytes_sent(Slapi_Counter *counter);
 PRUint64 g_get_num_bytes_sent(void);
 void g_set_default_referral(struct berval **ldap_url);
 struct berval **g_get_default_referral(void);
@@ -1265,6 +1265,13 @@ int c_get_shutdown(void);
 int g_get_global_lastmod(void);
 /* Ref_Array *g_get_global_referrals(void); */
 struct snmp_vars_t *g_get_global_snmp_vars(void);
+struct snmp_vars_t *alloc_global_snmp_vars();
+struct snmp_vars_t *alloc_per_thread_snmp_vars(int32_t maxthread);
+void thread_private_snmp_vars_set_idx(int32_t idx);
+struct snmp_vars_t *g_get_per_thread_snmp_vars(void);
+struct snmp_vars_t *g_get_first_thread_snmp_vars(int *cookie);
+struct snmp_vars_t *g_get_next_thread_snmp_vars(int *cookie);
+void init_thread_private_snmp_vars();
 void FrontendConfig_init(void);
 int g_get_slapd_security_on(void);
 char *config_get_versionstring(void);

--- a/ldap/servers/slapd/search.c
+++ b/ldap/servers/slapd/search.c
@@ -69,7 +69,7 @@ do_search(Slapi_PBlock *pb)
     ber = operation->o_ber;
 
     /* count the search request */
-    slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsSearchOps);
+    slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsSearchOps);
 
     /*
      * Parse the search request.  It looks like this:
@@ -191,11 +191,11 @@ do_search(Slapi_PBlock *pb)
     /* check and record the scope for snmp */
     if (scope == LDAP_SCOPE_ONELEVEL) {
         /* count the one level search request */
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsOneLevelSearchOps);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsOneLevelSearchOps);
 
     } else if (scope == LDAP_SCOPE_SUBTREE) {
         /* count the subtree search request */
-        slapi_counter_increment(g_get_global_snmp_vars()->ops_tbl.dsWholeSubtreeSearchOps);
+        slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsWholeSubtreeSearchOps);
     }
 
     /* filter - returns a "normalized" version */

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1977,6 +1977,14 @@ struct snmp_entries_tbl_t
     Slapi_Counter *dsConsumerHits;
 };
 
+struct snmp_server_tbl_t
+{
+    /* general purpose counters */
+    Slapi_Counter *dsOpInitiated;
+    Slapi_Counter *dsOpCompleted;
+    Slapi_Counter *dsEntriesSent;
+    Slapi_Counter *dsBytesSent;
+};
 struct snmp_int_tbl_t
 {
     /* interaction table */
@@ -1996,6 +2004,7 @@ struct snmp_vars_t
 {
     struct snmp_ops_tbl_t ops_tbl;
     struct snmp_entries_tbl_t entries_tbl;
+    struct snmp_server_tbl_t server_tbl;
     struct snmp_int_tbl_t int_tbl[NUM_SNMP_INT_TBL_ROWS];
 };
 

--- a/ldap/servers/slapd/snmp_collator.c
+++ b/ldap/servers/slapd/snmp_collator.c
@@ -91,57 +91,65 @@ static int
 snmp_collator_init(void)
 {
     int i;
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
 
     /*
-     * Create the global SNMP counters
+     * Create the per threads SNMP counters
      */
-    g_get_global_snmp_vars()->ops_tbl.dsAnonymousBinds = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsUnAuthBinds = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsSimpleAuthBinds = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsStrongAuthBinds = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsBindSecurityErrors = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsInOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsReadOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsCompareOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsAddEntryOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsRemoveEntryOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsModifyEntryOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsModifyRDNOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsListOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsSearchOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsOneLevelSearchOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsWholeSubtreeSearchOps = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsReferrals = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsChainings = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsSecurityErrors = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsErrors = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsConnections = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsConnectionSeq = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsBytesRecv = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsBytesSent = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsEntriesReturned = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsReferralsReturned = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads = slapi_counter_new();
-    g_get_global_snmp_vars()->ops_tbl.dsMaxThreadsHits = slapi_counter_new();
-    g_get_global_snmp_vars()->entries_tbl.dsSupplierEntries = slapi_counter_new();
-    g_get_global_snmp_vars()->entries_tbl.dsCopyEntries = slapi_counter_new();
-    g_get_global_snmp_vars()->entries_tbl.dsCacheEntries = slapi_counter_new();
-    g_get_global_snmp_vars()->entries_tbl.dsCacheHits = slapi_counter_new();
-    g_get_global_snmp_vars()->entries_tbl.dsConsumerHits = slapi_counter_new();
+    for (snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        snmp_vars->ops_tbl.dsAnonymousBinds = slapi_counter_new();
+        snmp_vars->ops_tbl.dsUnAuthBinds = slapi_counter_new();
+        snmp_vars->ops_tbl.dsSimpleAuthBinds = slapi_counter_new();
+        snmp_vars->ops_tbl.dsStrongAuthBinds = slapi_counter_new();
+        snmp_vars->ops_tbl.dsBindSecurityErrors = slapi_counter_new();
+        snmp_vars->ops_tbl.dsInOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsReadOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsCompareOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsAddEntryOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsRemoveEntryOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsModifyEntryOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsModifyRDNOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsListOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsSearchOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsOneLevelSearchOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsWholeSubtreeSearchOps = slapi_counter_new();
+        snmp_vars->ops_tbl.dsReferrals = slapi_counter_new();
+        snmp_vars->ops_tbl.dsChainings = slapi_counter_new();
+        snmp_vars->ops_tbl.dsSecurityErrors = slapi_counter_new();
+        snmp_vars->ops_tbl.dsErrors = slapi_counter_new();
+        snmp_vars->ops_tbl.dsConnections = slapi_counter_new();
+        snmp_vars->ops_tbl.dsConnectionSeq = slapi_counter_new();
+        snmp_vars->ops_tbl.dsBytesRecv = slapi_counter_new();
+        snmp_vars->ops_tbl.dsBytesSent = slapi_counter_new();
+        snmp_vars->ops_tbl.dsEntriesReturned = slapi_counter_new();
+        snmp_vars->ops_tbl.dsReferralsReturned = slapi_counter_new();
+        snmp_vars->ops_tbl.dsConnectionsInMaxThreads = slapi_counter_new();
+        snmp_vars->ops_tbl.dsMaxThreadsHits = slapi_counter_new();
+        snmp_vars->entries_tbl.dsSupplierEntries = slapi_counter_new();
+        snmp_vars->entries_tbl.dsCopyEntries = slapi_counter_new();
+        snmp_vars->entries_tbl.dsCacheEntries = slapi_counter_new();
+        snmp_vars->entries_tbl.dsCacheHits = slapi_counter_new();
+        snmp_vars->entries_tbl.dsConsumerHits = slapi_counter_new();
+        snmp_vars->server_tbl.dsOpInitiated = slapi_counter_new();
+        snmp_vars->server_tbl.dsOpCompleted = slapi_counter_new();
+        snmp_vars->server_tbl.dsEntriesSent = slapi_counter_new();
+        snmp_vars->server_tbl.dsBytesSent = slapi_counter_new();
 
-    /* Initialize the global interaction table */
-    for (i = 0; i < NUM_SNMP_INT_TBL_ROWS; i++) {
-        g_get_global_snmp_vars()->int_tbl[i].dsIntIndex = i + 1;
-        strncpy(g_get_global_snmp_vars()->int_tbl[i].dsName, "Not Available",
-                sizeof(g_get_global_snmp_vars()->int_tbl[i].dsName));
-        g_get_global_snmp_vars()->int_tbl[i].dsTimeOfCreation = 0;
-        g_get_global_snmp_vars()->int_tbl[i].dsTimeOfLastAttempt = 0;
-        g_get_global_snmp_vars()->int_tbl[i].dsTimeOfLastSuccess = 0;
-        g_get_global_snmp_vars()->int_tbl[i].dsFailuresSinceLastSuccess = 0;
-        g_get_global_snmp_vars()->int_tbl[i].dsFailures = 0;
-        g_get_global_snmp_vars()->int_tbl[i].dsSuccesses = 0;
-        strncpy(g_get_global_snmp_vars()->int_tbl[i].dsURL, "Not Available",
-                sizeof(g_get_global_snmp_vars()->int_tbl[i].dsURL));
+        /* Initialize the global interaction table */
+        for (i = 0; i < NUM_SNMP_INT_TBL_ROWS; i++) {
+            snmp_vars->int_tbl[i].dsIntIndex = i + 1;
+            strncpy(snmp_vars->int_tbl[i].dsName, "Not Available",
+                    sizeof (snmp_vars->int_tbl[i].dsName));
+            snmp_vars->int_tbl[i].dsTimeOfCreation = 0;
+            snmp_vars->int_tbl[i].dsTimeOfLastAttempt = 0;
+            snmp_vars->int_tbl[i].dsTimeOfLastSuccess = 0;
+            snmp_vars->int_tbl[i].dsFailuresSinceLastSuccess = 0;
+            snmp_vars->int_tbl[i].dsFailures = 0;
+            snmp_vars->int_tbl[i].dsSuccesses = 0;
+            strncpy(snmp_vars->int_tbl[i].dsURL, "Not Available",
+                    sizeof (snmp_vars->int_tbl[i].dsURL));
+        }
     }
 
     /* Get the semaphore */
@@ -188,6 +196,13 @@ set_snmp_interaction_row(char *host, int port, int error)
     int isnew = 0;
     char *dsName;
     char *dsURL;
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
+
+    /* The interactions table is using the default (first) snmp_vars*/
+    snmp_vars = g_get_first_thread_snmp_vars(&cookie);
+    if (snmp_vars == NULL)
+        return;
 
     /* stevross: our servers don't have a concept of dsName as a distinguished name
                as specified in the MIB. Make this "Not Available" for now waiting for
@@ -204,34 +219,34 @@ set_snmp_interaction_row(char *host, int port, int error)
     index = search_interaction_table(dsURL, &isnew);
     if (isnew) {
         /* fillin the new row from scratch*/
-        g_get_global_snmp_vars()->int_tbl[index].dsIntIndex = index;
-        strncpy(g_get_global_snmp_vars()->int_tbl[index].dsName, dsName,
-                sizeof(g_get_global_snmp_vars()->int_tbl[index].dsName));
-        g_get_global_snmp_vars()->int_tbl[index].dsTimeOfCreation = time(0);
-        g_get_global_snmp_vars()->int_tbl[index].dsTimeOfLastAttempt = time(0);
+        snmp_vars->int_tbl[index].dsIntIndex = index;
+        strncpy(snmp_vars->int_tbl[index].dsName, dsName,
+                sizeof(snmp_vars->int_tbl[index].dsName));
+        snmp_vars->int_tbl[index].dsTimeOfCreation = time(0);
+        snmp_vars->int_tbl[index].dsTimeOfLastAttempt = time(0);
         if (error == 0) {
-            g_get_global_snmp_vars()->int_tbl[index].dsTimeOfLastSuccess = time(0);
-            g_get_global_snmp_vars()->int_tbl[index].dsFailuresSinceLastSuccess = 0;
-            g_get_global_snmp_vars()->int_tbl[index].dsFailures = 0;
-            g_get_global_snmp_vars()->int_tbl[index].dsSuccesses = 1;
+            snmp_vars->int_tbl[index].dsTimeOfLastSuccess = time(0);
+            snmp_vars->int_tbl[index].dsFailuresSinceLastSuccess = 0;
+            snmp_vars->int_tbl[index].dsFailures = 0;
+            snmp_vars->int_tbl[index].dsSuccesses = 1;
         } else {
-            g_get_global_snmp_vars()->int_tbl[index].dsTimeOfLastSuccess = 0;
-            g_get_global_snmp_vars()->int_tbl[index].dsFailuresSinceLastSuccess = 1;
-            g_get_global_snmp_vars()->int_tbl[index].dsFailures = 1;
-            g_get_global_snmp_vars()->int_tbl[index].dsSuccesses = 0;
+            snmp_vars->int_tbl[index].dsTimeOfLastSuccess = 0;
+            snmp_vars->int_tbl[index].dsFailuresSinceLastSuccess = 1;
+            snmp_vars->int_tbl[index].dsFailures = 1;
+            snmp_vars->int_tbl[index].dsSuccesses = 0;
         }
-        strncpy(g_get_global_snmp_vars()->int_tbl[index].dsURL, dsURL,
-                sizeof(g_get_global_snmp_vars()->int_tbl[index].dsURL));
+        strncpy(snmp_vars->int_tbl[index].dsURL, dsURL,
+                sizeof(snmp_vars->int_tbl[index].dsURL));
     } else {
         /* just update the appropriate fields */
-        g_get_global_snmp_vars()->int_tbl[index].dsTimeOfLastAttempt = time(0);
+        snmp_vars->int_tbl[index].dsTimeOfLastAttempt = time(0);
         if (error == 0) {
-            g_get_global_snmp_vars()->int_tbl[index].dsTimeOfLastSuccess = time(0);
-            g_get_global_snmp_vars()->int_tbl[index].dsFailuresSinceLastSuccess = 0;
-            g_get_global_snmp_vars()->int_tbl[index].dsSuccesses += 1;
+            snmp_vars->int_tbl[index].dsTimeOfLastSuccess = time(0);
+            snmp_vars->int_tbl[index].dsFailuresSinceLastSuccess = 0;
+            snmp_vars->int_tbl[index].dsSuccesses += 1;
         } else {
-            g_get_global_snmp_vars()->int_tbl[index].dsFailuresSinceLastSuccess += 1;
-            g_get_global_snmp_vars()->int_tbl[index].dsFailures += 1;
+            snmp_vars->int_tbl[index].dsFailuresSinceLastSuccess += 1;
+            snmp_vars->int_tbl[index].dsFailures += 1;
         }
     }
     slapi_unlock_mutex(interaction_table_mutex);
@@ -273,23 +288,30 @@ search_interaction_table(char *dsURL, int *isnew)
     int index = 0;
     time_t oldestattempt;
     time_t currentattempt;
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
 
-    oldestattempt = g_get_global_snmp_vars()->int_tbl[0].dsTimeOfLastAttempt;
+    /* The interactions table is using the default (first) snmp_vars*/
+    snmp_vars = g_get_first_thread_snmp_vars(&cookie);
+    if (snmp_vars == NULL)
+        return index;
+
+    oldestattempt = snmp_vars->int_tbl[0].dsTimeOfLastAttempt;
     *isnew = 1;
 
     for (i = 0; i < NUM_SNMP_INT_TBL_ROWS; i++) {
-        if (!strcmp(g_get_global_snmp_vars()->int_tbl[i].dsURL, "Not Available")) {
+        if (!strcmp(snmp_vars->int_tbl[i].dsURL, "Not Available")) {
             /* found it -- this is new, first time for this row */
             index = i;
             break;
-        } else if (!strcmp(g_get_global_snmp_vars()->int_tbl[i].dsURL, dsURL)) {
+        } else if (!strcmp(snmp_vars->int_tbl[i].dsURL, dsURL)) {
             /* found it  -- it was already there*/
             *isnew = 0;
             index = i;
             break;
         } else {
             /* not found so figure out oldest row */
-            currentattempt = g_get_global_snmp_vars()->int_tbl[i].dsTimeOfLastAttempt;
+            currentattempt = snmp_vars->int_tbl[i].dsTimeOfLastAttempt;
 
             if (currentattempt <= oldestattempt) {
                 index = i;
@@ -570,34 +592,149 @@ snmp_collator_update(time_t start_time __attribute__((unused)), void *arg __attr
 static void
 snmp_update_ops_table(void)
 {
-    stats->ops_stats.dsAnonymousBinds = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsAnonymousBinds);
-    stats->ops_stats.dsUnAuthBinds = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsUnAuthBinds);
-    stats->ops_stats.dsSimpleAuthBinds = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSimpleAuthBinds);
-    stats->ops_stats.dsStrongAuthBinds = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsStrongAuthBinds);
-    stats->ops_stats.dsBindSecurityErrors = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBindSecurityErrors);
-    stats->ops_stats.dsInOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsInOps);
-    stats->ops_stats.dsReadOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReadOps);
-    stats->ops_stats.dsCompareOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsCompareOps);
-    stats->ops_stats.dsAddEntryOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsAddEntryOps);
-    stats->ops_stats.dsRemoveEntryOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsRemoveEntryOps);
-    stats->ops_stats.dsModifyEntryOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsModifyEntryOps);
-    stats->ops_stats.dsModifyRDNOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsModifyRDNOps);
-    stats->ops_stats.dsListOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsListOps);
-    stats->ops_stats.dsSearchOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSearchOps);
-    stats->ops_stats.dsOneLevelSearchOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsOneLevelSearchOps);
-    stats->ops_stats.dsWholeSubtreeSearchOps = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsWholeSubtreeSearchOps);
-    stats->ops_stats.dsReferrals = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReferrals);
-    stats->ops_stats.dsChainings = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsChainings);
-    stats->ops_stats.dsSecurityErrors = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSecurityErrors);
-    stats->ops_stats.dsErrors = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsErrors);
-    stats->ops_stats.dsConnections = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnections);
-    stats->ops_stats.dsConnectionSeq = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnectionSeq);
-    stats->ops_stats.dsConnectionsInMaxThreads = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads);
-    stats->ops_stats.dsMaxThreadsHits = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsMaxThreadsHits);
-    stats->ops_stats.dsBytesRecv = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBytesRecv);
-    stats->ops_stats.dsBytesSent = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBytesSent);
-    stats->ops_stats.dsEntriesReturned = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsEntriesReturned);
-    stats->ops_stats.dsReferralsReturned = slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReferralsReturned);
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
+    int32_t total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsAnonymousBinds);
+    }
+    stats->ops_stats.dsAnonymousBinds = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsUnAuthBinds);
+    }
+    stats->ops_stats.dsUnAuthBinds = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSimpleAuthBinds);
+    }
+    stats->ops_stats.dsSimpleAuthBinds = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsStrongAuthBinds);
+    }
+    stats->ops_stats.dsStrongAuthBinds = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBindSecurityErrors);
+    }
+    stats->ops_stats.dsBindSecurityErrors = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsInOps);
+    }
+    stats->ops_stats.dsInOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReadOps);
+    }
+    stats->ops_stats.dsReadOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsCompareOps);
+    }
+    stats->ops_stats.dsCompareOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsAddEntryOps);
+    }
+    stats->ops_stats.dsAddEntryOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsRemoveEntryOps);
+    }
+    stats->ops_stats.dsRemoveEntryOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsModifyEntryOps);
+    }
+    stats->ops_stats.dsModifyEntryOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsModifyRDNOps);
+    }
+    stats->ops_stats.dsModifyRDNOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsListOps);
+    }
+    stats->ops_stats.dsListOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSearchOps);
+    }
+    stats->ops_stats.dsSearchOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsOneLevelSearchOps);
+    }
+    stats->ops_stats.dsOneLevelSearchOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsWholeSubtreeSearchOps);
+    }
+    stats->ops_stats.dsWholeSubtreeSearchOps = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReferrals);
+    }
+    stats->ops_stats.dsReferrals = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsChainings);
+    }
+    stats->ops_stats.dsChainings = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSecurityErrors);
+    }
+    stats->ops_stats.dsSecurityErrors = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsErrors);
+    }
+    stats->ops_stats.dsErrors = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnections);
+    }
+    stats->ops_stats.dsConnections = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnectionSeq);
+    }
+    stats->ops_stats.dsConnectionSeq = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnectionsInMaxThreads);
+    }
+    stats->ops_stats.dsConnectionsInMaxThreads = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsMaxThreadsHits);
+    }
+    stats->ops_stats.dsMaxThreadsHits = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBytesRecv);
+    }
+    stats->ops_stats.dsBytesRecv = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBytesSent);
+    }
+    stats->ops_stats.dsBytesSent = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsEntriesReturned);
+    }
+    stats->ops_stats.dsEntriesReturned = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReferralsReturned);
+    }
+    stats->ops_stats.dsReferralsReturned = total;
 }
 
 /*
@@ -609,11 +746,34 @@ snmp_update_ops_table(void)
 static void
 snmp_update_entries_table(void)
 {
-    stats->entries_stats.dsSupplierEntries = slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsSupplierEntries);
-    stats->entries_stats.dsCopyEntries = slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCopyEntries);
-    stats->entries_stats.dsCacheEntries = slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCacheEntries);
-    stats->entries_stats.dsCacheHits = slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCacheHits);
-    stats->entries_stats.dsConsumerHits = slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsConsumerHits);
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
+    int32_t total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsSupplierEntries);
+    }
+    stats->entries_stats.dsSupplierEntries = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCopyEntries);
+    }
+    stats->entries_stats.dsCopyEntries = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCacheEntries);
+    }
+    stats->entries_stats.dsCacheEntries = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCacheHits);
+    }
+    stats->entries_stats.dsCacheHits = total;
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsConsumerHits);
+    }
+    stats->entries_stats.dsConsumerHits = total;
 }
 
 /*
@@ -626,18 +786,25 @@ static void
 snmp_update_interactions_table(void)
 {
     int i;
+    int cookie;
+    struct snmp_vars_t *snmp_vars;
+    
+    /* The interactions table is using the default (first) snmp_vars*/
+    snmp_vars = g_get_first_thread_snmp_vars(&cookie);
+    if (snmp_vars == NULL)
+        return;
 
     for (i = 0; i < NUM_SNMP_INT_TBL_ROWS; i++) {
         stats->int_stats[i].dsIntIndex = i;
-        strncpy(stats->int_stats[i].dsName, g_get_global_snmp_vars()->int_tbl[i].dsName,
+        strncpy(stats->int_stats[i].dsName, snmp_vars->int_tbl[i].dsName,
                 sizeof(stats->int_stats[i].dsName));
-        stats->int_stats[i].dsTimeOfCreation = g_get_global_snmp_vars()->int_tbl[i].dsTimeOfCreation;
-        stats->int_stats[i].dsTimeOfLastAttempt = g_get_global_snmp_vars()->int_tbl[i].dsTimeOfLastAttempt;
-        stats->int_stats[i].dsTimeOfLastSuccess = g_get_global_snmp_vars()->int_tbl[i].dsTimeOfLastSuccess;
-        stats->int_stats[i].dsFailuresSinceLastSuccess = g_get_global_snmp_vars()->int_tbl[i].dsFailuresSinceLastSuccess;
-        stats->int_stats[i].dsFailures = g_get_global_snmp_vars()->int_tbl[i].dsFailures;
-        stats->int_stats[i].dsSuccesses = g_get_global_snmp_vars()->int_tbl[i].dsSuccesses;
-        strncpy(stats->int_stats[i].dsURL, g_get_global_snmp_vars()->int_tbl[i].dsURL,
+        stats->int_stats[i].dsTimeOfCreation = snmp_vars->int_tbl[i].dsTimeOfCreation;
+        stats->int_stats[i].dsTimeOfLastAttempt = snmp_vars->int_tbl[i].dsTimeOfLastAttempt;
+        stats->int_stats[i].dsTimeOfLastSuccess = snmp_vars->int_tbl[i].dsTimeOfLastSuccess;
+        stats->int_stats[i].dsFailuresSinceLastSuccess = snmp_vars->int_tbl[i].dsFailuresSinceLastSuccess;
+        stats->int_stats[i].dsFailures = snmp_vars->int_tbl[i].dsFailures;
+        stats->int_stats[i].dsSuccesses = snmp_vars->int_tbl[i].dsSuccesses;
+        strncpy(stats->int_stats[i].dsURL, snmp_vars->int_tbl[i].dsURL,
                 sizeof(stats->int_stats[i].dsURL));
     }
 }
@@ -688,15 +855,19 @@ snmp_update_cache_stats(void)
         slapi_pblock_get(search_result_pb, SLAPI_PLUGIN_INTOP_RESULT, &search_result);
 
         if (search_result == 0) {
+            int cookie;
+            uint64_t total;
+            struct snmp_vars_t *snmp_vars;
             slapi_pblock_get(search_result_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES,
                              &search_entries);
 
-            /* set the entrycachehits */
-            slapi_counter_set_value(g_get_global_snmp_vars()->entries_tbl.dsCacheHits,
+            /* set the entrycachehits to the global counter*/
+            snmp_vars = g_get_first_thread_snmp_vars(&cookie);
+            slapi_counter_set_value(snmp_vars->entries_tbl.dsCacheHits,
                                     slapi_entry_attr_get_ulonglong(search_entries[0], "entrycachehits"));
 
-            /* set the currententrycachesize */
-            slapi_counter_set_value(g_get_global_snmp_vars()->entries_tbl.dsCacheEntries,
+            /* set the currententrycachesize  to the global counter */
+            slapi_counter_set_value(snmp_vars->entries_tbl.dsCacheEntries,
                                     slapi_entry_attr_get_ulonglong(search_entries[0], "currententrycachesize"));
         }
 
@@ -716,39 +887,174 @@ add_counter_to_value(Slapi_Entry *e, const char *type, PRUint64 countervalue)
 void
 snmp_as_entry(Slapi_Entry *e)
 {
-    add_counter_to_value(e, "AnonymousBinds", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsAnonymousBinds));
-    add_counter_to_value(e, "UnAuthBinds", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsUnAuthBinds));
-    add_counter_to_value(e, "SimpleAuthBinds", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSimpleAuthBinds));
-    add_counter_to_value(e, "StrongAuthBinds", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsStrongAuthBinds));
-    add_counter_to_value(e, "BindSecurityErrors", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBindSecurityErrors));
-    add_counter_to_value(e, "InOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsInOps));
-    add_counter_to_value(e, "ReadOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReadOps));
-    add_counter_to_value(e, "CompareOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsCompareOps));
-    add_counter_to_value(e, "AddEntryOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsAddEntryOps));
-    add_counter_to_value(e, "RemoveEntryOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsRemoveEntryOps));
-    add_counter_to_value(e, "ModifyEntryOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsModifyEntryOps));
-    add_counter_to_value(e, "ModifyRDNOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsModifyRDNOps));
-    add_counter_to_value(e, "ListOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsListOps));
-    add_counter_to_value(e, "SearchOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSearchOps));
-    add_counter_to_value(e, "OneLevelSearchOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsOneLevelSearchOps));
-    add_counter_to_value(e, "WholeSubtreeSearchOps", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsWholeSubtreeSearchOps));
-    add_counter_to_value(e, "Referrals", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReferrals));
-    add_counter_to_value(e, "Chainings", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsChainings));
-    add_counter_to_value(e, "SecurityErrors", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsSecurityErrors));
-    add_counter_to_value(e, "Errors", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsErrors));
-    add_counter_to_value(e, "Connections", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnections));
-    add_counter_to_value(e, "ConnectionSeq", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnectionSeq));
-    add_counter_to_value(e, "ConnectionsInMaxThreads", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsConnectionsInMaxThreads));
-    add_counter_to_value(e, "ConnectionsMaxThreadsCount", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsMaxThreadsHits));
-    add_counter_to_value(e, "BytesRecv", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBytesRecv));
-    add_counter_to_value(e, "BytesSent", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsBytesSent));
-    add_counter_to_value(e, "EntriesReturned", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsEntriesReturned));
-    add_counter_to_value(e, "ReferralsReturned", slapi_counter_get_value(g_get_global_snmp_vars()->ops_tbl.dsReferralsReturned));
-    add_counter_to_value(e, "SupplierEntries", slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsSupplierEntries));
-    add_counter_to_value(e, "CopyEntries", slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCopyEntries));
-    add_counter_to_value(e, "CacheEntries", slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCacheEntries));
-    add_counter_to_value(e, "CacheHits", slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsCacheHits));
-    add_counter_to_value(e, "ConsumerHits", slapi_counter_get_value(g_get_global_snmp_vars()->entries_tbl.dsConsumerHits));
+    int cookie;
+    uint64_t total;
+    struct snmp_vars_t *snmp_vars;
+    
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsAnonymousBinds);
+    }
+    add_counter_to_value(e, "AnonymousBinds", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsUnAuthBinds);
+    }
+    add_counter_to_value(e, "UnAuthBinds", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSimpleAuthBinds);
+    }
+    add_counter_to_value(e, "SimpleAuthBinds", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsStrongAuthBinds);
+    }
+    add_counter_to_value(e, "StrongAuthBinds", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBindSecurityErrors);
+    }
+    add_counter_to_value(e, "BindSecurityErrors", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsInOps);
+    }
+    add_counter_to_value(e, "InOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReadOps);
+    }
+    add_counter_to_value(e, "ReadOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsCompareOps);
+    }
+    add_counter_to_value(e, "CompareOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsAddEntryOps);
+    }
+    add_counter_to_value(e, "AddEntryOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsRemoveEntryOps);
+    }
+    add_counter_to_value(e, "RemoveEntryOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsModifyEntryOps);
+    }
+    add_counter_to_value(e, "ModifyEntryOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsModifyRDNOps);
+    }
+    add_counter_to_value(e, "ModifyRDNOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsListOps);
+    }
+    add_counter_to_value(e, "ListOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSearchOps);
+    }
+    add_counter_to_value(e, "SearchOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsOneLevelSearchOps);
+    }
+    add_counter_to_value(e, "OneLevelSearchOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsWholeSubtreeSearchOps);
+    }
+    add_counter_to_value(e, "WholeSubtreeSearchOps", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReferrals);
+    }
+    add_counter_to_value(e, "Referrals", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsChainings);
+    }
+    add_counter_to_value(e, "Chainings", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsSecurityErrors);
+    }
+    add_counter_to_value(e, "SecurityErrors", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsErrors);
+    }
+    add_counter_to_value(e, "Errors", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnections);
+    }
+    add_counter_to_value(e, "Connections", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnectionSeq);
+    }
+    add_counter_to_value(e, "ConnectionSeq", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsConnectionsInMaxThreads);
+    }
+    add_counter_to_value(e, "ConnectionsInMaxThreads", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsMaxThreadsHits);
+    }
+    add_counter_to_value(e, "ConnectionsMaxThreadsCount", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBytesRecv);
+    }
+    add_counter_to_value(e, "BytesRecv", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsBytesSent);
+    }
+    add_counter_to_value(e, "BytesSent", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsEntriesReturned);
+    }
+    add_counter_to_value(e, "EntriesReturned", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->ops_tbl.dsReferralsReturned);
+    }
+    add_counter_to_value(e, "ReferralsReturned", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsSupplierEntries);
+    }
+    add_counter_to_value(e, "SupplierEntries", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCopyEntries);
+    }
+    add_counter_to_value(e, "CopyEntries", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCacheEntries);
+    }
+    add_counter_to_value(e, "CacheEntries", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsCacheHits);
+    }
+    add_counter_to_value(e, "CacheHits", total);
+
+    for (total = 0, snmp_vars = g_get_first_thread_snmp_vars(&cookie); snmp_vars; snmp_vars = g_get_next_thread_snmp_vars(&cookie)) {
+        total += slapi_counter_get_value(snmp_vars->entries_tbl.dsConsumerHits);
+    }
+    add_counter_to_value(e, "ConsumerHits", total);
 }
 
 /*


### PR DESCRIPTION
… counters

Bug description:
	The servers manages a set of counters in order to report metrics either with SRCH
	"cn=monitor" or with SNMP agent.
	The counters are global and so the threads updating the counters are all accessing
	the same counters and same memory addresses. The counters are accessed by workers and/or listener threads.
	All of them are in competition to access the counter memory addresses that creates contention.

Fix description:
	The fix spread the set of global counters into a per thread set
	of global counters
	https://www.port389.org/docs/389ds/design/global-counters-contention.html

relates: https://github.com/389ds/389-ds-base/issues/4312

Reviewed by:

Platforms tested:  F34