### PR TITLE
Issue 4984 - BUG - pid file handling

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -499,15 +499,22 @@ write_start_pid_file(void)
      * admin programs. Please do not make changes here without
      * consulting the start/stop code for the admin code.
      */
-    if ((start_pid_file != NULL) && (fp = fopen(start_pid_file, "w")) != NULL) {
+    if (start_pid_file == NULL) {
+        return 0;
+    } else if ((fp = fopen(start_pid_file, "w")) != NULL) {
         fprintf(fp, "%d\n", getpid());
         fclose(fp);
         if (chmod(start_pid_file, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH) != 0) {
+            int rerrno = errno;
+            slapi_log_err(SLAPI_LOG_ERR, "write_start_pid_file", "file (%s) chmod failed (%d)\n", start_pid_file, rerrno);
             unlink(start_pid_file);
+            return -2;
         } else {
             return 0;
         }
     }
+    int rerrno = errno;
+    slapi_log_err(SLAPI_LOG_ERR, "write_start_pid_file", "file (%s) fopen failed (%d)\n", start_pid_file, rerrno);
     return -1;
 }
 
@@ -946,7 +953,12 @@ main(int argc, char **argv)
     * This removes the blank stares all round from start-slapd when the server
     * fails to start for some reason
     */
-    write_start_pid_file();
+    if (write_start_pid_file() != 0) {
+        slapi_log_err(SLAPI_LOG_CRIT, "main",
+                      "Shutting down as we are unable to write to the pid file location\n");
+        return_value = 1;
+        goto cleanup;
+    }
 
     /* Make sure we aren't going to run slapd in
      * a mode that is going to conflict with other

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -363,7 +363,7 @@ class DirSrv(SimpleLDAPObject, object):
         self.ldclt = Ldclt(self)
         self.saslmaps = SaslMappings(self)
 
-    def __init__(self, verbose=False, external_log=None):
+    def __init__(self, verbose=False, external_log=None, containerised=False):
         """
             This method does various initialization of DirSrv object:
             parameters:
@@ -387,6 +387,9 @@ class DirSrv(SimpleLDAPObject, object):
         self.uuid = str(uuid.uuid4())
         self.verbose = verbose
         self.serverid = None
+        # Are we a container? We get containerised in setup.py during SetupDs, and
+        # in other cases we use the marker to tell us.
+        self._containerised = os.path.exists(DSRC_CONTAINER) or containerised
 
         # If we have an external logger, use it!
         self.log = logger
@@ -1129,29 +1132,32 @@ class DirSrv(SimpleLDAPObject, object):
                         "-D",
                         self.ds_paths.config_dir,
                         "-i",
-                        self.ds_paths.pid_file],
+                        self.pid_file()],
                 self.log.debug("DEBUG: starting with %s" % cmd)
                 output = subprocess.check_output(*cmd, env=env, stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError:
-                self.log.error('Failed to start ns-slapd: "%s"' % output)
+            except subprocess.CalledProcessError as e:
+                self.log.error('Failed to start ns-slapd: "%s"' % e.output.decode())
+                self.log.error(e)
                 raise ValueError('Failed to start DS')
             count = timeout
-            pid = pid_from_file(self.ds_paths.pid_file)
+            pid = pid_from_file(self.pid_file())
             while (pid is None) and count > 0:
                 count -= 1
                 time.sleep(1)
-                pid = pid_from_file(self.ds_paths.pid_file)
+                pid = pid_from_file(self.pid_file())
             if pid == 0 or pid is None:
+                self.log.error("Unable to find pid (%s) of ns-slapd process" % self.pid_file())
                 raise ValueError('Failed to start DS')
             # Wait
             while not pid_exists(pid) and count > 0:
                 # It looks like DS changes the value in here at some point ...
                 # It's probably a DS bug, but if we "keep checking" the file, eventually
                 # we get the main server pid, and it's ready to go.
-                pid = pid_from_file(self.ds_paths.pid_file)
+                pid = pid_from_file(self.pid_file())
                 time.sleep(1)
                 count -= 1
             if not pid_exists(pid):
+                self.log.error("pid (%s) of ns-slapd process does not exist" % pid)
                 raise ValueError("Failed to start DS")
         if post_open:
             self.open()
@@ -1185,7 +1191,7 @@ class DirSrv(SimpleLDAPObject, object):
             # TODO: Make the pid path in the files things
             # TODO: use the status call instead!!!!
             count = timeout
-            pid = pid_from_file(self.ds_paths.pid_file)
+            pid = pid_from_file(self.pid_file())
             if pid == 0 or pid is None:
                 raise ValueError("Failed to stop DS")
             os.kill(pid, signal.SIGTERM)
@@ -1218,8 +1224,8 @@ class DirSrv(SimpleLDAPObject, object):
             return False
         else:
             self.log.debug("systemd status -> False")
-            pid = pid_from_file(self.ds_paths.pid_file)
-            self.log.debug("pid file %s -> %s" % (self.ds_paths.pid_file, pid))
+            pid = pid_from_file(self.pid_file())
+            self.log.debug("pid file %s -> %s" % (self.pid_file(), pid))
             if pid is None:
                 self.log.debug("No pidfile found for %s", self.serverid)
                 # No pidfile yet ...
@@ -1704,6 +1710,11 @@ class DirSrv(SimpleLDAPObject, object):
         if self.systemd_override is not None:
             return self.systemd_override
         return self.ds_paths.with_systemd
+
+    def pid_file(self):
+        if self._containerised:
+            return "/data/run/slapd-localhost.pid"
+        return self.ds_paths.pid_file
 
     def get_server_tls_subject(self):
         """ Get the servers TLS subject line for enrollment purposes.

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -849,7 +849,7 @@ class SetupDs(object):
 
         # Should I move this import? I think this prevents some recursion
         from lib389 import DirSrv
-        ds_instance = DirSrv(self.verbose)
+        ds_instance = DirSrv(self.verbose, containerised=self.containerised)
         if self.containerised:
             ds_instance.systemd_override = general['systemd']
 


### PR DESCRIPTION
Bug Description: When starting up in a container, if the pid
file location is not writeable, the dscontainer/lib389 tools can't
detect that the pid is running correctly, which causes the start
up to fail. This happened because the pid file location was
incorrectly set due to a previous change.

Fix Description: This forces the pid file path when we know
that we are in container mode, and also causes 389-ds to exit
with an error if we can not write to the pid file location.

fixes: https://github.com/389ds/389-ds-base/issues/4984

Author: William Brown <william@blackhats.net.au>

Review by: ???