### PR TITLE
Issue 5155 - RFE - Provide an option to abort an Auto Member rebuild task

### DIFF
--- a/dirsrvtests/tests/suites/automember_plugin/automember_abort_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/automember_abort_test.py
@@ -1,0 +1,94 @@
+import logging
+import pytest
+import os
+import time
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.plugins import AutoMembershipPlugin, AutoMembershipDefinitions
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups
+from lib389.topologies import topology_st as topo
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def automember_fixture(topo, request):
+    # Create group
+    group_obj = Groups(topo.standalone, DEFAULT_SUFFIX)
+    automem_group = group_obj.create(properties={'cn': 'testgroup'})
+
+    # Create users
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX, rdn=None)
+    NUM_USERS = 1000
+    for num in range(NUM_USERS):
+        num_ran = int(round(num))
+        USER_NAME = 'test%05d' % num_ran
+        users.create(properties={
+            'uid': USER_NAME,
+            'sn': USER_NAME,
+            'cn': USER_NAME,
+            'uidNumber': '%s' % num_ran,
+            'gidNumber': '%s' % num_ran,
+            'homeDirectory': '/home/%s' % USER_NAME,
+            'mail': '%s@redhat.com' % USER_NAME,
+            'userpassword': 'pass%s' % num_ran,
+        })
+
+
+    # Create automember definitions and regex rules
+    automember_prop = {
+        'cn': 'testgroup_definition',
+        'autoMemberScope': DEFAULT_SUFFIX,
+        'autoMemberFilter': 'objectclass=posixaccount',
+        'autoMemberDefaultGroup': automem_group.dn,
+        'autoMemberGroupingAttr': 'member:dn',
+    }
+    automembers = AutoMembershipDefinitions(topo.standalone)
+    auto_def = automembers.create(properties=automember_prop)
+    auto_def.add_regex_rule("regex1", automem_group.dn, include_regex=['uid=.*'])
+
+    # Enable plugin
+    automemberplugin = AutoMembershipPlugin(topo.standalone)
+    automemberplugin.enable()
+    topo.standalone.restart()
+
+
+def test_abort(automember_fixture, topo):
+    """Test the abort rebuild task
+
+    :id: 24763279-48ec-4c34-91b3-f681679dec3a
+    :setup: Standalone Instance
+    :steps:
+        1. Setup automember and create a bunch of users
+        2. Start rebuild task
+        3. Abort rebuild task
+        4. Verify rebuild task was aborted
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    automemberplugin = AutoMembershipPlugin(topo.standalone)
+
+    # Run rebuild task
+    task = automemberplugin.fixup(DEFAULT_SUFFIX, "objectclass=top")
+    time.sleep(1)
+
+    # Abort rebuild task
+    automemberplugin.abort_fixup()
+
+    # Wait for rebuild task to finish
+    task.wait()
+
+    # Check errors log for abort message
+    assert topo.standalone.searchErrorsLog("task was intentionally aborted")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/plugins/replication/repl5_replica_config.c
+++ b/ldap/servers/plugins/replication/repl5_replica_config.c
@@ -1508,7 +1508,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
      */
     if ((rid_str = slapi_entry_attr_get_ref(e, "replica-id")) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Missing replica-id attribute");
-        cleanruv_log(task, -1, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, -1, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OBJECT_CLASS_VIOLATION;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -1516,7 +1516,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
     rid = atoi(rid_str);
     if ((base_dn = slapi_entry_attr_get_ref(e, "replica-base-dn")) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Missing replica-base-dn attribute");
-        cleanruv_log(task, (int)rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, (int)rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OBJECT_CLASS_VIOLATION;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -1526,7 +1526,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Invalid value for replica-force-cleaning "
                                                                "(%s).  Value must be \"yes\" or \"no\" for task - (%s)",
                         force_cleaning, slapi_sdn_get_dn(task_dn));
-            cleanruv_log(task, (int)rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+            cleanruv_log(NULL, (int)rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
             *returncode = LDAP_OPERATIONS_ERROR;
             rc = SLAPI_DSE_CALLBACK_ERROR;
             goto out;
@@ -1545,7 +1545,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
     if (rid <= 0 || rid >= READ_ONLY_REPLICA_ID) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Invalid replica id (%d) for task - (%s)",
                     rid, slapi_sdn_get_dn(task_dn));
-        cleanruv_log(task, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -1553,7 +1553,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
     if (is_cleaned_rid(rid)) {
         /* we are already cleaning this rid */
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Replica id (%d) is already being cleaned", rid);
-        cleanruv_log(task, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -1564,7 +1564,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
     dn = slapi_sdn_new_dn_byval(base_dn);
     if ((replica = replica_get_replica_from_dn(dn)) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Could not find replica from dn(%s)", slapi_sdn_get_dn(dn));
-        cleanruv_log(task, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -1575,7 +1575,7 @@ replica_cleanall_ruv_task(Slapi_PBlock *pb __attribute__((unused)),
 
 out:
     if (rc) {
-        cleanruv_log(task, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "Task failed...(%d)", rc);
+        cleanruv_log(NULL, rid, CLEANALLRUV_ID, SLAPI_LOG_ERR, "Task failed...(%d)", rc);
         slapi_task_finish(task, *returncode);
     } else {
         rc = SLAPI_DSE_CALLBACK_OK;
@@ -2982,7 +2982,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
      */
     if ((rid_str = slapi_entry_attr_get_ref(e, "replica-id")) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Missing required attr \"replica-id\"");
-        cleanruv_log(task, -1, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, -1, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OBJECT_CLASS_VIOLATION;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -2995,14 +2995,14 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
     if (rid <= 0 || rid >= READ_ONLY_REPLICA_ID) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Invalid replica id (%d) for task - (%s)",
                     rid, slapi_sdn_get_dn(slapi_entry_get_sdn(e)));
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
     }
     if ((base_dn = slapi_entry_attr_get_ref(e, "replica-base-dn")) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Missing required attr \"replica-base-dn\"");
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OBJECT_CLASS_VIOLATION;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3010,7 +3010,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
     if (!is_cleaned_rid(rid) && !is_pre_cleaned_rid(rid)) {
         /* we are not cleaning this rid */
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Replica id (%d) is not being cleaned, nothing to abort.", rid);
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3018,7 +3018,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
     if (is_task_aborted(rid)) {
         /* we are already aborting this rid */
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Replica id (%d) is already being aborted", rid);
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3029,7 +3029,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
     sdn = slapi_sdn_new_dn_byval(base_dn);
     if ((replica = replica_get_replica_from_dn(sdn)) == NULL) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Failed to find replica from dn(%s)", base_dn);
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3041,7 +3041,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
         if (strcasecmp(certify_all, "yes") && strcasecmp(certify_all, "no")) {
             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Invalid value for \"replica-certify-all\", the value "
                                                                "must be \"yes\" or \"no\".");
-            cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+            cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
             *returncode = LDAP_OPERATIONS_ERROR;
             rc = SLAPI_DSE_CALLBACK_ERROR;
             goto out;
@@ -3061,7 +3061,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
                     "Exceeded maximum number of active ABORT CLEANALLRUV tasks(%d)",
                     CLEANRIDSIZ);
-        cleanruv_log(task, -1, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
+        cleanruv_log(NULL, -1, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "%s", returntext);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         goto out;
     }
@@ -3072,7 +3072,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
     payload = create_cleanruv_payload(ridstr);
 
     if (payload == NULL) {
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Failed to create extended op payload, aborting task");
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Failed to create extended op payload, aborting task");
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3088,7 +3088,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
      */
     data = (cleanruv_data *)slapi_ch_calloc(1, sizeof(cleanruv_data));
     if (data == NULL) {
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Failed to allocate abort_cleanruv_data.  Aborting task.");
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Failed to allocate abort_cleanruv_data.  Aborting task.");
         *returncode = LDAP_OPERATIONS_ERROR;
         rc = SLAPI_DSE_CALLBACK_ERROR;
         goto out;
@@ -3111,7 +3111,7 @@ replica_cleanall_ruv_abort(Slapi_PBlock *pb __attribute__((unused)),
                              (void *)data, PR_PRIORITY_NORMAL, PR_GLOBAL_THREAD,
                              PR_UNJOINABLE_THREAD, SLAPD_DEFAULT_THREAD_STACKSIZE);
     if (thread == NULL) {
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Unable to create abort thread.  Aborting task.");
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Unable to create abort thread.  Aborting task.");
         *returncode = LDAP_OPERATIONS_ERROR;
         slapi_ch_free_string(&data->certify);
         rc = SLAPI_DSE_CALLBACK_ERROR;
@@ -3122,7 +3122,7 @@ out:
     slapi_sdn_free(&sdn);
 
     if (rc != SLAPI_DSE_CALLBACK_OK) {
-        cleanruv_log(task, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Abort Task failed (%d)", rc);
+        cleanruv_log(NULL, rid, ABORT_CLEANALLRUV_ID, SLAPI_LOG_ERR, "Abort Task failed (%d)", rc);
         slapi_task_finish(task, rc);
     }
 

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -159,6 +159,7 @@ DN_EUUID_TASK = "cn=entryuuid task,%s" % DN_TASKS
 DN_TOMB_FIXUP_TASK = "cn=fixup tombstones,%s" % DN_TASKS
 DN_FIXUP_LINKED_ATTIBUTES = "cn=fixup linked attributes,%s" % DN_TASKS
 DN_AUTOMEMBER_REBUILD_TASK = "cn=automember rebuild membership,%s" % DN_TASKS
+DN_AUTOMEMBER_ABORT_REBUILD_TASK = "cn=automember abort rebuild,%s" % DN_TASKS
 DN_COMPACTDB_TASK = "cn=compact db,%s" % DN_TASKS
 
 # Script Constants

--- a/src/lib389/lib389/cli_conf/plugins/automember.py
+++ b/src/lib389/lib389/cli_conf/plugins/automember.py
@@ -164,6 +164,20 @@ def fixup(inst, basedn, log, args):
         log.info('Successfully added task entry')
 
 
+def abort(inst, basedn, log, args):
+    plugin = AutoMembershipPlugin(inst)
+    log.info('Attempting to add abort task entry... This will fail if Automembership plug-in is not enabled.')
+    if not plugin.status():
+        log.error("'%s' is disabled. Abort rebuild membership task can't be executed" % plugin.rdn)
+    fixup_task = plugin.abort_fixup(args.DN, args.filter)
+    fixup_task.wait()
+    exitcode = fixup_task.get_exit_code()
+    if exitcode != 0:
+        log.error('Abort rebuild membership task for %s has failed. Please, check logs')
+    else:
+        log.info('Successfully added abort task entry')
+
+
 def _add_parser_args_definition(parser):
     parser.add_argument('--grouping-attr',  required=True,
                         help='Specifies the name of the member attribute in the group entry and '
@@ -241,3 +255,5 @@ def create_parser(subparsers):
     fixup.add_argument('-s', '--scope', required=True, choices=['sub', 'base', 'one'], type=str.lower,
                        help='Sets the LDAP search scope for entries to fix up')
 
+    abort_fixup = subcommands.add_parser('abort-fixup', help='Abort the rebuild membership task.')
+    abort_fixup.set_defaults(func=abort)

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -1103,6 +1103,17 @@ class AutoMembershipPlugin(Plugin):
 
         return task
 
+    def abort_fixup(self):
+        """Create an automember abort rebuild task
+
+        :returns: an instance of Task(DSLdapObject)
+        """
+
+        task = tasks.AutomemberAbortRebuildTask(self._instance)
+        task.create()
+
+        return task
+
 
 class AutoMembershipDefinition(DSLdapObject):
     """A single instance of Auto Membership Plugin config entry

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -139,6 +139,20 @@ class AutomemberRebuildMembershipTask(Task):
         self._must_attributes.extend(['basedn', 'filter'])
 
 
+class AutomemberAbortRebuildTask(Task):
+    """A single instance of automember abort rebuild task entry
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    """
+
+    def __init__(self, instance, dn=None):
+        self.cn = 'automember_abort_' + Task._get_task_date()
+        dn = "cn=" + self.cn + "," + DN_AUTOMEMBER_ABORT_REBUILD_TASK
+
+        super(AutomemberAbortRebuildTask, self).__init__(instance, dn)
+
+
 class FixupLinkedAttributesTask(Task):
     """A single instance of fixup linked attributes task entry
 


### PR DESCRIPTION
Description:  Add an abort task for the autommeber rebuild task.  There
are cases where IPA can start spinning up schema compat search during
the rebuild which can bog down an entire system.  If this happens the
task can be aborted to prevent an outage.

Also found that in cleanAllRUV we wre trying to write to the task entry
in the task add callback function (which is too early to start updating
the task and triggers error 32 messages in the errors log).  So that
was fixed as well.

relates: https://github.com/389ds/389-ds-base/issues/5155

