### PR TITLE
Issue 5205 - error in backport of CLI changes

### DIFF
--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -509,6 +509,7 @@ class Backend(DSLdapObject):
 
     def _lint_cl_trimming(self):
         """Check that cl trimming is at least defined to prevent unbounded growth"""
+        suffix = self.get_attr_val_utf8('nsslapd-suffix')
         bename = self.lint_uid()
         replicas = Replicas(self._instance)
         try:


### PR DESCRIPTION
Bug Description:

Undefined variable `suffix` in `_lint_cl_trimming`.

Fix Description:

Backport `suffix` part from `dev` branch.

fixes: https://github.com/389ds/389-ds-base/issues/5205