### PR TITLE
ipa-replica-install with 389ds copr repo

### DIFF
--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -1718,7 +1718,7 @@ void dup_ldif_line(struct berval *copy, const char *line, const char *endline)
         if (copylen == 0) {
             break;
         }
-        if (*line == '#') {
+        if (*line == '#' && pos == 0) {
             pt++;
             continue;
         }


### PR DESCRIPTION
Issue with schema parsing: continuation line starting with " #" are wrongly considered as comment.
Fix is trivial (coment should be at the start of the unfolded line.)
Also added CI test schema / test_definition_with_sharp to verify this issue


reviewed by: @mreynolds389