### PR TITLE
Issue 5227 - UI - No way to move back to Get Started step

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
@@ -62,7 +62,7 @@ class AddGroup extends React.Component {
             ldifArray: [],
             resultVariant: 'default',
             commandOutput: "",
-            stepIdReached: 0,
+            stepIdReached: 1,
             noEmptyValue: false,
             adding: true,
             posixGroup: false,
@@ -99,10 +99,10 @@ class AddGroup extends React.Component {
             this.setState({
                 stepIdReached: this.state.stepIdReached < id ? id : this.state.stepIdReached
             });
-            if (id === 4) {
+            if (id === 5) {
                 // Generate the LDIF data.
                 this.generateLdifData();
-            } else if (id === 5) {
+            } else if (id === 6) {
                 // Create the LDAP entry.
                 const myLdifArray = this.state.ldifArray;
                 createLdapEntry(this.props.editorLdapServer,
@@ -132,7 +132,7 @@ class AddGroup extends React.Component {
         };
 
         this.onBack = ({ id }) => {
-            if (id === 4) {
+            if (id === 5) {
                 this.updateValuesTableRows(true);
             }
         };
@@ -598,37 +598,43 @@ class AddGroup extends React.Component {
         const addGroupSteps = [
             {
                 id: 1,
-                name: 'Select Group Type',
-                component: groupSelectStep,
-                canJumpTo: stepIdReached >= 1 && stepIdReached < 5,
+                name: this.props.firstStep[0].name,
+                component: this.props.firstStep[0].component,
+                canJumpTo: stepIdReached >= 1 && stepIdReached < 6,
                 hideBackButton: true
             },
             {
                 id: 2,
-                name: 'Select Name',
-                component: groupNameStep,
-                canJumpTo: stepIdReached >= 2 && stepIdReached < 5,
-                enableNext: groupName === '' ? false : true,
+                name: 'Select Group Type',
+                component: groupSelectStep,
+                canJumpTo: stepIdReached >= 2 && stepIdReached < 6,
             },
             {
                 id: 3,
-                name: 'Add Members',
-                component: selectMembersStep,
-                canJumpTo: stepIdReached >= 3 && stepIdReached < 5,
+                name: 'Select Name',
+                component: groupNameStep,
+                canJumpTo: stepIdReached >= 3 && stepIdReached < 6,
+                enableNext: groupName === '' ? false : true,
             },
             {
                 id: 4,
-                name: 'Create Group',
-                component: groupCreationStep,
-                nextButtonText: 'Create',
-                canJumpTo: stepIdReached >= 4 && stepIdReached < 5
+                name: 'Add Members',
+                component: selectMembersStep,
+                canJumpTo: stepIdReached >= 4 && stepIdReached < 6,
             },
             {
                 id: 5,
+                name: 'Create Group',
+                component: groupCreationStep,
+                nextButtonText: 'Create',
+                canJumpTo: stepIdReached >= 5 && stepIdReached < 6
+            },
+            {
+                id: 6,
                 name: 'Review Result',
                 component: groupReviewStep,
                 nextButtonText: 'Finish',
-                canJumpTo: stepIdReached >= 5,
+                canJumpTo: stepIdReached >= 6,
                 hideBackButton: true,
                 enableNext: !this.state.adding
             }

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addLdapEntry.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addLdapEntry.jsx
@@ -99,17 +99,17 @@ class AddLdapEntry extends React.Component {
             });
             // The function updateValuesTableRows() is called upon new seletion(s)
             // Make sure the values table is updated in case no selection was made.
-            if (id === 2) {
+            if (id === 3) {
                 // Just call this function in order to make sure the values table is up-to-date
                 // even after navigating back and forth.
                 this.updateAttributeTableRows();
-            } else if (id === 3) {
+            } else if (id === 4) {
                 // Remove attributes from removed objectclasses
                 this.cleanUpEntry();
-            } else if (id === 4) {
+            } else if (id === 5) {
                 // Generate the LDIF data at step 4.
                 this.generateLdifData();
-            } else if (id === 5) {
+            } else if (id === 6) {
                 // Create the LDAP entry.
                 createLdapEntry(this.props.editorLdapServer,
                     this.state.ldifArray,
@@ -892,38 +892,45 @@ class AddLdapEntry extends React.Component {
         const addEntrySteps = [
             {
                 id: 1,
-                name: 'Select ObjectClasses',
-                component: objectClassStep,
-                canJumpTo: stepIdReached >= 1 && stepIdReached < 5,
-                enableNext: selectedObjectClasses.length > 0,
+                name: this.props.firstStep[0].name,
+                component: this.props.firstStep[0].component,
+                canJumpTo: stepIdReached >= 1 && stepIdReached < 6,
+                hideBackButton: true
             },
             {
                 id: 2,
-                name: 'Select Attributes',
-                component: attributeStep,
-                canJumpTo: stepIdReached >= 2 && stepIdReached < 5,
-                enableNext: selectedAttributes.length > 0,
+                name: 'Select ObjectClasses',
+                component: objectClassStep,
+                canJumpTo: stepIdReached >= 2 && stepIdReached < 6,
+                enableNext: selectedObjectClasses.length > 0,
             },
             {
                 id: 3,
-                name: 'Edit Values',
-                component: entryValuesStep,
-                canJumpTo: stepIdReached >= 3 && stepIdReached < 5,
-                enableNext: validMods
+                name: 'Select Attributes',
+                component: attributeStep,
+                canJumpTo: stepIdReached >= 3 && stepIdReached < 6,
+                enableNext: selectedAttributes.length > 0,
             },
             {
                 id: 4,
-                name: 'LDIF Statements',
-                component: ldifStatementsStep,
-                nextButtonText: 'Create Entry',
-                canJumpTo: stepIdReached >= 4 && stepIdReached < 5
+                name: 'Edit Values',
+                component: entryValuesStep,
+                canJumpTo: stepIdReached >= 4 && stepIdReached < 6,
+                enableNext: validMods
             },
             {
                 id: 5,
+                name: 'LDIF Statements',
+                component: ldifStatementsStep,
+                nextButtonText: 'Create Entry',
+                canJumpTo: stepIdReached >= 5 && stepIdReached < 6
+            },
+            {
+                id: 6,
                 name: 'Review Result',
                 component: entryReviewStep,
                 nextButtonText: 'Finish',
-                canJumpTo: stepIdReached > 5,
+                canJumpTo: stepIdReached >= 6,
                 hideBackButton: true,
                 enableNext: !this.state.adding,
             }

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
@@ -79,7 +79,7 @@ class AddRole extends React.Component {
             commandOutput: '',
             resultVariant: 'default',
             allAttributesSelected: false,
-            stepIdReached: 0,
+            stepIdReached: 1,
             // currentStepId: 1,
             itemCountAddRole: 0,
             pageAddRole: 1,
@@ -149,17 +149,17 @@ class AddRole extends React.Component {
             this.setState({
                 stepIdReached: this.state.stepIdReached < id ? id : this.state.stepIdReached
             });
-            if (id === 3) {
+            if (id === 4) {
                 // Update the attributes table.
                 this.updateAttributesTableRows();
                 this.updateValuesTableRows();
-            } else if (id === 4) {
+            } else if (id === 5) {
                 // Update the values table.
                 this.updateValuesTableRows();
-            } else if (id === 5) {
+            } else if (id === 6) {
                 // Generate the LDIF data.
                 this.generateLdifData();
-            } else if (id === 6) {
+            } else if (id === 7) {
                 // Create the LDAP entry.
                 const myLdifArray = this.state.ldifArray;
                 createLdapEntry(this.props.editorLdapServer,
@@ -189,7 +189,7 @@ class AddRole extends React.Component {
         };
 
         this.onBack = ({ id }) => {
-            if (id === 4) {
+            if (id === 5) {
                 // true ==> Do not check the attribute selection when navigating back.
                 this.updateValuesTableRows(true);
             }
@@ -945,45 +945,52 @@ class AddRole extends React.Component {
         const addRoleSteps = [
             {
                 id: 1,
+                name: this.props.firstStep[0].name,
+                component: this.props.firstStep[0].component,
+                canJumpTo: stepIdReached >= 1 && stepIdReached < 7,
+                hideBackButton: true
+            },
+            {
+                id: 2,
                 name: 'Select Name & Type',
                 component: namingValAndTypeStep,
                 enableNext: namingVal === '' ? false : true,
-                hideBackButton: true
+                canJumpTo: stepIdReached >= 2 && stepIdReached < 7,
             },
             ...(roleType === 'nested' ? [
                 {
-                    id: 2,
+                    id: 3,
                     name: 'Add Nested Roles',
                     component: addRolesStep,
-                    canJumpTo: stepIdReached >= 2 && stepIdReached < 6
+                    canJumpTo: stepIdReached >= 3 && stepIdReached < 7
                 },
             ] : []),
             {
-                id: 3,
+                id: 4,
                 name: 'Select Attributes',
                 component: roleAttributesStep,
-                canJumpTo: stepIdReached >= 3 && stepIdReached < 6
-            },
-            {
-                id: 4,
-                name: 'Set Values',
-                component: roleValuesStep,
-                canJumpTo: stepIdReached >= 4 && stepIdReached < 6,
-                enableNext: noEmptyValue
+                canJumpTo: stepIdReached >= 4 && stepIdReached < 7
             },
             {
                 id: 5,
-                name: 'Create Role',
-                component: roleCreationStep,
-                nextButtonText: 'Create',
-                canJumpTo: stepIdReached >= 5 && stepIdReached < 6
+                name: 'Set Values',
+                component: roleValuesStep,
+                canJumpTo: stepIdReached >= 5 && stepIdReached < 7,
+                enableNext: noEmptyValue
             },
             {
                 id: 6,
+                name: 'Create Role',
+                component: roleCreationStep,
+                nextButtonText: 'Create',
+                canJumpTo: stepIdReached >= 6 && stepIdReached < 7
+            },
+            {
+                id: 7,
                 name: 'Review Result',
                 component: roleReviewStep,
                 nextButtonText: 'Finish',
-                canJumpTo: stepIdReached >= 5,
+                canJumpTo: stepIdReached >= 7,
                 hideBackButton: true,
                 enableNext: !this.state.adding
             }


### PR DESCRIPTION
Bug Description: There is no way to move back to the main New Entry
landing page. You can when entering A New User, but not when
entering Group, Organisational Unit, Role or a new custom entry.

Fix Desciption: Add an initial step to Group, Organisational Unit,
Role or a new custom entry creation.
Make sure that stepIdReached initialized with '1' value.

Fixes: https://github.com/389ds/389-ds-base/issues/5227

Reviewed by: ?