### PR TITLE
Issue 5332 - BUG - normalise filter as intended

### DIFF
--- a/dirsrvtests/tests/suites/filter/filter_test_aci_with_optimiser.py
+++ b/dirsrvtests/tests/suites/filter/filter_test_aci_with_optimiser.py
@@ -83,6 +83,35 @@ def test_filter_access(topo):
         assert len(entries) == 0
 
 
+def test_base_search_with_substring_filter(topo):
+    """Test that filter normalization works correctly with base search using
+    substring filter
+
+    :id: abc24774-4b07-481b-9f1f-9a209e459955
+    :setup: Standalone Instance
+    :steps:
+        1. Add ACI allowing search on "description"
+        2. Add "description" to root suffix and make it upper case to test normalization
+        3. Do base search with substring filter
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    # Add aci
+    ACI_TEXT = ('(targetattr="description")(version 3.0; acl "Anonymous read access"; allow' +
+                '(read, search, compare) userdn = "ldap:///anyone";)')
+    domain = Domain(topo.standalone, DEFAULT_SUFFIX)
+    domain.replace('aci', ACI_TEXT)
+    domain.replace('description', 'ACCESS')  # case is important
+
+    # open anonymous connection and do base search with substring filter
+    conn = Anonymous(topo.standalone).bind()
+    entries = conn.search_s(DEFAULT_SUFFIX, ldap.SCOPE_BASE, "description=ACCE*")
+    assert len(entries) == 1
+
+
 if __name__ == '__main__':
     # Run isolated
     # -s for DEBUG mode

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -802,6 +802,7 @@ typedef struct _back_search_result_set
     int sr_flags;                 /* Magic flags, defined below */
     int sr_current_sizelimit;     /* Current sizelimit */
     Slapi_Filter *sr_norm_filter; /* search filter pre-normalized */
+    Slapi_Filter *sr_norm_filter_intent; /* intended search filter pre-normalized */
 } back_search_result_set;
 #define SR_FLAG_MUST_APPLY_FILTER_TEST 1 /* If set in sr_flags, means that we MUST apply the filter test */
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -933,10 +933,12 @@ ldbm_back_search(Slapi_PBlock *pb)
         li->li_filter_bypass_check) {
         int rc = 0, filt_errs = 0;
         Slapi_Filter *filter = NULL;
+        Slapi_Filter *filter_intent = NULL;
 
         slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_search", "Applying Filter Test\n");
 
         slapi_pblock_get(pb, SLAPI_SEARCH_FILTER, &filter);
+        slapi_pblock_get(pb, SLAPI_SEARCH_FILTER_INTENDED, &filter_intent);
         if (NULL == filter) {
             tmp_err = LDAP_OPERATIONS_ERROR;
             tmp_desc = "Filter is not set";
@@ -944,11 +946,21 @@ ldbm_back_search(Slapi_PBlock *pb)
         }
         slapi_filter_free(sr->sr_norm_filter, 1);
         sr->sr_norm_filter = slapi_filter_dup(filter);
+
         /* step 1 - normalize all of the values used in the search filter */
         slapi_filter_normalize(sr->sr_norm_filter, PR_TRUE /* normalize values too */);
         /* step 2 - pre-compile the substr regex and the equality flags */
         rc = slapi_filter_apply(sr->sr_norm_filter, ldbm_search_compile_filter,
                                 NULL, &filt_errs);
+
+        if (rc == SLAPI_FILTER_SCAN_NOMORE && filter_intent) {
+            slapi_filter_free(sr->sr_norm_filter_intent, 1);
+            sr->sr_norm_filter_intent = slapi_filter_dup(filter_intent);
+            slapi_filter_normalize(sr->sr_norm_filter_intent, PR_TRUE /* normalize values too */);
+            rc = slapi_filter_apply(sr->sr_norm_filter_intent, ldbm_search_compile_filter,
+                                    NULL, &filt_errs);
+        }
+
         if (rc != SLAPI_FILTER_SCAN_NOMORE) {
             slapi_log_err(SLAPI_LOG_ERR,
                           "ldbm_back_search", "Could not pre-compile the search filter - error %d %d\n",
@@ -1467,9 +1479,13 @@ ldbm_back_next_search_entry(Slapi_PBlock *pb)
     }
 
     if (sr->sr_norm_filter) {
+        filter = sr->sr_norm_filter;
+    }
+
+    if (sr->sr_norm_filter_intent) {
         int val = 1;
         slapi_pblock_set(pb, SLAPI_PLUGIN_SYNTAX_FILTER_NORMALIZED, &val);
-        filter = sr->sr_norm_filter;
+        filter_intent = sr->sr_norm_filter_intent;
     }
 
     if (op_is_pagedresults(op)) {


### PR DESCRIPTION
Bug Description: Due to a mistake in the optimiser rework
the filter as intended was not normalised, causing some searches
to fail

Fix Description: Always normalise both filters.

fixes: https://github.com/389ds/389-ds-base/issues/5332

Author: William Brown <william@blackhats.net.au>

Review by: mreynolds (Thanks!)

Signed-off-by: Mark Reynolds <mreynolds@redhat.com>