### PR TITLE
Issue 5307 - VERSION_PREREL is not set correctly in CI builds

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -53,9 +53,9 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checkout and configure
-        run: cd $GITHUB_WORKSPACE && autoreconf -fvi && ./configure
+        run: autoreconf -fvi && ./configure
         env:
           CC: ${{ matrix.compiler }}
           CXX: ${{ matrix.cpp-compiler }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,7 +14,7 @@ jobs:
       image: quay.io/389ds/ci-images:test
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run NPM Audit CI
         run: cd $GITHUB_WORKSPACE/src/cockpit/389-console && npx audit-ci --config audit-ci.json

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,14 +26,17 @@ jobs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Get a list of all test suites
         id: set-matrix
         run: echo "::set-output name=matrix::$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})"
 
       - name: Build RPMs
-        run: cd $GITHUB_WORKSPACE && SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
+        run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
 
       - name: Tar build artifacts
         run: tar -cvf dist.tar dist/
@@ -54,7 +57,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3

--- a/VERSION.sh
+++ b/VERSION.sh
@@ -12,7 +12,7 @@ VERSION_MAJOR=2
 VERSION_MINOR=2
 VERSION_MAINT=0
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
-VERSION_PREREL=0
+VERSION_PREREL=
 VERSION_DATE=$(date -u +%Y%m%d%H%M)
 
 # Set the version and release numbers for local developer RPM builds. We


### PR DESCRIPTION
Bug Description:
VERSION_PREREL is used to set pre-release version (.a1, .rc1, etc).
If the build is done inside the git tree, it is set to
VERSION_PREREL=.${VERSION_DATE}git$COMMIT.
But since we don't do any Alpha or RC releases, it should be
empty by default and populated by date and git commit hash in the
development builds.
Additionally, in our CI git commands stopped working after git-2.36
resulting in an incorrect VERSION_PREREL.

Fix Description:
* Set VERSION_PREREL to an empty value
* Update GH actions to explicitly add $GITHUB_WORKSPACE directory to a
  list of safe directories.

Fixes: https://github.com/389ds/389-ds-base/issues/5307