### PR TITLE
Issue 379 - RFE - Compress rotated logs

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import glob
 import ldap
 import os
+import gzip
 
 from .report import getReport
 from lib389.paths import Paths
@@ -115,7 +116,13 @@ def pytest_runtest_makereport(item, call):
                     text = asan_report.read()
                     extra.append(pytest_html.extras.text(text, name=os.path.basename(f)))
             for f in glob.glob(f'{p.log_dir.split("/slapd",1)[0]}/*/*'):
-                if 'rotationinfo' not in f:
+                if f.endswith('gz'):
+                    with gzip.open(f, 'rb') as dirsrv_log:
+                        text = dirsrv_log.read()
+                        log_name = os.path.basename(f)
+                        instance_name = os.path.basename(os.path.dirname(f)).split("slapd-",1)[1]
+                        extra.append(pytest_html.extras.text(text, name=f"{instance_name}-{log_name}"))
+                elif 'rotationinfo' not in f:
                     with open(f) as dirsrv_log:
                         text = dirsrv_log.read()
                         log_name = os.path.basename(f)

--- a/dirsrvtests/tests/suites/logging/logging_compression_test.py
+++ b/dirsrvtests/tests/suites/logging/logging_compression_test.py
@@ -1,0 +1,121 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import glob
+import ldap
+import logging
+import pytest
+import os
+import time
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.dseldif import DSEldif
+from lib389.topologies import topology_st as topo
+from lib389.idm.domain import Domain
+
+log = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.tier1
+
+def log_rotated_count(log_type, log_dir, check_compressed=False):
+    # Check if the log was rotated
+    log_file = f'{log_dir}/{log_type}.2*'
+    if check_compressed:
+        log_file += ".gz"
+    return len(glob.glob(log_file))
+
+
+def update_and_sleep(suffix, sleep=True):
+    for loop in range(2):
+        for count in range(10):
+            suffix.replace('description', str(count))
+            suffix.get_attr_val('description')
+            with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+                suffix.add('doesNotExist', 'error')
+        if sleep:
+            # log rotation smallest unit is 1 minute
+            time.sleep(61)
+        else:
+            # should still sleep for a little bit
+            time.sleep(1)
+
+
+def test_logging_compression(topo):
+    """Test logging compression works, and log rotation/deletion is still
+    functional.  This also tests a mix of non-compressed/compressed logs.
+
+    :id: 15b5ed0e-628c-48e5-a61e-43908590c9f1
+    :setup: Standalone Instance
+    :steps:
+        1. Enable all the logs (audit,and auditfail)
+        2. Set an aggressive rotation/deletion policy
+        3. Make sure all logs are rotated at least once
+        4. Enable log compression on all logs
+        5. Make sure all logs are rotated again and are compressed
+        6. Make sure log deletion is working
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+
+    inst = topo.standalone
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    timeunit = "minute"  # This is the smallest time unit available
+    log_dir = inst.get_log_dir()
+
+    # Enable all the logs (audit, and auditfail)
+    inst.stop()
+    dse_ldif = DSEldif(inst)
+    dse_ldif.replace('cn=config', 'nsslapd-auditfaillog', log_dir + "/auditfail")
+    inst.start()
+
+    inst.config.set('nsslapd-auditlog-logging-enabled', 'on')
+    inst.config.set('nsslapd-auditfaillog-logging-enabled', 'on')
+    inst.config.set('nsslapd-accesslog-logbuffering', 'off')
+    inst.config.set('nsslapd-errorlog-level', '64')
+
+    # Set an aggressive rotation/deletion policy for all logs
+    for ds_log in ['accesslog', 'auditlog', 'auditfaillog', 'errorlog']:
+        inst.config.set('nsslapd-' + ds_log + '-logrotationtime', '1')
+        inst.config.set('nsslapd-' + ds_log + '-logrotationtimeunit', timeunit)
+        inst.config.set('nsslapd-' + ds_log + '-maxlogsize', '1')
+        inst.config.set('nsslapd-' + ds_log + '-maxlogsperdir', '3')
+
+    # Perform ops that will write to each log
+    update_and_sleep(suffix)
+
+    # Make sure logs are rotated
+    for log_type in ['access', 'audit', 'auditfail', 'errors']:
+        assert log_rotated_count(log_type, log_dir) > 0
+
+    # Enable log compression on all logs
+    for ds_log in ['accesslog', 'auditlog', 'auditfaillog', 'errorlog']:
+        inst.config.set('nsslapd-' + ds_log + '-compress', 'on')
+
+    # Perform ops that will write to each log
+    update_and_sleep(suffix)
+
+    # Make sure all logs were rotated again and are compressed
+    for log_type in ['access', 'audit', 'auditfail', 'errors']:
+        assert log_rotated_count(log_type, log_dir, check_compressed=True) > 0
+
+    # Make sure log deletion is working
+    update_and_sleep(suffix, sleep=False)
+    for log_type in ['access', 'audit', 'auditfail', 'errors']:
+        assert log_rotated_count(log_type, log_dir) == 2
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -181,6 +181,10 @@ slapi_onoff_t init_accesslog_rotationsync_enabled;
 slapi_onoff_t init_errorlog_rotationsync_enabled;
 slapi_onoff_t init_auditlog_rotationsync_enabled;
 slapi_onoff_t init_auditfaillog_rotationsync_enabled;
+slapi_onoff_t init_accesslog_compress_enabled;
+slapi_onoff_t init_auditlog_compress_enabled;
+slapi_onoff_t init_auditfaillog_compress_enabled;
+slapi_onoff_t init_errorlog_compress_enabled;
 slapi_onoff_t init_accesslog_logging_enabled;
 slapi_onoff_t init_accesslogbuffering;
 slapi_onoff_t init_external_libs_debug_enabled;
@@ -332,6 +336,22 @@ static struct config_get_and_set
      log_set_logging, SLAPD_ACCESS_LOG,
      (void **)&global_slapdFrontendConfig.accesslog_logging_enabled,
      CONFIG_ON_OFF, NULL, &init_accesslog_logging_enabled, NULL},
+    {CONFIG_ACCESSLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
+     log_set_compression, SLAPD_ACCESS_LOG,
+     (void **)&global_slapdFrontendConfig.accesslog_compress,
+     CONFIG_ON_OFF, NULL, &init_accesslog_compress_enabled, NULL},
+    {CONFIG_AUDITLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
+     log_set_compression, SLAPD_AUDIT_LOG,
+     (void **)&global_slapdFrontendConfig.auditlog_compress,
+     CONFIG_ON_OFF, NULL, &init_auditlog_compress_enabled, NULL},
+    {CONFIG_AUDITFAILLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
+     log_set_compression, SLAPD_AUDITFAIL_LOG,
+     (void **)&global_slapdFrontendConfig.auditfaillog_compress,
+     CONFIG_ON_OFF, NULL, &init_auditfaillog_compress_enabled, NULL},
+    {CONFIG_ERRORLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
+     log_set_compression, SLAPD_ERROR_LOG,
+     (void **)&global_slapdFrontendConfig.errorlog_compress,
+     CONFIG_ON_OFF, NULL, &init_errorlog_compress_enabled, NULL},
     {CONFIG_PORT_ATTRIBUTE, config_set_port,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.port,
@@ -1746,6 +1766,7 @@ FrontendConfig_init(void)
     cfg->accessloglevel = SLAPD_DEFAULT_ACCESSLOG_LEVEL;
     init_accesslogbuffering = cfg->accesslogbuffering = LDAP_ON;
     init_csnlogging = cfg->csnlogging = LDAP_ON;
+    init_accesslog_compress_enabled = cfg->accesslog_compress = LDAP_OFF;
 
     init_errorlog_logging_enabled = cfg->errorlog_logging_enabled = LDAP_ON;
     init_external_libs_debug_enabled = cfg->external_libs_debug_enabled = LDAP_OFF;
@@ -1763,6 +1784,7 @@ FrontendConfig_init(void)
     cfg->errorlog_exptime = SLAPD_DEFAULT_LOG_EXPTIME;
     cfg->errorlog_exptimeunit = slapi_ch_strdup(SLAPD_INIT_LOG_EXPTIMEUNIT);
     cfg->errorloglevel = SLAPD_DEFAULT_FE_ERRORLOG_LEVEL;
+    init_errorlog_compress_enabled = cfg->errorlog_compress = LDAP_OFF;
 
     init_auditlog_logging_enabled = cfg->auditlog_logging_enabled = LDAP_OFF;
     cfg->auditlog_mode = slapi_ch_strdup(SLAPD_INIT_LOG_MODE);
@@ -1780,6 +1802,7 @@ FrontendConfig_init(void)
     cfg->auditlog_exptimeunit = slapi_ch_strdup(SLAPD_INIT_LOG_EXPTIMEUNIT);
     init_auditlog_logging_hide_unhashed_pw =
         cfg->auditlog_logging_hide_unhashed_pw = LDAP_ON;
+    init_auditlog_compress_enabled = cfg->auditlog_compress = LDAP_OFF;
 
     init_auditfaillog_logging_enabled = cfg->auditfaillog_logging_enabled = LDAP_OFF;
     cfg->auditfaillog_mode = slapi_ch_strdup(SLAPD_INIT_LOG_MODE);
@@ -1797,6 +1820,7 @@ FrontendConfig_init(void)
     cfg->auditfaillog_exptimeunit = slapi_ch_strdup(SLAPD_INIT_LOG_EXPTIMEUNIT);
     init_auditfaillog_logging_hide_unhashed_pw =
         cfg->auditfaillog_logging_hide_unhashed_pw = LDAP_ON;
+    init_auditfaillog_compress_enabled = cfg->auditfaillog_compress = LDAP_OFF;
 
 #ifdef HAVE_CLOCK_GETTIME
     init_logging_hr_timestamps =

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -860,6 +860,7 @@ int log_update_errorlogdir(char *pathname, int apply);
 int log_update_auditlogdir(char *pathname, int apply);
 int log_update_auditfaillogdir(char *pathname, int apply);
 int log_set_logging(const char *attrname, char *value, int logtype, char *errorbuf, int apply);
+int log_set_compression(const char *attrname, char *value, int logtype, char *errorbuf, int apply);
 int check_log_max_size(
     char *maxdiskspace_str,
     char *mlogsize_str,

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2135,6 +2135,10 @@ typedef struct _slapdEntryPoints
 #define CONFIG_AUDITFAILLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-auditfaillog-logging-enabled"
 #define CONFIG_AUDITLOG_LOGGING_HIDE_UNHASHED_PW "nsslapd-auditlog-logging-hide-unhashed-pw"
 #define CONFIG_AUDITFAILLOG_LOGGING_HIDE_UNHASHED_PW "nsslapd-auditfaillog-logging-hide-unhashed-pw"
+#define CONFIG_ACCESSLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-accesslog-compress"
+#define CONFIG_AUDITLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditlog-compress"
+#define CONFIG_AUDITFAILLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditfaillog-compress"
+#define CONFIG_ERRORLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-errorlog-compress"
 #define CONFIG_UNHASHED_PW_SWITCH_ATTRIBUTE "nsslapd-unhashed-pw-switch"
 #define CONFIG_ROOTDN_ATTRIBUTE "nsslapd-rootdn"
 #define CONFIG_ROOTPW_ATTRIBUTE "nsslapd-rootpw"
@@ -2457,6 +2461,7 @@ typedef struct _slapdFrontendConfig
     int accessloglevel;
     slapi_onoff_t accesslogbuffering;
     slapi_onoff_t csnlogging;
+    slapi_onoff_t accesslog_compress;
 
     /* ERROR LOG */
     slapi_onoff_t errorlog_logging_enabled;
@@ -2474,6 +2479,7 @@ typedef struct _slapdFrontendConfig
     char *errorlog_exptimeunit;
     int errorloglevel;
     slapi_onoff_t external_libs_debug_enabled;
+    slapi_onoff_t errorlog_compress;
 
     /* AUDIT LOG */
     char *auditlog; /* replication audit file */
@@ -2492,6 +2498,7 @@ typedef struct _slapdFrontendConfig
     int auditlog_exptime;
     char *auditlog_exptimeunit;
     slapi_onoff_t auditlog_logging_hide_unhashed_pw;
+    slapi_onoff_t auditlog_compress;
 
     /* AUDIT FAIL LOG */
     char *auditfaillog;
@@ -2510,6 +2517,7 @@ typedef struct _slapdFrontendConfig
     int auditfaillog_exptime;
     char *auditfaillog_exptimeunit;
     slapi_onoff_t auditfaillog_logging_hide_unhashed_pw;
+    slapi_onoff_t auditfaillog_compress;
 
     char *logging_backend;
 #ifdef HAVE_CLOCK_GETTIME

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -190,6 +190,8 @@ Requires:         perl-sigtrap
 %endif
 # Needed for password dictionary checks
 Requires:         cracklib-dicts
+# Log compression
+Requires:         zlib-devel
 # Picks up our systemd deps.
 %{?systemd_requires}
 

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -13,6 +13,7 @@ import {
     GridItem,
     NumberInput,
     Spinner,
+    Switch,
     Tab,
     Tabs,
     TabTitleText,
@@ -50,6 +51,7 @@ const rotation_attrs = [
     'nsslapd-accesslog-logrotationtimeunit',
     'nsslapd-accesslog-maxlogsize',
     'nsslapd-accesslog-maxlogsperdir',
+    'nsslapd-accesslog-compress'
 ];
 
 const rotation_attrs_no_time = [
@@ -58,6 +60,7 @@ const rotation_attrs_no_time = [
     'nsslapd-accesslog-logrotationtimeunit',
     'nsslapd-accesslog-maxlogsize',
     'nsslapd-accesslog-maxlogsperdir',
+    'nsslapd-accesslog-compress'
 ];
 
 const exp_attrs = [
@@ -104,6 +107,7 @@ export class ServerAccessLog extends React.Component {
         };
 
         this.handleChange = this.handleChange.bind(this);
+        this.handleSwitchChange = this.handleSwitchChange.bind(this);
         this.handleTimeChange = this.handleTimeChange.bind(this);
         this.loadConfig = this.loadConfig.bind(this);
         this.refreshConfig = this.refreshConfig.bind(this);
@@ -196,6 +200,15 @@ export class ServerAccessLog extends React.Component {
         this.setState({
             [attr]: value,
         }, () => { this.validateSaveBtn(nav_tab, attr, value) } );
+    }
+
+    handleSwitchChange(value) {
+        // log compression
+        this.setState({
+            'nsslapd-accesslog-compress': value
+        }, () => {
+            this.validateSaveBtn('rotation', 'nsslapd-accesslog-compress', value);
+        });
     }
 
     handleTimeChange(time_str) {
@@ -318,6 +331,7 @@ export class ServerAccessLog extends React.Component {
                     const attrs = config.attrs;
                     let enabled = false;
                     let buffering = false;
+                    let compress = false;
                     const level_val = parseInt(attrs['nsslapd-accesslog-level'][0]);
                     const rows = [...this.state.rows];
 
@@ -326,6 +340,9 @@ export class ServerAccessLog extends React.Component {
                     }
                     if (attrs['nsslapd-accesslog-logbuffering'][0] == "on") {
                         buffering = true;
+                    }
+                    if (attrs['nsslapd-accesslog-compress'][0] == "on") {
+                        compress = true;
                     }
                     for (const row in rows) {
                         if (rows[row].level & level_val) {
@@ -356,6 +373,7 @@ export class ServerAccessLog extends React.Component {
                         'nsslapd-accesslog-logrotationtimeunit': attrs['nsslapd-accesslog-logrotationtimeunit'][0],
                         'nsslapd-accesslog-maxlogsize': attrs['nsslapd-accesslog-maxlogsize'][0],
                         'nsslapd-accesslog-maxlogsperdir': attrs['nsslapd-accesslog-maxlogsperdir'][0],
+                        'nsslapd-accesslog-compress': compress,
                         rows: rows,
                         // Record original values
                         _rows:  JSON.parse(JSON.stringify(rows)),
@@ -374,6 +392,7 @@ export class ServerAccessLog extends React.Component {
                         '_nsslapd-accesslog-logrotationtimeunit': attrs['nsslapd-accesslog-logrotationtimeunit'][0],
                         '_nsslapd-accesslog-maxlogsize': attrs['nsslapd-accesslog-maxlogsize'][0],
                         '_nsslapd-accesslog-maxlogsperdir': attrs['nsslapd-accesslog-maxlogsperdir'][0],
+                        '_nsslapd-accesslog-compress': compress,
                     });
                 })
                 .fail(err => {
@@ -393,6 +412,7 @@ export class ServerAccessLog extends React.Component {
         const attrs = this.state.attrs;
         let enabled = false;
         let buffering = false;
+        let compress = false;
         const level_val = parseInt(attrs['nsslapd-accesslog-level'][0]);
         const rows = [...this.state.rows];
 
@@ -401,6 +421,9 @@ export class ServerAccessLog extends React.Component {
         }
         if (attrs['nsslapd-accesslog-logbuffering'][0] == "on") {
             buffering = true;
+        }
+        if (attrs['nsslapd-accesslog-compress'][0] == "on") {
+            compress = true;
         }
         for (const row in rows) {
             if (rows[row].level & level_val) {
@@ -431,6 +454,7 @@ export class ServerAccessLog extends React.Component {
             'nsslapd-accesslog-logrotationtimeunit': attrs['nsslapd-accesslog-logrotationtimeunit'][0],
             'nsslapd-accesslog-maxlogsize': attrs['nsslapd-accesslog-maxlogsize'][0],
             'nsslapd-accesslog-maxlogsperdir': attrs['nsslapd-accesslog-maxlogsperdir'][0],
+            'nsslapd-accesslog-compress': compress,
             rows: rows,
             // Record original values
             _rows: JSON.parse(JSON.stringify(rows)),
@@ -449,6 +473,7 @@ export class ServerAccessLog extends React.Component {
             '_nsslapd-accesslog-logrotationtimeunit': attrs['nsslapd-accesslog-logrotationtimeunit'][0],
             '_nsslapd-accesslog-maxlogsize': attrs['nsslapd-accesslog-maxlogsize'][0],
             '_nsslapd-accesslog-maxlogsperdir': attrs['nsslapd-accesslog-maxlogsperdir'][0],
+            '_nsslapd-accesslog-compress': compress,
         }, this.props.enableTree);
     }
 
@@ -682,6 +707,18 @@ export class ServerAccessLog extends React.Component {
                                         time={rotationTime}
                                         onChange={this.handleTimeChange}
                                         is24Hour
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="Compress (gzip) the log after it's rotated.">
+                                <GridItem className="ds-label" span={3}>
+                                    Compress Rotated Logs
+                                </GridItem>
+                                <GridItem className="ds-label" span={8}>
+                                    <Switch
+                                        id="nsslapd-accesslog-compress"
+                                        isChecked={this.state['nsslapd-accesslog-compress']}
+                                        onChange={this.handleSwitchChange}
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -12,6 +12,7 @@ import {
     GridItem,
     NumberInput,
     Spinner,
+    Switch,
     Tab,
     Tabs,
     TabTitleText,
@@ -43,6 +44,7 @@ const rotation_attrs = [
     'nsslapd-auditlog-logrotationtimeunit',
     'nsslapd-auditlog-maxlogsize',
     'nsslapd-auditlog-maxlogsperdir',
+    'nsslapd-auditlog-compress'
 ];
 
 const rotation_attrs_no_time = [
@@ -51,6 +53,7 @@ const rotation_attrs_no_time = [
     'nsslapd-auditlog-logrotationtimeunit',
     'nsslapd-auditlog-maxlogsize',
     'nsslapd-auditlog-maxlogsperdir',
+    'nsslapd-auditlog-compress'
 ];
 
 const exp_attrs = [
@@ -81,6 +84,7 @@ export class ServerAuditLog extends React.Component {
         };
 
         this.handleChange = this.handleChange.bind(this);
+        this.handleSwitchChange = this.handleSwitchChange.bind(this);
         this.handleTimeChange = this.handleTimeChange.bind(this);
         this.loadConfig = this.loadConfig.bind(this);
         this.refreshConfig = this.refreshConfig.bind(this);
@@ -153,7 +157,7 @@ export class ServerAuditLog extends React.Component {
             [disableBtnName]: disableSaveBtn
         });
     }
-l
+
     handleChange(e, nav_tab) {
         const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
         const attr = e.target.id;
@@ -161,6 +165,15 @@ l
         this.setState({
             [attr]: value,
         }, () => { this.validateSaveBtn(nav_tab, attr, value) } );
+    }
+
+    handleSwitchChange(value) {
+        // log compression
+        this.setState({
+            'nsslapd-auditlog-compress': value
+        }, () => {
+            this.validateSaveBtn('rotation', 'nsslapd-auditlog-compress', value);
+        });
     }
 
     handleTimeChange(time_str) {
@@ -268,9 +281,13 @@ l
                     const config = JSON.parse(content);
                     const attrs = config.attrs;
                     let enabled = false;
+                    let compressed = false;
 
                     if (attrs['nsslapd-auditlog-logging-enabled'][0] == "on") {
                         enabled = true;
+                    }
+                    if (attrs['nsslapd-auditlog-compress'][0] == "on") {
+                        compressed = true;
                     }
 
                     this.setState({
@@ -292,6 +309,7 @@ l
                         'nsslapd-auditlog-logrotationtimeunit': attrs['nsslapd-auditlog-logrotationtimeunit'][0],
                         'nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
                         'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
+                        'nsslapd-auditlog-compress': compressed,
                         // Record original values
                         '_nsslapd-auditlog': attrs['nsslapd-auditlog'][0],
                         '_nsslapd-auditlog-logexpirationtime': attrs['nsslapd-auditlog-logexpirationtime'][0],
@@ -306,6 +324,7 @@ l
                         '_nsslapd-auditlog-logrotationtimeunit': attrs['nsslapd-auditlog-logrotationtimeunit'][0],
                         '_nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
                         '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
+                        '_nsslapd-auditlog-compress': compressed,
                     });
                 })
                 .fail(err => {
@@ -324,9 +343,13 @@ l
     loadConfig() {
         const attrs = this.state.attrs;
         let enabled = false;
+        let compressed = false;
 
         if (attrs['nsslapd-auditlog-logging-enabled'][0] == "on") {
             enabled = true;
+        }
+        if (attrs['nsslapd-auditlog-compress'][0] == "on") {
+            compressed = true;
         }
 
         this.setState({
@@ -348,6 +371,7 @@ l
             'nsslapd-auditlog-logrotationtimeunit': attrs['nsslapd-auditlog-logrotationtimeunit'][0],
             'nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
             'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
+            'nsslapd-auditlog-compress': compressed,
             // Record original values,
             '_nsslapd-auditlog': attrs['nsslapd-auditlog'][0],
             '_nsslapd-auditlog-logexpirationtime': attrs['nsslapd-auditlog-logexpirationtime'][0],
@@ -362,6 +386,7 @@ l
             '_nsslapd-auditlog-logrotationtimeunit': attrs['nsslapd-auditlog-logrotationtimeunit'][0],
             '_nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
             '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
+            '_nsslapd-auditlog-compress': compressed,
         }, this.props.enableTree);
     }
 
@@ -531,6 +556,18 @@ l
                                         onChange={this.handleTimeChange}
                                         is24Hour
                                     />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="Compress (gzip) the log after it's rotated.">
+                                <GridItem className="ds-label" span={3}>
+                                    Compress Rotated Logs
+                                </GridItem>
+                                <GridItem span={8}>
+                                    <Switch
+                                        id="nsslapd-auditlog-compress"
+                                        isChecked={this.state['nsslapd-auditlog-compress']}
+                                        onChange={this.handleSwitchChange}
+                                    />`
                                 </GridItem>
                             </Grid>
                         </Form>

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -11,6 +11,7 @@ import {
     GridItem,
     NumberInput,
     Spinner,
+    Switch,
     Tab,
     Tabs,
     TabTitleText,
@@ -42,6 +43,7 @@ const rotation_attrs = [
     'nsslapd-auditfaillog-logrotationtimeunit',
     'nsslapd-auditfaillog-maxlogsize',
     'nsslapd-auditfaillog-maxlogsperdir',
+    'nsslapd-auditfaillog-compress'
 ];
 
 const rotation_attrs_no_time = [
@@ -50,6 +52,7 @@ const rotation_attrs_no_time = [
     'nsslapd-auditfaillog-logrotationtimeunit',
     'nsslapd-auditfaillog-maxlogsize',
     'nsslapd-auditfaillog-maxlogsperdir',
+    'nsslapd-auditfaillog-compress'
 ];
 
 const exp_attrs = [
@@ -80,6 +83,7 @@ export class ServerAuditFailLog extends React.Component {
         };
 
         this.handleChange = this.handleChange.bind(this);
+        this.handleSwitchChange = this.handleSwitchChange.bind(this);
         this.handleTimeChange = this.handleTimeChange.bind(this);
         this.loadConfig = this.loadConfig.bind(this);
         this.refreshConfig = this.refreshConfig.bind(this);
@@ -162,6 +166,14 @@ export class ServerAuditFailLog extends React.Component {
         }, () => { this.validateSaveBtn(nav_tab, attr, value) } );
     }
 
+    handleSwitchChange(value) {
+        // log compression
+        this.setState({
+            'nsslapd-auditfaillog-compress': value
+        }, () => {
+            this.validateSaveBtn('rotation', 'nsslapd-auditfaillog-compress', value);
+        });
+    }
 
     handleTimeChange(time_str) {
         let disableSaveBtn = true;
@@ -269,9 +281,13 @@ export class ServerAuditFailLog extends React.Component {
                     const config = JSON.parse(content);
                     const attrs = config.attrs;
                     let enabled = false;
+                    let compressed = false;
 
                     if (attrs['nsslapd-auditfaillog-logging-enabled'][0] == "on") {
                         enabled = true;
+                    }
+                    if (attrs['nsslapd-auditfaillog-compress'][0] == "on") {
+                        compressed = true;
                     }
 
                     this.setState(() => (
@@ -294,6 +310,7 @@ export class ServerAuditFailLog extends React.Component {
                             'nsslapd-auditfaillog-logrotationtimeunit': attrs['nsslapd-auditfaillog-logrotationtimeunit'][0],
                             'nsslapd-auditfaillog-maxlogsize': attrs['nsslapd-auditfaillog-maxlogsize'][0],
                             'nsslapd-auditfaillog-maxlogsperdir': attrs['nsslapd-auditfaillog-maxlogsperdir'][0],
+                            'nsslapd-auditfaillog-compress': compressed,
                             // Record original values
                             '_nsslapd-auditfaillog': attrs['nsslapd-auditfaillog'][0],
                             '_nsslapd-auditfaillog-logexpirationtime': attrs['nsslapd-auditfaillog-logexpirationtime'][0],
@@ -308,6 +325,7 @@ export class ServerAuditFailLog extends React.Component {
                             '_nsslapd-auditfaillog-logrotationtimeunit': attrs['nsslapd-auditfaillog-logrotationtimeunit'][0],
                             '_nsslapd-auditfaillog-maxlogsize': attrs['nsslapd-auditfaillog-maxlogsize'][0],
                             '_nsslapd-auditfaillog-maxlogsperdir': attrs['nsslapd-auditfaillog-maxlogsperdir'][0],
+                            '_nsslapd-auditfaillog-compress': compressed,
                         })
                     );
                 })
@@ -327,9 +345,13 @@ export class ServerAuditFailLog extends React.Component {
     loadConfig() {
         const attrs = this.state.attrs;
         let enabled = false;
+        let compressed = false;
 
         if (attrs['nsslapd-auditfaillog-logging-enabled'][0] == "on") {
             enabled = true;
+        }
+        if (attrs['nsslapd-auditfaillog-compress'][0] == "on") {
+            compressed = true;
         }
 
         this.setState({
@@ -351,6 +373,7 @@ export class ServerAuditFailLog extends React.Component {
             'nsslapd-auditfaillog-logrotationtimeunit': attrs['nsslapd-auditfaillog-logrotationtimeunit'][0],
             'nsslapd-auditfaillog-maxlogsize': attrs['nsslapd-auditfaillog-maxlogsize'][0],
             'nsslapd-auditfaillog-maxlogsperdir': attrs['nsslapd-auditfaillog-maxlogsperdir'][0],
+            'nsslapd-auditfaillog-compress': compressed,
             // Record original values,
             '_nsslapd-auditfaillog': attrs['nsslapd-auditfaillog'][0],
             '_nsslapd-auditfaillog-logexpirationtime': attrs['nsslapd-auditfaillog-logexpirationtime'][0],
@@ -365,6 +388,7 @@ export class ServerAuditFailLog extends React.Component {
             '_nsslapd-auditfaillog-logrotationtimeunit': attrs['nsslapd-auditfaillog-logrotationtimeunit'][0],
             '_nsslapd-auditfaillog-maxlogsize': attrs['nsslapd-auditfaillog-maxlogsize'][0],
             '_nsslapd-auditfaillog-maxlogsperdir': attrs['nsslapd-auditfaillog-maxlogsperdir'][0],
+            '_nsslapd-auditfaillog-compress': compressed,
         }, this.props.enableTree);
     }
 
@@ -532,6 +556,18 @@ export class ServerAuditFailLog extends React.Component {
                                         time={rotationTime}
                                         onChange={this.handleTimeChange}
                                         is24Hour
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="Compress (gzip) the log after it's rotated.">
+                                <GridItem className="ds-label" span={3}>
+                                    Compress Rotated Logs
+                                </GridItem>
+                                <GridItem span={8}>
+                                    <Switch
+                                        id="nsslapd-auditfaillog-compress"
+                                        isChecked={this.state['nsslapd-auditfaillog-compress']}
+                                        onChange={this.handleSwitchChange}
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -13,6 +13,7 @@ import {
     GridItem,
     NumberInput,
     Spinner,
+    Switch,
     Tab,
     Tabs,
     TabTitleText,
@@ -49,6 +50,7 @@ const rotation_attrs = [
     'nsslapd-errorlog-logrotationtimeunit',
     'nsslapd-errorlog-maxlogsize',
     'nsslapd-errorlog-maxlogsperdir',
+    'nsslapd-errorlog-compress'
 ];
 
 const rotation_attrs_no_time = [
@@ -57,6 +59,7 @@ const rotation_attrs_no_time = [
     'nsslapd-errorlog-logrotationtimeunit',
     'nsslapd-errorlog-maxlogsize',
     'nsslapd-errorlog-maxlogsperdir',
+    'nsslapd-errorlog-compress'
 ];
 
 const exp_attrs = [
@@ -114,6 +117,7 @@ export class ServerErrorLog extends React.Component {
         };
 
         this.handleChange = this.handleChange.bind(this);
+        this.handleSwitchChange = this.handleSwitchChange.bind(this);
         this.handleTimeChange = this.handleTimeChange.bind(this);
         this.loadConfig = this.loadConfig.bind(this);
         this.refreshConfig = this.refreshConfig.bind(this);
@@ -206,6 +210,15 @@ export class ServerErrorLog extends React.Component {
         this.setState({
             [attr]: value,
         }, () => { this.validateSaveBtn(nav_tab, attr, value) } );
+    }
+
+    handleSwitchChange(value) {
+        // log compression
+        this.setState({
+            'nsslapd-errorlog-compress': value
+        }, () => {
+            this.validateSaveBtn('rotation', 'nsslapd-errorlog-compress', value);
+        });
     }
 
     handleTimeChange(time_str) {
@@ -327,12 +340,17 @@ export class ServerErrorLog extends React.Component {
                     const config = JSON.parse(content);
                     const attrs = config.attrs;
                     let enabled = false;
+                    let compressed = false;
                     const level_val = parseInt(attrs['nsslapd-errorlog-level'][0]);
                     const rows = [...this.state.rows];
 
                     if (attrs['nsslapd-errorlog-logging-enabled'][0] == "on") {
                         enabled = true;
                     }
+                    if (attrs['nsslapd-errorlog-compress'][0] == "on") {
+                        compressed = true;
+                    }
+
                     for (const row in rows) {
                         if (rows[row].level & level_val) {
                             rows[row].selected = true;
@@ -362,6 +380,7 @@ export class ServerErrorLog extends React.Component {
                             'nsslapd-errorlog-logrotationtimeunit': attrs['nsslapd-errorlog-logrotationtimeunit'][0],
                             'nsslapd-errorlog-maxlogsize': attrs['nsslapd-errorlog-maxlogsize'][0],
                             'nsslapd-errorlog-maxlogsperdir': attrs['nsslapd-errorlog-maxlogsperdir'][0],
+                            'nsslapd-errorlog-compress': compressed,
                             rows: rows,
                             // Record original values
                             _rows:  JSON.parse(JSON.stringify(rows)),
@@ -379,6 +398,7 @@ export class ServerErrorLog extends React.Component {
                             '_nsslapd-errorlog-logrotationtimeunit': attrs['nsslapd-errorlog-logrotationtimeunit'][0],
                             '_nsslapd-errorlog-maxlogsize': attrs['nsslapd-errorlog-maxlogsize'][0],
                             '_nsslapd-errorlog-maxlogsperdir': attrs['nsslapd-errorlog-maxlogsperdir'][0],
+                            '_nsslapd-errorlog-compress': compressed,
                         })
                     );
                 })
@@ -398,11 +418,15 @@ export class ServerErrorLog extends React.Component {
     loadConfig() {
         const attrs = this.state.attrs;
         let enabled = false;
+        let compressed = false;
         const level_val = parseInt(attrs['nsslapd-errorlog-level'][0]);
         const rows = [...this.state.rows];
 
         if (attrs['nsslapd-errorlog-logging-enabled'][0] == "on") {
             enabled = true;
+        }
+        if (attrs['nsslapd-errorlog-compress'][0] == "on") {
+            compressed = true;
         }
         for (const row in rows) {
             if (rows[row].level & level_val) {
@@ -432,6 +456,7 @@ export class ServerErrorLog extends React.Component {
             'nsslapd-errorlog-logrotationtimeunit': attrs['nsslapd-errorlog-logrotationtimeunit'][0],
             'nsslapd-errorlog-maxlogsize': attrs['nsslapd-errorlog-maxlogsize'][0],
             'nsslapd-errorlog-maxlogsperdir': attrs['nsslapd-errorlog-maxlogsperdir'][0],
+            'nsslapd-errorlog-compress': compressed,
             rows: rows,
             // Record original values
             _rows: JSON.parse(JSON.stringify(rows)),
@@ -449,6 +474,7 @@ export class ServerErrorLog extends React.Component {
             '_nsslapd-errorlog-logrotationtimeunit': attrs['nsslapd-errorlog-logrotationtimeunit'][0],
             '_nsslapd-errorlog-maxlogsize': attrs['nsslapd-errorlog-maxlogsize'][0],
             '_nsslapd-errorlog-maxlogsperdir': attrs['nsslapd-errorlog-maxlogsperdir'][0],
+            '_nsslapd-errorlog-compress': compressed,
         }, this.props.enableTree);
     }
 
@@ -671,6 +697,18 @@ export class ServerErrorLog extends React.Component {
                                         time={rotationTime}
                                         onChange={this.handleTimeChange}
                                         is24Hour
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="Compress (gzip) the log after it's rotated.">
+                                <GridItem className="ds-label" span={3}>
+                                    Compress Rotated Logs
+                                </GridItem>
+                                <GridItem span={8}>
+                                    <Switch
+                                        id="nsslapd-errorlog-compress"
+                                        isChecked={this.state['nsslapd-errorlog-compress']}
+                                        onChange={this.handleSwitchChange}
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1624,6 +1624,10 @@ class DirSrv(SimpleLDAPObject, object):
         """Return the server identifier."""
         return self.serverid
 
+    def get_log_dir(self):
+        """Return the server instance ldif directory."""
+        return self.ds_paths.log_dir
+
     def get_ldif_dir(self):
         """Return the server instance ldif directory."""
         return self.ds_paths.ldif_dir

--- a/src/lib389/lib389/dirsrv_log.py
+++ b/src/lib389/lib389/dirsrv_log.py
@@ -308,7 +308,7 @@ class DirsrvErrorLog(DirsrvLog):
     """Directory Server Error log class"""
     def __init__(self, dirsrv):
         """Init the Error log class
-        @param diursrv - A DirSrv object
+        @param dirsrv - A DirSrv object
         """
         super(DirsrvErrorLog, self).__init__(dirsrv)
         self.prog_m1 = re.compile(r'^(?P<timestamp>\[.*\])\s(?P<message>.*)')


### PR DESCRIPTION
Description:

After rotating a log compress it using gzip.  Required updating the
rotation/deletion policy to account for the longer log name (.gz)

relates: https://github.com/389ds/389-ds-base/issues/379

This requires an update to selinux to work on RHEL.  See:  https://bugzilla.redhat.com/show_bug.cgi?id=2081797