### PR TITLE
Issue 2790 - Set db home directory by default

### DIFF
--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -59,7 +59,7 @@ access_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/access
 audit_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/audit
 error_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/errors
 db_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/db
-db_home_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/db
+db_home_dir = /dev/shm/slapd-{instance_name}
 backup_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/bak
 ldif_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/ldif
 

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -767,7 +767,7 @@ class SetupDs(object):
         self.log.info("Create file system structures ...")
         # Create all the needed paths
         # we should only need to make bak_dir, cert_dir, config_dir, db_dir, ldif_dir, lock_dir, log_dir, run_dir?
-        for path in ('backup_dir', 'cert_dir', 'db_dir', 'ldif_dir', 'lock_dir', 'log_dir', 'run_dir'):
+        for path in ('backup_dir', 'cert_dir', 'db_dir', 'db_home_dir', 'ldif_dir', 'lock_dir', 'log_dir', 'run_dir'):
             self.log.debug("ACTION: creating %s", slapd[path])
             try:
                 os.umask(0o007)  # For parent dirs that get created -> sets 770 for perms
@@ -904,7 +904,7 @@ class SetupDs(object):
         if general['selinux']:
             self.log.info("Perform SELinux labeling ...")
             selinux_paths = ('backup_dir', 'cert_dir', 'config_dir', 'db_dir',
-                             'ldif_dir', 'lock_dir', 'log_dir',
+                             'ldif_dir', 'lock_dir', 'log_dir', 'db_home_dir',
                              'run_dir', 'schema_dir', 'tmp_dir')
             for path in selinux_paths:
                 selinux_restorecon(slapd[path])


### PR DESCRIPTION
Description:  

The selinux rules (selinux-policy-3.14.3-79) have been updated to support /dev/shm/slapd-INST

Set db home by default

Relates: https://github.com/389ds/389-ds-base/issues/2790

