### PR TITLE
Issue 5252 - During DEL, vlv search can erroneously return NULL candi…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -1095,6 +1095,15 @@ vlv_build_idl(backend *be, PRUint32 start, PRUint32 stop, dbi_db_t *db __attribu
         idl_append(idl, *(ID *)data.data);
         if (++recno <= stop + 1) {
             err = dblayer_cursor_op(dbc, DBI_OP_NEXT, &key, &data);
+            if (err == DBI_RC_NOTFOUND) {
+                /* The provided limit (stop) is outdated and there
+                 * is no more record after the current limit.
+                 * This can occur if entries are deleted at the same time
+                 * of vlv search.
+                 */
+                err = 0;
+                break;
+            }
         }
     }
     if (err != 0) {


### PR DESCRIPTION
…date

Bug description:
	vlv_build_idl builds a candidate list from a starting to ending
	points. By the time the ending point is computed (like in
        vlvIndex_get_indexlength) and is finally used, the actual
        number of record may reduced. In such case the ending point
        does no longer exist, and cursor(NEXT) hits the end
        of the index (DBI_RC_NOTFOUND).
        The if that occurs, the current candidate list is valid
        and should be returned.

Fix description:
	On DBI_RC_NOTFOUND, exit from the start to end loop
        without error.

relates: https://github.com/389ds/389-ds-base/issues/5252

Reviewed by:

Platforms tested: