### PR TITLE
Issue 4932 - CLI - add parser aliases to long arg names

### DIFF
--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -1221,7 +1221,7 @@ def create_parser(subparsers):
     # Replication Configuration
     ############################################
 
-    repl_parser = subparsers.add_parser('replication', help='Manage replication for a suffix')
+    repl_parser = subparsers.add_parser('replication', aliases=['repl'], help='Manage replication for a suffix')
     repl_subcommands = repl_parser.add_subparsers(help='Replication Configuration')
 
     repl_enable_parser = repl_subcommands.add_parser('enable', help='Enable replication for a suffix')

--- a/src/lib389/lib389/cli_idm/initialise.py
+++ b/src/lib389/lib389/cli_idm/initialise.py
@@ -16,7 +16,7 @@ def initialise(inst, basedn, log, args):
     s_ent.apply()
 
 def create_parser(subparsers):
-    initialise_parser = subparsers.add_parser('initialise', help="Initialise a backend with domain information and sample entries")
+    initialise_parser = subparsers.add_parser('initialise', aliases=['init'], help="Initialise a backend with domain information and sample entries")
     initialise_parser.set_defaults(func=initialise)
     initialise_parser.add_argument('--version', help="The version of entries to create.", default=INSTALL_LATEST_CONFIG)
 

--- a/src/lib389/lib389/cli_idm/organizationalunit.py
+++ b/src/lib389/lib389/cli_idm/organizationalunit.py
@@ -56,7 +56,7 @@ def rename(inst, basedn, log, args, warn=True):
     _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
 
 def create_parser(subparsers):
-    ou_parser = subparsers.add_parser('organizationalunit', help='Manage organizational units')
+    ou_parser = subparsers.add_parser('organizationalunit', aliases=['ou'], help='Manage organizational units')
 
     subcommands = ou_parser.add_subparsers(help='action')
 


### PR DESCRIPTION
Description:

In dsidm "organizationalunit", and "initialise" and be abbreviated to
shorter names, and in dsconf "replication" could use use an alias.

relates: https://github.com/389ds/389-ds-base/issues/4932

Reviewed by: ?