### PR TITLE
Issue 5032 - Fix configure option in specfile

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -393,6 +393,9 @@ autoreconf -fiv
            --with-systemdgroupname=%{groupname} \
            --libexecdir=%{_libexecdir}/%{pkgname} \
            $ASAN_FLAGS $MSAN_FLAGS $TSAN_FLAGS $UBSAN_FLAGS $RUST_FLAGS $CLANG_FLAGS $COCKPIT_FLAGS \
+%if 0%{?fedora} >= 34 || 0%{?rhel} >= 9
+           --with-libldap-r=no \
+%endif
            --enable-cmocka
 
 # Avoid "Unknown key name 'XXX' in section 'Service', ignoring." warnings from systemd on older releases


### PR DESCRIPTION
Description: Lildap_r is no longer used since Fedora 34 and
is completely removed from Fedora 36 and older.
Hence, adjust the specfile accordingly.

Relates: https://github.com/389ds/389-ds-base/issues/5032

Reviewed by: ?