### PR TITLE
Issue 4962 - Fix various UI bugs - Database and Backups

### DIFF
--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -259,10 +259,15 @@ export class DSInstance extends React.Component {
                                             }
                                         },
                                         () => {
-                                            this.setState({
-                                                serverId: serverId,
-                                                wasActiveList: []
-                                            });
+                                            this.setState(
+                                                {
+                                                    serverId: serverId,
+                                                    wasActiveList: []
+                                                },
+                                                () => {
+                                                    this.loadBackups();
+                                                }
+                                            );
                                         }
                                     );
                                 });
@@ -275,10 +280,15 @@ export class DSInstance extends React.Component {
                                 }
                             },
                             () => {
-                                this.setState({
-                                    serverId: serverId,
-                                    wasActiveList: []
-                                });
+                                this.setState(
+                                    {
+                                        serverId: serverId,
+                                        wasActiveList: []
+                                    },
+                                    () => {
+                                        this.loadBackups();
+                                    }
+                                );
                             }
                         );
                     }
@@ -294,10 +304,15 @@ export class DSInstance extends React.Component {
                             }
                         },
                         () => {
-                            this.setState({
-                                serverId: serverId,
-                                wasActiveList: []
-                            });
+                            this.setState(
+                                {
+                                    serverId: serverId,
+                                    wasActiveList: []
+                                },
+                                () => {
+                                    this.loadBackups();
+                                }
+                            );
                         }
                     );
                 });
@@ -385,13 +400,19 @@ export class DSInstance extends React.Component {
             // Get the server version from the monitor
             cmd = ["dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.state.serverId + ".socket", "monitor", "server"];
             log_cmd("loadBackups", "Get the server version", cmd);
-            cockpit.spawn(cmd, { superuser: true, err: "message" }).done(content => {
-                const monitor = JSON.parse(content);
-                this.setState({
-                    backupRows: rows,
-                    version: monitor.attrs.version[0],
-                });
-            });
+            cockpit
+                    .spawn(cmd, { superuser: true, err: "message" }).done(content => {
+                        const monitor = JSON.parse(content);
+                        this.setState({
+                            backupRows: rows,
+                            version: monitor.attrs.version[0],
+                        });
+                    })
+                    .fail(_ => {
+                        this.setState({
+                            backupRows: rows,
+                        });
+                    });
         });
     }
 

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -350,11 +350,34 @@ export class Backups extends React.Component {
                 .done(content => {
                     this.props.reload();
                     this.closeBackupModal();
-                    this.props.addNotification(
-                        "success",
-                        `Server has been backed up`
-                    );
-                })
+                    const cmd = [
+                        "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+                        "config", "get", "nsslapd-bakdir"
+                    ];
+                    log_cmd("doBackup", "Get the backup directory", cmd);
+                    cockpit
+                            .spawn(cmd, { superuser: true, err: "message" })
+                            .done(content => {
+                                const config = JSON.parse(content);
+                                const attrs = config.attrs;
+                                this.props.addNotification(
+                                    "success",
+                                    `Server has been backed up. You can find the backup in ${attrs['nsslapd-bakdir'][0]} directory on the server machine.`
+                                );
+                            })
+                            .fail(err => {
+                                const errMsg = JSON.parse(err);
+                                this.props.addNotification(
+                                    "success",
+                                    `Server has been backed up.`
+                                );
+                                this.props.addNotification(
+                                    "error",
+                                    `Error while trying to get the server's backup directory- ${errMsg.desc}`
+                                );
+                        });
+                }
+                )
                 .fail(err => {
                     const errMsg = JSON.parse(err);
                     this.props.reload();
@@ -509,13 +532,35 @@ export class Backups extends React.Component {
                 .done(content => {
                     this.props.reload();
                     this.closeExportModal();
-                    this.props.addNotification(
-                        "success",
-                        `Database export complete`
-                    );
                     this.setState({
                         showExportModal: false,
                     });
+                    const cmd = [
+                        "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+                        "config", "get", "nsslapd-ldifdir"
+                    ];
+                    log_cmd("doExport", "Get the backup directory", cmd);
+                    cockpit
+                            .spawn(cmd, { superuser: true, err: "message" })
+                            .done(content => {
+                                const config = JSON.parse(content);
+                                const attrs = config.attrs;
+                                this.props.addNotification(
+                                    "success",
+                                    `Database export complete. You can find the LDIF file in ${attrs['nsslapd-ldifdir'][0]} directory on the server machine.`
+                                );
+                            })
+                            .fail(err => {
+                                const errMsg = JSON.parse(err);
+                                this.props.addNotification(
+                                    "success",
+                                    `Database export complete.`
+                                );
+                                this.props.addNotification(
+                                    "error",
+                                    `Error while trying to get the server's LDIF directory- ${errMsg.desc}`
+                                );
+                            });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -82,7 +82,7 @@ export class GlobalDatabaseConfig extends React.Component {
             });
         };
 
-        this.maxValue = 2000000000;
+        this.maxValue = 2147483647;
         this.onMinusConfig = (id) => {
             this.setState({
                 [id]: Number(this.state[id]) - 1
@@ -358,10 +358,10 @@ export class GlobalDatabaseConfig extends React.Component {
                         <GridItem span={8}>
                             <NumberInput
                                 value={dblocksPause}
-                                min={1}
+                                min={0}
                                 max={this.maxValue}
                                 onMinus={() => { this.onMinusConfig("dblocksMonitoringPause") }}
-                                onChange={(e) => { this.onConfigChange(e, "dblocksMonitoringPause", 1, 0) }}
+                                onChange={(e) => { this.onConfigChange(e, "dblocksMonitoringPause", 0, 0) }}
                                 onPlus={() => { this.onPlusConfig("dblocksMonitoringPause") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
@@ -378,7 +378,7 @@ export class GlobalDatabaseConfig extends React.Component {
             db_cache_form =
                 <div className="ds-margin-left">
                     <Grid
-                        title="Enable database and entry cache auto-tuning using a percentage of the system's current resources (nsslapd-cache-autosize)."
+                        title="Enable database and entry cache auto-tuning using a percentage of the system's current resources (nsslapd-cache-autosize). If 0 is set, the default value is used instead."
                         className="ds-margin-top"
                     >
                         <GridItem className="ds-label" span={6}>
@@ -387,10 +387,10 @@ export class GlobalDatabaseConfig extends React.Component {
                         <GridItem span={6}>
                             <NumberInput
                                 value={this.state.autosize}
-                                min={1}
+                                min={0}
                                 max={100}
                                 onMinus={() => { this.onMinusConfig("autosize") }}
-                                onChange={(e) => { this.onConfigChange(e, "autosize", 1, 100) }}
+                                onChange={(e) => { this.onConfigChange(e, "autosize", 0, 100) }}
                                 onPlus={() => { this.onPlusConfig("autosize") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
@@ -402,7 +402,7 @@ export class GlobalDatabaseConfig extends React.Component {
                         </GridItem>
                     </Grid>
                     <Grid
-                        title="Sets the percentage of memory that is used for the database cache. The remaining percentage is used for the entry cache (nsslapd-cache-autosize-split)."
+                        title="Sets the percentage of memory that is used for the database cache. The remaining percentage is used for the entry cache (nsslapd-cache-autosize-split). If 0 is set, the default value is used instead."
                         className="ds-margin-top"
                     >
                         <GridItem className="ds-label" span={6}>
@@ -412,9 +412,9 @@ export class GlobalDatabaseConfig extends React.Component {
                             <NumberInput
                                 value={this.state.autosizesplit}
                                 min={1}
-                                max={100}
+                                max={99}
                                 onMinus={() => { this.onMinusConfig("autosizesplit") }}
-                                onChange={(e) => { this.onConfigChange(e, "autosizesplit", 1, 100) }}
+                                onChange={(e) => { this.onConfigChange(e, "autosizesplit", 1, 99) }}
                                 onPlus={() => { this.onPlusConfig("autosizesplit") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
@@ -577,10 +577,10 @@ export class GlobalDatabaseConfig extends React.Component {
                         <GridItem span={8}>
                             <NumberInput
                                 value={this.state.idscanlimit}
-                                min={1}
+                                min={100}
                                 max={this.maxValue}
                                 onMinus={() => { this.onMinusConfig("idscanlimit") }}
-                                onChange={(e) => { this.onConfigChange(e, "idscanlimit", 1, 0) }}
+                                onChange={(e) => { this.onConfigChange(e, "idscanlimit", 100, 0) }}
                                 onPlus={() => { this.onPlusConfig("idscanlimit") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
@@ -765,7 +765,7 @@ export class GlobalDatabaseConfig extends React.Component {
                                 </GridItem>
                             </Grid>
                             <Grid
-                                title="The interval in seconds when the database is compacted (nsslapd-db-compactdb-interval).  The default is 30 days at midnight."
+                                title="The interval in seconds when the database is compacted (nsslapd-db-compactdb-interval). The default is 30 days at midnight. 0 is no compaction."
                                 className="ds-margin-top"
                             >
                                 <GridItem className="ds-label" span={4}>
@@ -774,10 +774,10 @@ export class GlobalDatabaseConfig extends React.Component {
                                 <GridItem span={8}>
                                     <NumberInput
                                         value={this.state.compactinterval}
-                                        min={1}
+                                        min={0}
                                         max={this.maxValue}
                                         onMinus={() => { this.onMinusConfig("compactinterval") }}
-                                        onChange={(e) => { this.onConfigChange(e, "compactinterval", 1, 0) }}
+                                        onChange={(e) => { this.onConfigChange(e, "compactinterval", 0, 0) }}
                                         onPlus={() => { this.onPlusConfig("compactinterval") }}
                                         inputName="input"
                                         inputAriaLabel="number input"
@@ -797,10 +797,10 @@ export class GlobalDatabaseConfig extends React.Component {
                                 <GridItem span={8}>
                                     <NumberInput
                                         value={this.state.chxpoint}
-                                        min={1}
-                                        max={this.maxValue}
+                                        min={10}
+                                        max={300}
                                         onMinus={() => { this.onMinusConfig("chxpoint") }}
-                                        onChange={(e) => { this.onConfigChange(e, "chxpoint", 1, 0) }}
+                                        onChange={(e) => { this.onConfigChange(e, "chxpoint", 10, 0) }}
                                         onPlus={() => { this.onPlusConfig("chxpoint") }}
                                         inputName="input"
                                         inputAriaLabel="number input"

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -30,6 +30,7 @@ from lib389.cli_base import (
     )
 import json
 import ldap
+from ldap.dn import str2dn
 
 arg_to_attr = {
         'lookthroughlimit': 'nsslapd-lookthroughlimit',
@@ -94,7 +95,7 @@ def _search_backend_dn(inst, be_name):
         cn = ensure_str(be.get_attr_val('cn')).lower()
         suffix = ensure_str(be.get_attr_val('nsslapd-suffix')).lower()
         del_be_name = be_name.lower()
-        if cn == del_be_name or suffix == del_be_name:
+        if cn == del_be_name or str2dn(suffix) == str2dn(del_be_name):
             dn = be.dn
             found = True
             break
@@ -107,7 +108,7 @@ def _get_backend(inst, name):
     for be in be_insts:
         be_suffix = ensure_str(be.get_attr_val_utf8_l('nsslapd-suffix')).lower()
         cn = ensure_str(be.get_attr_val_utf8_l('cn')).lower()
-        if be_suffix == name.lower() or cn == name.lower():
+        if str2dn(be_suffix) == str2dn(name.lower()) or cn == name.lower():
             return be
 
     raise ValueError('Could not find backend suffix: {}'.format(name))
@@ -118,7 +119,7 @@ def _get_index(inst, bename, attr):
     for be in be_insts:
         be_suffix = ensure_str(be.get_attr_val_utf8_l('nsslapd-suffix'))
         cn = ensure_str(be.get_attr_val_utf8_l('cn')).lower()
-        if be_suffix == bename.lower() or cn == bename.lower():
+        if str2dn(be_suffix) == str2dn(bename.lower()) or cn == bename.lower():
             for index in be.get_indexes().list():
                 idx_name = index.get_attr_val_utf8_l('cn').lower()
                 if idx_name == attr.lower():

--- a/src/lib389/lib389/mappingTree.py
+++ b/src/lib389/lib389/mappingTree.py
@@ -7,7 +7,7 @@
 # --- END COPYRIGHT BLOCK ---
 
 import ldap
-from ldap.dn import str2dn, dn2str
+from ldap.dn import str2dn, dn2str, is_dn
 from lib389._constants import *
 from lib389.properties import *
 from lib389.utils import suffixfilt, normalizeDN
@@ -448,3 +448,20 @@ class MappingTrees(DSLdapObjects):
             else:
                 processing = False
         raise ldap.NO_SUCH_OBJECT(f"{entry_dn} doesn't belong to any suffix")
+
+    def get(self, selector=[], dn=None, json=False):
+        """Create a test user with uid=test_user_UID rdn
+
+        :param uid: User id
+        :type uid: int
+        :param gid: Group id
+        :type gid: int
+
+        :returns: DSLdapObject of the created entry
+        """
+
+        # Normalise escaped characters
+        if is_dn(selector):
+            selector = dn2str(str2dn(selector))
+
+        return super(MappingTrees, self).get(selector, dn, json)


### PR DESCRIPTION
Description:

Bug 1751280 - [RFE] Cockpit : Provide the access path to the exported suffix
Bug 1861805 - 389-ds-base: Accepting nsslapd-db-checkpoint-interval values in negative.
Bug 1926516 - Cannot load the DB with suffix with characters escaped by a backslash.
Bug 1986388 - Cockpit: "Manage backups" list is empty if dirsrv service is stopped

Related: https://github.com/389ds/389-ds-base/issues/5001

Reviewed by: ?