### PR TITLE
Issue 5327 - Validate test metadata

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/389ds/ci-images:test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run testimony
+        if: always()
+        run: testimony validate -c dirsrvtests/testimony.yaml dirsrvtests/tests/suites
+
+      - name: Check for duplicate IDs
+        if: always()
+        run: python3 dirsrvtests/check_for_duplicate_ids.py dirsrvtests/tests/suites

--- a/dirsrvtests/check_for_duplicate_ids.py
+++ b/dirsrvtests/check_for_duplicate_ids.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+
+
+def check_for_duplicates(path):
+    """Check for duplicate id tokens in tests"""
+    prefix = ":id:"
+    cmd = ["grep", "-rhi", f"{prefix}", path]
+    p = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
+    ids = [x.replace(prefix, "").strip() for x in p.stdout.decode().splitlines()]
+    return set([x for x in ids if ids.count(x) > 1])
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} path_to_tests")
+        sys.exit(1)
+    else:
+        path = sys.argv[1]
+        if os.path.exists(path):
+            dups = check_for_duplicates(path)
+            if len(dups) > 0:
+                print("Found duplicate ids:")
+                for dup in dups:
+                    print(dup)
+                sys.exit(1)
+            else:
+                print("No duplicates found")
+                sys.exit(0)
+        else:
+            print(f"Path {path} doesn't exist, exiting...")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dirsrvtests/testimony.yaml
+++ b/dirsrvtests/testimony.yaml
@@ -1,0 +1,14 @@
+---
+id:
+    required: True
+setup: {}
+steps: {}
+expectedresults: {}
+requirement:
+    required: False
+feature:
+    required: False
+customerscenario:
+    required: False
+parametrized:
+    required: False

--- a/dirsrvtests/tests/longduration/automembers_long_test.py
+++ b/dirsrvtests/tests/longduration/automembers_long_test.py
@@ -218,7 +218,7 @@ def test_adding_300_user(topo_m4, _create_entries):
     :steps:
         1. Add 300 user entries matching the inclusive regex rules at topo_m4.ms['supplier1']
         2. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -258,7 +258,7 @@ def test_adding_1000_users(topo_m4, _create_entries):
         1. Add 1000 user entries matching the inclusive/exclusive
         regex rules at topo_m4.ms['supplier1']
         2. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -299,7 +299,7 @@ def test_adding_3000_users(topo_m4, _create_entries):
         1. Add 3000 user entries matching the inclusive/exclusive regex
         rules at topo_m4.ms['supplier1']
         2. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -339,7 +339,7 @@ def test_3000_users_matching_all_exclusive_regex(topo_m4, _create_entries):
         1. Add 3000 user entries matching the inclusive/exclusive regex
         rules at topo_m4.ms['supplier1']
         2. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -379,7 +379,7 @@ def test_no_matching_inclusive_regex_rules(topo_m4, _create_entries):
         1. Add 3000 user entries matching the inclusive/exclusive regex
         rules at topo_m4.ms['supplier1']
         2. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -419,7 +419,7 @@ def test_adding_deleting_and_re_adding_the_same_3000(topo_m4, _create_entries):
         3. Delete 3000 users
         4. Again add 3000 users
         5. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -475,7 +475,7 @@ def test_re_adding_the_same_3000_users(topo_m4, _create_entries):
         3. Delete 3000 users
         4. Again add 3000 users
         5. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -530,7 +530,7 @@ def test_users_with_different_uid_and_gid_nos(topo_m4, _create_entries):
         3. Delete 3000 users
         4. Again add 3000 users
         5. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -594,7 +594,7 @@ def test_bulk_users_to_non_automemscope(topo_m4, _create_entries):
         2. Add 3000 user entries to non-automem_scope at topo_m4.ms['supplier1']
         3. Run AutomemberRebuildMembershipTask
         4. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -660,7 +660,7 @@ def test_automemscope_and_running_modrdn(topo_m4, _create_entries):
         2. Add 3000 user entries to non-automem_scope at topo_m4.ms['supplier1']
         3. Run AutomemberRebuildMembershipTask
         4. Check the same created in rest suppliers
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass

--- a/dirsrvtests/tests/longduration/db_protect_long_test.py
+++ b/dirsrvtests/tests/longduration/db_protect_long_test.py
@@ -308,7 +308,7 @@ def test_db_protect(topo):
         12. Logs the differences
         13. Assert if differences is not empty
 
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
         3. Operation successful

--- a/dirsrvtests/tests/stress/cos/cos_scale_template_test.py
+++ b/dirsrvtests/tests/stress/cos/cos_scale_template_test.py
@@ -77,7 +77,7 @@ def test_indirect_template_scale(topology_st):
         5. Add the user to the cos template and assert it works.
         6. Add 25,000 templates to the database
         7. Search the user. It should not exceed THRESHOLD.
-    :expected results:
+    :expectedresults:
         1. It is enabled.
         2. It is created.
         3. Is is created.

--- a/dirsrvtests/tests/suites/acl/aci_excl_filter_test.py
+++ b/dirsrvtests/tests/suites/acl/aci_excl_filter_test.py
@@ -74,22 +74,23 @@ def test_aci_with_exclude_filter(topo, add_anon_aci_access):
     :steps:
         1. Bind to a new Standalone instance
         2. Generate text for the Access Control Instruction(ACI) and add to the standalone instance
-           -Create a test user 'admin' with a marker -> deniedattr = 'telephonenumber'
-        3. Create 2 top Organizational units (ou) under the same root suffix
-        4. Create 2 test users for each Organizational unit (ou) above with the same username 'admin'
-        5. Bind to the Standalone instance as the user 'admin' from the ou created in step 4 above
-           - Search for user(s) ' admin in the subtree that satisfy this criteria:
-               DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, cn_filter, [deniedattr, 'dn']
-        6.  The search should return 2 entries with the username 'admin'
-        7.  Verify that the users found do not have the --> deniedattr = 'telephonenumber' marker
+        3. Create a test user 'admin' with a marker -> deniedattr = 'telephonenumber'
+        4. Create 2 top Organizational units (ou) under the same root suffix
+        5. Create 2 test users for each Organizational unit (ou) above with the same username 'admin'
+        6. Bind to the Standalone instance as the user 'admin' from the ou created in step 4 above
+        7. Search for user(s) ' admin in the subtree that satisfy this criteria: DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, cn_filter, [deniedattr, 'dn']
+        8. The search should return 2 entries with the username 'admin'
+        9. Verify that the users found do not have the --> deniedattr = 'telephonenumber' marker
     :expectedresults:
         1. Bind should be successful
-        2. Operation to create 2 Orgs (ou) should be successful
-        3. Operation to create 2 (admin*) users should be successful
-        4. Operation should be successful.
-        5. Operation should be successful 
-        6. Should successfully return 2 users that match "admin*"
-        7. PASS - users found do not have the --> deniedattr = 'telephonenumber' marker
+        2. Operation should be successful
+        3. Operation should be successful
+        4. Operation to create 2 Orgs (ou) should be successful
+        5. Operation to create 2 (admin*) users should be successful
+        6. Operation should be successful
+        7. Operation should be successful 
+        8. Should successfully return 2 users that match "admin*"
+        9. PASS - users found do not have the --> deniedattr = 'telephonenumber' marker
 
     """
 

--- a/dirsrvtests/tests/suites/acl/globalgroup_part2_test.py
+++ b/dirsrvtests/tests/suites/acl/globalgroup_part2_test.py
@@ -53,7 +53,7 @@ def aci_of_user(request, topo):
 
 
 @pytest.fixture(scope="module")
-def test_user(request, topo):
+def add_test_user(request, topo):
     for demo in ['Product Development', 'Accounting', 'nestedgroup']:
         OrganizationalUnit(topo.standalone, "ou={},{}".format(demo, DEFAULT_SUFFIX)).create(properties={'ou': demo})
 
@@ -100,7 +100,7 @@ def test_user(request, topo):
                            })
 
 
-def test_undefined_in_group_eval_five(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_five(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as Group dn is not allowed so members will not allowed access.
 
@@ -129,7 +129,7 @@ def test_undefined_in_group_eval_five(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_six(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_six(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as tested user is not a member of allowed Group dn
 
@@ -157,7 +157,7 @@ def test_undefined_in_group_eval_six(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_seven(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_seven(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as tested user is not a member of allowed Group dn
 
@@ -185,7 +185,7 @@ def test_undefined_in_group_eval_seven(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_eight(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_eight(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as Group dn is not allowed so members will not allowed access.
 
@@ -213,7 +213,7 @@ def test_undefined_in_group_eval_eight(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_nine(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_nine(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as Group dn is not allowed so members will not allowed access.
 
@@ -241,7 +241,7 @@ def test_undefined_in_group_eval_nine(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_ten(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_ten(topo, add_test_user, aci_of_user):
     """
         Test the userattr keyword to ensure that it evaluates correctly.
 
@@ -270,7 +270,7 @@ def test_undefined_in_group_eval_ten(topo, test_user, aci_of_user):
     user.remove("description", [ALLGROUPS_GLOBAL, GROUPG_GLOBAL])
 
 
