### PR TITLE
Issue 5129 - BUG - Incorrect fn signature in add_index

### DIFF
--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -719,7 +719,7 @@ class Backend(DSLdapObject):
                 return
         raise ValueError("Can not delete index because it does not exist")
 
-    def add_index(self, attr_name, types, matching_rules=[], reindex=False):
+    def add_index(self, attr_name, types, matching_rules=None, reindex=False):
         """ Add an index.
 
         :param attr_name - name of the attribute to index
@@ -736,7 +736,9 @@ class Backend(DSLdapObject):
             mrs = []
             for mr in matching_rules:
                 mrs.append(mr)
-            props['nsMatchingRule'] = mrs
+            # Only add if there are actually rules present in the list.
+            if len(mrs) > 0:
+                props['nsMatchingRule'] = mrs
         new_index.create(properties=props, basedn="cn=index," + self._dn)
 
         if reindex:


### PR DESCRIPTION
Bug Description: Due to an incorrect function signature,
it was possible to cause add index to fail by trying to
add an empty mr set.

Fix Description: Fix the function signature and make
the function more robust.

fixes: https://github.com/389ds/389-ds-base/issues/5129

Author: William Brown <william@blackhats.net.au>

Review by: ???