### PR TITLE
Issue 4731 - Promoting/demoting a replica can crash the server

### DIFF
--- a/dirsrvtests/tests/suites/replication/promote_demote_test.py
+++ b/dirsrvtests/tests/suites/replication/promote_demote_test.py
@@ -1,0 +1,67 @@
+import logging
+import pytest
+import os
+from lib389._constants import DEFAULT_SUFFIX,  ReplicaRole
+from lib389.topologies import topology_m1h1c1 as topo
+from lib389.replica import Replicas, ReplicationManager, Agreements
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+def test_promote_demote(topo):
+    """Test promoting and demoting a replica
+
+    :id: 75edff64-f987-4ed5-a03d-9bee73c0fbf0
+    :setup: 2 Supplier Instances
+    :steps:
+        1. Promote Hub to a Supplier
+        2. Test replication works
+        3. Demote the supplier to a consumer
+        4. Test replication works
+        5. Promote consumer to supplier
+        6. Test replication works
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+
+    supplier = topo.ms["supplier1"]
+    supplier_replica = Replicas(supplier).get(DEFAULT_SUFFIX)
+    bind_dn = supplier_replica.get_attr_val_utf8('nsDS5ReplicaBindDN')
+    hub = topo.hs["hub1"]
+    hub_replica = Replicas(hub).get(DEFAULT_SUFFIX)
+    consumer = topo.cs["consumer1"]
+
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+
+    # promote replica
+    hub_replica.promote(ReplicaRole.SUPPLIER, binddn=bind_dn, rid='55')
+    repl.test_replication(supplier, consumer)
+
+    # Demote the replica
+    hub_replica.demote(ReplicaRole.CONSUMER)
+    repl.test_replication(supplier, hub)
+
+    # promote replica and init it
+    hub_replica.promote(ReplicaRole.SUPPLIER, binddn=bind_dn, rid='56')
+    agmt = Agreements(supplier).list()[0]
+    agmt.begin_reinit()
+    agmt.wait_reinit()
+
+    # init consumer
+    agmt = Agreements(hub).list()[0]
+    agmt.begin_reinit()
+    agmt.wait_reinit()
+    repl.test_replication(supplier, consumer)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -799,6 +799,12 @@ cl5WriteOperationTxn(cldb_Handle *cldb, const slapi_operation_parameters *op, vo
         return CL5_BAD_DATA;
     }
 
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
+                      "cl5WriteOperationTxn - changelog is not initialized\n");
+        return CL5_BAD_DATA;
+    }
+
     pthread_mutex_lock(&(cldb->stLock));
     if (cldb->dbState != CL5_STATE_OPEN) {
         if (cldb->dbState == CL5_STATE_IMPORT) {
@@ -948,6 +954,11 @@ cl5CreateReplayIterator(Private_Repl_Protocol *prp, const RUV *consumerRuv, CL5R
     *iterator = NULL;
 
     cldb = replica_get_cl_info(replica);
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
+                      "cl5CreateReplayIterator - Changelog is not available (NULL)\n");
+        return CL5_BAD_STATE;
+    }
     pthread_mutex_lock(&(cldb->stLock));
     if (cldb->dbState != CL5_STATE_OPEN) {
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
@@ -4403,6 +4414,10 @@ void
 cl5CleanRUV(ReplicaId rid, Replica *replica)
 {
     cldb_Handle *cldb = replica_get_cl_info(replica);
+
+    if (cldb == NULL) {
+        return;
+    }
     ruv_delete_replica(cldb->purgeRUV, rid);
     ruv_delete_replica(cldb->maxRUV, rid);
 }

--- a/ldap/servers/plugins/replication/repl5_plugins.c
+++ b/ldap/servers/plugins/replication/repl5_plugins.c
@@ -996,6 +996,11 @@ write_changelog_and_ruv(Slapi_PBlock *pb)
 
         /* changelog database information to pass to the write function */
         cldb = replica_get_cl_info(r);
+        if (cldb == NULL) {
+            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
+                          "write_changelog_and_ruv - changelog is not initialized\n");
+            return return_value;
+        }
 
         /* for replicated operations, we log the original, non-urp data which is
            saved in the operation extension */

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1510,7 +1510,7 @@ class Replica(DSLdapObject):
         :param *replica_dirsrvs: DirSrv instance, DirSrv instance, ...
         :type *replica_dirsrvs: list of DirSrv
 
-        :returns: True - if all servers have recevioed the update by this
+        :returns: True - if all servers have received the update by this
                   replica, otherwise return False
         :raises: LDAPError - when failing to update/search database
         """


### PR DESCRIPTION
Bug Description:  

The server will crash if you demote a supplier with no changelog.

Fix Description:  

Check if the changelog pointer is NULL before dereferencing it.

relates: https://github.com/389ds/389-ds-base/issues/4731

