### PR TITLE
openldap_to_ds - Migrating database for monitoring interface lead to crash

### DIFF
--- a/src/lib389/lib389/migrate/openldap/config.py
+++ b/src/lib389/lib389/migrate/openldap/config.py
@@ -107,18 +107,23 @@ class olDatabase(object):
         assert len(entries) == 1
         self.config = entries.pop()
         self.log.debug(f"{self.config}")
+        monitoring_database = ((self.config[1]['olcDatabase'][0]).decode().split('}', 1)[1].lower()) == "monitor"
 
         # olcSuffix, olcDbIndex, entryUUID
-        self.suffix = ensure_str(self.config[1]['olcSuffix'][0])
+        if not monitoring_database:
+            self.suffix = ensure_str(self.config[1]['olcSuffix'][0])
+        else:
+            self.suffix = ""
         self.idx = name.split('}', 1)[0].split('{', 1)[1]
         self.uuid = ensure_str(self.config[1]['entryUUID'][0])
 
         self.index = []
-        for x in self.config[1]['olcDbIndex']:
-            (attr, idx_types) = ensure_str(x).split(' ', 1)
-            attr = attr.strip()
-            for idx_type in idx_types.split(','):
-                self.index.append((attr, idx_type.strip()))
+        if not monitoring_database:
+            for x in self.config[1]['olcDbIndex']:
+                (attr, idx_types) = ensure_str(x).split(' ', 1)
+                attr = attr.strip()
+                for idx_type in idx_types.split(','):
+                    self.index.append((attr, idx_type.strip()))
 
         self.log.debug(f"settings -> {self.suffix}, {self.idx}, {self.uuid}, {self.index}")
 


### PR DESCRIPTION
**Issue Description**
When using migration utility `openldap_to_ds` to migrate an OpenLDAP server where database for monitoring interface exists it result into following crash:

```
# openldap_to_ds instance slapd_config slapd_ldif
Examining OpenLDAP Configuration ...
Traceback (most recent call last):
File "/usr/sbin/openldap_to_ds", line 250, in <module>
result = do_migration(inst, log, args, skip_overlays)
File "/usr/sbin/openldap_to_ds", line 178, in do_migration
config = olConfig(args.slapd_config, log)
File "/usr/lib/python3.6/site-packages/lib389/migrate/openldap/config.py", line 307, in __init__
for db in dbs
File "/usr/lib/python3.6/site-packages/lib389/migrate/openldap/config.py", line 307, in <listcomp>
for db in dbs
File "/usr/lib/python3.6/site-packages/lib389/migrate/openldap/config.py", line 112, in __init__
self.suffix = ensure_str(self.config[1]['olcSuffix'][0])
KeyError: 'olcSuffix'

During the handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/usr/sbin/openldap_to_ds", line 257, in <module>
log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
AttributeError: 'str' object has no attribute 'values'
```

Config entries related to monitoring interface doesn't have key `olcSuffix` nor `olcDbIndex`. So let's just skip it for this particular case.

**Steps to Reproduce**
Steps to reproduce the behavior:
1. Install OpenLDAP, create database for monitoring interface `dn: olcDatabase={2}Monitor,cn=config`.
2. Use `openldap_to_ds` to migrate it to a 389 Directory Server.
3. Wait for crash.

**Expected results**
Converting an OpenLDAP server to a 389 Directory Server instance without any crash.