### PR TITLE
Issue 4973 - installer changes permissions on /run

### DIFF
--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -34,7 +34,7 @@ sysconf_dir = @sysconfdir@
 initconfig_dir = @initconfigdir@
 config_dir = @instconfigdir@/slapd-{instance_name}
 local_state_dir = @localstatedir@
-run_dir = @localrundir@
+run_dir = @localrundir@/dirsrv
 # This is the expected location of ldapi.
 ldapi = @localrundir@/slapd-{instance_name}.socket
 pid_file = @localrundir@/slapd-{instance_name}.pid

--- a/src/lib389/lib389/instance/remove.py
+++ b/src/lib389/lib389/instance/remove.py
@@ -52,9 +52,9 @@ def remove_ds_instance(dirsrv, force=False):
     remove_paths['ldif_dir'] = dirsrv.ds_paths.ldif_dir
     remove_paths['lock_dir'] = dirsrv.ds_paths.lock_dir
     remove_paths['log_dir'] = dirsrv.ds_paths.log_dir
-    # remove_paths['run_dir'] = dirsrv.ds_paths.run_dir
     remove_paths['inst_dir'] = dirsrv.ds_paths.inst_dir
     remove_paths['etc_sysconfig'] = "%s/sysconfig/dirsrv-%s" % (dirsrv.ds_paths.sysconf_dir, dirsrv.serverid)
+    remove_paths['ldapi'] = dirsrv.ds_paths.ldapi
 
     tmpfiles_d_path = dirsrv.ds_paths.tmpfiles_d + "/dirsrv-" + dirsrv.serverid + ".conf"
 
@@ -79,14 +79,6 @@ def remove_ds_instance(dirsrv, force=False):
     _log.debug("Found instance marker at %s! Proceeding to remove ..." % dse_ldif_path)
 
     ### ANY NEW REMOVAL ACTION MUST BE BELOW THIS LINE!!!
-
-    # Remove LDAPI socket file
-    ldapi_path = os.path.join(dirsrv.ds_paths.run_dir, "slapd-%s.socket" % dirsrv.serverid)
-    if os.path.exists(ldapi_path):
-        try:
-            os.remove(ldapi_path)
-        except OSError as e:
-            _log.debug(f"Failed to remove LDAPI socket ({ldapi_path})  Error: {str(e)}")
 
     # Remove these paths:
     # for path in ('backup_dir', 'cert_dir', 'config_dir', 'db_dir',

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -734,10 +734,6 @@ class SetupDs(object):
                 dse += line.replace('%', '{', 1).replace('%', '}', 1)
 
         with open(os.path.join(slapd['config_dir'], 'dse.ldif'), 'w') as file_dse:
-            if os.path.exists(os.path.dirname(slapd['ldapi'])):
-                ldapi_path = slapd['ldapi']
-            else:
-                ldapi_path = os.path.join(slapd['run_dir'], "slapd-%s.socket" % slapd['instance_name'])
             dse_fmt = dse.format(
                 schema_dir=slapd['schema_dir'],
                 lock_dir=slapd['lock_dir'],
@@ -762,7 +758,7 @@ class SetupDs(object):
                 db_home_dir=slapd['db_home_dir'],
                 db_lib=slapd['db_lib'],
                 ldapi_enabled="on",
-                ldapi=ldapi_path,
+                ldapi=slapd['ldapi'],
                 ldapi_autobind="on",
             )
             file_dse.write(dse_fmt)
@@ -864,7 +860,7 @@ class SetupDs(object):
             SER_ROOT_PW: self._raw_secure_password,
             SER_DEPLOYED_DIR: slapd['prefix'],
             SER_LDAPI_ENABLED: 'on',
-            SER_LDAPI_SOCKET: ldapi_path,
+            SER_LDAPI_SOCKET: slapd['ldapi'],
             SER_LDAPI_AUTOBIND: 'on'
         }
 
@@ -908,12 +904,9 @@ class SetupDs(object):
             self.log.info("Perform SELinux labeling ...")
             selinux_paths = ('backup_dir', 'cert_dir', 'config_dir', 'db_dir',
                              'ldif_dir', 'lock_dir', 'log_dir', 'db_home_dir',
-                             'schema_dir', 'tmp_dir')
+                             'run_dir', 'schema_dir', 'tmp_dir')
             for path in selinux_paths:
                 selinux_restorecon(slapd[path])
-
-            # Don't run restorecon on the entire /run directory
-            selinux_restorecon(slapd['run_dir'] + '/dirsrv')
 
             selinux_label_port(slapd['port'])
 


### PR DESCRIPTION
Description:  

There was a regression when we switched over to using /run that caused the installer to try and create /run which caused the ownership to change.  Fixed this by changing the "run_dir" to /run/dirsrv

relates: https://github.com/389ds/389-ds-base/issues/4973
