### PR TITLE
Issue 5193 - Incomplete ruv occasionally returned from ruv search

### DIFF
--- a/ldap/servers/plugins/replication/repl5_ruv.c
+++ b/ldap/servers/plugins/replication/repl5_ruv.c
@@ -1145,6 +1145,10 @@ ruv_to_valuearray(RUV *ruv)
     for (ruv_e = dl_get_first(ruv->elements, &cookie);
          NULL != ruv_e;
          ruv_e = dl_get_next(ruv->elements, &cookie)) {
+        /* Skip over an ruv with no purl */
+        if (NULL == ruv_e->replica_purl) {
+            continue;
+        }
 
         ruv_element_to_string(ruv_e, &bv, NULL, 0);
         value = slapi_value_new_berval(&bv);

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -851,7 +851,11 @@ class RUV(object):
                 # Don't add rids if they have no csn (no writes) yet.
                 rid = pr[1]
                 self._rids.append(rid)
-                self._rid_url[rid] = pr[2]
+                try:
+                    self._rid_url[rid] = pr[2]
+                except IndexError:
+                    self._rids.remove(rid)
+                    continue
                 self._rid_rawruv[rid] = r
                 try:
                     self._rid_csn[rid] = pr[3]


### PR DESCRIPTION
    Bug Description:
    An intermittent condition occurs during cleanallruv (force) CI tests
    which results in an incomplete ruv being returned to the client.This
    generates an "IndexError" in lib389 because of the ruv->replica_purl
    being NULL.

    Fix Description:
    During an ruv search we iterate over the in memory ruv list. Skip over
    an ruv if we detect ruv->replica_purl == NULL.

    Fixes: https://github.com/389ds/389-ds-base/issues/5193

    Reviewed by: @progier389 @mreynolds389  (Thanks)