### PR TITLE
Issue 5290 - Importing certificate chain files via "import-server-key-cert" no longer works

### DIFF
--- a/dirsrvtests/tests/suites/tls/tls_import_ca_chain_test.py
+++ b/dirsrvtests/tests/suites/tls/tls_import_ca_chain_test.py
@@ -41,14 +41,27 @@ def test_tls_import_chain(topology_st):
         tls.add_cert(nickname='CA_CHAIN_1', input_file=CA_CHAIN_FILE)
 
     with pytest.raises(ValueError):
-        tls.add_server_key_and_cert(KEY_FILE, CRT_CHAIN_FILE)
-    with pytest.raises(ValueError):
-        tls.add_server_key_and_cert(KEY_CHAIN_FILE, CRT_CHAIN_FILE)
-    with pytest.raises(ValueError):
-        tls.add_server_key_and_cert(KEY_FILE, KEY_CHAIN_FILE)
-
-    with pytest.raises(ValueError):
         tls.import_rsa_crt(crt=CRT_CHAIN_FILE)
     with pytest.raises(ValueError):
         tls.import_rsa_crt(ca=CA_CHAIN_FILE)
 
+def test_tls_import_chain_pk12util(topology_st):
+    """Test that importing certificate chain files via pk12util does not report
+    any errors
+
+    :id: c38b2cf9-93f0-4168-ab23-c74ac21ad59f
+
+    :steps:
+        1. Attempt to import a ca chain
+
+    :expectedresults:
+        1. Chain is successfully imported, no errors raised
+    """
+
+    topology_st.standalone.stop()
+    tls = NssSsl(dirsrv=topology_st.standalone)
+    tls.reinit()
+
+    tls.add_server_key_and_cert(KEY_FILE, CRT_CHAIN_FILE)
+    tls.add_server_key_and_cert(KEY_CHAIN_FILE, CRT_CHAIN_FILE)
+    tls.add_server_key_and_cert(KEY_FILE, KEY_CHAIN_FILE)

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -1039,9 +1039,6 @@ only.
         if not os.path.exists(input_cert):
             raise ValueError("The cert file ({}) does not exist".format(input_cert))
 
-        self._assert_not_chain(input_key)
-        self._assert_not_chain(input_cert)
-
         self.log.debug(f"Importing key and cert -> {input_key}, {input_cert}")
 
         p12_bundle = "%s/temp_server_key_cert.p12" % self._certdb


### PR DESCRIPTION
Remove assertions from add_server_key_and_cert since pk12util has no issues importing certificate chain files
