### PR TITLE
Issue 4096 - Missing perl dependencies for logconv.pl

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -182,8 +182,10 @@ Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $ver
 # Needed by logconv.pl
 Requires:         perl-DB_File
 Requires:         perl-Archive-Tar
+%if 0%{?fedora} >= 33 || 0%{?rhel} >= 9
 Requires:         perl-debugger
 Requires:         perl-sigtrap
+%endif
 # Needed for password dictionary checks
 Requires:         cracklib-dicts
 # Picks up our systemd deps.


### PR DESCRIPTION
Bug Description:
Split perl dependencies are not available in EPEL8.

Fix Description:
Use split perl dependencies only on Fedora >= 33 and
RHEL >= 9.

Fixes: https://github.com/389ds/389-ds-base/issues/4096

Reviewed by: ???