### PR TITLE
Issue 5024 - BUG - windows ro replica sigsegv

### DIFF
--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -724,10 +724,11 @@ class ReplicaLegacy(object):
         #
         # Create the changelog
         #
-        try:
-            self.conn.changelog.create()
-        except ldap.LDAPError as e:
-            raise ValueError('Failed to create changelog: %s' % str(e))
+        if not ds_supports_new_changelog():
+            try:
+                self.conn.changelog.create()
+            except ldap.LDAPError as e:
+                raise ValueError('Failed to create changelog: %s' % str(e))
 
         #
         # Check that a RID was provided, and its a valid number


### PR DESCRIPTION
Bug Description: After 1.4.3, the changelog moves into the main database rather than being a
seperate entity. This caused a situation where it was possible to create and configure a
changelog while also acting as a read-only replica. This allows individuals to create a
windows sync agreement, however during the upgrade to 1.4.4 where we move the changelog into
the main DB, I can only assume we either delete or ignore the CL if the replica is readonly.

As a result, this caused a situation where the replica information and agreement existed, but
the changelog did not. During startup as the agreement was processed, an attempt to open the
CL was made, but caused a NULL pointer dereference which prevented server startup.

Fix Description: This fixes the issue on a number of fronts. First, we remove the original
NULL pointer dereference in cl5_api.c. We correct a bug in promote in lib389 that prevented
consumer to supplier promotion. And finally, this adds a hardening check to better communicate
to users in this situation what steps they need to take.

fixes: https://github.com/389ds/389-ds-base/issues/5024

Author: William Brown <william@blackhats.net.au>

Review by: ???