### PR TITLE
Issue 5065 - Crash in suite plugins - test_dna_max_value

### DIFF
--- a/dirsrvtests/tests/suites/plugins/dna_interval_test.py
+++ b/dirsrvtests/tests/suites/plugins/dna_interval_test.py
@@ -189,3 +189,6 @@ def test_dna_interval_with_different_values(topology_st, dna_plugin, attr_value)
         log.info("Make an update and verify it raises error as the new interval value is more than dnaMaxValue")
         with pytest.raises(ldap.OPERATIONS_ERROR):
             user.replace('uidNumber', '-1')
+
+        # Check that instance did not crashed
+        assert topology_st.standalone.status()


### PR DESCRIPTION
dna pre operation plugin modify the modifiers list but does not update the block in case of error. This leads to have freed data linked in pblock and SIGSEGV when trying to use them to generate the audit log records.

Solution is to systematically update the pblock modifiers list in case of modify operation.

Also modified to test case to insure that server is still up at the end.

Issue: [5065](https://github.com/389ds/389-ds-base/issues/5065)

reviewde by:  [@droideck](https://github.com/droideck)