### PR TITLE
Issue 5052 - BUG - Custom filters prevented entry deletion

### DIFF
--- a/ldap/servers/plugins/replication/repl5_agmt.c
+++ b/ldap/servers/plugins/replication/repl5_agmt.c
@@ -486,6 +486,8 @@ agmt_new_from_entry(Slapi_Entry *e)
             ra->agreement_type = REPLICA_TYPE_WINDOWS;
             windows_init_agreement_from_entry(ra, e);
         } else {
+            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
+                          "agmt_new_from_entry: type -> %d\n", replica_get_type(replica));
             slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name,
                           "agmt_new_from_entry: failed to initialise windows replication"
                           "agreement \"%s\" - replica is not a supplier (may be hub or consumer).\n",


### PR DESCRIPTION
Bug Description: When a custom filter was provided, entries
which were deleted in AD did not have that event correctly
reflected in 389-ds. This was due to the behaviour that when
an entry in AD is deleted, it is marked with a "deleted" flag
which the objectClass=* filter would (accidentally) collect
when it did a search. However, a custom user filter being
specified would in some cases (such as a memberOf filter)
NOT show up the deletion since the entry was considered
to have moved out of scope rather than being a full delete.

Fix Description: In the case that we have a userfilter, we
wrap it in an OR condition that always requests isDeleted
flags so that we can correctly reflect the delete status.

fixes: https://github.com/389ds/389-ds-base/issues/5052

Author: William Brown <william@blackhats.net.au>

Review by: ???