### PR TITLE
Issue 5149 - Build failure on EL8 - undefined reference to `twalk_r'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ AC_CHECK_FUNCS([endpwent ftruncate getcwd getaddrinfo inet_pton inet_ntop localt
 
 # These functions are *required* without option.
 AC_CHECK_FUNCS([clock_gettime], [], AC_MSG_ERROR([unable to locate required symbol clock_gettime]))
+AC_CHECK_FUNCS([twalk_r], [], AC_MSG_ERROR([cannot locate required symbol twalk_r: use glibc-2.30 or higher ]))
 
 # This will detect if we need to add the LIBADD_DL value for us.
 LT_LIB_DLLOAD

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -177,6 +177,8 @@ Requires:         cyrus-sasl-plain
 # this is needed for backldbm
 Requires:         libdb
 Requires:         lmdb
+# twalk_r is only available in glibc-2.30 or higher
+Requires:         glibc => 2.30
 # This picks up libperl.so as a Requires, so we add this versioned one
 Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 # Needed by logconv.pl


### PR DESCRIPTION
Description:
back-ldbm uses `twalk_r` which is only available in glibc-2.30 or
higher. This results in a compilation warning and a linking error on
systems where this symbol is not available, for example EL8.

Fix Description:
* Add an autoconf check for the required symbol
* Add an explicit requirement for glibc => 2.30 in the spec file.

Fixes: https://github.com/389ds/389-ds-base/issues/5149

Reviewed by: ???