### PR TITLE
Issue 5098 - Multiple issues around replication and CI test test_online_reinit_may_hang

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -845,12 +845,14 @@ def test_online_reinit_may_hang(topo_with_sigkill):
         1. Export the database
         2. Move RUV entry to the top in the ldif file
         3. Import the ldif file
-        4. Online replica initializaton
+        4. Check that replication is still working
+        5. Online replica initializaton
     :expectedresults:
         1. Ldif file should be created successfully
         2. RUV entry should be on top in the ldif file
         3. Import should be successful
-        4. Server should not hang and consume 100% CPU
+        4. Replication should work
+        5. Server should not hang and consume 100% CPU
     """
     M1 = topo_with_sigkill.ms["supplier1"]
     M2 = topo_with_sigkill.ms["supplier2"]
@@ -863,6 +865,11 @@ def test_online_reinit_may_hang(topo_with_sigkill):
     M1.ldif2db(DEFAULT_BENAME, None, None, None, ldif_file)
     M1.start()
     # After this server may hang
+    # Exporting idle server with replication data and reimporting
+    # should not break replication (Unless we hit issue 5098)
+    # So let check that replication is still working.
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.test_replication_topology(topo_with_sigkill)
     agmt = Agreements(M1).list()[0]
     agmt.begin_reinit()
     (done, error) = agmt.wait_reinit()

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -1714,7 +1714,7 @@ replica_check_for_data_reload(Replica *r, void *arg __attribute__((unused)))
             return -1;
         }
 
-        if (upper_bound_ruv) {
+        if (upper_bound_ruv && ruv_replica_count(upper_bound_ruv) > 0) {
             ruv_obj = replica_get_ruv(r);
             r_ruv = object_get_data(ruv_obj);
             PR_ASSERT(r_ruv);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -2576,7 +2576,7 @@ bdb_import_foreman(void *param)
                  */
 #define RUVRDN SLAPI_ATTR_UNIQUEID "=" RUV_STORAGE_ENTRY_UNIQUEID
                 if (!slapi_be_issuffix(inst->inst_be, backentry_get_sdn(fi->entry)) &&
-                    strcasecmp(backentry_get_ndn(fi->entry), RUVRDN) /* NOT nsuniqueid=ffffffff-... */) {
+                    strcasecmp(slapi_entry_get_nrdn_const(fi->entry->ep_entry), RUVRDN) /* NOT nsuniqueid=ffffffff-... */) {
                     import_log_notice(job, SLAPI_LOG_WARNING, "bdb_import_foreman",
                                       "Skipping entry \"%s\" which has no parent, ending at line %d "
                                       "of file \"%s\"",


### PR DESCRIPTION
Missing CSN Issue: 
  replica_check_for_data_reload calls replica_log_ruv_elements (that creates the dummy changelog starting entries) when erasing the changelog or if the changelog RUV is missing
  But the issue is that the changelog RUV is not missing when the changelog is empty because _cl5ReadRUV creates a new one (by callng _cl5ConstructRUV)  if the RUV entry is not found in changelog.

 Solution is to check if changelog ruv is empty by using ruv_replica_count
    in replica_check_for_data_reload:
    if (upper_bound_ruv && ruv_replica_count(upper_bound_ruv) > 0) {

The missing csn issue is hidden in bdb case because of a second problem: 
   RUV defined before the suffix get skipped.
In fact this case was already coded in bdb but the test to handle it was buggy (entry dn was compared to RUV rdn instead of entry rdn)

reviewed by: