### PR TITLE
Use local_simple_allocate in dsctl so that isLocal is always set properly

### DIFF
--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -155,7 +155,7 @@ if __name__ == '__main__':
             log.error("Unable to access instance information. Are you running as the correct user? (usually dirsrv or root)")
         sys.exit(1)
 
-    inst.allocate(insts[0])
+    inst.local_simple_allocate(insts[0]['server-id'])
     log.debug('Instance allocated')
 
     try:


### PR DESCRIPTION
This changes the method that's used to allocate an instance in `dsctl`.  
Assuming `dsctl` is always used to manage local instances (hope that's correct) `local_simple_allocate` seems to be the right method to call. It (among other things) ensures that `isLocal` is always set properly (see also #4959)