### PR TITLE
Issue 5135 - UI - Disk monitoring threshold does update properly

### DIFF
--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -2173,9 +2173,9 @@ config_set_disk_threshold(const char *attrname, char *value, char *errorbuf, int
 
     errno = 0;
     threshold = strtoll(value, &endp, 10);
-    if (*endp != '\0' || threshold <= 4096 || errno == ERANGE) {
+    if (*endp != '\0' || threshold < 4096 || errno == ERANGE) {
         slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
-                              "%s: \"%s\" is invalid, threshold must be greater than 4096 and less then %lld",
+                              "%s: \"%s\" is invalid, threshold must be greater than or equal to 4096 and less then %lld",
                               attrname, value, (long long int)LONG_MAX);
         retVal = LDAP_OPERATIONS_ERROR;
         return retVal;

--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -767,6 +767,7 @@ export class LDAPEditor extends React.Component {
                     });
                 }
             },
+            /*
             {
                 title: 'Roles ...',
                 isDisabled: true,
@@ -780,6 +781,7 @@ export class LDAPEditor extends React.Component {
                 title: 'Smart Referrals ...',
                 isDisabled: true
             },
+            */
             {
                 isSeparator: true
             },

--- a/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
@@ -451,6 +451,7 @@ class EditorTreeView extends React.Component {
             >
                 ACIs ...
             </DropdownItem>,
+            /*
             <DropdownItem
                 isDisabled
                 key="tree-view-roles"
@@ -469,6 +470,7 @@ class EditorTreeView extends React.Component {
             >
                 Smart Referrals ...
             </DropdownItem>,
+            */
             <DropdownSeparator key="separator-3" />,
             <DropdownItem
                 key="tree-view-delete"

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -5,6 +5,7 @@ import {
     Button,
     Checkbox,
     Form,
+    FormHelperText,
     FormSelect,
     FormSelectOption,
     Grid,
@@ -269,6 +270,13 @@ export class ServerSettings extends React.Component {
             if (value == "" && (typeof value !== "boolean")) {
                 valueErr = true;
                 disableSaveBtn = true;
+            }
+            if (attr === 'nsslapd-disk-monitoring-threshold') {
+                const numVal = Number(value);
+                if (numVal < 4096) {
+                    valueErr = true;
+                    disableSaveBtn = true;
+                }
             }
         } else if (nav_tab == "adv") {
             // Handle special cases for anon limit dn
@@ -850,15 +858,17 @@ export class ServerSettings extends React.Component {
                                 min={4096}
                                 max={9223372036854775807}
                                 onMinus={() => { this.onMinusConfig("nsslapd-disk-monitoring-threshold", "diskmon") }}
-                                onChange={(e) => { this.onConfigChange(e, "nsslapd-disk-monitoring-threshold", 4096, 9223372036854775807, "diskmon") }}
+                                onChange={(e) => { this.onConfigChange(e, "nsslapd-disk-monitoring-threshold", 1, 9223372036854775807, "diskmon") }}
                                 onPlus={() => { this.onPlusConfig("nsslapd-disk-monitoring-threshold", "diskmon") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
                                 minusBtnAriaLabel="minus"
                                 plusBtnAriaLabel="plus"
                                 widthChars={8}
-                                validated={this.state.errObjDiskMon.diskThreshold ? ValidatedOptions.error : ValidatedOptions.default}
                             />
+                            <FormHelperText isError isHidden={!this.state.errObjDiskMon['nsslapd-disk-monitoring-threshold']}>
+                                Value must be greater than or equal to 4096
+                            </FormHelperText>
                         </GridItem>
                     </Grid>
                     <Grid
@@ -880,7 +890,6 @@ export class ServerSettings extends React.Component {
                                 minusBtnAriaLabel="minus"
                                 plusBtnAriaLabel="plus"
                                 widthChars={8}
-                                validated={this.state.errObjDiskMon.diskThreshold ? ValidatedOptions.error : ValidatedOptions.default}
                             />
                         </GridItem>
                     </Grid>


### PR DESCRIPTION
Description:

If you try entering a value manually and start with an empty field
it overwrites the value with 4096 as it's trying to incorrectly
enforce a minimum value.

relates: https://github.com/389ds/389-ds-base/issues/5135

