### PR TITLE
Issue 5160 - BUG - x- prefix in descr-oid can confuse oid parser

### DIFF
--- a/dirsrvtests/tests/data/openldap_2_389/1/slapd.d/cn=config/cn=schema/cn={5}test.ldif
+++ b/dirsrvtests/tests/data/openldap_2_389/1/slapd.d/cn=config/cn=schema/cn={5}test.ldif
@@ -1,0 +1,12 @@
+dn: cn={5}test
+objectClass: olcSchemaConfig
+cn: {5}test
+olcAttributeTypes: {0}( x-attribute NAME 'x-attribute' DESC 'desc' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
+olcObjectClasses: {0}( x-object-oid NAME 'x-object' DESC 'desc' SUP top STRUCTURAL MUST x-attribute )
+structuralObjectClass: olcSchemaConfig
+entryUUID: 86660309-e157-4ebb-be06-a5d7e3c877bc
+creatorsName: cn=config
+createTimestamp: 20200224020101Z
+entryCSN: 20200224020101.085642Z#000000#000#000000
+modifiersName: cn=config
+modifyTimestamp: 20200224020101Z

--- a/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
+++ b/dirsrvtests/tests/suites/openldap_2_389/migrate_test.py
@@ -50,9 +50,6 @@ def test_parse_openldap_slapdd():
     assert any(['suseModuleConfiguration' in x.names for x in config.schema.classes])
 
 
-
-
-
 @pytest.mark.skipif(ds_is_older('1.4.3'), reason="Not implemented")
 def test_migrate_openldap_slapdd(topology_st):
     """

--- a/dirsrvtests/tests/suites/schema/x_attribute_descr_oid_test.py
+++ b/dirsrvtests/tests/suites/schema/x_attribute_descr_oid_test.py
@@ -1,0 +1,53 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 William Brown <william@blackhats.net.au>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+
+import os
+import logging
+import pytest
+import ldap
+
+from lib389.topologies import topology_st as topology
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.schema import Schema
+
+pytestmark = pytest.mark.tier1
+
+def test_x_descr_oid(topology):
+    """Test import of an attribute using descr-oid format that starts
+    with an X-. This should "fail" with a descriptive error message.
+
+    :id: 9308bdbd-363c-45a9-8223-9a6c925dba37
+
+    :setup: Standalone instance
+
+    :steps:
+        1. Add invalid x-attribute
+        2. Add valid x-attribute
+        3. Add invalid x-object
+        4. Add valid x-object
+
+    :expectedresults:
+        1. raises INVALID_SYNTAX
+        2. success
+        3. raises INVALID_SYNTAX
+        4. success
+    """
+    inst = topology.standalone
+
+    schema = Schema(inst)
+
+    with pytest.raises(ldap.INVALID_SYNTAX):
+        schema.add('attributeTypes', "( x-attribute-oid NAME 'x-attribute' DESC 'desc' EQUALITY  caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'user defined' )")
+    schema.add('attributeTypes', "( 1.2.3.4.5.6.7.8.9.10 NAME 'x-attribute' DESC 'desc' EQUALITY  caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'user defined' )")
+
+    with pytest.raises(ldap.INVALID_SYNTAX):
+        schema.add('objectClasses', "( x-object-oid NAME 'x-object' DESC 'desc' SUP TOP AUXILIARY MAY ( x-attribute ) X-ORIGIN 'user defined' )")
+    schema.add('objectClasses', "( 1.2.3.4.5.6.7.8.9.11 NAME 'x-object' DESC 'desc' SUP TOP AUXILIARY MAY ( x-attribute ) X-ORIGIN 'user defined' )")
+


### PR DESCRIPTION
Bug Description: Attributes and objectclasses with an x- prefix to their
name such as x-attribute or x-object can confuse the schema parser as it
is ambiguous if the term is a descr-oid or an x- field.

Fix Description: Improve our oid schema parse check to specifically warn
about this case, and improve the migration tool to pre-alert the user
that the schema value they want to migrate is not valid for 389.

fixes: https://github.com/389ds/389-ds-base/issues/5160

Author: William Brown <william@blackhats.net.au>

Review by: ???