### PR TITLE
Issue 5025 - RFE - remove useless logging

### DIFF
--- a/ldap/servers/slapd/attr.c
+++ b/ldap/servers/slapd/attr.c
@@ -958,9 +958,6 @@ attr_get_value_cmp_fn(const Slapi_Attr *attr, value_compare_fn_type *compare_fn)
 {
     int rc = LDAP_PROTOCOL_ERROR;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "attr_get_value_cmp_fn",
-                  "=> attr_get_value_cmp_fn\n");
-
     *compare_fn = NULL;
 
     if (attr == NULL) {
@@ -1001,7 +998,6 @@ attr_get_value_cmp_fn(const Slapi_Attr *attr, value_compare_fn_type *compare_fn)
     rc = LDAP_SUCCESS;
 
 done:
-    slapi_log_err(SLAPI_LOG_TRACE, "attr_get_value_cmp_fn", "<= attr_get_value_cmp_fn \n");
     return rc;
 }
 

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -779,8 +779,6 @@ str2entry_dupcheck(const char *rawdn, const char *s, int flags, int read_statein
     /* Check if we should be performing strict validation. */
     strict = config_get_dn_validate_strict();
 
-    slapi_log_err(SLAPI_LOG_TRACE, "str2entry_dupcheck", "==>\n");
-
     e = slapi_entry_alloc();
     slapi_entry_init(e, NULL, NULL);
     next = s;

--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -784,8 +784,6 @@ slapi_vattr_filter_test_ext_internal(
 {
     int rc = LDAP_SUCCESS;
 
-    slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "=>\n");
-
     /*
      * RJP: Not sure if this is semantically right, but we have to
      * return something if f is NULL. If there is no filter,
@@ -795,11 +793,8 @@ slapi_vattr_filter_test_ext_internal(
         return (0);
     }
 
-    slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "<=\n");
-
     switch (f->f_choice) {
     case LDAP_FILTER_EQUALITY:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "EQUALITY\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_ava.ava_type,
                                     &f->f_ava.ava_value);
@@ -812,7 +807,6 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_SUBSTRINGS:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "SUBSTRINGS\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_sub_type, NULL);
             *access_check_done = 1;
@@ -824,7 +818,6 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_GE:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "GE\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_ava.ava_type,
                                     &f->f_ava.ava_value);
@@ -837,7 +830,6 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_LE:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "LE\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_ava.ava_type,
                                     &f->f_ava.ava_value);
@@ -850,7 +842,6 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_PRESENT:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "PRESENT\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_type, NULL);
             *access_check_done = 1;
@@ -862,7 +853,6 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_APPROX:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "APPROX\n");
         if (verify_access) {
             rc = test_filter_access(pb, e, f->f_ava.ava_type,
                                     &f->f_ava.ava_value);
@@ -875,25 +865,21 @@ slapi_vattr_filter_test_ext_internal(
         break;
 
     case LDAP_FILTER_EXTENDED:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "EXTENDED\n");
         rc = test_extensible_filter(pb, e, &f->f_mr, verify_access,
                                     only_check_access, access_check_done);
         break;
 
     case LDAP_FILTER_AND:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "AND\n");
         rc = vattr_test_filter_list_and(pb, e, f->f_and,
                                         LDAP_FILTER_AND, verify_access, only_check_access, access_check_done);
         break;
 
     case LDAP_FILTER_OR:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "OR\n");
         rc = vattr_test_filter_list_or(pb, e, f->f_or,
                                        LDAP_FILTER_OR, verify_access, only_check_access, access_check_done);
         break;
 
     case LDAP_FILTER_NOT:
-        slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "NOT\n");
         rc = slapi_vattr_filter_test_ext_internal(pb, e, f->f_not, verify_access, only_check_access, access_check_done);
         if (verify_access && only_check_access) {
             /* dont play with access control return codes
@@ -934,8 +920,6 @@ slapi_vattr_filter_test_ext_internal(
         rc = -1;
     }
 
-
-    slapi_log_err(SLAPI_LOG_FILTER, "slapi_vattr_filter_test_ext_internal", "<= %d\n", rc);
     return (rc);
 }
 

--- a/ldap/servers/slapd/pagedresults.c
+++ b/ldap/servers/slapd/pagedresults.c
@@ -784,10 +784,7 @@ pagedresults_cleanup_all(Connection *conn, int needlock)
     int i;
     PagedResults *prp = NULL;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_cleanup_all", "=>\n");
-
     if (NULL == conn) {
-        slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_cleanup_all", "<= Connection is NULL\n");
         return 0;
     }
 
@@ -814,7 +811,6 @@ pagedresults_cleanup_all(Connection *conn, int needlock)
     if (needlock) {
         pthread_mutex_unlock(&(conn->c_mutex));
     }
-    slapi_log_err(SLAPI_LOG_TRACE, "pagedresults_cleanup_all", "<= %d\n", rc);
     return rc;
 }
 

--- a/ldap/servers/slapd/plugin_syntax.c
+++ b/ldap/servers/slapd/plugin_syntax.c
@@ -587,7 +587,6 @@ slapi_attr_values2keys_sv_pb(
     struct slapdplugin *pi = NULL;
     IFP v2k_fn = NULL;
 
-    slapi_log_err(SLAPI_LOG_FILTER, "slapi_attr_values2keys_sv_pb", "=>\n");
     if ((sattr->a_plugin == NULL)) {
         /* could be lazy plugin initialization, get it now */
         slapi_attr_init_syntax((Slapi_Attr *)sattr);
@@ -629,8 +628,6 @@ slapi_attr_values2keys_sv_pb(
     }
 
 done:
-    slapi_log_err(SLAPI_LOG_FILTER,
-                  "slapi_attr_values2keys_sv_pb", "<= %d\n", rc);
     return (rc);
 }
 

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -3184,8 +3184,6 @@ pw_copy_entry_ext(Slapi_Entry *src_e, Slapi_Entry *dest_e)
     struct slapi_pw_entry_ext *dest_extp = NULL;
 
     if ((-1 == pw_entry_objtype) || (-1 == pw_entry_handle)) {
-        slapi_log_err(SLAPI_LOG_TRACE, "pw_copy_entry_ext",
-                      "pw_entry_extension is not registered\n");
         return LDAP_OPERATIONS_ERROR;
     }
 
@@ -3194,8 +3192,6 @@ pw_copy_entry_ext(Slapi_Entry *src_e, Slapi_Entry *dest_e)
         src_e,
         pw_entry_handle);
     if (NULL == src_extp) {
-        slapi_log_err(SLAPI_LOG_TRACE, "pw_copy_entry_ext",
-                      "Source pw_entry_extension is not set\n");
         return LDAP_NO_SUCH_ATTRIBUTE;
     }
 
@@ -3206,8 +3202,6 @@ pw_copy_entry_ext(Slapi_Entry *src_e, Slapi_Entry *dest_e)
         pw_entry_handle);
     if (NULL == dest_extp) {
         slapi_rwlock_unlock(src_extp->pw_entry_lock);
-        slapi_log_err(SLAPI_LOG_TRACE, "pw_copy_entry_ext",
-                      "dest pw_entry_extension is not set\n");
         return LDAP_NO_SUCH_ATTRIBUTE;
     }
 


### PR DESCRIPTION
Bug Description: Many of these trace log records serve no value, they don't help with debugging,
they create noise, performance issues, and just shouldn't exist.

Fix Description: Delete the offending lines.

fixes: https://github.com/389ds/389-ds-base/issues/5025

Author: William Brown <william@blackhats.net.au>

Review by: ???