### PR TITLE
Issue 5276 - CLI - improve task handling

### DIFF
--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -2830,7 +2830,7 @@ memberof_fixup_task_thread(void *arg)
     slapi_td_set_dn(slapi_ch_strdup(td->bind_dn));
 
     slapi_task_begin(task, 1);
-    slapi_task_log_notice(task, "Memberof task starts (arg: %s) ...\n",
+    slapi_task_log_notice(task, "Memberof task starts (arg: %s) ...",
                           td->filter_str);
     slapi_log_err(SLAPI_LOG_INFO, MEMBEROF_PLUGIN_SUBSYSTEM,
                   "memberof_fixup_task_thread - Memberof task starts (filter: \"%s\") ...\n",
@@ -2864,7 +2864,7 @@ memberof_fixup_task_thread(void *arg)
             slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                           "memberof_fixup_task_thread - Failed to get be backend from (%s)\n",
                           td->dn);
-            slapi_task_log_notice(task, "Memberof task - Failed to get be backend from (%s)\n",
+            slapi_task_log_notice(task, "Memberof task - Failed to get be backend from (%s)",
                                   td->dn);
             rc = -1;
             goto done;
@@ -2885,8 +2885,8 @@ done:
     }
     memberof_free_config(&configCopy);
 
-    slapi_task_log_notice(task, "Memberof task finished.");
-    slapi_task_log_status(task, "Memberof task finished.");
+    slapi_task_log_notice(task, "Memberof task finished.\n");
+    slapi_task_log_status(task, "Memberof task finished.\n");
     slapi_task_inc_progress(task);
 
     /* this will queue the destruction of the task */
@@ -3013,7 +3013,7 @@ memberof_fix_memberof(MemberOfConfig *config, Slapi_Task *task, task_data *td)
         errmsg = ldap_err2string(result);
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                       "memberof_fix_memberof - Failed (%s)\n", errmsg);
-        slapi_task_log_notice(task, "Memberof task failed (%s)\n", errmsg);
+        slapi_task_log_notice(task, "Memberof task failed (%s)", errmsg);
     }
 
     slapi_pblock_destroy(search_pb);

--- a/src/lib389/lib389/cli_conf/plugins/entryuuid.py
+++ b/src/lib389/lib389/cli_conf/plugins/entryuuid.py
@@ -1,14 +1,16 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2021 William Brown <william@blackhats.net.au>
+# Copyright (C) 2022 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-import ldap
-from lib389.plugins import EntryUUIDPlugin
-from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add
+
+from lib389.plugins import EntryUUIDPlugin, EntryUUIDFixupTasks
+from lib389.cli_conf import add_generic_plugin_parsers
+from lib389.utils import get_task_status
 
 def do_fixup(inst, basedn, log, args):
     plugin = EntryUUIDPlugin(inst)
@@ -17,12 +19,21 @@ def do_fixup(inst, basedn, log, args):
         log.error("'%s' is disabled. Fix up task can't be executed" % plugin.rdn)
         return
     fixup_task = plugin.fixup(args.DN, args.filter)
-    fixup_task.wait()
-    exitcode = fixup_task.get_exit_code()
-    if exitcode != 0:
-        log.error('EntryUUID fixup task has failed. Please, check the error log for more - %s' % exitcode)
+    if args.wait:
+        log.info(f'Waiting for fixup task "{fixup_task.dn}" to complete.  You can safely exit by pressing Control C ...')
+        fixup_task.wait(timeout=None)
+        exitcode = fixup_task.get_exit_code()
+        if exitcode != 0:
+            log.error(f'EntryUUID fixup task "{fixup_task.dn}" for {args.DN} has failed (error {exitcode}). Please, check logs')
+        else:
+            log.info('Fixup task successfully completed')
     else:
-        log.info('Successfully added task entry')
+        log.info(f'Successfully added task entry "{fixup_task.dn}". This task is running in the background. To track its progress you can use the "fixup-status" command.')
+
+
+def do_fixup_status(inst, basedn, log, args):
+    get_task_status(inst, log, EntryUUIDFixupTasks, dn=args.dn, show_log=args.show_log,
+                    watch=args.watch, use_json=args.json)
 
 def create_parser(subparsers):
     referint = subparsers.add_parser('entryuuid', help='Manage and configure EntryUUID plugin')
