### PR TITLE
Issue 5304: Need a compatibility option about sub suffix handling

### DIFF
--- a/dirsrvtests/tests/suites/mapping_tree/regression_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/regression_test.py
@@ -1,0 +1,130 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import ldap
+import logging
+import os
+import pytest
+from lib389.backend import Backends, Backend
+from lib389.dbgen import dbgen_users
+from lib389.mappingTree import MappingTrees
+from lib389.topologies import topology_st
+
+try:
+    from lib389.backend import BackendSuffixView
+    has_orphan_attribute = True
+except ImportError:
+    has_orphan_attribute = False
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+BESTRUCT = [
+    { "bename" : "parent", "suffix": "dc=parent" },
+    { "bename" : "child1", "suffix": "dc=child1,dc=parent" },
+    { "bename" : "child2", "suffix": "dc=child2,dc=parent" },
+]
+
+
+@pytest.fixture(scope="function")
+def topo(topology_st, request):
+    bes = []
+
+    def fin():
+        for be in bes:
+            be.delete()
+
+    if not DEBUGGING:
+        request.addfinalizer(fin)
+
+    inst = topology_st.standalone
+    ldif_files = {}
+    for d in BESTRUCT:
+        bename = d['bename']
+        suffix = d['suffix']
+        log.info(f'Adding suffix: {suffix} and backend: {bename}...')
+        backends = Backends(inst)
+        try:
+            be = backends.create(properties={'nsslapd-suffix': suffix, 'name': bename})
+            # Insert at list head so that children backends get deleted before parent one.
+            bes.insert(0, be)
+        except ldap.UNWILLING_TO_PERFORM as e:
+            if str(e) == "Mapping tree for this suffix exists!":
+                pass
+            else:
+                raise e
+
+        ldif_dir = inst.get_ldif_dir()
+        ldif_files[bename] = os.path.join(ldif_dir, f'default_{bename}.ldif')
+        dbgen_users(inst, 5, ldif_files[bename], suffix)
+    inst.stop()
+    for d in BESTRUCT:
+        bename = d['bename']
+        inst.ldif2db(bename, None, None, None, ldif_files[bename])
+    inst.start()
+    return topology_st
+
+# Parameters for test_change_repl_passwd
+EXPECTED_ENTRIES = (("dc=parent", 39), ("dc=child1,dc=parent", 13), ("dc=child2,dc=parent", 13))
+@pytest.mark.parametrize(
+    "orphan_param",
+    [
+        pytest.param( ( True, { "dc=parent": 2, "dc=child1,dc=parent":1, "dc=child2,dc=parent":1}), id="orphan-is-true" ),
+        pytest.param( ( False, { "dc=parent": 3, "dc=child1,dc=parent":1, "dc=child2,dc=parent":1}), id="orphan-is-false" ),
+        pytest.param( ( None, { "dc=parent": 3, "dc=child1,dc=parent":1, "dc=child2,dc=parent":1}), id="no-orphan" ),
+    ],
+)
+
+
+@pytest.mark.bz2083589
+@pytest.mark.skipif(not has_orphan_attribute, reason = "compatibility attribute not yet implemented in this version")
+def test_sub_suffixes(topo, orphan_param):
+    """ check the entries found on suffix/sub-suffix
+    used int
+
+    :id: 5b4421c2-d851-11ec-a760-482ae39447e5
+    :feature: mapping-tree
+    :setup: Standalone instance with 3 additional backends:
+             dc=parent, dc=child1,dc=parent, dc=childr21,dc=parent
+    :steps:
+        1. set orphan attribute mapping tree entry for dc=child1,dc=parent
+            according to orphan_param value
+        2. restart the server to rebuild the mapping tree
+        r32. For each suffix: search the suffix
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Number of entries should be the expected one
+    """
+    mt = MappingTrees(topo.standalone).get('dc=child1,dc=parent')
+    orphan = orphan_param[0]
+    expected_values = orphan_param[1]
+    if orphan is True:
+        mt.replace('orphan', 'true')
+    elif orphan is False:
+        mt.replace('orphan', 'false')
+    elif orphan is None:
+        mt.remove_all('orphan')
+    topo.standalone.restart()
+
+    for suffix, expected in expected_values.items():
+        log.info(f'Verifying domain component entries count for search under {suffix} ...')
+        entries = topo.standalone.search_s(suffix, ldap.SCOPE_SUBTREE, "(dc=*)")
+        assert len(entries) == expected
+        log.info('Found {expected} domain component entries as expected while searching {suffix}')
+
+    log.info('Test PASSED')
+
+

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -1304,3 +1304,204 @@ class DSLdapObjects(DSLogging, DSLints):
                 raise ldap.NO_SUCH_OBJECT
             insts = []
         return insts
+
+class CompositeDSLdapObject(DSLdapObject):
+    """A virtual view as a single object that merges two entry attributes.
+       This class is not supposed to be called directly but through subclasses.
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param dn: Global dn
+    :type dn: str
+    """
+
+    def __init__(self, instance, dn=None):
+        super(CompositeDSLdapObject, self).__init__(instance, dn)
+        self._entries =[]
+        self._map = {}
+        self.log = None
+
+    def add_component(self, entry, attrs):
+        """Add a new entry as element of the composite entry.
+           An attribute may belong to different entries,
+           if that is the case:
+                the attribute is written in all entries
+                the attribute is read from last entry containing it.
+
+        :param entry: An entry object
+        :type entry: DSLdapObject
+        :param attrs: Attributes from the entry that are in the composite entry.
+        :type attrs: (str,...)
+        """
+
+        idx = len(self._entries)
+        self._entries.append(entry)
+        for attr in attrs:
+            nattr = attr.lower()
+            if nattr in self._map:
+                self._map[nattr].append(idx)
+            else:
+                self._map[nattr] = [idx,]
+
+    def _find_idx(self, attr, must_have=True):
+        """Find the entry index."""
+        nattr = ensure_str(attr).lower()
+        try:
+            return self._map[nattr]
+        except KeyError:
+            if must_have:
+                raise ValueError(f'No mapping for attribute {attr} in composite object')
+            return []
+
+    def _unsafe_raw_entry(self):
+        raise NotImplementedError("Composite objects have no raw view.")
+
+    def exists(self):
+        for entry in self._entries:
+            if not entry.exists():
+                return False
+        return True
+
+    def search(self, scope="subtree", filter='objectclass=*'):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def get_basedn(self):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def present(self, attr, value=None):
+        for entry in self._entries:
+            if not entry.present():
+                return False
+        return True
+
+    def _spread_set(self, dataset, set2attr_fn):
+        """Separate a set of data to a set per entry."""
+        res = []
+        for entry in self._entries:
+            res.append([])
+        for data in dataset:
+            attr = set2attr_fn(data)
+            for idx in self._find_idx(attr):
+                res[idx].append(data)
+        return res
+
+    def _spread_dict(self, datadict):
+        """Separate a dict of data where key is the attribure to a dict per entry."""
+        res = {}
+        for entry in self._entries:
+            res.append({})
+        for attr in datadict.keys():
+            for idx in self._find_idx(attr):
+                res[idx][attr] = datadict[attr]
+        return res
+
+    def replace_many(self, *args):
+        dataset = self._spread_set(*args, lambda x: x[0])
+        for idx in range(0, self._entries):
+            if len(dataset[idx]) > 0:
+                self._entries[idx].replace_many(*dataset[idx])
+
+    def ensure_attr_state(self, state):
+        # Hard to implement because some requires attributes may be common to several entries
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def set(self, key, value, action=ldap.MOD_REPLACE):
+        v = { ldap.MOD_REPLACE : "REPLACE",
+              ldap.MOD_ADD : "ADD",
+              ldap.MOD_DELETE: "DEL" }
+        for idx in self._find_idx(key):
+            self._entries[idx].set(key, value, action)
+
+    def apply_mods(self, mods):
+        dataset = self._spread_set(*args, lambda x: x[1])
+        for idx in range(0, self._entries):
+            if len(dataset[idx]) > 0:
+                self._entries[idx].apply_mods(*dataset[idx])
+
+    def get_all_attrs(self, use_json=False):
+        res = {}
+        idx = 0
+        for entry in self._entries:
+            attrs = entry.get_all_attrs(use_json)
+            for attr in attrs.keys():
+                if idx in self._find_idx(attr, False):
+                    res[attr] = attrs[attr]
+            idx += 1
+        return res
+
+    def get_all_attrs_utf8(self, use_json=False):
+        res = {}
+        idx = 0
+        for entry in self._entries:
+            attrs = entry.get_all_attrs_utf8(use_json)
+            for attr in attrs.keys():
+                if idx in self._find_idx(attr, False):
+                    res[attr] = attrs[attr]
+            idx += 1
+        return res
+
+    def get_attrs_vals(self, keys, use_json=False):
+        res = {}
+        dataset = self._spread_set(*args, lambda x: x)
+        for idx in range(0, self._entries):
+            if len(dataset[idx]) > 0:
+                res.update(self._entries[idx].apply_mods(*dataset[idx], use_json))
+
+    def get_attrs_vals_utf8(self, keys, use_json=False):
+        res = {}
+        dataset = self._spread_set(*args, lambda x: x)
+        for idx in range(0, self._entries):
+            if len(dataset[idx]) > 0:
+                res.update(self._entries[idx].apply_mods(*dataset[idx], use_json))
+
+    def get_attr_vals(self, key, use_json=False):
+        idx = self._find_idx(key)[-1]
+        return self._entries[idx].get_attr_vals(key, use_json)
+
+    def get_attr_val(self, key, use_json=False):
+        idx = self._find_idx(key)[-1]
+        return self._entries[idx].get_attr_vals(key, use_json)
+
+    def add_values(self, values):
+        raise DeprecationWarning("Not implemented any more.")
+
+    def replace_values(self, values):
+        raise DeprecationWarning("Not implemented any more.")
+
+    def set_values(self, values, action=ldap.MOD_REPLACE):
+        raise DeprecationWarning("Not implemented any more.")
+
+    def rename(self, new_rdn, newsuperior=None, deloldrdn=True):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def delete(self, recursive=False):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def _validate(self, rdn, properties, basedn):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def _create(self, rdn=None, properties=None, basedn=None, ensure=False):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def create(self, rdn=None, properties=None, basedn=None):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def ensure_state(self, rdn=None, properties=None, basedn=None):
+        raise NotImplementedError("Cannot use this method on composite objects.")
+
+    def display(self, attrlist=['*']):
+        """Get an entry but represent it as a string LDIF
+        :returns: LDIF formatted string
+        """
+        eattrs = {}
+        idx = 0
+        for entry in self._entries:
+            e = _search_ext_s(entry._instance,entry._dn, ldap.SCOPE_BASE, entry._object_filter, attrlist=attrlist,
+                                        serverctrls=entry._server_controls, clientctrls=entry._client_controls,
+                                        escapehatch='i am sure')[0]
+            for attr, vals in e.iterAttrs():
+                if idx in self._find_idx(attr, False):
+                    eattrs[attr] = vals
+            idx += 1
+        e = Entry((self.dn, eattrs))
+        return e.__repr__()

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -16,7 +16,7 @@ from lib389 import Entry
 
 # Need to fix this ....
 
-from lib389._mapped_object import DSLdapObjects, DSLdapObject
+from lib389._mapped_object import DSLdapObjects, DSLdapObject, CompositeDSLdapObject
 from lib389.mappingTree import MappingTrees
 from lib389.exceptions import NoSuchEntryError, InvalidArgumentError
 from lib389.replica import Replicas, Changelog
@@ -1134,3 +1134,27 @@ class DatabaseConfig(DSLdapObject):
             else:
                 # Unknown attribute
                 raise ValueError("Can not update database configuration with unknown attribute: " + attr)
+
+
+class BackendSuffixView(CompositeDSLdapObject):
+    """ Composite view between backend and mapping tree entries
+        used by: dsconf instance backend suffix ...
+    """
+
+    def __init__(self, instance, be):
+        super(BackendSuffixView, self).__init__(instance, be.dn)
+        be_args = [
+            'nsslapd-cachememsize',
+            'nsslapd-cachesize',
+            'nsslapd-dncachememsize',
+            'nsslapd-readonly',
+            'nsslapd-referral',
+            'nsslapd-require-index',
+        ]
+        mt_args = [
+            'orphan',
+            'nsslapd-state',
+        ]
+        mt = be._mts.get(be.get_suffix())
+        self.add_component(be, be_args)
+        self.add_component(mt, mt_args)

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -7,7 +7,7 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-from lib389.backend import Backend, Backends, DatabaseConfig
+from lib389.backend import Backend, Backends, DatabaseConfig, BackendSuffixView
 from lib389.configurations.sample import (
     create_base_domain,
     create_base_org,
@@ -163,16 +163,14 @@ def backend_list(inst, basedn, log, args):
 def backend_get(inst, basedn, log, args):
     rdn = _get_arg(args.selector, msg="Enter %s to retrieve" % RDN)
     be = _get_backend(inst, rdn)
-    be_state = be.get_state()
+    bev = BackendSuffixView(inst, be)
     if args.json:
-        entry = be.get_all_attrs_json()
+        entry = bev.get_all_attrs_json()
         entry_dict = json.loads(entry)
-        entry_dict['attrs']['nsslapd-state'] = [be_state]
         log.info(json.dumps(entry_dict, indent=4))
     else:
-        entry = be.display()
+        entry = bev.display()
         updated_entry = entry[:-1]  # remove \n
-        updated_entry += "nsslapd-state: " + be_state
         log.info(updated_entry)
 
 
@@ -473,35 +471,47 @@ def backend_set(inst, basedn, log, args):
     if args.enable and args.disable:
         raise ValueError("You can not enable and disable a backend at the same time")
     if args.enable_readonly and args.disable_readonly:
-        raise ValueError("You can not set the backend to be both enabled and disabled at the same time")
+        raise ValueError("You can not set the backend readonly mode to be both enabled and disabled at the same time")
+    if args.enable_orphan and args.disable_orphan:
+        raise ValueError("You can not set the backend orphan mode to be both enabled and disabled at the same time")
 
     # Update backend
+    need_restart = False
     be = _get_backend(inst, args.be_name)
+    bev = BackendSuffixView(inst, be)
     if args.enable_readonly:
-        be.set('nsslapd-readonly', 'on')
+        bev.set('nsslapd-readonly', 'on')
     if args.disable_readonly:
-        be.set('nsslapd-readonly', 'off')
+        bev.set('nsslapd-readonly', 'off')
+    if args.enable_orphan:
+        bev.set('orphan', 'true')
+        need_restart = True
+    if args.disable_orphan:
+        bev.set('orphan', 'false')
+        need_restart = True
     if args.add_referral:
-        be.add('nsslapd-referral', args.add_referral)
+        bev.add('nsslapd-referral', args.add_referral)
     if args.del_referral:
-        be.remove('nsslapd-referral', args.del_referral)
+        bev.remove('nsslapd-referral', args.del_referral)
     if args.cache_size:
-        be.set('nsslapd-cachesize', args.cache_size)
+        bev.set('nsslapd-cachesize', args.cache_size)
     if args.cache_memsize:
-        be.set('nsslapd-cachememsize', args.cache_memsize)
+        bev.set('nsslapd-cachememsize', args.cache_memsize)
     if args.dncache_memsize:
-        be.set('nsslapd-dncachememsize', args.dncache_memsize)
+        bev.set('nsslapd-dncachememsize', args.dncache_memsize)
     if args.require_index:
-        be.set('nsslapd-require-index', 'on')
+        bev.set('nsslapd-require-index', 'on')
     if args.ignore_index:
-        be.set('nsslapd-require-index', 'off')
+        bev.set('nsslapd-require-index', 'off')
     if args.state:
-        be.set_state(args.state)
+        bev.set_state(args.state)
     if args.enable:
         be.enable()
     if args.disable:
         be.disable()
     log.info("The backend configuration was successfully updated")
+    if need_restart:
+        log.warn("Warning! The server instance must be restarted to take in account that configuration change.")
 
 
 def db_config_get(inst, basedn, log, args):
@@ -855,6 +865,8 @@ def create_parser(subparsers):
     set_backend_parser.set_defaults(func=backend_set)
     set_backend_parser.add_argument('--enable-readonly', action='store_true', help='Enables read-only mode for the backend database')
     set_backend_parser.add_argument('--disable-readonly', action='store_true', help='Disables read-only mode for the backend database')
+    set_backend_parser.add_argument('--enable-orphan', action='store_true', help='Disconnect a subsuffix from its parent suffix.')
+    set_backend_parser.add_argument('--disable-orphan', action='store_true', help='Let the subsuffix be connected to its parent suffix.')
     set_backend_parser.add_argument('--require-index', action='store_true', help='Allows only indexed searches')
     set_backend_parser.add_argument('--ignore-index', action='store_true', help='Allows all searches even if they are unindexed')
     set_backend_parser.add_argument('--add-referral', help='Adds an LDAP referral to the backend')


### PR DESCRIPTION
Issue #4373 has obsoleted the nsslapd-parent-suffix config attribute 
(this attribute is now ignored )
This fixed a common configuration error but that cause regression 
to some users deployment that requires that search does not get 
forwarded to sub suffix (as it was the case in old versions 
if nsslapd-parent-suffix was not configured.)

The solution is to add an "orphan" compatibility attribute to the 
mapping tree entry that force the parent suffix to be the root entry 
(ignoring the dn relationship)

This attribute may be configured by using
  dsconf instance backend suffix --enable-orphan bename
  dsconf instance backend suffix -disable-orphan bename

Issue #5304

Reviewed by: ?
