### PR TITLE
Issue 5311 - Missing Requires for acl in the spec file

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -163,6 +163,7 @@ Requires:         policycoreutils-python-utils
 Requires:         libsemanage-python%{python3_pkgversion}
 # the following are needed for some of our scripts
 Requires:         openldap-clients
+Requires:         acl
 # this is needed to setup SSL if you are not using the
 # administration server package
 Requires:         nss-tools


### PR DESCRIPTION
Description:
Add missing Requires for acl package that contains setfacl used by
ds_systemd_ask_password_acl script.

Fixes: https://github.com/389ds/389-ds-base/issues/5311

Reviewed by: ???