### PR TITLE
Issue 5273 - CLI - add arg completer for instance name

### DIFF
--- a/src/lib389/cli/dsconf
+++ b/src/lib389/cli/dsconf
@@ -33,12 +33,12 @@ from lib389.cli_base import disconnect_instance, connect_instance
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389.cli_base import setup_script_logger
 from lib389.cli_base import format_error_to_dict
-
+from lib389.utils import instance_choices
 
 parser = argparse.ArgumentParser(allow_abbrev=True)
 parser.add_argument('instance',
         help="The name of the instance or its LDAP URL, such as ldap://server.example.com:389",
-    )
+    ).completer = instance_choices
 parser.add_argument('-v', '--verbose',
         help="Display verbose operation tracing during command execution",
         action='store_true', default=False

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -15,7 +15,7 @@ import argparse, argcomplete
 import sys
 import signal
 import os
-from lib389.utils import get_instance_list
+from lib389.utils import get_instance_list, instance_choices
 from lib389 import DirSrv
 from lib389.cli_ctl import instance as cli_instance
 from lib389.cli_ctl import dbtasks as cli_dbtasks
@@ -40,7 +40,7 @@ parser.add_argument('-v', '--verbose',
     )
 parser.add_argument('instance', nargs='?', default=False,
         help="The name of the instance to act upon",
-    )
+    ).completer = instance_choices
 parser.add_argument('-j', '--json',
         help="Return result in JSON object",
         default=False, action='store_true'

--- a/src/lib389/cli/dsidm
+++ b/src/lib389/cli/dsidm
@@ -16,6 +16,7 @@ import signal
 import ldap
 import argparse
 import argcomplete
+from lib389.utils import get_instance_list, instance_choices
 from lib389._constants import DSRC_HOME
 from lib389.cli_idm import account as cli_account
 from lib389.cli_idm import initialise as cli_init
@@ -30,12 +31,11 @@ from lib389.cli_base import connect_instance, disconnect_instance, setup_script_
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389.cli_base import format_error_to_dict
 
-
 parser = argparse.ArgumentParser(allow_abbrev=True)
 # First, add the LDAP options
 parser.add_argument('instance',
         help="The name of the instance or its LDAP URL, such as ldap://server.example.com:389",
-    )
+    ).completer = instance_choices
 parser.add_argument('-b', '--basedn',
         help="Base DN (root naming context) of the instance to manage",
         default=None

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1307,6 +1307,15 @@ def get_instance_list():
     insts.sort()
     return insts
 
+# used by arg parse completers
+def instance_choices(prefix, parsed_args, **kwargs):
+    insts = get_instance_list()
+    inst_names = []
+    for inst in insts:
+        inst_names.append(inst)
+        inst_names.append(inst.replace("slapd-", ""))
+
+    return inst_names
 
 def get_user_is_ds_owner():
     # Check if we have permission to administer the DS instance. This is required


### PR DESCRIPTION
Description:

For convenience it would be nice to have auto compeletion for the instance
name when using the CLI tools.

relates: https://github.com/389ds/389-ds-base/issues/5273

Reviewed by: ?