### PR TITLE
Issue 5038 - BUG - dsconf tls may fail due to incorrect cert path

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1657,6 +1657,8 @@ class DirSrv(SimpleLDAPObject, object):
         return self.ds_paths.config_dir
 
     def get_cert_dir(self):
+        if self._containerised:
+            return "/data/config"
         return self.ds_paths.cert_dir
 
     def get_sysconf_dir(self):


### PR DESCRIPTION
Bug Description: Early in lib389 startup, certain functions are not
available, especially in dsconf. This means we can't read the live value
for the certdir, and we haven't overriden in it the container
so dsconf tls fails.

Fix Description: Apply the manual container path consistent with
other overrides

fixes: https://github.com/389ds/389-ds-base/issues/5038

Author: William Brown <william@blackhats.net.au>

Review by: ???