### PR TITLE
Issue 4898 - Implement bdb to lmdb CLI migration tools

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -1,0 +1,115 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import logging
+import pytest
+import ldap
+import os
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.backend import DatabaseConfig
+from lib389.cli_ctl.dblib import (FakeArgs, dblib_bdb2mdb, dblib_mdb2bdb, dblib_cleanup)
+from lib389.idm.user import UserAccounts
+from lib389.replica import ReplicationManager
+from lib389.topologies import topology_m2 as topo_m2
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def init_user(topo_m2, request):
+    """Initialize a user - Delete and re-add test user
+    """
+    s1 = topo_m2.ms["supplier1"]
+    users = UserAccounts(s1, DEFAULT_SUFFIX)
+    try:
+        user_data = {'uid': 'test entry',
+                     'cn': 'test entry',
+                     'sn': 'test entry',
+                     'uidNumber': '3000',
+                     'gidNumber': '4000',
+                     'homeDirectory': '/home/test_entry',
+                     'userPassword': 'foo'}
+        test_user = users.create(properties=user_data)
+    except ldap.ALREADY_EXISTS:
+        pass
+    except ldap.SERVER_DOWN:
+        pass
+
+    def fin():
+        try:
+            test_user.delete()
+        except ldap.NO_SUCH_OBJECT:
+            pass
+
+    request.addfinalizer(fin)
+
+
+def _check_db(inst, log, impl):
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    # Cannot use inst..get_db_lib() because it caches the value
+    assert DatabaseConfig(inst).get_db_lib() == impl
+    assert users.get('test entry')
+
+    db_files = os.listdir(inst.dbdir)
+    mdb_list = ['data.mdb', 'INFO.mdb', 'lock.mdb']
+    bdb_list = ['__db.001', 'DBVERSION', '__db.003', 'userRoot', 'log.0000000001', '__db.002']
+    mdb_list.sort()
+    bdb_list.sort()
+    db_files.sort()
+    log.debug(f"INFO: _check_db dbdir={inst.dbdir}")
+    log.debug(f"INFO: _check_db db_files={db_files}")
+    log.debug(f"INFO: _check_db mdb_list={mdb_list}")
+    log.debug(f"INFO: _check_db bdb_list={bdb_list}")
+    if impl == 'bdb':
+        assert db_files == bdb_list
+        assert db_files != mdb_list
+    else:
+        assert db_files != bdb_list
+        assert db_files == mdb_list
+
+
+def test_dblib_migration(topo_m2, init_user):
+    """
+    Verify dsctl dblib xxxxxxx  sub commands ( migration between bdb and lmdb )
+
+    :id: 5d327c34-e77a-46e5-a8aa-0a552f9bbdef
+    :setup: Two suppliers Instance
+    :steps:
+        1. Determine current database
+        2. Switch to the other database
+        3 Check that
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    s1 = topo_m2.ms["supplier1"]
+    s2 = topo_m2.ms["supplier2"]
+    db_lib = s1.get_db_lib()
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    users = UserAccounts(s1, DEFAULT_SUFFIX)
+    assert users.get('test entry')
+    args = FakeArgs({'tmpdir': None})
+    if db_lib == 'bdb':
+        dblib_bdb2mdb(s1, log, args)
+        dblib_cleanup(s1, log, args)
+        _check_db(s1, log, 'mdb')
+        repl.test_replication_topology([s1, s2])
+        dblib_mdb2bdb(s1, log, args)
+        dblib_cleanup(s1, log, args)
+        _check_db(s1, log, 'bdb')
+        repl.test_replication_topology([s1, s2])
+    else:
+        dblib_mdb2bdb(s1, log, args)
+        dblib_cleanup(s1, log, args)
+        _check_db(s1, log, 'bdb')
+        repl.test_replication_topology([s1, s2])
+        dblib_bdb2mdb(s1, log, args)
+        dblib_cleanup(s1, log, args)
+        _check_db(s1, log, 'mdb')
+        repl.test_replication_topology([s1, s2])

--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -58,7 +58,7 @@ def _check_db(inst, log, impl):
 
     db_files = os.listdir(inst.dbdir)
     if inst.ds_paths.db_home_dir is not None and inst.ds_paths.db_home_dir != inst.dbdir:
-        db_files.append(os.listdir(inst.ds_paths.db_home_dir))
+        db_files.extend(os.listdir(inst.ds_paths.db_home_dir))
     mdb_list = ['data.mdb', 'INFO.mdb', 'lock.mdb']
     bdb_list = ['__db.001', 'DBVERSION', '__db.003', 'userRoot', 'log.0000000001', '__db.002']
     mdb_list.sort()

--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -57,6 +57,8 @@ def _check_db(inst, log, impl):
     assert users.get('test entry')
 
     db_files = os.listdir(inst.dbdir)
+    if inst.ds_paths.db_home_dir is not None and inst.ds_paths.db_home_dir != inst.dbdir:
+        db_files.append(os.listdir(inst.ds_paths.db_home_dir))
     mdb_list = ['data.mdb', 'INFO.mdb', 'lock.mdb']
     bdb_list = ['__db.001', 'DBVERSION', '__db.003', 'userRoot', 'log.0000000001', '__db.002']
     mdb_list.sort()

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
@@ -135,6 +135,7 @@ int bdb_init(struct ldbminfo *li, config_info *config_array)
     priv->dblayer_in_import_fn = &bdb_public_in_import;
     priv->dblayer_get_db_suffix_fn = &bdb_public_get_db_suffix;
     priv->dblayer_compact_fn = &bdb_public_dblayer_compact;
+    priv->dblayer_dbi_db_remove_fn = &bdb_public_delete_db;
 
     bdb_fake_priv = *priv; /* Copy the callbaks for bdb_be() */
     return 0;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6876,50 +6876,76 @@ bdb_public_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count)
 int
 bdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_t **env, dbi_db_t **db)
 {
-    int rc;
+    struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
+    dblayer_private *priv = li->li_dblayer_private;
+    bdb_config *conf = (bdb_config *)li->li_dblayer_config;
+    bdb_db_env **ppEnv = (bdb_db_env**)&priv->dblayer_env;
+    char dbhome[MAXPATHLEN];
     DB_ENV *bdb_env = NULL;
     DB *bdb_db = NULL;
-    char dbhome[MAXPATHLEN];
-    int flags;
     struct stat st;
+    int flags;
+    char *pt;
+    int rc;
 
     strncpy(dbhome, db_filename, MAXPATHLEN);
-    if (stat(dbhome, &st) != 0) {
-        perror(dbhome);
+    pt = dbhome + strlen(dbhome);
+    if (stat(dbhome, &st) != 0 || ((st.st_mode & S_IFMT) == S_IFREG)) {
+        /* remove the file name to get li_directory */
+        while (--pt > dbhome && *pt != '/');
+        *pt = 0;
+    }
+    li->li_directory = slapi_ch_strdup(dbhome);
+    /* Now lets find the dbhome */
+    while (pt > dbhome) {
+        strcpy(pt, "/DBVERSION");
+        if (stat(dbhome, &st) == 0) {
+            /* Found the dbhome */
+            *pt = 0;
+            break;
+        }
+        while (--pt >= dbhome && *pt != '/');
+    }
+    if (pt <= dbhome) {
+        fprintf(stderr, "bdb_public_private_open: Unable to determine dbhome from %s\n", db_filename);
         return EINVAL;
     }
-
-    if ((st.st_mode & S_IFMT) == S_IFREG) {
-        char *pt = strrchr(dbhome, '/');
-        if (pt) {
-            *pt = 0;
-            pt = strrchr(dbhome, '/');
-        }
-        if (pt) {
-            *pt = 0;
-        }
-    }
-
-
-    rc = db_env_create(&bdb_env, 0);
-    if (rc == 0) {
-        if (rw) {
-            flags = DB_CREATE | DB_INIT_MPOOL;
-            rc = bdb_env->open(bdb_env, dbhome, flags, 0);
-        } else {
+    *pt = 0;
+    li->li_config_mutex = PR_NewLock();
+    conf->bdb_dbhome_directory = slapi_ch_strdup(dbhome);
+    if (rw) {
+        /* Setup a fully transacted environment */
+        priv->dblayer_env = NULL;
+        conf->bdb_enable_transactions = 1;
+        conf->bdb_enable_transactions = 0;
+        conf->bdb_tx_max = 50;
+        rc = bdb_start(li, DBLAYER_NORMAL_MODE);
+    } else {
+        /* Setup minimal environment */
+        rc = db_env_create(&bdb_env, 0);
+        if (rc == 0) {
             flags = DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE;
             rc = bdb_env->open(bdb_env, NULL, flags, 0);
         }
     }
+
     if (rc == 0) {
-        rc = db_create(&bdb_db, bdb_env, 0);
+        rc = db_create((DB**)db, bdb_env, 0);
+        bdb_db = *db;
     }
     if (rc == 0) {
-        flags = rw ? 0 : DB_RDONLY;
-        rc = bdb_db->open(bdb_db, NULL, db_filename, NULL, DB_UNKNOWN, flags, 0);
+        if (rw) {
+            DB_OPEN((*ppEnv)->bdb_openflags,
+                    (DB*)*db, NULL /* txnid */, db_filename, NULL /* subname */, DB_BTREE,
+                    DB_CREATE | DB_THREAD, priv->dblayer_file_mode, rc);
+        } else {
+            rc = bdb_db->open(bdb_db, NULL, db_filename, NULL, DB_UNKNOWN, DB_RDONLY, 0);
+        }
     }
+
     *env = bdb_env;
     *db = bdb_db;
+
     return bdb_map_error(__FUNCTION__, rc);
 }
 
@@ -7149,4 +7175,15 @@ bdb_compact(struct ldbminfo *li, PRBool just_changelog)
     slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact", "Compacting databases finished.\n");
 
     return rc;
+}
+
+int
+bdb_public_delete_db(backend *be, dbi_db_t *db)
+{
+    /* Used in dbscan context */
+    char dbName[MAXPATHLEN];
+
+    strncpy(dbName, bdb_public_get_db_filename(db), MAXPATHLEN);
+    bdb_close_file((DB**)&db);
+    return unlink(dbName);
 }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -128,6 +128,7 @@ void bdb_public_config_get(struct ldbminfo *li, char *attrname, char *value);
 int bdb_public_config_set(struct ldbminfo *li, char *attrname, int apply_mod, int mod_op, int phase, char *value);
 int bdb_public_dblayer_compact(Slapi_Backend *be, PRBool just_changelog);
 int bdb_close_file(DB **db);
+int bdb_public_delete_db(backend *be, dbi_db_t *db);
 
 
 /* dbimpl callbacks */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -185,6 +185,7 @@ int mdb_init(struct ldbminfo *li, config_info *config_array)
     priv->dblayer_get_db_suffix_fn = &dbmdb_public_get_db_suffix;
     priv->dblayer_compact_fn = &dbmdb_public_dblayer_compact;
     priv->dblayer_clear_vlv_cache_fn = &dbmdb_public_clear_vlv_cache;
+    priv->dblayer_delete_db_fn = &dbmdb_public_delete_db;
 
     dbmdb_fake_priv = *priv; /* Copy the callbaks for dbmdb_be() */
     return 0;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -185,7 +185,7 @@ int mdb_init(struct ldbminfo *li, config_info *config_array)
     priv->dblayer_get_db_suffix_fn = &dbmdb_public_get_db_suffix;
     priv->dblayer_compact_fn = &dbmdb_public_dblayer_compact;
     priv->dblayer_clear_vlv_cache_fn = &dbmdb_public_clear_vlv_cache;
-    priv->dblayer_delete_db_fn = &dbmdb_public_delete_db;
+    priv->dblayer_dbi_db_remove_fn = &dbmdb_public_delete_db;
 
     dbmdb_fake_priv = *priv; /* Copy the callbaks for dbmdb_be() */
     return 0;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -3022,7 +3022,7 @@ dbmdb_import_worker(void *param)
             }
             if (is_objectclass_attribute) {
                 ret = index_addordel_string(be, SLAPI_ATTR_OBJECTCLASS,
-                                            SLAPI_ATTR_VALUE_TOMBSTONE, ep->ep_id, BE_INDEX_ADD, NULL);
+                                            SLAPI_ATTR_VALUE_TOMBSTONE, ep->ep_id, BE_INDEX_ADD, dbmdb_get_wctx(job, info, WCTX_GENERIC));
                 if (0 != ret) {
                     /* Something went wrong, eg disk filled up */
                     goto error;
@@ -3060,7 +3060,7 @@ dbmdb_import_worker(void *param)
                 if (tomb_csn) {
                     csn_as_string(tomb_csn, PR_FALSE, tomb_csnstr);
                     ret = index_addordel_string(be, SLAPI_ATTR_TOMBSTONE_CSN,
-                                                tomb_csnstr, ep->ep_id, BE_INDEX_ADD, NULL);
+                                                tomb_csnstr, ep->ep_id, BE_INDEX_ADD, dbmdb_get_wctx(job, info, WCTX_GENERIC));
                     if (0 != ret) {
                         /* Something went wrong, eg disk filled up */
                         goto error;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -754,7 +754,7 @@ dbi_dbslist_t *dbmdb_list_dbs(const char *dbhome)
     int i;
 
     strncpy(ctx.home, dbhome, MAXPATHLEN);
-    if (dbmdb_make_env(&ctx, 1, 0444)) {
+    if (dbmdb_make_env(&ctx, 1, 0644)) {
         return NULL;
     }
     dbs = (dbi_dbslist_t*)slapi_ch_calloc(ctx.nbdbis+1, sizeof (dbi_dbslist_t));

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2786,3 +2786,12 @@ dbmdb_public_clear_vlv_cache(Slapi_Backend *be, dbi_txn_t *txn, dbi_db_t *db)
     slapi_ch_free_string((char**)&rcdbi.dbname);
     return rc;
 }
+
+int
+dbmdb_public_delete_db(Slapi_Backend *be, dbi_db_t *db)
+{
+    struct ldbminfo *li = (struct ldbminfo *)(be->be_database->plg_private);
+    dbmdb_ctx_t *ctx = MDB_CONFIG(li);
+
+    return dbmdb_dbi_remove(ctx, &db);
+}

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2581,7 +2581,7 @@ int find_mdb_home(const char *db_filename, char *home, const char **dbname)
         pt = home + strlen(home);
         if (pt+10 >= &home[MAXPATHLEN])
             return DBI_RC_NOTFOUND;
-        strcpy(pt, "/data.mdb");
+        strcpy(pt, "/INFO.mdb");
         if (stat(home, &st) == 0) {
             /* Found dbhome */
             *pt = 0;
@@ -2602,7 +2602,7 @@ int find_mdb_home(const char *db_filename, char *home, const char **dbname)
 }
 
 int
-dbmdb_public_private_open(backend *be, const char *db_filename, dbi_env_t **env, dbi_db_t **db)
+dbmdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_t **env, dbi_db_t **db)
 {
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
     dbmdb_ctx_t *ctx = (dbmdb_ctx_t*) slapi_ch_calloc(1, sizeof *ctx);
@@ -2614,13 +2614,13 @@ dbmdb_public_private_open(backend *be, const char *db_filename, dbi_env_t **env,
     if (rc)
         return DBI_RC_NOTFOUND;
 
-    rc = dbmdb_make_env(ctx, 1, 0444);
+    rc = dbmdb_make_env(ctx, rw?0:1, 0644);
     if (rc) {
         return dbmdb_map_error(__FUNCTION__, rc);
     }
     *env = ctx->env;
 
-    rc = dbmdb_open_dbi_from_filename(&dbi, be, dbname, NULL, MDB_OPEN_DIRTY_DBI);
+    rc = dbmdb_open_dbi_from_filename(&dbi, be, dbname, NULL, MDB_OPEN_DIRTY_DBI | rw ?  MDB_CREATE : 0);
     if (rc) {
         return dbmdb_map_error(__FUNCTION__, rc);
     }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -387,6 +387,7 @@ dbi_error_t dbmdb_map_error(const char *funcname, int err);
 dbi_dbslist_t *dbmdb_list_dbs(const char *dbhome);
 int dbmdb_public_in_import(ldbm_instance *inst);
 const char *dbmdb_public_get_db_suffix(void);
+int dbmdb_public_delete_db(Slapi_Backend *be, dbi_db_t *db);
 
 
 /* dbimpl helpers */

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -399,7 +399,7 @@ const char *dblayer_op2str(dbi_op_t op)
 }
 
 /* Open db env, db and db file privately */
-int dblayer_private_open(const char *plgname, const char *dbfilename, Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db)
+int dblayer_private_open(const char *plgname, const char *dbfilename, int rw, Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db)
 {
     struct ldbminfo *li;
     int rc;
@@ -420,7 +420,7 @@ int dblayer_private_open(const char *plgname, const char *dbfilename, Slapi_Back
     /* Then open the env database plugin */
     if (!rc) {
         dblayer_private *priv = li->li_dblayer_private;
-        rc = priv->dblayer_private_open_fn(*be, dbfilename, env, db);
+        rc = priv->dblayer_private_open_fn(*be, dbfilename, rw, env, db);
     }
     if (rc) {
         dblayer_private_close(be, env, db);

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -479,3 +479,9 @@ dbi_dbslist_t *dblayer_list_dbs(const char *dbimpl_name, const char *dbhome)
     return dbs;
 }
 
+int dblayer_db_remove(Slapi_Backend *be, dbi_db_t *db)
+{
+    dblayer_private *priv = dblayer_get_priv(be);
+    return priv->dblayer_dbi_db_remove_fn(be, db);
+}
+

--- a/ldap/servers/slapd/back-ldbm/dbimpl.h
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.h
@@ -161,6 +161,7 @@ int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count);
 int dblayer_private_open(const char *plgname, const char *dbfilename, int rw, Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db);
 int dblayer_private_close(Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db);
 dbi_dbslist_t *dblayer_list_dbs(const char *dbimpl_name, const char *dbhome);
+int dblayer_db_remove(Slapi_Backend *be, dbi_db_t *db);
 
 
 #endif /* _DBIMPL_H */

--- a/ldap/servers/slapd/back-ldbm/dbimpl.h
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.h
@@ -158,7 +158,7 @@ const char *dblayer_strerror(int error);
 const char *dblayer_op2str(dbi_op_t op);
 int dblayer_cursor_get_count(dbi_cursor_t *cursor, dbi_recno_t *count);
 
-int dblayer_private_open(const char *plgname, const char *dbfilename, Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db);
+int dblayer_private_open(const char *plgname, const char *dbfilename, int rw, Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db);
 int dblayer_private_close(Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db);
 dbi_dbslist_t *dblayer_list_dbs(const char *dbimpl_name, const char *dbhome);
 

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -110,7 +110,7 @@ typedef int dblayer_dbi_txn_commit_fn_t(dbi_txn_t *txn);
 typedef int dblayer_dbi_txn_abort_fn_t(dbi_txn_t *txn);
 typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, dbi_txn_t *txn, int *count);
 typedef int dblayer_cursor_get_count_fn_t(dbi_cursor_t *cursor, dbi_recno_t *count);
-typedef int dblayer_private_open_fn_t(backend *be, const char *db_filename, dbi_env_t **env, dbi_db_t **db);
+typedef int dblayer_private_open_fn_t(backend *be, const char *db_filename, int rw, dbi_env_t **env, dbi_db_t **db);
 typedef int dblayer_private_close_fn_t(dbi_env_t **env, dbi_db_t **db);
 typedef int ldbm_back_wire_import_fn_t(Slapi_PBlock *pb);
 typedef int dblayer_restore_file_init_fn_t(struct ldbminfo *li);

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -120,6 +120,7 @@ typedef dbi_dbslist_t *dblayer_list_dbs_fn_t(const char *dbhome);
 typedef int dblayer_in_import_fn_t(ldbm_instance *inst);
 typedef const char *dblayer_get_db_suffix_fn_t(void);
 typedef int dblayer_clear_vlv_cache_fn_t(backend *be, dbi_txn_t *txn, dbi_db_t *db);
+typedef int dblayer_dbi_db_remove_fn_t(backend *be, dbi_db_t *db);
 
 struct dblayer_private
 {
@@ -200,6 +201,7 @@ struct dblayer_private
     dblayer_get_db_suffix_fn_t *dblayer_get_db_suffix_fn;
     dblayer_compact_fn_t *dblayer_compact_fn;
     dblayer_clear_vlv_cache_fn_t *dblayer_clear_vlv_cache_fn;
+    dblayer_dbi_db_remove_fn_t *dblayer_dbi_db_remove_fn;
 };
 
 #define DBLAYER_PRIV_SET_DATA_DIR 0x1

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -17,6 +17,7 @@
  * TODO: indirect indexes
  */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -52,6 +53,9 @@
 #define SHOWSUMMARY 0x8
 #define LISTDBS 0x10
 #define ASCIIDATA 0x20
+#define EXPORT 0x40
+#define IMPORT 0x80
+#define REMOVE 0x100
 
 /* stolen from slapi-plugin.h */
 #define SLAPI_OPERATION_BIND 0x00000001UL
@@ -93,6 +97,20 @@ typedef struct
     uint32_t id[1];
 } IDL;
 
+/* back-ldbm.h and proto-back-ldbm.h cannot be easily included here
+ * so let redefines the minimum to use txn
+ */
+typedef struct backend backend;
+typedef void *back_txnid;
+typedef struct back_txn {
+    void *txn;
+    void *foo[1];    /* just reserve enough space to store a txn */
+} back_txn;
+int dblayer_txn_begin(backend *be, back_txnid parent_txn, back_txn *txn);
+int dblayer_txn_commit(backend *be, back_txn *txn);
+int dblayer_txn_abort(backend *be, back_txn *txn);
+void dblayer_init_pvt_txn();
+
 #define RDN_BULK_FETCH_BUFFER_SIZE (8 * 1024)
 typedef struct _rdn_elem
 {
@@ -124,6 +142,7 @@ long match_cnt = 0;
 long ind_cnt = 0;
 long allids_cnt = 0;
 long other_cnt = 0;
+char *dump_name = NULL; 
 
 static Slapi_Backend *be = NULL; /* Pseudo backend used to interact with db */
 
@@ -1077,6 +1096,8 @@ usage(char *argv0)
     printf("    -n              display ID list lengths\n");
     printf("    -r              display the conents of ID list\n");
     printf("    -s              Summary of index counts\n");
+    printf("    -I file         Import database content from file\n");
+    printf("    -X file         Export database content in file\n");
     printf("  sample usages:\n");
     printf("    # list the db files\n");
     printf("    %s -D mdb -L /var/lib/dirsrv/slapd-i/db/\n", p0);
@@ -1145,6 +1166,219 @@ int dump_ascii(dbi_cursor_t *cursor, dbi_val_t *key, dbi_val_t *data)
     return rc;
 }
 
+static int
+_file_format_error()
+{
+    fprintf(stderr, "importdb failed: Invalid file format.\n");
+    return -2;
+}
+
+static void
+_push_val(const char *v, dbi_val_t *val)
+{
+    if (val->size >= val->ulen) {
+        if (val->ulen <= 0) {
+            val->ulen = 200;
+        } else {
+            val->ulen *= 2;
+        }
+        val->data = slapi_ch_realloc(val->data, val->ulen);
+    }
+    ((char*)(val->data))[val->size++] = strtol(v, NULL, 16);
+}
+
+
+static int
+_read_line(FILE *file, int *keyword, dbi_val_t *val)
+{
+    char v[3] = {0};
+    int c;
+
+    *keyword = -1;
+    val->size = 0;
+    enum { ST_POS0, ST_POS1, ST_POS2, ST_COMMENT, ST_VAL1, ST_VAL2 } state;
+    state = ST_POS0;
+    while ((c = fgetc(file)) != EOF) {
+        switch (state) {
+            case ST_COMMENT:
+                if (c == '\n') {
+                    state = ST_POS0;
+                }
+                continue;
+            case ST_VAL1:
+                if (c == '\n') {
+                    return 0;
+                }
+                if (!isxdigit(c)) {
+                    return _file_format_error();
+                }
+                v[0] = c;
+                state = ST_VAL2;
+                continue;
+            case ST_VAL2:
+                if (!isxdigit(c)) {
+                    return _file_format_error();
+                }
+                v[1] = c;
+                state = ST_VAL1;
+                _push_val(v, val);
+                continue;
+            case ST_POS0:
+                switch (c) {
+                    case '\n':
+                        continue;
+                    case '#':
+                        state = ST_COMMENT;
+                        continue;
+                    case 'k':
+                    case 'v':
+                    case 'e':
+                        state = ST_POS1;
+                        *keyword = c;
+                        continue;
+                    default:
+                        return _file_format_error();
+                }
+                /* NOTREACHED */
+            case ST_POS1:
+                if (c!= ':') {
+                    return _file_format_error();
+                }
+                state = ST_POS2;
+                continue;
+            case ST_POS2:
+                if (c!= ' ') {
+                    return _file_format_error();
+                }
+                state = ST_VAL1;
+                continue;
+        }
+    }
+    return EOF;
+}
+
+int
+importdb(const char *dbimpl_name, const char *filename, const char *dump_name)
+{
+    FILE *dump = fopen(dump_name, "r");
+    dbi_val_t key = {0}, data = {0};
+    struct back_txn txn = {0};
+    dbi_env_t *env = NULL;
+    dbi_db_t *db = NULL;
+    int keyword = 0;
+    int nbrec = 0;
+    int ret = 0;
+
+    dblayer_init_pvt_txn();
+
+    if (!dump) {
+        printf("Failed to open dump file %s. Error %d: %s\n", dump_name, errno, strerror(errno));
+        return 1;
+    }
+
+    if (dblayer_private_open(dbimpl_name, filename, 1, &be, &env, &db)) {
+        printf("Can't initialize db plugin: %s\n", dbimpl_name);
+        return 1;
+    }
+
+    ret = dblayer_txn_begin(be, NULL, &txn);
+
+    while (ret == 0 &&
+           !_read_line(dump, &keyword, &key) && keyword == 'k' &&
+           !_read_line(dump, &keyword, &data) && keyword == 'v') {
+        ret = dblayer_db_op(be, db, txn.txn, DBI_OP_PUT, &key, &data);
+        if (nbrec++ % 1000 == 0) {
+            ret = dblayer_txn_commit(be, &txn) |
+                dblayer_txn_begin(be, NULL, &txn);
+        }
+    }
+    if (nbrec % 1000 != 0) {
+        ret = dblayer_txn_commit(be, &txn);
+    }
+    fclose(dump);
+    dblayer_value_free(be, &key);
+    dblayer_value_free(be, &data);
+    if (dblayer_private_close(&be, &env, &db)) {
+        printf("Unable to shutdown the db plugin: %s\n", dblayer_strerror(1));
+        return 1;
+    }
+    return ret;
+}
+
+void print_value(FILE *dump, char *keyword, unsigned char *data, int len) 
+{
+    fprintf(dump,"%s", keyword);
+    while (len-- >0) {
+        fprintf(dump,"%02x", *data++);
+    }
+    fprintf(dump,"\n");
+}
+
+int
+exportdb(const char *dbimpl_name, const char *filename, const char *dump_name)
+{
+    FILE *dump = fopen(dump_name, "w");
+    dbi_val_t key = {0}, data = {0};
+    dbi_cursor_t cursor = {0};
+    dbi_env_t *env = NULL;
+    dbi_db_t *db = NULL;
+    int ret = 0;
+
+    if (!dump) {
+        printf("Failed to open dump file %s. Error %d: %s\n", dump_name, errno, strerror(errno));
+        return 1;
+    }
+
+    if (dblayer_private_open(dbimpl_name, filename, 0, &be, &env, &db)) {
+        printf("Can't initialize db plugin: %s\n", dbimpl_name);
+        return 1;
+    }
+
+    /* cursor through the db */
+
+    ret = dblayer_new_cursor(be, db, NULL, &cursor);
+    if (ret != 0) {
+        printf("Can't create db cursor: %s\n", dblayer_strerror(ret));
+        return 1;
+    }
+
+    fprintf(dump, "# %s\n", filename);
+
+    /* Position cursor at the matching key */
+    ret = dblayer_cursor_op(&cursor, DBI_OP_MOVE_TO_FIRST,  &key, &data);
+    while (ret == DBI_RC_SUCCESS) {
+        print_value(dump, "k: ", key.data, key.size);
+        print_value(dump, "v: ", data.data, data.size);
+        fprintf(dump, "\n");
+        if (ferror(dump)) {
+            printf("Failed to write in dump file %s. Error %d: %s\n", dump_name, errno, strerror(errno));
+            break;
+        }
+        ret = dblayer_cursor_op(&cursor, DBI_OP_NEXT,  &key, &data);
+    }
+    if (ret == DBI_RC_NOTFOUND) {
+        fprintf(dump, "e: \n");
+        ret = 0;
+    }
+    fclose(dump);
+    dblayer_value_free(be, &key);
+    dblayer_value_free(be, &data);
+    dblayer_cursor_op(&cursor, DBI_OP_CLOSE, NULL, NULL);
+    if (dblayer_private_close(&be, &env, &db)) {
+        printf("Unable to shutdown the db plugin: %s\n", dblayer_strerror(1));
+        return 1;
+    }
+    return ret;
+}
+
+int
+removedb(const char *dbimpl_name, const char *filename)
+{
+}
+
+
+
+
 int
 main(int argc, char **argv)
 {
@@ -1159,7 +1393,7 @@ main(int argc, char **argv)
     char * dbimpl_name = "bdb";
     int c;
 
-    while ((c = getopt(argc, argv, "Af:RL:l:nG:srk:K:hvt:D:")) != EOF) {
+    while ((c = getopt(argc, argv, "Af:RL:l:nG:srk:K:hvt:D:X:I:d")) != EOF) {
         switch (c) {
         case 'A':
             display_mode |= ASCIIDATA;
@@ -1214,10 +1448,33 @@ main(int argc, char **argv)
         case 'D':
             dbimpl_name = optarg;
             break;
+        case 'X':
+            display_mode |= EXPORT;
+            dump_name = optarg;
+            break;
+        case 'I':
+            display_mode |= IMPORT;
+            dump_name = optarg;
+            break;
+        case 'd':
+            display_mode |= REMOVE;
+            break;
         case 'h':
         default:
             usage(argv[0]);
         }
+    }
+
+    if (display_mode & EXPORT) {
+        return exportdb(dbimpl_name, filename, dump_name);
+    }
+
+    if (display_mode & IMPORT) {
+        return importdb(dbimpl_name, filename, dump_name);
+    }
+
+    if (display_mode & REMOVE) {
+        return removedb(dbimpl_name, filename);
     }
 
     if (display_mode & LISTDBS) {
@@ -1250,7 +1507,7 @@ main(int argc, char **argv)
         }
     }
 
-    if (dblayer_private_open(dbimpl_name, filename, &be, &env, &db)) {
+    if (dblayer_private_open(dbimpl_name, filename, 0, &be, &env, &db)) {
         printf("Can't initialize db plugin: %s\n", dbimpl_name);
         ret = 1;
         goto done;

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -1266,7 +1266,6 @@ importdb(const char *dbimpl_name, const char *filename, const char *dump_name)
     dbi_env_t *env = NULL;
     dbi_db_t *db = NULL;
     int keyword = 0;
-    int nbrec = 0;
     int ret = 0;
 
     dblayer_init_pvt_txn();

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -25,6 +25,7 @@ from lib389.cli_ctl import nsstate as cli_nsstate
 from lib389.cli_ctl import dbgen as cli_dbgen
 from lib389.cli_ctl import dsrc as cli_dsrc
 from lib389.cli_ctl import cockpit as cli_cockpit
+from lib389.cli_ctl import dblib as cli_dblib
 from lib389.cli_ctl.instance import instance_remove_all
 from lib389.cli_base import (
     disconnect_instance,
@@ -64,6 +65,7 @@ cli_nsstate.create_parser(subparsers)
 cli_dbgen.create_parser(subparsers)
 cli_dsrc.create_parser(subparsers)
 cli_cockpit.create_parser(subparsers)
+cli_dblib.create_parser(subparsers)
 
 argcomplete.autocomplete(parser)
 

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -572,7 +572,7 @@ class DirSrv(SimpleLDAPObject, object):
                 self.serverid = args.get(SER_SERVERID_PROP, None)
                 self.isLocal = True
             else:
-                self.isLocal = isLocalHost(self.host)
+            self.isLocal = isLocalHost(self.host)
 
         self.log.debug("Allocate %s with %s:%s", self.__class__, self.host, (self.sslport or self.port))
 
@@ -2717,18 +2717,17 @@ class DirSrv(SimpleLDAPObject, object):
 
         return True
 
-    def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, replication,
+    def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, repl_data,
                 outputfile, export_cl=False):
         """
         @param bename - The backend name of the database to export
         @param suffixes - List/tuple of suffixes to export
         @param excludeSuffixes - List/tuple of suffixes to exclude from export
         @param encrypt - Perform attribute encryption
