### PR TITLE
Issue 4678 - Added test cases

### DIFF
--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -352,6 +352,7 @@ def test_ignore_virtual_attrs(topo):
     """Test nsslapd-ignore-virtual-attrs configuration attribute
 
     :id: 9915d71b-2c71-4ac0-91d7-92655d53541b
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
@@ -425,6 +426,7 @@ def test_ignore_virtual_attrs_after_restart(topo):
        its value on restart
 
     :id: ac368649-4fda-473c-9ef8-e0c728b162af
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config

--- a/dirsrvtests/tests/suites/cos/cos_test.py
+++ b/dirsrvtests/tests/suites/cos/cos_test.py
@@ -98,6 +98,7 @@ def test_vattr_on_cos_definition(topo, reset_ignore_vattr):
        added it is moved to OFF
 
     :id: e7ef5254-386f-4362-bbb4-9409f3f51b08
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
@@ -105,12 +106,14 @@ def test_vattr_on_cos_definition(topo, reset_ignore_vattr):
          3. Create a cos definition for employeeType
          4. Check the value of nsslapd-ignore-virtual-attrs should be OFF (with a delay for postop processing)
          5. Check a message "slapi_vattrspi_regattr - Because employeeType,.." in error logs
+         6. Check after deleting cos definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON
     :expectedresults:
          1. This should be successful
          2. This should be successful
          3. This should be successful
          4. This should be successful
          5. This should be successful
+         6. This should be successful
     """
 
     log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
@@ -135,7 +138,11 @@ def test_vattr_on_cos_definition(topo, reset_ignore_vattr):
     topo.standalone.stop()
     assert topo.standalone.searchErrorsLog("slapi_vattrspi_regattr - Because employeeType is a new registered virtual attribute , nsslapd-ignore-virtual-attrs was set to \'off\'")
     topo.standalone.start()
+    log.info("Delete a cos definition")
     cosdef.delete()
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON")
+    topo.standalone.restart()
+    assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
 
 if __name__ == "__main__":
     CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
