### PR TITLE
Issue 4962 - Fix various UI bugs - dsctl and ciphers

### DIFF
--- a/src/cockpit/389-console/src/lib/security/ciphers.jsx
+++ b/src/cockpit/389-console/src/lib/security/ciphers.jsx
@@ -5,6 +5,7 @@ import {
     Form,
     FormSelect,
     FormSelectOption,
+    FormHelperText,
     Grid,
     GridItem,
     Select,
@@ -147,11 +148,13 @@ export class Ciphers extends React.Component {
             saving: true
         });
         let prefs = this.state.cipherPref;
-        for (const cipher of this.state.allowCiphers) {
-            prefs += ",+" + cipher;
-        }
-        for (const cipher of this.state.denyCiphers) {
-            prefs += ",-" + cipher;
+        if (this.state.cipherPref !== "default") {
+            for (const cipher of this.state.allowCiphers) {
+                prefs += ",+" + cipher;
+            }
+            for (const cipher of this.state.denyCiphers) {
+                prefs += ",-" + cipher;
+            }
         }
 
         const cmd = [
@@ -408,6 +411,9 @@ export class Ciphers extends React.Component {
                                     <FormSelectOption key="2" value="+all" label="All Ciphers" />
                                     <FormSelectOption key="3" value="-all" label="No Ciphers" />
                                 </FormSelect>
+                                <FormHelperText isHidden={this.state.cipherPref !== "default"}>
+                                    Default cipher suite is chosen. It enables the default ciphers advertised by NSS except weak ciphers.{(this.state.allowCiphers.length !== 0 || this.state.denyCiphers.length !== 0) ? " Any data in the 'Allow Specific Ciphers' and 'Deny Specific Ciphers' fields will be cleaned after the restart." : ""}
+                                </FormHelperText>
                             </GridItem>
                         </Grid>
                         <Grid>
@@ -418,6 +424,7 @@ export class Ciphers extends React.Component {
                                 <Select
                                     variant={SelectVariant.typeaheadMulti}
                                     typeAheadAriaLabel="Type a cipher"
+                                    isDisabled={this.state.cipherPref === "default"}
                                     onToggle={this.onAllowCipherToggle}
                                     onSelect={this.handleAllowCipherChange}
                                     onClear={this.onAllowCipherClear}
@@ -445,6 +452,7 @@ export class Ciphers extends React.Component {
                                 <Select
                                     variant={SelectVariant.typeaheadMulti}
                                     typeAheadAriaLabel="Type a cipher"
+                                    isDisabled={this.state.cipherPref === "default"}
                                     onToggle={this.onDenyCipherToggle}
                                     onSelect={this.handleDenyCipherChange}
                                     onClear={this.onDenyCipherClear}

--- a/src/lib389/cli/dsconf
+++ b/src/lib389/cli/dsconf
@@ -118,8 +118,12 @@ if __name__ == '__main__':
 
     # Assert we have a resources to work on.
     if not hasattr(args, 'func'):
-        log.error("No action provided, here is some --help.")
-        parser.print_help()
+        errmsg = "No action provided, here is some --help."
+        if args.json:
+            sys.stderr.write('{"desc": "%s"}\n' % errmsg)
+        else:
+            log.error(errmsg)
+            parser.print_help()
         sys.exit(1)
 
     if not args.verbose:

--- a/src/lib389/cli/dscreate
+++ b/src/lib389/cli/dscreate
@@ -65,8 +65,12 @@ if __name__ == '__main__':
 
     # Assert we have a resources to work on.
     if not hasattr(args, 'func'):
-        log.error("No action provided, here is some --help.")
-        parser.print_help()
+        errmsg = "No action provided, here is some --help."
+        if args.json:
+            sys.stderr.write('{"desc": "%s"}\n' % errmsg)
+        else:
+            log.error(errmsg)
+            parser.print_help()
         sys.exit(1)
 
     if not args.verbose:

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -100,14 +100,22 @@ if __name__ == '__main__':
         instance_remove_all(log, args)
         sys.exit(0)
     elif not args.instance:
-        log.error("error: the following arguments are required: instance")
-        parser.print_help()
+        errmsg = "error: the following arguments are required: instance"
+        if args.json:
+            sys.stderr.write("{'desc': '%s'}\n" % errmsg)
+        else:
+            log.error(errmsg)
+            parser.print_help()
         sys.exit(1)
 
     # Assert we have a resources to work on.
     if not hasattr(args, 'func'):
-        log.error("No action provided, here is some --help.")
-        parser.print_help()
+        errmsg = "No action provided, here is some --help."
+        if args.json:
+            sys.stderr.write("{'desc': '%s'}\n" % errmsg)
+        else:
+            log.error(errmsg)
+            parser.print_help()
         sys.exit(1)
 
     # Connect
@@ -126,15 +134,25 @@ if __name__ == '__main__':
         except (PermissionError, IOError) as e:
             log.error("Unable to access instance information. Are you running as the correct user? (usually dirsrv or root)")
             msg = format_error_to_dict(e)
-            log.error("Error: %s" % " - ".join(msg.values()))
+            if args.json:
+                sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
+            else:
+                log.error("Error: %s" % " - ".join(msg.values()))
             sys.exit(1)
         except Exception as e:
             msg = format_error_to_dict(e)
-            log.error("Error: %s" % " - ".join(msg.values()))
+            if args.json:
+                sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
+            else:
+                log.error("Error: %s" % " - ".join(msg.values()))
             sys.exit(1)
     if len(insts) != 1:
-        log.error("No such instance '%s'" % args.instance)
-        log.error("Unable to access instance information. Are you running as the correct user? (usually dirsrv or root)")
+        errmsg = "No such instance '%s'" % args.instance
+        if args.json:
+            sys.stderr.write('{"desc": "%s"}\n' % errmsg)
+        else:
+            log.error(errmsg)
+            log.error("Unable to access instance information. Are you running as the correct user? (usually dirsrv or root)")
         sys.exit(1)
 
     inst.allocate(insts[0])

--- a/src/lib389/cli/dsidm
+++ b/src/lib389/cli/dsidm
@@ -109,12 +109,20 @@ if __name__ == '__main__':
 
     # Assert we have a resources to work on.
     if not hasattr(args, 'func'):
-        log.error("No action provided, here is some --help.")
-        parser.print_help()
+        errmsg = "No action provided, here is some --help."
+        if args.json:
+            sys.stderr.write('{"desc": "%s"}\n' % errmsg)
+        else:
+            log.error(errmsg)
+            parser.print_help()
         sys.exit(1)
 
     if dsrc_inst['basedn'] is None:
-        log.error("Must provide a basedn!")
+        errmsg = "Must provide a basedn!"
+        if args.json:
+            sys.stderr.write('{"desc": "%s"}\n' % errmsg)
+        else:
+            log.error(errmsg)
         sys.exit(1)
 
     if not args.verbose:


### PR DESCRIPTION
Description: Don't start/stop instance if it's already started/stopped.
Add JSON error output to the basic CLI tool's operations.
Fix Ciphers Tab behaviour so it's aligned with the documentation and the
core functionality.

Relates: https://github.com/389ds/389-ds-base/issues/4962

Reviewed by: ?