### PR TITLE
Issue 5313 - dbgen test uses deprecated -h HOST and -p PORT options f…

### DIFF
--- a/dirsrvtests/tests/suites/clu/dbgen_test.py
+++ b/dirsrvtests/tests/suites/clu/dbgen_test.py
@@ -56,7 +56,8 @@ def run_ldapmodify_from_file(instance, ldif_file, output_to_check=None):
     LDAP_MOD = '/usr/bin/ldapmodify'
     log.info('Add entries from ldif file with ldapmodify')
     result = subprocess.check_output([LDAP_MOD, '-cx', '-D', DN_DM, '-w', PASSWORD,
-                                      '-h', instance.host, '-p', str(instance.port), '-af', ldif_file])
+        '-H', f'ldap://{instance.host}:{instance.port}', '-af', ldif_file])
+
     if output_to_check is not None:
         assert output_to_check in ensure_str(result)
 

--- a/dirsrvtests/tests/suites/clu/dbgen_test_usan.py
+++ b/dirsrvtests/tests/suites/clu/dbgen_test_usan.py
@@ -74,7 +74,8 @@ def run_ldapmodify_from_file(instance, ldif_file, output_to_check=None):
     LDAP_MOD = '/usr/bin/ldapmodify'
     log.info('Add entries from ldif file with ldapmodify')
     result = subprocess.check_output([LDAP_MOD, '-cx', '-D', DN_DM, '-w', PASSWORD,
-                                      '-h', instance.host, '-p', str(instance.port), '-af', ldif_file])
+        '-H', f'ldap://{instance.host}:{instance.port}', '-af', ldif_file])
+
     if output_to_check is not None:
         assert output_to_check in ensure_str(result)
 


### PR DESCRIPTION
…or ldapmodify

Bug Description:
OpenLDAP 2.6+ deprecated -h HOST and -p PORT options in all their command
line tools. They are not allowed anymore and cause 'unknown option -' errors.
See https://bugs.openldap.org/show_bug.cgi?id=8618

dbgen test uses ldapmodify with deprecated -h HOST and -p PORT options.
On F36 with OpenLDAP 2.6.x this test fails.

Fix Description:
Use -H URL option for client tools.

Fixes: https://github.com/389ds/389-ds-base/issues/5313

Reviewed by: ???