### PR TITLE
    Issue 5013 - backport of try_lock to 1.3.10

### DIFF
--- a/ldap/servers/slapd/abandon.c
+++ b/ldap/servers/slapd/abandon.c
@@ -88,7 +88,7 @@ do_abandon(Slapi_PBlock *pb)
      * flag and abort the operation at a convenient time.
      */
 
-    PR_EnterMonitor(pb_conn->c_mutex);
+    pthread_mutex_lock(&(pb_conn->c_mutex));
     for (o = pb_conn->c_ops; o != NULL; o = o->o_next) {
         if (o->o_msgid == id && o != pb_op)
             break;
@@ -151,7 +151,7 @@ do_abandon(Slapi_PBlock *pb)
                          o->o_results.r.r_search.nentries, (int64_t)o_hr_time_end.tv_sec, (int64_t)o_hr_time_end.tv_nsec);
     }
 
-    PR_ExitMonitor(pb_conn->c_mutex);
+    pthread_mutex_unlock(&(pb_conn->c_mutex));
     /*
      * Wake up the persistent searches, so they
      * can notice if they've been abandoned.

--- a/ldap/servers/slapd/bind.c
+++ b/ldap/servers/slapd/bind.c
@@ -236,7 +236,7 @@ do_bind(Slapi_PBlock *pb)
         slapi_pblock_get(pb, SLAPI_PWPOLICY, &pw_response_requested);
     }
 
-    PR_EnterMonitor(pb_conn->c_mutex);
+    pthread_mutex_lock(&(pb_conn->c_mutex));
 
     bind_credentials_clear(pb_conn, PR_FALSE, /* do not lock conn */
                            PR_FALSE /* do not clear external creds. */);
@@ -267,7 +267,7 @@ do_bind(Slapi_PBlock *pb)
      * bound user can work properly
      */
     pb_conn->c_needpw = 0;
-    PR_ExitMonitor(pb_conn->c_mutex);
+    pthread_mutex_unlock(&(pb_conn->c_mutex));
 
     log_bind_access(pb, dn ? dn : "empty", method, version, saslmech, NULL);
 

--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -171,25 +171,7 @@ connection_table_get_connection(Connection_Table *ct, int sd)
         PR_ASSERT(c->c_next == NULL);
         PR_ASSERT(c->c_prev == NULL);
         PR_ASSERT(c->c_extension == NULL);
-        
-	if(c->c_state == CONN_STATE_INIT) {
-		c->c_state = CONN_STATE_INIT;
 
-		pthread_mutexattr_t monitor_attr = {0};
-		pthread_mutexattr_init(&monitor_attr);
-		pthread_mutexattr_settype(&monitor_attr, PTHREAD_MUTEX_RECURSIVE);
-		if (pthread_mutex_init(&(c->c_mutex), &monitor_attr) != 0) {
-			slapi_log_err(SLAPI_LOG_ERR, "connection_table_get_connection", "pthread_mutex_init failed\n");
-			exit(1);
-		}
-
-		c->c_pdumutex = PR_NewLock();
-		if (c->c_pdumutex == NULL) {
-			c->c_pdumutex = NULL;
-			slapi_log_err(SLAPI_LOG_ERR, "connection_table_get_connection", "PR_NewLock failed\n");
-			exit(1);
-		}
-	}
         /* Let's make sure there's no cruft left on there from the last time this connection was used. */
         /* Note: no need to lock c->c_mutex because this function is only
          * called by one thread (the slapd_daemon thread), and if we got this

--- a/ldap/servers/slapd/extendop.c
+++ b/ldap/servers/slapd/extendop.c
@@ -136,10 +136,10 @@ extop_handle_import_start(Slapi_PBlock *pb, char *extoid __attribute__((unused))
      */
     slapi_pblock_get(pb, SLAPI_CONNECTION, &pb_conn);
     if (pb_conn) {
-        PR_EnterMonitor(pb_conn->c_mutex);
+        pthread_mutex_lock(&(pb_conn->c_mutex));
         pb_conn->c_flags |= CONN_FLAG_IMPORT;
         pb_conn->c_bi_backend = be;
-        PR_ExitMonitor(pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pb_conn->c_mutex));
     }
 
     slapi_pblock_set(pb, SLAPI_EXT_OP_RET_OID, EXTOP_BULK_IMPORT_START_OID);
@@ -164,11 +164,11 @@ extop_handle_import_done(Slapi_PBlock *pb, char *extoid __attribute__((unused)),
     Connection *pb_conn;
 
     slapi_pblock_get(pb, SLAPI_CONNECTION, &pb_conn);
-    PR_EnterMonitor(pb_conn->c_mutex);
+    pthread_mutex_lock(&(pb_conn->c_mutex));
     pb_conn->c_flags &= ~CONN_FLAG_IMPORT;
     be = pb_conn->c_bi_backend;
     pb_conn->c_bi_backend = NULL;
-    PR_ExitMonitor(pb_conn->c_mutex);
+    pthread_mutex_unlock(&(pb_conn->c_mutex));
 
     if ((be == NULL) || (be->be_wire_import == NULL)) {
         /* can this even happen? */

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -583,7 +583,7 @@ slapi_connection_acquire(Slapi_Connection *conn)
 {
     int rc;
 
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     /* rc = connection_acquire_nolock(conn); */
     /* connection in the closing state can't be acquired */
     if (conn->c_flags & CONN_FLAG_CLOSING) {
@@ -596,7 +596,7 @@ slapi_connection_acquire(Slapi_Connection *conn)
         conn->c_refcnt++;
         rc = 0;
     }
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     return (rc);
 }
 
@@ -606,7 +606,7 @@ slapi_connection_remove_operation(Slapi_PBlock *pb __attribute__((unused)), Slap
     int rc = 0;
     Slapi_Operation **olist = &conn->c_ops;
     Slapi_Operation **tmp;
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     /* connection_remove_operation_ext(pb, conn,op); */
     for (tmp = olist; *tmp != NULL && *tmp != op; tmp = &(*tmp)->o_next)
         ; /* NULL */
@@ -635,7 +635,7 @@ slapi_connection_remove_operation(Slapi_PBlock *pb __attribute__((unused)), Slap
             rc = 0;
         }
     }
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     return (rc);
 }
 

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -668,7 +668,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
        * In async paged result case, the search result might be released
        * by other theads.  We need to double check it in the locked region.
        */
-            PR_EnterMonitor(pb_conn->c_mutex);
+            pthread_mutex_lock(&(pb_conn->c_mutex));
             pr_search_result = pagedresults_get_search_result(pb_conn, operation, 1 /*locked*/, pr_idx);
             if (pr_search_result) {
                 if (pagedresults_is_abandoned_or_notavailable(pb_conn, 1 /*locked*/, pr_idx)) {
@@ -676,7 +676,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                     /* Previous operation was abandoned and the simplepaged object is not in use. */
                     send_ldap_result(pb, 0, NULL, "Simple Paged Results Search abandoned", 0, NULL);
                     rc = LDAP_SUCCESS;
-                    PR_ExitMonitor(pb_conn->c_mutex);
+                    pthread_mutex_unlock(&(pb_conn->c_mutex));
                     goto free_and_return;
                 } else {
                     slapi_pblock_set(pb, SLAPI_SEARCH_RESULT_SET, pr_search_result);
@@ -690,7 +690,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                 pr_stat = PAGEDRESULTS_SEARCH_END;
                 rc = LDAP_SUCCESS;
             }
-            PR_ExitMonitor(pb_conn->c_mutex);
+            pthread_mutex_unlock(&(pb_conn->c_mutex));
             pagedresults_unlock(pb_conn, pr_idx);
 
             if ((PAGEDRESULTS_SEARCH_END == pr_stat) || (0 == pnentries)) {
@@ -811,10 +811,10 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                 /* PAGED RESULTS */
                 if (op_is_pagedresults(operation)) {
                     /* cleanup the slot */
-                    PR_EnterMonitor(pb_conn->c_mutex);
+                    pthread_mutex_lock(&(pb_conn->c_mutex));
                     pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
                     rc = pagedresults_set_current_be(pb_conn, NULL, pr_idx, 1);
-                    PR_ExitMonitor(pb_conn->c_mutex);
+                    pthread_mutex_unlock(&(pb_conn->c_mutex));
                 }
                 if (1 == flag_no_such_object) {
                     break;
@@ -855,11 +855,11 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                     slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_SET, &sr);
                     if ((PAGEDRESULTS_SEARCH_END == pr_stat) || (0 == pnentries)) {
                         /* no more entries, but at least another backend */
-                        PR_EnterMonitor(pb_conn->c_mutex);
+                        pthread_mutex_lock(&(pb_conn->c_mutex));
                         pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
                         be->be_search_results_release(&sr);
                         rc = pagedresults_set_current_be(pb_conn, next_be, pr_idx, 1);
-                        PR_ExitMonitor(pb_conn->c_mutex);
+                        pthread_mutex_unlock(&(pb_conn->c_mutex));
                         pr_stat = PAGEDRESULTS_SEARCH_END; /* make sure stat is SEARCH_END */
                         if (NULL == next_be) {
                             /* no more entries && no more backends */
@@ -887,9 +887,9 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                     next_be = NULL; /* to break the loop */
                     if (operation->o_status & SLAPI_OP_STATUS_ABANDONED) {
                         /* It turned out this search was abandoned. */
-                        PR_EnterMonitor(pb_conn->c_mutex);
+                        pthread_mutex_lock(&(pb_conn->c_mutex));
                         pagedresults_free_one_msgid_nolock(pb_conn, operation->o_msgid);
-                        PR_ExitMonitor(pb_conn->c_mutex);
+                        pthread_mutex_unlock(&(pb_conn->c_mutex));
                         /* paged-results-request was abandoned; making an empty cookie. */
                         pagedresults_set_response_control(pb, 0, estimate, -1, pr_idx);
                         send_ldap_result(pb, 0, NULL, "Simple Paged Results Search abandoned", 0, NULL);

--- a/ldap/servers/slapd/pagedresults.c
+++ b/ldap/servers/slapd/pagedresults.c
@@ -98,7 +98,7 @@ pagedresults_parse_control_value(Slapi_PBlock *pb,
         return LDAP_UNWILLING_TO_PERFORM;
     }
 
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     /* the ber encoding is no longer needed */
     ber_free(ber, 1);
     if (cookie.bv_len <= 0) {
@@ -206,7 +206,7 @@ bail:
             }
         }
     }
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
 
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_parse_control_value",
                   "<= idx %d\n", *index);
@@ -300,7 +300,7 @@ pagedresults_free_one(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_free_one",
                   "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (conn->c_pagedresults.prl_count <= 0) {
             slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_free_one",
                           "conn=%" PRIu64 " paged requests list count is %d\n",
@@ -311,7 +311,7 @@ pagedresults_free_one(Connection *conn, Operation *op, int index)
             conn->c_pagedresults.prl_count--;
             rc = 0;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
 
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_free_one", "<= %d\n", rc);
@@ -363,11 +363,11 @@ pagedresults_get_current_be(Connection *conn, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_current_be", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             be = conn->c_pagedresults.prl_list[index].pr_current_be;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_current_be", "<= %p\n", be);
@@ -382,13 +382,13 @@ pagedresults_set_current_be(Connection *conn, Slapi_Backend *be, int index, int 
                   "pagedresults_set_current_be", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
         if (!nolock)
-            PR_EnterMonitor(conn->c_mutex);
+            pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_current_be = be;
         }
         rc = 0;
         if (!nolock)
-            PR_ExitMonitor(conn->c_mutex);
+            pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_current_be", "<= %d\n", rc);
@@ -407,13 +407,13 @@ pagedresults_get_search_result(Connection *conn, Operation *op, int locked, int 
                   locked ? "locked" : "not locked", index);
     if (conn && (index > -1)) {
         if (!locked) {
-            PR_EnterMonitor(conn->c_mutex);
+            pthread_mutex_lock(&(conn->c_mutex));
         }
         if (index < conn->c_pagedresults.prl_maxlen) {
             sr = conn->c_pagedresults.prl_list[index].pr_search_result_set;
         }
         if (!locked) {
-            PR_ExitMonitor(conn->c_mutex);
+            pthread_mutex_unlock(&(conn->c_mutex));
         }
     }
     slapi_log_err(SLAPI_LOG_TRACE,
@@ -433,7 +433,7 @@ pagedresults_set_search_result(Connection *conn, Operation *op, void *sr, int lo
                   index, sr);
     if (conn && (index > -1)) {
         if (!locked)
-            PR_EnterMonitor(conn->c_mutex);
+            pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             PagedResults *prp = conn->c_pagedresults.prl_list + index;
             if (!(prp->pr_flags & CONN_FLAG_PAGEDRESULTS_ABANDONED) || !sr) {
@@ -443,7 +443,7 @@ pagedresults_set_search_result(Connection *conn, Operation *op, void *sr, int lo
             rc = 0;
         }
         if (!locked)
-            PR_ExitMonitor(conn->c_mutex);
+            pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_search_result", "=> %d\n", rc);
@@ -460,11 +460,11 @@ pagedresults_get_search_result_count(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_search_result_count", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             count = conn->c_pagedresults.prl_list[index].pr_search_result_count;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_search_result_count", "<= %d\n", count);
@@ -481,11 +481,11 @@ pagedresults_set_search_result_count(Connection *conn, Operation *op, int count,
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_search_result_count", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_search_result_count = count;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE,
@@ -506,11 +506,11 @@ pagedresults_get_search_result_set_size_estimate(Connection *conn,
                   "pagedresults_get_search_result_set_size_estimate",
                   "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             count = conn->c_pagedresults.prl_list[index].pr_search_result_set_size_estimate;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_search_result_set_size_estimate", "<= %d\n",
@@ -532,11 +532,11 @@ pagedresults_set_search_result_set_size_estimate(Connection *conn,
                   "pagedresults_set_search_result_set_size_estimate",
                   "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_search_result_set_size_estimate = count;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE,
@@ -555,11 +555,11 @@ pagedresults_get_with_sort(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_with_sort", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             flags = conn->c_pagedresults.prl_list[index].pr_flags & CONN_FLAG_PAGEDRESULTS_WITH_SORT;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_with_sort", "<= %d\n", flags);
@@ -576,14 +576,14 @@ pagedresults_set_with_sort(Connection *conn, Operation *op, int flags, int index
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_with_sort", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             if (flags & OP_FLAG_SERVER_SIDE_SORTING) {
                 conn->c_pagedresults.prl_list[index].pr_flags |=
                     CONN_FLAG_PAGEDRESULTS_WITH_SORT;
             }
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_set_with_sort", "<= %d\n", rc);
@@ -600,11 +600,11 @@ pagedresults_get_unindexed(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_unindexed", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             flags = conn->c_pagedresults.prl_list[index].pr_flags & CONN_FLAG_PAGEDRESULTS_UNINDEXED;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_unindexed", "<= %d\n", flags);
@@ -621,12 +621,12 @@ pagedresults_set_unindexed(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_unindexed", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_flags |=
                 CONN_FLAG_PAGEDRESULTS_UNINDEXED;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE,
@@ -644,11 +644,11 @@ pagedresults_get_sort_result_code(Connection *conn, Operation *op, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_sort_result_code", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             code = conn->c_pagedresults.prl_list[index].pr_sort_result_code;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_get_sort_result_code", "<= %d\n", code);
@@ -665,11 +665,11 @@ pagedresults_set_sort_result_code(Connection *conn, Operation *op, int code, int
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_sort_result_code", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_sort_result_code = code;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE,
@@ -687,11 +687,11 @@ pagedresults_set_timelimit(Connection *conn, Operation *op, time_t timelimit, in
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_timelimit", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             slapi_timespec_expire_at(timelimit, &(conn->c_pagedresults.prl_list[index].pr_timelimit_hr));
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
         rc = 0;
     }
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_set_timelimit", "<= %d\n", rc);
@@ -746,7 +746,7 @@ pagedresults_cleanup(Connection *conn, int needlock)
     }
 
     if (needlock) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
     }
     for (i = 0; conn->c_pagedresults.prl_list &&
                 i < conn->c_pagedresults.prl_maxlen;
@@ -765,7 +765,7 @@ pagedresults_cleanup(Connection *conn, int needlock)
     }
     conn->c_pagedresults.prl_count = 0;
     if (needlock) {
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_cleanup", "<= %d\n", rc);
     return rc;
@@ -792,7 +792,7 @@ pagedresults_cleanup_all(Connection *conn, int needlock)
     }
 
     if (needlock) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
     }
     for (i = 0; conn->c_pagedresults.prl_list &&
                 i < conn->c_pagedresults.prl_maxlen;
@@ -812,7 +812,7 @@ pagedresults_cleanup_all(Connection *conn, int needlock)
     conn->c_pagedresults.prl_maxlen = 0;
     conn->c_pagedresults.prl_count = 0;
     if (needlock) {
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_cleanup_all", "<= %d\n", rc);
     return rc;
@@ -831,7 +831,7 @@ pagedresults_check_or_set_processing(Connection *conn, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_check_or_set_processing", "=>\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             ret = (conn->c_pagedresults.prl_list[index].pr_flags &
                    CONN_FLAG_PAGEDRESULTS_PROCESSING);
@@ -839,7 +839,7 @@ pagedresults_check_or_set_processing(Connection *conn, int index)
             conn->c_pagedresults.prl_list[index].pr_flags |=
                                               CONN_FLAG_PAGEDRESULTS_PROCESSING;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_check_or_set_processing", "<= %d\n", ret);
@@ -858,7 +858,7 @@ pagedresults_reset_processing(Connection *conn, int index)
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_reset_processing", "=> idx=%d\n", index);
     if (conn && (index > -1)) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             ret = (conn->c_pagedresults.prl_list[index].pr_flags &
                    CONN_FLAG_PAGEDRESULTS_PROCESSING);
@@ -866,7 +866,7 @@ pagedresults_reset_processing(Connection *conn, int index)
             conn->c_pagedresults.prl_list[index].pr_flags &=
                                              ~CONN_FLAG_PAGEDRESULTS_PROCESSING;
         }
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_reset_processing", "<= %d\n", ret);
@@ -977,9 +977,9 @@ pagedresults_lock(Connection *conn, int index)
     if (!conn || (index < 0) || (index >= conn->c_pagedresults.prl_maxlen)) {
         return;
     }
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     prp = conn->c_pagedresults.prl_list + index;
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     if (prp->pr_mutex) {
         PR_Lock(prp->pr_mutex);
     }
@@ -993,9 +993,9 @@ pagedresults_unlock(Connection *conn, int index)
     if (!conn || (index < 0) || (index >= conn->c_pagedresults.prl_maxlen)) {
         return;
     }
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     prp = conn->c_pagedresults.prl_list + index;
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     if (prp->pr_mutex) {
         PR_Unlock(prp->pr_mutex);
     }
@@ -1010,11 +1010,11 @@ pagedresults_is_abandoned_or_notavailable(Connection *conn, int locked, int inde
         return 1; /* not abandoned, but do not want to proceed paged results op. */
     }
     if (!locked) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
     }
     prp = conn->c_pagedresults.prl_list + index;
     if (!locked) {
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
     return prp->pr_flags & CONN_FLAG_PAGEDRESULTS_ABANDONED;
 }
@@ -1039,13 +1039,13 @@ pagedresults_set_search_result_pb(Slapi_PBlock *pb, void *sr, int locked)
                   "pagedresults_set_search_result_pb", "=> idx=%d, sr=%p\n", index, sr);
     if (conn && (index > -1)) {
         if (!locked)
-            PR_EnterMonitor(conn->c_mutex);
+            pthread_mutex_lock(&(conn->c_mutex));
         if (index < conn->c_pagedresults.prl_maxlen) {
             conn->c_pagedresults.prl_list[index].pr_search_result_set = sr;
             rc = 0;
         }
         if (!locked)
-            PR_ExitMonitor(conn->c_mutex);
+            pthread_mutex_unlock(&(conn->c_mutex));
     }
     slapi_log_err(SLAPI_LOG_TRACE,
                   "pagedresults_set_search_result_pb", "<= %d\n", rc);

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -427,9 +427,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_DN \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(char **)value) = (NULL == pblock->pb_conn->c_dn ? NULL : slapi_ch_strdup(pblock->pb_conn->c_dn));
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_AUTHTYPE: /* deprecated */
         if (pblock->pb_conn == NULL) {
@@ -437,9 +437,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_AUTHTYPE \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         authtype = pblock->pb_conn->c_authtype;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         if (authtype == NULL) {
             (*(char **)value) = NULL;
         } else if (strcasecmp(authtype, SLAPD_AUTH_NONE) == 0) {
@@ -464,52 +464,52 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_AUTHMETHOD \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(char **)value) = pblock->pb_conn->c_authtype ? slapi_ch_strdup(pblock->pb_conn->c_authtype) : NULL;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_CLIENTNETADDR:
         if (pblock->pb_conn == NULL) {
             memset(value, 0, sizeof(PRNetAddr));
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         if (pblock->pb_conn->cin_addr == NULL) {
             memset(value, 0, sizeof(PRNetAddr));
         } else {
             (*(PRNetAddr *)value) =
                 *(pblock->pb_conn->cin_addr);
         }
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
 	case SLAPI_CONN_CLIENTNETADDR_ACLIP:
         if (pblock->pb_conn == NULL) {
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(PRNetAddr **) value) = pblock->pb_conn->cin_addr_aclip;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_SERVERNETADDR:
         if (pblock->pb_conn == NULL) {
             memset(value, 0, sizeof(PRNetAddr));
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         if (pblock->pb_conn->cin_destaddr == NULL) {
             memset(value, 0, sizeof(PRNetAddr));
         } else {
             (*(PRNetAddr *)value) =
                 *(pblock->pb_conn->cin_destaddr);
         }
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_CLIENTIP:
         if (pblock->pb_conn == NULL) {
             memset(value, 0, sizeof(struct in_addr));
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         if (pblock->pb_conn->cin_addr == NULL) {
             memset(value, 0, sizeof(struct in_addr));
         } else {
@@ -524,14 +524,14 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                 memset(value, 0, sizeof(struct in_addr));
             }
         }
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_SERVERIP:
         if (pblock->pb_conn == NULL) {
             memset(value, 0, sizeof(struct in_addr));
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         if (pblock->pb_conn->cin_destaddr == NULL) {
             memset(value, 0, sizeof(PRNetAddr));
         } else {
@@ -546,7 +546,7 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                 memset(value, 0, sizeof(struct in_addr));
             }
         }
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_IS_REPLICATION_SESSION:
         if (pblock->pb_conn == NULL) {
@@ -554,9 +554,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_IS_REPLICATION_SESSION \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(int *)value) = pblock->pb_conn->c_isreplication_session;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_IS_SSL_SESSION:
         if (pblock->pb_conn == NULL) {
@@ -564,9 +564,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_IS_SSL_SESSION \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(int *)value) = pblock->pb_conn->c_flags & CONN_FLAG_SSL;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_SASL_SSF:
         if (pblock->pb_conn == NULL) {
@@ -574,9 +574,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_SASL_SSF \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(int *)value) = pblock->pb_conn->c_sasl_ssf;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_SSL_SSF:
         if (pblock->pb_conn == NULL) {
@@ -584,9 +584,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_SSL_SSF \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(int *)value) = pblock->pb_conn->c_ssl_ssf;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_LOCAL_SSF:
         if (pblock->pb_conn == NULL) {
@@ -594,9 +594,9 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_LOCAL_SSF \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         (*(int *)value) = pblock->pb_conn->c_local_ssf;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_CERT:
         if (pblock->pb_conn == NULL) {
@@ -2574,19 +2574,19 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
                           "Connection is NULL and hence cannot access SLAPI_CONN_AUTHMETHOD \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         slapi_ch_free((void **)&pblock->pb_conn->c_authtype);
         pblock->pb_conn->c_authtype = slapi_ch_strdup((char *)value);
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_CLIENTNETADDR_ACLIP:
         if (pblock->pb_conn == NULL) {
             break;
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         slapi_ch_free((void **)&pblock->pb_conn->cin_addr_aclip);
         pblock->pb_conn->cin_addr_aclip = (PRNetAddr *)value;
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
     case SLAPI_CONN_IS_REPLICATION_SESSION:
         if (pblock->pb_conn == NULL) {
@@ -2595,9 +2595,9 @@ slapi_pblock_set(Slapi_PBlock *pblock, int arg, void *value)
                           "Connection is NULL and hence cannot access SLAPI_CONN_IS_REPLICATION_SESSION \n");
             return (-1);
         }
-        PR_EnterMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_lock(&(pblock->pb_conn->c_mutex));
         pblock->pb_conn->c_isreplication_session = *((int *)value);
-        PR_ExitMonitor(pblock->pb_conn->c_mutex);
+        pthread_mutex_unlock(&(pblock->pb_conn->c_mutex));
         break;
 
     /* stuff related to config file processing */
@@ -4208,7 +4208,7 @@ void
 bind_credentials_clear(Connection *conn, PRBool lock_conn, PRBool clear_externalcreds)
 {
     if (lock_conn) {
-        PR_EnterMonitor(conn->c_mutex);
+        pthread_mutex_lock(&(conn->c_mutex));
     }
 
     if (conn->c_dn != NULL) {                   /* a non-anonymous bind has occurred */
@@ -4234,7 +4234,7 @@ bind_credentials_clear(Connection *conn, PRBool lock_conn, PRBool clear_external
     }
 
     if (lock_conn) {
-        PR_ExitMonitor(conn->c_mutex);
+        pthread_mutex_unlock(&(conn->c_mutex));
     }
 }
 
@@ -4397,10 +4397,10 @@ slapi_pblock_set_op_stack_elem(Slapi_PBlock *pb, void *stack_elem)
 void
 bind_credentials_set(Connection *conn, char *authtype, char *normdn, char *extauthtype, char *externaldn, CERTCertificate *clientcert, Slapi_Entry *bind_target_entry)
 {
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     bind_credentials_set_nolock(conn, authtype, normdn,
                                 extauthtype, externaldn, clientcert, bind_target_entry);
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
 }
 
 void

--- a/ldap/servers/slapd/psearch.c
+++ b/ldap/servers/slapd/psearch.c
@@ -278,9 +278,9 @@ ps_send_results(void *arg)
 
     /* need to acquire a reference to this connection so that it will not
        be released or cleaned up out from under us */
-    PR_EnterMonitor(pb_conn->c_mutex);
+    pthread_mutex_lock(&(pb_conn->c_mutex));
     conn_acq_flag = connection_acquire_nolock(pb_conn);
-    PR_ExitMonitor(pb_conn->c_mutex);
+    pthread_mutex_unlock(&(pb_conn->c_mutex));
 
     if (conn_acq_flag) {
         slapi_log_err(SLAPI_LOG_CONNS, "ps_send_results",
@@ -397,7 +397,7 @@ ps_send_results(void *arg)
 
     conn = pb_conn; /* save to release later - connection_remove_operation_ext will NULL the pb_conn */
     /* Clean up the connection structure */
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
 
     slapi_log_err(SLAPI_LOG_CONNS, "ps_send_results",
                   "conn=%" PRIu64 " op=%d Releasing the connection and operation\n",
@@ -409,7 +409,7 @@ ps_send_results(void *arg)
     if (conn_acq_flag == 0) { /* we acquired it, so release it */
         connection_release_nolock(conn);
     }
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     conn = NULL;
 
     PR_DestroyLock(ps->ps_lock);

--- a/ldap/servers/slapd/saslbind.c
+++ b/ldap/servers/slapd/saslbind.c
@@ -781,7 +781,7 @@ ids_sasl_listmech(Slapi_PBlock *pb)
         sasl_conn = (sasl_conn_t *)pb_conn->c_sasl_conn;
         if (sasl_conn != NULL) {
             /* sasl library mechanisms are connection dependent */
-            PR_EnterMonitor(pb_conn->c_mutex);
+            pthread_mutex_lock(&(pb_conn->c_mutex));
             if (sasl_listmech(sasl_conn,
                               NULL, /* username */
                               "", ",", "",
@@ -795,7 +795,7 @@ ids_sasl_listmech(Slapi_PBlock *pb)
                 charray_free(others);
                 slapi_ch_free((void **)&dupstr);
             }
-            PR_ExitMonitor(pb_conn->c_mutex);
+            pthread_mutex_unlock(&(pb_conn->c_mutex));
         }
     }
 
@@ -889,13 +889,13 @@ ids_sasl_check_bind(Slapi_PBlock *pb)
         return;
     }
 
-    PR_EnterMonitor(pb_conn->c_mutex); /* BIG LOCK */
+    pthread_mutex_lock(&(pb_conn->c_mutex)); /* BIG LOCK */
     continuing = pb_conn->c_flags & CONN_FLAG_SASL_CONTINUE;
     pb_conn->c_flags &= ~CONN_FLAG_SASL_CONTINUE; /* reset flag */
 
     sasl_conn = (sasl_conn_t *)pb_conn->c_sasl_conn;
     if (sasl_conn == NULL) {
-        PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+        pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
         send_ldap_result(pb, LDAP_AUTH_METHOD_NOT_SUPPORTED, NULL,
                          "sasl library unavailable", 0, NULL);
         return;
@@ -979,7 +979,7 @@ sasl_start:
         if (sasl_conn == NULL) {
             send_ldap_result(pb, LDAP_AUTH_METHOD_NOT_SUPPORTED, NULL,
                              "sasl library unavailable", 0, NULL);
-            PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+            pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
             return;
         }
     }
@@ -995,7 +995,7 @@ sasl_check_result:
         /* retrieve the authenticated username */
         if (sasl_getprop(sasl_conn, SASL_USERNAME,
                          (const void **)&username) != SASL_OK) {
-            PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+            pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
             send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL,
                              "could not obtain sasl username", 0, NULL);
             break;
@@ -1016,7 +1016,7 @@ sasl_check_result:
             }
         }
         if (dn == NULL) {
-            PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+            pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
             send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL,
                              "could not get auth dn from sasl", 0, NULL);
             break;
@@ -1058,7 +1058,7 @@ sasl_check_result:
                                     slapi_ch_strdup(normdn),
                                     NULL, NULL, NULL, bind_target_entry);
 
-        PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+        pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
 
         if (plugin_call_plugins(pb, SLAPI_PLUGIN_PRE_BIND_FN) != 0) {
             break;
@@ -1116,13 +1116,13 @@ sasl_check_result:
         /* see if we negotiated a security layer */
         if (*ssfp > 0) {
             /* Enable SASL I/O on the connection */
-            PR_EnterMonitor(pb_conn->c_mutex);
+            pthread_mutex_lock(&(pb_conn->c_mutex));
             connection_set_io_layer_cb(pb_conn, sasl_io_enable, NULL, NULL);
 
             /* send successful result before sasl_io_enable can be pushed by another incoming op */
             send_ldap_result(pb, LDAP_SUCCESS, NULL, NULL, 0, NULL);
 
-            PR_ExitMonitor(pb_conn->c_mutex);
+            pthread_mutex_unlock(&(pb_conn->c_mutex));
         } else {
             /* send successful result */
             send_ldap_result(pb, LDAP_SUCCESS, NULL, NULL, 0, NULL);
@@ -1135,7 +1135,7 @@ sasl_check_result:
 
     case SASL_CONTINUE: /* another step needed */
         pb_conn->c_flags |= CONN_FLAG_SASL_CONTINUE;
-        PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+        pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
 
         if (plugin_call_plugins(pb, SLAPI_PLUGIN_PRE_BIND_FN) != 0) {
             break;
@@ -1157,7 +1157,7 @@ sasl_check_result:
 
     case SASL_NOMECH:
 
-        PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+        pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
         send_ldap_result(pb, LDAP_AUTH_METHOD_NOT_SUPPORTED, NULL,
                          "sasl mechanism not supported", 0, NULL);
         break;
@@ -1165,7 +1165,7 @@ sasl_check_result:
     default: /* other error */
         errstr = sasl_errdetail(sasl_conn);
 
-        PR_ExitMonitor(pb_conn->c_mutex); /* BIG LOCK */
+        pthread_mutex_unlock(&(pb_conn->c_mutex)); /* BIG LOCK */
         slapi_pblock_set(pb, SLAPI_PB_RESULT_TEXT, (void *)errstr);
         send_ldap_result(pb, LDAP_INVALID_CREDENTIALS, NULL, NULL, 0, NULL);
         break;

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1606,9 +1606,15 @@ typedef int (*Conn_IO_Layer_cb)(struct conn *, void *data);
 struct Conn_Private;
 typedef struct Conn_private Conn_private;
 
+typedef enum _conn_state {
+    CONN_STATE_FREE = 0,
+    CONN_STATE_INIT = 1,
+} conn_state;
+
 typedef struct conn
 {
     Sockbuf *c_sb;                   /* ber connection stuff          */
+    conn_state c_state;              /* Used in connection table and done to see what's free or not. Later we could use this for other state handlings. */
     int c_sd;                        /* the actual socket descriptor      */
     int c_ldapversion;               /* version of LDAP protocol       */
     char *c_dn;                      /* current DN bound to this conn  */
@@ -1633,7 +1639,7 @@ typedef struct conn
     uint64_t c_anonlimits_set;       /* default anon limits are set */
     PRInt32 c_threadnumber;          /* # threads used in this conn    */
     int c_refcnt;                    /* # ops refering to this conn    */
-    PRMonitor *c_mutex;              /* protect each conn structure; need to be re-entrant */
+    pthread_mutex_t c_mutex;         /* protect each conn structure; need to be re-entrant */
     PRLock *c_pdumutex;              /* only write one pdu at a time   */
     time_t c_idlesince;              /* last time of activity on conn  */
     int c_idletimeout;               /* local copy of idletimeout */

--- a/ldap/servers/slapd/start_tls_extop.c
+++ b/ldap/servers/slapd/start_tls_extop.c
@@ -173,7 +173,7 @@ start_tls(Slapi_PBlock *pb)
     /* At least we know that the request was indeed an Start TLS one. */
 
     slapi_pblock_get(pb, SLAPI_CONNECTION, &conn);
-    PR_EnterMonitor(conn->c_mutex);
+    pthread_mutex_lock(&(conn->c_mutex));
     /* cannot call slapi_send_ldap_result with mutex locked - will deadlock if ber_flush returns error */
     if (conn->c_prfd == (PRFileDesc *)NULL) {
         slapi_log_err(SLAPI_LOG_PLUGIN, "start_tls",
@@ -249,7 +249,7 @@ start_tls(Slapi_PBlock *pb)
      * we send a success response back to the client. */
     ldapmsg = "Start TLS request accepted.Server willing to negotiate SSL.";
 unlock_and_return:
-    PR_ExitMonitor(conn->c_mutex);
+    pthread_mutex_unlock(&(conn->c_mutex));
     slapi_send_ldap_result(pb, ldaprc, NULL, ldapmsg, 0, NULL);
 
     return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
@@ -317,7 +317,7 @@ start_tls_graceful_closure(Connection *c, Slapi_PBlock *pb, int is_initiator)
        */
     }
 
-    PR_EnterMonitor(c->c_mutex);
+    pthread_mutex_lock(&(c->c_mutex));
 
     /* "Unimport" the socket from SSL, i.e. get rid of the upper layer of the
      * file descriptor stack, which represents SSL.
@@ -347,7 +347,7 @@ start_tls_graceful_closure(Connection *c, Slapi_PBlock *pb, int is_initiator)
 
     bind_credentials_clear(c, PR_FALSE, PR_TRUE);
 
-    PR_ExitMonitor(c->c_mutex);
+    pthread_mutex_unlock(&(c->c_mutex));
 
     return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
 }

--- a/ldap/servers/slapd/unbind.c
+++ b/ldap/servers/slapd/unbind.c
@@ -75,9 +75,9 @@ do_unbind(Slapi_PBlock *pb)
     }
 
     /* target spec is used to decide which plugins are applicable for the operation */
-    PR_EnterMonitor(pb_conn->c_mutex);
+    pthread_mutex_lock(&(pb_conn->c_mutex));
     operation_set_target_spec_str(operation, pb_conn->c_dn);
-    PR_ExitMonitor(pb_conn->c_mutex);
+    pthread_mutex_unlock(&(pb_conn->c_mutex));
 
     /* ONREPL - plugins should be called and passed bind dn and, possibly, other data */
 


### PR DESCRIPTION
    Description: A change was previously made to connection
    management where the connection lock was replaced with a try_lock.
    This change resulted in a performance improvement in connection handling.

    This change was merged to 1.4.1.6 but not to the 1.3.10 branch, this
    issue looks at backporting this change to 1.3.10.

    relates: https://github.com/389ds/389-ds-base/issues/3550

    Fixes: https://github.com/389ds/389-ds-base/issues/5013

    Reviewed by: ?