### PR TITLE
ds_selinux_restorecon.sh: always exit 0

### DIFF
--- a/wrappers/ds_selinux_restorecon.sh.in
+++ b/wrappers/ds_selinux_restorecon.sh.in
@@ -29,5 +29,6 @@ then
     exit 0
 fi
 
-# Now run restorecon
-restorecon ${DS_HOME_DIR}
+# Now run restorecon, but don't die if it fails (could be that the
+# directory doesn't exist)
+restorecon ${DS_HOME_DIR} || :


### PR DESCRIPTION
We don't want to error out and give up on starting the service
if the restorecon fails - it might just be that the directory
doesn't exist and doesn't need restoring. Issue identified and
fix suggested by Simon Farnsworth.

https://bugzilla.redhat.com/show_bug.cgi?id=2047323

Signed-off-by: Adam Williamson <awilliam@redhat.com>