### PR TITLE
Issue 5249 - dscontainer: ImportError: cannot import name 'get_default_db_lib' from 'lib389.utils'

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -43,7 +43,6 @@ from lib389.passwd import password_generate
 from lib389.nss_ssl import NssSsl, CERT_NAME
 from lib389.paths import Paths
 from lib389.config import LDBMConfig
-from lib389.utils import get_default_db_lib
 from lib389._constants import (
     DSRC_CONTAINER,
     CONTAINER_TLS_SERVER_KEY,
@@ -90,17 +89,14 @@ def _begin_environment_config():
     # TODO: Should we set replication agreements from env?
     autotune_pct = os.getenv("DS_MEMORY_PERCENTAGE", None)
     if autotune_pct is not None:
-        if get_default_db_lib() == "mdb":
-            log.warning("DS_MEMORY_PERCENTAGE is present, but setting entry cache is not supported for MDB")
-        else:
-            try:
-                autotune_pct = int(autotune_pct)
-            except:
-                log.warning("Invalid DS_MEMORY_PERCENTAGE - resetting to system default value")
-                autotune_pct = 0
-            log.debug("Setting LDBM Autotune Percentage to: %s", autotune_pct)
-            ldbmconfig = LDBMConfig(inst)
-            ldbmconfig.set("nsslapd-cache-autosize", str(autotune_pct))
+        try:
+            autotune_pct = int(autotune_pct)
+        except:
+            log.warning("Invalid DS_MEMORY_PERCENTAGE - resetting to system default value")
+            autotune_pct = 0
+        log.debug("Setting LDBM Autotune Percentage to: %s", autotune_pct)
+        ldbmconfig = LDBMConfig(inst)
+        ldbmconfig.set("nsslapd-cache-autosize", str(autotune_pct))
 
     inst.close()
 


### PR DESCRIPTION
Description:
A cherry picked commit from master ebc8ff4 introduced a regression
in 389-ds-base-2.0 branch:

```
Traceback (most recent call last):
  File "/usr/libexec/dirsrv/dscontainer", line 46, in <module>
    from lib389.utils import get_default_db_lib
ImportError: cannot import name 'get_default_db_lib' from 'lib389.utils' (/usr/lib/python3.10/site-packages/lib389/utils.py)
```

`get_default_db_lib()` and support for mdb doesn't exist in 2.0,
so we should remove this check from `dscontainer`.

Fixes: https://github.com/389ds/389-ds-base/issues/5249