### PR TITLE
Issue 5092 - BUG - pin concread for el8.5

### DIFF
--- a/src/librslapd/Cargo.toml
+++ b/src/librslapd/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 slapd = { path = "../slapd" }
 libc = "0.2"
-concread =  "^0.2.20"
+concread =  "=0.2.20"
 
 [build-dependencies]
 cbindgen = "0.9"


### PR DESCRIPTION
Bug Description: el8.5 doesn't have a new enough
rust compiler to build anything with edition 2021

Fix Description: pin concread to an earlier version

fixes: https://github.com/389ds/389-ds-base/issues/5092

Author: William Brown <william@blackhats.net.au>

Review by: ???