### PR TITLE
Issue 5018 - RFE - openSUSE systemd hardening

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -393,6 +393,11 @@ autoreconf -fiv
            $ASAN_FLAGS $MSAN_FLAGS $TSAN_FLAGS $UBSAN_FLAGS $RUST_FLAGS $CLANG_FLAGS $COCKPIT_FLAGS \
            --enable-cmocka
 
+# Avoid "Unknown key name 'XXX' in section 'Service', ignoring." warnings from systemd on older releases
+%if 0%{?rhel} < 9
+  sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' src/unit/fonehome.service
+%endif
+
 %if 0%{?rhel} > 7 || 0%{?fedora}
 # lib389
 pushd ./src/lib389

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -395,7 +395,7 @@ autoreconf -fiv
 
 # Avoid "Unknown key name 'XXX' in section 'Service', ignoring." warnings from systemd on older releases
 %if 0%{?rhel} < 9
-  sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' src/unit/fonehome.service
+  sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' %{_builddir}/%{name}-%{version}%{?prerel}/wrappers/*.service.in
 %endif
 
 %if 0%{?rhel} > 7 || 0%{?fedora}

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -394,7 +394,7 @@ autoreconf -fiv
            --enable-cmocka
 
 # Avoid "Unknown key name 'XXX' in section 'Service', ignoring." warnings from systemd on older releases
-%if 0%{?rhel} < 9
+%if 0%{?rhel} && 0%{?rhel} < 9
   sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' %{_builddir}/%{name}-%{version}%{?prerel}/wrappers/*.service.in
 %endif
 

--- a/wrappers/systemd-snmp.service.in
+++ b/wrappers/systemd-snmp.service.in
@@ -11,6 +11,18 @@ After=network.target
 Type=forking
 PIDFile=/run/dirsrv/ldap-agent.pid
 ExecStart=@sbindir@/ldap-agent @configdir@/ldap-agent.conf
+PrivateTmp=on
+# https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
 
 [Install]
 WantedBy=multi-user.target

--- a/wrappers/systemd.template.service.custom.conf.in
+++ b/wrappers/systemd.template.service.custom.conf.in
@@ -43,12 +43,6 @@ TimeoutStopSec=600
 # this as DS will autodetect your threads / cpus and adjust as needed.
 #LimitNPROC=
 
-# Possible hardening options:
-#PrivateDevices=yes
-#ProtectSystem=yes
-#ProtectHome=yes
-#PrivateTmp=yes
-
 # Preload jemalloc
 Environment=LD_PRELOAD=@libdir@/@package_name@/lib/libjemalloc.so.2
 

--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -16,6 +16,19 @@ PIDFile=/run/@package_name@/slapd-%i.pid
 ExecStartPre=@libexecdir@/ds_systemd_ask_password_acl @instconfigdir@/slapd-%i/dse.ldif
 ExecStart=@sbindir@/ns-slapd -D @instconfigdir@/slapd-%i -i /run/@package_name@/slapd-%i.pid
 PrivateTmp=on
+# https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
+ProtectSystem=full
+# Protectsystem full mounts /etc ro, so we need to allow /etc/dirsrv to be writeable here.
+ReadWritePaths=@instconfigdir@
+ProtectHome=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Bug Description: The openSUSE/SUSE product security team is currently engaged in a project to
assist hardening projects systemd services with a number of options that can help prevent
certain attack classes. Rather than just having this in openSUSE we can have this upstream
to benefit all of us.

https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort

Fix Description: Add the recommended hardening options to 389-ds.

fixes: https://github.com/389ds/389-ds-base/issues/5018

Author: William Brown <william@blackhats.net.au>

Review by: ???