### PR TITLE
Issue 5126 - Memory leak in slapi_ldap_get_lderrno

### DIFF
--- a/dirsrvtests/tests/suites/gssapi_repl/gssapi_repl_test.py
+++ b/dirsrvtests/tests/suites/gssapi_repl/gssapi_repl_test.py
@@ -9,6 +9,7 @@
 import pytest
 from lib389.tasks import *
 from lib389.utils import *
+from lib389.agreement import *
 from lib389.topologies import topology_m2
 
 pytestmark = pytest.mark.tier2
@@ -65,10 +66,27 @@ def _allow_machine_account(inst, name):
     # First we need to get the mapping tree dn
     mt = inst.mappingtree.list(suffix=DEFAULT_SUFFIX)[0]
     inst.modify_s('cn=replica,%s' % mt.dn, [
-        (ldap.MOD_REPLACE, 'nsDS5ReplicaBindDN', "uid=%s,ou=Machines,%s" % (name, DEFAULT_SUFFIX))
+        (ldap.MOD_REPLACE, 'nsDS5ReplicaBindDN', f"uid={name},ou=Machines,{DEFAULT_SUFFIX}".encode('utf-8'))
     ])
 
+def _verify_etc_hosts():
+    #Check if /etc/hosts is compatible with the test
+    NEEDED_HOSTS = ( ('ldapkdc.example.com', '127.0.0.1'),
+                     ('ldapkdc1.example.com', '127.0.1.1'),
+                     ('ldapkdc2.example.com', '127.0.2.1'))
+    found_hosts = {}
+    with open('/etc/hosts','r') as f:
+        for l in f:
+            s = l.split()
+            if len(s) < 2:
+                continue
+            for nh in NEEDED_HOSTS:
+                if (s[0] == nh[1] and s[1] == nh[0]):
+                    found_hosts[s[1]] = True
+    return len(found_hosts) == len(NEEDED_HOSTS)
 
+@pytest.mark.skipif(not _verify_etc_hosts(), reason="/etc/hosts does not contains the needed hosts.")
+@pytest.mark.skipif(True, reason="Test disabled because it requires specific kerberos requirement (server principal, keytab, etc ...")
 def test_gssapi_repl(topology_m2):
     """Test gssapi authenticated replication agreement of two suppliers using KDC
 
@@ -94,8 +112,6 @@ def test_gssapi_repl(topology_m2):
          6. Test User should be created on M1 and M2 both
          7. Test User should be created on M1 and M2 both
     """
-
-    return
     supplier1 = topology_m2.ms["supplier1"]
     supplier2 = topology_m2.ms["supplier2"]
 
@@ -121,6 +137,7 @@ def test_gssapi_repl(topology_m2):
     properties = {RA_NAME: r'meTo_$host:$port',
                   RA_METHOD: 'SASL/GSSAPI',
                   RA_TRANSPORT_PROT: defaultProperties[REPLICATION_TRANSPORT]}
+    supplier1.agreement.delete(suffix=SUFFIX, consumer_host=supplier2.host, consumer_port=supplier2.port)
     m1_m2_agmt = supplier1.agreement.create(suffix=SUFFIX, host=supplier2.host, port=supplier2.port, properties=properties)
     if not m1_m2_agmt:
         log.fatal("Fail to create a supplier -> supplier replica agreement")
@@ -133,6 +150,7 @@ def test_gssapi_repl(topology_m2):
     properties = {RA_NAME: r'meTo_$host:$port',
                   RA_METHOD: 'SASL/GSSAPI',
                   RA_TRANSPORT_PROT: defaultProperties[REPLICATION_TRANSPORT]}
+    supplier2.agreement.delete(suffix=SUFFIX, consumer_host=supplier1.host, consumer_port=supplier1.port)
     m2_m1_agmt = supplier2.agreement.create(suffix=SUFFIX, host=supplier1.host, port=supplier1.port, properties=properties)
     if not m2_m1_agmt:
         log.fatal("Fail to create a supplier -> supplier replica agreement")
@@ -145,8 +163,9 @@ def test_gssapi_repl(topology_m2):
     #
     # Initialize all the agreements
     #
-    supplier1.agreement.init(SUFFIX, HOST_SUPPLIER_2, PORT_SUPPLIER_2)
-    supplier1.waitForReplInit(m1_m2_agmt)
+    agmt = Agreement(supplier1, m1_m2_agmt)
+    agmt.begin_reinit()
+    agmt.wait_reinit()
 
     # Check replication is working...
     if supplier1.testReplication(DEFAULT_SUFFIX, supplier2):

