### PR TITLE
Issue 5217 - Simplify instance creation and administration by non root

### DIFF
--- a/dirsrvtests/tests/suites/setup_ds/dscreate_test.py
+++ b/dirsrvtests/tests/suites/setup_ds/dscreate_test.py
@@ -7,6 +7,11 @@
 # --- END COPYRIGHT BLOCK ---
 import sys
 import pytest
+import subprocess
+import logging
+import pwd
+import re
+from tempfile import TemporaryDirectory
 from lib389 import DirSrv
 from lib389.cli_base import LogCapture
 from lib389.instance.setup import SetupDs
@@ -18,10 +23,17 @@ from lib389.utils import ds_is_older
 pytestmark = [pytest.mark.tier0,
               pytest.mark.skipif(ds_is_older('1.4.1.2'), reason="Needs a compatible systemd unit, see PR#50213")]
 
+DEBUGGING = os.getenv('DEBUGGING', False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
 INSTANCE_PORT = 54321
 INSTANCE_SECURE_PORT = 54322
 INSTANCE_SERVERID = 'standalone'
-DEBUGGING = True
+#DEBUGGING = True
 
 MAJOR, MINOR, _, _, _ = sys.version_info
 
@@ -115,3 +127,133 @@ def test_setup_ds_minimal(topology):
     topology.standalone.start()
     # Okay, actually remove the instance
     remove_ds_instance(topology.standalone)
+
+def write_file(fname, pwd, is_runnable, lines):
+    log.debug(f'Creating file {fname} with:')
+    with open(fname, 'wt') as f:
+        for line in lines:
+            log.debug(line)
+            f.write(line+'\n')
+        os.chown(fname, pwd.pw_uid, pwd.pw_gid)
+        if (is_runnable):
+            os.chmod(fname, 0o755)
+    log.debug(f'End of file: {fname}')
+
+def test_setup_ds_as_non_root():
+    """Test creating an instance as a non root user
+
+    :id: c727998e-a960-11ec-898e-482ae39447e5
+    :setup: no instance
+    :steps:
+        1. Add linux user NON_ROOT_USER if it does not already exist
+        2. Create a temporary directory
+        3. Create test.sh script that
+             Set Paths
+             Run dscreate ds-root
+             Run dscreate from-file
+             Add a backend
+             Search users in backend and store output in a file
+             Stop the instance
+        4. Create a dscreate template file
+        5. Run su - NON_ROOT_USER test.sh
+        6. Check that pid file exists and kill the associated process
+        7. Check demo_user is in the search result
+        8. Check that test.sh returned 0
+        9. (Implicit task): remove the temporary
+
+
+    :expectedresults:
+        1. No error.
+        2. No error.
+        3. No error.
+        4. No error.
+        5. No error.
+        6. Should fail to kill the process (That is supposed to be stopped)
+        7. demo_user should be in search result
+        8. return code should be 0
+        9. No error.
+
+    """
+
+    # Add linux user NON_ROOT_USER if it does not already exist
+    NON_ROOT_USER='user1'
+    try:
+        pwd_nru = pwd.getpwnam(NON_ROOT_USER)
+    except KeyError:
+        subprocess.run(('/usr/sbin/useradd', NON_ROOT_USER))
+        pwd_nru = pwd.getpwnam(NON_ROOT_USER)
+
+    # Create a temporary directory
+    with TemporaryDirectory() as dir:
+        os.chown(dir, pwd_nru.pw_uid, pwd_nru.pw_gid)
+        # Prepare test script
+        if DEBUGGING:
+            dbg_script = (
+                'savedir()',
+                '{',
+                f'    cp -R {dir} /tmp/dbg_test_setup_ds_as_non_root',
+                '}',
+                'trap savedir exit',
+                'trap savedir err',
+            )
+        else:
+            dbg_script = ( )
+        # Export current path and python path in test script
+        # to insure that right binary/libraries are used
+        path = os.environ['PATH']
+        pythonpath = os.getenv('PYTHONPATH', '')
+        write_file(f'{dir}/test.sh', pwd_nru, True, (
+            '#!/usr/bin/bash',
+            'set -x',
+            *dbg_script,
+            f'export PATH="{dir}/bin:{path}:$PATH"',
+            f'export PYTHONPATH="{pythonpath}:$PYTHONPATH"',
+            'set -e # Exit on error',
+            'type dscreate',
+            f'dscreate ds-root {dir}/root {dir}/bin',
+            'hash -d dscreate # Remove dscreate from hash to use the new one',
+            'type dscreate',
+            f'dscreate from-file {dir}/t',
+            f'dsconf {INSTANCE_SERVERID} backend create --suffix dc=foo,dc=bar --be-name=foo --create-entries',
+            f'ldapsearch -x -H ldap://localhost:{INSTANCE_PORT} -D "cn=directory manager" -w {PW_DM} -b dc=foo,dc=bar "uid=*" | tee {dir}/search.out',
+            f'dsctl {INSTANCE_SERVERID} stop',
+            'exit 0',
+        ))
+        # Prepare dscreate template
+        write_file(f'{dir}/t', pwd_nru, False, (
+            '[general]',
+            '[slapd]',
+            f'port = {INSTANCE_PORT}',
+            f'instance_name = {INSTANCE_SERVERID}',
+            f'root_password = {PW_DM}',
+            f'secure_port = {INSTANCE_SECURE_PORT}',
+            '[backend-userroot]',
+            'create_suffix_entry = True',
+            'require_index = True',
+            'sample_entries = yes',
+            'suffix = dc=example,dc=com',
+        ))
+        # Run the script as NON_ROOT_USER
+        log.debug(f'Run script {dir}/test.sh as user {NON_ROOT_USER}')
+        result = subprocess.run(('/usr/bin/su', '-', NON_ROOT_USER, f'{dir}/test.sh'), capture_output=True, text=True)
+        log.info(f'test.sh stdout is: {str(result.stdout)}')
+        log.info(f'test.sh stderr is: {str(result.stderr)}')
+
+        # Check that pid file exists
+        log.debug(f'Check that pid file {dir}/root/run/dirsrv/slapd-{INSTANCE_SERVERID}.pid exist')
+        pid_filename = f'{dir}/root/run/dirsrv/slapd-{INSTANCE_SERVERID}.pid'
+        with open(pid_filename, 'rt') as f:
+            pid = int(f.readline())
+        assert pid>1
+        # Signal the 389ds instance to stop (and raise an exception if we can do that)
+        # because the process should already be stopped.
+        log.debug(f'Check that instance with pid {pid} is stopped')
+        with pytest.raises(OSError) as e_info:
+            os.kill(pid, 15)
+        # Let check that demo_user is in the search result
+        log.debug(f'Check that {dir}/search.out contains with pid {pid} is stopped')
+        with open(f'{dir}/search.out', 'rt') as f:
+            assert(re.findall('demo_user', f.read()))
+        log.debug(f'Check that Wtest.sh finihed successfully.')
+        assert(result.returncode == 0)
+    # Instance got deleted by the with cleanup

--- a/src/lib389/cli/dscreate
+++ b/src/lib389/cli/dscreate
@@ -14,12 +14,23 @@ import argparse, argcomplete
 import sys
 import signal
 import json
+from textwrap import dedent
 from lib389 import DirSrv
 from lib389.cli_ctl import instance as cli_instance
 from lib389.cli_base import setup_script_logger
 from lib389.cli_base import format_error_to_dict
 
-parser = argparse.ArgumentParser()
+
+epilog = """
+            Example of install by a non root user:
+                PATH=$HOME/bin:$PATH # Should be in .profile
+                dscreate ds-root $HOME/mydsroot $HOME/bin
+                hash -d dscreate # bash command to insure new dscreate wrapper will be used
+                dscreate interactive
+                # Note: Make sure to use non priviledged port number (i.e > 1000)
+         """
+
+parser = argparse.ArgumentParser(epilog=dedent(epilog), formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('-v', '--verbose',
                     help="Display verbose operation tracing during command execution",
                     action='store_true', default=False, dest='verbose')
@@ -40,9 +51,13 @@ interactive_parser.set_defaults(func=cli_instance.instance_create_interactive)
 template_parser = subparsers.add_parser('create-template', help="Display an example inf answer file, or provide a file name to write it to disk.")
 template_parser.add_argument('--advanced', action='store_true', default=False,
     help="Add advanced options to the template - changing the advanced options may make your instance install fail")
-template_parser.add_argument('template_file', nargs="?", default=None, help="Write example template to this file")
+template_parser.add_argument('template_file', nargs="?", default='None', help="Write example template to this file")
 template_parser.set_defaults(func=cli_instance.instance_example)
 
+subtree_parser = subparsers.add_parser('ds-root', help="Prepare a root directory in which non root user can create, run and administer instances.")
+subtree_parser.add_argument('root_dir', default=None, help="A directory that will be used as virtual root.")
+subtree_parser.add_argument('bin_dir', nargs="?", default=None, help="A directory in which administration wrappers are installed. (Should be in PATH)")
+subtree_parser.set_defaults(func=cli_instance.prepare_ds_root)
 argcomplete.autocomplete(parser)
 
 # handle a control-c gracefully

--- a/src/lib389/lib389/cli_ctl/instance.py
+++ b/src/lib389/lib389/cli_ctl/instance.py
@@ -7,8 +7,11 @@
 # --- END COPYRIGHT BLOCK ---
 
 import os
+import pwd
+import grp
 import json
 import time
+from shutil import copytree, copyfile
 from lib389 import DirSrv
 from lib389.instance.setup import SetupDs
 from lib389.utils import get_instance_list
@@ -117,6 +120,135 @@ def instance_example(inst, log, args):
         print(g2b.collect_help(advanced=args.advanced))
         print(s2b.collect_help(advanced=args.advanced))
         print(b2b.collect_help(advanced=args.advanced))
+    return True
+
+
+def prepare_ds_root(inst, log, args):
+    def get_dest(path):
+        # Compute the destination path from original path
+        if path.startswith('/usr/'):
+            return f'{args.root_dir}/{path[5:]}'
+        return f'{args.root_dir}/{path}'
+
+    def copy_and_substitute(file, sub_list):
+        # Copy .inf file and apply all sub_list modifiers to each line
+        #  Supported modifier are:
+        #    (WORD, pattern, value) ==> Replace first occurance of pattern by value
+        #    (LINE, pattern, value) ==> Replace line statring with pattern
+        #                                 by: pattern = value
+        log.debug(f'Update {get_dest(file)} from {file}')
+        with open(file, 'rt') as fin:
+            with open(get_dest(file), 'wt') as fout:
+                for line in fin:
+                    for k, p, v in sub_list:
+                        if k == 'WORD':
+                            line = line.replace(p, v, 1)
+                        if k == 'LINE':
+                            if line.startswith(p):
+                                line = f'{p} = {v}\n'
+                    fout.write(line)
+
+    def copy_and_skip_entry(file, pattern_list):
+        # copy ldif file skipping entries containing a pattern from pattern_list
+        class Entry:
+            # Helper class to handle the ldif entries
+            def __init__(self):
+                self.skip = False
+                self.entry = ""
+
+            def add_line(self, line):
+                self.entry += line
+                for p in pattern_list:
+                    if p in line:
+                        self.skip = True
+
+            def write(self, fout):
+                if not self.skip:
+                    fout.write(self.entry)
+
+        log.debug(f'Update {get_dest(file)} from {file}')
+        with open(file, 'rt') as fin:
+            with open(get_dest(file), 'wt') as fout:
+                entry = Entry()
+                for line in fin:
+                    entry.add_line(line)
+                    if line == "\n":
+                        entry.write(fout)
+                        entry = Entry()
+                entry.write(fout)
+
+    uid = os.getuid()
+    if uid == 0:
+        raise ValueError("ds-root subcommand should not be run by root user.")
+    user = pwd.getpwuid(uid).pw_name
+    group = grp.getgrgid(os.getgid()).gr_name
+
+    # Perform consistency checks then create the wrappers
+    if args.bin_dir:
+        found = False
+        for path in os.environ['PATH'].split(':'):
+            if path.startswith('.'):
+                continue
+            if path == args.bin_dir:
+                found = True
+                break
+            if os.path.exists(f'{path}/dsconf'):
+                log.error(f'bin_dir argument should be before {path} in PATH')
+                return False
+        if not found:
+            log.error(f'bin_dir argument should be in PATH')
+            return False
+        os.makedirs(args.bin_dir, 0o755, True)
+        for wrapper in ['dsconf',  'dscreate',  'dsctl',  'dsidm']:
+            log.debug(f'Creating {args.bin_dir}/{wrapper} wrapper')
+            with open(f'{args.bin_dir}/{wrapper}', 'wt') as f:
+                f.write('#!/bin/sh\n')
+                f.write(f'export PATH="{args.root_dir}:$PATH"\n')
+                f.write(f'export PREFIX="{args.root_dir}"\n')
+                f.write(f'export INSTALL_PREFIX="{args.root_dir}"\n')
+                p = "${@}"
+                f.write(f'exec /usr/sbin/{wrapper} "{p}"\n')
+            os.chmod(f'{args.bin_dir}/{wrapper}', 0o755)
+    os.makedirs(args.root_dir, 0o700, True)
+    # Copy subtrees
+    for dir in ['/usr/share/dirsrv/', '/etc/dirsrv/config',  '/etc/dirsrv/schema', ]:
+        destdir = get_dest(dir)
+        log.debug(f'Copying {dir} into {destdir}')
+        os.makedirs(destdir, 0o755, True)
+        copytree(dir, destdir, dirs_exist_ok=True)
+    # Create empty directories
+    for dir in ['/tmp', ]:
+        destdir = get_dest(dir)
+        log.debug(f'Creating directory {destdir}')
+        os.makedirs(destdir, 0o755, True)
+    # Copy binaries
+    for bin in ['/usr/sbin/ns-slapd']:
+        destbin = get_dest(bin)
+        log.debug(f'Copying {bin} into {destbin}')
+        os.makedirs(os.path.dirname(destbin), 0o755, True)
+        copyfile(bin, destbin)
+    # And finally, update the template files
+    for dse in ('/usr/share/dirsrv/data/template-dse-minimal.ldif', '/usr/share/dirsrv/data/template-dse.ldif'):
+        copy_and_skip_entry(dse, ('libpwdchan-plugin',))
+    # Use PO and PF to escape { } in formatted strings
+    PO = '{'
+    PF = '}'
+    copy_and_substitute('/usr/share/dirsrv/inf/defaults.inf', (
+            ('WORD', ' /', f' {args.root_dir}/'),
+            ('LINE', 'with_selinux', 'no'),
+            ('LINE', 'with_systemd', '0'),
+            ('LINE', 'user', user),
+            ('LINE', 'group', group),
+            ('LINE', 'prefix', args.root_dir),
+            ('LINE', 'bin_dir', '/usr/bin'),
+            ('LINE', 'sbin_dir', '/usr/sbin'),
+            ('LINE', 'lib_dir', '/usr/lib64'),
+            ('LINE', 'data_dir', f'{args.root_dir}/share'),
+            ('LINE', 'inst_dir', f'{args.root_dir}/lib64/slapd-{PO}instance_name{PF}'),
+            ('LINE', 'plugin_dir', '/usr/lib64/dirsrv/plugins'),
+            ('LINE', 'system_schema_dir', f'{args.root_dir}/share/dirsrv/schema'),
+       ))
+
     return True
 
 


### PR DESCRIPTION
Goal: 
    Allow any user to easily create and administrate directory server instances

Solution:
    Add a ds-root subcommand to dscreate:
```
       ds-root             Prepare a root directory in which non root user can create, run and administrate instances.
       usage: dscreate ds-root [-h] root_dir [bin_dir]

       positional arguments:
         root_dir    A directory that will be used as virtual root.
         bin_dir     A directory in which administration wrappers are installed. (Should be in PATH)

      Example of install by a non root user:
          PATH=$HOME/bin:$PATH # Should be in .profile
          dscreate ds-root $HOME/mydsroot $HOME/bin
          hash -d dscreate # bash command to insure new dscreate wrapper will be used
          dscreate interactive
          # Note: Make sure to use non priviledged port number (i.e > 1000)

```
   
   This command prepare a subtree root directory for the directory server instances) and optionally a set of wrapper around administrative commands.
   

Issue: [5217](https://github.com/389ds/389-ds-base/issues/5217)
Reviewed by: mreynolds
   