### PR TITLE
Issue 5053 - Improve GitHub Actions debugging

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -1,19 +1,37 @@
 import os
+import sys
 import glob
 import json
 
-suites = next(os.walk('dirsrvtests/tests/suites/'))[1]
+# If we have arguments passed to the script, use them as the test names to run
+if len(sys.argv) > 1:
+    suites = sys.argv[1:]
+    valid_suites = []
+    # Validate if the path is a valid file or directory with files
+    for suite in suites:
+        test_path = os.path.join("dirsrvtests/tests/suites/", suite)
+        if os.path.exists(test_path) and not os.path.islink(test_path):
+            if os.path.isfile(test_path) and test_path.endswith(".py"):
+                valid_suites.append(suite)
+            elif os.path.isdir(test_path):
+                valid_suites.append(suite)
+    suites = valid_suites
 
-# Filter out snmp as it is an empty directory:
-suites.remove('snmp')
+else:
+    # Use tests from the source
+    suites = next(os.walk('dirsrvtests/tests/suites/'))[1]
 
-# Run each replication test module separately to speed things up
-suites.remove('replication')
-repl_tests = glob.glob('dirsrvtests/tests/suites/replication/*_test.py')
-suites += [repl_test.replace('dirsrvtests/tests/suites/', '') for repl_test in repl_tests]
-suites.sort()
+    # Filter out snmp as it is an empty directory:
+    suites.remove('snmp')
+
+    # Run each replication test module separately to speed things up
+    suites.remove('replication')
+    repl_tests = glob.glob('dirsrvtests/tests/suites/replication/*_test.py')
+    suites += [repl_test.replace('dirsrvtests/tests/suites/', '') for repl_test in repl_tests]
+    suites.sort()
 
 suites_list = [{ "suite": suite} for suite in suites]
 matrix = {"include": suites_list}
 
 print(json.dumps(matrix))
+

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,16 @@ on:
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      pytest_tests:
+        description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
+        required: false
+        default: false
+      debug_enabled:
+        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
 
 jobs:
   build:
@@ -20,7 +30,7 @@ jobs:
 
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "::set-output name=matrix::$(python3 .github/scripts/generate_matrix.py)"
+        run: echo "::set-output name=matrix::$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})"
 
       - name: Build RPMs
         run: cd $GITHUB_WORKSPACE && SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
@@ -46,6 +56,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
     - name: Install dependencies
       run: |
         sudo apt update -y
@@ -53,6 +69,7 @@ jobs:
         sudo cp .github/daemon.json /etc/docker/daemon.json
         sudo systemctl unmask docker
         sudo systemctl start docker
+
     - name: Download RPMs
       uses: actions/download-artifact@master
       with:


### PR DESCRIPTION
Description:
This commit adds `workflow_dispatch` trigger with 2 inputs.
First input specifies what test suites or test modules should be
executed. Paths should be delimited by space and be relative to
dirsrvtests/tests/suites/, i.e. input
```
basic replication/acceptance_test.py
```
will execute tests under `basic` test suite directory and
`replication/acceptance_test.py` module.
Only existing paths are accepted, everything else will be filtered out.

Second input is a boolean that enables debugging with tmate:
https://github.com/marketplace/actions/debugging-with-tmate
By default it's `false`, so set it to `true` when you need to rerun the
test with remote access.

Action is configured to use SSH key(s) registered with your GitHub
profile.

Connection string will be logged in "Setup tmate session" step in the
test logs.

Once you inside the tmate session, run `touch continue` to continue the
workflow. When ontainer with pytest is started, run
`docker exec -ti $(docker ps -q) /bin/bash` to get inside the container
to inspect it.

Fixes: https://github.com/389ds/389-ds-base/issues/5053

Reviewed by: ???