### PR TITLE
Issue 5011 - test_replica_backup_and_restore random failure

### DIFF
--- a/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
+++ b/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
@@ -434,7 +434,7 @@ def list_agmt_towards(topo_m4, serverid):
     res = []
     for inst in topo_m4:
         for agmt in Agreements(inst).list():
-            if agmt.get_attr_val_utf8(AGMT_PORT) == topo_m4.ms[serverid].port:
+            if agmt.get_attr_val_int(AGMT_PORT) == topo_m4.ms[serverid].port:
                 res.append(agmt)
     return res
 


### PR DESCRIPTION
Bug description:
	fourwaymmr_test.py::test_replica_backup_and_restore checks
	that, on a given supplier, after an offline LDIF import,
	entries that are present in the LDIF do exist.
	The problem is that some entries 'uid=test_user_2[0-4]'
	has been deleted before the import and others suppliers may
	replicate the DEL before the test checks that the entries exist.
	To prevent that, replication agreement toward the given supplier
	are pause.
	The bug is that list_agmt_toward compare string port with
	an int, so no replication agreement are selected

Fix description:
	Change the RA port into a 'int'

relates: https://github.com/389ds/389-ds-base/issues/5011

Reviewed by:

Platforms tested: F34