### PR TITLE
Issue 5117 - Revert skipif line from CI test

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -962,6 +962,7 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
+pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="389-ds-base-snmp package is not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 


### PR DESCRIPTION
Description: The CI test, basic_test.py::test_basic_ldapagent used a
skipif decorator to check if 389-ds-base-snmp was installed before
proceeding. This skipif was removed in error and needs to be reverted.

Fixes: https://github.com/389ds/389-ds-base/issues/5117

Reviewed by: jchapman (one line commit rule)