### PR TITLE
Issue 5105 - During a bind, if the target entry is not reachable the …

### DIFF
--- a/ldap/servers/slapd/pw_verify.c
+++ b/ldap/servers/slapd/pw_verify.c
@@ -64,12 +64,14 @@ pw_verify_be_dn(Slapi_PBlock *pb, Slapi_Entry **referral)
 
     int mt_result = slapi_mapping_tree_select(pb, &be, referral, NULL, 0);
     if (mt_result != LDAP_SUCCESS) {
+        slapi_send_ldap_result(pb, LDAP_UNAVAILABLE, NULL, NULL, 0, NULL);
         return SLAPI_BIND_NO_BACKEND;
     }
 
     if (*referral) {
         /* If we have a referral, this is NULL */
         PR_ASSERT(be == NULL);
+        slapi_send_ldap_result(pb, LDAP_REFERRAL, NULL, NULL, 0, NULL);
         return SLAPI_BIND_REFERRAL;
     }
 
@@ -78,6 +80,7 @@ pw_verify_be_dn(Slapi_PBlock *pb, Slapi_Entry **referral)
     if (be->be_bind == NULL) {
         /* Selected backend doesn't support binds! */
         slapi_be_Unlock(be);
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, NULL, 0, NULL);
         return LDAP_OPERATIONS_ERROR;
     }
     slapi_pblock_set(pb, SLAPI_PLUGIN, be->be_database);


### PR DESCRIPTION
…operation may complete without sending result

Bug description:
	A bind operation can skip sending back operation result.
	This can happen in rare condition like backend is not available
	or in referral mode or did not define a bind callback.

Fix description:
	Catch those errors condition and send an operation result.

relates: https://github.com/389ds/389-ds-base/issues/5105

Reviewed by:

Platforms tested: F34