### PR TITLE
Issue 5145 - Fix covscan errors

### DIFF
--- a/ldap/servers/plugins/acl/acl_ext.c
+++ b/ldap/servers/plugins/acl/acl_ext.c
@@ -188,12 +188,13 @@ acl_operation_ext_constructor(void *object __attribute__((unused)), void *parent
     if (NULL == aclpb) {
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "acl_operation_ext_constructor - Operation extension allocation Failed\n");
+    } else {
+        /* targetfilter_cache toggle set during aclpb allocation
+         * to avoid accessing configuration during the evaluation
+         * of each aci
+         */
+        aclpb->targetfilter_cache_enabled = config_get_targetfilter_cache();
     }
-    /* targetfilter_cache toggle set during aclpb allocation
-     * to avoid accessing configuration during the evaluation
-     * of each aci
-     */
-    aclpb->targetfilter_cache_enabled = config_get_targetfilter_cache();
 
     TNF_PROBE_0_DEBUG(acl_operation_ext_constructor_end, "ACL", "");
 

--- a/ldap/servers/plugins/pam_passthru/pam_ptimpl.c
+++ b/ldap/servers/plugins/pam_passthru/pam_ptimpl.c
@@ -358,9 +358,12 @@ do_one_pam_auth(
     }
 
     rc = pam_end(pam_handle, rc);
-    report_pam_error("during pam_end", rc, pam_handle);
+    if (rc != PAM_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_ERR, PAM_PASSTHRU_PLUGIN_SUBSYSTEM,
+                      "do_one_pam_auth - Error during pam_end (%d)\n", rc);
+    }
     slapi_unlock_mutex(PAMLock);
-/* not in critical section any more */
+    /* not in critical section any more */
 
 done:
     delete_my_str_buf(&pam_id);

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -864,8 +864,10 @@ void csngen_multi_suppliers_test(void)
     for (_csngen_tester_state=0; _csngen_tester_state < NB_TEST_STATES; _csngen_tester_state++) {
         for (i=0; i< NB_TEST_MASTERS; i++) {
             _csngen_tester_state_rid = i+1;
+            csn = NULL;
             rc = csngen_new_csn(gen[i], &csn, PR_FALSE);
             if (rc) {
+                csn_free(&csn);
                 continue;
             }
             csngen_dump_state(gen[i], SLAPI_LOG_INFO);
@@ -874,8 +876,10 @@ void csngen_multi_suppliers_test(void)
                 slapi_log_err(SLAPI_LOG_ERR, "csngen_multi_suppliers_test",
                               "CSN generated in disorder state=%d rid=%d\n", _csngen_tester_state, _csngen_tester_state_rid);
                 _csngen_tester_state = NB_TEST_STATES;
+                csn_free(&csn);
                 break;
             }
+            csn_free(&last_csn);
             last_csn = csn;
 
             for (j=0; j< NB_TEST_MASTERS; j++) {
@@ -890,4 +894,5 @@ void csngen_multi_suppliers_test(void)
             }
         }
     }
+    csn_free(&last_csn);
 }

--- a/ldap/servers/slapd/saslbind.c
+++ b/ldap/servers/slapd/saslbind.c
@@ -865,6 +865,7 @@ ids_sasl_listmech(Slapi_PBlock *pb, PRBool get_all_mechs)
     } else {
         /* The allowed list was empty, just take our supported list. */
         ret = sup_ret;
+        charray_free(config_ret);
     }
 
     /*

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -403,8 +403,7 @@ export class SearchDatabase extends React.Component {
             const start = 2 * (page - 1) * perPage;
             const end = 2 * page * perPage;
             const pagedRows = this.state.rows.slice(start, end);
-            let i = 0;
-            for (i; i < pagedRows.length - 1; i++) {
+            for (let i = 0; i < pagedRows.length - 1; i++) {
                 if (i % 2 === 0) {
                     pagedRows[i + 1].parent = i;
                 }

--- a/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
@@ -951,8 +951,7 @@ class ReferentialIntegrity extends React.Component {
                                     type="text"
                                     id="configContainerScope"
                                     aria-describedby="horizontal-form-name-helper"
-                                    name="configExcludeEntryScope"
-
+                                    name="configContainerScope"
                                     onChange={(str, e) => { this.handleModalChange(e) }}
                                     validated={errorModal.configContainerScope ? ValidatedOptions.error : ValidatedOptions.default}
                                 />

--- a/wrappers/ds_selinux_restorecon.sh.in
+++ b/wrappers/ds_selinux_restorecon.sh.in
@@ -15,7 +15,7 @@ then
     exit 0
 fi
 
-if ! command -v restorecon &> /dev/null
+if ! command -v restorecon >/dev/null 2>&1
 then
     # restorecon is not available
     exit 0


### PR DESCRIPTION
Description: 

Fix latest covscan errors on latest 389-ds-base-2.0

Resource leaks:

    csngen_multi_suppliers_test() -> csn & last_csn are not properly handled
    ids_sasl_listmech() -> leaks config_ret

Copy & Paste:
    referentialIntegrity.jsx -> copy & paste error with component name (harmless)

Null Dereference:

    acl_ext.c -> aclpb is dereferenced on allocation error

Use After Free

    pam_ptimpl.c -> do_one_pam_auth() happens on pam_end() error

relates: https://github.com/389ds/389-ds-base/issues/5145

