### PR TITLE
Issue 5230 - Race condition in RHDS disk monitoring functions

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -206,7 +206,9 @@ static int time_shutdown = 0;
 char *
 disk_mon_get_mount_point(char *dir)
 {
+    struct mntent mntbuf;
     struct mntent *mnt;
+    char buf[4096 + 1] = {0}; /* enough for 2 paths */
     struct stat s;
     dev_t dev_id;
     FILE *fp;
@@ -219,7 +221,7 @@ disk_mon_get_mount_point(char *dir)
     if ((fp = setmntent("/proc/mounts", "r")) == NULL) {
         return NULL;
     }
-    while ((mnt = getmntent(fp))) {
+    while ((mnt = getmntent_r(fp, &mntbuf, buf, 4096))) {
         if (stat(mnt->mnt_dir, &s) != 0) {
             continue;
         }


### PR DESCRIPTION
Bug description:
	Disk monitoring fetch file system info using
        getmntent system call.
        It should rather use MT safe getmnent_r

Fix description:
	use getmntent_r

relates: #5230

Reviewed by:

Platforms tested: F35