### PR TITLE
Issue 5346 - New connection table fails with ASAN failures

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -132,9 +132,9 @@ connection_table_new(int table_size)
     ct->size = table_size;
     ct->list_num = SLAPD_DEFAULT_NUM_LISTENERS;
 
-    ct->list_size = table_size/ct->list_num + 1; /* +1 to avoid rounding issue */
+    ct->list_size = (table_size+ct->list_num-1)/ct->list_num; /* to avoid rounding issue */
     ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
-    ct->c = (Connection **)slapi_ch_calloc(1, table_size * sizeof(Connection));
+    ct->c = (Connection **)slapi_ch_calloc(1, table_size * sizeof(Connection *));
     ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, table_size * sizeof(struct POLL_STRUCT));
     ct->table_mutex = PR_NewLock();
     /* Allocate the freelist */
@@ -181,13 +181,13 @@ connection_table_new(int table_size)
             ct->c[ct_list][i].c_fdi = SLAPD_INVALID_SOCKET_INDEX;
 
             if (pthread_mutex_init(&(ct->c[ct_list][i].c_mutex), &monitor_attr) != 0) {
-                slapi_log_err(SLAPI_LOG_ERR, "connection_table_get_connection", "pthread_mutex_init failed\n");
+                slapi_log_err(SLAPI_LOG_ERR, "connection_table_new", "pthread_mutex_init failed\n");
                 exit(1);
             }
 
             ct->c[ct_list][i].c_pdumutex = PR_NewLock();
             if (ct->c[ct_list][i].c_pdumutex == NULL) {
-                slapi_log_err(SLAPI_LOG_ERR, "connection_table_get_connection", "PR_NewLock failed\n");
+                slapi_log_err(SLAPI_LOG_ERR, "connection_table_new", "PR_NewLock failed\n");
                 exit(1);
             }
 


### PR DESCRIPTION
Bug Description: Commit 489b585a67bf9b91c33a93cf8b0c6c7bca398bee
contains a buffer overflow that causes asan failures.

Fix Decription: Removed the overflow, corrected an incorrect memory
allocation and corrected some debug strings.

fixes: https://github.com/389ds/389-ds-base/issues/5346
relates: https://github.com/389ds/389-ds-base/issues/4812

Reviewed by: ??