-        @param replication - Export the replication data
+        @param repl_data - Export the replication data
         @param outputfile - The filename for the exported LDIF
         @return - True if export succeeded
         """
-        self.log.debug(f"db2ldif(bename={bename}, suffixes={suffixes}, excludeSuffixes={excludeSuffixes}, encrypt={encrypt}, replication={replication}, outputfile={outputfile}, export_cl={export_cl}")
         DirSrvTools.lib389User(user=DEFAULT_USER)
         prog = os.path.join(self.ds_paths.sbin_dir, 'ns-slapd')
 
@@ -2759,7 +2758,7 @@ class DirSrv(SimpleLDAPObject, object):
                 cmd.append(excludeSuffix)
         if encrypt:
             cmd.append('-E')
-        if replication and not export_cl:
+        if repl_data and not export_cl:
             cmd.append('-r')
         if export_cl:
             cmd.append('-R')
@@ -2775,7 +2774,6 @@ class DirSrv(SimpleLDAPObject, object):
             else:
                 ldifname = os.path.join(self.ds_paths.ldif_dir, "%s-%s.ldif" % (self.serverid, tnow))
             cmd.append(ldifname)
-        self.log.debug(f"db2ldif run: {str(cmd)}")
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -572,7 +572,7 @@ class DirSrv(SimpleLDAPObject, object):
                 self.serverid = args.get(SER_SERVERID_PROP, None)
                 self.isLocal = True
             else:
-            self.isLocal = isLocalHost(self.host)
+                self.isLocal = isLocalHost(self.host)
 
         self.log.debug("Allocate %s with %s:%s", self.__class__, self.host, (self.sslport or self.port))
 

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -567,7 +567,12 @@ class DirSrv(SimpleLDAPObject, object):
                 DirSrvTools.searchHostsFile(self.host, None)
         # Check if we are local only if we haven't found that yet
         if not self.isLocal:
-            self.isLocal = isLocalHost(self.host)
+            if self.host is None and SER_SERVERID_PROP in args:
+                # Lets assume that local serverid is provided.
+                self.serverid = args.get(SER_SERVERID_PROP, None)
+                self.isLocal = True
+            else:
+                self.isLocal = isLocalHost(self.host)
 
         self.log.debug("Allocate %s with %s:%s", self.__class__, self.host, (self.sslport or self.port))
 
@@ -2712,17 +2717,18 @@ class DirSrv(SimpleLDAPObject, object):
 
         return True
 
-    def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, repl_data,
+    def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, replication,
                 outputfile, export_cl=False):
         """
         @param bename - The backend name of the database to export
         @param suffixes - List/tuple of suffixes to export
         @param excludeSuffixes - List/tuple of suffixes to exclude from export
         @param encrypt - Perform attribute encryption
