### PR TITLE
Issue 4982 - BUG - missing inttypes.h

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -2838,7 +2838,7 @@ slapd_debug_level_log(int level)
     }
 
     /* second pass: construct the debug level string */
-    p = msg = slapi_ch_malloc(len);
+    p = msg = slapi_ch_calloc(1, len);
     count = 0;
     for (i = 0; NULL != slapd_debug_level_map[i].dle_string; ++i) {
         if (!slapd_debug_level_map[i].dle_hide &&

--- a/ldap/servers/snmp/main.c
+++ b/ldap/servers/snmp/main.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include "ldap-agent.h"


### PR DESCRIPTION
Bug Description: Missing inttypes.h in main.c of snmp causes
clang to fail to build the file.

Fix Description: Add missing header.

fixes: https://github.com/389ds/389-ds-base/issues/4982

Author: William Brown <william@blackhats.net.au>

Review by: ???