### PR TITLE
Issue 4976 - Failure in suites/import/import_test.py::test_fast_slow_…

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -369,12 +369,12 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
         2. Measure offline import time duration total_time1
         3. Now nsslapd-db-private-import-mem:off
         4. Measure offline import time duration total_time2
-        5. (total_time2 - total_time1) < 1
+        5. total_time1 < total_time2
         6. Set nsslapd-db-private-import-mem:on, nsslapd-import-cache-autosize: -1
         7. Measure offline import time duration total_time1
         8. Now nsslapd-db-private-import-mem:off
         9. Measure offline import time duration total_time2
-        10. (total_time2 - total_time1) < 1
+        10. total_time1 < total_time2
     :expected results:
         1. Operation successful
         2. Operation successful
@@ -401,7 +401,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("total_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert (total_time2 - total_time1) < 1
+    assert total_time1 < total_time2
 
     # Set nsslapd-db-private-import-mem:on, nsslapd-import-cache-autosize: -1
     config.replace_many(
@@ -420,7 +420,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("toral_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert (total_time2 - total_time1) < 1
+    assert total_time1 < total_time2
 
 
 @pytest.mark.bz175063


### PR DESCRIPTION
…import

Bug Description:
Previous change 6b10f1795f52395aa46d48a6f0428d126b35a90d had a wrong
assumption that total_time1 and total_time2 have a very insignificant
difference in case nsslapd-db-private-import-mem is set to 'off'.
In reality it is insignificant only on a smaller number of entries.
A recent change in libdb exposed this wrong assumption. With this change
__db.00* files get the maximum size in advance, instead of expanding
them when needed.

Fix Description:
Revert 6b10f1795f52395aa46d48a6f0428d126b35a90d.

Fixes: https://github.com/389ds/389-ds-base/issues/4976

Reviewed by: ???