### PR TITLE
4992 fix slapd socket

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -253,7 +253,7 @@ def begin_magic():
         s2b.set('ldif_dir', '/data/ldif')
         s2b.set('run_dir', '/data/run')
         s2b.set('lock_dir', '/data/run/lock')
-        s2b.set('ldapi', '/data/run/slapd.socket')
+        s2b.set('ldapi', '/data/run/slapd-localhost.socket')
 
         s2b.set('log_dir', '/data/logs')
         s2b.set('access_log', '/data/logs/access')


### PR DESCRIPTION
    Issue 4992 - BUG - slapd.socket container fix

    Bug Description: A recent fix exposed that we were incorrectly
    setting the container socket for ldapi.

    Fix Description: Correct this to be consistent.

    fixes: https://github.com/389ds/389-ds-base/issues/4992

    Author: William Brown <william@blackhats.net.au>

    Review by: ???