--- a/dirsrvtests/tests/suites/replication/sasl_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/sasl_m2_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2017 Red Hat, Inc.
+# Copyright (C) 2022 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -91,6 +91,8 @@ def use_valgrind(topo_m2, request):
     set_sasl_md5_client_auth(m2, m1)
     m1.stop()
     m2.stop()
+    m1.systemd_override = False
+    m2.systemd_override = False
     valgrind_enable(m1.ds_paths.sbin_dir, gen_valgrind_wrapper(m1.ds_paths.sbin_dir))
 
     def fin():
@@ -128,6 +130,7 @@ def test_repl_sasl_md5_auth(topo_m2):
     repl.test_replication_topology(topo_m2)
 
 
+@pytest.mark.skipif(not os.path.exists('/usr/bin/valgrind'), reason="valgrind is not installed.")
 def test_repl_sasl_leak(topo_m2, use_valgrind):
     """Test replication with SASL digest-md5 authentication
 

--- a/dirsrvtests/tests/suites/replication/sasl_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/sasl_m2_test.py
@@ -1,0 +1,182 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2017 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import pytest
+import ldap
+import uuid
+from lib389.utils import ds_is_older, valgrind_enable, valgrind_disable, valgrind_get_results_file, valgrind_check_file
+
+from lib389.idm.services import ServiceAccounts
+from lib389.idm.group import Groups
+from lib389.config import CertmapLegacy, Config
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.agreement import Agreements
+from lib389._mapped_object import DSLdapObject
+from lib389.replica import ReplicationManager, Replicas, BootstrapReplicationManager
+from lib389.topologies import topology_m2 as topo_m2
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+def set_sasl_md5_client_auth(inst, to):
+    # Create the certmap before we restart
+    cm = CertmapLegacy(to)
+    certmaps = cm.list()
+    certmaps['default']['nsSaslMapRegexString'] = '^dn:\\(.*\\)'
+    certmaps['default']['nsSaslMapBaseDNTemplate'] = 'cn=config'
+    certmaps['default']['nsSaslMapFilterTemplate'] = '(objectclass=*)'
+    cm.set(certmaps)
+
+    Config(to).replace("passwordStorageScheme", 'CLEAR')
+
+    # Create a repl manager on the replica
+    replication_manager_pwd = 'secret12'
+    brm = BootstrapReplicationManager(to)
+    try:
+        brm.delete()
+    except ldap.NO_SUCH_OBJECT:
+        pass
+    brm.create(properties={
+        'cn': brm.common_name,
+        'userPassword': replication_manager_pwd
+    })
+    replication_manager_dn = brm.dn
+
+    replica = Replicas(inst).get(DEFAULT_SUFFIX)
+    replica.set('nsDS5ReplicaBindDN', brm.dn)
+    replica.remove_all('nsDS5ReplicaBindDNgroup')
+    agmt = replica.get_agreements().list()[0]
+    agmt.replace_many(
+        ('nsDS5ReplicaBindMethod', 'SASL/DIGEST-MD5'),
+        ('nsDS5ReplicaTransportInfo', 'LDAP'),
+        ('nsDS5ReplicaPort', str(to.port)),
+        ('nsDS5ReplicaBindDN', replication_manager_dn),
+        ('nsDS5ReplicaCredentials', replication_manager_pwd),
+    )
+
+
+def gen_valgrind_wrapper(dir):
+    name=f"{dir}/VALGRIND"
+    with open(name, 'w') as f:
+        f.write('#!/bin/sh\n')
+        f.write('export SASL_PATH=foo\n')
+        f.write(f'valgrind -q --tool=memcheck --leak-check=yes --leak-resolution=high --num-callers=50 --log-file=/var/tmp/slapd.vg.$$ {dir}/ns-slapd.original "$@"\n')
+    os.chmod(name, 0o755)
+    return name
+
+@pytest.fixture
+def use_valgrind(topo_m2, request):
+    """Adds entries to the supplier1"""
+
+    log.info("Enable valgrind")
+    m1 = topo_m2.ms['supplier1']
+    m2 = topo_m2.ms['supplier2']
+    if m1.has_asan():
+        pytest.skip('Tescase using valgring cannot run on asan enabled build')
+        return
+    set_sasl_md5_client_auth(m1, m2)
+    set_sasl_md5_client_auth(m2, m1)
+    m1.stop()
+    m2.stop()
+    valgrind_enable(m1.ds_paths.sbin_dir, gen_valgrind_wrapper(m1.ds_paths.sbin_dir))
+
+    def fin():
+        log.info("Disable valgrind")
+        valgrind_disable(m1.ds_paths.sbin_dir)
+
+    request.addfinalizer(fin)
+
+
+def test_repl_sasl_md5_auth(topo_m2):
+    """Test replication with SASL digest-md5 authentication
+
+    :id: 922d16f8-662a-4915-a39e-0aecd7c8e6e2
+    :setup: Two supplier replication
+    :steps:
+        1. Set sasl digest/md4 on both suppliers 
+        2. Restart the instance
+        3. Check that replication works
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Replication works
+    """
+
+    m1 = topo_m2.ms['supplier1']
+    m2 = topo_m2.ms['supplier2']
+
+    set_sasl_md5_client_auth(m1, m2)
+    set_sasl_md5_client_auth(m2, m1)
+
+    m1.restart()
+    m2.restart()
+
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.test_replication_topology(topo_m2)
+
+
+def test_repl_sasl_leak(topo_m2, use_valgrind):
+    """Test replication with SASL digest-md5 authentication
+
+    :id: 180e088e-841c-11ec-af4f-482ae39447e5
+    :setup: Two supplier replication,  valgrind
+    :steps:
+        1. Set sasl digest/md4 on both suppliers 
+        2. Break sasl by setting invalid PATH
+        3. Restart the instances
+        4. Perform a change
+        5. Poke replication 100 times
+        6. Stop server
+        7. Check presence of "SASL(-4): no mechanism available: No worthy mechs found" message in error log
+        8 Check that there is no leak about slapi_ldap_get_lderrno
+    :expectedresults:
+        1. Success
+        2. Success
+        2. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+    """
+
+    m1 = topo_m2.ms['supplier1']
+    m2 = topo_m2.ms['supplier2']
+
+    os.environ["SASL_PATH"] = 'foo'
+
+    m1.start()
+    m2.start()
+
+    resfile=valgrind_get_results_file(m1)
+
+    # Perform a change
+    from_groups = Groups(m1, basedn=DEFAULT_SUFFIX, rdn=None)
+    from_group = from_groups.get('replication_managers')
+    change = str(uuid.uuid4())
+    from_group.replace('description', change)
+
+    # Poke replication to trigger thev leak
+    replica = Replicas(m1).get(DEFAULT_SUFFIX)
+    agmt = Agreements(m1, replica.dn).list()[0]
+    for i in range(0, 100):
+        agmt.pause()
+        agmt.resume()
+
+    m1.stop()
+    assert m1.searchErrorsLog("worthy")
+    assert not valgrind_check_file(resfile, 'slapi_ldap_get_lderrno');
+

--- a/ldap/servers/plugins/chainingdb/cb_search.c
+++ b/ldap/servers/plugins/chainingdb/cb_search.c
@@ -348,10 +348,9 @@ chainingdb_build_candidate_list(Slapi_PBlock *pb)
                     warned_rc = 1;
                 }
                 cb_send_ldap_result(pb, rc, NULL, ENDUSERMSG, 0, NULL);
-                /* BEWARE: matched_msg and error_msg points */
+                /* BEWARE: matched_msg points */
                 /* to ld fields.                */
                 matched_msg = NULL;
-                error_msg = NULL;
                 rc = -1;
             }
 
@@ -694,10 +693,9 @@ chainingdb_next_search_entry(Slapi_PBlock *pb)
                 }
                 cb_send_ldap_result(pb, rc, matched_msg, ENDUSERMSG, 0, NULL);
 
-                /* BEWARE: Don't free matched_msg && error_msg */
+                /* BEWARE: Don't free matched_msg */
                 /* Points to the ld fields               */
                 matched_msg = NULL;
-                error_msg = NULL;
                 retcode = -1;
             } else {
                 /* Add control response sent by the farm server */

--- a/ldap/servers/plugins/passthru/ptbind.c
+++ b/ldap/servers/plugins/passthru/ptbind.c
@@ -33,6 +33,8 @@ passthru_simple_bind_once_s(PassThruServer *srvr, const char *dn, struct berval 
  * are only interested in recovering silently when the remote server is up
  * but decided to close our connection, we retry without pausing between
  * attempts.
+ *
+ * Note that errmsgp must be freed by the caller.
  */
 int
 passthru_simple_bind_s(Slapi_PBlock *pb, PassThruServer *srvr, int tries, const char *dn, struct berval *creds, LDAPControl **reqctrls, int *lderrnop, char **matcheddnp, char **errmsgp, struct berval ***refurlsp, LDAPControl ***resctrlsp)

--- a/ldap/servers/plugins/replication/repl5_connection.c
+++ b/ldap/servers/plugins/replication/repl5_connection.c
@@ -244,6 +244,7 @@ conn_delete_internal(Repl_Connection *conn)
     PR_ASSERT(NULL != conn);
     close_connection_internal(conn);
     /* slapi_ch_free accepts NULL pointer */
+    slapi_ch_free_string(&conn->last_ldap_errmsg);
     slapi_ch_free((void **)&conn->hostname);
     slapi_ch_free((void **)&conn->binddn);
     slapi_ch_free((void **)&conn->plain);
@@ -450,6 +451,7 @@ conn_read_result_ex(Repl_Connection *conn, char **retoidp, struct berval **retda
         char *s = NULL;
 
         rc = slapi_ldap_get_lderrno(conn->ld, NULL, &s);
+        slapi_ch_free_string(&conn->last_ldap_errmsg);
         conn->last_ldap_errmsg = s;
         conn->last_ldap_error = rc;
         /* some errors will require a disconnect and retry the connection
@@ -1937,6 +1939,7 @@ bind_and_check_pwp(Repl_Connection *conn, char *binddn, char *password)
                           agmt_get_long_name(conn->agmt),
                           mech ? mech : "SIMPLE", rc,
                           ldap_err2string(rc), errmsg ? errmsg : "");
+            slapi_ch_free_string(&errmsg);
         } else {
             char *errmsg = NULL;
             /* errmsg is a pointer directly into the ld structure - do not free */
@@ -1946,6 +1949,7 @@ bind_and_check_pwp(Repl_Connection *conn, char *binddn, char *password)
                           agmt_get_long_name(conn->agmt),
                           mech ? mech : "SIMPLE", rc,
                           ldap_err2string(rc), errmsg ? errmsg : "");
+            slapi_ch_free_string(&errmsg);
         }
 
         return (CONN_OPERATION_FAILED);

--- a/ldap/servers/plugins/replication/windows_connection.c
+++ b/ldap/servers/plugins/replication/windows_connection.c
@@ -331,6 +331,7 @@ windows_perform_operation(Repl_Connection *conn, int optype, const char *dn, LDA
                               "windows_perform_operation - %s: Received error %d: %s for %s operation\n",
                               agmt_get_long_name(conn->agmt),
                               rc, s ? s : "NULL", op_string);
+                slapi_ch_free_string(&s);
                 conn->last_ldap_error = rc;
                 /* some errors will require a disconnect and retry the connection
                    later */
@@ -1709,6 +1710,7 @@ bind_and_check_pwp(Repl_Connection *conn, char *binddn, char *password)
                           agmt_get_long_name(conn->agmt),
                           mech ? mech : "SIMPLE", rc,
                           ldap_err2string(rc), errmsg);
+            slapi_ch_free_string(&errmsg);
         } else {
             char *errmsg = NULL;
             /* errmsg is a pointer directly into the ld structure - do not free */
@@ -1718,6 +1720,7 @@ bind_and_check_pwp(Repl_Connection *conn, char *binddn, char *password)
                           agmt_get_long_name(conn->agmt),
                           mech ? mech : "SIMPLE", rc,
                           ldap_err2string(rc), errmsg);
+            slapi_ch_free_string(&errmsg);
         }
 
         slapi_log_err(SLAPI_LOG_TRACE, windows_repl_plugin_name, "<= bind_and_check_pwp - CONN_OPERATION_FAILED\n");

--- a/ldap/servers/slapd/ldaputil.c
+++ b/ldap/servers/slapd/ldaputil.c
@@ -367,6 +367,8 @@ slapi_ldap_url_parse(const char *url, LDAPURLDesc **ludpp, int require_dn, int *
 
 #include <sasl/sasl.h>
 
+
+/* Warning: caller must free s (if not NULL) */
 int
 slapi_ldap_get_lderrno(LDAP *ld, char **m, char **s)
 {
@@ -381,6 +383,9 @@ slapi_ldap_get_lderrno(LDAP *ld, char **m, char **s)
         ldap_get_option(ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, s);
 #else
         ldap_get_option(ld, LDAP_OPT_ERROR_STRING, s);
+        if (*s) {
+            *s = slapi_ch_strdup(*s);
+        }
 #endif
     }
     return rc;
@@ -1494,6 +1499,7 @@ slapd_ldap_sasl_interactive_bind(
                           mech ? mech : "SIMPLE",
                           rc, ldap_err2string(rc), errmsg,
                           errno, slapd_system_strerror(errno));
+            slapi_ch_free_string(&errmsg);
             if (can_retry_bind(ld, mech, bindid, creds, rc, errmsg)) {
                 ; /* pass through to retry one time */
             } else {

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -494,8 +494,10 @@ def valgrind_enable(sbin_dir, wrapper=None):
     :raise EnvironmentError: If script is not run as 'root'
     '''
 
-    if os.geteuid() != 0:
-        log.error('This script must be run as root to use valgrind')
+    if not os.access(sbin_dir, os.W_OK):
+        # Note: valgrind has no limitation but  ns-slapd must be replaced
+        # This check allows non root user to use custom install prefix
+        log.error('This script must be run as root to use valgrind (Should at least be able to write in {sbin_dir})')
         raise EnvironmentError
 
     if not wrapper:
@@ -541,7 +543,8 @@ def valgrind_enable(sbin_dir, wrapper=None):
                       e.strerror)
 
     # Disable selinux
-    os.system('setenforce 0')
+    if os.geteuid() == 0:
+        os.system('setenforce 0')
 
     log.info('Valgrind is now enabled.')
 
@@ -558,8 +561,10 @@ def valgrind_disable(sbin_dir):
     :raise EnvironmentError: If script is not run as 'root'
     '''
 
-    if os.geteuid() != 0:
-        log.error('This script must be run as root to use valgrind')
+    if not os.access(sbin_dir, os.W_OK):
+        # Note: valgrind has no limitation but  ns-slapd must be replaced
+        # This check allows non root user to use custom install prefix
+        log.error('This script must be run as root to use valgrind (Should at least be able to write in {sbin_dir})')
         raise EnvironmentError
 
     nsslapd_orig = '%s/ns-slapd' % sbin_dir
@@ -583,7 +588,8 @@ def valgrind_disable(sbin_dir):
                          e.strerror)
 
     # Enable selinux
-    os.system('setenforce 1')
+    if os.geteuid() == 0:
+        os.system('setenforce 1')
 
     log.info('Valgrind is now disabled.')
 
@@ -609,7 +615,7 @@ def valgrind_get_results_file(dirsrv_inst):
 
     # Run the command and grab the output
     p = os.popen(cmd)
-    results_file = p.readline()
+    results_file = p.readline().strip()
     p.close()
 
     return results_file

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -51,7 +51,7 @@ from ldapurl import LDAPUrl
 from contextlib import closing
 
 import lib389
-from lib389.paths import Paths
+from lib389.paths import ( Paths, DEFAULTS_PATH )
 from lib389.dseldif import DSEldif
 from lib389._constants import (
         DEFAULT_USER, VALGRIND_WRAPPER, DN_CONFIG, CFGSUFFIX, LOCALHOST,
@@ -546,6 +546,18 @@ def valgrind_enable(sbin_dir, wrapper=None):
     if os.geteuid() == 0:
         os.system('setenforce 0')
 
+    # Disable systemd by turning off with_system in .inf file
+    old_path = Paths()._get_defaults_loc(DEFAULTS_PATH)
+    new_path = f'{old_path}.orig'
+    os.rename(old_path, new_path)
+    with open(new_path, 'rt') as fin:
+       with open(old_path, 'wt') as fout:
+            for line in fin:
+                if line.startswith('with_systemd'):
+                    fout.write('with_systemd = 0\n')
+                else:
+                    fout.write(line)
+
     log.info('Valgrind is now enabled.')
 
 
@@ -590,6 +602,12 @@ def valgrind_disable(sbin_dir):
     # Enable selinux
     if os.geteuid() == 0:
         os.system('setenforce 1')
+
+    # Restore .inf file (for systemd)
+    new_path = Paths()._get_defaults_loc(DEFAULTS_PATH)
+    old_path = f'{new_path}.orig'
+    if os.path.exists(old_path):
+        os.replace(old_path, new_path)
 
     log.info('Valgrind is now disabled.')
 


### PR DESCRIPTION
The problem is that some time ago libldap API replaced  ​LDAP_OPT_ERROR_STRING whose data should not be freed by
LDAP_OPT_DIAGNOSTIC_MESSAGE whose data must be freed.
slapi_ldap_get_lderrno was adapted to use the new option but the callers were not modified to free the value.

The Solution:
 Insure that we also need to free slapi_ldap_get_lderrno value if legacy LDAP_OPT_ERROR_STRING is used (by duping the value)
 Insure that the callers free the value.

Added test case about replication using SASL/Digest-md5 authentication
Added test case to check this leak 
Also updated test case about SASL/GSSAPI to be comapatible with current lib389 framework but marked as skipped because it requires a specific configuration (This path should be tested by IPA tests)
Fixed valgrind lib389 function to run on prefixed installation without needing to be root.
At last I also improved lib389 mapped object to have a better diagnostic when LDAP operation fails (by adding the request within the exception)
 
 issue: [5126](https://github.com/389ds/389-ds-base/issues/5126)

Reviewd by: @droideck
  