### PR TITLE
Issue 5122 - dsconf instance backend suffix set doesn't accept backend name

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -108,7 +108,12 @@ def _get_backend(inst, name):
     for be in be_insts:
         be_suffix = ensure_str(be.get_attr_val_utf8_l('nsslapd-suffix')).lower()
         cn = ensure_str(be.get_attr_val_utf8_l('cn')).lower()
-        if str2dn(be_suffix) == str2dn(name.lower()) or cn == name.lower():
+        try:
+            if str2dn(be_suffix) == str2dn(name.lower()):
+                return be
+        except ldap.DECODING_ERROR:
+            pass
+        if cn == name.lower():
             return be
 
     raise ValueError('Could not find backend suffix: {}'.format(name))


### PR DESCRIPTION
Issue: The function that get the Backend object tries to decode the argument as a DN (to compare the suffix) and generates a Decoding exception if it is not a DN.
Solution: The test should be split to check for suffix equality while ignoring the exception or to check for backend name equality

Reviewed by:

Issue: [5122](https://github.com/389ds/389-ds-base/issues/5122)