### PR TITLE
Issue 5032 - Fix OpenLDAP version check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,7 @@ PROFILING_LINKS = @profiling_links@
 NSPR_LINK = $(NSPR_LIBS)
 NSS_LINK = $(NSS_LIBS)
 
-# OpenLDAP 2.6 and newer versions don't have libldap_r shared library (only libldap)
+# OpenLDAP 2.5 and newer versions don't have libldap_r shared library (only libldap)
 # For the older versions we should compile with libldap_r
 if WITH_LIBLDAP_R
 LDAPSDK_LINK = @openldap_lib@ -lldap_r@ol_libver@ @ldap_lib_ldif@ -llber@ol_libver@

--- a/configure.ac
+++ b/configure.ac
@@ -870,7 +870,7 @@ AM_CONDITIONAL(OPENLDAP,test "$with_openldap" = "yes")
 
 # check for --with-libldap-r
 AC_MSG_CHECKING(for --with-libldap-r)
-AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so shared library (default: if OpenLDAP version is less than 2.5, then libldap_r.so will be used, else - libldap.so)]),
+AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use lldap_r shared library (default: if OpenLDAP version is less than 2.5, then lldap_r will be used, else - lldap)]),
 [
   if test "$withval" = "no"; then
     AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -870,7 +870,7 @@ AM_CONDITIONAL(OPENLDAP,test "$with_openldap" = "yes")
 
 # check for --with-libldap-r
 AC_MSG_CHECKING(for --with-libldap-r)
-AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so shared library (default: if OpenLDAP version is less than 2.6, then libldap_r.so will be used, else - libldap.so)]),
+AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so shared library (default: if OpenLDAP version is less than 2.5, then libldap_r.so will be used, else - libldap.so)]),
 [
   if test "$withval" = "no"; then
     AC_MSG_RESULT(no)
@@ -882,7 +882,7 @@ AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so share
 ],
 OPENLDAP_VERSION=`ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([0-9]\+\.[0-9]\+\.[0-9]\+\) .*/\1/p')`
 AC_MSG_RESULT([$OPENLDAP_VERSION])
-AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.6], [ with_libldap_r=no ], [ with_libldap_r=yes ]))
+AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.5], [ with_libldap_r=no ], [ with_libldap_r=yes ]))
 
 AM_CONDITIONAL([WITH_LIBLDAP_R],[test "$with_libldap_r" = yes])
 


### PR DESCRIPTION
Description: In the Upstream, libldap_r has been merged with libldap
starting from openldap-2.5.
Fix the version check in configure.ac and the comments.

Fixes: https://github.com/389ds/389-ds-base/issues/5032

Reviewed by: ?