### PR TITLE
Issue 4299 - UI - fix minor issues with ldap editor

### DIFF
--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -209,7 +209,8 @@ export class LDAPEditor extends React.Component {
                 const params = {
                     serverId: this.props.serverId,
                     baseDn: suffixDN,
-                    parentId: parentId
+                    parentId: parentId,
+                    addNotification: this.props.addNotification,
                 };
 
                 getRootSuffixEntryDetails(params, this.updateTableRootSuffixes);
@@ -305,7 +306,8 @@ export class LDAPEditor extends React.Component {
             });
             const params = {
                 serverId: this.props.serverId,
-                baseDn: id
+                baseDn: id,
+                addNotification: this.props.addNotification,
             };
             getOneLevelEntries(params, this.processDirectChildren);
         }
@@ -365,18 +367,20 @@ export class LDAPEditor extends React.Component {
         });
         const params = {
             serverId: this.props.serverId,
-            baseDn: dn
+            baseDn: dn,
+            addNotification: this.props.addNotification,
         };
         getOneLevelEntries(params, this.processDirectChildren);
     }
 
     // Process the entries that are direct children.
-    processDirectChildren = (directChildren) => {
+    processDirectChildren = (directChildren, params) => {
         this.setState({
             loading: true
         });
         const childrenRows = [];
         let rowNumber = 0;
+
         directChildren.map(aChild => {
             const info = JSON.parse(aChild);
             const numSubCellInfo = parseInt(info.numSubordinates) > 0
@@ -883,6 +887,7 @@ export class LDAPEditor extends React.Component {
                             onReload={this.handleReload}
                             refreshing={this.state.refreshing}
                             allObjectclasses={this.state.allObjectclasses}
+                            addNotification={this.props.addNotification}
                         />
                     </Tab>
                     <Tab eventKey={1} title={<TabTitleText>Table View</TabTitleText>}>
@@ -922,6 +927,7 @@ export class LDAPEditor extends React.Component {
                                 onCollapse={this.handleCollapse}
                                 columns={columns}
                                 actionResolver={this.actionResolver}
+                                addNotification={this.props.addNotification}
                             />
                         </div>
                     </Tab>

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/options.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/options.jsx
@@ -1,24 +1,23 @@
 // LDAP options.
 const LdapOptions = {
-  sizeLimit: 1000,
-  timeLimit: 5
+    sizeLimit: 5000,
+    timeLimit: 10
 };
+
 // Size limit.
 export function setSizeLimit (limit) {
-  LdapOptions.sizeLimit = limit;
-  console.log(`LdapOptions.sizeLimit = ${LdapOptions.sizeLimit}`);
+    LdapOptions.sizeLimit = limit;
 };
 
 export function getSizeLimit () {
-  return LdapOptions.sizeLimit;
+    return LdapOptions.sizeLimit;
 }
 
 // Time limit.
 export function setTimeLimit (limit) {
-  LdapOptions.timeLimit = limit;
-  console.log(`LdapOptions.timeLimit = ${LdapOptions.timeLimit}`);
+    LdapOptions.timeLimit = limit;
 };
 
 export function getTimeLimit () {
-  return LdapOptions.timeLimit;
+    return LdapOptions.timeLimit;
 }

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -515,17 +515,19 @@ export function getOneLevelEntries (params, oneLevelCallback) {
       searchResult = data;
     })
     .catch((err, data) => {
-    // .fail(err => {
       console.log('FAIL err.exit_status ==> ' + err.exit_status);
       console.log('FAIL err.message ==> ' + err.message);
       if (err.exit_status === 4) {
-        console.log('Size limit hit');
         // Use the partial data.
         searchResult = data;
-        // TODO: Check other relevant error codes ( 32, 53 ...)
+        const size_limit = getSizeLimit();
+        params.addNotification(
+            "info",
+            `Size limit of ${size_limit} was exceeded.  The child entries of "${params.baseDn}" have been truncated.`
+        );
       } else {
         searchResult = null;
-        oneLevelCallback(null, { status: err.exit_status, msg: err.message });
+        oneLevelCallback(null, params, { status: err.exit_status, msg: err.message });
       }
     })
     .finally(() => {
@@ -568,7 +570,7 @@ export function getOneLevelEntries (params, oneLevelCallback) {
         }
       });
       // Process the list of entries.
-      oneLevelCallback(allEntries, null);
+      oneLevelCallback(allEntries, params, null);
     });
 }
 

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -59,6 +59,7 @@ export class SearchDatabase extends React.Component {
             timeLimit: 30,
             isExpanded: false,
             searchSuffix: "",
+            baseDN: "",
             searchType: 'Search Text',
             searchText: "",
             getOperationalAttrs: false,
@@ -256,9 +257,17 @@ export class SearchDatabase extends React.Component {
     componentDidMount() {
         const suffixList =  this.props.suffixList;
         const searchBase = this.props.searchBase;
+        let baseDN = searchBase;  // Drop down list of selected suffix
+        for (const suffix of suffixList) {
+            if (baseDN.includes(suffix)) {
+                baseDN = suffix;
+                break;
+            }
+        }
         this.setState({
             searchBase: searchBase ? searchBase : suffixList.length > 0 ? suffixList[0] : "",
             searchSuffix: this.props.suffixList.length > 0 ? this.props.suffixList[0] : "",
+            baseDN: baseDN
         });
     }
 
@@ -362,6 +371,7 @@ export class SearchDatabase extends React.Component {
         this.setState({
             searchSuffix: value,
             searchBase: value,
+            baseDN: value,
         });
     }
 
@@ -541,7 +551,7 @@ export class SearchDatabase extends React.Component {
                                 <GridItem span={4}>
                                     <FormSelect
                                         id="searchSuffix"
-                                        value={this.state.searchSuffix}
+                                        value={this.state.baseDN}
                                         onChange={(value, event) => {
                                             this.handleSuffixChange(event);
                                         }}
@@ -853,7 +863,7 @@ export class SearchDatabase extends React.Component {
                     </ExpandableSection>
                 </Form>
                 <div className="ds-indent">
-                    <div className={this.state.searching ? "ds-margin-top-xlg ds-center" : "ds-hidden"}>
+                    <div className={this.state.searching ? "ds-margin-top-lg ds-center" : "ds-hidden"}>
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 Searching <i>{this.state.searchBase}</i> ...
@@ -862,6 +872,9 @@ export class SearchDatabase extends React.Component {
                         <Spinner className="ds-margin-top-lg" size="xl" />
                     </div>
                     <div className={searching ? "ds-hidden" : ""}>
+                        <center>
+                            <p><b>Results:</b> {total}</p>
+                        </center>
                         <EditorTableView
                             key={searching}
                             loading={searching}

--- a/src/cockpit/389-console/src/lib/ldap_editor/tableView.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/tableView.jsx
@@ -66,6 +66,7 @@ class EditorTableView extends React.Component {
                            perPage={this.props.perPage}
                            onSetPage={(_evt, value) => this.props.onSetPage(value)}
                            onPerPageSelect={(_evt, value) => this.props.onPerPageSelect(value)}
+                           dropDirection="up"
                        />
                    }
                </div>;

--- a/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
@@ -117,6 +117,7 @@ class EditorTreeView extends React.Component {
                 this.updateEntryRows(treeViewItem);
                 return;
             }
+
             this.setState({
                 searching: true,
             }, () => {
@@ -172,6 +173,12 @@ class EditorTreeView extends React.Component {
             this.props.setTreeFirstClicked(false);
         }
     }
+
+    showEntryLoading = (isEntryLoading) => {
+        this.setState({
+            searching: isEntryLoading ? true : false
+        });
+    };
 
     showTreeLoadingState = (isTreeLoading) => {
         this.setState({
@@ -388,10 +395,12 @@ class EditorTreeView extends React.Component {
                     });
                 }
             });
+
             // Update the refresh time.
             this.setState({
                 latestEntryRefreshTime: Date.now(),
             });
+            this.showEntryLoading(false);
         });
     };
 
@@ -562,6 +571,8 @@ class EditorTreeView extends React.Component {
                                     showTreeLoadingState={this.showTreeLoadingState}
                                     refreshButtonTriggerTime={refreshButtonTriggerTime}
                                     handleEntryRefresh={this.refreshEntry}
+                                    addNotification={this.props.addNotification}
+                                    isDisabled={isTreeLoading}
                                 />
                             }
                         </GridItem>


### PR DESCRIPTION
Description:  Improved how treeview handles loading subtrees with large
number of entries.  Previously, the parent entry would not be
displayed while loading its child entries, and if a timeout occurred
then the paretn entry would not be loading inthe UI, nad you could not
do or see anything with it.

In the search form, the dropdown list showing the backend was not updated 
when multiple backends are available, it will now update to the correct suffix 
when "Search" is selected on a subtree from the tree/table view.

Also added a pop modal when an error occurs when searching the database.

relates: https://github.com/389ds/389-ds-base/issues/4299

Reviewed by: ?