### PR TITLE
Issue 5333 - 389-ds-base fails to build with Python 3.11

### DIFF
--- a/src/lib389/lib389/cli_conf/plugins/passthroughauth.py
+++ b/src/lib389/lib389/cli_conf/plugins/passthroughauth.py
@@ -238,12 +238,6 @@ def create_parser(subparsers):
     subcommands = passthroughauth_parser.add_subparsers(help='action')
     add_generic_plugin_parsers(subcommands, PassThroughAuthenticationPlugin)
 
-    enable = subcommands.add_parser('enable', help='Enable the pass through authentication plugins')
-    enable.set_defaults(func=enable_plugins)
-
-    disable = subcommands.add_parser('disable', help='Disable the pass through authentication plugins')
-    disable.set_defaults(func=disable_plugins)
-
     list = subcommands.add_parser('list', help='List pass-though plugin URLs or PAM configurations')
     subcommands_list = list.add_subparsers(help='action')
     list_urls = subcommands_list.add_parser('urls', help='Lists URLs')


### PR DESCRIPTION
Bug Description:
389-ds-base fails to build with Python 3.11:
argparse.ArgumentError: argument {show,enable,disable,status}:
conflicting subparser: enable

Argparse is more strict in 3.11.0b3 and doesn't allow duplicate
subcommands, which we apparently had in pass-through-auth plugin.

Fix Description:
Remove duplicate subcommands from pass-through-auth plugin

Fixes: https://github.com/389ds/389-ds-base/issues/5333

Reviewed by: ???