### PR TITLE
Issue 3584 - Fix PBKDF2_SHA256 hashing in FIPS mode

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -31,16 +31,6 @@ libfaketime.reexec_if_needed()
 log = logging.getLogger(__name__)
 
 
-def is_fips():
-    if os.path.exists('/proc/sys/crypto/fips_enabled'):
-        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
-            state = f.readline().strip()
-            if state == '1':
-                return True
-            else:
-                return False
-
-
 def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
     args = FakeArgs()
     args.instance = instance.serverid

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -185,6 +185,58 @@ nsslapd-plugininitfunc: pbkdf2_sha256_pwd_storage_scheme_init
 nsslapd-plugintype: pwdstoragescheme
 nsslapd-pluginenabled: on
 
+dn: cn=PBKDF2,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2
+
+dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA1
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha1_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA1
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA1\
+
+dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA256
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha256_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA256
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA256\
+
+dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA512
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA512
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA512
+
 dn: cn=AES,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -232,6 +232,58 @@ nsslapd-plugininitfunc: pbkdf2_sha256_pwd_storage_scheme_init
 nsslapd-plugintype: pwdstoragescheme
 nsslapd-pluginenabled: on
 
+dn: cn=PBKDF2,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2
+
+dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA1
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha1_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA1
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA1\
+
+dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA256
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha256_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA256
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA256\
+
+dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+cn: PBKDF2-SHA512
+nsslapd-pluginpath: libpwdchan-plugin
+nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init
+nsslapd-plugintype: pwdstoragescheme
+nsslapd-pluginenabled: on
+nsslapd-pluginId: PBKDF2-SHA512
+nsslapd-pluginVersion: none
+nsslapd-pluginVendor: 389 Project
+nsslapd-pluginDescription: PBKDF2-SHA512
+
 dn: cn=AES,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -2931,8 +2931,20 @@ slapd_do_all_nss_ssl_init(int slapd_exemode, int importexport_encrypt, int s_por
      * is enabled or not. We use NSS for random number generation and
      * other things even if we are not going to accept SSL connections.
      * We also need NSS for attribute encryption/decryption on import and export.
+     *
+     * It's important to remember that while in FIPS mode the administrator should always enable
+     * the security, otherwise we don't call slapd_pk11_authenticate which is a requirement for FIPS mode
      */
+    PRBool isFIPS = slapd_pk11_isFIPS();
     int init_ssl = config_get_security();
+
+    if (isFIPS && !init_ssl) {
+        slapi_log_err(SLAPI_LOG_WARNING, "slapd_do_all_nss_ssl_init",
+                      "ERROR: TLS is not enabled, and the machine is in FIPS mode. "
+                      "Some functionality won't work correctly (for example, "
+                      "users with PBKDF2_SHA256 password scheme won't be able to log in). "
+                      "It's highly advisable to enable TLS on this instance.\n");
+    }
 
     if (slapd_exemode == SLAPD_EXEMODE_SLAPD) {
         init_ssl = init_ssl && (0 != s_port) && (s_port <= LDAP_PORT_MAX);

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1548,6 +1548,10 @@ class DirSrv(SimpleLDAPObject, object):
         :param post_open: Open the server connection after restart.
         :type post_open: bool
         """
+        if self.config.get_attr_val_utf8_l("nsslapd-security") == 'on':
+            self.restart(post_open=post_open)
+            return
+
         # If it doesn't exist, create a cadb.
         ssca = NssSsl(dbpath=self.get_ssca_dir())
         if not ssca._db_exists():

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -11,7 +11,7 @@ import logging
 import socket  # For hostname detection for GSSAPI tests
 import pytest
 from lib389 import DirSrv
-from lib389.utils import generate_ds_params
+from lib389.utils import generate_ds_params, is_fips
 from lib389.mit_krb5 import MitKrb5
 from lib389.saslmap import SaslMappings
 from lib389.replica import ReplicationManager, Replicas
@@ -103,6 +103,10 @@ def _create_instances(topo_dict, suffix):
             if role == ReplicaRole.HUB:
                 hs[instance.serverid] = instance
                 instances.update(hs)
+            # We should always enable TLS while in FIPS mode because otherwise NSS database won't be
+            # configured in a FIPS compliant way
+            if is_fips():
+                instance.enable_tls()
             if DEBUGGING:
                 instance.config.set('nsslapd-errorlog-level','8192')
                 instance.config.set('nsslapd-accesslog-level','260')

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1434,3 +1434,17 @@ def is_valid_hostname(hostname):
 
 def get_default_db_lib():
     return os.getenv('NSSLAPD_DB_LIB', default=DEFAULT_DB_LIB)
+
+
+def is_fips():
+    if os.path.exists('/proc/sys/crypto/fips_enabled'):
+        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
+            state = f.readline().strip()
+            if state == '1':
+                return True
+            else:
+                return False
+    else:
+        return False
+
+


### PR DESCRIPTION
Issue Description: Use PK11_Decrypt function to get hash data
because PK11_ExtractKeyValue function is forbidden in FIPS mode.
We can't extract keys while in FIPS mode. But we use PK11_ExtractKeyValue
for hashes, and it's not forbidden.

We can't use OpenSSL's PBKDF2-SHA256 implementation right now because
we need to support an upgrade procedure while in FIPS mode (update
hash on bind). For that, we should fix existing PBKDF2 usage, and we can
switch to OpenSSL's PBKDF2-SHA256 in the following versions.

Fix Description: Use PK11_Decrypt function to get the data.

Enable TLS on all CI test topologies while in FIPS because without
that we don't set up the NSS database correctly.

Add PBKDF2-SHA256 (OpenSSL) to ldif templates, so the password scheme is
discoverable by internal functions.

https://github.com/389ds/389-ds-base/issues/3584

Reviewed by: ?