### PR TITLE
Issue 5197 - Build break in lib389 with INSTALL_PREFIX

### DIFF
--- a/src/lib389/setup.py
+++ b/src/lib389/setup.py
@@ -13,7 +13,8 @@
 #
 
 from setuptools import setup, find_packages
-from os import path
+from os import path, environ
+from sys import argv
 import build_manpages as bm
 if bm.__version__ < '2.1':
     from build_manpages import build_manpages as bm
@@ -29,6 +30,18 @@ version = "1.4.0.1"
 
 with open(path.join(here, 'README.md'), 'r') as f:
     long_description = f.read()
+
+#
+# For some historical reason when using prefix install 
+#  files that should be in /usr/sbin/, /usr/share/ are
+#  in $PREFIX/sbin, $PREFIX/share
+# So lets mimick this behavior
+
+prefix=environ.get('INSTALL_PREFIX', '/usr')
+print(f"argv={argv}")
+if prefix != "/usr" and 'install' in argv and '--prefix' not in argv:
+    argv.append('--prefix')
+    argv.append(prefix)
 
 setup(
     name='lib389',
@@ -59,21 +72,21 @@ setup(
 
     # find lib389/clitools -name ds\* -exec echo \''{}'\', \;
     data_files=[
-        ('/usr/sbin/', [
+        (prefix+'/sbin/', [
             'cli/dsctl',
             'cli/dsconf',
             'cli/dscreate',
             'cli/dsidm',
             'cli/openldap_to_ds',
             ]),
-        ('/usr/share/man/man8', [
+        (prefix+'/share/man/man8', [
             'man/dsctl.8',
             'man/dsconf.8',
             'man/dscreate.8',
             'man/dsidm.8',
             'man/openldap_to_ds.8',
             ]),
-        ('/usr/libexec/dirsrv/', [
+        (prefix+'/libexec/dirsrv/', [
             'cli/dscontainer',
             ]),
     ],


### PR DESCRIPTION
Issue: make lib389 and lib389-install tries to install binaries in / instead of in $INSTALL_PREFIX
 so the build fails when following https://www.port389.org/docs/389ds/development/building.html#building-into-a-prefix-location-non-standardnot-root instructions

Solution: Add the prefix to the data 
(Note there is a trick: to get same result than previous builds and the other parts of the Makefile /usr should be removed when using a prefix)
 
 Issue: [5197](https://github.com/389ds/389-ds-base/issues/5197)
 
 Reviewd by: ?  