@@ -36,4 +47,12 @@ def create_parser(subparsers):
     fixup.add_argument('-f', '--filter',
                        help='Filter for entries to fix up.\n If omitted, all entries under base DN'
                             'will have their EntryUUID attribute regenerated if not present.')
+    fixup.add_argument('--wait', action='store_true',
+                       help="Wait for the task to finish, this could take a long time")
 
+    fixup_status = subcommands.add_parser('fixup-status', help='Check the status of a fix-up task')
+    fixup_status.set_defaults(func=do_fixup_status)
+    fixup_status.add_argument('--dn', help="The task entry's DN")
+    fixup_status.add_argument('--show-log', action='store_true', help="Display the task log")
+    fixup_status.add_argument('--watch', action='store_true',
+                       help="Watch the task's status and wait for it to finish")

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2022 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -15,7 +15,9 @@ from lib389._mapped_object import DSLdapObjects, DSLdapObject
 from lib389.lint import DSRILE0001, DSRILE0002
 from lib389.utils import ensure_str, ensure_list_bytes
 from lib389.schema import Schema
-from lib389._constants import DN_PLUGIN
+from lib389._constants import (
+        DN_PLUGIN, DN_MBO_TASK, DN_AUTOMEMBER_REBUILD_TASK, DN_FIXUP_LINKED_ATTIBUTES,
+        DN_EUUID_TASK)
 from lib389.properties import (
         PLUGINS_OBJECTCLASS_VALUE, PLUGIN_PROPNAME_TO_ATTRNAME,
         PLUGINS_ENABLE_ON_VALUE, PLUGINS_ENABLE_OFF_VALUE, PLUGIN_ENABLE
@@ -953,7 +955,10 @@ class MemberOfPlugin(Plugin):
         task_properties = {'basedn': basedn}
         if _filter is not None:
             task_properties['filter'] = _filter
-        task.create(properties=task_properties)
+        try:
+            task.create(properties=task_properties)
+        except ldap.NO_SUCH_OBJECT:
+            raise ValueError("The fixup task can not be run, the memberOf plugin is not fully enabled.")
 
         return task
 
@@ -2080,6 +2085,78 @@ class DNAPluginSharedConfigs(DSLdapObjects):
 
         co = self._entry_to_instance(dn=None, entry=None)
         return co.create(properties, self._basedn)
+
+
+class MemberOfFixupTasks(DSLdapObjects):
+    """A DSLdapObjects entity which represents memberOf fixup tasks
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param task_dn: dn for a specific task
+    :type basedn: str
+    """
+
+    def __init__(self, instance, task_dn=None):
+        super(MemberOfFixupTasks, self).__init__(instance)
+        self._objectclasses = ['top']
+        self._filterattrs = ['cn']
+        self._childobject = DSLdapObject
+        self._basedn = DN_MBO_TASK
+        self._scope = ldap.SCOPE_ONELEVEL
+
+
+class AutoMembershipFixupTasks(DSLdapObjects):
+    """A DSLdapObjects entity which represents automember fixup tasks
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param task_dn: dn for a specific task
+    :type basedn: str
+    """
+
+    def __init__(self, instance, task_dn=None):
+        super(AutoMembershipFixupTasks, self).__init__(instance)
+        self._objectclasses = ['top']
+        self._filterattrs = ['cn']
+        self._childobject = DSLdapObject
+        self._basedn = DN_AUTOMEMBER_REBUILD_TASK
+        self._scope = ldap.SCOPE_ONELEVEL
+
+
+class LinkedAttributesFixupTasks(DSLdapObjects):
+    """A DSLdapObjects entity which represents automember fixup tasks
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param task_dn: dn for a specific task
+    :type basedn: str
+    """
+
+    def __init__(self, instance, task_dn=None):
+        super(LinkedAttributesFixupTasks, self).__init__(instance)
+        self._objectclasses = ['top']
+        self._filterattrs = ['cn']
+        self._childobject = DSLdapObject
+        self._basedn = DN_FIXUP_LINKED_ATTIBUTES
+        self._scope = ldap.SCOPE_ONELEVEL
+
+
+class EntryUUIDFixupTasks(DSLdapObjects):
+    """A DSLdapObjects entity which represents automember fixup tasks
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param task_dn: dn for a specific task
+    :type basedn: str
+    """
+
+    def __init__(self, instance, task_dn=None):
+        super(EntryUUIDFixupTasks, self).__init__(instance)
+        self._objectclasses = ['top']
+        self._filterattrs = ['cn']
+        self._childobject = DSLdapObject
+        self._basedn = DN_EUUID_TASK
+        self._scope = ldap.SCOPE_ONELEVEL
 
 
 class Plugins(DSLdapObjects):

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -91,15 +91,16 @@ class Task(DSLdapObject):
     def wait(self, timeout=120):
         """Wait until task is complete."""
 
-        count = 0
+        time_passed = 0
+        sleep_interval = 2
         if timeout is None:
             self._log.debug("No timeout is set, this may take a long time ...")
 
-        while timeout is None or count < timeout:
+        while timeout is None or time_passed < timeout:
             if self.is_complete():
                 break
-            count = count + 1
-            time.sleep(2)
+            time_passed = time_passed + sleep_interval
+            time.sleep(sleep_interval)
 
     def create(self, rdn=None, properties={}, basedn=None):
         """Create a Task entry

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2022 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -24,6 +24,7 @@ except ImportError:
         p.stdout, p.stdin = popen2(cmd_l)
         return p
 
+import json
 import re
 import os
 import logging
@@ -32,7 +33,7 @@ import ldap
 import socket
 import time
 import stat
-from datetime import datetime
+from datetime import (datetime, timedelta)
 import sys
 import filecmp
 import pwd
@@ -1460,3 +1461,144 @@ def is_fips():
         return False
 
 
+def convert_timestamp(timestamp):
+    """Convert createtimestamp to ctime: 20170405184656Z ----> Wed Apr  5 19:46:56 2017
+    :param timestamp - A timestamp from the server
+    :return - the ctime of the timestamp
+    """
+    if timestamp:
+        time_tuple = (int(timestamp[:4]), int(timestamp[4:6]), int(timestamp[6:8]),
+                      int(timestamp[8:10]), int(timestamp[10:12]), int(timestamp[12:14]),
+                      0, 0, 0)
+        secs = time.mktime(time_tuple)
+        return time.ctime(secs)
+    else:
+        return ""
+
+
+def elapsed_time(timestamp1, timestamp2):
+    """Take two timestamps from the server and get the diff
+    """
+    if timestamp1 and timestamp2:
+        time1_tuple = (int(timestamp1[:4]), int(timestamp1[4:6]), int(timestamp1[6:8]),
+                       int(timestamp1[8:10]), int(timestamp1[10:12]), int(timestamp1[12:14]),
+                       0, 0, 0)
+        time2_tuple = (int(timestamp2[:4]), int(timestamp2[4:6]), int(timestamp2[6:8]),
+                       int(timestamp2[8:10]), int(timestamp2[10:12]), int(timestamp2[12:14]),
+                       0, 0, 0)
+        time1_secs = time.mktime(time1_tuple)
+        time2_secs = time.mktime(time2_tuple)
+        elapsed_secs = time2_secs - time1_secs
+        return str(timedelta(seconds=elapsed_secs))
+    else:
+        return ""
+
+def get_task_status(inst, log, taskObj, dn=None, show_log=False, watch=False, use_json=False):
+    """Get the status of a Task, if "watching" keep looping over the tasks
+    :param inst: DirSrv Object
+    :type inst: Object
+    :param log: Logging Object
+    :type log: Object
+    :param taskObj: Lib389 Object (task object from plugins.py)
+    :type taskObj: Object
+    :param dn: A task DN to get the status for (if omitted all tasks for checked)
+    :type dn: str
+    :param show_log: Show the task's log attribute (could be lengthy)
+    :type show_log: boolean
+    :param watch: Keep looping over the task until it completes
+    :type watch: boolean
+    :param use_json: Report the status in JSON
+    :type use_json: boolean
+    """
+
+    tasks = taskObj(inst).list()
+    all_finished = False
+    while not all_finished:
+        task_list = []
+        all_finished = True
+        for task in tasks:
+            task_base_dn = task.get_attr_val_utf8_l('basedn')
+            if task_base_dn is None:
+                # Try linked attr, it uses a different attr name
+                task_base_dn = task.get_attr_val_utf8_l('linkdn')
+            task_filter = task.get_attr_val_utf8_l('filter')
+            status = task.get_attr_val_utf8('nsTaskStatus')
+            exitcode = task.get_attr_val_utf8('nsTaskExitcode')
+            task_log =  task.get_attr_val_utf8('nsTaskLog')
+            task_created = task.get_attr_val_utf8('nsTaskCreated')
+            task_ended = task.get_attr_val_utf8('modifyTimestamp')
+            if task_base_dn is None:
+                task_base_dn = ""
+            if task_filter is None:
+                task_filter = ""
+            if status is None:
+                status = ""
+            if exitcode is None:
+                all_finished = False
+                task_ended = ""
+                exitcode = "Not finished ..."
+
+                # Calc elapsed time for running task
+                curr_time = int(time.time())  # Use the current time
+                time_tuple = (int(task_created[:4]), int(task_created[4:6]), int(task_created[6:8]),
+                              int(task_created[8:10]), int(task_created[10:12]), int(task_created[12:14]),
+                              0, 0, 0)
+                start_time = int(time.mktime(time_tuple))
+                elapsed_secs = curr_time - start_time
+                elapsed_time_str = str(timedelta(seconds=elapsed_secs))
+            else:
+                # Task is finished, use start and end times to calc elapsed time
+                elapsed_time_str = elapsed_time(task_created, task_ended)
+
+            if not show_log:
+                task_log = ""
+
+            if (dn is not None and dn.lower() == task.dn.lower()) or dn is None:
+                    task_list.append({
+                        'dn': task.dn,
+                        'basedn': task_base_dn,
+                        'filter': task_filter,
+                        'log': task_log,
+                        'status': status,
+                        'created': task_created,
+                        'created_str': convert_timestamp(task_created),
+                        'ended': task_ended,
+                        'ended_str': convert_timestamp(task_ended),
+                        'elapsed_time':  elapsed_time_str,
+                        'exitcode': exitcode
+                    })
+
+        # Display the status
+        if use_json:
+            log.info(json.dumps({"type": "list", "items": task_list}, indent=4))
+        else:
+            num_of_tasks = len(task_list)
+            count = 1
+            plural = ""
+            if num_of_tasks != 1:
+                plural = "s"
+            log.info(f'Found {num_of_tasks} fix-up task{plural}\n')
+
+            for task in task_list:
+                log.info(f"[{count}] Task: {task['dn']}")
+                log.info("-" * 80)
+                log.info(f" - Base DN:       {task['basedn']}")
+                if task['filter']:
+                    log.info(f" - Filter:        {task['filter']}")
+                log.info(f" - Status:        {task['status']}")
+                log.info(f" - Started:       {task['created_str']} ({task['created']})")
+                if task['ended_str']:
+                    log.info(f" - Ended:         {task['ended_str']} ({task['ended']})")
+                else:
+                    log.info(" - Ended:")
+                log.info(f" - Elapsed Time:  {task['elapsed_time']}")
+                log.info(f" - Exit Code:     {task['exitcode']}")
+                if show_log:
+                    log.info(f" - Log:\n{task['log']}")
+                log.info("")
+                count += 1
+        if not watch or all_finished:
+            break
+        elif not use_json:
+            log.info("Refreshing status ...")
+        time.sleep(2)


### PR DESCRIPTION
Description:  We have several fixup tasks that hte cli tools can
perform.  Most them wait for the task to finish but some tasks run for
a long time and the CLI tools actually timeout while waiting.  When this
happens nothing is logged that the CLI timed out waiting for the task.

Instead we should add a "--wait" option if you actually want to wait for
the task, and added a new "fixup-status" argument to display the status
for existing tasks.

relates: https://github.com/389ds/389-ds-base/issues/5276

Reviewed by: ?