### PR TITLE
Issue 5048 - Support for nsslapd-tcp-fin-timeout and nsslapd-tcp-keepalive-time

### DIFF
--- a/ldap/admin/src/70-dirsrv.conf
+++ b/ldap/admin/src/70-dirsrv.conf
@@ -34,11 +34,6 @@ net.ipv4.tcp_slow_start_after_idle = 0
 # 1027 == 0x400 + 0x2 + 0x1
 net.ipv4.tcp_fastopen=1027
 
-# Decrease the time default value for tcp_fin_timeout connection
-net.ipv4.tcp_fin_timeout = 30
-# Decrease the time default value for tcp_keepalive_time connection
-# this means we find "dead" connections faster.
-net.ipv4.tcp_keepalive_time = 300
 # Provide more ports and timewait buckets to increase connectivity
 net.ipv4.tcp_max_tw_buckets = 262144
 

--- a/ldap/schema/01core389.ldif
+++ b/ldap/schema/01core389.ldif
@@ -326,6 +326,8 @@ attributeTypes: ( 2.16.840.1.113730.3.1.2371 NAME 'nsDS5ReplicaBootstrapBindDN' 
 attributeTypes: ( 2.16.840.1.113730.3.1.2372 NAME 'nsDS5ReplicaBootstrapCredentials' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2373 NAME 'nsDS5ReplicaBootstrapBindMethod' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2374 NAME 'nsDS5ReplicaBootstrapTransportInfo' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2387 NAME 'nsslapd-tcp-fin-timeout' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2388 NAME 'nsslapd-tcp-keepalive-time' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 #
 # objectclasses
 #

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1302,6 +1302,14 @@ static struct config_get_and_set
      (void **)&global_slapdFrontendConfig.ldapssotoken_ttl,
      CONFIG_INT, NULL, SLAPD_DEFAULT_LDAPSSOTOKEN_TTL_STR, NULL},
 #endif
+    {CONFIG_TCP_FIN_TIMEOUT, config_set_tcp_fin_timeout,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.tcp_fin_timeout, CONFIG_INT,
+     (ConfigGetFunc)config_get_tcp_fin_timeout, SLAPD_DEFAULT_TCP_FIN_TIMEOUT_STR, NULL},
+    {CONFIG_TCP_KEEPALIVE_TIME, config_set_tcp_keepalive_time,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.tcp_keepalive_time, CONFIG_INT,
+     (ConfigGetFunc)config_get_tcp_keepalive_time, SLAPD_DEFAULT_TCP_KEEPALIVE_TIME_STR, NULL},
     /* End config */
     };
 
@@ -1857,6 +1865,8 @@ FrontendConfig_init(void)
 #else
     init_enable_ldapssotoken = cfg->enable_ldapssotoken = LDAP_OFF;
 #endif
+    cfg->tcp_fin_timeout = SLAPD_DEFAULT_TCP_FIN_TIMEOUT;
+    cfg->tcp_keepalive_time = SLAPD_DEFAULT_TCP_KEEPALIVE_TIME;
 
     /* Done, unlock!  */
     CFG_UNLOCK_WRITE(cfg);
