### PR TITLE
Issue 4994 - Revert retrocl dependency workaround

### DIFF
--- a/dirsrvtests/tests/suites/retrocl/basic_test.py
+++ b/dirsrvtests/tests/suites/retrocl/basic_test.py
@@ -16,7 +16,7 @@ from lib389.utils import *
 from lib389.tasks import *
 from lib389.cli_base import FakeArgs, connect_instance, disconnect_instance
 from lib389.cli_base.dsrc import dsrc_arg_concat
-from lib389.cli_conf.plugins.retrochangelog import retrochangelog_add_attr
+from lib389.cli_conf.plugins.retrochangelog import retrochangelog_add
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.idm.domain import Domain
 from lib389._mapped_object import DSLdapObjects
@@ -119,7 +119,7 @@ def test_retrocl_exclude_attr_add(topology_st):
     args.bindpw = None
     args.prompt = False
     args.exclude_attrs = ATTR_HOMEPHONE
-    args.func = retrochangelog_add_attr
+    args.func = retrochangelog_add
     dsrc_inst = dsrc_arg_concat(args, None)
     inst = connect_instance(dsrc_inst, False, args)
     result = args.func(inst, None, log, args)
@@ -252,7 +252,7 @@ def test_retrocl_exclude_attr_mod(topology_st):
     args.bindpw = None
     args.prompt = False
     args.exclude_attrs = ATTR_CARLICENSE
-    args.func = retrochangelog_add_attr
+    args.func = retrochangelog_add
     dsrc_inst = dsrc_arg_concat(args, None)
     inst = connect_instance(dsrc_inst, False, args)
     result = args.func(inst, None, log, args)

--- a/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
+++ b/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
@@ -6,13 +6,9 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-# JC Work around for missing dependency on https://github.com/389ds/389-ds-base/pull/4344
-import ldap
 
 from lib389.plugins import RetroChangelogPlugin
-# JC Work around for missing dependency https://github.com/389ds/389-ds-base/pull/4344
-# from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr
-from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, _args_to_attrs
+from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr
 
 arg_to_attr = {
     'is_replicated': 'isReplicated',
@@ -29,33 +25,6 @@ def retrochangelog_edit(inst, basedn, log, args):
     plugin = RetroChangelogPlugin(inst)
     generic_object_edit(plugin, log, args, arg_to_attr)
 
-# JC Work around for missing dependency https://github.com/389ds/389-ds-base/pull/4344
-def retrochangelog_add_attr(inst, basedn, log, args):
-    log = log.getChild('retrochangelog_add_attr')
-    plugin = RetroChangelogPlugin(inst)
-    generic_object_add_attr(plugin, log, args, arg_to_attr)
-
-# JC Work around for missing dependency https://github.com/389ds/389-ds-base/pull/4344
-def generic_object_add_attr(dsldap_object, log, args, arg_to_attr):
-    """Add an attribute to the entry. This differs to 'edit' as edit uses replace,
-    and this allows multivalues to be added.
-
-    dsldap_object should be a single instance of DSLdapObject with a set dn
-    """
-    log = log.getChild('generic_object_add_attr')
-    # Gather the attributes
-    attrs = _args_to_attrs(args, arg_to_attr)
-
-    modlist = []
-    for attr, value in attrs.items():
-        if not isinstance(value, list):
-            value = [value]
-        modlist.append((ldap.MOD_ADD, attr, value))
-    if len(modlist) > 0:
-        dsldap_object.apply_mods(modlist)
-        log.info("Successfully changed the %s", dsldap_object.dn)
-    else:
-        raise ValueError("There is nothing to set in the %s plugin entry" % dsldap_object.dn)
 
 def retrochangelog_add(inst, basedn, log, args):
     log = log.getChild('retrochangelog_add')


### PR DESCRIPTION
Description: The RetroCL exclude attribute RFE was dependent on the
functionality of a commit that didn't make into the rhel 8.5 build. A
work around was committed that added the missing methods.

Since then the previous commit has been merged, so there now exists two
definitions of the same method, these need to be removed.

fixes: https://github.com/389ds/389-ds-base/issues/4994

relates: https://github.com/389ds/389-ds-base/issues/4791

Reviewed by: ?