### PR TITLE
Issue 5294 - Report Portal 5 is not processing test results XML file

### DIFF
--- a/dirsrvtests/tests/suites/filter/large_filter_test.py
+++ b/dirsrvtests/tests/suites/filter/large_filter_test.py
@@ -140,7 +140,7 @@ FILTERS = ['(&(objectClass=person)(|(manager=uid=fmcdonnagh,dc=anuj,dc=com)'
 
 @pytest.mark.bz772777
 @pytest.mark.parametrize("real_value", FILTERS)
-def test_large_filter(topo, _create_entries, real_value):
+def test_large_filter(topo, _create_entries, real_value, ids=FILTERS):
     """Exercise large eq filter with dn syntax attributes
 
         :id: abe3e6de-9ecc-11e8-adf0-8c16451d917b


### PR DESCRIPTION
Bug Description: Report Portal 5 is not processing an XML file with
test parameters exceeding 1024 char.

Fix Description: Fix the test case by using ids.

fixes: https://github.com/389ds/389-ds-base/issues/5294

Review by: ???