### PR TITLE
Issue 5088 - dsctl dblib broken because of a merge issue

### DIFF
--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -25,6 +25,7 @@ from lib389.cli_ctl import nsstate as cli_nsstate
 from lib389.cli_ctl import dbgen as cli_dbgen
 from lib389.cli_ctl import dsrc as cli_dsrc
 from lib389.cli_ctl import cockpit as cli_cockpit
+from lib389.cli_ctl import dblib as cli_dblib
 from lib389.cli_ctl.instance import instance_remove_all
 from lib389.cli_base import (
     disconnect_instance,
@@ -64,6 +65,7 @@ cli_nsstate.create_parser(subparsers)
 cli_dbgen.create_parser(subparsers)
 cli_dsrc.create_parser(subparsers)
 cli_cockpit.create_parser(subparsers)
+cli_dblib.create_parser(subparsers)
 
 argcomplete.autocomplete(parser)
 


### PR DESCRIPTION
A simple "git restore -s 55fb438a41789ae4daa35d18a65be2c918e75b24 dsctl" to remove the wrong commit

Issue: [5088](https://github.com/389ds/389-ds-base/issues/5088)

Reviewd by: @droideck