### PR TITLE
Issue #5113 - Increase timestamp precision for development builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,6 @@
 srpm:
+	# Install git in the buildroot to correctly generate commit hash
+	dnf install -y git
 	# Generate spec file
 	make -f rpm.mk rpmroot
 	# Install build dependencies

--- a/VERSION.sh
+++ b/VERSION.sh
@@ -13,7 +13,7 @@ VERSION_MINOR=1
 VERSION_MAINT=0
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=
-VERSION_DATE=$(date -u +%Y%m%d)
+VERSION_DATE=$(date -u +%Y%m%d%H%M)
 
 # Set the version and release numbers for local developer RPM builds. We
 # set these here because we do not want the git commit hash in the RPM

--- a/rpm.mk
+++ b/rpm.mk
@@ -1,9 +1,9 @@
 PWD ?= $(shell pwd)
 RPMBUILD ?= $(PWD)/rpmbuild
 RPM_VERSION ?= $(shell $(PWD)/rpm/rpmverrel.sh version)
-RPM_RELEASE ?= $(shell $(PWD)/rpm/rpmverrel.sh release)
-VERSION_PREREL ?= $(shell $(PWD)/rpm/rpmverrel.sh prerel)
-RPM_VERSION_PREREL ?= $(shell $(PWD)/rpm/rpmverrel.sh prerel | sed -e 's/\./-/')
+RPM_RELEASE := $(shell $(PWD)/rpm/rpmverrel.sh release)
+VERSION_PREREL := $(shell $(PWD)/rpm/rpmverrel.sh prerel)
+RPM_VERSION_PREREL := $(subst .,-,$(VERSION_PREREL))
 PACKAGE = 389-ds-base
 RPM_NAME_VERSION = $(PACKAGE)-$(RPM_VERSION)$(RPM_VERSION_PREREL)
 NAME_VERSION = $(PACKAGE)-$(RPM_VERSION)$(VERSION_PREREL)


### PR DESCRIPTION
Bug Description:

We use %Y%m%d timestamp format for development and copr builds.
Copr builds are done on each commit. If multiple commits were done during
the same day, packages would have the same version.

Additionally, git is missing in the buildroot, this makes prerel version
to be empty and copr builds do not contain commit hash information in their
verison.

Fix Description:

* Change timestamp format to %Y%m%d%H%M.
* Modify rpm.mk to evaluate version information only once, instead of
  calling shell script every time and get different results.
* Update copr Makefile to install git as a dependency.

Fixes: https://github.com/389ds/389-ds-base/issues/5113