### PR TITLE
Issue 5079 - BUG - multiple ways to specific primary

### DIFF
--- a/ldap/servers/plugins/replication/repl5_agmt.c
+++ b/ldap/servers/plugins/replication/repl5_agmt.c
@@ -482,7 +482,9 @@ agmt_new_from_entry(Slapi_Entry *e)
 
     /* DBDB: review this code */
     if (slapi_entry_attr_hasvalue(e, "objectclass", "nsDSWindowsReplicationAgreement")) {
-        if (replica_get_type(replica) == REPLICA_TYPE_PRIMARY) {
+        if (replica_get_type(replica) == REPLICA_TYPE_PRIMARY
+           || (replica_get_type(replica) == REPLICA_TYPE_UPDATABLE && replica_is_flag_set(replica, REPLICA_LOG_CHANGES))
+        ) {
             ra->agreement_type = REPLICA_TYPE_WINDOWS;
             windows_init_agreement_from_entry(ra, e);
         } else {


### PR DESCRIPTION
Bug Description: In a winsync environment, we can only sync
changes to a primary replica. There are however, multiple
ways to specify which server is a primary for a replication
agreement, and I only accounted for one of them.

Fix Description: Improve the check to account for the
other primary replica flags.

fixes: https://github.com/389ds/389-ds-base/issues/5079

Author: William Brown <william@blackhats.net.au>

Review by: ???