### PR TITLE
Issue 5208 - incomplete backport of fix for issue 5024

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -29,6 +29,13 @@ RUST_ON = 1
 
 COCKPIT_ON = 1
 
+# PERL_ON is deprecated and turns on the LEGACY_ON, this for not breaking people's workflows.
+PERL_ON = 1
+LEGACY_ON = 0
+ifeq ($(PERL_ON), 1)
+	LEGACY_ON = 1
+endif
+
 clean:
 	rm -rf dist
 	rm -rf rpmbuild
@@ -107,6 +114,7 @@ rpmroot:
 	-e s/__TSAN_ON__/$(TSAN_ON)/ \
 	-e s/__UBSAN_ON__/$(UBSAN_ON)/ \
 	-e s/__COCKPIT_ON__/$(COCKPIT_ON)/ \
+	-e s/__LEGACY_ON__/$(LEGACY_ON)/ \
 	-e s/__CLANG_ON__/$(CLANG_ON)/ \
 	-e s/__BUNDLE_JEMALLOC__/$(BUNDLE_JEMALLOC)/ \
 	rpm/$(PACKAGE).spec.in > $(RPMBUILD)/SPECS/$(PACKAGE).spec

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -21,7 +21,8 @@ from itertools import permutations
 from lib389._constants import *
 from lib389.properties import *
 from lib389.utils import (normalizeDN, escapeDNValue, ensure_bytes, ensure_str,
-                          ensure_list_str, ds_is_older, copy_with_permissions)
+                          ensure_list_str, ds_is_older, copy_with_permissions,
+                          ds_supports_new_changelog)
 from lib389 import DirSrv, Entry, NoSuchEntryError, InvalidArgumentError
 from lib389._mapped_object import DSLdapObjects, DSLdapObject
 from lib389.passwd import password_generate


### PR DESCRIPTION
Bug Description:

Undefined name `ds_supports_new_changelog` in module
`lib389.replica`.

Fix Description:

Import missing `ds_supports_new_changelog` from `lib389.utils`.

related: https://github.com/389ds/389-ds-base/issues/5208

Reviewed by: