### PR TITLE
Issue 4962 - Fix various UI bugs - Plugins

### DIFF
--- a/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
@@ -250,6 +250,10 @@ class AccountPolicy extends React.Component {
                         });
                     })
                     .fail(_ => {
+                        this.props.addNotification(
+                            "warning",
+                            `Warning! Account Policy config entry "${this.state.configArea}" doesn't exist!`
+                        );
                         this.setState({
                             sharedConfigExists: false
                         });
@@ -983,6 +987,7 @@ class AccountPolicy extends React.Component {
                                     key="manage"
                                     variant="primary"
                                     onClick={this.openModal}
+                                    isDisabled={saveBtnDisabled}
                                 >
                                     {this.state.sharedConfigExists ? "Manage Config" : "Create Config"}
                                 </Button>

--- a/src/cockpit/389-console/src/lib/plugins/dna.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/dna.jsx
@@ -1495,6 +1495,7 @@ DNAPlugin.propTypes = {
     savePluginHandler: PropTypes.func,
     pluginListHandler: PropTypes.func,
     addNotification: PropTypes.func,
+    toggleLoadingHandler: PropTypes.func
 };
 
 DNAPlugin.defaultProps = {

--- a/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
@@ -332,7 +332,6 @@ class ReferentialIntegrity extends React.Component {
 
     saveConfig() {
         const {
-            updateDelay,
             membershipAttr,
             entryScope,
             excludeEntryScope,
@@ -340,6 +339,7 @@ class ReferentialIntegrity extends React.Component {
             logFile,
             referintConfigEntry,
         } = this.state;
+        const updateDelay = this.state.updateDelay.toString();
 
         let cmd = [
             "dsconf",

--- a/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
@@ -210,6 +210,9 @@ class RetroChangelog extends React.Component {
                         `Successfully updated the Retro Changelog`
                     );
                     this.props.pluginListHandler();
+                    this.setState({
+                        saving: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
@@ -218,6 +221,9 @@ class RetroChangelog extends React.Component {
                         `Failed to update Retro Changelog Plugin - ${errMsg.desc}`
                     );
                     this.props.pluginListHandler();
+                    this.setState({
+                        saving: false
+                    });
                 });
     }
 

--- a/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
@@ -449,17 +449,23 @@ class RootDNAccessControl extends React.Component {
                 .done(content => {
                     this.props.addNotification(
                         "success",
-                        `Successfully updated the Retro Changelog`
+                        `Successfully updated the RootDN Access Control`
                     );
                     this.props.pluginListHandler();
+                    this.setState({
+                        saving: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
                     this.props.addNotification(
                         "error",
-                        `Failed to update Retro Changelog Plugin - ${errMsg.desc}`
+                        `Failed to update RootDN Access Control Plugin - ${errMsg.desc}`
                     );
                     this.props.pluginListHandler();
+                    this.setState({
+                        saving: false
+                    });
                 });
     }
 

--- a/src/cockpit/389-console/src/lib/plugins/winsync.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/winsync.jsx
@@ -60,6 +60,7 @@ class WinSync extends React.Component {
         this.toggleFixupModal = this.toggleFixupModal.bind(this);
         this.validateConfig = this.validateConfig.bind(this);
         this.validateModal = this.validateModal.bind(this);
+        this.savePlugin = this.savePlugin.bind(this);
     }
 
     toggleFixupModal() {

--- a/src/cockpit/389-console/src/plugins.jsx
+++ b/src/cockpit/389-console/src/plugins.jsx
@@ -476,6 +476,7 @@ export class Plugins extends React.Component {
                         savePluginHandler={this.savePlugin}
                         pluginListHandler={this.pluginList}
                         addNotification={this.props.addNotification}
+                        toggleLoadingHandler={this.toggleLoading}
                         wasActiveList={this.props.wasActiveList}
                         attributes={this.state.attributes}
                         key={this.props.wasActiveList}


### PR DESCRIPTION
Description:

Bug 1816526 - restart instance after plugin enabled/disabled should depend on 'nsslapd-dynamic-plugins' status
Bug 2011183 - Retro Changelog plugin - saving any configuration is stuck in loading
Bug 2011187 - Posix Winsync Plugin - configuration is not saved
Bug 2011188 - DNA plugin fails to be enabled
Bug 2011751 - Referential Integrity Plugin - unable to save changes
Bug 2011767 - RootDN Access Control Plugin - configuration stuck and a wrong message is displayed
Bug 2011814 - Account Policy Plugin - configuration failing with error

relates: #4962

Reviewed by: ?