### PR TITLE
Issue 5180 - snmp_collator tries to unlock NULL mutex

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1248,12 +1248,14 @@ slapd_daemon(daemon_ports_t *ports)
 #endif
 
     if (!in_referral_mode) {
-        /* Close SNMP collator after the plugins closed...
+        /* Close SNMP collator (if counters are enabled) after the plugins closed...
          * Replication plugin still performs internal ops that
          * may try to increment snmp stats.
          * Fix for defect 523780
          */
-        snmp_collator_stop();
+        if (config_get_slapi_counters()) {
+            snmp_collator_stop();
+        }
         mapping_tree_free();
     }
 


### PR DESCRIPTION
Bug description: A slapi_unlock_mutex is attempted on a NULL mutex.

Fix description: SNMP collator is started if counters are enabled,
but is stopped without checking if counters are enabled. This results
in an unlock on a mutex that hasnt been initialised.
A check is added before snmp_collator_stop() is called.

Fixes: https://github.com/389ds/389-ds-base/issues/5180

Reviewed by: