### PR TITLE
Issue 5279 - dscontainer: TypeError: unsupported operand type(s) for …

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -358,7 +358,7 @@ binddn = cn=Directory Manager
     # Wait on the health check to show we are ready for ldapi.
     healthy = False
     startup_timeout = os.getenv("DS_STARTUP_TIMEOUT", 60)
-    max_failure_count = int(startup_timeout / 3)
+    max_failure_count = int(int(startup_timeout) / 3)
     for i in range(0, max_failure_count):
         if ds_proc is None:
             log.warning("ns-slapd pid has disappeared ...")


### PR DESCRIPTION
…/: 'str' and 'int'

Bug Description:
When DS_STARTUP_TIMEOUT is specified, dscontainer fails with:

TypeError: unsupported operand type(s) for /: 'str' and 'int'

Fix Description:
os.getenv returns a string when a variable is present, so the value
must be converted to int.

Fixes: https://github.com/389ds/389-ds-base/issues/5279

Reviewed by: ???