### PR TITLE
Issue 4976 - Failure in suites/import/import_test.py::test_fast_slow_…

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -36,12 +36,10 @@ else:
 log = logging.getLogger(__name__)
 
 bdb_values = {
-  'deltat1' : 1,
   'wait30' : 30
 }
 
 mdb_values = {
-  'deltat1' : 4,
   'wait30' : 60
 }
 
@@ -385,12 +383,12 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
         2. Measure offline import time duration total_time1
         3. Now nsslapd-db-private-import-mem:off
         4. Measure offline import time duration total_time2
-        5. (total_time2 - total_time1) < values['deltat1']
+        5. total_time1 < total_time2
         6. Set nsslapd-db-private-import-mem:on, nsslapd-import-cache-autosize: -1
         7. Measure offline import time duration total_time1
         8. Now nsslapd-db-private-import-mem:off
         9. Measure offline import time duration total_time2
-        10. (total_time2 - total_time1) < values['deltat1']
+        10. total_time1 < total_time2
     :expected results:
         1. Operation successful
         2. Operation successful
@@ -417,7 +415,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("total_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert (total_time2 - total_time1) < values['deltat1']
+    assert total_time1 < total_time2
 
     # Set nsslapd-db-private-import-mem:on, nsslapd-import-cache-autosize: -1
     config.replace_many(
@@ -436,7 +434,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("toral_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert (total_time2 - total_time1) < values['deltat1']
+    assert total_time1 < total_time2
 
 
 @pytest.mark.bz175063


### PR DESCRIPTION
…import

Bug description:
	A large merge #4923 removed #4976 fix

Fix description:
	The test test_fast_slow_import purpose is to verify
        that private import is faster than shared one.
        It is too complex to manage a limit to the private/shared
        durations
        Revert to #4923 fix

relates: #4923

Reviewed by: Pierre Rogier, Viktor Ashirov

Platforms tested: PR-CI