### PR TITLE
Issue 5257 - nsslapd-subtree-rename-switch option broken

### DIFF
--- a/dirsrvtests/tests/suites/replication/encryption_cl5_test.py
+++ b/dirsrvtests/tests/suites/replication/encryption_cl5_test.py
@@ -64,7 +64,7 @@ def _check_unhashed_userpw_encrypted(inst, change_type, user_dn, user_pw, is_enc
     count = 0
     for entry in dbscanOut.split(b'dbid: '):
         if ensure_bytes('operation: {}'.format(change_type)) in entry and\
-           ensure_bytes(ATTRIBUTE) in entry and ensure_bytes(user_dn) in entry:
+           ensure_bytes(ATTRIBUTE) in entry and ensure_bytes(user_dn.lower()) in entry.lower():
             count += 1
             user_pw_attr = ensure_bytes('{}: {}'.format(ATTRIBUTE, user_pw))
             if is_encrypted:

--- a/dirsrvtests/tests/suites/replication/moddn_off_and_entrydn_test.py
+++ b/dirsrvtests/tests/suites/replication/moddn_off_and_entrydn_test.py
@@ -1,0 +1,107 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import pytest
+import os
+import time
+from lib389._constants import (
+    DN_CONFIG_LDBM, DEFAULT_SUFFIX, DEFAULT_BENAME,
+    REPLICA_PRECISE_PURGING, REPLICA_PURGE_DELAY, REPLICA_PURGE_INTERVAL)
+from lib389.topologies import topology_m1 as topo
+from lib389.dseldif import DSEldif
+from lib389.tombstone import Tombstones
+from lib389.idm.user import UserAccounts, TEST_USER_PROPERTIES
+
+pytestmark = pytest.mark.tier1
+
+def test_import_with_moddn_off(topo):
+    """Test that imports and replication work after switching to entrydn index
+
+    :id: c92d45cd-1a76-483b-a386-7ad0445f3c37
+    :setup: 2 Supplier Instances
+    :steps:
+        1. Create tombstone entry
+        2. Export db to ldif
+        3. Edit dse.ldif to disable subtree rename
+        4. Import ldif
+        5. Create new tombstone
+        6. Test tombstone purging
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+
+    m1 = topo.ms['supplier1']
+
+    users = UserAccounts(m1, DEFAULT_SUFFIX)
+    user = users.create(properties=TEST_USER_PROPERTIES)
+    tombstones = Tombstones(m1, DEFAULT_SUFFIX)
+    assert len(tombstones.list()) == 0
+
+    # Create tombstone
+    user.delete()
+    assert len(tombstones.list()) == 1
+    assert len(users.list()) == 0
+
+    ts = tombstones.get('testuser')
+    assert ts.exists()
+
+    # Stop server and export db
+    m1.stop()
+    ldif_dir = m1.get_ldif_dir()
+    ldif_file = ldif_dir + '/test.ldif'
+    assert m1.db2ldif(DEFAULT_BENAME, (DEFAULT_SUFFIX,),
+                      None, None, True, ldif_file)
+
+    # Edit dse.ldif
+    m1_dse_ldif = DSEldif(m1)
+    m1_dse_ldif.replace(DN_CONFIG_LDBM, 'nsslapd-subtree-rename-switch', 'off')
+
+    # Import LDIF
+    assert m1.ldif2db(DEFAULT_BENAME, None, None, None, ldif_file)
+    m1.start()
+
+    # Check for tombstone
+    assert len(tombstones.list()) == 1
+
+    # Create a new tombstone
+    users = UserAccounts(m1, DEFAULT_SUFFIX)
+    user_properties = {
+        'uid': 'tuser1',
+        'givenname': 'tuser1',
+        'cn': 'tuser1',
+        'sn': 'tuser1',
+        'uidNumber': '1000',
+        'gidNumber': '2000',
+        'homeDirectory': '/home/tuser1'
+    }
+    user = users.create(properties=user_properties)
+    user.delete()
+    assert len(tombstones.list()) == 2
+
+    # Test tombstone purging
+    args = {REPLICA_PRECISE_PURGING: b'on',
+            REPLICA_PURGE_DELAY: b'5',
+            REPLICA_PURGE_INTERVAL: b'5'}
+    m1.replica.setProperties(DEFAULT_SUFFIX, None, None, args)
+    time.sleep(6)
+    users.create_test_user(uid=1002)  # trigger replication to wake up
+    time.sleep(6)
+
+    assert len(tombstones.list()) == 0
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -1086,6 +1086,7 @@ objectclass: nsIndex
 cn: nsTombstoneCSN
 nssystemindex: true
 nsindextype: eq
+nsindextype: pres
 
 dn: cn=targetuniqueid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top

--- a/ldap/servers/slapd/back-ldbm/ancestorid.c
+++ b/ldap/servers/slapd/back-ldbm/ancestorid.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -144,7 +144,8 @@ ldbm_ancestorid_index_update(
             ndnv.bv_len = slapi_sdn_get_ndn_len(&sdn);
             err = 0;
             idl = index_read(be, LDBM_ENTRYDN_STR, indextype_EQUALITY, &ndnv, txn, &err);
-            if (idl == NULL) {
+            if (idl == NULL || idl->b_nids == 0) {
+                idl_free(&idl);
                 if (err != 0 && err != DB_NOTFOUND) {
                     ldbm_nasty("ldbm_ancestorid_index_update", sourcefile, 13140, err);
                     ret = err;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -180,11 +180,12 @@ add_op_attrs(Slapi_PBlock *pb, struct ldbminfo *li __attribute__((unused)), stru
             bv.bv_val = pdn;
             bv.bv_len = strlen(pdn);
             if ((idl = index_read(be, LDBM_ENTRYDN_STR, indextype_EQUALITY,
-                                  &bv, NULL, &err)) != NULL) {
+                                  &bv, NULL, &err)) != NULL && idl->b_nids > 0) {
                 pid = idl_firstid(idl);
                 idl_free(&idl);
             } else {
                 /* empty idl */
+                idl_free(&idl);
                 if (0 != err && DB_NOTFOUND != err) {
                     slapi_log_err(SLAPI_LOG_ERR, "add_op_attrs", "database error %d\n", err);
                     slapi_ch_free_string(&pdn);
@@ -502,7 +503,7 @@ bdb_fetch_subtrees(backend *be, char **include, int *err)
             bv.bv_val = include[i];
             bv.bv_len = strlen(include[i]);
             idl = index_read(be, LDBM_ENTRYDN_STR, indextype_EQUALITY, &bv, txn, err);
-            if (idl == NULL) {
+            if (idl == NULL || idl->b_nids == 0) {
                 if (DB_NOTFOUND == *err) {
                     slapi_log_err(SLAPI_LOG_INFO,
                                   "bdb_fetch_subtrees", "entrydn not indexed on '%s'; "

--- a/ldap/servers/slapd/back-ldbm/dn2entry.c
+++ b/ldap/servers/slapd/back-ldbm/dn2entry.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -38,6 +38,7 @@ dn2entry_ext(
     int flags,
     int *err)
 {
+    IDList *idl = NULL;
     ldbm_instance *inst;
     struct berval ndnv;
     struct backentry *e = NULL;
@@ -80,14 +81,12 @@ dn2entry_ext(
             }
             indexname = LDBM_ENTRYRDN_STR;
         } else {
-            IDList *idl = NULL;
             if ((idl = index_read(be, LDBM_ENTRYDN_STR, indextype_EQUALITY,
-                                  &ndnv, txn, err)) == NULL) {
+                                  &ndnv, txn, err)) == NULL || idl->b_nids == 0) {
                 /* There's no entry with this DN. */
                 goto bail;
             }
             id = idl_firstid(idl);
-            slapi_ch_free((void **)&idl);
             indexname = LDBM_ENTRYDN_STR;
         }
         /* convert entry id to entry */
@@ -111,6 +110,7 @@ dn2entry_ext(
         }
     }
 bail:
+    idl_free(&idl);
     slapi_log_err(SLAPI_LOG_TRACE, "dn2entry_ext", "<= %p\n", e);
     return (e);
 }

--- a/ldap/servers/slapd/back-ldbm/uniqueid2entry.c
+++ b/ldap/servers/slapd/back-ldbm/uniqueid2entry.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -46,7 +46,7 @@ uniqueid2entry(
         idv.bv_len = strlen(idv.bv_val);
 
         if ((idl = index_read(be, SLAPI_ATTR_UNIQUEID, indextype_EQUALITY, &idv, txn,
-                              err)) == NULL) {
+                              err)) == NULL || idl->b_nids == 0) {
             if (*err != 0 && *err != DB_NOTFOUND) {
                 goto ext;
             }
@@ -71,9 +71,7 @@ uniqueid2entry(
     }
 
 ext:
-    if (NULL != idl) {
-        slapi_ch_free((void **)&idl);
-    }
+    idl_free(&idl);
 
     slapi_log_err(SLAPI_LOG_TRACE, "uniqueid2entry", "<= %p\n", e);
     return (e);


### PR DESCRIPTION
Bug Description:

Disabling subtree renaming breaks imports and replication.

Fix Description:

The ID list management changed, and in most cases we need to check if
b_nids is greater than zero.  With this setting we also swqitch to
entrydn (from entryrdn), and we were not handling tobmstones correctly
when using the entrydn index.

fixes: https://github.com/389ds/389-ds-base/issues/5257
