### PR TITLE
Issue 5186 - UI - Fix SASL Mapping regex test feature

### DIFF
--- a/src/cockpit/389-console/src/lib/server/serverModals.jsx
+++ b/src/cockpit/389-console/src/lib/server/serverModals.jsx
@@ -125,7 +125,7 @@ export class SASLMappingModal extends React.Component {
                         <GridItem span={4}>
                             <Button
                                 className="ds-left-margin"
-                                isDisabled={this.props.testBtnDisabled}
+                                isDisabled={this.props.testBtnDisabled || this.props.error.saslMapRegex}
                                 variant="primary"
                                 onClick={this.props.handleTestRegex}
                             >


### PR DESCRIPTION
Description:

If the regex is invalid you are still able to click on the "Test"
button which then crashes the UI.  THe Test button needs to be disabled
if the regex is invalid

relates: https://github.com/389ds/389-ds-base/issues/5186
