### PR TITLE
Issue 5080 - BUG - multiple index types not handled in openldap migration

### DIFF
--- a/dirsrvtests/tests/data/openldap_2_389/1/slapd.d/cn=config/olcDatabase={1}mdb.ldif
+++ b/dirsrvtests/tests/data/openldap_2_389/1/slapd.d/cn=config/olcDatabase={1}mdb.ldif
@@ -9,6 +9,7 @@ olcSuffix: dc=example,dc=com
 olcRootDN: cn=Manager,dc=example,dc=com
 olcRootPW:: c2VjcmV0
 olcDbIndex: objectClass eq
+olcDbIndex: uid eq,pres,sub
 structuralObjectClass: olcMdbConfig
 entryUUID: 401a528e-eaf5-1039-8667-dbfbf2f5e6dd
 creatorsName: cn=config

--- a/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
+++ b/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
@@ -39,9 +39,18 @@ def test_parse_openldap_slapdd():
 
     # Do we have databases?
     assert len(config.databases) == 2
+    # Check that we unpacked uid eq,pres,sub correctly.
+    assert len(config.databases[0].index) == 4
+    assert ('objectClass', 'eq') in config.databases[0].index
+    assert ('uid', 'eq') in config.databases[0].index
+    assert ('uid', 'pres') in config.databases[0].index
+    assert ('uid', 'sub') in config.databases[0].index
 
     # Did our schema parse?
     assert any(['suseModuleConfiguration' in x.names for x in config.schema.classes])
+
+
+
 
 
 @pytest.mark.skipif(ds_is_older('1.4.3'), reason="Not implemented")

--- a/src/lib389/lib389/migrate/openldap/config.py
+++ b/src/lib389/lib389/migrate/openldap/config.py
@@ -113,10 +113,12 @@ class olDatabase(object):
         self.idx = name.split('}', 1)[0].split('{', 1)[1]
         self.uuid = ensure_str(self.config[1]['entryUUID'][0])
 
-        self.index = [
-            tuple(ensure_str(x).split(' '))
-            for x in self.config[1]['olcDbIndex']
-        ]
+        self.index = []
+        for x in self.config[1]['olcDbIndex']:
+            (attr, idx_types) = ensure_str(x).split(' ', 1)
+            attr = attr.strip()
+            for idx_type in idx_types.split(','):
+                self.index.append((attr, idx_type.strip()))
 
         self.log.debug(f"settings -> {self.suffix}, {self.idx}, {self.uuid}, {self.index}")
 


### PR DESCRIPTION
Bug Description: In migration from openldap we were not correctly
handling how we parsed indexed attributes with multiple types of
indexes applied.

Fix Description: Fix the parsing and add tests for this scenario

fixes: https://github.com/389ds/389-ds-base/issues/5080

Author: William Brown <william@blackhats.net.au>

Review by: ???