### PR TITLE
Issue 5323 - BUG - Fix issue in mdb tests with monitor

### DIFF
--- a/src/lib389/lib389/migrate/openldap/config.py
+++ b/src/lib389/lib389/migrate/openldap/config.py
@@ -107,7 +107,8 @@ class olDatabase(object):
         assert len(entries) == 1
         self.config = entries.pop()
         self.log.debug(f"{self.config}")
-        monitoring_database = ((self.config[1]['olcDatabase'][0]).decode().split('}', 1)[1].lower()) == "monitor"
+
+        monitoring_database = "monitor" in (self.config[1]['olcDatabase'][0]).decode().lower()
 
         # olcSuffix, olcDbIndex, entryUUID
         if not monitoring_database:


### PR DESCRIPTION
Bug Description: due to the way that the monitor check worked
it would fail if the database name did not have a } in it.

Fix Description: Change the check to be a bit more robust to
various DB types.

fixes: https://github.com/389ds/389-ds-base/issues/5323

Author: William Brown <william@blackhats.net.au>

Review by: ???