-def test_undefined_in_group_eval_eleven(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_eleven(topo, add_test_user, aci_of_user):
     """
         Aci will not allow access as description is there with the user entry which is not allowed in ACI
 
@@ -301,7 +301,7 @@ def test_undefined_in_group_eval_eleven(topo, test_user, aci_of_user):
     user.remove("description", [ALLGROUPS_GLOBAL, GROUPH_GLOBAL])
 
 
-def test_undefined_in_group_eval_twelve(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_twelve(topo, add_test_user, aci_of_user):
     """
         Test with the parent keyord that Yields TRUE as description is present in tested entry
 
@@ -330,7 +330,7 @@ def test_undefined_in_group_eval_twelve(topo, test_user, aci_of_user):
     user.remove("description", [ALLGROUPS_GLOBAL, GROUPD_GLOBAL])
 
 
-def test_undefined_in_group_eval_fourteen(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_fourteen(topo, add_test_user, aci_of_user):
     """
         Test with parent keyword that Yields FALSE as description is not present in tested entry
 
@@ -361,7 +361,7 @@ def test_undefined_in_group_eval_fourteen(topo, test_user, aci_of_user):
     user.remove("description", [ALLGROUPS_GLOBAL, GROUPG_GLOBAL])
 
 
-def test_undefined_in_group_eval_fifteen(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_fifteen(topo, add_test_user, aci_of_user):
     """
         Here do the same tests for userattr  with the parent keyword.
 
@@ -387,7 +387,7 @@ def test_undefined_in_group_eval_fifteen(topo, test_user, aci_of_user):
     UserAccount(conn, NEWCHILDSCRATCHENTRY_GLOBAL).add("description", DEEPUSER_GLOBAL)
 
 
-def test_undefined_in_group_eval_sixteen(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_sixteen(topo, add_test_user, aci_of_user):
     """
         Test with parent keyword with not key
 
@@ -416,7 +416,7 @@ def test_undefined_in_group_eval_sixteen(topo, test_user, aci_of_user):
         user.add("description",DEEPUSER_GLOBAL)
 
 
-def test_undefined_in_group_eval_seventeen(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_seventeen(topo, add_test_user, aci_of_user):
     """
         Test with the parent keyord that Yields TRUE as description is present in tested entry
 
@@ -444,7 +444,7 @@ def test_undefined_in_group_eval_seventeen(topo, test_user, aci_of_user):
     user.remove("description", [ALLGROUPS_GLOBAL, GROUPD_GLOBAL])
 
 
-def test_undefined_in_group_eval_eighteen(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_eighteen(topo, add_test_user, aci_of_user):
     """
         Test with parent keyword with not key
 

--- a/dirsrvtests/tests/suites/acl/globalgroup_test.py
+++ b/dirsrvtests/tests/suites/acl/globalgroup_test.py
@@ -56,7 +56,7 @@ def aci_of_user(request, topo):
 
 
 @pytest.fixture(scope="module")
-def test_user(request, topo):
+def add_test_user(request, topo):
     for demo in ['Product Development', 'Accounting', 'Product Testing', 'nestedgroup', 'ACLGroup']:
         OrganizationalUnit(topo.standalone, "ou={},{}".format(demo, DEFAULT_SUFFIX)).create(properties={'ou': demo})
 
@@ -122,7 +122,7 @@ def test_user(request, topo):
                            })
 
 
-def test_caching_changes(topo, aci_of_user, test_user):
+def test_caching_changes(topo, aci_of_user, add_test_user):
     """
         Add user and then test deny
 
@@ -152,7 +152,7 @@ def test_caching_changes(topo, aci_of_user, test_user):
     UserAccount(topo.standalone, 'uid=test_user_1000,ou=ACLGroup,dc=example,dc=com').delete()
 
 
-def test_deny_group_member_all_rights_to_user(topo, aci_of_user, test_user):
+def test_deny_group_member_all_rights_to_user(topo, aci_of_user, add_test_user):
     """
         Try deleting user while no access
 
@@ -179,7 +179,7 @@ def test_deny_group_member_all_rights_to_user(topo, aci_of_user, test_user):
         user.delete()
 
 
-def test_deny_group_member_all_rights_to_group_members(topo, aci_of_user, test_user):
+def test_deny_group_member_all_rights_to_group_members(topo, aci_of_user, add_test_user):
     """
         Deny group member all rights
 
@@ -208,7 +208,7 @@ def test_deny_group_member_all_rights_to_group_members(topo, aci_of_user, test_u
     UserAccount(topo.standalone, 'uid=test_user_1000,ou=ACLGroup,dc=example,dc=com').delete()
 
 
-def test_deeply_nested_groups_aci_denial(topo, test_user, aci_of_user):
+def test_deeply_nested_groups_aci_denial(topo, add_test_user, aci_of_user):
     """
         Test deeply nested groups (1)
         This aci will not allow search or modify to a user too deep to be detected.
@@ -237,7 +237,7 @@ def test_deeply_nested_groups_aci_denial(topo, test_user, aci_of_user):
         user.delete()
 
 
-def test_deeply_nested_groups_aci_denial_two(topo, test_user, aci_of_user):
+def test_deeply_nested_groups_aci_denial_two(topo, add_test_user, aci_of_user):
     """
         Test deeply nested groups (2)
         This aci will allow search and modify
@@ -265,7 +265,7 @@ def test_deeply_nested_groups_aci_denial_two(topo, test_user, aci_of_user):
     user.remove("sn", "Fred")
 
 
-def test_deeply_nested_groups_aci_allow(topo, test_user, aci_of_user):
+def test_deeply_nested_groups_aci_allow(topo, add_test_user, aci_of_user):
     """
         Test deeply nested groups (3)
         This aci will allow search and modify
@@ -293,7 +293,7 @@ def test_deeply_nested_groups_aci_allow(topo, test_user, aci_of_user):
     user.remove("sn", "Fred")
 
 
-def test_deeply_nested_groups_aci_allow_two(topo, test_user, aci_of_user):
+def test_deeply_nested_groups_aci_allow_two(topo, add_test_user, aci_of_user):
     """
         This aci will not allow search or modify to a user too deep to be detected.
 
@@ -321,7 +321,7 @@ def test_deeply_nested_groups_aci_allow_two(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval(topo, add_test_user, aci_of_user):
     """
 
         This aci will not allow access .
@@ -350,7 +350,7 @@ def test_undefined_in_group_eval(topo, test_user, aci_of_user):
     assert user.get_attr_val_utf8('uid') == 'scratchEntry'
 
 
-def test_undefined_in_group_eval_two(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_two(topo, add_test_user, aci_of_user):
     """
         This aci will allow access
 
@@ -378,7 +378,7 @@ def test_undefined_in_group_eval_two(topo, test_user, aci_of_user):
     user.remove("sn", "Fred")
 
 
-def test_undefined_in_group_eval_three(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_three(topo, add_test_user, aci_of_user):
     """
         This aci will allow access
 
@@ -406,7 +406,7 @@ def test_undefined_in_group_eval_three(topo, test_user, aci_of_user):
     user.remove("sn", "Fred")
 
 
-def test_undefined_in_group_eval_four(topo, test_user, aci_of_user):
+def test_undefined_in_group_eval_four(topo, add_test_user, aci_of_user):
     """
         This aci will not allow access
 

--- a/dirsrvtests/tests/suites/acl/search_real_part2_test.py
+++ b/dirsrvtests/tests/suites/acl/search_real_part2_test.py
@@ -48,7 +48,7 @@ def aci_of_user(request, topo):
 
 
 @pytest.fixture(scope="module")
-def test_uer(request, topo):
+def add_test_user(request, topo):
     topo.standalone.config.loglevel((ErrorLog.ACL_SUMMARY,))
 
     ous = OrganizationalUnits(topo.standalone, DEFAULT_SUFFIX)
@@ -78,7 +78,7 @@ def test_uer(request, topo):
     })
 
 
-def test_deny_all_access_with__target_set_on_non_leaf(topo, test_uer, aci_of_user):
+def test_deny_all_access_with__target_set_on_non_leaf(topo, add_test_user, aci_of_user):
     """Search Test 11 Deny all access with != target set on non-leaf
 
     :id: f1c5d72a-6e11-11e8-aa9d-8c16451d917b
@@ -112,7 +112,7 @@ def test_deny_all_access_with__target_set_on_non_leaf(topo, test_uer, aci_of_use
 
 
 def test_deny_all_access_with__target_set_on_wildcard_non_leaf(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 12 Deny all access with != target set on wildcard non-leaf
 
@@ -148,7 +148,7 @@ def test_deny_all_access_with__target_set_on_wildcard_non_leaf(
 
 
 def test_deny_all_access_with__target_set_on_wildcard_leaf(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 13 Deny all access with != target set on wildcard leaf
 
@@ -184,7 +184,7 @@ def test_deny_all_access_with__target_set_on_wildcard_leaf(
 
 
 def test_deny_all_access_with_targetfilter_using_equality_search(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 14 Deny all access with targetfilter using equality search
 
@@ -220,7 +220,7 @@ def test_deny_all_access_with_targetfilter_using_equality_search(
 
 
 def test_deny_all_access_with_targetfilter_using_equality_search_two(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Test that Search Test 15 Deny all access with targetfilter using != equality search
 
@@ -256,7 +256,7 @@ def test_deny_all_access_with_targetfilter_using_equality_search_two(
 
 
 def test_deny_all_access_with_targetfilter_using_substring_search(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Test that Search Test 16 Deny all access with targetfilter using substring search
 
@@ -292,7 +292,7 @@ def test_deny_all_access_with_targetfilter_using_substring_search(
 
 
 def test_deny_all_access_with_targetfilter_using_substring_search_two(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Test that Search Test 17 Deny all access with targetfilter using != substring search
 
@@ -329,7 +329,7 @@ def test_deny_all_access_with_targetfilter_using_substring_search_two(
 
 
 def test_deny_all_access_with_targetfilter_using_boolean_or_of_two_equality_search(
-    topo, test_uer, aci_of_user, request
+    topo, add_test_user, aci_of_user, request
 ):
     """Search Test 18 Deny all access with targetfilter using boolean OR of two equality search
 
@@ -368,7 +368,7 @@ def test_deny_all_access_with_targetfilter_using_boolean_or_of_two_equality_sear
     assert UserAccount(topo.standalone, USER_ANUJ).get_attr_val_utf8('uid') == 'Anuj Borah'
 
 
-def test_deny_all_access_to__userdn_two(topo, test_uer, aci_of_user):
+def test_deny_all_access_to__userdn_two(topo, add_test_user, aci_of_user):
     """Search Test 19 Deny all access to != userdn
 
     :id: 693496c0-6e12-11e8-80dc-8c16451d917b
@@ -401,7 +401,7 @@ def test_deny_all_access_to__userdn_two(topo, test_uer, aci_of_user):
     assert 4 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=*)'))
 
 
-def test_deny_all_access_with_userdn(topo, test_uer, aci_of_user):
+def test_deny_all_access_with_userdn(topo, add_test_user, aci_of_user):
     """Search Test 20 Deny all access with userdn
 
     :id: 75aada86-6e12-11e8-bd34-8c16451d917b
@@ -435,7 +435,7 @@ def test_deny_all_access_with_userdn(topo, test_uer, aci_of_user):
 
 
 def test_deny_all_access_with_targetfilter_using_presence_search(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 21 Deny all access with targetfilter using presence search
 

--- a/dirsrvtests/tests/suites/acl/search_real_part3_test.py
+++ b/dirsrvtests/tests/suites/acl/search_real_part3_test.py
@@ -50,7 +50,7 @@ def aci_of_user(request, topo):
 
 
 @pytest.fixture(scope="module")
-def test_uer(request, topo):
+def add_test_user(request, topo):
     topo.standalone.config.loglevel((ErrorLog.ACL_SUMMARY,))
 
     for i in ['Product Development', 'Accounting']:
@@ -79,7 +79,7 @@ def test_uer(request, topo):
     })
 
 
-def test_deny_search_access_to_userdn_with_ldap_url(topo, test_uer, aci_of_user):
+def test_deny_search_access_to_userdn_with_ldap_url(topo, add_test_user, aci_of_user):
     """Search Test 23 Deny search access to userdn with LDAP URL
 
     :id: 94f082d8-6e12-11e8-be72-8c16451d917b
@@ -115,7 +115,7 @@ def test_deny_search_access_to_userdn_with_ldap_url(topo, test_uer, aci_of_user)
     UserAccount(topo.standalone, USER_ANANDA).remove('roomnumber', '3445')
 
 
-def test_deny_search_access_to_userdn_with_ldap_url_two(topo, test_uer, aci_of_user):
+def test_deny_search_access_to_userdn_with_ldap_url_two(topo, add_test_user, aci_of_user):
     """Search Test 24 Deny search access to != userdn with LDAP URL
 
     :id: a1ee05d2-6e12-11e8-8260-8c16451d917b
@@ -152,7 +152,7 @@ def test_deny_search_access_to_userdn_with_ldap_url_two(topo, test_uer, aci_of_u
 
 
 def test_deny_search_access_to_userdn_with_ldap_url_matching_all_users(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 25 Deny search access to userdn with LDAP URL matching all users
 
@@ -186,7 +186,7 @@ def test_deny_search_access_to_userdn_with_ldap_url_matching_all_users(
     assert 4 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=*)'))
 
 
-def test_deny_read_access_to_a_dynamic_group(topo, test_uer, aci_of_user):
+def test_deny_read_access_to_a_dynamic_group(topo, add_test_user, aci_of_user):
     """Search Test 26 Deny read access to a dynamic group
 
     :id: c0c5290e-6e12-11e8-a900-8c16451d917b
@@ -226,7 +226,7 @@ def test_deny_read_access_to_a_dynamic_group(topo, test_uer, aci_of_user):
 
 
 def test_deny_read_access_to_dynamic_group_with_host_port_set_on_ldap_url(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 27 Deny read access to dynamic group with host:port set on LDAP URL
 
@@ -267,7 +267,7 @@ def test_deny_read_access_to_dynamic_group_with_host_port_set_on_ldap_url(
 
 
 def test_deny_read_access_to_dynamic_group_with_scope_set_to_one_in_ldap_url(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 28 Deny read access to dynamic group with scope set to "one" in LDAP URL
 
@@ -308,7 +308,7 @@ def test_deny_read_access_to_dynamic_group_with_scope_set_to_one_in_ldap_url(
     group.delete()
 
 
-def test_deny_read_access_to_dynamic_group_two(topo, test_uer, aci_of_user):
+def test_deny_read_access_to_dynamic_group_two(topo, add_test_user, aci_of_user):
     """Search Test 29 Deny read access to != dynamic group
 
     :id: eae2a6c6-6e12-11e8-80f3-8c16451d917b
@@ -351,7 +351,7 @@ def test_deny_read_access_to_dynamic_group_two(topo, test_uer, aci_of_user):
 
 
 def test_deny_access_to_group_should_deny_access_to_all_uniquemember(
-    topo, test_uer, aci_of_user, request
+    topo, add_test_user, aci_of_user, request
 ):
     """Search Test 38 Deny access to group should deny access to all uniquemember (including chain group)
 
@@ -404,7 +404,7 @@ def test_deny_access_to_group_should_deny_access_to_all_uniquemember(
     assert 4 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=*)'))
 
 
-def test_entry_with_lots_100_attributes(topo, test_uer, aci_of_user):
+def test_entry_with_lots_100_attributes(topo, add_test_user, aci_of_user):
     """Search Test 39 entry with lots (>100) attributes
 
     :id: fc155f74-6e12-11e8-96ac-8c16451d917b

--- a/dirsrvtests/tests/suites/acl/search_real_test.py
+++ b/dirsrvtests/tests/suites/acl/search_real_test.py
@@ -49,7 +49,7 @@ def aci_of_user(request, topo):
 
 
 @pytest.fixture(scope="module")
-def test_uer(request, topo):
+def add_test_user(request, topo):
     topo.standalone.config.loglevel((ErrorLog.ACL_SUMMARY,))
 
     for i in ['Product Development', 'Accounting']:
@@ -78,7 +78,7 @@ def test_uer(request, topo):
     })
 
 
-def test_deny_all_access_with_target_set(topo, test_uer, aci_of_user):
+def test_deny_all_access_with_target_set(topo, add_test_user, aci_of_user):
     """Test that Deny all access with target set
 
     :id: 0550e680-6e0e-11e8-82f4-8c16451d917b
@@ -111,7 +111,7 @@ def test_deny_all_access_with_target_set(topo, test_uer, aci_of_user):
     assert 1 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=Ananda*)'))
 
 
-def test_deny_all_access_to_a_target_with_wild_card(topo, test_uer, aci_of_user):
+def test_deny_all_access_to_a_target_with_wild_card(topo, add_test_user, aci_of_user):
     """Search Test 2 Deny all access to a target with wild card
 
     :id: 1c370f98-6e11-11e8-9f10-8c16451d917b
@@ -146,7 +146,7 @@ def test_deny_all_access_to_a_target_with_wild_card(topo, test_uer, aci_of_user)
     assert 1 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=Ananda*)'))
 
 
-def test_deny_all_access_without_a_target_set(topo, test_uer, aci_of_user):
+def test_deny_all_access_without_a_target_set(topo, add_test_user, aci_of_user):
     """Search Test 3 Deny all access without a target set
 
     :id: 2dbeb36a-6e11-11e8-ab9f-8c16451d917b
@@ -180,7 +180,7 @@ def test_deny_all_access_without_a_target_set(topo, test_uer, aci_of_user):
 
 
 def test_deny_read_search_and_compare_access_with_target_and_targetattr_set(
-    topo, test_uer, aci_of_user
+    topo, add_test_user, aci_of_user
 ):
     """Search Test 4 Deny read, search and compare access with target and targetattr set
 
@@ -214,7 +214,7 @@ def test_deny_read_search_and_compare_access_with_target_and_targetattr_set(
     assert 1 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(ou=Accounting)'))
 
 
-def test_deny_read_access_to_multiple_groupdns(topo, test_uer, aci_of_user):
+def test_deny_read_access_to_multiple_groupdns(topo, add_test_user, aci_of_user):
     """Search Test 6 Deny read access to multiple groupdn's
 
     :id: 8f3ba440-6e11-11e8-8b20-8c16451d917b
@@ -265,7 +265,7 @@ def test_deny_read_access_to_multiple_groupdns(topo, test_uer, aci_of_user):
     posix_group.delete()
 
 
-def test_deny_all_access_to_userdnattr(topo, test_uer, aci_of_user):
+def test_deny_all_access_to_userdnattr(topo, add_test_user, aci_of_user):
     """Search Test 7 Deny all access to userdnattr"
 
     :id: ae482494-6e11-11e8-ae33-8c16451d917b
@@ -300,7 +300,7 @@ def test_deny_all_access_to_userdnattr(topo, test_uer, aci_of_user):
     UserAccount(topo.standalone, USER_ANUJ).remove('manager', USER_ANANDA)
 
 
-def test_deny_all_access_with__target_set(topo, test_uer, aci_of_user, request):
+def test_deny_all_access_with__target_set(topo, add_test_user, aci_of_user, request):
     """Search Test 8 Deny all access with != target set
 
     :id: bc00aed0-6e11-11e8-be66-8c16451d917b
@@ -330,7 +330,7 @@ def test_deny_all_access_with__target_set(topo, test_uer, aci_of_user, request):
     assert 4 == len(Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(cn=*)'))
 
 
-def test_deny_all_access_with__targetattr_set(topo, test_uer, aci_of_user):
+def test_deny_all_access_with__targetattr_set(topo, add_test_user, aci_of_user):
     """Search Test 9 Deny all access with != targetattr set
 
     :id: d2d73b2e-6e11-11e8-ad3d-8c16451d917b
@@ -381,7 +381,7 @@ def test_deny_all_access_with__targetattr_set(topo, test_uer, aci_of_user):
     user.delete()
 
 
-def test_deny_all_access_with_targetattr_set(topo, test_uer, aci_of_user):
+def test_deny_all_access_with_targetattr_set(topo, add_test_user, aci_of_user):
     """Search Test 10 Deny all access with targetattr set
 
     :id: e1602ff2-6e11-11e8-8e55-8c16451d917b

--- a/dirsrvtests/tests/suites/acl/syntax_test.py
+++ b/dirsrvtests/tests/suites/acl/syntax_test.py
@@ -194,9 +194,7 @@ FAILED = [('test_targattrfilters_18',
 @pytest.mark.parametrize("real_value", [a[1] for a in FAILED],
                          ids=[a[0] for a in FAILED])
 def test_aci_invalid_syntax_fail(topo, real_value):
-    """
-
-    Try to set wrong ACI syntax.
+    """Try to set wrong ACI syntax.
 
         :id: 83c40784-fff5-49c8-9535-7064c9c19e7e
         :parametrized: yes
@@ -216,9 +214,7 @@ def test_aci_invalid_syntax_fail(topo, real_value):
 @pytest.mark.parametrize("real_value", [a[1] for a in INVALID],
                          ids=[a[0] for a in INVALID])
 def test_aci_invalid_syntax(topo, real_value):
-    """
-
-    Try to set wrong ACI syntax.
+    """Try to set wrong ACI syntax.
 
         :id: e8bf20b6-48be-4574-8300-056e42a0f0a8
         :parametrized: yes

--- a/dirsrvtests/tests/suites/automember_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/basic_test.py
@@ -314,7 +314,7 @@ def test_disable_the_plug_in(topo, _create_all_entries):
     :steps:
         1. Disable the plug-in and check the status
         2. Enable the plug-in and check the status
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -333,7 +333,7 @@ def test_custom_config_area(topo, _create_all_entries):
     :steps:
         1. Check whether the plugin can be configured for custom config area
         2. After adding custom config area can be removed
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -359,7 +359,7 @@ def test_ability_to_control_behavior_of_modifiers_name(topo, _create_all_entries
         6. Check the internalModifiersname in the user entry
         7. Unset nsslapd-plugin-binddn-tracking attribute under
            cn=config and delete the test enteries
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -400,7 +400,7 @@ def test_posixaccount_objectclass_automemberdefaultgroup(topo, _create_all_entri
     :steps:
         1. Add users with PosixAccount ObjectClass
         2. Verify the same user added as a member to autoMemberDefaultGroup
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -425,7 +425,7 @@ def test_duplicated_member_attributes_added_when_the_entry_is_re_created(topo, _
         4. It should not present as member in all automember groups
         5. Recreate same user
         6. It should present as member in all automember groups
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -455,7 +455,7 @@ def test_multi_valued_automemberdefaultgroup_for_hostgroups(topo, _create_all_en
         2. Check user is present in all Automember Groups as member
         3. Delete the user
         4. Check user is not present in all Automember Groups
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -483,7 +483,7 @@ def test_plugin_creates_member_attributes_of_the_automemberdefaultgroup(topo, _c
         1. Add a non existing user to some groups as member
         2. Then Create the user
         3. Check the same user is present to other groups also as member
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -515,7 +515,7 @@ def test_multi_valued_automemberdefaultgroup_with_uniquemember(topo, _create_all
         3. Add user uniquemember attributes
         4. Check uniqueMember attribute in groups
         5. Revert the changes done above
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -566,7 +566,7 @@ def test_invalid_automembergroupingattr_member(topo, _create_all_entries):
         3. Check member attribute on other groups
         4. Check member attribute on group where object class was changed
         5. Revert the object class where it was changed
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should fail (ldap.UNWILLING_TO_PERFORM)
         3. Should success
@@ -596,7 +596,7 @@ def test_valid_and_invalid_automembergroupingattr(topo, _create_all_entries):
         3. Check member attribute on other groups
         4. Check member attribute on groups where object class was changed
         5. Revert the object class where it was changed
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should fail (ldap.UNWILLING_TO_PERFORM)
         3. Should success
@@ -636,7 +636,7 @@ def test_add_regular_expressions_for_user_groups_and_check_for_member_attribute_
     :steps:
         1. Add user with a match with regular expressions for user groups
         2. check for member attribute after adding users
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -669,7 +669,7 @@ def test_matching_gid_role_inclusive_regular_expression(topo, _create_all_entrie
         1. Create users with matching gid nos and Role for the Inclusive regular expression
         2. It will be filtered with gidNumber, uidNumber and nsAdminGroupName
         3. It will a match for contract_grp
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -711,7 +711,7 @@ def test_gid_and_role_inclusive_exclusive_regular_expression(topo, _create_all_e
         2. It will be filtered with gidNumber, uidNumber and nsAdminGroupName
         3. It will not match for contract_grp(Exclusive regular expression)
         4. It will match for default_group(Inclusive regular expression)
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -749,7 +749,7 @@ def test_managers_contractors_exclusive_regex_rules_member_uid(topo, _create_all
         memberUid created in Default grp
         2. It will be filtered with gidNumber, uidNumber and nsAdminGroupName
         3. It will match for default_group1 and default_group2(Inclusive regular expression)
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -784,7 +784,7 @@ def test_managers_inclusive_regex_rule(topo, _create_all_entries,
         2. It will be filtered with gidNumber, uidNumber and nsAdminGroupName(Supervisor)
         3. It will match for managers_grp(Inclusive regular expression)
         4. It will not match for contract_grp(Exclusive regular expression)
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -807,7 +807,7 @@ def test_reject_invalid_config_and_we_donot_deadlock_the_server(topo, _create_al
     :steps:
         1. Verify DS reject invalid config,
         2. This operation don't deadlock the server
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -887,7 +887,7 @@ def test_automemtask_re_build_task(topo, _create_all_entries, _startuptask, _fix
         1. Add 10 users and enable autoMembers plug-in
         2. Run automembers re-build task to create the member attributes
         3. Search for any error logs
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -950,7 +950,7 @@ def test_automemtask_export_task(topo, _create_all_entries, _startuptask, _fixtu
     :steps:
         1. Add 10 users and enable autoMembers plug-in
         2. Run automembers export task to create an ldif file with member attributes
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
     """
@@ -986,7 +986,7 @@ def test_automemtask_mapping(topo, _create_all_entries, _startuptask, _fixture_f
     :steps:
         1. Add 10 users and enable autoMembers plug-in
         2. Run automembers Mapping task with input/output ldif files
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -1019,7 +1019,7 @@ def test_automemtask_re_build(topo, _create_all_entries, _startuptask, _fixture_
     :steps:
         1. Add 10 users with inetOrgPerson object class
         2. Run automembers re-build task to create the member attributes, exp to FAIL
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should not success
     """
@@ -1053,7 +1053,7 @@ def test_automemtask_export(topo, _create_all_entries, _startuptask, _fixture_fo
     :steps:
         1. Add 10 users with inetOrgPerson objectClass
         2. Run automembers export task to create an ldif file with member attributes, exp to FAIL
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should not success
     """
@@ -1092,7 +1092,7 @@ def test_automemtask_run_re_build(topo, _create_all_entries, _startuptask, _fixt
         1. Add 10 users with inetOrgPerson obj class
         2. Change plugin config
         3. Enable plug-in and run re-build task to create the member attributes
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -1137,7 +1137,7 @@ def test_automemtask_run_export(topo, _create_all_entries, _startuptask, _fixtur
         1. Add 10 users with inetOrgPerson objectClass
         2. change plugin config
         3. Run export task to create an ldif file with member attributes
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success

--- a/dirsrvtests/tests/suites/automember_plugin/configuration_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/configuration_test.py
@@ -25,7 +25,7 @@ def test_configuration(topo):
         1. Automembership plugin fails in a MMR setup, if data and config
         area mixed in the plugin configuration
         2. Plugin configuration should throw proper error messages if not configured properly
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -718,18 +718,25 @@ def test_basic_search_lookthroughlimit(topology_st, limit, resp, import_example_
     :setup: Standalone instance, add example.ldif to the database, search filter (uid=*).
 
     :steps:
-         1. Import ldif user file.
-         2. Change lookthroughlimit to 200.
-         3. Bind to server as low priv user
-         4. Run search 1 with "high" lookthroughlimit.
-         5. Change lookthroughlimit to 50.
-         6. Run search 2 with "low" lookthroughlimit.
-         8. Delete user from DB.
-         9. Reset lookthroughlimit to original.
+        1. Import ldif user file.
+        2. Change lookthroughlimit to 200.
+        3. Bind to server as low priv user
+        4. Run search 1 with "high" lookthroughlimit.
+        5. Change lookthroughlimit to 50.
+        6. Run search 2 with "low" lookthroughlimit.
+        7. Delete user from DB.
+        8. Reset lookthroughlimit to original.
 
     :expectedresults:
-         1. First search should complete with no error.
-         2. Second search should return ldap.ADMINLIMIT_EXCEEDED error.
+        1. Success
+        2. Success
+        3. Success
+        4. Success, first search should complete with no error.
+        5. Success
+        6. Success, second search should return ldap.ADMINLIMIT_EXCEEDED error.
+        7. Success
+        8. Success
+
     """
 
     log.info('Running test_basic_search_lookthroughlimit...')
@@ -1268,8 +1275,8 @@ def test_bind_entry_missing_passwd(topology_st):
     :steps:
         1. Bind as database entry that does not have userpassword set
         2. Bind as database entry that does not exist
-        1. Bind as cn=config entry that does not have userpassword set
-        2. Bind as cn=config entry that does not exist
+        3. Bind as cn=config entry that does not have userpassword set
+        4. Bind as cn=config entry that does not exist
     :expectedresults:
         1. Fails with error 49
         2. Fails with error 49

--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -79,17 +79,18 @@ def _check_db(inst, log, impl):
 
 def test_dblib_migration(topo_m2, init_user):
     """
-    Verify dsctl dblib xxxxxxx  sub commands ( migration between bdb and lmdb )
+    Verify dsctl dblib xxxxxxx sub commands (migration between bdb and lmdb)
 
     :id: 5d327c34-e77a-46e5-a8aa-0a552f9bbdef
     :setup: Two suppliers Instance
     :steps:
         1. Determine current database
         2. Switch to the other database
-        3 Check that
+        3. Check that replication works
     :expectedresults:
         1. Success
         2. Success
+        3. Success
     """
     s1 = topo_m2.ms["supplier1"]
     s2 = topo_m2.ms["supplier2"]

--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -284,26 +284,6 @@ def test_defaultnamingcontext(topo):
     b2.delete()
 
 
-@pytest.mark.xfail(reason="This may fail due to bug 1610234")
-def test_defaultnamingcontext_1(topo):
-    """This test case should be part of function test_defaultnamingcontext
-       Please move it back after we have a fix for bug 1610234
-    """
-    log.info("Remove the original suffix which is currently nsslapd-defaultnamingcontext"
-             "and check nsslapd-defaultnamingcontext become empty.")
-
-    """ Please remove these declarations after moving the test
-        to function test_defaultnamingcontext
-    """
-    backends = Backends(topo.standalone)
-    test_db2 = 'test2_db'
-    test_suffix2 = 'dc=test2,dc=com'
-    b2 = backends.create(properties={'cn': test_db2,
-                                     'nsslapd-suffix': test_suffix2})
-    b2.delete()
-    assert topo.standalone.config.get_attr_val_utf8('nsslapd-defaultnamingcontext') == ' '
-
-
 @pytest.mark.bz602456
 def test_allow_add_delete_config_attributes(topo):
     """Tests configuration attributes are allowed to add and delete
@@ -563,8 +543,7 @@ def test_require_internal_index(topo):
         1. Set "nsslapd-require-internalop-index" to "on"
         2. Enable RI plugin, and configure it to use an attribute that is not indexed
         3. Create a user and add it a group
-        4. Deleting user should be rejected as the RI plugin issues an
-        unindexed internal search
+        4. Deleting user should be rejected as the RI plugin issues an unindexed internal search
     :expectedresults:
         1. Success
         2. Success

--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
@@ -540,7 +540,6 @@ def test_readonly_on_threshold_below_half_of_the_threshold(topo, setup, reset_lo
     :customerscenario: True
     :setup: Standalone
     :steps:
-    :expectedresults:
         1. Go straight below 1/2 of the threshold
         2. Verify that the backend is in read-only mode
         3. Go back above the threshold

--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -740,6 +740,17 @@ def test_access_log_truncated_search_message(topology_st, clean_access_logs):
 @pytest.mark.bz1732053
 @pytest.mark.ds50510
 def test_etime_at_border_of_second(topology_st, clean_access_logs):
+    """Test that the etime reported in the access log doesn't contain wrong nsec value
+
+    :id: 622be191-235b-4e1f-b581-2627fb10e494
+    :setup: Standalone instance
+    :steps:
+         1. Run rsearch
+         2. Check access logs
+    :expectedresults:
+         1. Success
+         2. No etime with 0.199xxx (everything should be few ms)
+    """
     topo = topology_st.standalone
 
     prog = os.path.join(topo.ds_paths.bin_dir, 'rsearch')

--- a/dirsrvtests/tests/suites/entryuuid/basic_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/basic_test.py
@@ -39,6 +39,7 @@ UUID_MAX = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 @pytest.mark.skipif(ds_is_older('1.4.3.27'), reason="CLI Entryuuid is not available in prior versions")
 def test_cli_entryuuid_plugin_fixup(topology):
     """Test that dsconf CLI entryuuid attribute is enabled and can execute.
+
     :id: 91b46be2-ac3f-11ec-a38a-98fa9ba19b65
     :parametrized: yes
     :customerscenario: True

--- a/dirsrvtests/tests/suites/export/export_test.py
+++ b/dirsrvtests/tests/suites/export/export_test.py
@@ -45,14 +45,14 @@ def run_db2ldif_and_clear_logs(topology, instance, backend, ldif, output_msg, en
 def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
     """Export with dsctl db2ldif, giving a ldif file path which can't be accessed by the user (dirsrv by default)
 
-    :id: ca91eda7-27b1-4750-a013-531a63d3f5b0
+    :id: 511e7702-7685-4951-9966-38f402d6214b
     :setup: Standalone Instance - entries imported in the db
     :steps:
         1. Stop the server
         2. Launch db2ldif with an non accessible ldif file path 
         3. Catch the reported error code
         4. check the error reported in the errors log
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation properly fails, without crashing
         3. An error code different from 139 (segmentation fault) should be reported
@@ -92,7 +92,7 @@ def test_db2ldif_cli_with_non_accessible_ldif_file_path(topo):
         2. Launch db2ldif with an non accessible ldif file path 
         3. Catch the reported error code
         4. check the error reported in the errors log
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation properly fails, without crashing
         3. An error code different from 139 (segmentation fault) should be reported
@@ -135,7 +135,7 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path_output(topo):
         1. Stop the server
         2. Launch db2ldif with a non accessible ldif file path 
         3. check the error reported in the command output
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation properly fails
         3. An clear error message is reported as output of the cli

--- a/dirsrvtests/tests/suites/filter/filter_cert_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_cert_test.py
@@ -32,7 +32,7 @@ def test_positive(topo):
         :steps:
             1. Create entries with userCertificate field.
             2. Try to search/filter them with userCertificate field.
-        :expected results:
+        :expectedresults:
             1. Pass
             2. Pass
     """

--- a/dirsrvtests/tests/suites/filter/filter_index_match_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_index_match_test.py
@@ -413,7 +413,7 @@ def _create_index_entry(topology_st):
     :setup: Standalone
     :steps:
         1. Test index entries can be created.
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     indexes = Indexes(topology_st.standalone)
@@ -437,7 +437,7 @@ def test_valid_invalid_attributes(topology_st, _create_index_entry, index):
         2. Delete existing entry
         3. Create entry with an attribute that uses that matching rule providing duplicate
            values that are duplicates according to the equality matching rule.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Fail(ldap.TYPE_OR_VALUE_EXISTS)
@@ -464,7 +464,7 @@ def test_mods(topology_st, _create_index_entry, mod):
         2. Add an attribute that uses that matching mod providing duplicate
            values that are duplicates according to the equality matching.
         3. Delete existing entry
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Fail(ldap.TYPE_OR_VALUE_EXISTS)
         3. Pass
@@ -490,7 +490,7 @@ def test_mods_replace(topology_st, _create_index_entry, mode):
         2. Add an attribute that uses that matching mode providing duplicate
            values that are duplicates according to the equality matching.
         3. Delete existing entry
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Fail(ldap.TYPE_OR_VALUE_EXISTS)
         3. Pass
@@ -516,7 +516,7 @@ def test_mods_delete(topology_st, _create_index_entry, mode):
         2. Add an attribute that uses that matching mode providing duplicate
            values that are duplicates according to the equality matching.
         3. Delete existing entry
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Fail(ldap.NO_SUCH_ATTRIBUTE)
         3. Pass
@@ -781,7 +781,7 @@ def test_search_positive_negative(topology_st, _create_entries):
     :steps:
         1.For valid filer output should match the exact value given.
         2. For invalid filter there should not be any output.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -852,12 +852,12 @@ LIST_EXT_ATTR_COUNT = [
 def test_do_extensible_search(topology_st, _create_entries, attr, value):
     """Match filter and output.
 
-    :id: abe3e6dd-9ecc-11e8-adf0-8c16451d917c
+    :id: 50dd45c4-061f-43ce-843c-19c44da1e9b8
     :parametrized: yes
     :setup: Standalone
     :steps:
         1. Filer output should match the exact value given.
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     cos = CosTemplates(topology_st.standalone, DEFAULT_SUFFIX)

--- a/dirsrvtests/tests/suites/filter/filter_indexing_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_indexing_test.py
@@ -106,7 +106,7 @@ def test_positive(topo, _create_entries, real_value):
     :setup: Standalone
     :steps:
         1. Try to pass filter rules as per the condition .
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     assert Accounts(topo.standalone, DEFAULT_SUFFIX).filter(real_value)
@@ -120,7 +120,7 @@ def test_indexing_schema(topo, _create_entries):
     :steps:
         1. Add attribute types to Schema.
         2. Try to pass filter rules as per the condition .
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -142,7 +142,7 @@ def test_indexing(topo, _create_entries, real_value):
     :setup: Standalone
     :steps:
         1. Try to pass filter rules as per the condition .
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     cos = CosTemplates(topo.standalone, DEFAULT_SUFFIX, rdn='ou=People')
@@ -158,7 +158,7 @@ def test_indexing_negative(topo, _create_entries, real_value):
     :setup: Standalone
     :steps:
         1. Try to pass negative filter rules as per the condition .
-    :expected results:
+    :expectedresults:
         1. Fail
     """
     cos = CosTemplates(topo.standalone, DEFAULT_SUFFIX, rdn='ou=People')

--- a/dirsrvtests/tests/suites/filter/filter_match_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_match_test.py
@@ -607,7 +607,7 @@ def test_matching_rules(topology_st):
     :steps:
         1. Search for matching rule.
         2. Matching rule should be there in schema.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -626,7 +626,7 @@ def test_add_attribute_types(topology_st):
     :setup: Standalone
     :steps:
         1. Add new attribute types to schema.
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     for attribute in ATTR:
@@ -645,7 +645,7 @@ def test_valid_invalid_attributes(topology_st, rule):
         2. Delete existing entry
         3. Create entry with an attribute that uses that matching rule providing duplicate
            values that are duplicates according to the equality matching rule.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Fail(ldap.TYPE_OR_VALUE_EXISTS)
@@ -672,7 +672,7 @@ def test_valid_invalid_modes(topology_st, mode):
         2. Add an attribute that uses that matching mode providing duplicate
            values that are duplicates according to the equality matching.
         3. Delete existing entry
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Fail(ldap.TYPE_OR_VALUE_EXISTS)
         3. Pass
@@ -701,7 +701,7 @@ def test_valid_invalid_mode_replace(topology_st, mode):
         4. Delete existing attribute
         5. Try to delete the deleted attribute again.
         6. Delete entry
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Fail(ldap.TYPE_OR_VALUE_EXISTS)
@@ -748,7 +748,7 @@ def test_match_count(topology_st, _searches, attr, po_value, ne_attr):
     :steps:
         1. Filter rules as per the condition and assert the no of output.
         2. Negative filter with no outputs.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -766,7 +766,7 @@ def test_extensible_search(topology_st, _searches, attr, value):
     :setup: Standalone
     :steps:
         1. Filer output should match the exact value given.
-    :expected results:
+    :expectedresults:
         1. Pass
     """
     cos = CosTemplates(topology_st.standalone, DEFAULT_SUFFIX)

--- a/dirsrvtests/tests/suites/filter/filter_with_non_root_user_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_with_non_root_user_test.py
@@ -346,7 +346,7 @@ def test_telephone(topo, _create_entries, real_value):
         :setup: Standalone
         :steps:
             1. Pass filter rules as per the condition .
-        :expected results:
+        :expectedresults:
             2. Pass
         """
     conn = UserAccount(topo.standalone, f'uid=jreuter,ou=People,{DEFAULT_SUFFIX}').bind(PW_DM)
@@ -363,7 +363,7 @@ def test_all_positive(topo, _create_entries, real_value):
         :setup: Standalone
         :steps:
             1. Pass filter rules as per the condition .
-        :expected results:
+        :expectedresults:
             1. Pass
         """
     conn = UserAccount(topo.standalone, f'uid=tclow,ou=People,{DEFAULT_SUFFIX}').bind(PW_DM)
@@ -379,7 +379,7 @@ def test_all_negative(topo, _create_entries, real_value):
         :setup: Standalone
         :steps:
             1. Pass filter rules as per the negative condition .
-        :expected results:
+        :expectedresults:
             1. Fail
         """
     conn = UserAccount(topo.standalone, f'uid=tclow,ou=People,{DEFAULT_SUFFIX}').bind(PW_DM)

--- a/dirsrvtests/tests/suites/filter/filterscanlimit_test.py
+++ b/dirsrvtests/tests/suites/filter/filterscanlimit_test.py
@@ -176,7 +176,7 @@ def test_invalid_configuration(topo):
     :setup: Standalone instance
     :steps:
         1. Try change nsIndexIDListScanLimit
-    :expected results:
+    :expectedresults:
         1. This should pass
     """
     for i in ['4000',
@@ -214,7 +214,7 @@ def test_idlistscanlimit(topo):
          5. restart instance
          6. Search created entries
          7. indexing works after restart
-    :expected results:
+    :expectedresults:
          1. This should pass
          2. This should pass
          3. This should pass

--- a/dirsrvtests/tests/suites/filter/large_filter_test.py
+++ b/dirsrvtests/tests/suites/filter/large_filter_test.py
@@ -150,7 +150,7 @@ def test_large_filter(topo, _create_entries, real_value, ids=FILTERS):
             1. Try to pass filter rules as per the condition.
             2. Bind with any user.
             3. Try to pass filter rules with new binding.
-        :expected results:
+        :expectedresults:
             1. Pass
             2. Pass
             3. Pass

--- a/dirsrvtests/tests/suites/filter/schema_validation_test.py
+++ b/dirsrvtests/tests/suites/filter/schema_validation_test.py
@@ -132,7 +132,7 @@ def test_filter_validation_warn_safe(topology_st):
     """Test that queries which are invalid, are correctly marked as "notes=F" in
     the access log, and return no entries or partial sets.
 
-    :id: 8b2b23fe-d878-435c-bc84-8c298be4ca1f
+    :id: 7c8b3374-63c7-4201-9032-faae84c86d50
     :setup: Standalone instance
     :steps:
         1. Search a well formed query

--- a/dirsrvtests/tests/suites/filter/vfilter_attribute_test.py
+++ b/dirsrvtests/tests/suites/filter/vfilter_attribute_test.py
@@ -206,7 +206,7 @@ def test_all_together_positive(topo, _create_test_entries, filter_test, conditio
         :steps:
             1. Create Filter rules.
             2. Try to pass filter rules as per the condition .
-        :expected results:
+        :expectedresults:
             1. It should pass
             2. It should pass
         """

--- a/dirsrvtests/tests/suites/filter/vfilter_simple_test.py
+++ b/dirsrvtests/tests/suites/filter/vfilter_simple_test.py
@@ -524,7 +524,7 @@ def test_param_positive(topo, _create_test_entries, real_value):
     :steps:
         1. Create Filter rules.
         2. Try to pass filter rules as per the condition .
-    :expected results:
+    :expectedresults:
         1. It should pass
         2. It should pass
     """
@@ -543,7 +543,7 @@ def test_param_negative(topo, _create_test_entries, real_value):
         1. Create Filter rules.
         2. Try to pass filter rules as per the condition .
         3. All Filters will give 0 output as these are negative test cases.
-    :expected results:
+    :expectedresults:
         1. It should pass
         2. It should pass
         3. no output

--- a/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
+++ b/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
@@ -38,7 +38,7 @@ def test_verify_trees(topo_m4):
     :setup: 4 Instances with replication
     :steps:
         1. All 4 suppliers should have consistent data now
-    :expected results:
+    :expectedresults:
         1. Should success
     """
     # all 4 suppliers should have consistent data now
@@ -62,7 +62,7 @@ def test_sync_through_to_all_4_suppliers(topo_m4, _cleanupentris):
     :steps:
         1. Insert fresh data into M2 - about 100 entries
         2. Begin verification process
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
     """
@@ -88,7 +88,7 @@ def test_modify_some_data_in_m3(topo_m4):
     :setup: 4 Instances with replication
     :steps:
         1. Modify some data in M3 , wait for 20 seconds ,check trees on all 4 suppliers
-    :expected results:
+    :expectedresults:
         1. Should success
     """
     # modify some data in M3
@@ -122,7 +122,7 @@ def test_delete_a_few_entries_in_m4(topo_m4, _cleanupentris):
         1. Delete a few entries in M4 ,
         2. Wait for 60 seconds for them to propagate,
         3. Verify trees
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success
@@ -152,7 +152,7 @@ def test_replicated_multivalued_entries(topo_m4):
     :setup: 4 Instances with replication
     :steps:
         1. Replicated multivalued entries are ordered the same way on all consumers
-    :expected results:
+    :expectedresults:
         1. Should success
     """
     # This test case checks that replicated multivalued entries are
@@ -195,7 +195,7 @@ def test_bad_replication_agreement(topo_m4):
     :setup: 4 Instances with replication
     :steps:
         1. Create the bad replication agreement and try to add it
-    :expected results:
+    :expectedresults:
         1. Should not success
     """
     # The return code for adding a bad replication agreement to the directory server is now
@@ -265,7 +265,7 @@ def test_nsds5replicaenabled_verify(topo_m4):
         2. Add data
         3. Delete data
         4. Very the replication
-    :expected results:
+    :expectedresults:
         1. Should  success
         2. Should  success
         3. Should  success
@@ -374,7 +374,7 @@ def test_create_an_entry_on_the_supplier(topo_m4):
     :setup: standalone
     :steps:
         1. Shut down one instance and create an entry on the supplier
-    :expected results:
+    :expectedresults:
         1. Should not success
     """
     # Bug 830344: Shut down one instance and create an entry on the supplier
@@ -399,7 +399,7 @@ def test_bob_acceptance_tests(topo_m4):
         1. Add entry
         2. Run multiple modrdn_s operation on supplier1
         3. Check everything is fine.
-    :expected results:
+    :expectedresults:
         1. Should  success
         2. Should  success
         3. Should  success
@@ -451,7 +451,7 @@ def test_replica_backup_and_restore(topo_m4):
         3. Delete entries on supplier1
         4. Restore entries ldif2db
         5. Check entries
-    :expected results:
+    :expectedresults:
         1. Should success
         2. Should success
         3. Should success

--- a/dirsrvtests/tests/suites/fractional/fractional_test.py
+++ b/dirsrvtests/tests/suites/fractional/fractional_test.py
@@ -102,7 +102,7 @@ def test_fractional_agreements(_create_entries):
         3. The attributes should be present on the two suppliers with traditional replication
            agreements
         4. Should be missing on both consumers with fractional agreements.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -131,7 +131,7 @@ def test_read_only_consumer(_create_entries):
         1. Add test entry
         2. First attempt to modify an attribute that should be visible (mail)
         3. Then attempt to modify one that should not be visible (roomnumber)
-    :expected results:
+    :expectedresults:
         1. Success
         2. Fail(ldap.INSUFFICIENT_ACCESS)
         3. Fail(ldap.INSUFFICIENT_ACCESS)
@@ -160,7 +160,7 @@ def test_read_write_supplier(_create_entries):
         3. Then attempt to modify one that should not be visible (roomnumber)
         4. The change to mail should appear on all servers; the change to
            room number should only appear on the suppliers INST[0] and INST[1].
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -203,7 +203,7 @@ def test_filtered_attributes(_create_entries):
            CONSUMER1 or CONSUMER2.
         3. The entry should be present in all servers.  Filtered attributes should not
            be available from the consumers with fractional replication agreements.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -244,7 +244,7 @@ def test_fewer_changes_in_single_operation(_create_entries):
         2. Fewer changes (but more than one) in a single operation to fractionally
            replicated attributes than the number of fractionally replicated attributes.
         3. All servers are still alive.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -303,7 +303,7 @@ def test_newly_added_attribute_nsds5replicatedattributelisttotal(_create_entries
         2. No memberOf plugin enabled on read only replicas
         3. The attributes mentioned in the nsds5replicatedattributelist
            excluded from incremental updates.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -333,7 +333,7 @@ def test_attribute_nsds5replicatedattributelisttotal(_create_entries, _add_user_
         3. No memberOf plugin enabled in other consumers,ie., the read only replicas
            won't get incremental updates for the attributes mentioned in the list.
         4. Run total update and verify the same attributes added/modified in the read-only replicas.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -369,7 +369,7 @@ def test_implicit_replication_of_password_policy(_create_entries):
         3. Try binding user with incorrect password (twice)
         4. Make sure user got locked
         5. Run total update and verify the same attributes added/modified in the read-only replicas.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. FAIL(ldap.INVALID_CREDENTIALS)

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -266,7 +266,7 @@ def test_healthcheck_pwdfile_bad_file_perm(topology_st):
 def test_healthcheck_certif_expiring_within_30d(topology_st):
     """Check if HealthCheck returns DSCERTLE0001 code
 
-    :id: c2165032-88ba-4978-a4ca-2fecfd8c35d8
+    :id: f30b8115-0fd3-4c1d-9f5a-383bea7ea869
     :setup: Standalone instance
     :steps:
         1. Create DS instance

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -259,7 +259,7 @@ def test_healthcheck_check_option(topology_st):
 def test_healthcheck_standalone_tls(topology_st):
     """Check functionality of HealthCheck Tool on TLS enabled standalone instance with no errors
 
-    :id: 4844b446-3939-4fbd-b14b-293b20bb8be0
+    :id: 832374e6-6d2c-42af-80c8-d3685dbfa234
     :setup: Standalone instance
     :steps:
         1. Create DS instance
@@ -286,7 +286,7 @@ def test_healthcheck_standalone_tls(topology_st):
 def test_healthcheck_replication(topology_m2):
     """Check functionality of HealthCheck Tool on replication instance with no errors
 
-    :id: 9ee6d491-d6d7-4c2c-ac78-70d08f054166
+    :id: d7751cc3-271c-4c33-b296-8a4c8941233e
     :setup: 2 MM topology
     :steps:
         1. Create a two suppliers replication topology
@@ -411,7 +411,7 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
 def test_healthcheck_unable_to_query_backend(topology_st):
     """Check if HealthCheck returns DSBLE0002 code
 
-    :id: 716b1ff1-94bd-4780-98b8-96ff8ef21e30
+    :id: 01de2fe5-079d-4166-b4c9-1f1e00bb091c
     :setup: Standalone instance
     :steps:
         1. Create DS instance

--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -205,13 +205,13 @@ def test_import_with_index(topo, _import_clean):
     """
     Add an index, then import via cn=tasks
 
-    :id: 5bf75c47-a283-430e-a65c-3c5fd8dbadb8
+    :id: 9ddaf0df-7298-42bb-bdfa-a889ee68bc09
     :setup: Standalone Instance
     :steps:
         1. Creating the room number index
         2. Importing online
         3. Import is done -- verifying that it worked
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
         3. Operation successful
@@ -241,13 +241,13 @@ def test_online_import_with_warning(topo, _import_clean):
     """
     Import an ldif file with syntax errors, verify skipped entry warning code
 
-    :id: 5bf75c47-a283-430e-a65c-3c5fd8dbadb8
+    :id: 9b44cd0e-9d4b-4ae9-b750-cc7ba58d4529
     :setup: Standalone Instance
     :steps:
         1. Create standalone Instance
         2. Create an ldif file with an entry that violates syntax check (empty givenname)
         3. Online import of troublesome ldif file
-    :expected results:
+    :expectedresults:
         1. Successful import with skipped entry warning
         """
     topo.standalone.restart()
@@ -275,7 +275,7 @@ def test_crash_on_ldif2db(topo, _import_clean):
     :steps:
         1. Delete the cn=monitor entry for an LDBM backend instance
         2. Restart the server and verify that the LDBM monitor entry was re-created.
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
     """
@@ -296,7 +296,7 @@ def test_ldif2db_allows_entries_without_a_parent_to_be_imported(topo, _import_cl
     :steps:
         1. Import the offending LDIF data - offline
         2. Violates schema, ending line
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation Fail
     """
@@ -312,6 +312,7 @@ def test_ldif2db_allows_entries_without_a_parent_to_be_imported(topo, _import_cl
 
 def test_ldif2db_syntax_check(topo, _import_clean):
     """ldif2db should return a warning when a skipped entry has occured.
+
     :id: 85e75670-42c5-4062-9edc-7f117c97a06f
     :setup:
         1. Standalone Instance
@@ -319,7 +320,7 @@ def test_ldif2db_syntax_check(topo, _import_clean):
     :steps:
         1. Create an ldif file which violates the syntax checking rule
         2. Stop the server and import ldif file with ldif2db
-    :expected results:
+    :expectedresults:
         1. ldif2db import returns a warning to signify skipped entries
     """
     import_ldif1 = _create_syntax_err_ldif(topo)
@@ -342,7 +343,7 @@ def test_issue_a_warning_if_the_cache_size_is_smaller(topo, _import_clean):
         3. Check that cachememsize is sufficiently small
         4. Import some users to make id2entry.db big
         5. Warning message should be there in error logs
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
         3. Operation successful
@@ -397,7 +398,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
         8. Now nsslapd-db-private-import-mem:off
         9. Measure offline import time duration total_time2
         10. total_time1 < total_time2
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
         3. Operation successful
@@ -456,7 +457,7 @@ def test_entry_with_escaped_characters_fails_to_import_and_index(topo, _import_c
         2. Remove some of the other entries that were successfully imported.
         3. Now re-index the database.
         4. Should not return error.
-    :expected results:
+    :expectedresults:
         1. Operation successful
         2. Operation successful
         3. Operation successful

--- a/dirsrvtests/tests/suites/mapping_tree/mt_cursed_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/mt_cursed_test.py
@@ -66,14 +66,11 @@ def test_mapping_tree_inverted(topology):
     https://www.port389.org/docs/389ds/design/mapping_tree_assembly.html
 
     :id: 024c4960-3aac-4d05-bc51-963dfdeb16ca
-
     :setup: Standalone instance (no backends)
-
     :steps:
         1. Add two backends without mapping trees.
         2. Add the mapping trees with inverted parent-suffix definitions.
         3. Attempt to search the definitions
-
     :expectedresults:
         1. Success
         2. Success
@@ -116,14 +113,11 @@ def test_mapping_tree_nonexist_parent(topology):
     https://www.port389.org/docs/389ds/design/mapping_tree_assembly.html
 
     :id: 7a9a09bd-7604-48f7-93cb-abff9e0d0131
-
     :setup: Standalone instance (no backends)
-
     :steps:
         1. Add one backend without mapping tree
         2. Configure the mapping tree with a non-existant parent suffix
         3. Attempt to search the backend
-
     :expectedresults:
         1. Success
         2. Success
@@ -149,11 +143,26 @@ def test_mapping_tree_nonexist_parent(topology):
 
 # Two same length (dc=example,dc=com    dc=abcdefg,dc=abc)
 def test_mapping_tree_same_length(topology):
+    """Test mapping tree with backends that have same lengths (dc=example,dc=com and dc=abcdefg,dc=abc)
+
+    :id: 7b9fcffe-e786-4895-b530-00215aaa7e84
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add two backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
     # First create two Backends, without mapping trees.
     be1 = create_backend(inst, 'userRootA', 'dc=example,dc=com')
     be2 = create_backend(inst, 'userRootB', 'dc=abcdefg,dc=hij')
-    # Okay, now we create the mapping trees for these backends, and we *invert* them in the parent config setting
+    # Okay, now we create the mapping trees for these backends
     mts = MappingTrees(inst)
     mtb = mts.create(properties={
         'cn': 'dc=example,dc=com',
@@ -179,11 +188,26 @@ def test_mapping_tree_same_length(topology):
 
 # Flipped DC comps (dc=exmaple,dc=com  dc=com,dc=example)
 def test_mapping_tree_flipped_components(topology):
+    """Test mapping tree with backends that have flipped DC components (dc=example,dc=com and dc=com,dc=example)
+
+    :id: 55264933-2a81-428b-aec9-c8f9a64400d1
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add two backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
     # First create two Backends, without mapping trees.
     be1 = create_backend(inst, 'userRootA', 'dc=example,dc=com')
     be2 = create_backend(inst, 'userRootB', 'dc=com,dc=example')
-    # Okay, now we create the mapping trees for these backends, and we *invert* them in the parent config setting
+    # Okay, now we create the mapping trees for these backends
     mts = MappingTrees(inst)
     mtb = mts.create(properties={
         'cn': 'dc=example,dc=com',
@@ -207,10 +231,25 @@ def test_mapping_tree_flipped_components(topology):
     assert dc_ex.exists()
     assert dc_ab.exists()
 
-# Weirdnesting (dc=exmaple,dc=com, dc=com,dc=example, dc=com,dc=example,dc=com)
+# Weird nesting (dc=exmaple,dc=com, dc=com,dc=example, dc=com,dc=example,dc=com)
 def test_mapping_tree_weird_nesting(topology):
+    """Test mapping tree with backends that have weired nesting (dc=exmaple,dc=com, dc=com,dc=example, dc=com,dc=example,dc=com)
+
+    :id: 02fbfaa5-15ef-43d2-a52f-c011e496e8cd
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add 3 backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
-    # First create two Backends, without mapping trees.
+    # First create 3 Backends, without mapping trees.
     be1 = create_backend(inst, 'userRootA', 'dc=example,dc=com')
     be2 = create_backend(inst, 'userRootB', 'dc=com,dc=example')
     be3 = create_backend(inst, 'userRootC', 'dc=com,dc=example,dc=com')
@@ -249,13 +288,28 @@ def test_mapping_tree_weird_nesting(topology):
 
 # Diff lens (dc=myserver, dc=a,dc=b,dc=c,dc=d, dc=example,dc=com)
 def test_mapping_tree_mixed_length(topology):
+    """Test mapping tree with backends that have different lengths (dc=myserver, dc=a,dc=b,dc=c,dc=d, dc=example,dc=com)
+
+    :id: ce43abf2-335c-4327-a883-b20a40e5571c
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add 5 backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
-    # First create two Backends, without mapping trees.
+    # First create 5 Backends, without mapping trees.
     be1 = create_backend(inst, 'userRootA', 'dc=myserver')
-    be1 = create_backend(inst, 'userRootB', 'dc=m')
-    be1 = create_backend(inst, 'userRootC', 'dc=a,dc=b,dc=c,dc=d,dc=e')
-    be1 = create_backend(inst, 'userRootD', 'dc=example,dc=com')
-    be1 = create_backend(inst, 'userRootE', 'dc=myldap')
+    be2 = create_backend(inst, 'userRootB', 'dc=m')
+    be3 = create_backend(inst, 'userRootC', 'dc=a,dc=b,dc=c,dc=d,dc=e')
+    be4 = create_backend(inst, 'userRootD', 'dc=example,dc=com')
+    be5 = create_backend(inst, 'userRootE', 'dc=myldap')
 
     mts = MappingTrees(inst)
     mts.create(properties={
@@ -304,6 +358,21 @@ def test_mapping_tree_mixed_length(topology):
 
 # 50 suffixes, shallow nest (dc=example,dc=com, then dc=00 -> dc=50)
 def test_mapping_tree_many_shallow(topology):
+    """Test mapping tree with 50 backends, shallow nesting 
+
+    :id: c15dc565-fa9d-41c9-91f9-24543079ce31
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add 50 backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
     dcs = [ ('dc=x%s,dc=example,dc=com' % x, 'userRoot%s' % x) for x in range(0,50) ]
 
@@ -327,6 +396,21 @@ def test_mapping_tree_many_shallow(topology):
 
 # 50 suffixes, deeper nesting (dc=example,dc=com, dc=00  -> dc=10 and dc=a,dc=b,dc=c,dc=d,dc=XX,dc=example,dc=com)
 def test_mapping_tree_many_deep_nesting(topology):
+    """Test mapping tree with 50 backends, deep nesting (dc=example,dc=com, dc=00  -> dc=10 and dc=a,dc=b,dc=c,dc=d,dc=XX,dc=example,dc=com)
+
+    :id: 519e5fb7-e8d1-42fe-800c-ba157054a7d9
+    :setup: Standalone instance (no backends)
+    :steps:
+        1. Add 50 backends without mapping trees
+        2. Create the mapping trees for these backends
+        3. Check that domains exist
+        4. Restart and check again
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success 
+        4. Success
+    """
     inst = topology.standalone
     be_count = 0
     dcs = []
@@ -362,10 +446,4 @@ def test_mapping_tree_many_deep_nesting(topology):
     inst.restart()
     for dc_a in dc_asserts:
         assert dc_a.exists()
-
-
-
-
-
-
 

--- a/dirsrvtests/tests/suites/mapping_tree/referral_during_tot_init_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/referral_during_tot_init_test.py
@@ -19,6 +19,23 @@ pytestmark = pytest.mark.tier1
 
 @pytest.mark.skipif(ds_is_older("1.4.0.0"), reason="Not implemented")
 def test_referral_during_tot(topology_m2):
+    """Test referrals during total init
+
+    :id: 2a030f15-89ae-4acc-880d-bd2263a6be33
+    :setup: 2 suppliers
+    :steps:
+        1. Create test user on supplier2
+        2. Create a bunch of entries in supplier1
+        3. Recreate the user on supplier1 also, so that if the init finishes first we don't lose the user on supplier2
+        4. Initialize replica on supplier1
+        5. While that's happening try to bind as a user to supplier2
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. This should trigger the referral code.
+    """
 
     supplier1 = topology_m2.ms["supplier1"]
     supplier2 = topology_m2.ms["supplier2"]
@@ -37,7 +54,7 @@ def test_referral_during_tot(topology_m2):
     supplier1.stop()
     supplier1.ldif2db(bename=None, excludeSuffixes=None, encrypt=False, suffixes=[DEFAULT_SUFFIX], import_file=import_ldif)
     supplier1.start()
-    # Recreate the user on m1 also, so that if the init finishes first ew don't lose the user on m2
+    # Recreate the user on supplier1 also, so that if the init finishes first we don't lose the user on supplier2
     users = UserAccounts(supplier1, DEFAULT_SUFFIX)
     u = users.create(properties=TEST_USER_PROPERTIES)
     u.set('userPassword', 'password')

--- a/dirsrvtests/tests/suites/mapping_tree/regression_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/regression_test.py
@@ -97,12 +97,11 @@ def test_sub_suffixes(topo, orphan_param):
     :id: 5b4421c2-d851-11ec-a760-482ae39447e5
     :feature: mapping-tree
     :setup: Standalone instance with 3 additional backends:
-             dc=parent, dc=child1,dc=parent, dc=childr21,dc=parent
+            dc=parent, dc=child1,dc=parent, dc=childr21,dc=parent
     :steps:
-        1. set orphan attribute mapping tree entry for dc=child1,dc=parent
-            according to orphan_param value
-        2. restart the server to rebuild the mapping tree
-        r32. For each suffix: search the suffix
+        1. Det orphan attribute mapping tree entry for dc=child1,dc=parent according to orphan_param value
+        2. Restart the server to rebuild the mapping tree
+        3. For each suffix: search the suffix
     :expectedresults:
         1. Success
         2. Success

--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -151,17 +151,14 @@ def test_monitor_backend(topo):
 @pytest.mark.bz1903539
 @pytest.mark.ds4528
 def test_num_subordinates_with_monitor_suffix(topo):
-    """This test is to compare the numSubordinates value on the root entry
-    with the actual number of direct subordinate(s).
+    """This test is to compare the numSubordinates value on the root entry with the actual number of direct subordinate(s).
 
     :id: fdcfe0ac-33c3-4252-bf38-79819ec58a51
     :setup: Single instance
     :steps:
-        1. Create sample entries and perform a search with basedn as cn=monitor,
-        filter as "(objectclass=*)" and scope as base.
+        1. Create sample entries and perform a search with basedn as cn=monitor, filter as "(objectclass=*)" and scope as base.
         2. Extract the numSubordinates value.
-        3. Perform another search with basedn as cn=monitor, filter as
-        "(|(objectclass=*)(objectclass=ldapsubentry))" and scope as one.
+        3. Perform another search with basedn as cn=monitor, filter as "(\|(objectclass=*)(objectclass=ldapsubentry))" and scope as one.
         4. Compare numSubordinates value with the number of sub-entries.
     :expectedresults:
         1. Success

--- a/dirsrvtests/tests/suites/password/password_TPR_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_TPR_policy_test.py
@@ -154,18 +154,20 @@ def test_only_user_can_reset_TPR(topo, _add_user, set_global_TPR_policies):
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create 2 users with appropriate password
-    3. Create Global TPR policy enable passwordMustChange: on
-    3. Trigger Temporary password and reset user1 password
-    3. Bind as user#2 and attempt to Reset user#1 password as user#2
-    4. Verify admin can reset users#1,2 passwords
+        1. Create DS Instance
+        2. Create 2 users with appropriate password
+        3. Create Global TPR policy enable passwordMustChange: on
+        4. Trigger Temporary password and reset user1 password
+        5. Bind as user#2 and attempt to Reset user#1 password as user#2
+        6. Verify admin can reset users#1,2 passwords
 
-    :expected results:
-    1. Success
-    2. Success
-    3. Fail(ldap.INSUFFICIENT_ACCESS)
-    4. Success 
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Fail(ldap.INSUFFICIENT_ACCESS)
+        6. Success 
 
 """
     log.info('Creating 2 users with appropriate password')
@@ -188,26 +190,26 @@ def test_local_TPR_supercedes_global_TPR(topo, _add_user, set_global_TPR_policie
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create user with appropriate password
-    3. Configure the Global Password policies with passwordTPRMaxUse 5     
-    4. Configure different local password policy for passwordTPRMaxUse 3
-    5. Trigger TPR by resetting the user password above
-    6. Attempt an ldap search with an incorrect bind password for user above
-    7. Repeat as many times as set by attribute passwordTPRMaxUse
-    8. Should lock the account after value is set in the local passwordTPRMaxUse is reached
-    9. Try to search with the correct password account will be locked.
+        1. Create DS Instance
+        2. Create user with appropriate password
+        3. Configure the Global Password policies with passwordTPRMaxUse 5     
+        4. Configure different local password policy for passwordTPRMaxUse 3
+        5. Trigger TPR by resetting the user password above
+        6. Attempt an ldap search with an incorrect bind password for user above
+        7. Repeat as many times as set by attribute passwordTPRMaxUse
+        8. Should lock the account after value is set in the local passwordTPRMaxUse is reached
+        9. Try to search with the correct password account will be locked.
 
-    :expected results:
-    1. Success
-    2. Success
-    3. Fail(ldap.INSUFFICIENT_ACCESS)
-    4. Success
-    5. Success
-    6. Success
-    7. Success
-    8. Success
-    9. Success 
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Fail(ldap.INSUFFICIENT_ACCESS)
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Success 
 
 """
 
@@ -241,21 +243,21 @@ def test_once_TPR_reset_old_passwd_invalid(topo, _add_user, set_global_TPR_polic
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create user jdoe1 with appropriate password
-    3. Configure the Global Password policies enable passwordMustChange
-    4. Trigger TPR by resetting the user jdoe1 password above
-    5. Attempt to login with the old password
-    6. Login as jdoe1 with the correct password and update the new password
+        1. Create DS Instance
+        2. Create user jdoe1 with appropriate password
+        3. Configure the Global Password policies enable passwordMustChange
+        4. Trigger TPR by resetting the user jdoe1 password above
+        5. Attempt to login with the old password
+        6. Login as jdoe1 with the correct password and update the new password
 
 
-    :expected results:
-    1. Success
-    2. Success
-    3. Success
-    4. Success
-    5. Fail(ldap.CONSTRAINT_VIOLATION)
-    6. Success
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Fail(ldap.CONSTRAINT_VIOLATION)
+        6. Success
 
 """
     new_password = 'test_password'
@@ -288,22 +290,22 @@ def test_reset_pwd_before_passwordTPRDelayValidFrom(topo, _add_user, set_global_
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create user jdoe2 with appropriate password
-    3. Configure the Global Password policies disable passwordTPRDelayValidFrom to -1
-    4. Trigger TPR by resetting the user jdoe1 password above
-    5. Attempt to bind and rebind immediately 
-    6. Set passwordTPRDelayValidFrom - 5secs elapses and bind rebind before 5 secs elapses
-    6. Wait for the passwordTPRDelayValidFrom value to elapse and try to reset passwd
+        1. Create DS Instance
+        2. Create user jdoe2 with appropriate password
+        3. Configure the Global Password policies disable passwordTPRDelayValidFrom to -1
+        4. Trigger TPR by resetting the user jdoe1 password above
+        5. Attempt to bind and rebind immediately 
+        6. Set passwordTPRDelayValidFrom - 5secs elapses and bind rebind before 5 secs elapses
+        7. Wait for the passwordTPRDelayValidFrom value to elapse and try to reset passwd
 
-    :expected results:
-    1. Success
-    2. Success
-    3. Success
-    4. Success
-    5. Success
-    6. Fail(ldap.LDAP_CONSTRAINT_VIOLATION)
-    7. Success
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Fail(ldap.LDAP_CONSTRAINT_VIOLATION)
+        7. Success
 
 
 """
@@ -330,16 +332,17 @@ def test_admin_resets_pwd_TPR_attrs_reset(topo, _add_user, set_global_TPR_polici
     """Test When the ‘userpassword’ is updated (update_pw_info) by an administrator 
        and it exists a TPR policy, then the server flags that the entry has a 
        TPR password with ‘pwdTPRReset: TRUE’, ‘pwdTPRExpTime’ and ‘pwdTPRUseCount’.
+
     :id: e6a84dc0-f142-11eb-8c96-fa163e1f582c
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create user jdoe2 with appropriate password
-    3. Configure the Global Password policies enable 
-    4. Trigger TPR by resetting the user jdoe1 password above
-    5. Reset the users password ‘userpassword’
-    6. Check that ‘pwdTPRExpTime’ and ‘pwdTPRUseCount’ are updated
+        1. Create DS Instance
+        2. Create user jdoe2 with appropriate password
+        3. Configure the Global Password policies enable 
+        4. Trigger TPR by resetting the user jdoe1 password above
+        5. Reset the users password ‘userpassword’
+        6. Check that ‘pwdTPRExpTime’ and ‘pwdTPRUseCount’ are updated
     :expectedresults:
         1. Success
         2. Success
@@ -373,16 +376,17 @@ def test_admin_resets_pwd_TPR_attrs_reset(topo, _add_user, set_global_TPR_polici
 
 def test_user_resets_pwd_TPR_attrs_reset(topo, _add_user, set_global_TPR_policies):
     """Test once password is reset attributes are set to FALSE
+
     :id: 6614068a-ee7d-11eb-b1a3-98fa9ba19b65
     :customerscenario: True
     :setup: Standalone
     :steps:
-    1. Create DS Instance
-    2. Create user jdoe2 with appropriate password
-    3. Configure the Global Password policies and set passwordMustChange on
-    4. Trigger TPR by resetting the user jdoe1 password above
-    5. Reset the users password ‘userpassword’
-    6. Check that pwdTPRReset, pwdTPRUseCount, pwdTPRValidFrom, pwdTPRExpireAt are RESET
+        1. Create DS Instance
+        2. Create user jdoe2 with appropriate password
+        3. Configure the Global Password policies and set passwordMustChange on
+        4. Trigger TPR by resetting the user jdoe1 password above
+        5. Reset the users password ‘userpassword’
+        6. Check that pwdTPRReset, pwdTPRUseCount, pwdTPRValidFrom, pwdTPRExpireAt are RESET
     :expectedresults:
         1. Success
         2. Success
@@ -424,17 +428,18 @@ def test_user_resets_pwd_TPR_attrs_reset(topo, _add_user, set_global_TPR_policie
 
 def test_TPR_replication_entry(topo_m2c2):
     """Test once password is reset attributes are set to FALSE
+
         :id: f8b98042-ff07-11eb-b938-98fa9ba19b65
         :customerscenario: True
         :setup: Replicated 2 Suppliers 2 Consumers
         :steps:
-        1. Create Replicated Topology with 2 suppliers and 2 consumers
-        2. Create users on each replica
-        3. Verify that 'pwdTPRReset', 'pwdTPRUseCount', 'pwdTPRValidFrom', 'pwdTPRExpireAt' are set to None
-        3. Configure the Global Password policies and set passwordMustChange on supplier1
-        4. Trigger TPR by resetting the users password above
-        5. Reset the users password ‘userpassword’
-        6. Check that pwdTPRReset, pwdTPRUseCount, pwdTPRValidFrom, pwdTPRExpireAt are updated on every replica
+            1. Create Replicated Topology with 2 suppliers and 2 consumers
+            2. Create users on each replica
+            3. Verify that 'pwdTPRReset', 'pwdTPRUseCount', 'pwdTPRValidFrom', 'pwdTPRExpireAt' are set to None
+            4. Configure the Global Password policies and set passwordMustChange on supplier1
+            5. Trigger TPR by resetting the users password above
+            6. Reset the users password ‘userpassword’
+            7. Check that pwdTPRReset, pwdTPRUseCount, pwdTPRValidFrom, pwdTPRExpireAt are updated on every replica
         :expectedresults:
             1. Success
             2. Success
@@ -442,6 +447,7 @@ def test_TPR_replication_entry(topo_m2c2):
             4. Success
             5. Success
             6. Success
+            7. Success
 
         """
     repl_list = ['supplier1', 'supplier2', 'consumer1', 'consumer2']

--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -198,7 +198,7 @@ def test_password_change_section(topo, _policy_setup, _fixture_for_password_chan
         25. Administrator Reseting to original password
         26. Try to change password with invalid credentials.  Should see error message
         27. Changing current password (('passwordchange', 'off') for joe)
-    :expected results:
+    :expectedresults:
         1. Success(As its is not belong to any password policy)
         2. Success
         3. Fail(pw policy is set to no)
@@ -439,7 +439,7 @@ def test_password_syntax_section(topo, _policy_setup, _fixture_for_syntax_sectio
         18. Setting policy to Check Password Syntax again
         19. Try to change to a password that violates length
         20. Change to a password that meets length requirement
-    :expected results:
+    :expectedresults:
         1. Fail(invalid cred)
         2. Fail(constaint viol.)
         3. Fail(Syntax error)
@@ -693,7 +693,7 @@ def test_password_history_section(topo, _policy_setup, _fixture_for_password_his
             13. Setting policy to NOT keep password histories
             14. Changing current password from ``*2 to ``*2``
             15. Try to change ``*2`` to ``*1``, should succeed
-        :expected results:
+        :expectedresults:
             1. Success
             2. Success
             3. Fail(ldap.CONSTRAINT_VIOLATION)
@@ -881,7 +881,7 @@ def test_password_minimum_age_section(topo, _policy_setup, _fixture_for_password
             3. Wait 5 secs and try to change again.  Should fail.
             4. Wait more time to complete password min age
             5. Now user can change password
-        :expected results:
+        :expectedresults:
             1. Success
             2. Success
             3. Fail(ldap.CONSTRAINT_VIOLATION)
@@ -959,7 +959,7 @@ def test_account_lockout_and_lockout_duration_section(topo, _policy_setup, _fixt
             4. Try to bind with invalid credentials
             5. Attempt to bind with valid pw after timeout is up
             6. Resetting with root can break lockout
-        :expected results:
+        :expectedresults:
             1. Fail(ldap.INVALID_CREDENTIALS)
             2. Fail(ldap.CONSTRAINT_VIOLATION)
             3. Success
@@ -1090,7 +1090,7 @@ def test_grace_limit_section(topo, _policy_setup, _fixture_for_grace_limit):
         13. Modify the users passwords to start the clock
         14. Users should be blocked
         15. Removing the passwordgracelimit attribute should make it default to 0
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Fail(ldap.INVALID_CREDENTIALS)
@@ -1304,7 +1304,7 @@ def test_additional_corner_cases(topo, _policy_setup, _fixture_for_additional_ca
         6. Try to change password to the value of ou, which is trivial. Should get error.
         7. No error for fred and dbyers as they are not included in PW policy.
         8. Revert changes for fred and dbyers
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Fail(CONSTRAINT_VIOLATION)

--- a/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def test_user(topology_st, request):
+def add_test_user(topology_st, request):
     """User for binding operation"""
     topology_st.standalone.config.set('nsslapd-auditlog-logging-enabled', 'on')
     log.info('Adding test user {}')
@@ -60,7 +60,7 @@ def test_user(topology_st, request):
 
 
 @pytest.fixture(scope="module")
-def password_policy(topology_st, test_user):
+def password_policy(topology_st, add_test_user):
     """Set up password policy for subtree and user"""
 
     pwp = PwPolicyManager(topology_st.standalone)
@@ -73,7 +73,7 @@ def password_policy(topology_st, test_user):
 
 @pytest.mark.bz1845094
 @pytest.mark.skipif(ds_is_older('1.4.3.3'), reason="Not implemented")
-def test_pwdReset_by_user_DM(topology_st, test_user):
+def test_pwdReset_by_user_DM(topology_st, add_test_user):
     """Test new password policy attribute "pwdReset"
 
     :id: 232bc7dc-8cb6-11eb-9791-98fa9ba19b65
@@ -85,7 +85,7 @@ def test_pwdReset_by_user_DM(topology_st, test_user):
         3. Check that the pwdReset attribute is set to TRUE
         4. Bind as the Directory manager and attempt to change the pwdReset to FALSE
         5. Check that pwdReset is NOT SET to FALSE
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Successful bind as DS user, pwdReset as DS user fails w UNWILLING_TO_PERFORM
@@ -116,7 +116,7 @@ def test_pwdReset_by_user_DM(topology_st, test_user):
 
 
 @pytest.mark.skipif(ds_is_older('1.4.3.3'), reason="Not implemented")
-def test_pwd_reset(topology_st, test_user):
+def test_pwd_reset(topology_st, add_test_user):
     """Test new password policy attribute "pwdReset"
 
     :id: 03db357b-4800-411e-a36e-28a534293004
@@ -129,7 +129,7 @@ def test_pwd_reset(topology_st, test_user):
         4. Bind as the user and change its password
         5. Check that pwdReset is now set to FALSE
         6. Reset password policy configuration
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -170,7 +170,7 @@ def test_pwd_reset(topology_st, test_user):
                          [('on', 'off', ldap.UNWILLING_TO_PERFORM),
                           ('off', 'off', ldap.UNWILLING_TO_PERFORM),
                           ('off', 'on', False), ('on', 'on', False)])
-def test_change_pwd(topology_st, test_user, password_policy,
+def test_change_pwd(topology_st, add_test_user, password_policy,
                     subtree_pwchange, user_pwchange, exception):
     """Verify that 'passwordChange' attr works as expected
     User should have a priority over a subtree.
@@ -230,7 +230,7 @@ def test_change_pwd(topology_st, test_user, password_policy,
         user.reset_password(TEST_USER_PWD)
 
 
-def test_pwd_min_age(topology_st, test_user, password_policy):
+def test_pwd_min_age(topology_st, add_test_user, password_policy):
     """If we set passwordMinAge to some value, for example to 10, then it
     should not allow the user to change the password within 10 seconds after
     his previous change.

--- a/dirsrvtests/tests/suites/password/pwdPolicy_temporary_password.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_temporary_password.py
@@ -77,7 +77,7 @@ def test_global_tpr_maxuse_1(topology_st, test_user, request):
         7. Bind with a valid password 5 times and check CONSTRAINT_VIOLATION
            and check passwordTPRRetryCount overpass the limit by 1 (6)
         8. Reset password policy configuration
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -191,7 +191,7 @@ def test_global_tpr_maxuse_2(topology_st, test_user, request):
         7. Bind successfully with a valid password 10 times
            and check passwordTPRRetryCount returns to 0
         8. Reset password policy configuration
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -296,7 +296,7 @@ def test_global_tpr_maxuse_3(topology_st, test_user, request):
         7. Bindd with valid password and reset the password
         8. Check we can bind again and SRCH succeeds
         9. Reset password policy configuration
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -407,7 +407,7 @@ def test_global_tpr_maxuse_4(topology_st, test_user, request):
         8. Bind as user and reset its password
         9. Check that user can not update pwdTPRUseCount => INSUFFICIENT_ACCESS
         10. Check that DM can update pwdTPRUseCount
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -523,7 +523,7 @@ def test_local_tpr_maxuse_5(topology_st, test_user, request):
         9. Bind with a valid password 10 times and check CONSTRAINT_VIOLATION
            and check passwordTPRUseCount increases
         10. Reset password policy configuration and remove local password from user
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -671,7 +671,7 @@ def test_global_tpr_delayValidFrom_1(topology_st, test_user, request):
         6. Check that Validity is not reached yet
            pwdTPRValidFrom >= now + passwordTPRDelayValidFrom - 2 (safety)
         7. Bind with valid password, Fails because of CONSTRAINT_VIOLATION
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -738,7 +738,7 @@ def test_global_tpr_delayValidFrom_2(topology_st, test_user, request):
         7. Bind with valid password, reset password
            to allow further searches
         8. Check bound user can search attribute ('uid')
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -817,7 +817,7 @@ def test_global_tpr_delayValidFrom_3(topology_st, test_user, request):
         11. Bound as DM, check user has the right to
             modify pwdTPRValidFrom
 
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -912,7 +912,7 @@ def test_global_tpr_delayExpireAt_1(topology_st, test_user, request):
         5. Reset the password
         6. Wait for passwordTPRDelayExpireAt=6s + 2s (safety)
         7. Bind with valid password should fail with ldap.CONSTRAINT_VIOLATION
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -983,7 +983,7 @@ def test_global_tpr_delayExpireAt_2(topology_st, test_user, request):
         5. Reset the password
         6. Wait for 1s
         7. Bind with valid password should succeeds
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -1064,7 +1064,7 @@ def test_global_tpr_delayExpireAt_3(topology_st, test_user, request):
         11. Bound as DM, check user has the right to
             modify pwdTPRExpireAt
 
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
@@ -565,7 +565,7 @@ def test_password_expire_works(topology_st):
         5. Modify the users password
         6. Modify the user one more time to make sur etime has been reset
         7. turn off the password policy
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/password/pwd_upgrade_on_bind_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_upgrade_on_bind_test.py
@@ -165,8 +165,8 @@ def test_password_hash_on_upgrade_clearcrypt(topology_st):
             2. The bind succeeds
             3. The PW is CLEAR
             4. The set succeeds
-            4. The bind succeeds
-            5. The PW is CRYPT
+            5. The bind succeeds
+            6. The PW is CRYPT
     """
     # Make sure the server is set to pkbdf
     topology_st.standalone.config.set('nsslapd-allow-hashed-passwords', 'on')

--- a/dirsrvtests/tests/suites/password/pwp_gracel_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_gracel_test.py
@@ -39,7 +39,7 @@ def test_password_gracelimit_section(topo):
         11. Setting the passwordMaxAge to 3 seconds once more and the passwordGraceLimit to 0
         12. Modify the users passwords to start the clock
         13. Users should be blocked automatically after 3 second
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/password/pwp_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_test.py
@@ -87,7 +87,7 @@ def test_passwordchange_to_no(topo, _fix_password):
         5. Set Password change to May Change Password
         6. Try to change password fo a user even password
         7. Try to change password with invalid credentials.  Should see error message.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -137,7 +137,7 @@ def test_password_check_syntax(topo, _fix_password):
         15. Setting policy to Check Password Syntax again
         16. Try to change to a password that violates length
         17. Reset Password
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -209,7 +209,7 @@ def test_too_big_password(topo, _fix_password):
         4. Checking that the passwordhistory attribute has been added
         5. Add a password test for long long password
         6. Changing number of password in history to 6 and passwordhistory off
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -253,7 +253,7 @@ def test_pwminage(topo, _fix_password):
         3. Change current password
         4. Try to change password again
         5. Try now after 3 secs is up,  should work.
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -293,7 +293,7 @@ def test_invalid_credentials(topo, _fix_password):
         8. Now bind again with valid password: We should be locked
         9. Delete dby3rs before exiting
         10. Reset server
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -370,7 +370,7 @@ def test_expiration_date(topo, _fix_password):
         10. Set password history ON
         11. Modify password Once
         12. Try to change the password with same one
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -443,7 +443,7 @@ def test_passwordlockout(topo, _fix_password):
         17. Reset password using admin login
         18. Try to login as the user to check the unlocking of account. Will also change the
             password back to original
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/password/regression_of_bugs_test.py
+++ b/dirsrvtests/tests/suites/password/regression_of_bugs_test.py
@@ -121,7 +121,7 @@ def test_local_password_policy(topo, _add_user):
         6. Add another generic user but do not include the password (userpassword)
         7. Use admin user to perform a password update on generic user
         8. We don't need this ACI anymore. Delete it
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -165,7 +165,7 @@ def test_passwordexpirationtime_attribute(topo, _add_user):
     :setup: Standalone
     :steps:
         1. Check that the passwordExpirationTime attribute is set to the epoch date
-    :expected results:
+    :expectedresults:
         1. Success
     """
     Config(topo.standalone).replace('passwordMustChange', 'on')
@@ -218,7 +218,7 @@ def test_admin_group_to_modify_password(topo, _add_user):
         28. Change admins
         29. Change user's password by ex-admin user
         30. Change admin user's password by ex-admin user
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -429,7 +429,7 @@ def test_password_max_failure_should_lockout_password(topo):
         3. Set maximum number of login tries to 3
         4. Turn off passwordLegacyPolicy
         5. Turn off local password policy, so that global is applied
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -472,7 +472,7 @@ def test_pwd_update_time_attribute(topo):
             check passwordUpdateTime should be changed
         11. Try setting Invalid value for passwordTrackUpdateTime
         12. Try setting Invalid value for pwdupdatetime
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -537,7 +537,7 @@ def test_password_track_update_time(topo):
         9. Check current pwdUpdateTime
         10. Set passwordTrackUpdateTime to ON and modify test entry's pwd,
             check passwordUpdateTime should be changed
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -606,7 +606,7 @@ def test_signal_11(topo):
     :steps:
         1. Adding new user
         2. Modifying user passwod of uid=bz973583
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
     """

--- a/dirsrvtests/tests/suites/plugins/accpol_test.py
+++ b/dirsrvtests/tests/suites/plugins/accpol_test.py
@@ -377,7 +377,7 @@ def test_glremv_lastlogin(topology_st, accpol_global):
         5. Check if users are inactivated, expected error 19.
         6. Replace lastLoginTime attribute and check if account is activated
         7. User should be activated based on lastLoginTime attribute, expected 0
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -419,7 +419,7 @@ def test_glact_login(topology_st, accpol_global):
         3. Run ldapsearch as normal user, expected error 19.
         4. Replace the lastLoginTime attribute and check if account is activated
         5. Run ldapsearch as normal user, expected 0.
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -465,7 +465,7 @@ def test_glinact_limit(topology_st, accpol_global):
         14. Replace the lastLoginTime attribute and check if account is activated
         15. Modify accountInactivityLimit to 12 secs, which is the default
         16. Run ldapsearch as normal user, expected 0.
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -547,7 +547,7 @@ def test_glnologin_attr(topology_st, accpol_global):
         16. Replace the lastLoginTime attribute and check if account is activated
         17. Modify accountInactivityLimit to 12 secs, which is the default
         18. Run ldapsearch as normal user, expected 0.
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -626,7 +626,7 @@ def test_glnoalt_stattr(topology_st, accpol_global):
         4. Remove lastLoginTime attribute from the user entry
         5. Run ldapsearch as normal user, expected 0. no lastLoginTime attribute present
         6. Wait till it reaches accountInactivityLimit and check users, expected error 19
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -674,7 +674,7 @@ def test_glattr_modtime(topology_st, accpol_global):
         5. Check if user is activated based on ModifyTimeStamp attribute, expected 0
         6. Change the plugin to use createTimeStamp and remove lastLoginTime attribute
         7. Check if account is inactivated, expected error 19
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -728,7 +728,7 @@ def test_glnoalt_nologin(topology_st, accpol_global):
         8. Set altstateattrname to createTimeStamp
         9. Check if user account is inactivated based on createTimeStamp attribute.
         10. Account should be inactivated, expected error 19
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -787,7 +787,7 @@ def test_glinact_nsact(topology_st, accpol_global):
         7. Check if account is activated, expected error 19
         8. Replace the lastLoginTime attribute and check if account is activated
         9. Run ldapsearch as normal user, expected 0.
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -837,7 +837,7 @@ def test_glinact_acclock(topology_st, accpol_global):
         5. Wait for passwordlockoutduration and check if account is active
         6. Check if account is unlocked, expected error 19, since account is inactivated
         7. Replace the lastLoginTime attribute and check users, expected 0
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -897,7 +897,7 @@ def test_glnact_pwexp(topology_st, accpol_global):
         7. Run ldapsearch as normal user, expected error 19.
         8. Replace the lastLoginTime attribute and check if account is activated
         9. Run ldapsearch as normal user, expected 0.
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -979,7 +979,7 @@ def test_locact_inact(topology_st, accpol_local):
         4. Wait till accountInactivityLimit is exceeded
         5. Run ldapsearch as normal user and check if its inactivated, expected error 19.
         6. Replace user's lastLoginTime attribute and check if its activated, expected 0
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -1026,7 +1026,7 @@ def test_locinact_modrdn(topology_st, accpol_local):
         5. Wait till accountInactivityLimit exceeded
         6. Move users from ou=groups subtree to ou=people subtree
         7. Check if users are inactivated, expected error 19
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -1073,7 +1073,7 @@ def test_locact_modrdn(topology_st, accpol_local):
         3. Move users from ou=people to ou=groups subtree
         4. Wait till accountInactivityLimit is exceeded
         5. Check if users are active in ou=groups subtree, expected 0
-    :assert:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/plugins/managed_entry_test.py
+++ b/dirsrvtests/tests/suites/plugins/managed_entry_test.py
@@ -59,7 +59,7 @@ def test_binddn_tracking(topo, _create_inital):
         7. Check the time stamp of UPG should be changed now
         8. Check the creatorsname should be user dn and internalCreatorsname should be plugin name
         9. Check if a managed group entry was created
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -115,7 +115,7 @@ class WithObjectClass(Account):
 def test_mentry01(topo, _create_inital):
     """Test Managed Entries basic functionality
 
-    :id: 9b87493b-0493-46f9-8364-6099d0e5d806
+    :id: 863678bb-9383-42cf-b2a8-8763f4908650
     :setup: Standalone Instance
     :steps:
         1. Check the plug-in status
@@ -133,7 +133,7 @@ def test_mentry01(topo, _create_inital):
         13. Deleting mepManagedBy attribute and running ModRDN operation to check if it creates a new UPG
         14. Change the RDN of template entry, DSA Unwilling to perform error expected
         15. Change the RDN of cn=Users to cn=TestUsers and check UPG are deleted
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success

--- a/dirsrvtests/tests/suites/pwp_storage/storage_test.py
+++ b/dirsrvtests/tests/suites/pwp_storage/storage_test.py
@@ -51,7 +51,7 @@ def test_check_password_scheme(topo, value):
         1. Change password scheme and create user with password.
         2. check password scheme is set .
         3. Delete user
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -71,7 +71,7 @@ def test_clear_scheme(topo):
         1. Change password scheme and create user with password.
         2. check password scheme is set .
         3. Delete user
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -90,7 +90,7 @@ def test_check_two_scheme(topo):
         1. Change password scheme and create user with password.
         2. check password scheme is set .
         3. Delete user
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass
@@ -114,7 +114,7 @@ def test_check_pbkdf2_sha256(topo):
     :steps:
         1. Try to delete PBKDF2_SHA256.
         2. Should not deleted PBKDF2_SHA256 and server should up.
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
     """
@@ -140,7 +140,7 @@ def test_check_ssha512(topo):
         1. Try to delete SSHA512Plugin.
         2. Should deleted SSHA512Plugin and server should not up.
         3. Restore dse file to recover
-    :expected results:
+    :expectedresults:
         1. Pass
         2. Pass
         3. Pass

--- a/dirsrvtests/tests/suites/replication/regression_m2c2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2c2_test.py
@@ -186,8 +186,8 @@ def test_csngen_state_not_updated_if_different_uuid(topo_m2c2):
              (to clear the ruvs and generates different generation uuid)
         5. Perform on line init from supplier1 to consumer1 and supplier2 to consumer2
         6. Perform update on both suppliers
-        7: Check that c1 has no time skew
-        8: Check that c2 has time skew
+        7. Check that c1 has no time skew
+        8. Check that c2 has time skew
         9. Init supplier2 from supplier1
         10. Perform update on supplier2
         11. Check that c1 has time skew

--- a/dirsrvtests/tests/suites/replication/replica_config_test.py
+++ b/dirsrvtests/tests/suites/replication/replica_config_test.py
@@ -265,6 +265,19 @@ def test_agmt_num_modify(topo, attr, too_small, too_big, overflow, notnum, valid
 @pytest.mark.bz1546739
 def test_same_attr_yields_same_return_code(topo):
     """Test that various operations with same incorrect attribute value yield same return code
+
+    :id: 4bae88d7-0da8-4a71-b062-9d0ff4e472cf
+    :setup: standalone instance
+    :steps:
+        1. Purge all replica details
+        2. Perform an invalid create operation
+        3. Setup replica
+        4. Perform an invalid modify operation
+    :expectedresults:
+        1. Success
+        2. Value is rejected
+        3. Success
+        4. Value is rejected
     """
     attr = 'nsDS5ReplicaId'
 

--- a/dirsrvtests/tests/suites/replication/sasl_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/sasl_m2_test.py
@@ -144,11 +144,11 @@ def test_repl_sasl_leak(topo_m2, use_valgrind):
         5. Poke replication 100 times
         6. Stop server
         7. Check presence of "SASL(-4): no mechanism available: No worthy mechs found" message in error log
-        8 Check that there is no leak about slapi_ldap_get_lderrno
+        8. Check that there is no leak about slapi_ldap_get_lderrno
     :expectedresults:
         1. Success
         2. Success
-        2. Success
+        3. Success
         4. Success
         5. Success
         6. Success

--- a/dirsrvtests/tests/suites/replication/series_of_repl_bugs_test.py
+++ b/dirsrvtests/tests/suites/replication/series_of_repl_bugs_test.py
@@ -49,7 +49,7 @@ def test_deletions_are_not_replicated(topo_m2):
         6. Check user`s USN on Supplier 2
         7. Delete user
         8. Check that deletion of user propagated to Supplier 1
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -96,7 +96,7 @@ def test_error_20(topo_m2, _delete_after):
     :steps:
         1. Add user
         2. Change multivalue attribute
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
     """
@@ -159,7 +159,7 @@ def test_segfaults(topo_m2, _delete_after):
         3. Search for tombstone entry
         4. Try to delete tombstone entry
         5. Check if server is still alive
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -191,7 +191,7 @@ def test_adding_deleting(topo_m2, _delete_after):
         1. Adding entry
         2. Adding attribute with 11 values to entry
         3. Removing 4 values from the attribute in the entry
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -229,7 +229,7 @@ def test_deleting_twice(topo_m2):
         1. Adding entry
         2. Deleting the same entry from s1
         3. Deleting the same entry from s2 after some seconds
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -264,7 +264,7 @@ def test_rename_entry(topo_m2, _delete_after):
         4. Change will not reflect on other supplier
         5. Turn on agreement on both
         6. Change will reflect on other supplier
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -310,7 +310,7 @@ def test_userpassword_attribute(topo_m2, _delete_after):
         2. Check that user's  has been propogated to Supplier 2
         3. modify user's userpassword attribute on supplier 2
         4. check the error logs on suppler 1 to make sure the error message is not there
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds
@@ -357,7 +357,7 @@ def test_tombstone_modrdn(topo_m2):
         2. Delete user - should leave tombstone entry
         3. Search for tombstone entry
         4. Try to modrdn with deleteoldrdn
-    :expected results:
+    :expectedresults:
         1. Should succeeds
         2. Should succeeds
         3. Should succeeds

--- a/dirsrvtests/tests/suites/replication/tls_client_auth_repl_test.py
+++ b/dirsrvtests/tests/suites/replication/tls_client_auth_repl_test.py
@@ -95,7 +95,7 @@ def tls_client_auth(topo_m2):
 def test_ssl_transport(tls_client_auth):
     """Test different combinations for nsDS5ReplicaTransportInfo values
 
-    :id: 922d16f8-662a-4915-a39e-0aecd7c8e6e2
+    :id: a3157108-cb98-43e9-ba16-8fb21a4a03e9
     :setup: Two supplier replication, enabled TLS client auth
     :steps:
         1. Set nsDS5ReplicaTransportInfoCheck: SSL or StartTLS or TLS

--- a/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
+++ b/dirsrvtests/tests/suites/replication/virtual_attribute_replication_test.py
@@ -101,6 +101,7 @@ def test_vattr_on_filtered_role_with_replication(topo, request):
     """Test nsslapd-ignore-virtual-attrs configuration attribute
        The attribute is ON by default. If a filtered role is
        added it is moved to OFF in replication scenario
+
     :id: 7b29be88-c8ca-409b-bbb7-ce3962f73f91
     :customerscenario: True
     :setup: Supplier Consumer

--- a/dirsrvtests/tests/suites/rewriters/adfilter_test.py
+++ b/dirsrvtests/tests/suites/rewriters/adfilter_test.py
@@ -43,8 +43,24 @@ def _create_user(inst, schema_container, name, salt):
 
 
 def test_adfilter_objectCategory(topology_st):
-    """
-    Test adfilter objectCategory rewriter function
+    """Test adfilter objectCategory rewriter function
+
+    :id: 9c6493c9-1ee0-4bc2-b5db-7253a04fb6f8
+    :setup: Standalone instance
+    :steps:
+         1. Add a objectsid rewriter (from librewriters.so)
+         2. Add a dummy schema definition of objectsid to prevent nsslapd-verify-filter-schema
+         3. Restart the server (to load the rewriter)
+         4. Check EQUALITY filter rewrite
+         5. Check SUBSTRING search is not replaced
+         6. Check PRESENCE search is not replaced so it selects all entries having objectCategory
+    :expectedresults:
+         1. Add operation should PASS.
+         2. Add operations should PASS.
+         3. Restart should PASS
+         4. Search returns only one entry
+         5. Search returns zero entries
+         6. Search returns all (20) entries
     """
 
     librewriters = os.path.join( topology_st.standalone.ds_paths.lib_dir, 'dirsrv/librewriters.so')
@@ -89,24 +105,20 @@ def objectsid_to_sid(objectsid):
 
 @pytest.mark.skipif(samba_missing, reason="It is missing samba python bindings")
 def test_adfilter_objectSid(topology_st):
-    """
-    Test adfilter objectCategory rewriter function
+    """Test adfilter objectCategory rewriter function with samba container/users
 
     :id: fc5880ff-4305-47ba-84fb-38429e264e9e
-
     :setup: Standalone instance
-
     :steps:
-         1. add a objectsid rewriter (from librewriters.so)
-         2. add a dummy schema definition of objectsid to prevent nsslapd-verify-filter-schema
-         3. restart the server (to load the rewriter)
+         1. Add a objectsid rewriter (from librewriters.so)
+         2. Add a dummy schema definition of objectsid to prevent nsslapd-verify-filter-schema
+         3. Restart the server (to load the rewriter)
          4. Add "samba" container/users
          5. Searches using objectsid in string format
-
     :expectedresults:
          1. Add operation should PASS.
          2. Add operations should PASS.
-         3. restart should PASS
+         3. Restart should PASS
          4. Add "samba" users should PASS
          5. Search returns only one entry
     """

--- a/dirsrvtests/tests/suites/rewriters/basic_test.py
+++ b/dirsrvtests/tests/suites/rewriters/basic_test.py
@@ -15,8 +15,14 @@ pytestmark = [pytest.mark.tier2,
 rewriters_container = "cn=rewriters,cn=config"
 
 def test_rewriters_container(topology_st):
-    """
-    Test checks that rewriters container exists
+    """Test checks that rewriters container exists
+
+    :id: 5514ae43-546b-4165-beac-896f7f0c9197
+    :setup: Standalone instance
+    :steps:
+         1. Check container of rewriteers
+    :expectedresults:
+         1. Search returns only one entry
     """
 
     # Check container of rewriters
@@ -26,8 +32,18 @@ def test_rewriters_container(topology_st):
     log.info('Test PASSED')
 
 def test_foo_filter_rewriter(topology_st):
-    """
-    Test that example filter rewriter 'foo' is register and search use it
+    """Test that example filter rewriter 'foo' is register and search use it
+
+    :id: d16cf7e9-4973-4747-8694-65818156a28e
+    :setup: Standalone instance
+    :steps:
+         1. Register foo filter rewriters
+         2. Restart the server
+         3. Check that the filter 'foo=foo' is rewritten into 'cn=foo'
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Success
     """
 
     libslapd = os.path.join( topology_st.standalone.ds_paths.lib_dir, 'dirsrv/libslapd.so')

--- a/dirsrvtests/tests/suites/schema/schema_test.py
+++ b/dirsrvtests/tests/suites/schema/schema_test.py
@@ -123,7 +123,16 @@ def atgetdiffs(ldschema, at1, at2):
 
 
 def test_schema_comparewithfiles(topology_st):
-    '''Compare the schema from ldap cn=schema with the schema files'''
+    """Compare the schema from ldap cn=schema with the schema files
+
+    :id: 31f0233e-a7e6-442f-8b05-c0b095e93387
+    :setup: Standalone instance
+    :steps:
+        1. Compare the schema from ldap cn=schema with the schema from files
+
+    :expectedresults:
+        1. Schema in cn=schema and files should be the same
+    """
 
     log.info('Running test_schema_comparewithfiles...')
 
@@ -203,7 +212,7 @@ def test_gecos_mixed_definition_topo(topo_m2, request):
     """Check that replication is still working if schema contains
        definitions that does not conform with a replicated entry
 
-    :id: d5940e71-d18a-4b71-aaf7-b9185361fffe
+    :id: 0a1b4f8c-e84a-4cc4-82c8-2561b1126786
     :setup: Two suppliers replication setup
     :steps:
         1. Create a testuser on M1

--- a/dirsrvtests/tests/suites/setup_ds/dscreate_test.py
+++ b/dirsrvtests/tests/suites/setup_ds/dscreate_test.py
@@ -62,6 +62,23 @@ def topology(request):
     return TopologyInstance(instance)
 
 def test_setup_ds_minimal_dry(topology):
+    """Test minimal DS setup - dry run
+
+    :id: 82637910-e279-11ec-a785-3497f624ea11
+    :setup: standalone instance
+    :steps:
+        1. Create the setupDS
+        2. Give it the right types
+        3. Get the dicts from Type2Base, as though they were from _validate_ds_2_config
+        4. Override instance name, root password, port and secure port
+        5. Assert we did not change the system
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
     # Unset PYTHONPATH to avoid mixing old CLI tools and new lib389
     tmp_env = os.environ
     if "PYTHONPATH" in tmp_env:
@@ -95,6 +112,29 @@ def test_setup_ds_minimal_dry(topology):
     assert(len(insts) == 0)
 
 def test_setup_ds_minimal(topology):
+    """Test minimal DS setup
+
+    :id: 563c3ec4-e27b-11ec-970e-3497f624ea11
+    :setup: standalone instance
+    :steps:
+        1. Create the setupDS
+        2. Give it the right types
+        3. Get the dicts from Type2Base, as though they were from _validate_ds_2_config
+        4. Override instance name, root password, port and secure port
+        5. Assert we did change the system
+        6. Make sure we can connect
+        7. Make sure we can start stop.
+        8. Remove the instance
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+    """
     # Create the setupDs
     lc = LogCapture()
     # Give it the right types.

--- a/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
@@ -245,7 +245,7 @@ def test_sync_repl_mep(topology, request):
         3. start sync_repl client
         4. Add users with PosixAccount ObjectClass (mep will update it several times)
         5. Check that the received cookie are progressing
-    :expected results:
+    :expectedresults:
         1. Success
         2. Success
         3. Success
@@ -453,22 +453,21 @@ def test_sync_repl_cookie_with_failure(topology, init_sync_repl_plugins, request
     :id: e0103448-170e-4080-8f22-c34606447ce2
     :setup: Standalone Instance
     :steps:
-      1.: initialization/cleanup done by init_sync_repl_plugins fixture
-      2.: update group2 so that it will not accept 'member' attribute (set by memberof)
-      3.: create a thread dedicated to run a sync repl client
-      4.: Create a group that will be the only update received by sync repl client
-      5.: Create (9) users that will generate nested updates (automember/memberof).
-          creation will fail because 'member' attribute is not allowed in group2
-      6.: stop sync repl client and collect the list of cookie.change_no
-      7.: check that the list of cookie.change_no contains only the group 'step 11'
+      1. initialization/cleanup done by init_sync_repl_plugins fixture
+      2. update group2 so that it will not accept 'member' attribute (set by memberof)
+      3. create a thread dedicated to run a sync repl client
+      4. Create a group that will be the only update received by sync repl client
+      5. Create (9) users that will generate nested updates (automember/memberof). Creation will fail because 'member' attribute is not allowed in group2
+      6. stop sync repl client and collect the list of cookie.change_no
+      7. check that the list of cookie.change_no contains only the group 'step 11'
     :expectedresults:
-      1.: succeeds
-      2.: succeeds
-      3.: succeeds
-      4.: succeeds
-      5.: Fails (expected)
-      6.: succeeds
-      7.: succeeds
+      1. succeeds
+      2. succeeds
+      3. succeeds
+      4. succeeds
+      5. Fails (expected)
+      6. succeeds
+      7. succeeds
     """
     inst = topology[0]
 

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -28,7 +28,7 @@ def test_bulk_import_when_the_backend_with_vlv_was_recreated(topology_m2):
     Testing bulk import when the backend with VLV was recreated.
     If the test passes without the server crash, 47966 is verified.
 
-    :id: 512963fa-fe02-11e8-b1d3-8c16451d917b
+    :id: 37d42d12-2544-49a0-81ef-7dbfb69edc0f
     :setup: Replication with two suppliers.
     :steps:
         1. Generate vlvSearch entry


### PR DESCRIPTION
Bug Description:
Metadata in our tests' docstrings is used for test case and requirements
import in our test case management system. But it's prone to copy-paste
issues (duplicate unique test case IDs), formatting issues (RST parser
is not always happy) or it's simply missing. We should use automatic
validation for test metadata as part of our PR CI so that all new test
cases have valid docstrings and unique IDs.

Fix Description:
* Add a new Validate workflow to run on each PR. It runs testimony that
  validates docstrings
* Add missing docstrings.
* Rename test_user fixtures to avoid confusion with pytest test functions.
* Fix token names and indentation.
* Add a python script to check for duplicate `:id:` tokens
* Fix duplicate `:id:` tokens.

Fixes: https://github.com/389ds/389-ds-base/issues/5327

Reviewed by: ???