### PR TITLE
Issue 5239 - Nightly copr builds are broken

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,6 +6,13 @@ srpm:
 	# Install build dependencies
 	dnf install -y dnf-plugins-core
 	dnf builddep -y --skip-broken --spec rpmbuild/SPECS/389-ds-base.spec --best --allowerasing --setopt=install_weak_deps=False
+	# chown files in current working directory to root:root
+	# because when npm is run as root, scripts are always run
+	# with the effective uid and gid of the working directory owner.
+	# copr-rpmbuild runs mock with CAP_SETUID and CAP_SETGID
+	# capabilities dropped, and build commands are executed as root.
+	# So npm fails if current working directory is not owned by root.
+	chown -R root:root .
 	# Generate srpm
 	SKIP_AUDIT_CI=1 make -f rpm.mk srpms
 	


### PR DESCRIPTION
Bug Description:
Nightly builds started to fail during srpm generation step

`copr-rpmbuild` executes mock with `mock-source-build.cfg`
config that drops a lot of capabilities, including CAP_SETUID and
CAP_SETGID, used by npm.

From
https://github.com/npm/cli/blob/latest/changelogs/CHANGELOG-7.md#all-lifecycle-scripts

> The user, group, uid, gid, and unsafe-perms configurations are
> no longer relevant. When npm is run as root, scripts are always
> run with the effective uid and gid of the working directory owner.

Files had `root:mockbuild` ownership, and `npm` was running under
root, so `npm` tried to set gid to `mockbuild` user and was denied.

Fix Description:
We should always chown files in $CWD to `root:root` since
the `make srpm` step is executed under root user.

Fixes: https://github.com/389ds/389-ds-base/issues/5239

Reviewed by: ???