-        @param repl_data - Export the replication data
+        @param replication - Export the replication data
         @param outputfile - The filename for the exported LDIF
         @return - True if export succeeded
         """
+        self.log.debug(f"db2ldif(bename={bename}, suffixes={suffixes}, excludeSuffixes={excludeSuffixes}, encrypt={encrypt}, replication={replication}, outputfile={outputfile}, export_cl={export_cl}")
         DirSrvTools.lib389User(user=DEFAULT_USER)
         prog = os.path.join(self.ds_paths.sbin_dir, 'ns-slapd')
 
@@ -2753,7 +2759,7 @@ class DirSrv(SimpleLDAPObject, object):
                 cmd.append(excludeSuffix)
         if encrypt:
             cmd.append('-E')
-        if repl_data and not export_cl:
+        if replication and not export_cl:
             cmd.append('-r')
         if export_cl:
             cmd.append('-R')
@@ -2769,6 +2775,7 @@ class DirSrv(SimpleLDAPObject, object):
             else:
                 ldifname = os.path.join(self.ds_paths.ldif_dir, "%s-%s.ldif" % (self.serverid, tnow))
             cmd.append(ldifname)
+        self.log.debug(f"db2ldif run: {str(cmd)}")
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -571,6 +571,7 @@ class DirSrv(SimpleLDAPObject, object):
                 # Lets assume that local serverid is provided.
                 self.serverid = args.get(SER_SERVERID_PROP, None)
                 self.isLocal = True
+                self.setup_ldapi()
             else:
                 self.isLocal = isLocalHost(self.host)
 

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -367,12 +367,9 @@ def dblib_mdb2bdb(inst, log, args):
         if 'has_id2entry' not in be:
             continue
         log.info(f"Backends exportation {progress*100/total_dbsize:2f}% ({bename})")
-        os.chown(be['ldifname'], uid, gid)
         log.debug(f"inst.db2ldif({bename}, None, None, {encrypt}, True, {be['ldifname']})")
         inst.db2ldif(bename, None, None, encrypt, True, be['ldifname'], False)
         be['cl5'] = export_changelog(be, 'mdb')
-        for f in glob.glob(f'{dbdir}/*'):
-            os.chown(f, uid, gid)
         progress += 1
     log.info("Backends exportation 100%")
     dbhome=backends["config"]["dbdir"]
@@ -396,9 +393,12 @@ def dblib_mdb2bdb(inst, log, args):
             continue
         log.info(f"Backends importation {progress*100/total_dbsize:2f}% ({bename})")
         log.debug(f"inst.ldif2db({bename}, None, None, {encrypt}, {be['ldifname']})")
+        os.chown(be['ldifname'], uid, gid)
         inst.ldif2db(bename, None, None, encrypt, be['ldifname'])
         if be['cl5'] is True:
             import_changelog(be, 'bdb')
+        for f in glob.glob(f'{dbdir}/*'):
+            os.chown(f, uid, gid)
         progress += be['dbsize']
     log.info("Backends importation 100%")
     set_files_owner(inst, backends)

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -1,0 +1,389 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2021 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import os
+import re
+import glob
+import shutil
+from lib389.paths import Paths
+from lib389.backend import Backends
+from lib389.dseldif import DSEldif
+from lib389.replica import Replicas
+import fnmatch
+import logging
+import subprocess
+
+
+DBLIB_LDIF_PREFIX = "__dblib-"
+DEFAULT_DBMAP_SIZE = 2 * 1024 * 1024 * 1024
+DBSIZE_MARGIN = 1.2
+DBI_MARGIN = 60
+
+MDB_INFO = "INFO.mdb"
+MDB_MAP = "data.mdb"
+MDB_LOCK = "lock.mdb"
+
+LDBM_DN = "cn=config,cn=ldbm database,cn=plugins,cn=config"
+
+def get_ldif_dir(instance): 
+    """
+    Get the server's LDIF directory.
+    """
+    server_dir = instance.get_ldif_dir()
+    if server_dir is not None:
+        return server_dir
+    return "/foo"
+
+def get_backends(log, dse, tmpdir):
+    """
+    Get the backends and some associated data
+    Note: inst is not connected so Backends(inst).list() cannot be used.
+          So lets directly parse the data from the ldif file
+    """
+    res = {}
+    for entry in dse._contents:
+        found = re.search(r'^dn: cn=([^,]*), *cn=ldbm database.*', entry)
+        if found:
+            dn = found[0][4:]
+            bename = found[1]
+            suffix = dse.get(dn, "nsslapd-suffix", True)
+            dbdir = dse.get(dn, "nsslapd-directory", True)
+            dblib = dse.get(dn, "nsslapd-backend-implement", True)
+            ldifname = f'{tmpdir}/{DBLIB_LDIF_PREFIX}{bename}.ldif'
+            cl5name = f'{tmpdir}/{DBLIB_LDIF_PREFIX}{bename}.cl5.dbtxt'
+            cl5dbname = f'{dbdir}/replication_changelog.db'
+            dbsize = 0
+            entrysize = 0
+            for f in glob.glob(f'{dbdir}/id2entry.db*'):
+                entrysize = os.path.getsize(f)
+            for f in glob.glob(f'{dbdir}/*.db*'):
+                dbsize += os.path.getsize(f)
+            indexes = dse.get_indexes(bename)
+            # Let estimate the numbe of dbis : id2entry + 1 per regular index + 2 per vlv index
+            dbi = 1 + len(indexes) + len ([index for index in indexes if index.startswith("vlv#")])
+
+            res[bename] =( {
+                 'dn'        :  dn,
+                 'bename'    :  bename,
+                 'suffix'    :  suffix,
+                 'dbdir'     :  dbdir,
+                 'dbsize'    :  dbsize,
+                 'dblib'     :  dblib,
+                 'ldifname'  :  ldifname,
+                 'cl5name'   :  cl5name,
+                 'cl5dbname' :  cl5dbname,
+                 'dbsize'    :  dbsize,
+                 'entrysize' :  entrysize,
+                 'indexes'   :  indexes,
+                 'dbi'       :  dbi
+            })
+    #log.info(f'get_backends returns: {str(res)}')
+    return res
+
+def get_mdb_dbis(dbdir):
+    # Returns a map  containings associating the backend (Could be None)
+    # to a map associating the dbi filename to a map describing its statistics.
+    result = {}
+    output = run_dbscan(['-D', 'mdb', '-L', dbdir])
+    for line in output.split("\n"):
+        found = re.search(f'^ {dbdir}/?([^/]*)?/([^/]*) flags: .*state:.([^ ]*).*nb_entries=([0-9]*)', line)
+        if (found):
+            bename = found[1]
+            if bename == '':
+                bename = None
+            filename = found[2]
+            state = found[3]
+            nbentries = found[4]
+            if bename not in result:
+                result[bename] = {}
+            result[bename][filename] = { 'bename' : bename, 'filename' : filename, 'state' : state, 'nbentries' : nbentries }
+    return result
+
+
+def size_fmt(num):
+    for unit in [ "B", "KB", "MB", "GB", "TB" ]:
+        if (num < 1024):
+            return f"{num:3.1f} {unit}"
+        num /= 1024
+    return f"{num:.1f} TB"
+
+def run_dbscan(args):
+    prefix = os.environ.get('PREFIX', "")
+    prog = f'{prefix}/bin/dbscan'
+    args.insert(0, prog)
+    output = subprocess.check_output(args, encoding='utf-8', stderr=subprocess.STDOUT)
+    return output
+
+
+def export_changelog(log, be, dblib):
+    # Export backend changelog
+    try:
+        run_dbscan(['-D', dblib, '-f', be['cl5dbname'], '-X', be['cl5name']])
+        return True
+    except Exception as e:
+        log.exception(e)
+        return False
+
+
+def import_changelog(log, be, dblib):
+    # import backend changelog
+    try:
+        run_dbscan(['-D', dblib, '-f', be['cl5dbname'], '-I', be['cl5name']])
+        return True
+    except Exception as e:
+        log.exception(e)
+        return False
+
+
+
+
+def dblib_bdb2mdb(inst, log, args):
+    if args.tmpdir is None:
+        tmpdir = get_ldif_dir(inst)
+    try:
+        os.makedirs(tmpdir, 0o750, True)
+    except OSError as e:
+        log.error(f"Failed trying to create the directory {tmpdir} needed to store the ldif files, error: {str(e)}")
+        return
+
+    # Cannot use Backends(inst).list() because it requires a connection.
+    # lets use directlt the dse.ldif after having stopped the instance
+
+    inst.stop()
+    dse = DSEldif(inst)
+    backends = get_backends(log, dse, tmpdir)
+    dbmapdir = backends['config']['dbdir']
+    dblib = backends['config']['dblib']
+
+    if dblib == "mdb":
+        log.error(f"Instance {inst.serverid} is already configured with lmdb.")
+        return
+
+    # Remove ldif files and mdb files 
+    dblib_cleanup(inst, log, args)
+
+    # Compute the needed space and the lmdb map configuration
+    total_dbsize = 0
+    total_entrysize = 0
+    total_dbi = 3
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if be['dbsize'] == 0:
+            continue
+        total_dbsize += be['dbsize']
+        total_entrysize += be['entrysize']
+        total_dbi += be['dbi']
+
+    # Round up dbmap size
+    dbmap_size = DEFAULT_DBMAP_SIZE
+    while ( total_dbsize * DBSIZE_MARGIN > dbmap_size ):
+        dbmap_size *= 1.25
+
+    # Round up number of dbis
+    nbdbis = 1
+    while nbdbis < total_dbi + DBI_MARGIN:
+        nbdbis *= 2
+
+    log.info(f"Required space for LDIF files is about {size_fmt(total_entrysize)}")
+    log.info(f"Required space for DBMAP files is about {size_fmt(dbmap_size)}")
+    log.info(f"Required number of dbi is {nbdbis}")
+
+    # Generate the info file (so dbscan could generate the map) 
+    with open(f'{dbmapdir}/{MDB_INFO}', 'w') as f:
+        f.write(f'LIBVERSION=9025\n')
+        f.write(f'DATAVERSION=0\n')
+        f.write(f'MAXSIZE={dbmap_size}\n')
+        f.write(f'MAXREADERS=50\n')
+        f.write(f'MAXDBS={nbdbis}\n')
+
+
+    if os.stat(dbmapdir).st_dev == os.stat(tmpdir).st_dev:
+        total, used, free = shutil.disk_usage(dbmapdir)
+        if free < total_entrysize + dbmap_size:
+            log.error(f"Not enough space on {dbmapdir} to migrate to lmdb (Need {size_fmt(total_entrysize + dbmap_size)}, Have {size_fmt(free)})")
+            return
+    else:
+        total, used, free = shutil.disk_usage(dbmapdir)
+        if free < dbmap_size:
+            log.error(f"Not enough space on {dbmapdir} to migrate to lmdb (Need {size_fmt(dbmap_size)}, Have {size_fmt(free)})")
+            return
+        total, used, free = shutil.disk_usage(tmpdir)
+        if free < total_entrysize:
+            log.error("Not enough space on {tmpdir} to migrate to lmdb (Need {size_fmt(total_entrysize)}, Have {size_fmt(free)})")
+            return
+    progress = 0
+    encrypt = False # Should be a args param ?
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if be['dbsize'] == 0:
+            continue
+        log.info(f"Backends exportation {progress*100/total_dbsize:2f}% ({bename})")
+        log.debug(f"inst.db2ldif({bename}, None, None, {encrypt}, True, {be['ldifname']})")
+        inst.db2ldif(bename, None, None, encrypt, True, be['ldifname'], True)
+        be['cl5'] = export_changelog(log, be, 'bdb')
+        progress += be['dbsize']
+    log.info(f"Backends exportation 100%")
+
+    log.info(f"Updating dse.ldif file")
+    # switch nsslapd-backend-implement in the dse.ldif
+    cfgbe = backends['config']
+    dn = cfgbe['dn']
+    dse.replace(dn, 'nsslapd-backend-implement', 'mdb')
+
+    # Add the lmdb config entry
+    dn = f'cn=mdb,{dn}'
+    try:
+        dse.delete_dn(dn)
+    except Exception:
+        pass
+    dse.add_entry ([
+        f"dn: {dn}\n",
+        f"objectClass: extensibleobject\n",
+        f"objectClass: top\n",
+        f"cn: mdb\n",
+        f"nsslapd-mdb-max-size: {dbmap_size}\n",
+        f"nsslapd-mdb-max-readers: 0\n",
+        f"nsslapd-mdb-max-dbs: {nbdbis}\n",
+        f"nsslapd-db-durable-transaction: on\n",
+        f"nsslapd-search-bypass-filter-test: on\n",
+        f"nsslapd-serial-lock: on\n"
+    ])
+
+    # Reimport all exported backends and changelog
+    progress = 0
+    encrypt = False # Should be a args param ?
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if be['dbsize'] == 0:
+            continue
+        log.info(f"Backends importation {progress*100/total_dbsize:2f}% ({bename})")
+        log.debug(f"inst.ldif2db({bename}, None, None, {encrypt}, {be['ldifname']})")
+        inst.ldif2db(bename, None, None, encrypt, be['ldifname'])
+        if be['cl5'] is True:
+            import_changelog(log, be, 'mdb')
+        progress += be['dbsize']
+    log.info(f"Backends importation 100%")
+    inst.start()
+    log.info(f"Migration from Berkeley database to lmdb is done.")
+
+def dblib_mdb2bdb(inst, log, args):
+    if args.tmpdir is None:
+        tmpdir = get_ldif_dir(inst)
+    try:
+        os.makedirs(tmpdir, 0o750, True)
+    except OSError as e:
+        log.error(f"Failed trying to create the directory {tmpdir} needed to store the ldif files, error: {str(e)}")
+        return
+
+    # Cannot use Backends(inst).list() because it requires a connection.
+    # lets use directlt the dse.ldif after having stopped the instance
+
+    inst.stop()
+    dse = DSEldif(inst)
+    backends = get_backends(log, dse, tmpdir)
+    dbmapdir = backends['config']['dbdir']
+    dblib = backends['config']['dblib']
+    dbis = get_mdb_dbis(dbmapdir)
+
+    if dblib == "bdb":
+        log.error(f"Instance {inst.serverid} is already configured with bdb.")
+        return
+
+    # Remove ldif files and bdb files 
+    dblib_cleanup(inst, log, args)
+
+    for be in dbis:
+        if be is None:
+            continue
+        id2entry = dbis[be]['id2entry.db']
+        if int(id2entry['nbentries']) > 0:
+            backends[be]['has_id2entry'] = True
+
+    # Compute the needed space and the lmdb map configuration
+    dbmap_size = os.path.getsize(f'{dbmapdir}/{MDB_MAP}')
+    # Clearly over evaluated (but better than nothing )
+    total_entrysize = dbmap_size
+
+    log.info(f"Required space for LDIF files is about {size_fmt(total_entrysize)}")
+    log.info(f"Required space for bdb files is about {size_fmt(dbmap_size)}")
+
+    if os.stat(dbmapdir).st_dev == os.stat(tmpdir).st_dev:
+        total, used, free = shutil.disk_usage(dbmapdir)
+        if free < total_entrysize + dbmap_size:
+            log.error(f"Not enough space on {dbmapdir} to migrate to bdb (Need {size_fmt(total_entrysize + dbmap_size)}, Have {size_fmt(free)})")
+            return
+    else:
+        total, used, free = shutil.disk_usage(dbmapdir)
+        if free < dbmap_size:
+            log.error(f"Not enough space on {dbmapdir} to migrate to bdb (Need {size_fmt(dbmap_size)}, Have {size_fmt(free)})")
+            return
+        total, used, free = shutil.disk_usage(tmpdir)
+        if free < total_entrysize:
+            log.error("Not enough space on {tmpdir} to migrate to bdb (Need {size_fmt(total_entrysize)}, Have {size_fmt(free)})")
+            return
+    progress = 0
+    encrypt = False # Should be a args param ?
+    total_dbsize = 0
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if 'has_id2entry' not in be:
+            continue
+        total_dbsize += 1
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if 'has_id2entry' not in be:
+            continue
+        log.info(f"Backends exportation {progress*100/total_dbsize:2f}% ({bename})")
+        log.debug(f"inst.db2ldif({bename}, None, None, {encrypt}, True, {be['ldifname']})")
+        inst.db2ldif(bename, None, None, encrypt, True, be['ldifname'], True)
+        be['cl5'] = export_changelog(log, be, 'mdb')
+        progress += 1
+    log.info(f"Backends exportation 100%")
+
+    log.info(f"Updating dse.ldif file")
+    # switch nsslapd-backend-implement in the dse.ldif
+    cfgbe = backends['config']
+    dn = cfgbe['dn']
+    dse.replace(dn, 'nsslapd-backend-implement', 'mdb')
+
+    # bdb entries should still be here
+
+    # Reimport all exported backends and changelog
+    progress = 0
+    encrypt = False # Should be a args param ?
+    for bename, be in backends.items():
+        # Keep only backend associated with a db
+        if 'has_id2entry' not in be:
+            continue
+        log.info(f"Backends importation {progress*100/total_dbsize:2f}% ({bename})")
+        log.debug(f"inst.ldif2db({bename}, None, None, {encrypt}, {be['ldifname']})")
+        inst.ldif2db(bename, None, None, encrypt, be['ldifname'])
+        if be['cl5'] is True:
+            import_changelog(log, be, 'bdb')
+        progress += be['dbsize']
+    log.info(f"Backends importation 100%")
+    inst.start()
+    log.info(f"Migration from ldbm to Berkeley database is done.")
+
+def dblib_cleanup(inst, log, args):
+    pass
+
+def create_parser(subparsers):
+    dblib_parser = subparsers.add_parser('dblib', help="database library (i.e bdb/lmdb) migration")
+    subcommands = dblib_parser.add_subparsers(help="action")
+
+    dblib_bdb2mdb_parser = subcommands.add_parser('bdb2mdb', help='Migrate bdb databases to lmdb')
+    dblib_bdb2mdb_parser.set_defaults(func=dblib_bdb2mdb)
+    dblib_bdb2mdb_parser.add_argument('--tmpdir', help="ldif migration files directory path.")
+
+    dblib_mdb2bdb_parser = subcommands.add_parser('mdb2bdb', help='Migrate lmdb databases to bdb')
+    dblib_mdb2bdb_parser.set_defaults(func=dblib_mdb2bdb)
+    dblib_mdb2bdb_parser.add_argument('--tmpdir', help="ldif migration files directory path.")
+
+    dblib_cleanup_parser = subcommands.add_parser('cleanup', help='Remove migration ldif file and old database')
+    dblib_cleanup_parser.set_defaults(func=dblib_cleanup)

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -420,6 +420,7 @@ def dblib_cleanup(inst, log, args):
     dse = DSEldif(inst)
     backends = get_backends(log, dse, tmpdir)
     dbmapdir = backends['config']['dbdir']
+    dbhome = inst.ds_paths.db_home_dir
     dblib = backends['config']['dblib']
 
     # Remove all ldif and changelog file
@@ -436,6 +437,11 @@ def dblib_cleanup(inst, log, args):
                 rm(f)
             rm(f'{dbdir}/DBVERSION')
             os.rmdir(dbdir)
+        if dbhome != dbdir:
+            for f in glob.glob(f'{dbhome}/*.db*'):
+                rm(f)
+            rm(f'{dbhome}/DBVERSION')
+
     if dblib == "bdb":
         rm(f'{dbmapdir}/INFO.mdb')
         rm(f'{dbmapdir}/data.mdb')

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -397,7 +397,7 @@ def dblib_mdb2bdb(inst, log, args):
         inst.ldif2db(bename, None, None, encrypt, be['ldifname'])
         if be['cl5'] is True:
             import_changelog(be, 'bdb')
-        for f in glob.glob(f'{dbdir}/*'):
+        for f in glob.glob(f'{be["dbdir"]}/*'):
             os.chown(f, uid, gid)
         progress += be['dbsize']
     log.info("Backends importation 100%")

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -401,7 +401,6 @@ def dblib_mdb2bdb(inst, log, args):
             os.chown(f, uid, gid)
         progress += be['dbsize']
     log.info("Backends importation 100%")
-    set_files_owner(inst, backends)
     inst.start()
     log.info("Migration from ldbm to Berkeley database is done.")
 

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -437,22 +437,18 @@ def dblib_cleanup(inst, log, args):
                 rm(f)
             rm(f'{dbdir}/DBVERSION')
             os.rmdir(dbdir)
-        if dbhome != dbdir:
-            for f in glob.glob(f'{dbhome}/*.db*'):
-                rm(f)
-            rm(f'{dbhome}/DBVERSION')
 
     if dblib == "bdb":
         rm(f'{dbmapdir}/INFO.mdb')
         rm(f'{dbmapdir}/data.mdb')
         rm(f'{dbmapdir}/lock.mdb')
     else:
-        for f in glob.glob(f'{dbmapdir}/__db.*'):
+        for f in glob.glob(f'{dbhome}/__db.*'):
             rm(f)
         for f in glob.glob(f'{dbmapdir}/log.*'):
             rm(f)
-        rm(f'{dbmapdir}/DBVERSION')
-        rm(f'{dbmapdir}/guardian')
+        rm(f'{dbhome}/DBVERSION')
+        rm(f'{dbhome}/guardian')
 
 
 def create_parser(subparsers):

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -448,7 +448,7 @@ def dblib_cleanup(inst, log, args):
         for f in glob.glob(f'{dbmapdir}/log.*'):
             rm(f)
         rm(f'{dbhome}/DBVERSION')
-        rm(f'{dbhome}/guardian')
+        rm(f'{dbmapdir}/guardian')
 
 
 def create_parser(subparsers):

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -159,6 +159,20 @@ class DSEldif(DSLint):
 
         return indexes
 
+
+    def add_entry(self, entry):
+        """Add a new entry
+
+        :param entry: the entry to add in ldif format
+        :type value: str list
+        """
+
+        if self._contents[-1] != "\n":
+            self._contents.append("\n")
+        self._contents.extend(entry)
+        self._update()
+
+
     def add(self, entry_dn, attr, value):
         """Add an attribute under a given entry
 

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -913,6 +913,9 @@ class SetupDs(object):
 
         # Start the server
         # Make changes using the temp root
+        self.log.debug(f"asan_enabled={ds_instance.has_asan()}")
+        self.log.debug(f"libfaketime installed ={'libfaketime' in sys.modules}")
+        assert_c(not ds_instance.has_asan() or 'libfaketime' not in sys.modules, "libfaketime python module is incompatible with ASAN build.")
         ds_instance.start(timeout=60)
         ds_instance.open()
 


### PR DESCRIPTION

This PR add a "dblib" sub menu to dsctl command  that implements three subcommands:
  - dsctl instance dblib bdb2mdb       --> migrate the instance database from bdb to lmdb
  - dsctl instance dblib mdb2bdb       --> migrate the instance database from lmdb to bdb
  - dsctl instance dblib cleanup          --> remove the migration ldif files and the unused database files
  
Note: as far as cleanup action is not use both databases exists on the instance and you can
  switch db by using dsconf then restart the instance:
 dsconf supplier1 backend config set --db_lib XXX  (XXX is bdb or mdb)
 
 Issue: 4898

Reviewed by:

Tested on: Fedora 34