### PR TITLE
Issue 5291 - Harden ReplicationManager.wait_for_replication

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -589,14 +589,19 @@ def test_fetch_bindDnGroup(topo_m2):
     repl = ReplicationManager(DEFAULT_SUFFIX)
     repl.wait_for_replication(M1, M2, timeout=20)
 
+    save_values = [] # Save original value to restore them at the end of the test
     # Define the group as the replication manager and fetch interval as 60sec
     replicas = Replicas(M1)
     replica = replicas.list()[0]
+    save_values.append((replica, 'nsDS5ReplicaBindDnGroupCheckInterval', replica.get_attr_val_utf8('nsDS5ReplicaBindDnGroupCheckInterval')))
+    save_values.append((replica, 'nsDS5ReplicaBindDnGroup', replica.get_attr_val_utf8('nsDS5ReplicaBindDnGroup')))
     replica.apply_mods([(ldap.MOD_REPLACE, 'nsDS5ReplicaBindDnGroupCheckInterval', '60'),
                         (ldap.MOD_REPLACE, 'nsDS5ReplicaBindDnGroup', group_M1.dn)])
 
     replicas = Replicas(M2)
     replica = replicas.list()[0]
+    save_values.append((replica, 'nsDS5ReplicaBindDnGroupCheckInterval', replica.get_attr_val_utf8('nsDS5ReplicaBindDnGroupCheckInterval')))
+    save_values.append((replica, 'nsDS5ReplicaBindDnGroup', replica.get_attr_val_utf8('nsDS5ReplicaBindDnGroup')))
     replica.apply_mods([(ldap.MOD_REPLACE, 'nsDS5ReplicaBindDnGroupCheckInterval', '60'),
                         (ldap.MOD_REPLACE, 'nsDS5ReplicaBindDnGroup', group_M1.dn)])
 
@@ -608,6 +613,8 @@ def test_fetch_bindDnGroup(topo_m2):
     for inst in (M1, M2):
         agmts = Agreements(inst)
         agmt = agmts.list()[0]
+        save_values.append((agmt, 'nsDS5ReplicaBindDN', agmt.get_attr_val_utf8('nsDS5ReplicaBindDN')))
+        save_values.append((agmt, 'nsds5ReplicaCredentials', agmt.get_attr_val_utf8('nsds5ReplicaCredentials')))
         agmt.replace('nsDS5ReplicaBindDN', create_user.dn.encode())
         agmt.replace('nsds5ReplicaCredentials', PASSWD.encode())
 
@@ -673,6 +680,10 @@ def test_fetch_bindDnGroup(topo_m2):
     assert(count <= 1)
     count = pattern_errorlog(errorlog_M2, regex, start_location=restart_location_M2)
     assert(count <= 1)
+
+    # Restore the agmt values to avoid impacting the other tests.
+    for entry, attr, val in save_values:
+        entry.replace(attr, val)
 
 
 def test_plugin_bind_dn_tracking_and_replication(topo_m2):


### PR DESCRIPTION
ReplicationManager.wait_for_replication may wrongly fails without no way to determine if the error is normal or not.
Solution to harden the function is to also check the description value ob the "from" side
And if servers are in sync but not having the expected value

LOG A DIFFERENT MESSAGE
REDO THE CHANGE (because previous one may have been overwritten by URP)

If the timeout (now set to 60 seconds by default) expires then log last 30 lines from replication plugin in error log
 on both instances.  (to capture the last replication session)
This change helped me to understand why test_change_repl_passwd[using-bind-group] fails while it pass when running alone.
 So I also fixed test_fetch_bindDnGroup test to restore the configuration and avoid impacting the other tests.

Issue 5291

Reviewed by: @mreynolds389
