### PR TITLE
Issue 5237 - audit-ci: Cannot convert undefined or null to object

### DIFF
--- a/src/cockpit/389-console/package.json
+++ b/src/cockpit/389-console/package.json
@@ -21,7 +21,7 @@
     "@babel/eslint-parser": "^7.13.14",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
-    "audit-ci": "^3.1.1",
+    "audit-ci": "^6.1.1",
     "babel-loader": "^8.0.6",
     "cockpit": "^0.1.1",
     "compression-webpack-plugin": "^9.0.0",


### PR DESCRIPTION
Description:
Update audit-ci to the latest version that works with NPM >=7.

Fixes: https://github.com/389ds/389-ds-base/issues/5237

Reviewed by: ???