### PR TITLE
Issue 4978 - make installer robust

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -269,6 +269,8 @@ def selinux_label_port(port, remove_label=False):
     :type remove_label: boolean
     :raises: ValueError: Error message
     """
+    if port is None:
+        return
     try:
         import selinux
     except ImportError:
@@ -665,7 +667,8 @@ def isLocalHost(host_name):
         Uses gethostbyname()
     """
     # first see if this is a "well known" local hostname
-    if host_name == 'localhost' or \
+    if host_name is None or \
+       host_name == 'localhost' or \
        host_name == 'localhost.localdomain' or \
        host_name == socket.gethostname():
         return True


### PR DESCRIPTION
Description:  

When run in a container the server can fail to start because the installer sets the db_home_dir to /dev/shm, but in containers the default size of /dev/shm is too small for libdb. We should detect if we are in a container and not set db_home_dir to /dev/shm.

During instance removal, if an instance was not properly created then it can not be removed either. Make the uninstall more robust to accept some errors and continue removing the instance.

relates: https://github.com/389ds/389-ds-base/issues/4978

