### PR TITLE
Issue 5127 - run restorecon on /dev/shm at server startup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -692,7 +692,7 @@ schema_DATA = $(srcdir)/ldap/schema/99user.ldif
 libexec_SCRIPTS =
 
 if SYSTEMD
-libexec_SCRIPTS += wrappers/ds_systemd_ask_password_acl
+libexec_SCRIPTS += wrappers/ds_systemd_ask_password_acl wrappers/ds_selinux_restorecon.sh
 endif
 
 if ENABLE_COCKPIT

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -604,6 +604,7 @@ fi
 %{_sbindir}/openldap_to_ds
 %{_mandir}/man8/openldap_to_ds.8.gz
 %{_libexecdir}/%{pkgname}/ds_systemd_ask_password_acl
+%{_libexecdir}/%{pkgname}/ds_selinux_restorecon.sh
 %{_mandir}/man5/99user.ldif.5.gz
 %{_mandir}/man5/certmap.conf.5.gz
 %{_mandir}/man5/slapd-collations.conf.5.gz

--- a/wrappers/ds_selinux_restorecon.sh.in
+++ b/wrappers/ds_selinux_restorecon.sh.in
@@ -1,0 +1,33 @@
+#!/bin/sh
+# BEGIN COPYRIGHT BLOCK
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# END COPYRIGHT BLOCK
+
+# Make sure we have the path to the dse.ldif
+if [ -z $1 ]
+then
+    echo "usage: ${0} /etc/dirsrv/slapd-<instance>/dse.ldif"
+    exit 0
+fi
+
+if ! command -v restorecon &> /dev/null
+then
+    # restorecon is not available
+    exit 0
+fi
+
+# Grep the db_home_dir out of the config file
+DS_HOME_DIR=`grep 'nsslapd-db-home-directory: ' $1 | awk '{print $2}'`
+if [ -z "$DS_HOME_DIR" ]
+then
+    # No DB home set, that's ok
+    exit 0
+fi
+
+# Now run restorecon
+restorecon ${DS_HOME_DIR}

--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -14,6 +14,7 @@ EnvironmentFile=-@initconfigdir@/@package_name@
 EnvironmentFile=-@initconfigdir@/@package_name@-%i
 PIDFile=/run/@package_name@/slapd-%i.pid
 ExecStartPre=@libexecdir@/ds_systemd_ask_password_acl @instconfigdir@/slapd-%i/dse.ldif
+ExecStartPre=@libexecdir@/ds_selinux_restorecon.sh @instconfigdir@/slapd-%i/dse.ldif
 ExecStart=@sbindir@/ns-slapd -D @instconfigdir@/slapd-%i -i /run/@package_name@/slapd-%i.pid
 PrivateTmp=on
 # https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort


### PR DESCRIPTION
Description:

Update the systemd service file to execute a script that runs
restorecon on the DB home directory.  This addresses issues with
backup/restore, reboot, and FS restore issues that can happen when
/dev/shm is missing or created outside of dscreate.

relates: https://github.com/389ds/389-ds-base/issues/5127

Reviewed by: ?