@@ -8332,6 +8342,74 @@ config_get_ldapssotoken_ttl()
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     return slapi_atomic_load_32(&(slapdFrontendConfig->ldapssotoken_ttl), __ATOMIC_ACQUIRE);
+}
+
+int
+config_set_tcp_fin_timeout(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    long tcp_fin_timeout;
+    char *endp;
+
+    if (config_value_is_null(attrname, value, errorbuf, 0)) {
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    errno = 0;
+    tcp_fin_timeout = strtol(value, &endp, 10);
+    if (*endp != '\0' || errno == ERANGE) {
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "(%s) value (%s) is invalid\n", attrname, value);
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    if (apply) {
+        slapi_atomic_store_32(&(slapdFrontendConfig->tcp_fin_timeout), tcp_fin_timeout, __ATOMIC_RELEASE);
+    }
+    return LDAP_SUCCESS;
+}
+
+int
+config_get_tcp_fin_timeout()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int retVal;
+
+    retVal = slapdFrontendConfig->tcp_fin_timeout;
+    return retVal;
+}
+
+int
+config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    long tcp_keepalive_time;
+    char *endp;
+
+    if (config_value_is_null(attrname, value, errorbuf, 0)) {
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    errno = 0;
+    tcp_keepalive_time = strtol(value, &endp, 10);
+    if (*endp != '\0' || errno == ERANGE || tcp_keepalive_time < 1) {
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "(%s) value (%s) is invalid\n", attrname, value);
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    if (apply) {
+        slapi_atomic_store_32(&(slapdFrontendConfig->tcp_keepalive_time), tcp_keepalive_time, __ATOMIC_RELEASE);
+    }
+    return LDAP_SUCCESS;
+}
+
+int
+config_get_tcp_keepalive_time()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int retVal;
+
+    retVal = slapdFrontendConfig->tcp_keepalive_time;
+    return retVal;
 }
 
 /*

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -618,6 +618,10 @@ int32_t config_set_ldapssotoken_secret(const char *attrname, char *value, char *
 int32_t config_set_ldapssotoken_ttl(const char *attrname, char *value, char *errorbuf, int apply);
 int32_t config_get_ldapssotoken_ttl(void);
 
+int config_set_tcp_fin_timeout(const char *attrname, char *value, char *errorbuf, int apply);
+int config_get_tcp_fin_timeout(void);
+int config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply);
+int config_get_tcp_keepalive_time(void);
 
 int is_abspath(const char *);
 char *rel2abspath(char *);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -412,6 +412,11 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_PW_MAX_CLASS_CHARS_ATTRIBUTE 0
 #define SLAPD_DEFAULT_PW_MAX_CLASS_CHARS_ATTRIBUTE_STR "0"
 
+#define SLAPD_DEFAULT_TCP_FIN_TIMEOUT 30
+#define SLAPD_DEFAULT_TCP_FIN_TIMEOUT_STR "30"
+#define SLAPD_DEFAULT_TCP_KEEPALIVE_TIME 300
+#define SLAPD_DEFAULT_TCP_KEEPALIVE_TIME_STR "300"
+
 #define MIN_THREADS 16
 #define MAX_THREADS 512
 
@@ -2311,6 +2316,9 @@ typedef struct _slapdEntryPoints
 #define CONFIG_LDAPSSOTOKEN_SECRET   "nsslapd-ldapssotoken-secret"
 #define CONFIG_LDAPSSOTOKEN_TTL      "nsslapd-ldapssotoken-ttl-secs"
 
+#define CONFIG_TCP_FIN_TIMEOUT       "nsslapd-tcp-fin-timeout"
+#define CONFIG_TCP_KEEPALIVE_TIME    "nsslapd-tcp-keepalive-time"
+
 /*
  * Define the backlog number for use in listen() call.
  * We use the same definition as in ldapserver/include/base/systems.h
@@ -2609,6 +2617,9 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t enable_ldapssotoken;
     char *ldapssotoken_secret;
     slapi_int_t ldapssotoken_ttl;
+
+    slapi_int_t tcp_fin_timeout;
+    slapi_int_t tcp_keepalive_time;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */


### PR DESCRIPTION
Description:
Installing 389-ds modifies system parameters by 70-dirsrv.conf.
"net.ipv4.tcp_fin_timeout" and "net.ipv4.tcp_keepalive_time" can be set for
389-ds sockets using setsockopt(). System parameters should not be changed
as much as possible and should only be applied to 389-ds sockets.

Fix Description:
To set parameters for 389-ds sockets, following two attributes have been added.
- nsslapd-tcp-fin-timeout
- nsslapd-tcp-keepalive-time

"net.ipv4.tcp_fin_timeout" and "net.ipv4.tcp_keepalive_time" of 70-dirsrv.conf
are no longer needed.

Relates: https://github.com/389ds/389-ds-base/issues/5048