### PR TITLE
Ensure prop dictionary only contains strings

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -696,7 +696,7 @@ class DirSrv(SimpleLDAPObject, object):
             ldifconn = LDIFConn(filename)
             configentry = ldifconn.get(DN_CONFIG)
             for key in args_dse_keys:
-                prop[key] = configentry.getValue(args_dse_keys[key])
+                prop[key] = ensure_str(configentry.getValue(args_dse_keys[key]))
                 # SER_HOST            (host) nsslapd-localhost
                 # SER_PORT            (port) nsslapd-port
                 # SER_SECURE_PORT     (sslport) nsslapd-secureport


### PR DESCRIPTION
https://github.com/389ds/389-ds-base/blob/829ea4113fee15f9bf5779734f9d2ddf0281e49b/src/lib389/lib389/__init__.py#L559

Since `self.ldapi_enabled` is a bytes object, `self.ldapi_enabled == 'on'` will be `False` even if `self.ldapi_enabled` is `b'on'`. Bytes objects need to be decoded before comparing them to strings.