### PR TITLE
Issue 5176 - CI rewriter fails when libslapd.so.0 does not exist

### DIFF
--- a/dirsrvtests/tests/suites/rewriters/basic_test.py
+++ b/dirsrvtests/tests/suites/rewriters/basic_test.py
@@ -30,7 +30,9 @@ def test_foo_filter_rewriter(topology_st):
     Test that example filter rewriter 'foo' is register and search use it
     """
 
-    libslapd = os.path.join( topology_st.standalone.ds_paths.lib_dir, 'dirsrv/libslapd.so.0')
+    libslapd = os.path.join( topology_st.standalone.ds_paths.lib_dir, 'dirsrv/libslapd.so')
+    if not os.path.exists(libslapd):
+        libslapd = os.path.join( topology_st.standalone.ds_paths.lib_dir, 'dirsrv/libslapd.so.0')
     # register foo filter rewriters
     topology_st.standalone.add_s(Entry((
         "cn=foo_filter,cn=rewriters,cn=config", {


### PR DESCRIPTION
Bug description:
	rewriter test assumes that the library libslapd.so.0
	exists (/usr/lib64/dirsrv/libslapd.so.0).
	On 389-ds-base-2.0, only libslapd.so exists.

Fix description:
	The test case should test if libslapd.so exists
        If not then fall back to libslapd.so.0

relates: https://github.com/389ds/389-ds-base/issues/5176

Reviewed by:

Platforms tested: F35