### PR TITLE
Issue 5271 - Serialization of pam_passthrough causing high etimes

### DIFF
--- a/ldap/servers/plugins/pam_passthru/pam_passthru.h
+++ b/ldap/servers/plugins/pam_passthru/pam_passthru.h
@@ -79,6 +79,8 @@ typedef struct pam_passthruconfig
     PRBool pamptconfig_fallback;              /* if false, failure here fails entire bind */
                                               /* if true, failure here falls through to regular bind */
     PRBool pamptconfig_secure;                /* if true, plugin only operates on secure connections */
+    PRBool pamptconfig_thread_safe;           /* if true, the underlying pam module is thread safe */
+                                              /* if false, the module is not thread safe => serialize calls */
     char *pamptconfig_pam_ident_attr;         /* name of attribute in user entry for ENTRY map method */
     int pamptconfig_map_method1;              /* how to map the BIND DN to the PAM identity */
     int pamptconfig_map_method2;              /* how to map the BIND DN to the PAM identity */
@@ -101,6 +103,7 @@ typedef struct pam_passthruconfig
 #define PAMPT_MAP_METHOD_ATTR "pamIDMapMethod"       /* single valued */
 #define PAMPT_FALLBACK_ATTR "pamFallback"            /* single */
 #define PAMPT_SECURE_ATTR "pamSecure"                /* single */
+#define PAMPT_THREAD_SAFE_ATTR "pamModuleIsThreadSafe" /* single */
 #define PAMPT_SERVICE_ATTR "pamService"              /* single */
 #define PAMPT_FILTER_ATTR "pamFilter"                /* single */
 

--- a/ldap/servers/plugins/pam_passthru/pam_ptconfig.c
+++ b/ldap/servers/plugins/pam_passthru/pam_ptconfig.c
@@ -579,6 +579,7 @@ pam_passthru_apply_config(Slapi_Entry *e)
     char *dn = NULL;
     PRBool fallback;
     PRBool secure;
+    PRBool thread_safe;
     Pam_PassthruConfig *entry = NULL;
     PRCList *list;
     Slapi_Attr *a = NULL;
@@ -592,6 +593,7 @@ pam_passthru_apply_config(Slapi_Entry *e)
     includes = slapi_entry_attr_get_charray(e, PAMPT_INCLUDES_ATTR);
     fallback = slapi_entry_attr_get_bool(e, PAMPT_FALLBACK_ATTR);
     filter_str = slapi_entry_attr_get_charptr(e, PAMPT_FILTER_ATTR);
+    thread_safe = slapi_entry_attr_get_bool(e, PAMPT_THREAD_SAFE_ATTR);
     /* Require SSL/TLS if the secure attr is not specified.  We
      * need to check if the attribute is present to make this
      * determiniation. */
@@ -622,6 +624,7 @@ pam_passthru_apply_config(Slapi_Entry *e)
 
     entry->pamptconfig_fallback = fallback;
     entry->pamptconfig_secure = secure;
+    entry->pamptconfig_thread_safe = thread_safe;
 
     if (!entry->pamptconfig_service ||
         (new_service && PL_strcmp(entry->pamptconfig_service, new_service))) {

--- a/ldap/servers/plugins/pam_passthru/pam_ptimpl.c
+++ b/ldap/servers/plugins/pam_passthru/pam_ptimpl.c
@@ -230,7 +230,8 @@ do_one_pam_auth(
     char *pam_service,        /* name of service for pam_start() */
     char *map_ident_attr,     /* for ENTRY method, name of attribute holding pam identity */
     PRBool fallback,          /* if true, failure here should fallback to regular bind */
-    int pw_response_requested /* do we need to send pwd policy resp control */
+    int pw_response_requested, /* do we need to send pwd policy resp control */
+    PRBool module_thread_safe /* if not thread safe, make sure only one thread auth at a time */
     )
 {
     MyStrBuf pam_id;
@@ -277,7 +278,9 @@ do_one_pam_auth(
     my_data.pb = pb;
     my_data.pam_identity = pam_id.str;
     my_pam_conv.appdata_ptr = &my_data;
-    slapi_lock_mutex(PAMLock);
+    if (! module_thread_safe) {
+        slapi_lock_mutex(PAMLock);
+    }
     /* from this point on we are in the critical section */
     rc = pam_start(pam_service, pam_id.str, &my_pam_conv, &pam_handle);
     report_pam_error("during pam_start", rc, pam_handle);
@@ -362,7 +365,9 @@ do_one_pam_auth(
         slapi_log_err(SLAPI_LOG_ERR, PAM_PASSTHRU_PLUGIN_SUBSYSTEM,
                       "do_one_pam_auth - Error during pam_end (%d)\n", rc);
     }
-    slapi_unlock_mutex(PAMLock);
+    if (! module_thread_safe) {
+        slapi_unlock_mutex(PAMLock);
+    }
     /* not in critical section any more */
 
 done:
@@ -428,6 +433,7 @@ pam_passthru_do_pam_auth(Slapi_PBlock *pb, Pam_PassthruConfig *cfg)
     PRBool final_method;
     PRBool fallback = PR_FALSE;
     int pw_response_requested;
+    PRBool module_thread_safe = PR_FALSE;
     LDAPControl **reqctrls = NULL;
 
     /* get the methods and other info */
@@ -439,6 +445,8 @@ pam_passthru_do_pam_auth(Slapi_PBlock *pb, Pam_PassthruConfig *cfg)
     init_my_str_buf(&pam_service, cfg->pamptconfig_service);
 
     fallback = cfg->pamptconfig_fallback;
+    
+    module_thread_safe = cfg->pamptconfig_thread_safe;
 
     slapi_pblock_get(pb, SLAPI_REQCONTROLS, &reqctrls);
     slapi_pblock_get(pb, SLAPI_PWPOLICY, &pw_response_requested);
@@ -448,15 +456,15 @@ pam_passthru_do_pam_auth(Slapi_PBlock *pb, Pam_PassthruConfig *cfg)
 
     final_method = (method2 == PAMPT_MAP_METHOD_NONE);
     rc = do_one_pam_auth(pb, method1, final_method, pam_service.str, pam_id_attr.str, fallback,
-                         pw_response_requested);
+                         pw_response_requested, module_thread_safe);
     if ((rc != LDAP_SUCCESS) && !final_method) {
         final_method = (method3 == PAMPT_MAP_METHOD_NONE);
         rc = do_one_pam_auth(pb, method2, final_method, pam_service.str, pam_id_attr.str, fallback,
-                             pw_response_requested);
+                             pw_response_requested, module_thread_safe);
         if ((rc != LDAP_SUCCESS) && !final_method) {
             final_method = PR_TRUE;
             rc = do_one_pam_auth(pb, method3, final_method, pam_service.str, pam_id_attr.str, fallback,
-                                 pw_response_requested);
+                                 pw_response_requested, module_thread_safe);
         }
     }
 


### PR DESCRIPTION
Bug description:
	calls to PAM authentication are serialized by DS.
	libpam is thread-safe and some module may also be
        thread-safe.
        Because serialization impacts performance, an administator
        should be allowed to remove the serialization in case
        the pam module is thread safe

Fix description:
	If the pam configuration entry contains 'pamThreadSafe: TRUE'
        then futher calls to pam_start/pam_authenticate/pam_end are not
        serialized

relates: #5271

Reviewed by: