### PR TITLE
Issue 5324 - plugin acceptance test needs hardening

### DIFF
--- a/dirsrvtests/tests/suites/plugins/acceptance_test.py
+++ b/dirsrvtests/tests/suites/plugins/acceptance_test.py
@@ -162,6 +162,7 @@ def test_acctpolicy(topo, args=None):
     directoryOperation X-ORIGIN 'dirsrvtests' )"
     Schema(inst).add('attributetypes', test_attribute)
     ap_config.replace('stateattrname', 'testLastLoginTime')
+    time.sleep(1)
 
     ############################################################################
     # Test plugin


### PR DESCRIPTION
Description:

On slow VM's the schema & config update nmeedsa sleep after it before we
do the bind.

relates: https://github.com/389ds/389-ds-base/issues/5324

