### PR TITLE
Issue 4866 - CLI - when enabling replciation set changelog trimming by default

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -66,7 +66,7 @@ def set_changelog_trimming(instance):
     inst_changelog = Changelog(instance, suffix=DEFAULT_SUFFIX)
 
     log.info('Set nsslapd-changelogmaxage to 30d')
-    inst_changelog.add('nsslapd-changelogmaxage', '30')
+    inst_changelog.set_max_age('30d')
 
 
 @pytest.mark.ds50873

--- a/dirsrvtests/tests/suites/replication/acceptance_test.py
+++ b/dirsrvtests/tests/suites/replication/acceptance_test.py
@@ -15,7 +15,7 @@ from lib389.topologies import topology_m4 as topo_m4
 from lib389.topologies import topology_m2 as topo_m2
 from . import get_repl_entries
 from lib389.idm.user import UserAccount
-from lib389.replica import ReplicationManager
+from lib389.replica import ReplicationManager, Changelog
 from lib389._constants import *
 
 pytestmark = pytest.mark.tier0
@@ -642,6 +642,22 @@ def test_csngen_task(topo_m2):
     time.sleep(10)
     log.info('Check the error log contains strings showing csn generator is tested')
     assert m1.searchErrorsLog("_csngen_gen_tester_main")
+
+
+def test_default_cl_trimming_enabled(topo_m2):
+    """Check that changelog trimming was enabled by default
+
+    :id: c37b9a28-f961-4867-b8a1-e81edd7f9bf3
+    :setup: Supplier Instance
+    :steps:
+        1. Check changelog has trimming set up by default
+    :expectedresults:
+        1. Success
+    """
+
+    # Set up changelog trimming by default
+    cl = Changelog(topo_m2.ms["supplier1"], DEFAULT_SUFFIX)
+    assert cl.get_attr_val_utf8("nsslapd-changelogmaxage") == "7d"
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1745,6 +1745,19 @@ class Replicas(DSLdapObjects):
         self._childobject = Replica
         self._basedn = DN_MAPPING_TREE
 
+    def create(self, rdn=None, properties=None):
+        replica = super(Replicas, self).create(rdn, properties)
+
+        # Set up changelog trimming by default
+        if properties is not None:
+            for attr, val in properties.items():
+                if attr.lower() == 'nsds5replicaroot':
+                    cl = Changelog(self._instance, val[0])
+                    cl.set_max_age("7d")
+                    break
+
+        return replica
+
     def get(self, selector=[], dn=None):
         """Get a child entry (DSLdapObject, Replica, etc.) with dn or selector
         using a base DN and objectClasses of our object (DSLdapObjects, Replicas, etc.)
@@ -2448,7 +2461,7 @@ class ReplicationManager(object):
     def wait_while_replication_is_progressing(self, from_instance, to_instance, timeout=5):
         """ Wait while replication is progressing
             used by wait_for_replication to avoid timeout because of
-              slow replication (typically when traces have been added) 
+              slow replication (typically when traces have been added)
             Returns true is repliaction is stalled.
 
         :param from_instance: The instance whos state we we want to check from


### PR DESCRIPTION
Description:  

Enable changelog trimming by default when enabling replication.

relates: https://github.com/389ds/389-ds-base/issues/4866

