### PR TITLE
Revert slapi-plugin.h change from PR 4924

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -59,7 +59,6 @@ typedef unsigned char u_int8_t;
 typedef unsigned int u_int32_t;
 typedef unsigned short u_int16_t;
 #endif
-#include "dbimpl.h"
 
 #define dptr  data
 #define dsize size
@@ -76,6 +75,7 @@ typedef unsigned short u_int16_t;
 #include "slap.h"
 #include "slapi-plugin.h"
 #include "slapi-private.h"
+#include "dbimpl.h"
 #include "avl.h"
 #include "portable.h"
 #include "proto-slap.h"

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -2483,7 +2483,7 @@ vslapd_log_error(
  * severity - LOG_ERR, LOG_WARNING, LOG_INFO, etc
  */
 int
-slapi_log_error(int loglevel, char *subsystem, const char *fmt, ...)
+slapi_log_error(int loglevel, const char *subsystem, const char *fmt, ...)
 {
     va_list ap_err;
     va_list ap_file;
@@ -2544,7 +2544,7 @@ slapi_log_error(int loglevel, char *subsystem, const char *fmt, ...)
 }
 
 int
-slapi_log_error_ext(int loglevel, char *subsystem, const char *fmt, va_list varg1, va_list varg2)
+slapi_log_error_ext(int loglevel, const char *subsystem, const char *fmt, va_list varg1, va_list varg2)
 {
     int rc = 0;
 

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -2483,7 +2483,7 @@ vslapd_log_error(
  * severity - LOG_ERR, LOG_WARNING, LOG_INFO, etc
  */
 int
-slapi_log_error(int loglevel, const char *subsystem, const char *fmt, ...)
+slapi_log_error(int loglevel, char *subsystem, const char *fmt, ...)
 {
     va_list ap_err;
     va_list ap_file;
@@ -2544,7 +2544,7 @@ slapi_log_error(int loglevel, const char *subsystem, const char *fmt, ...)
 }
 
 int
-slapi_log_error_ext(int loglevel, const char *subsystem, const char *fmt, va_list varg1, va_list varg2)
+slapi_log_error_ext(int loglevel, char *subsystem, const char *fmt, va_list varg1, va_list varg2)
 {
     int rc = 0;
 

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6030,14 +6030,32 @@ int slapi_register_plugin_ext(const char *plugintype, int enabled, const char *i
 /*
  * logging
  */
-int slapi_log_error(int loglevel, char *subsystem, const char *fmt, ...)
+#ifdef _SLDAPD_H_
+/*
+ * Use modern definition that avoid complaint about removing const from string literal
+ * ( Note: this is binary compatible with old API definition so no problem here )
+ */
+int slapi_log_error(int loglevel, const char *subsystem, const char *fmt, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 3, 4)));
 #else
     ;
 #endif
 
-int slapi_log_error_ext(int loglevel, char *subsystem, const char *fmt, va_list varg1, va_list varg2);
+int slapi_log_error_ext(int loglevel, const char *subsystem, const char *fmt, va_list varg1, va_list varg2);
+#else
+/* Use the old legacy definition because some external tester redefine these functions
+ * and changing the prototype would break their compilation
+ */
+int slapi_log_error(int loglevel, char *subsystem, char *fmt, ...)
+#ifdef __GNUC__
+    __attribute__((format(printf, 3, 4)));
+#else
+    ;
+#endif
+
+int slapi_log_error_ext(int loglevel, char *subsystem, char *fmt, va_list varg1, va_list varg2);
+#endif
 
 /* allowed values for the "severity" parameter */
 #define SLAPI_LOG_FATAL       0

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6030,14 +6030,14 @@ int slapi_register_plugin_ext(const char *plugintype, int enabled, const char *i
 /*
  * logging
  */
-int slapi_log_error(int loglevel, const char *subsystem, const char *fmt, ...)
+int slapi_log_error(int loglevel, char *subsystem, const char *fmt, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 3, 4)));
 #else
     ;
 #endif
 
-int slapi_log_error_ext(int loglevel, const char *subsystem, const char *fmt, va_list varg1, va_list varg2);
+int slapi_log_error_ext(int loglevel, char *subsystem, const char *fmt, va_list varg1, va_list varg2);
 
 /* allowed values for the "severity" parameter */
 #define SLAPI_LOG_FATAL       0


### PR DESCRIPTION
Fix slapi-plugin.h change because although it does not break compatibility with old plugin, 
  it cause trouble to some tester tools that mimic the roles of ns-slapd server (and refine slapi_log_error and slapi_log_error_ext)
Using by default the old interface and using the new interface only when including slapd.h (a private include).
(that avoid being plagued by warning about const getting removed from string literal)
BTW: In term of binaries both interfaces are equivalent (i.e compatible when compilation does not fail) so we can use safely plugin using old or new interface with ns-slapd using the other one.