### PR TITLE
Issue 5214 - CI Test tests/suites/replication/virtual_attribute_repli…

### DIFF
--- a/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
+++ b/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
@@ -15,6 +15,7 @@ from lib389.idm.organization import Organization
 from lib389.topologies import topology_m1c1 as topo
 from lib389.idm.role import FilteredRoles, ManagedRoles
 from lib389.cos import  CosClassicDefinition, CosClassicDefinitions, CosTemplate
+from lib389.replica import ReplicationManager
 
 logging.getLogger(__name__).setLevel(logging.INFO)
 log = logging.getLogger(__name__)
@@ -87,6 +88,10 @@ def test_vattr_on_cos_definition_with_replication(topo, reset_ignore_vattr):
     c.start()
     log.info("Delete a cos definition")
     cosdef.delete()
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    log.info("Check Delete was propagated")
+    repl.wait_for_replication(s, c)
+
     log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs is back to ON over consumer")
     s.restart()
     c.restart()


### PR DESCRIPTION
…cation_test.py

Bug description:
	The test test_vattr_on_cos_definition_with_replication creates
	a COS in a supplier/consumer topology.
        With that virtual attribute, nsslapd-ignore-virtual-attrs gets
        the value OFF.
        Then it deletes the COS on the supplier but does not wait
        that the DEL is propagated to the consumer before restarting
        the consumer.
        The consequence is that at startup, consumer may keep
        nsslapd-ignore-virtual-attrs=OFF

Fix description:
        Wait that replication is in sync before restarting the consumer

relates: #5214

Reviewed by:

Platforms tested: F34