### PR TITLE
Issue 5124 - dscontainer fails to create an instance

### DIFF
--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -37,7 +37,7 @@ local_state_dir = @localstatedir@
 run_dir = @localrundir@/dirsrv
 # This is the expected location of ldapi.
 ldapi = @localrundir@/slapd-{instance_name}.socket
-pid_file = @localrundir@/slapd-{instance_name}.pid
+pid_file = @localrundir@/dirsrv/slapd-{instance_name}.pid
 ldapi_listen = on
 ldapi_autobind = on
 inst_dir = @serverdir@/slapd-{instance_name}


### PR DESCRIPTION
Bug Description:
After 5f05bc7af82edf4690c0dce0ceaab8ac328b70a6 dscontainer fails to
create an intance, because it tries to write PID file to /run instead
of /run/dirsrv as was previously.

Fix Description:
Change pid_file in defaults.inf back to /run/dirsrv/slapd-{instance_name}.pid

Fixes: https://github.com/389ds/389-ds-base/issues/5124