### PR TITLE
Issue 5319 - dsctl_tls_test.py fails with openssl-3.x

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import ssl
 import os
 from lib389.topologies import topology_st as topo
 from lib389.nss_ssl import NssSsl
@@ -69,7 +70,10 @@ def test_tls_command_returns_error_text(topo):
         assert False
     except ValueError as e:
         assert '255' not in str(e)
-        assert 'unable to load private key' in str(e)
+        if 'OpenSSL 3' in ssl.OPENSSL_VERSION:
+            assert 'Could not read private key from' in str(e)
+        else:
+            assert 'unable to load private key' in str(e)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug Description:
openssl-3.x has changed error message when an invalid private key is
attempted to use.

Fix Description:
Add a version check for openssl and expect for a new error message when
openssl-3.x is used.

Fixes: https://github.com/389ds/389-ds-base/issues/5319

Reviewed by: ???