### PR TITLE
Issue 4943 - Fix csn generator to limit time skew drift

### DIFF
--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -328,7 +328,7 @@ csngen_adjust_time(CSNGen *gen, const CSN *csn)
 
     remote_offset = remote_time - CSN_CALC_TSTAMP(gen);
     if (remote_offset > 0) {
-        if (!ignore_time_skew && (remote_offset > CSN_MAX_TIME_ADJUST)) {
+        if (!ignore_time_skew && (gen->state.remote_offset + remote_offset > CSN_MAX_TIME_ADJUST)) {
             slapi_log_err(SLAPI_LOG_ERR, "csngen_adjust_time",
                           "Adjustment limit exceeded; value - %ld, limit - %ld\n",
                           remote_offset, (long)CSN_MAX_TIME_ADJUST);

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -17,7 +17,6 @@
 #include <string.h>
 #include "prcountr.h"
 #include "slap.h"
-#include <math.h>
 
 
 #define CSN_MAX_SEQNUM 0xffff              /* largest sequence number */
@@ -817,12 +816,24 @@ _csngen_local_tester_main(void *data)
 int _csngen_tester_state;
 int _csngen_tester_state_rid;
 
+static int
+_mynoise(int time, int len, double height)
+{
+   if (((time/len) % 2) == 0) {
+        return -height + 2 * height * ( time % len ) / (len-1);
+   } else {
+        return height - 2 * height * ( time % len ) / (len-1);
+   }
+}
+
+
 int32_t _csngen_tester_gettime(struct timespec *tp)
 {
-    int vtime = _csngen_tester_state / 30;
+    int vtime = _csngen_tester_state ;
     tp->tv_sec = 0x1000000 + vtime + 2 * _csngen_tester_state_rid;
     if (_csngen_tester_state_rid == 3) {
-        tp->tv_sec += ( 0.5 * sin(vtime*1.0) * 1.9 );
+        /* tp->tv_sec += _mynoise(vtime, 10, 1.5); */
+        tp->tv_sec += _mynoise(vtime, 30, 15);
     }
     return 0;
 }

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6767,8 +6767,17 @@ time_t slapi_current_time(void) __attribute__((deprecated));
  *
  * \param tp - a timespec struct where the system time is set
  * \return result code, upon success tp is set to the system time
+ * as a clock in UTC timezone. This clock adjusts with ntp steps,
+ * and should NOT be used for timer information.
  */
 int32_t slapi_clock_gettime(struct timespec *tp);
+/* 
+ * slapi_clock_gettime should have better been called
+ * slapi_clock_utc_gettime but sice the function pre-existed
+ * we are just adding an alias (to avoid risking to break
+ * some custom plugins)
+ */
+#define slapi_clock_utc_gettime slapi_clock_gettime
 
 /**
  * Returns the current system time as a hr clock relative to uptime


### PR DESCRIPTION
Fix some oddity in csngen code so that 
 - new csn is greater than old csn and remote csn
 - local_offset mainly increase when system clocks goes backward
    with two exceptions:
      increased 1 second if seqnum rolls over.
      set to 1 seconds if local_offset is zero  and remote offset is detected (in this case remote_offset is decreased by
         1 to compensate)
  - local_offset may decrease (until 0) when system clock increase    
  - remote offset increase when a csn generated locally would be lesser than the remote csn
  - remote offset never decrease

Test done: 
   all CI tests that pass on master are pass
   csngen_test is ok.
   csngen_multi_suppliers_test is OK (==> csn always increase) it also shows that a small noise (+- 1 sec) does not generate time skew drift but larger noise (+- 15 sec) generates drift. 
      
Issue: [4943](https://github.com/389ds/389-ds-base/issues/4943)

Reviewer: @tbordaz and @mreynolds389 