### PR TITLE
Issue 5074 - retro changelog cli updates

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -720,14 +720,17 @@ int
 retrocl_attr_in_exclude_attrs(char *attr, int attrlen)
 {
     int i = 0;
-    if (attr && attrlen > 0 && retrocl_nexclude_attrs > 0) {
-        while (retrocl_exclude_attrs[i]) {
-            if (strncmp(retrocl_exclude_attrs[i], attr, attrlen) == 0) {
-                slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME,"retrocl_attr_in_exclude_attrs - excluding attr (%s).\n", attr);
-                return 1;
+
+    if (retrocl_exclude_attrs) {
+        if (attr && attrlen > 0 && retrocl_nexclude_attrs > 0) {
+            while (retrocl_exclude_attrs[i]) {
+                if (strncmp(retrocl_exclude_attrs[i], attr, attrlen) == 0) {
+                    slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME,"retrocl_attr_in_exclude_attrs - excluding attr (%s).\n", attr);
+                    return 1;
+                }
+                i++;
             }
-            i++;
         }
+        return 0;
     }
-    return 0;
 }

--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -731,6 +731,6 @@ retrocl_attr_in_exclude_attrs(char *attr, int attrlen)
                 i++;
             }
         }
-        return 0;
     }
+    return 0;
 }

--- a/src/lib389/lib389/cli_conf/__init__.py
+++ b/src/lib389/lib389/cli_conf/__init__.py
@@ -73,6 +73,25 @@ def generic_object_add_attr(dsldap_object, log, args, arg_to_attr):
     else:
         raise ValueError("There is nothing to set in the %s plugin entry" % dsldap_object.dn)
 
+def generic_object_del_attr(dsldap_object, log, args, arg_to_attr):
+    """Delete an attribute from an entry.
+
+    dsldap_object should be a single instance of DSLdapObject with a set dn
+    """
+    log = log.getChild('generic_object_del_attr')
+    # Gather the attributes
+    attrs = _args_to_attrs(args, arg_to_attr)
+
+    modlist = []
+    for attr, value in attrs.items():
+        if not isinstance(value, list):
+            value = [value]
+        modlist.append((ldap.MOD_DELETE, attr, value))
+    if len(modlist) > 0:
+        dsldap_object.apply_mods(modlist)
+        log.info("Successfully deleted attribute %s", str(value))
+    else:
+        raise ValueError("There is nothing to delete in the %s plugin entry" % dsldap_object.dn)
 
 def generic_object_edit(dsldap_object, log, args, arg_to_attr):
     """Replace or delete an attribute on an entry.

--- a/src/lib389/lib389/cli_conf/__init__.py
+++ b/src/lib389/lib389/cli_conf/__init__.py
@@ -89,7 +89,7 @@ def generic_object_del_attr(dsldap_object, log, args, arg_to_attr):
         modlist.append((ldap.MOD_DELETE, attr, value))
     if len(modlist) > 0:
         dsldap_object.apply_mods(modlist)
-        log.info("Successfully deleted attribute %s", str(value))
+        log.info("Successfully changed the %s", dsldap_object.dn)
     else:
         raise ValueError("There is nothing to delete in the %s plugin entry" % dsldap_object.dn)
 

--- a/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
+++ b/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
@@ -5,10 +5,8 @@
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
-
-
 from lib389.plugins import RetroChangelogPlugin
-from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr
+from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr, generic_object_del_attr
 
 arg_to_attr = {
     'is_replicated': 'isReplicated',
@@ -31,6 +29,10 @@ def retrochangelog_add(inst, basedn, log, args):
     plugin = RetroChangelogPlugin(inst)
     generic_object_add_attr(plugin, log, args, arg_to_attr)
 
+def retrochangelog_del(inst, basedn, log, args):
+    log = log.getChild('retrochangelog_add')
+    plugin = RetroChangelogPlugin(inst)
+    generic_object_del_attr(plugin, log, args, arg_to_attr)
 
 def _add_parser_args(parser):
     parser.add_argument('--is-replicated', choices=['TRUE', 'FALSE'], type=str.upper,
@@ -43,16 +45,16 @@ def _add_parser_args(parser):
                         help='Specifies the name of the directory in which the changelog database '
                              'is created the first time the plug-in is run')
     parser.add_argument('--max-age',
-                        help='This attribute specifies the maximum age of any entry '
-                             'in the changelog.  Used to trim the changelog (nsslapd-changelogmaxage)')
+                        help='Specifies the maximum age of any entry in the changelog.  Used to trim the '
+                            'changelog (nsslapd-changelogmaxage)')
     parser.add_argument('--trim-interval',
                         help='. nsslapd-changelog-trim-interval)')
-    parser.add_argument('--exclude-suffix',
-                        help='This attribute specifies the suffix which will be excluded '
-                             'from the scope of the plugin (nsslapd-exclude-suffix)')
-    parser.add_argument('--exclude-attrs',
-                        help='This attribute specifies the attributes which will be excluded '
-                             'from the scope of the plugin (nsslapd-exclude-attrs)')
+    parser.add_argument('--exclude-suffix', nargs='*',
+                        help='Specifies the suffix which will be excluded from the scope of the plugin '
+                            '(nsslapd-exclude-suffix)')
+    parser.add_argument('--exclude-attrs', nargs='*',
+                        help='Specifies the attributes which will be excluded from the scope of the plugin '
+                            '(nsslapd-exclude-attrs)')
 
 
 def create_parser(subparsers):
@@ -68,3 +70,6 @@ def create_parser(subparsers):
     addp.set_defaults(func=retrochangelog_add)
     _add_parser_args(addp)
 
+    delp = subcommands.add_parser('del', help='Delete an attribute from plugin scope')
+    delp.set_defaults(func=retrochangelog_del)
+    _add_parser_args(delp)


### PR DESCRIPTION
Bug description: The cli does not allow for the creation of multiple
exclude attributes in one call. When there are multiple exclude
attributes defined, the cli doesn't allow removal of an individual
exclude attribute. Using the set command deletes all excluded
attributes.

Fix description: Modify parser to take multiple arguments in a single
call. Add atribute del method to lib389 cli_conf.

Fixes: https://github.com/389ds/389-ds-base/issues/5074

Reviewed by: ?