### PR TITLE
Issue 5210 - Python undefined names in lib389

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -241,7 +241,9 @@ def _ds_shutil_copytree(src, dst, symlinks=False, ignore=None, copy_function=cop
                     # code with a custom `copy_function` may rely on copytree
                     # doing the right thing.
                     os.symlink(linkto, dstname)
-                    copystat(srcname, dstname, follow_symlinks=not symlinks)
+                    shutil.copystat(
+                        srcname, dstname, follow_symlinks=not symlinks
+                    )
                 else:
                     # ignore dangling symlink if the flag is on
                     if not os.path.exists(linkto) and ignore_dangling_symlinks:
@@ -303,6 +305,7 @@ class DirSrv(SimpleLDAPObject, object):
 
             @raise ldap.CONFIDENTIALITY_REQUIRED - missing TLS:
         """
+        uri = self.toLDAPURL()
         if hasattr(ldap, 'PYLDAP_VERSION') and MAJOR >= 3:
             super(DirSrv, self).__init__(uri, bytes_mode=False, trace_level=TRACE_LEVEL)
         else:
@@ -922,7 +925,7 @@ class DirSrv(SimpleLDAPObject, object):
         with suppress(Exception):
             dse_ldif = DSEldif(None, self)
             self._db_lib = dse_ldif.get(DN_CONFIG_LDBM, "nsslapd-backend-implement", single=True)
-            return _self.db_lib
+            return self._db_lib
         return get_default_db_lib()
 
     def delete(self):
@@ -1471,7 +1474,7 @@ class DirSrv(SimpleLDAPObject, object):
         for f in glob.glob("%s*" % self.accesslog):
             self.log.debug("restoreFS: before restore remove file %s", f)
             os.remove(f)
-        log.debug("restoreFS: remove audit logs %s" % self.accesslog)
+        self.log.debug("restoreFS: remove audit logs %s" % self.auditlog)
         for f in glob.glob("%s*" % self.auditlog):
             self.log.debug("restoreFS: before restore remove file %s", f)
             os.remove(f)

--- a/src/lib389/lib389/_entry.py
+++ b/src/lib389/lib389/_entry.py
@@ -14,6 +14,7 @@ import binascii
 from ldap.cidict import cidict
 import sys
 
+from lib389.exceptions import MissingEntryError
 from lib389._constants import *
 from lib389.properties import *
 from lib389.utils import (ensure_str, ensure_bytes, ensure_list_bytes, display_log_data)

--- a/src/lib389/lib389/cli_idm/role.py
+++ b/src/lib389/lib389/cli_idm/role.py
@@ -15,8 +15,9 @@ from lib389.idm.role import (
     FilteredRoles,
     NestedRoles,
     MUST_ATTRIBUTES,
-    MUST_ATTRIBUTES_NESTED
-    )
+    MUST_ATTRIBUTES_NESTED,
+    RDN,
+)
 from lib389.cli_base import (
     populate_attr_arguments,
     _get_arg,

--- a/src/lib389/lib389/idm/role.py
+++ b/src/lib389/lib389/idm/role.py
@@ -21,6 +21,7 @@ MUST_ATTRIBUTES_NESTED = [
     'cn',
     'nsRoleDN'
 ]
+RDN = 'cn'
 
 class RoleState(Enum):
     ACTIVATED = "activated"
@@ -47,7 +48,7 @@ class Role(DSLdapObject):
 
     def __init__(self, instance, dn=None):
         super(Role, self).__init__(instance, dn)
-        self._rdn_attribute = 'cn'
+        self._rdn_attribute = RDN
         self._create_objectclasses = [
             'top',
             'LDAPsubentry',
@@ -256,7 +257,7 @@ class FilteredRole(Role):
 
     def __init__(self, instance, dn=None):
         super(FilteredRole, self).__init__(instance, dn)
-        self._rdn_attribute = 'cn'
+        self._rdn_attribute = RDN
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsFilteredRoleDefinition']
 
         self._protected = False
@@ -291,7 +292,7 @@ class ManagedRole(Role):
 
     def __init__(self, instance, dn=None):
         super(ManagedRole, self).__init__(instance, dn)
-        self._rdn_attribute = 'cn'
+        self._rdn_attribute = RDN
         self._create_objectclasses = ['nsSimpleRoleDefinition', 'nsManagedRoleDefinition']
 
         self._protected = False
@@ -327,7 +328,7 @@ class NestedRole(Role):
     def __init__(self, instance, dn=None):
         super(NestedRole, self).__init__(instance, dn)
         self._must_attributes = MUST_ATTRIBUTES_NESTED
-        self._rdn_attribute = 'cn'
+        self._rdn_attribute = RDN
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsNestedRoleDefinition']
 
         self._protected = False

--- a/src/lib389/lib389/mit_krb5.py
+++ b/src/lib389/lib389/mit_krb5.py
@@ -92,7 +92,7 @@ class MitKrb5(object):
         # Raise a scary warning about eating your krb settings
         if self.warnings:
             print("This will alter / erase your krb5 and kdc settings.")
-            raw_input("Ctrl-C to exit, or press ENTER to continue.")
+            input("Ctrl-C to exit, or press ENTER to continue.")
         print("Kerberos primary password: %s" % self.krb_primary_password)
 
         # If we don't have the directories for this, create them.
@@ -169,7 +169,7 @@ class MitKrb5(object):
         assert(self.check_realm())
         if self.warnings:
             print("This will ERASE your kdc settings.")
-            raw_input("Ctrl-C to exit, or press ENTER to continue.")
+            input("Ctrl-C to exit, or press ENTER to continue.")
         # If the pid exissts, try to kill it.
         if os.path.isfile(self.kdcpid):
             with open(self.kdcpid, 'r') as pfile:

--- a/src/lib389/lib389/paths.py
+++ b/src/lib389/lib389/paths.py
@@ -204,7 +204,7 @@ class Paths(object):
                 raise KeyError('Invalid defaults.inf, missing key %s' % k)
         return True
 
-    def _pretty_exception(err, msg):
+    def _pretty_exception(self, err, msg):
         # Remap LDAPError exceptions to get a nicer stack than python-ldap one
         # Lets grab the data from the exception (a bit painfull but I did not find any better way)
         result = None
@@ -250,7 +250,7 @@ class Paths(object):
                 # Search in config.
                 break
             if err is not None:
-                raise _pretty_exception(err, f"while searching attribute {attr} in entry {dn} on server {self.serverid}")
+                raise self._pretty_exception(err, f"while searching attribute {attr} in entry {dn} on server {self.serverid}")
             # If the server doesn't have it, fall back to our configuration.
             if attr is not None:
                 v = ensure_str(ent.getValue(attr))

--- a/src/lib389/lib389/schema.py
+++ b/src/lib389/lib389/schema.py
@@ -710,7 +710,7 @@ class SchemaLegacy(object):
         if len(matchingRule) != 1:
             # This is an error.
             if json:
-                raise ValueError('Could not find matchingrule: ' + objectclassname)
+                raise ValueError('Could not find matchingrule: ' + mr_name)
             else:
                 return None
         matchingRule = matchingRule[0]

--- a/src/lib389/lib389/tests/cli/conf_plugins/automember_test.py
+++ b/src/lib389/lib389/tests/cli/conf_plugins/automember_test.py
@@ -33,7 +33,6 @@ def test_namenotexists_listdefinition(topology):
     
     with pytest.raises(ldap.NO_SUCH_OBJECT):
         automember_cli.list_definition(topology.standalone, None, topology.logcap.log, args)
-        log.info("Definition for instance {} does not exist".format(args.name))
         
 
 def test_createdefinition(topology):
@@ -69,7 +68,6 @@ def test_invalidattributes_createdefinition(topology):
 
     with pytest.raises(ldap.INVALID_SYNTAX):
         automember_cli.create_definition(topology.standalone, None, topology.logcap.log, args)
-        log.info("There are invalid attributes in the definition.")
 
 
 def test_ifnameexists_createdefinition(topology):
@@ -88,7 +86,6 @@ def test_ifnameexists_createdefinition(topology):
     
     with pytest.raises(ldap.ALREADY_EXISTS):
         automember_cli.create_definition(topology.standalone, None, topology.logcap.log, args)
-        log.info("Definition for instance {} already exists.".format(args.name))
 
 
 def test_editdefinition(topology):
@@ -119,4 +116,3 @@ def test_nonexistentinstance_removedefinition(topology):
 
     with pytest.raises(ldap.NO_SUCH_OBJECT):
         automember_cli.remove_definition(topology.standalone, None, topology.logcap.log, args)
-        log.info("Definition for instance {} does not exist.".format(args.name))

--- a/src/lib389/lib389/tools.py
+++ b/src/lib389/lib389/tools.py
@@ -19,6 +19,7 @@ import time
 import shutil
 import subprocess
 import tarfile
+import urllib
 import re
 import glob
 import pwd
@@ -487,7 +488,7 @@ class DirSrvTools(object):
         """run the remove instance command"""
         prog = os.path.join(_ds_paths.sbin_dir, 'dsctl')
         try:
-            cmd = "%s slapd-%s remove --do-it" % (prog, self.serverid)
+            cmd = "%s slapd-%s remove --do-it" % (prog, dirsrv.serverid)
             log.info('Running: {}'.format(" ".join(cmd)))
             subprocess.check_call(cmd)
         except subprocess.CalledProcessError as e:
@@ -508,7 +509,8 @@ class DirSrvTools(object):
                 instance.prefix
                 instance.backup
         '''
-        instance = lib389.DirSrv(verbose=True)
+        from lib389 import DirSrv
+        instance = DirSrv(verbose=True)
         instance.allocate(args)
 
         return instance


### PR DESCRIPTION
Bug Description:

There are several Python undefined names in lib389. Usually they are
plain errors caused by refactorings, typos, etc.

Fix Description:
- added missing imports
- fixed typos

Note: `lib389.tests.cli.conf_plugin_test` was not fixed yet. I'm not sure
whether it should be removed completely or only
plugin_{enable,disable,get_dn} parts.

fixes: https://github.com/389ds/389-ds-base/issues/5210

Reviewed by: