### PR TITLE
Issue 5281 - HIGH - basic test does not run

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -985,7 +985,6 @@ def test_basic_systemctl(topology_st, import_example_ldif):
     log.info('test_basic_systemctl: PASSED')
 
 
-pytestmark = pytest.mark.skipif(get_rpm_version("389-ds-base-snmp") == "not installed", reason="389-ds-base-snmp package is not present")
 def test_basic_ldapagent(topology_st, import_example_ldif):
     """Tests that the ldap agent starts
 
@@ -1004,6 +1003,8 @@ def test_basic_ldapagent(topology_st, import_example_ldif):
 
     log.info('Running test_basic_ldapagent...')
 
+    if not os.path.exists(os.path.join(topology_st.standalone.get_sbin_dir(), 'ldap-agent')):
+        pytest.skip("ldap-agent is not present")
     var_dir = topology_st.standalone.get_local_state_dir()
 
     config_file = os.path.join(topology_st.standalone.get_sysconf_dir(), 'dirsrv/config/agent.conf')


### PR DESCRIPTION
Bug Description:
test_basic_ldapagent has an incorrect pytestmark that checks for presence
of 389-ds-base-snmp package that might not exist on other distros than
Fedora/RHEL. It's also a second declaration of the pytestmark that
overrides previous one at the beginning of the test.

Fix Description:
Instead of checking for package presence, check for `ldap-agent` binary.

Fixes: https://github.com/389ds/389-ds-base/issues/5281

Reviewed by: ???