### PR TITLE
Issue 5050 - bdb bulk op fails if fs page size > 8K

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6586,6 +6586,13 @@ int bdb_public_cursor_bulkop(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *key,
     if (bdb_cur == NULL)
         return DBI_RC_INVALID;
 
+    if (bulkdata->v.size < bdb_cur->dbp->pgsize) {
+        /* Make sure that size is 1024 aligned and >= db page size */
+        long size = (bdb_cur->dbp->pgsize + 1023L) & ~1023L;
+        int flags = bulkdata->v.flags & (DBI_VF_BULK_DATA|DBI_VF_BULK_RECORD);
+        dblayer_bulk_set_buffer(bulkdata->be, bulkdata, slapi_ch_malloc(size), size, flags);
+    }
+
     bdb_dbival2dbt(key, &bdb_key, PR_FALSE);
     bdb_dbival2dbt(&bulkdata->v, &bdb_data, PR_FALSE);
     switch (op)


### PR DESCRIPTION
Issue: Getting replication failure when db is set on file system having page size greater than 8K
libdb - BDB0623 DB_MULTIPLE/DB_MULTIPLE_KEY buffers must be aligned, at least page size and multiples of 1KB
bdb_map_error - bdb_public_cursor_bulkop failed with db error 22 : Invalid argument

because when using bdb, db bulk operation (that retrieve several records in a single operation) must have a buffer size that is both 1024 bytes aligned and greater of equal to the db page size which default to the underlying file system page size 
  (and the initial buffer size is hardcoded to 8K in ds389)

Solution is to alloc a new buffer if the provided buffer does not fulfill the requirements.

Issue: [5050](https://github.com/389ds/389-ds-base/issues/5050)

Reviewed by:
