### PR TITLE
Issue 5095 - sync-repl with openldap may send truncated syncUUID

### DIFF
--- a/ldap/servers/plugins/sync/sync.h
+++ b/ldap/servers/plugins/sync/sync.h
@@ -131,7 +131,7 @@ int sync_update_persist_betxn_pre_op(Slapi_PBlock *pb);
 int sync_parse_control_value(struct berval *psbvp, ber_int_t *mode, int *reload, char **cookie);
 int sync_create_state_control(Slapi_Entry *e, LDAPControl **ctrlp, int type, Sync_Cookie *cookie, PRBool openldap_compat);
 int sync_create_sync_done_control(LDAPControl **ctrlp, int refresh, char *cookie);
-int sync_intermediate_msg(Slapi_PBlock *pb, int tag, Sync_Cookie *cookie, char **uuids);
+int sync_intermediate_msg(Slapi_PBlock *pb, int tag, Sync_Cookie *cookie, struct berval **uuids);
 int sync_result_msg(Slapi_PBlock *pb, Sync_Cookie *cookie);
 int sync_result_err(Slapi_PBlock *pb, int rc, char *msg);
 

--- a/ldap/servers/plugins/sync/sync_refresh.c
+++ b/ldap/servers/plugins/sync/sync_refresh.c
@@ -745,6 +745,7 @@ void
 sync_send_deleted_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count, Sync_Cookie *cookie)
 {
     char *syncUUIDs[SYNC_MAX_DELETED_UUID_BATCH + 1] = {0};
+    struct berval *ber_syncUUIDs[SYNC_MAX_DELETED_UUID_BATCH + 1] = {0};
     size_t uuid_index = 0;
 
     PR_ASSERT(cookie);
@@ -764,9 +765,15 @@ sync_send_deleted_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count,
             } else {
                 /* max number of uuids to be sent in one sync info message */
                 syncUUIDs[uuid_index] = NULL;
-                sync_intermediate_msg(pb, LDAP_TAG_SYNC_ID_SET, cookie, (char **)&syncUUIDs);
+                for (size_t i = 0; i < uuid_index; i++) {
+                    ber_syncUUIDs[i] = (struct berval *) slapi_ch_malloc(sizeof(struct berval));
+                    ber_syncUUIDs[i]->bv_val = syncUUIDs[i];
+                    ber_syncUUIDs[i]->bv_len = 16;
+                }
+                sync_intermediate_msg(pb, LDAP_TAG_SYNC_ID_SET, cookie, ber_syncUUIDs);
                 for (size_t i = 0; i < uuid_index; i++) {
                     slapi_ch_free((void **)&syncUUIDs[i]);
+                    slapi_ch_free((void **)&ber_syncUUIDs[i]);
                     syncUUIDs[i] = NULL;
                 }
                 uuid_index = 0;
@@ -777,9 +784,15 @@ sync_send_deleted_entries(Slapi_PBlock *pb, Sync_UpdateNode *upd, int chg_count,
     if (uuid_index > 0 && syncUUIDs[uuid_index - 1]) {
         /* more entries to send */
         syncUUIDs[uuid_index] = NULL;
-        sync_intermediate_msg(pb, LDAP_TAG_SYNC_ID_SET, cookie, (char **)&syncUUIDs);
+        for (size_t i = 0; i < uuid_index; i++) {
+            ber_syncUUIDs[i] = (struct berval *) slapi_ch_malloc(sizeof(struct berval));
+            ber_syncUUIDs[i]->bv_val = syncUUIDs[i];
+            ber_syncUUIDs[i]->bv_len = 16;
+        }
+        sync_intermediate_msg(pb, LDAP_TAG_SYNC_ID_SET, cookie, ber_syncUUIDs);
         for (size_t i = 0; i < uuid_index; i++) {
             slapi_ch_free((void **)&syncUUIDs[i]);
+            slapi_ch_free((void **)&ber_syncUUIDs[i]);
             syncUUIDs[i] = NULL;
         }
     }

--- a/ldap/servers/plugins/sync/sync_util.c
+++ b/ldap/servers/plugins/sync/sync_util.c
@@ -9,7 +9,7 @@
 #include "sync.h"
 #include "slap.h"  /* for LDAP_TAG_SK_REVERSE */
 
-static struct berval *create_syncinfo_value(int type, const char *cookie, const char **uuids);
+static struct berval *create_syncinfo_value(int type, const char *cookie, struct berval **uuids);
 static char *sync_cookie_get_server_info(Slapi_PBlock *pb);
 static char *sync_cookie_get_client_info(Slapi_PBlock *pb);
 
@@ -310,14 +310,14 @@ sync_cookie2str(Sync_Cookie *cookie)
 }
 
 int
-sync_intermediate_msg(Slapi_PBlock *pb, int tag, Sync_Cookie *cookie, char **uuids)
+sync_intermediate_msg(Slapi_PBlock *pb, int tag, Sync_Cookie *cookie, struct berval **uuids)
 {
     int rc;
     struct berval *syncInfo;
     LDAPControl *ctrlp = NULL;
     char *cookiestr = sync_cookie2str(cookie);
 
-    syncInfo = create_syncinfo_value(tag, cookiestr, (const char **)uuids);
+    syncInfo = create_syncinfo_value(tag, cookiestr, uuids);
 
     rc = slapi_send_ldap_intermediate(pb, &ctrlp, LDAP_SYNC_INFO, syncInfo);
     slapi_ch_free((void **)&cookiestr);
@@ -356,7 +356,7 @@ sync_result_err(Slapi_PBlock *pb, int err, char *msg)
 }
 
 static struct berval *
-create_syncinfo_value(int type, const char *cookie, const char **uuids)
+create_syncinfo_value(int type, const char *cookie, struct berval **uuids)
 {
     BerElement *ber;
     struct berval *bvp = NULL;
@@ -396,7 +396,7 @@ create_syncinfo_value(int type, const char *cookie, const char **uuids)
             ber_printf(ber, "s", cookie);
         }
         if (uuids) {
-            ber_printf(ber, "b[v]", 1, uuids);
+            ber_printf(ber, "b[V]", 1, uuids);
         }
         ber_printf(ber, "}");
         break;


### PR DESCRIPTION
Bug description:
	When using sync_repl from openldap, syncUUID (that identify an
	entry) is retrieved from targetEntryUUID rather than nsuniqueid.
	syncUUID is a 16 bytes long representation of targetEntryUUID.
        TargetEntryUUID can contain '00' so syncUUID can contain a
	byte with 0x00.
	When creating a syncInfo
(https://datatracker.ietf.org/doc/html/rfc4533#section-2.5)
	syncUUIDS is ber encoded with '[v]' taking a null terminated
	array of (char*). In such case the 0x00 char truncates the
	syncUUID.

Fix description:
	Instead of using a null terminated array of (char*), the
	fix uses a null terminated array of berval.

relates: https://github.com/389ds/389-ds-base/issues/5095

Reviewed by:

Platforms tested: F34