### PR TITLE
Issue 5262 - high contention in find_entry_internal_dn on mixed load

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_delete.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_delete.c
@@ -542,6 +542,7 @@ replace_entry:
                             if (cache_retry == RETRY_CACHE_LOCK &&
                                 cache_retry_count < LDBM_CACHE_RETRY_COUNT) {
                                 /* try again */
+                                CACHE_RETURN(&(inst->inst_cache), &parent);
                                 DS_Sleep(PR_MillisecondsToInterval(100));
                                 cache_retry_count++;
                                 continue;


### PR DESCRIPTION
Bug description:
	Under high mixed load (update/read), the pressure on the entry cache is
        so high that during an update by the time the entry is added into the
	cache, it is then removed from the cache before it is locked for the update.
	If such event occurs 1000 times in a raw, the update fails.

	Another issue is that when updating the parent entry of a
	deleted entry (numsubordinates), if it fails to lock the parent
        it does not return the parent entry. So refcnt becomes invalid.

Fix description:
        To reduce the likelyhood of failure, if an entry is removed from
        the entry cache before it is locked, then pause 100ms before
        retrying to upload/lock it.
        In the case of the failure to lock the parent entry, the entry
        should be returned.

relates: #5262

Reviewed by: