### PR TITLE
Issue 5170 - BUG - incorrect behaviour of filter test

### DIFF
--- a/dirsrvtests/tests/suites/filter/filter_test_aci_with_optimiser.py
+++ b/dirsrvtests/tests/suites/filter/filter_test_aci_with_optimiser.py
@@ -1,0 +1,91 @@
+
+
+import ldap
+import logging
+import pytest
+import os
+from lib389._constants import *
+from lib389.topologies import topology_st as topo
+from lib389.idm.domain import Domain
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.idm.account import Anonymous
+
+log = logging.getLogger(__name__)
+
+
+def test_filter_access(topo):
+    """Search that compound filters are correctly processed by access control
+
+    :id: ad6a3ffc-2620-4e76-909b-926f94c1a920
+    :setup: Standalone Instance
+    :steps:
+        1. Add anonymous aci
+        2. Add ou
+        2. Test good filters
+        4. Test bad filters
+    :expectedresults:
+        1. Success
+        2. Success
+        3. The good filters return the OU entry
+        4. The bad filters do not return the OU entry
+    """
+
+    # Add aci
+    ACI_TEXT = ('(targetattr="objectclass || cn")(version 3.0; acl "Anonymous read access"; allow' +
+                '(read, search, compare) userdn = "ldap:///anyone";)')
+    domain = Domain(topo.standalone, DEFAULT_SUFFIX)
+    domain.replace('aci', ACI_TEXT)
+
+    # To remove noise, delete EVERYTHING else.
+
+    ous = OrganizationalUnits(topo.standalone, DEFAULT_SUFFIX)
+    existing_ous = ous.list()
+    for eou in existing_ous:
+        eou.delete(recursive=True)
+
+    # Create restricted entry
+    OU_PROPS = {
+        'ou': 'restricted',
+        'description': 'secret data'
+    }
+    ou = ous.create(properties=OU_PROPS)
+    OU_DN = ou.dn
+
+    # Do anonymous search using different filters
+    GOOD_FILTERS = [
+        "(|(objectClass=top)(&(objectClass=organizationalunit)(description=secret data)))",
+        "(|(&(objectClass=organizationalunit)(description=secret data))(objectClass=top))",
+        "(|(objectClass=organizationalunit)(description=secret data)(sn=*))",
+        "(|(description=secret data)(objectClass=organizationalunit)(sn=*))",
+        "(|(sn=*)(description=secret data)(objectClass=organizationalunit))",
+        "(objectClass=top)",
+    ]
+    BAD_FILTERS = [
+        "(|(objectClass=person)(&(objectClass=organizationalunit)(description=secret data)))",
+        "(&(objectClass=top)(objectClass=organizationalunit)(description=secret data))",
+        "(|(&(description=*)(objectClass=top))(objectClass=person))",
+        "(description=secret data)",
+        "(description=*)",
+        "(ou=*)",
+    ]
+    conn = Anonymous(topo.standalone).bind()
+
+    # These searches should return the OU
+    for search_filter in GOOD_FILTERS:
+        entries = conn.search_s(OU_DN, ldap.SCOPE_SUBTREE, search_filter)
+        log.debug(f"Testing good filter: {search_filter} result: {len(entries)}")
+        assert len(entries) == 1
+
+    # These searches should not return the OU
+    for search_filter in BAD_FILTERS:
+        entries = conn.search_s(OU_DN, ldap.SCOPE_SUBTREE, search_filter)
+        log.debug(f"Testing bad filter: {search_filter} result: {len(entries)}")
+        assert len(entries) == 0
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1723,9 +1723,9 @@ ldbm_back_next_search_entry(Slapi_PBlock *pb)
                          * we have messed with internally - remember, our internal changes are secure!
                          */
                         slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_next_search_entry",
-                                      "Bypassing filter test\n");
+                                      "Bypassing filter test for %s\n", slapi_entry_get_dn_const(e->ep_entry));
                         if (ACL_CHECK_FLAG) {
-                            filter_test = slapi_vattr_filter_test_ext(pb, e->ep_entry, filter_intent, ACL_CHECK_FLAG, 1 /* Only perform access checking, thank you */);
+                            filter_test = slapi_vattr_filter_test(pb, e->ep_entry, filter_intent, ACL_CHECK_FLAG);
                         } else {
                             filter_test = 0;
                         }
@@ -1757,13 +1757,19 @@ ldbm_back_next_search_entry(Slapi_PBlock *pb)
                          * we need to STILL apply the filter test with "as executed" in case of a test threshold
                          * shortcut (lest we accidentally prevent the user seeing what they wanted ....)
                          */
-                        filter_test = slapi_vattr_filter_test_ext(pb, e->ep_entry, filter_intent, ACL_CHECK_FLAG, 1 /* Only perform access checking, thank you */);
+                        slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_next_search_entry",
+                                      "Applying filter test to %s\n", slapi_entry_get_dn_const(e->ep_entry));
+                        filter_test = slapi_vattr_filter_test(pb, e->ep_entry, filter_intent, ACL_CHECK_FLAG);
+                        slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_next_search_entry",
+                                      "Applying filter test intermediate value %d \n", filter_test);
                         if (filter_test == 0) {
                             filter_test = slapi_vattr_filter_test(pb, e->ep_entry, filter, 0);
                         }
                     }
                 }
             }
+            slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_next_search_entry",
+                          "filter test value %d %s \n", filter_test, slapi_entry_get_dn_const(e->ep_entry));
             if ((filter_test == 0) || (sr->sr_virtuallistview && (filter_test != -1)))
             /* ugaston - if filter failed due to subentries or tombstones (filter_test=-1),
              * just forget about it, since we don't want to return anything at all. */


### PR DESCRIPTION
Bug Description: In the filter test during access only
checks, OR conditions were not correctly evaluated. They
would have their access checked, but it was not confirmed
if this was the element that the entry matched. This mean
that queries could incorrectly reduce entries.

Fix Description: In the "access only" check mode, do not
handle it as a "special case", and apply the full OR check
algorithm to ensure that the component we are matching on
is indeed, the one we are accessing.

fixes: https://github.com/389ds/389-ds-base/issues/5170

Author: William Brown <william@blackhats.net.au>

Review by: ???