### PR TITLE
Issue 4904 - Fix various small issues

### DIFF
--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -386,7 +386,7 @@ slapi_exists_or_add_internal(
         0,
         NULL,
         NULL,
-        NULL,
+        plugin_get_default_component_id(),
         0);
 
     slapi_search_internal_pb(search_pb);
@@ -421,7 +421,7 @@ slapi_exists_or_add_internal(
         /* do the add */
         Slapi_PBlock *add_pb = slapi_pblock_new();
 
-        slapi_add_entry_internal_set_pb(add_pb, s_entry, NULL, NULL, 0);
+        slapi_add_entry_internal_set_pb(add_pb, s_entry, NULL, plugin_get_default_component_id(), 0);
         slapi_add_internal_pb(add_pb);
 
         slapi_pblock_get(add_pb, SLAPI_PLUGIN_INTOP_RESULT, &create_result);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -5805,7 +5805,7 @@ bdb__import_file_name(ldbm_instance *inst)
     char *fname = slapi_ch_smprintf("%s/.import_%s",
                                     inst->inst_parent_dir_name,
                                     inst->inst_dir_name);
-slapi_log_err(SLAPI_LOG_INFO, "bdb__import_file_name", "DBG: fname=%s\n", fname);
+    slapi_log_err(SLAPI_LOG_DEBUG, "bdb__import_file_name", "DBG: fname=%s\n", fname);
     return fname;
 }
 

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -33,7 +33,7 @@ from lib389.cli_base import (
     format_error_to_dict)
 from lib389._constants import DSRC_CONTAINER
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(allow_abbrev=False)
 parser.add_argument('-v', '--verbose',
         help="Display verbose operation tracing during command execution",
         action='store_true', default=False

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -40,7 +40,6 @@ arg_to_attr = {
         'directory': 'nsslapd-directory',
         'dbcachesize': 'nsslapd-dbcachesize',
         'logdirectory': 'nsslapd-db-logdirectory',
-        'durable_txn': 'nsslapd-db-durable-transaction',
         'txn_wait': 'nsslapd-db-transaction-wait',
         'checkpoint_interval': 'nsslapd-db-checkpoint-interval',
         'compactdb_interval': 'nsslapd-db-compactdb-interval',
@@ -1020,7 +1019,6 @@ def create_parser(subparsers):
     set_db_config_parser.add_argument('--directory', help='Specifies absolute path to database instance')
     set_db_config_parser.add_argument('--dbcachesize', help='Specifies the database index cache size in bytes')
     set_db_config_parser.add_argument('--logdirectory', help='Specifies the path to the directory that contains the database transaction logs')
-    set_db_config_parser.add_argument('--durable-txn', help='Enables or disables whether database transaction log entries are immediately written to the disk')
     set_db_config_parser.add_argument('--txn-wait', help='Sets whether the server should should wait if there are no db locks available')
     set_db_config_parser.add_argument('--checkpoint-interval', help='Sets the amount of time in seconds after which the server sends a '
                                                                     'checkpoint entry to the database transaction log')
@@ -1063,7 +1061,7 @@ def create_parser(subparsers):
                                                                   'WARNING: This parameter can trigger experimental code.')
     set_db_config_parser.add_argument('--deadlock-policy', help='Adjusts the backend database deadlock policy (Advanced setting)')
     set_db_config_parser.add_argument('--db-home-directory', help='Sets the directory for the database mmapped files (Advanced setting)')
-    set_db_config_parser.add_argument('--db_lib', help='Sets which db lib is used. Valid values are: bdb or mdb')
+    set_db_config_parser.add_argument('--db-lib', help='Sets which db lib is used. Valid values are: bdb or mdb')
 
     #######################################################
     # Database & Suffix Monitor

--- a/src/lib389/lib389/cli_ctl/dbgen.py
+++ b/src/lib389/lib389/cli_ctl/dbgen.py
@@ -161,7 +161,7 @@ def dbgen_create_users(inst, log, args):
         """
         Interactively get all the info ...
         """
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing required parameters '--number' and/or '--suffix', switching to Interactive mode ...")
 
         # Get the suffix
         args.suffix = get_input(log, "Enter the suffix", "dc=example,dc=com", "dn")
@@ -205,7 +205,7 @@ def dbgen_create_groups(inst, log, args):
         """
         Interactively get all the info ...
         """
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing required parameters '--number' and/or '--suffix', switching to Interactive mode ...")
 
         # Get the number of users to create
         args.number = get_input(log, "Enter the number of groups to create", 1, "int")
@@ -257,7 +257,7 @@ def dbgen_create_cos_def(inst, log, args):
     if args.type is None or args.parent is None or len(args.cos_attr) == 0 or \
         ((args.type == "classic" or args.type == "indirect") and args.cos_specifier is None) \
         or ((args.type == "classic" or args.type == "pointer") and args.cos_template is None):
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing some required parameters '--parent',  '--type', '--cos-specifier', or '--cos-template', switching to Interactive mode ...")
 
         # Get the number of users to create
         args.type = get_input(log, "Type of COS definition: \"classic\", \"pointer\", or \"indirect\"",
@@ -309,7 +309,7 @@ def dbgen_create_cos_tmp(inst, log, args):
     Create a COS template entry
     """
     if args.parent is None or args.cos_priority is None or args.cos_attr_val is None:
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing required parameters '--parent', '--cos-priority' or '--cos-attr-val', switching to Interactive mode ...")
 
         # Get the parent
         args.parent = get_input(log, "Enter the parent entry to add the COS template under", "dc=example,dc=com", "dn")
@@ -348,7 +348,7 @@ def dbgen_create_role(inst, log, args):
     if args.type is None or args.parent is None or \
         (args.type == "filtered" and args.filter is None) or \
         (args.type == "nested" and len(args.role_dn) == 0):
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing some required parameters '--type', '--parent'. '--filter', '--role-dn', switching to Interactive mode ...")
 
         # Get the number of users to create
         args.type = get_input(log, "Type of Role: \"managed\", \"filtered\", or \"nested\"",
@@ -407,7 +407,7 @@ def dbgen_create_mods(inst, log, args):
     """
 
     if args.num_users is None or args.parent is None:
-        log.info("Missing required parameters, switching to Interactive mode ...")
+        log.info("Missing required parameters '--num-users' and/or '--parent', switching to Interactive mode ...")
 
         # Create users
         args.create_users = get_input(log, "Do you want to create the user entries (yes/no)", True, "bool")


### PR DESCRIPTION
- Issue 4904 - Set the plugin identity before calling internal op.
- Issue 5232 - Remove --durable-txn from dsconf
- Issue 5195 - Improve error messages to state with settings are missing
- Issue 5169 - During LDIF import we log a debug message by default when we should
not
- Issue 5259 - dsctl --remove-all can be triggered with abbreviated arg
 name

relates: https://github.com/389ds/389-ds-base/issues/4904
relates: https://github.com/389ds/389-ds-base/issues/5232
relates: https://github.com/389ds/389-ds-base/issues/5195
relates: https://github.com/389ds/389-ds-base/issues/5169
relates: https://github.com/389ds/389-ds-base/issues/5259