+++ b/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
@@ -1,0 +1,217 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import logging
+import time
+import pytest
+import os
+from lib389._constants import PW_DM, DEFAULT_SUFFIX
+from lib389.idm.organization import Organization
+from lib389.topologies import topology_m1c1 as topo
+from lib389.idm.role import FilteredRoles, ManagedRoles
+from lib389.cos import  CosClassicDefinition, CosClassicDefinitions, CosTemplate
+
+logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.tier1
+
+DNBASE = "o=acivattr,{}".format(DEFAULT_SUFFIX)
+
+
+@pytest.fixture(scope="function")
+def reset_ignore_vattr(topo, request):
+    s = topo.ms['supplier1']
+    c = topo.cs['consumer1']
+    default_ignore_vattr_value = s.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs')
+    default_ignore_vattr_value = c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs')
+
+    def fin():
+        s.config.set('nsslapd-ignore-virtual-attrs', default_ignore_vattr_value)
+        c.config.set('nsslapd-ignore-virtual-attrs', default_ignore_vattr_value)
+
+    request.addfinalizer(fin)
+
+def test_vattr_on_cos_definition_with_replication(topo, reset_ignore_vattr):
+    """Test nsslapd-ignore-virtual-attrs configuration attribute
+       The attribute is ON by default. If a cos definition is
+       added it is moved to OFF in replication scenario
+
+    :id: c1fd8fa1-bd13-478b-9b33-e33b49c587bd
+    :customerscenario: True
+    :setup: Supplier Consumer
+    :steps:
+         1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config over consumer
+         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON over consumer
+         3. Create a cos definition for employeeType in supplier
+         4. Check the value of nsslapd-ignore-virtual-attrs should be OFF (with a delay for postop processing) over consumer
+         5. Check a message "slapi_vattrspi_regattr - Because employeeType,.." in error logs of consumer
+         6. Check after deleting cos definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON over consumer
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+         6. This should be successful
+    """
+    s = topo.ms['supplier1']
+    c = topo.cs['consumer1']
+    log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config over consumer")
+    assert c.config.present('nsslapd-ignore-virtual-attrs')
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON over consumer")
+    assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    # creating CosClassicDefinition in supplier
+    log.info("Create a cos definition")
+    properties = {'cosTemplateDn': 'cn=cosClassicGenerateEmployeeTypeUsingnsroleTemplates,{}'.format(DEFAULT_SUFFIX),
+                  'cosAttribute': 'employeeType',
+                  'cosSpecifier': 'nsrole',
+                  'cn': 'cosClassicGenerateEmployeeTypeUsingnsrole'}
+    cosdef = CosClassicDefinition(s,'cn=cosClassicGenerateEmployeeTypeUsingnsrole,{}'.format(DEFAULT_SUFFIX))\
+        .create(properties=properties)
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is OFF over consumer")
+    time.sleep(2)
+    assert c.config.present('nsslapd-ignore-virtual-attrs', 'off')
+
+    #stop both supplier and consumer
+    c.stop()
+    assert c.searchErrorsLog("slapi_vattrspi_regattr - Because employeeType is a new registered virtual attribute , nsslapd-ignore-virtual-attrs was set to \'off\'")
+    c.start()
+    log.info("Delete a cos definition")
+    cosdef.delete()
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON over consumer")
+    s.restart()
+    c.restart()
+    assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+def test_vattr_on_filtered_role_with_replication(topo, request):
+    """Test nsslapd-ignore-virtual-attrs configuration attribute
+       The attribute is ON by default. If a filtered role is
+       added it is moved to OFF in replication scenario
+    :id: 7b29be88-c8ca-409b-bbb7-ce3962f73f91
+    :customerscenario: True
+    :setup: Supplier Consumer
+    :steps:
+         1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config over consumer
+         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON over consumer
+         3. Create a filtered role in supplier
+         4. Check the value of nsslapd-ignore-virtual-attrs should be OFF over consumer
+         5. Check a message "roles_cache_trigger_update_role - Because of virtual attribute.." in error logs of consumer
+         6. Check after deleting role definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON over consumer
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+         6. This should be successful
+    """
+    s = topo.ms['supplier1']
+    c = topo.cs['consumer1']
+
+    log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config over consumer")
+    assert c.config.present('nsslapd-ignore-virtual-attrs')
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON over consumer")
+    assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    log.info("Create a filtered role")
+    try:
+        Organization(s).create(properties={"o": "acivattr"}, basedn=DEFAULT_SUFFIX)
+    except:
+        pass
+    roles = FilteredRoles(s, DNBASE)
+    roles.create(properties={'cn': 'FILTERROLEENGROLE', 'nsRoleFilter': 'cn=eng*'})
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF over consumer")
+    time.sleep(5)
+    assert c.config.present('nsslapd-ignore-virtual-attrs', 'off')
+
+    c.stop()
+    assert c.searchErrorsLog("roles_cache_trigger_update_role - Because of virtual attribute definition \(role\), nsslapd-ignore-virtual-attrs was set to \'off\'")
+
+    def fin():
+        s.restart()
+        c.restart()
+        try:
+            filtered_roles = FilteredRoles(s, DEFAULT_SUFFIX)
+            for i in filtered_roles.list():
+                i.delete()
+        except:
+            pass
+        log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON over consumer")
+        s.restart()
+        c.restart()
+        assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    request.addfinalizer(fin)
+
+def test_vattr_on_managed_role_replication(topo, request):
+    """Test nsslapd-ignore-virtual-attrs configuration attribute
+       The attribute is ON by default. If a managed role is
+       added it is moved to OFF in replcation scenario
+
+    :id: 446f2fc3-bbb2-4835-b14a-cb855db78c6f
+    :customerscenario: True
+    :setup: Supplier Consumer
+    :steps:
+         1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config over consumer
+         2. Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON over consumer
+         3. Create a managed role in supplier
+         4. Check the value of nsslapd-ignore-virtual-attrs should be OFF over consumer
+         5. Check a message "roles_cache_trigger_update_role - Because of virtual attribute.." in error logs of consumer
+         6. Check after deleting role definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON over consumer
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+         6. This should be successful
+    """
+    s = topo.ms['supplier1']
+    c = topo.cs['consumer1']
+    log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
+    assert c.config.present('nsslapd-ignore-virtual-attrs')
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be ON")
+    assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    log.info("Create a managed role")
+    roles = ManagedRoles(s, DEFAULT_SUFFIX)
+    role = roles.create(properties={"cn": 'ROLE1'})
+
+    log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF")
+    time.sleep(5)
+    assert c.config.present('nsslapd-ignore-virtual-attrs', 'off')
+
+    c.stop()
+    assert c.searchErrorsLog("roles_cache_trigger_update_role - Because of virtual attribute definition \(role\), nsslapd-ignore-virtual-attrs was set to \'off\'")
+
+    def fin():
+        s.restart()
+        c.restart()
+        try:
+            filtered_roles = ManagedRoles(s, DEFAULT_SUFFIX)
+            for i in filtered_roles.list():
+                i.delete()
+        except:
+            pass
+        log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON")
+        s.restart()
+        c.restart()
+        assert c.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
+
+    request.addfinalizer(fin)
+
+if __name__ == "__main__":
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s -v %s" % CURRENT_FILE)

--- a/dirsrvtests/tests/suites/roles/basic_test.py
+++ b/dirsrvtests/tests/suites/roles/basic_test.py
@@ -332,6 +332,7 @@ def test_vattr_on_filtered_role(topo, request):
        added it is moved to OFF
 
     :id: 88b3ad3c-f39a-4eb7-a8c9-07c685f11908
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
@@ -339,12 +340,14 @@ def test_vattr_on_filtered_role(topo, request):
          3. Create a filtered role
          4. Check the value of nsslapd-ignore-virtual-attrs should be OFF
          5. Check a message "roles_cache_trigger_update_role - Because of virtual attribute.." in error logs
+         6. Check after deleting role definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON
     :expectedresults:
          1. This should be successful
          2. This should be successful
          3. This should be successful
          4. This should be successful
          5. This should be successful
+         6. This should be successful
     """
 
     log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
@@ -375,7 +378,9 @@ def test_vattr_on_filtered_role(topo, request):
                 i.delete()
         except:
             pass
-        topo.standalone.config.set('nsslapd-ignore-virtual-attrs', 'on')
+        log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON")
+        topo.standalone.restart()
+        assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
 
     request.addfinalizer(fin)
 
@@ -385,6 +390,7 @@ def test_vattr_on_filtered_role_restart(topo, request):
     nsslapd-ignore-virtual-attrs should be set to 'off'
 
     :id: 972183f7-d18f-40e0-94ab-580e7b7d78d0
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
@@ -450,6 +456,7 @@ def test_vattr_on_managed_role(topo, request):
        added it is moved to OFF
 
     :id: 664b722d-c1ea-41e4-8f6c-f9c87a212346
+    :customerscenario: True
     :setup: Standalone instance
     :steps:
          1. Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config
@@ -457,12 +464,14 @@ def test_vattr_on_managed_role(topo, request):
          3. Create a managed role
          4. Check the value of nsslapd-ignore-virtual-attrs should be OFF
          5. Check a message "roles_cache_trigger_update_role - Because of virtual attribute.." in error logs
+         6. Check after deleting role definition value of attribute nsslapd-ignore-virtual-attrs is set back to ON
     :expectedresults:
          1. This should be successful
          2. This should be successful
          3. This should be successful
          4. This should be successful
          5. This should be successful
+         6. This should be successful
     """
 
     log.info("Check the attribute nsslapd-ignore-virtual-attrs is present in cn=config")
@@ -489,7 +498,9 @@ def test_vattr_on_managed_role(topo, request):
                 i.delete()
         except:
             pass
-        topo.standalone.config.set('nsslapd-ignore-virtual-attrs', 'on')
+        log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON")
+        topo.standalone.restart()
+        assert topo.standalone.config.get_attr_val_utf8('nsslapd-ignore-virtual-attrs') == "on"
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
Bug Description: Added test cases to check nsslapd-ignore-virtual-attrs
is set back to ON when cos/roles are deleted. Added test cases to check if
it works in replication setup.

Relates: https://github.com/389ds/389-ds-base/issues/4678

Reviewed by: ??