### PR TITLE
Issue 5082 - slugify: ModuleNotFoundError when running test cases

### DIFF
--- a/dirsrvtests/requirements.txt
+++ b/dirsrvtests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-libfaketime
+slugify


### PR DESCRIPTION
Description: slugify: ModuleNotFoundError when running test cases

Relates: https://github.com/389ds/389-ds-base/issues/5082

Reviewed by: ?