### PR TITLE
Issue 5332 - BUG - normalise filter as intended

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -802,6 +802,7 @@ typedef struct _back_search_result_set
     int sr_flags;                 /* Magic flags, defined below */
     int sr_current_sizelimit;     /* Current sizelimit */
     Slapi_Filter *sr_norm_filter; /* search filter pre-normalized */
+    Slapi_Filter *sr_norm_filter_intent; /* intended search filter pre-normalized */
 } back_search_result_set;
 #define SR_FLAG_MUST_APPLY_FILTER_TEST 1 /* If set in sr_flags, means that we MUST apply the filter test */
 


### PR DESCRIPTION
Bug Description: Due to a mistake in the optimiser rework
the filter as intended was not normalised, causing some searches
to fail

Fix Description: Always normalise both filters.

fixes: https://github.com/389ds/389-ds-base/issues/5332

Author: William Brown <william@blackhats.net.au>

Review by: ???