### PR TITLE
Issue 4092 - systemd-tmpfiles warnings

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -410,6 +410,9 @@ export XCFLAGS=$RPM_OPT_FLAGS
 
 make %{?_smp_mflags}
 
+# Fix systemd-tmpfiles warning about legacy paths:
+sed -i 's#/var/run#/run#g' %{_builddir}/%{name}-%{version}%{?prerel}/ldap/admin/src/defaults.inf
+
 %install
 rm -rf $RPM_BUILD_ROOT
 


### PR DESCRIPTION
Bug Description:
systemd-tmpfiles warns about legacy paths in our tmpfiles configs.
Using /var/run also introduces a race condition, see the following
issue https://github.com/389ds/389-ds-base/issues/766

Fix Description:
Update paths in defaults.inf during rpm build. This doesn't affect local
prefix builds as they continue to use localstatedir.

Relates: https://github.com/389ds/389-ds-base/issues/766
Relates: https://github.com/389ds/389-ds-base/issues/4092

Reviewed by: @mreynolds389 (Thanks!)