### PR TITLE
Issue 5335 - RFE - Add Security Audit Log

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -204,6 +204,7 @@ PAM_LINK = -lpam
 EVENT_LINK = $(EVENT_LIBS)
 PW_CRACK_LINK = -lcrack
 ZLIB_LINK = -lz
+JSON_C_LINK = -ljson-c
 
 LIBSOCKET=@LIBSOCKET@
 LIBNSL=@LIBNSL@
@@ -218,7 +219,7 @@ if HPUX
 AM_LDFLAGS = -lpthread
 else
 #AM_LDFLAGS = -Wl,-z,defs
-AM_LDFLAGS = $(ZLIB_LINK) $(PW_CRACK_LINK) $(RUST_LDFLAGS) $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS) $(UBSAN_CFLAGS) $(PROFILING_LINKS) $(CLANG_LDFLAGS) $(EXPORT_LDFLAGS)
+AM_LDFLAGS = $(ZLIB_LINK) $(JSON_C_LINK) $(PW_CRACK_LINK) $(RUST_LDFLAGS) $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS) $(UBSAN_CFLAGS) $(PROFILING_LINKS) $(CLANG_LDFLAGS) $(EXPORT_LDFLAGS)
 endif #end hpux
 
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info

--- a/dirsrvtests/tests/suites/logging/logging_config_test.py
+++ b/dirsrvtests/tests/suites/logging/logging_config_test.py
@@ -60,9 +60,10 @@ def test_logging_digit_config(topo, attr, invalid_vals, valid_vals):
     auditlog_attr = "nsslapd-auditlog-{}".format(attr)
     auditfaillog_attr = "nsslapd-auditfaillog-{}".format(attr)
     errorlog_attr = "nsslapd-errorlog-{}".format(attr)
+    securitylog_attr = "nsslapd-securitylog-{}".format(attr)
 
     # Test each log
-    for attr in [accesslog_attr, auditlog_attr, auditfaillog_attr, errorlog_attr]:
+    for attr in [accesslog_attr, auditlog_attr, auditfaillog_attr, errorlog_attr, securitylog_attr]:
         # Invalid values
         for invalid_val in invalid_vals:
             with pytest.raises(ldap.LDAPError):

--- a/dirsrvtests/tests/suites/logging/security_basic_test.py
+++ b/dirsrvtests/tests/suites/logging/security_basic_test.py
@@ -1,0 +1,241 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import ldap
+import json
+import logging
+import pytest
+import os
+import re
+import signal
+import subprocess
+import time
+from lib389._constants import DEFAULT_SUFFIX, PASSWORD, DN_DM
+from lib389.topologies import topology_st as topo
+from lib389.idm.user import UserAccount, UserAccounts
+from lib389.dirsrv_log import DirsrvSecurityLog
+from lib389.utils import ensure_str
+from lib389.idm.domain import Domain
+
+
+log = logging.getLogger(__name__)
+
+DN = "uid=security,ou=people," + DEFAULT_SUFFIX
+DN_NO_ENTRY = "uid=fredSomething,ou=people," + DEFAULT_SUFFIX
+DN_NO_BACKEND = "uid=not_there,o=nope," + DEFAULT_SUFFIX
+DN_QUOATED = "uid=\"cn=mark\",ou=people," + DEFAULT_SUFFIX
+DN_QUOATED_ESCAPED = "uid=cn\\3dmark,ou=people," + DEFAULT_SUFFIX
+DN_LONG = "uid=" + ("z" * 520) + ",ou=people," + DEFAULT_SUFFIX
+DN_LONG_TRUNCATED = "uid=" + ("z" * 508) + "..."
+
+
+@pytest.fixture
+def setup_test(topo, request):
+    """Disable log buffering"""
+    topo.standalone.config.set('nsslapd-securitylog-logbuffering', 'off')
+
+    """Add a test user"""
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    try:
+        users.create(properties={
+            'uid': 'security',
+            'cn': 'security',
+            'sn': 'security',
+            'uidNumber': '3000',
+            'gidNumber': '4000',
+            'homeDirectory': '/home/security',
+            'description': 'test security logging with this user',
+            'userPassword': PASSWORD
+        })
+    except ldap.ALREADY_EXISTS:
+        pass
+
+
+def check_log(inst, event_id, msg, dn=None):
+    """Check the security log
+    """
+    time.sleep(1)  # give a little time to flush to disk
+
+    security_log = DirsrvSecurityLog(inst)
+    log_lines = security_log.readlines()
+    for line in log_lines:
+        if re.match(r'[ \t]', line):
+            # Skip log title lines
+            continue
+
+    event = json.loads(line)
+    if dn is not None:
+        if event['dn'] == dn.lower() and event['event'] == event_id and event['msg'] == msg:
+            # Found it
+            return
+    elif event['event'] == event_id and event['msg'] == msg:
+            # Found it
+            return
+
+    assert False
+
+
+def test_invalid_binds(topo, setup_test):
+    """Test the various bind scenarios that should be logged in the security log
+
+    :id: b82e3fb9-f1af-4a75-8d96-5e5d284f31c5
+    :setup: Standalone Instance
+    :steps:
+        1. Test successful bind is logged
+        2. Test bad password is logged
+        3. Test no such entry is logged
+        4. Test no such entry is logged (quoated dn)
+        5. Test no such entry is logged (truncated dn)
+        6. Test no such backend is logged
+        7. Test account lockout is logged
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+    """
+
+    inst = topo.standalone
+    user_entry = UserAccount(inst, DN)
+
+    # Good bind
+    user_entry.bind(PASSWORD)
+    check_log(inst, "BIND_SUCCESS", "", DN)
+
+    # Bad password
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user_entry.bind("wrongpassword")
+    check_log(inst, "BIND_FAILED", "INVALID_PASSWORD", DN)
+
+    # No_such_entry
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        UserAccount(inst, DN_NO_ENTRY).bind(PASSWORD)
+    check_log(inst, "BIND_FAILED", "NO_SUCH_ENTRY", DN_NO_ENTRY)
+
+    # No_such_entry (quoted)
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        UserAccount(inst, DN_QUOATED).bind(PASSWORD)
+    check_log(inst, "BIND_FAILED", "NO_SUCH_ENTRY", DN_QUOATED_ESCAPED)
+
+    # No such entry (truncated dn)
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        UserAccount(inst, DN_LONG).bind(PASSWORD)
+    check_log(inst, "BIND_FAILED", "NO_SUCH_ENTRY", DN_LONG_TRUNCATED)
+
+    # No_such_backend
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        UserAccount(inst, DN_NO_BACKEND).bind(PASSWORD)
+    check_log(inst, "BIND_FAILED", "NO_SUCH_ENTRY", DN_NO_BACKEND)
+
+
+def test_authorization(topo, setup_test):
+    """Test the authorization event by performing a modification that the user
+    is not allowed to do.
+
+    :id: 17a62670-f86d-4b39-9ee7-e7d36b973ec8
+    :setup: Standalone Instance
+    :steps:
+        1. Bind as a unprivileged user
+        2. Attempt to modify restricted resource
+        3. Security authorization event is logged
+    :expectedresults:
+        1. Success
+        2. Should fail
+        3. Success
+    """
+    inst = topo.standalone
+
+    # Bind as a user
+    user_entry = UserAccount(inst, DN)
+    user_conn = user_entry.bind(PASSWORD)
+
+    # Try modifying a restricted resource
+    suffix = Domain(user_conn, DEFAULT_SUFFIX)
+    with pytest.raises(ldap.INSUFFICIENT_ACCESS):
+        suffix.replace('description', 'not allowed')
+
+    # Check that an authorization event was logged
+    check_log(inst, "AUTHZ_ERROR", f"target_dn=({DEFAULT_SUFFIX})")
+
+
+def test_account_lockout(topo, setup_test):
+    """Specify a test case purpose or name here
+
+    :id: b70494f0-7d8e-4d90-8265-9d009bbb08b4
+    :setup: Standalone Instance
+    :steps:
+        1. Configure account lockout
+        2. Bind using the wrong password until the account is locked
+        3. Check for account lockout event
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = topo.standalone
+
+    # Configure account lockout
+    inst.config.set('passwordlockout', 'on')
+    inst.config.set('passwordMaxFailure', '2')
+
+    # Force entry to get locked out
+    user_entry = UserAccount(inst, DN)
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user_entry.bind("wrong")
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user_entry.bind("wrong")
+    with pytest.raises(ldap.CONSTRAINT_VIOLATION):
+        # Should fail with good or bad password
+        user_entry.bind(PASSWORD)
+
+    # Check that an account locked event was logged for this DN
+    check_log(inst, "BIND_FAILED", "ACCOUNT_LOCKED", DN)
+
+
+def test_tcp_events(topo, setup_test):
+    """Trigger a TCP_ERROR event event that should be logged in the security log
+
+    :id: 2f653508-89ae-4325-9fed-a2c4ab304149
+    :setup: Standalone Instance
+    :steps:
+        1. Start ldapmodify in its interactive mode
+        2. Get the pid of ldapmodify
+        3. Kill ldapmodify
+        4. Check that a TCP_ERROR is in the security log
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    inst = topo.standalone
+
+    # Start interactive ldapamodfy command
+    ldap_cmd = ['ldapmodify', '-x', '-D', DN_DM, '-w', PASSWORD,
+        '-H', f'ldap://{inst.host}:{inst.port}']
+    subprocess.Popen(ldap_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+    time.sleep(3)  # need some time for ldapmodify to actually launch
+
+    # Get ldapmodify pid
+    result = subprocess.check_output(['pidof','ldapmodify'])
+    ldapmodify_pid = ensure_str(result)
+
+    # Kill ldapmodify and check the log
+    os.kill(int(ldapmodify_pid), signal.SIGKILL)
+    check_log(inst, "TCP_ERROR", "Bad Ber Tag or uncleanly closed connection - B1")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -58,6 +58,7 @@ log_dir = @localstatedir@/log/dirsrv/slapd-{instance_name}
 access_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/access
 audit_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/audit
 error_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/errors
+security_log = @localstatedir@/log/dirsrv/slapd-{instance_name}/security
 db_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/db
 db_home_dir = /dev/shm/slapd-{instance_name}
 backup_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/bak

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -12,6 +12,7 @@ nsslapd-bakdir: %bak_dir%
 nsslapd-rundir: %run_dir%
 nsslapd-instancedir: %inst_dir%
 nsslapd-accesslog: %log_dir%/access
+nsslapd-securitylog: %log_dir%/security
 nsslapd-localhost: %fqdn%
 nsslapd-port: %ds_port%
 nsslapd-localuser: %ds_user%

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -196,6 +196,7 @@ connection_cleanup(Connection *conn)
     slapi_ch_free((void **)&conn->cin_destaddr);
     slapi_ch_free((void **)&conn->cin_addr_aclip);
     slapi_ch_free_string(&conn->c_ipaddr);
+    slapi_ch_free_string(&conn->c_serveripaddr);
     if (conn->c_domain != NULL) {
         ber_bvecfree(conn->c_domain);
         conn->c_domain = NULL;
@@ -420,6 +421,7 @@ connection_reset(Connection *conn, int ns, PRNetAddr *from, int fromLen __attrib
     conn->c_ssl_ssf = 0;
     conn->c_local_ssf = 0;
     conn->c_ipaddr = slapi_ch_strdup(str_ip);
+    conn->c_serveripaddr = slapi_ch_strdup(str_destip);
 }
 
 /* Create a pool of threads for handling the operations */
@@ -2312,6 +2314,7 @@ disconnect_server_nomutex_ext(Connection *conn, PRUint64 opconnid, int opid, PRE
                              conn->c_connid, opid, conn->c_sd,
                              slapd_pr_strerror(reason));
         }
+        slapi_log_security_tcp(conn, reason, slapd_pr_strerror(reason));
 
         if (!config_check_referral_mode()) {
             slapi_counter_decrement(g_get_per_thread_snmp_vars()->ops_tbl.dsConnections);

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1242,11 +1242,12 @@ slapd_daemon(daemon_ports_t *ports)
         mapping_tree_free();
     }
 
-    /* In theory, threads could be working "up to" this point
-     * so we only flush access logs when we can guarantee that the buffered
-     * content is "complete".
+    /*
+     * In theory, threads could be working "up to" this point so we only flush
+     * access & security logs when we can guarantee that the buffered content
+     * is "complete".
      */
-    log_access_flush();
+    logs_flush();
 
     be_cleanupall();
     plugin_dependency_freeall();

--- a/ldap/servers/slapd/house.c
+++ b/ldap/servers/slapd/house.c
@@ -35,7 +35,7 @@ housecleaning(void *cur_time __attribute__((unused)))
         /*
          * Looks simple, but could potentially take a long time.
          */
-        log_access_flush();
+        logs_flush();
 
         if (g_get_shutdown()) {
             break;

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -178,15 +178,19 @@ static int invalid_sasl_mech(char *str);
 
 /* CONFIG_ON_OFF */
 slapi_onoff_t init_accesslog_rotationsync_enabled;
+slapi_onoff_t init_securitylog_rotationsync_enabled;
 slapi_onoff_t init_errorlog_rotationsync_enabled;
 slapi_onoff_t init_auditlog_rotationsync_enabled;
 slapi_onoff_t init_auditfaillog_rotationsync_enabled;
 slapi_onoff_t init_accesslog_compress_enabled;
+slapi_onoff_t init_securitylog_compress_enabled;
 slapi_onoff_t init_auditlog_compress_enabled;
 slapi_onoff_t init_auditfaillog_compress_enabled;
 slapi_onoff_t init_errorlog_compress_enabled;
 slapi_onoff_t init_accesslog_logging_enabled;
 slapi_onoff_t init_accesslogbuffering;
+slapi_onoff_t init_securitylog_logging_enabled;
+slapi_onoff_t init_securitylogbuffering;
 slapi_onoff_t init_external_libs_debug_enabled;
 slapi_onoff_t init_errorlog_logging_enabled;
 slapi_onoff_t init_auditlog_logging_enabled;
@@ -340,6 +344,10 @@ static struct config_get_and_set
      log_set_compression, SLAPD_ACCESS_LOG,
      (void **)&global_slapdFrontendConfig.accesslog_compress,
      CONFIG_ON_OFF, NULL, &init_accesslog_compress_enabled, NULL},
+    {CONFIG_SECURITYLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
+     log_set_compression, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_compress,
+     CONFIG_ON_OFF, NULL, &init_securitylog_compress_enabled, NULL},
     {CONFIG_AUDITLOG_COMPRESS_ENABLED_ATTRIBUTE, NULL,
      log_set_compression, SLAPD_AUDIT_LOG,
      (void **)&global_slapdFrontendConfig.auditlog_compress,
@@ -722,6 +730,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.accessloglevel,
      CONFIG_INT, NULL, SLAPD_DEFAULT_ACCESSLOG_LEVEL_STR, NULL},
+    {CONFIG_SECURITYLOGLEVEL_ATTRIBUTE, config_set_securitylog_level,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.securityloglevel,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_ACCESSLOG_LEVEL_STR, NULL},
     {CONFIG_ERRORLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE, NULL,
      log_set_rotationtimeunit, SLAPD_ERROR_LOG,
      (void **)&global_slapdFrontendConfig.errorlog_rotationunit,
@@ -805,6 +817,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.accesslogbuffering,
      CONFIG_ON_OFF, NULL, &init_accesslogbuffering, NULL},
+    {CONFIG_SECURITYLOG_BUFFERING_ATTRIBUTE, config_set_securitylogbuffering,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.securitylogbuffering,
+     CONFIG_ON_OFF, NULL, &init_securitylogbuffering, NULL},
     {CONFIG_CSNLOGGING_ATTRIBUTE, config_set_csnlogging,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.csnlogging,
@@ -1276,7 +1292,66 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.auditfaillog,
      CONFIG_STRING_OR_EMPTY, NULL, "", NULL /* prevents deletion when null */},
-/* End audit fail log configuration */
+    /* Security Audit log configuration */
+    {CONFIG_SECURITYLOG_MODE_ATTRIBUTE, NULL,
+     log_set_mode, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_mode,
+     CONFIG_STRING, NULL, SLAPD_INIT_LOG_MODE, NULL},
+    {CONFIG_SECURITYLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE, NULL,
+     log_set_rotationsync_enabled, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_rotationsync_enabled,
+     CONFIG_ON_OFF, NULL, &init_securitylog_rotationsync_enabled, NULL},
+    {CONFIG_SECURITYLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE, NULL,
+     log_set_rotationsynchour, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_rotationsynchour,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_ROTATIONSYNCHOUR_STR, NULL},
+    {CONFIG_SECURITYLOG_LOGROTATIONSYNCMIN_ATTRIBUTE, NULL,
+     log_set_rotationsyncmin, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_rotationsyncmin,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_ROTATIONSYNCMIN_STR, NULL},
+    {CONFIG_SECURITYLOG_LOGROTATIONTIME_ATTRIBUTE, NULL,
+     log_set_rotationtime, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_rotationtime,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_ROTATIONTIME_STR, NULL},
+    {CONFIG_SECURITYLOG_MAXLOGDISKSPACE_ATTRIBUTE, NULL,
+     log_set_maxdiskspace, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_maxdiskspace,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_MAXDISKSPACE_STR, NULL},
+    {CONFIG_SECURITYLOG_MAXLOGSIZE_ATTRIBUTE, NULL,
+     log_set_logsize, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_maxlogsize,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_MAXLOGSIZE_STR, NULL},
+    {CONFIG_SECURITYLOG_LOGEXPIRATIONTIME_ATTRIBUTE, NULL,
+     log_set_expirationtime, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_exptime,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_EXPTIME_STR, NULL},
+    {CONFIG_SECURITYLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE, NULL,
+     log_set_numlogsperdir, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_maxnumlogs,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_MAXNUMLOGS_STR, NULL},
+    {CONFIG_SECURITYLOG_LIST_ATTRIBUTE, NULL,
+     NULL, 0, NULL,
+     CONFIG_CHARRAY, (ConfigGetFunc)config_get_securitylog_list, NULL, NULL},
+    {CONFIG_SECURITYLOG_LOGGING_ENABLED_ATTRIBUTE, NULL,
+     log_set_logging, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_logging_enabled,
+     CONFIG_ON_OFF, NULL, &init_securitylog_logging_enabled, NULL},
+    {CONFIG_SECURITYLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE, NULL,
+     log_set_expirationtimeunit, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_exptimeunit,
+     CONFIG_STRING_OR_UNKNOWN, NULL, SLAPD_INIT_LOG_EXPTIMEUNIT, NULL},
+    {CONFIG_SECURITYLOG_MINFREEDISKSPACE_ATTRIBUTE, NULL,
+     log_set_mindiskspace, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_minfreespace,
+     CONFIG_INT, NULL, SLAPD_DEFAULT_LOG_MINFREESPACE_STR, NULL},
+    {CONFIG_SECURITYLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE, NULL,
+     log_set_rotationtimeunit, SLAPD_SECURITY_LOG,
+     (void **)&global_slapdFrontendConfig.securitylog_rotationunit,
+     CONFIG_STRING_OR_UNKNOWN, NULL, SLAPD_INIT_SECURITYLOG_ROTATIONUNIT, NULL},
+    {CONFIG_SECURITYFILE_ATTRIBUTE, config_set_securitylog,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.securitylog,
+     CONFIG_STRING_OR_EMPTY, NULL, "", NULL /* prevents deletion when null */},
 /* warning: initialization makes pointer from integer without a cast [enabled by default]. Why do we get this? */
 #ifdef HAVE_CLOCK_GETTIME
     {CONFIG_LOGGING_HR_TIMESTAMPS, config_set_logging_hr_timestamps,
@@ -1767,6 +1842,24 @@ FrontendConfig_init(void)
     init_accesslogbuffering = cfg->accesslogbuffering = LDAP_ON;
     init_csnlogging = cfg->csnlogging = LDAP_ON;
     init_accesslog_compress_enabled = cfg->accesslog_compress = LDAP_OFF;
+
+    init_securitylog_logging_enabled = cfg->securitylog_logging_enabled = LDAP_ON;
+    cfg->securitylog_mode = slapi_ch_strdup(SLAPD_INIT_LOG_MODE);
+    cfg->securitylog_maxnumlogs = SLAPD_DEFAULT_LOG_SECURITY_MAXNUMLOGS;
+    cfg->securitylog_maxlogsize = SLAPD_DEFAULT_LOG_MAXLOGSIZE;
+    cfg->securitylog_rotationtime = SLAPD_DEFAULT_LOG_ROTATIONTIME;
+    cfg->securitylog_rotationunit = slapi_ch_strdup(SLAPD_INIT_SECURITYLOG_ROTATIONUNIT);
+    init_securitylog_rotationsync_enabled =
+        cfg->securitylog_rotationsync_enabled = LDAP_OFF;
+    cfg->securitylog_rotationsynchour = SLAPD_DEFAULT_LOG_ROTATIONSYNCHOUR;
+    cfg->securitylog_rotationsyncmin = SLAPD_DEFAULT_LOG_ROTATIONSYNCMIN;
+    cfg->securitylog_maxdiskspace = SLAPD_DEFAULT_LOG_SECURITY_MAXDISKSPACE;
+    cfg->securitylog_minfreespace = SLAPD_DEFAULT_LOG_MINFREESPACE;
+    cfg->securitylog_exptime = SLAPD_DEFAULT_LOG_EXPTIME;
+    cfg->securitylog_exptimeunit = slapi_ch_strdup(SLAPD_INIT_LOG_EXPTIMEUNIT);
+    cfg->securityloglevel = SLAPD_DEFAULT_SECURITYLOG_LEVEL;
+    init_securitylogbuffering = cfg->securitylogbuffering = LDAP_ON;
+    init_securitylog_compress_enabled = cfg->securitylog_compress = LDAP_ON;
 
     init_errorlog_logging_enabled = cfg->errorlog_logging_enabled = LDAP_ON;
     init_external_libs_debug_enabled = cfg->external_libs_debug_enabled = LDAP_OFF;
@@ -5109,7 +5202,6 @@ config_set_useroc(const char *attrname, char *value, char *errorbuf, int apply)
     return retVal;
 }
 
-
 int
 config_set_accesslog(const char *attrname, char *value, char *errorbuf, int apply)
 {
@@ -5124,13 +5216,41 @@ config_set_accesslog(const char *attrname, char *value, char *errorbuf, int appl
 
     if (retVal != LDAP_SUCCESS) {
         slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
-                              "Cannot open accesslog directory \"%s\", client accesses will not be logged.", value);
+                "Cannot open accesslog directory \"%s\", client accesses will not be logged.",
+                value);
     }
 
     if (apply) {
         CFG_LOCK_WRITE(slapdFrontendConfig);
         slapi_ch_free((void **)&(slapdFrontendConfig->accesslog));
         slapdFrontendConfig->accesslog = slapi_ch_strdup(value);
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+int
+config_set_securitylog(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    if (config_value_is_null(attrname, value, errorbuf, 1)) {
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    retVal = log_update_securitylogdir(value, apply);
+
+    if (retVal != LDAP_SUCCESS) {
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                "Cannot open securitylog directory \"%s\", client accesses will not be logged.",
+                value);
+    }
+
+    if (apply) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        slapi_ch_free((void **)&(slapdFrontendConfig->securitylog));
+        slapdFrontendConfig->securitylog = slapi_ch_strdup(value);
         CFG_UNLOCK_WRITE(slapdFrontendConfig);
     }
     return retVal;
@@ -5334,7 +5454,6 @@ config_set_errorlog_level(const char *attrname, char *value, char *errorbuf, int
     return retVal;
 }
 
-
 int
 config_set_accesslog_level(const char *attrname, char *value, char *errorbuf, int apply)
 {
@@ -5363,6 +5482,39 @@ config_set_accesslog_level(const char *attrname, char *value, char *errorbuf, in
         CFG_LOCK_WRITE(slapdFrontendConfig);
         g_set_accesslog_level(level);
         slapdFrontendConfig->accessloglevel = level;
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+int
+config_set_securitylog_level(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int retVal = LDAP_SUCCESS;
+    long level = 0;
+    char *endp = NULL;
+
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    if (config_value_is_null(attrname, value, errorbuf, 1)) {
+        return LDAP_OPERATIONS_ERROR;
+    }
+
+    errno = 0;
+    level = strtol(value, &endp, 10);
+
+    if (*endp != '\0' || errno == ERANGE || level < 0) {
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "%s: security log level \"%s\" is invalid,"
+                                                                   " security log level must range from 0 to %lld",
+                              attrname, value, (long long int)LONG_MAX);
+        retVal = LDAP_OPERATIONS_ERROR;
+        return retVal;
+    }
+
+    if (apply) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        g_set_securitylog_level(level);
+        slapdFrontendConfig->securityloglevel = level;
         CFG_UNLOCK_WRITE(slapdFrontendConfig);
     }
     return retVal;
@@ -6425,6 +6577,19 @@ config_get_accesslog()
 }
 
 char *
+config_get_securitylog()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char *retVal;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = config_copy_strval(slapdFrontendConfig->securitylog);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+char *
 config_get_errorlog()
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
@@ -6532,9 +6697,6 @@ config_get_errorlog_level()
     return retVal |= SLAPD_DEFAULT_ERRORLOG_LEVEL;
 }
 
-/*  return integer -- don't worry about locking similar to config_check_referral_mode
-    below */
-
 int
 config_get_accesslog_level()
 {
@@ -6546,8 +6708,16 @@ config_get_accesslog_level()
     return retVal;
 }
 
-/*  return integer -- don't worry about locking similar to config_check_referral_mode
-    below */
+int
+config_get_securitylog_level()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int retVal;
+
+    retVal = slapdFrontendConfig->securityloglevel;
+
+    return retVal;
+}
 
 int
 config_get_auditlog_logging_enabled()
@@ -6578,6 +6748,17 @@ config_get_accesslog_logging_enabled()
     int retVal;
 
     retVal = (int)slapdFrontendConfig->accesslog_logging_enabled;
+
+    return retVal;
+}
+
+int
+config_get_securitylog_logging_enabled()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int retVal;
+
+    retVal = (int)slapdFrontendConfig->securitylog_logging_enabled;
 
     return retVal;
 }
@@ -7361,6 +7542,12 @@ config_get_accesslog_list()
 }
 
 char **
+config_get_securitylog_list()
+{
+    return log_get_loglist(SLAPD_SECURITY_LOG);
+}
+
+char **
 config_get_auditlog_list()
 {
     return log_get_loglist(SLAPD_AUDIT_LOG);
@@ -7381,6 +7568,21 @@ config_set_accesslogbuffering(const char *attrname, char *value, char *errorbuf,
     retVal = config_set_onoff(attrname,
                               value,
                               &(slapdFrontendConfig->accesslogbuffering),
+                              errorbuf,
+                              apply);
+
+    return retVal;
+}
+
+int32_t
+config_set_securitylogbuffering(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int32_t retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    retVal = config_set_onoff(attrname,
+                              value,
+                              &(slapdFrontendConfig->securitylogbuffering),
                               errorbuf,
                               apply);
 
@@ -8875,6 +9077,24 @@ config_set_accesslog_enabled(int value)
         log_set_logging(CONFIG_ACCESSLOG_LOGGING_ENABLED_ATTRIBUTE, "on", SLAPD_ACCESS_LOG, errorbuf, CONFIG_APPLY);
     } else {
         log_set_logging(CONFIG_ACCESSLOG_LOGGING_ENABLED_ATTRIBUTE, "off", SLAPD_ACCESS_LOG, errorbuf, CONFIG_APPLY);
+    }
+    if (errorbuf[0] != '\0') {
+        slapi_log_err(SLAPI_LOG_ERR, "config_set_accesslog_enabled", "%s\n", errorbuf);
+    }
+}
+
+void
+config_set_securitylog_enabled(int value)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char errorbuf[SLAPI_DSE_RETURNTEXT_SIZE];
+    errorbuf[0] = '\0';
+
+    slapi_atomic_store_32(&(slapdFrontendConfig->securitylog_logging_enabled), value, __ATOMIC_RELEASE);
+    if (value) {
+        log_set_logging(CONFIG_SECURITYLOG_LOGGING_ENABLED_ATTRIBUTE, "on", SLAPD_SECURITY_LOG, errorbuf, CONFIG_APPLY);
+    } else {
+        log_set_logging(CONFIG_SECURITYLOG_LOGGING_ENABLED_ATTRIBUTE, "off", SLAPD_SECURITY_LOG, errorbuf, CONFIG_APPLY);
     }
     if (errorbuf[0] != '\0') {
         slapi_log_err(SLAPI_LOG_ERR, "config_set_accesslog_enabled", "%s\n", errorbuf);

--- a/ldap/servers/slapd/log.h
+++ b/ldap/servers/slapd/log.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -50,9 +50,9 @@
 
 #define LOG_SUCCESS            0 /* fine & dandy */
 #define LOG_CONTINUE           LOG_SUCCESS
-#define LOG_ERROR              1    /* default error case */
-#define LOG_EXCEEDED           2 /*err: > max logs allowed */
-#define LOG_ROTATE             3   /*ok; go to the next log */
+#define LOG_ERROR              1 /* default error case */
+#define LOG_EXCEEDED           2 /* err: > max logs allowed */
+#define LOG_ROTATE             3 /* ok; go to the next log */
 #define LOG_UNABLE_TO_OPENFILE 4
 #define LOG_DONE               5
 
@@ -130,6 +130,33 @@ struct logging_opts
     char *log_accessinfo_file;           /* access log rotation info file */
     LogBufferInfo *log_access_buffer;    /* buffer for access log */
     int log_access_compress;             /* Compress rotated logs */
+
+    /* These are security audit log specific */
+    int log_security_state;
+    int log_security_mode;                 /* access mode */
+    int log_security_maxnumlogs;           /* Number of logs */
+    PRInt64 log_security_maxlogsize;       /* max log size in bytes*/
+    int log_security_rotationtime;         /* time in units. */
+    int log_security_rotationunit;         /* time in units. */
+    int log_security_rotationtime_secs;    /* time in seconds */
+    int log_security_rotationsync_enabled; /* 0 or 1*/
+    int log_security_rotationsynchour;     /* 0-23 */
+    int log_security_rotationsyncmin;      /* 0-59 */
+    time_t log_security_rotationsyncclock; /* clock in seconds */
+    PRInt64 log_security_maxdiskspace;     /* space in bytes */
+    PRInt64 log_security_minfreespace;     /* free space in bytes */
+    int log_security_exptime;              /* time */
+    int log_security_exptimeunit;          /* unit time */
+    int log_security_exptime_secs;         /* time in secs */
+    int log_security_level;                /* security log level */
+    char *log_security_file;               /* security log file path */
+    LOGFD log_security_fdes;               /* fp for the cur security log */
+    unsigned int log_numof_security_logs;  /* number of logs */
+    time_t log_security_ctime;             /* log creation time */
+    LogFileInfo *log_security_logchain;    /* all the logs info */
+    char *log_securityinfo_file;           /* security log rotation info file */
+    LogBufferInfo *log_security_buffer;    /* buffer for security log */
+    int log_security_compress;             /* Compress rotated logs */
 
     /* These are error log specific */
     int log_error_state;
@@ -222,6 +249,11 @@ struct logging_opts
 #define LOG_ACCESS_LOCK_WRITE()   PR_Lock(loginfo.log_access_buffer->lock)
 #define LOG_ACCESS_UNLOCK_WRITE() PR_Unlock(loginfo.log_access_buffer->lock)
 
+#define LOG_SECURITY_LOCK_READ()    PR_Lock(loginfo.log_security_buffer->lock)
+#define LOG_SECURITY_UNLOCK_READ()  PR_Unlock(loginfo.log_security_buffer->lock)
+#define LOG_SECURITY_LOCK_WRITE()   PR_Lock(loginfo.log_security_buffer->lock)
+#define LOG_SECURITY_UNLOCK_WRITE() PR_Unlock(loginfo.log_security_buffer->lock)
+
 #define LOG_ERROR_LOCK_READ()    slapi_rwlock_rdlock(loginfo.log_error_rwlock)
 #define LOG_ERROR_UNLOCK_READ()  slapi_rwlock_unlock(loginfo.log_error_rwlock)
 #define LOG_ERROR_LOCK_WRITE()   slapi_rwlock_wrlock(loginfo.log_error_rwlock)
@@ -241,3 +273,4 @@ struct logging_opts
 #define TBUFSIZE 75                         /* size for time buffers */
 #define SLAPI_LOG_BUFSIZ 2048               /* size for data buffers */
 #define SLAPI_ACCESS_LOG_FMTBUF 128         /* size for access log formating line buffer */
+#define SLAPI_SECURITY_LOG_FMTBUF 256       /* size for security log formating line buffer */

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -292,10 +292,12 @@ int config_set_defaultreferral(const char *attrname, struct berval **value, char
 int config_set_timelimit(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_errorlog_level(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesslog_level(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_securitylog_level(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditlog(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditfaillog(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_userat(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesslog(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_securitylog(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_errorlog(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_pw_change(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_pw_must_change(const char *attrname, char *value, char *errorbuf, int apply);
@@ -378,6 +380,7 @@ int config_set_minssf(const char *attrname, char *value, char *errorbuf, int app
 int config_set_minssf_exclude_rootdse(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_validate_cert_switch(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesslogbuffering(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_securitylogbuffering(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_csnlogging(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_force_sasl_external(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_entryusn_global(const char *attrname, char *value, char *errorbuf, int apply);
@@ -501,6 +504,7 @@ int config_get_timelimit(void);
 char *config_get_pw_admin_dn(void);
 char *config_get_useroc(void);
 char *config_get_accesslog(void);
+char *config_get_securitylog(void);
 char *config_get_errorlog(void);
 char *config_get_auditlog(void);
 char *config_get_auditfaillog(void);
@@ -509,6 +513,7 @@ long long config_get_pw_minage(void);
 long long config_get_pw_warning(void);
 int config_get_errorlog_level(void);
 int config_get_accesslog_level(void);
+int config_get_securitylog_level(void);
 int config_get_auditlog_logging_enabled(void);
 int config_get_auditfaillog_logging_enabled(void);
 char *config_get_referral_mode(void);
@@ -531,6 +536,7 @@ char *config_get_rundir(void);
 char *config_get_saslpath(void);
 char **config_get_errorlog_list(void);
 char **config_get_accesslog_list(void);
+char **config_get_securitylog_list(void);
 char **config_get_auditlog_list(void);
 char **config_get_auditfaillog_list(void);
 int config_get_attrname_exceptions(void);
@@ -553,6 +559,7 @@ void config_set_accesslog_enabled(int value);
 void config_set_auditlog_enabled(int value);
 void config_set_auditfaillog_enabled(int value);
 int config_get_accesslog_logging_enabled(void);
+int config_get_securitylog_logging_enabled(void);
 int config_get_external_libs_debug_enabled(void);
 int config_get_disk_monitoring(void);
 int config_get_disk_threshold_readonly(void);
@@ -822,14 +829,16 @@ int slapi_log_access(int level, const char *fmt, ...)
 #else
     ;
 #endif
+int slapi_log_security(Slapi_PBlock *pb, const char *event_type, const char *msg);
+int slapi_log_security_tcp(Connection *pb_conn, PRErrorCode error, const char *msg);
 int slapd_log_audit(char *buffer, int buf_len, int sourcelog);
 int slapd_log_audit_internal(char *buffer, int buf_len, int *state);
 int slapd_log_auditfail(char *buffer, int buf_len);
 int slapd_log_auditfail_internal(char *buffer, int buf_len);
-void log_access_flush(void);
-
+void logs_flush(void);
 
 int access_log_openf(char *pathname, int locked);
+int security_log_openf(char *pathname, int locked);
 int error_log_openf(char *pathname, int locked);
 int audit_log_openf(char *pathname, int locked);
 int auditfail_log_openf(char *pathname, int locked);
@@ -840,7 +849,6 @@ char *g_get_access_log(void);
 char *g_get_error_log(void);
 char *g_get_audit_log(void);
 char *g_get_auditfail_log(void);
-void g_set_accesslog_level(int val);
 
 int log_set_mode(const char *attrname, char *mode_str, int logtype, char *errorbuf, int apply);
 int log_set_numlogsperdir(const char *attrname, char *numlogs_str, int logtype, char *errorbuf, int apply);
@@ -856,6 +864,7 @@ int log_set_expirationtime(const char *attrname, char *exptime_str, int logtype,
 int log_set_expirationtimeunit(const char *attrname, char *expunit, int logtype, char *errorbuf, int apply);
 char **log_get_loglist(int logtype);
 int log_update_accesslogdir(char *pathname, int apply);
+int log_update_securitylogdir(char *pathname, int apply);
 int log_update_errorlogdir(char *pathname, int apply);
 int log_update_auditlogdir(char *pathname, int apply);
 int log_update_auditfaillogdir(char *pathname, int apply);
@@ -871,6 +880,7 @@ int check_log_max_size(
 
 
 void g_set_accesslog_level(int val);
+void g_set_securitylog_level(int val);
 void log__delete_rotated_logs(void);
 
 /*

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -404,6 +404,9 @@ send_ldap_result_ext(
         /* first check for security errors */
         if (err == LDAP_INVALID_CREDENTIALS || err == LDAP_INAPPROPRIATE_AUTH || err == LDAP_AUTH_METHOD_NOT_SUPPORTED || err == LDAP_STRONG_AUTH_NOT_SUPPORTED || err == LDAP_STRONG_AUTH_REQUIRED || err == LDAP_CONFIDENTIALITY_REQUIRED || err == LDAP_INSUFFICIENT_ACCESS || err == LDAP_AUTH_UNKNOWN) {
             slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsSecurityErrors);
+            if (err == LDAP_INSUFFICIENT_ACCESS) {
+                slapi_log_security(pb, SECURITY_AUTHZ_ERROR, "");
+            }
         } else if (err != LDAP_REFERRAL && err != LDAP_OPT_REFERRALS && err != LDAP_PARTIAL_RESULTS) {
             /*madman man spec says not to count as normal errors
                 --security errors

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -315,6 +315,7 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 
 #define SLAPD_INIT_LOG_MODE "600"
 #define SLAPD_INIT_ACCESSLOG_ROTATIONUNIT    "day"
+#define SLAPD_INIT_SECURITYLOG_ROTATIONUNIT  "week"
 #define SLAPD_INIT_ERRORLOG_ROTATIONUNIT     "week"
 #define SLAPD_INIT_AUDITLOG_ROTATIONUNIT     "week"
 #define SLAPD_INIT_AUDITFAILLOG_ROTATIONUNIT "week"
@@ -328,6 +329,8 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_LOG_ROTATIONTIME_STR "1"
 #define SLAPD_DEFAULT_LOG_ACCESS_MAXNUMLOGS 10
 #define SLAPD_DEFAULT_LOG_ACCESS_MAXNUMLOGS_STR "10"
+#define SLAPD_DEFAULT_LOG_SECURITY_MAXNUMLOGS 10
+#define SLAPD_DEFAULT_LOG_SECURITY_MAXNUMLOGS_STR "10"
 #define SLAPD_DEFAULT_LOG_MAXNUMLOGS 2
 #define SLAPD_DEFAULT_LOG_MAXNUMLOGS_STR "2"
 #define SLAPD_DEFAULT_LOG_EXPTIME 1
@@ -335,6 +338,8 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 /* This is in MB */
 #define SLAPD_DEFAULT_LOG_ACCESS_MAXDISKSPACE 500
 #define SLAPD_DEFAULT_LOG_ACCESS_MAXDISKSPACE_STR "500"
+#define SLAPD_DEFAULT_LOG_SECURITY_MAXDISKSPACE 500
+#define SLAPD_DEFAULT_LOG_SECURITY_MAXDISKSPACE_STR "500"
 #define SLAPD_DEFAULT_LOG_MAXDISKSPACE 100
 #define SLAPD_DEFAULT_LOG_MAXDISKSPACE_STR "100"
 #define SLAPD_DEFAULT_LOG_MAXLOGSIZE 100
@@ -351,6 +356,8 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_FE_ERRORLOG_LEVEL_STR "16384"
 #define SLAPD_DEFAULT_ACCESSLOG_LEVEL 256
 #define SLAPD_DEFAULT_ACCESSLOG_LEVEL_STR "256"
+#define SLAPD_DEFAULT_SECURITYLOG_LEVEL 256
+#define SLAPD_DEFAULT_SECURITYLOG_LEVEL_STR "256"
 
 #define SLAPD_DEFAULT_DISK_THRESHOLD 2097152
 #define SLAPD_DEFAULT_DISK_THRESHOLD_STR "2097152"
@@ -1710,6 +1717,7 @@ typedef struct conn
     int c_ct_list;                   /* ct active list this conn is part of */
     int c_ns_close_jobs;             /* number of current close jobs */
     char *c_ipaddr;                  /* ip address str - used by monitor */
+    char *c_serveripaddr;            /* server ip address str - used by monitor */
     /* per conn static config */
     ber_len_t c_maxbersize;
     int32_t c_ioblocktimeout;
@@ -2055,6 +2063,20 @@ typedef struct _slapdEntryPoints
 #define SLAPD_ERROR_LOG 0x2
 #define SLAPD_AUDIT_LOG 0x4
 #define SLAPD_AUDITFAIL_LOG 0x8
+#define SLAPD_SECURITY_LOG 0x10
+
+/* Security log events */
+#define SECURITY_BIND_SUCCESS "BIND_SUCCESS"
+#define SECURITY_BIND_FAILED "BIND_FAILED"
+#define SECURITY_AUTHZ_ERROR "AUTHZ_ERROR"
+#define SECURITY_TCP_ERROR "TCP_ERROR"
+
+/* Security log messages */
+#define SECURITY_MSG_INVALID_PASSWD "INVALID_PASSWORD"
+#define SECURITY_MSG_NO_ENTRY "NO_SUCH_ENTRY"
+#define SECURITY_MSG_CERT_MAP_FAILED "CERT_MAP_FAILED"
+#define SECURITY_MSG_ACCOUNT_LOCKED "ACCOUNT_LOCKED"
+#define SECURITY_MSG_ANONYMOUS_BIND "ANONYMOUS_BIND"
 
 #define LOGGING_BACKEND_INTERNAL 0x1
 #define LOGGING_BACKEND_SYSLOG 0x2
@@ -2082,55 +2104,69 @@ typedef struct _slapdEntryPoints
 #define CONFIG_SCHEMAREPLACE_ATTRIBUTE "nsslapd-schemareplace"
 #define CONFIG_LOGLEVEL_ATTRIBUTE "nsslapd-errorlog-level"
 #define CONFIG_ACCESSLOGLEVEL_ATTRIBUTE "nsslapd-accesslog-level"
+#define CONFIG_SECURITYLOGLEVEL_ATTRIBUTE "nsslapd-securitylog-level"
 #define CONFIG_ACCESSLOG_MODE_ATTRIBUTE "nsslapd-accesslog-mode"
+#define CONFIG_SECURITYLOG_MODE_ATTRIBUTE "nsslapd-securitylog-mode"
 #define CONFIG_ERRORLOG_MODE_ATTRIBUTE "nsslapd-errorlog-mode"
 #define CONFIG_AUDITLOG_MODE_ATTRIBUTE "nsslapd-auditlog-mode"
 #define CONFIG_AUDITFAILLOG_MODE_ATTRIBUTE "nsslapd-auditfaillog-mode"
 #define CONFIG_ACCESSLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE "nsslapd-accesslog-maxlogsperdir"
+#define CONFIG_SECURITYLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE "nsslapd-securitylog-maxlogsperdir"
 #define CONFIG_ERRORLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE "nsslapd-errorlog-maxlogsperdir"
 #define CONFIG_AUDITLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE "nsslapd-auditlog-maxlogsperdir"
 #define CONFIG_AUDITFAILLOG_MAXNUMOFLOGSPERDIR_ATTRIBUTE "nsslapd-auditfaillog-maxlogsperdir"
 #define CONFIG_ACCESSLOG_MAXLOGSIZE_ATTRIBUTE "nsslapd-accesslog-maxlogsize"
+#define CONFIG_SECURITYLOG_MAXLOGSIZE_ATTRIBUTE "nsslapd-securitylog-maxlogsize"
 #define CONFIG_ERRORLOG_MAXLOGSIZE_ATTRIBUTE "nsslapd-errorlog-maxlogsize"
 #define CONFIG_AUDITLOG_MAXLOGSIZE_ATTRIBUTE "nsslapd-auditlog-maxlogsize"
 #define CONFIG_AUDITFAILLOG_MAXLOGSIZE_ATTRIBUTE "nsslapd-auditfaillog-maxlogsize"
 #define CONFIG_ACCESSLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE "nsslapd-accesslog-logrotationsync-enabled"
+#define CONFIG_SECURITYLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE "nsslapd-securitylog-logrotationsync-enabled"
 #define CONFIG_ERRORLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE "nsslapd-errorlog-logrotationsync-enabled"
 #define CONFIG_AUDITLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE "nsslapd-auditlog-logrotationsync-enabled"
 #define CONFIG_AUDITFAILLOG_LOGROTATIONSYNCENABLED_ATTRIBUTE "nsslapd-auditfaillog-logrotationsync-enabled"
 #define CONFIG_ACCESSLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE "nsslapd-accesslog-logrotationsynchour"
+#define CONFIG_SECURITYLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE "nsslapd-securitylog-logrotationsynchour"
 #define CONFIG_ERRORLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE "nsslapd-errorlog-logrotationsynchour"
 #define CONFIG_AUDITLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE "nsslapd-auditlog-logrotationsynchour"
 #define CONFIG_AUDITFAILLOG_LOGROTATIONSYNCHOUR_ATTRIBUTE "nsslapd-auditfaillog-logrotationsynchour"
 #define CONFIG_ACCESSLOG_LOGROTATIONSYNCMIN_ATTRIBUTE "nsslapd-accesslog-logrotationsyncmin"
+#define CONFIG_SECURITYLOG_LOGROTATIONSYNCMIN_ATTRIBUTE "nsslapd-securitylog-logrotationsyncmin"
 #define CONFIG_ERRORLOG_LOGROTATIONSYNCMIN_ATTRIBUTE "nsslapd-errorlog-logrotationsyncmin"
 #define CONFIG_AUDITLOG_LOGROTATIONSYNCMIN_ATTRIBUTE "nsslapd-auditlog-logrotationsyncmin"
 #define CONFIG_AUDITFAILLOG_LOGROTATIONSYNCMIN_ATTRIBUTE "nsslapd-auditfaillog-logrotationsyncmin"
 #define CONFIG_ACCESSLOG_LOGROTATIONTIME_ATTRIBUTE "nsslapd-accesslog-logrotationtime"
+#define CONFIG_SECURITYLOG_LOGROTATIONTIME_ATTRIBUTE "nsslapd-securitylog-logrotationtime"
 #define CONFIG_ERRORLOG_LOGROTATIONTIME_ATTRIBUTE "nsslapd-errorlog-logrotationtime"
 #define CONFIG_AUDITLOG_LOGROTATIONTIME_ATTRIBUTE "nsslapd-auditlog-logrotationtime"
 #define CONFIG_AUDITFAILLOG_LOGROTATIONTIME_ATTRIBUTE "nsslapd-auditfaillog-logrotationtime"
 #define CONFIG_ACCESSLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE "nsslapd-accesslog-logrotationtimeunit"
+#define CONFIG_SECURITYLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE "nsslapd-securitylog-logrotationtimeunit"
 #define CONFIG_ERRORLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE "nsslapd-errorlog-logrotationtimeunit"
 #define CONFIG_AUDITLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE "nsslapd-auditlog-logrotationtimeunit"
 #define CONFIG_AUDITFAILLOG_LOGROTATIONTIMEUNIT_ATTRIBUTE "nsslapd-auditfaillog-logrotationtimeunit"
 #define CONFIG_ACCESSLOG_MAXLOGDISKSPACE_ATTRIBUTE "nsslapd-accesslog-logmaxdiskspace"
+#define CONFIG_SECURITYLOG_MAXLOGDISKSPACE_ATTRIBUTE "nsslapd-securitylog-logmaxdiskspace"
 #define CONFIG_ERRORLOG_MAXLOGDISKSPACE_ATTRIBUTE "nsslapd-errorlog-logmaxdiskspace"
 #define CONFIG_AUDITLOG_MAXLOGDISKSPACE_ATTRIBUTE "nsslapd-auditlog-logmaxdiskspace"
 #define CONFIG_AUDITFAILLOG_MAXLOGDISKSPACE_ATTRIBUTE "nsslapd-auditfaillog-logmaxdiskspace"
 #define CONFIG_ACCESSLOG_MINFREEDISKSPACE_ATTRIBUTE "nsslapd-accesslog-logminfreediskspace"
+#define CONFIG_SECURITYLOG_MINFREEDISKSPACE_ATTRIBUTE "nsslapd-securitylog-logminfreediskspace"
 #define CONFIG_ERRORLOG_MINFREEDISKSPACE_ATTRIBUTE "nsslapd-errorlog-logminfreediskspace"
 #define CONFIG_AUDITLOG_MINFREEDISKSPACE_ATTRIBUTE "nsslapd-auditlog-logminfreediskspace"
 #define CONFIG_AUDITFAILLOG_MINFREEDISKSPACE_ATTRIBUTE "nsslapd-auditfaillog-logminfreediskspace"
 #define CONFIG_ACCESSLOG_LOGEXPIRATIONTIME_ATTRIBUTE "nsslapd-accesslog-logexpirationtime"
+#define CONFIG_SECURITYLOG_LOGEXPIRATIONTIME_ATTRIBUTE "nsslapd-securitylog-logexpirationtime"
 #define CONFIG_ERRORLOG_LOGEXPIRATIONTIME_ATTRIBUTE "nsslapd-errorlog-logexpirationtime"
 #define CONFIG_AUDITLOG_LOGEXPIRATIONTIME_ATTRIBUTE "nsslapd-auditlog-logexpirationtime"
 #define CONFIG_AUDITFAILLOG_LOGEXPIRATIONTIME_ATTRIBUTE "nsslapd-auditfaillog-logexpirationtime"
 #define CONFIG_ACCESSLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-accesslog-logexpirationtimeunit"
+#define CONFIG_SECURITYLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-securitylog-logexpirationtimeunit"
 #define CONFIG_ERRORLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-errorlog-logexpirationtimeunit"
 #define CONFIG_AUDITLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-auditlog-logexpirationtimeunit"
 #define CONFIG_AUDITFAILLOG_LOGEXPIRATIONTIMEUNIT_ATTRIBUTE "nsslapd-auditfaillog-logexpirationtimeunit"
 #define CONFIG_ACCESSLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-accesslog-logging-enabled"
+#define CONFIG_SECURITYLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-securitylog-logging-enabled"
 #define CONFIG_ERRORLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-errorlog-logging-enabled"
 #define CONFIG_EXTERNAL_LIBS_DEBUG_ENABLED "nsslapd-external-libs-debug-enabled"
 #define CONFIG_AUDITLOG_LOGGING_ENABLED_ATTRIBUTE "nsslapd-auditlog-logging-enabled"
@@ -2138,6 +2174,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_AUDITLOG_LOGGING_HIDE_UNHASHED_PW "nsslapd-auditlog-logging-hide-unhashed-pw"
 #define CONFIG_AUDITFAILLOG_LOGGING_HIDE_UNHASHED_PW "nsslapd-auditfaillog-logging-hide-unhashed-pw"
 #define CONFIG_ACCESSLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-accesslog-compress"
+#define CONFIG_SECURITYLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-securitylog-compress"
 #define CONFIG_AUDITLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditlog-compress"
 #define CONFIG_AUDITFAILLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditfaillog-compress"
 #define CONFIG_ERRORLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-errorlog-compress"
@@ -2147,6 +2184,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_ROOTPWSTORAGESCHEME_ATTRIBUTE "nsslapd-rootpwstoragescheme"
 #define CONFIG_AUDITFILE_ATTRIBUTE "nsslapd-auditlog"
 #define CONFIG_AUDITFAILFILE_ATTRIBUTE "nsslapd-auditfaillog"
+#define CONFIG_SECURITYFILE_ATTRIBUTE "nsslapd-securitylog"
 #define CONFIG_LASTMOD_ATTRIBUTE "nsslapd-lastmod"
 #define CONFIG_INCLUDE_ATTRIBUTE "nsslapd-include"
 #define CONFIG_DYNAMICCONF_ATTRIBUTE "nsslapd-dynamicconf"
@@ -2242,6 +2280,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_PW_ADMIN_DN_ATTRIBUTE "passwordAdminDN"
 #define CONFIG_PW_SEND_EXPIRING "passwordSendExpiringTime"
 #define CONFIG_ACCESSLOG_BUFFERING_ATTRIBUTE "nsslapd-accesslog-logbuffering"
+#define CONFIG_SECURITYLOG_BUFFERING_ATTRIBUTE "nsslapd-securitylog-logbuffering"
 #define CONFIG_CSNLOGGING_ATTRIBUTE "nsslapd-csnlogging"
 #define CONFIG_RETURN_EXACT_CASE_ATTRIBUTE "nsslapd-return-exact-case"
 #define CONFIG_RESULT_TWEAK_ATTRIBUTE "nsslapd-result-tweak"
@@ -2254,6 +2293,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_ENQUOTE_SUP_OC_ATTRIBUTE "nsslapd-enquote-sup-oc"
 #define CONFIG_BASEDN_ATTRIBUTE "nsslapd-certmap-basedn"
 #define CONFIG_ACCESSLOG_LIST_ATTRIBUTE "nsslapd-accesslog-list"
+#define CONFIG_SECURITYLOG_LIST_ATTRIBUTE "nsslapd-securitylog-list"
 #define CONFIG_ERRORLOG_LIST_ATTRIBUTE "nsslapd-errorlog-list"
 #define CONFIG_AUDITLOG_LIST_ATTRIBUTE "nsslapd-auditlog-list"
 #define CONFIG_AUDITFAILLOG_LIST_ATTRIBUTE "nsslapd-auditfaillog-list"
@@ -2464,6 +2504,25 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t accesslogbuffering;
     slapi_onoff_t csnlogging;
     slapi_onoff_t accesslog_compress;
+
+    /* SECURITY LOG */
+    char *securitylog;
+    slapi_onoff_t securitylog_logging_enabled;
+    char *securitylog_mode;
+    int securitylog_maxnumlogs;
+    int securitylog_maxlogsize;
+    slapi_onoff_t securitylog_rotationsync_enabled;
+    int securitylog_rotationsynchour;
+    int securitylog_rotationsyncmin;
+    int securitylog_rotationtime;
+    char *securitylog_rotationunit;
+    int securitylog_maxdiskspace;
+    int securitylog_minfreespace;
+    int securitylog_exptime;
+    char *securitylog_exptimeunit;
+    int securityloglevel;
+    slapi_onoff_t securitylogbuffering;
+    slapi_onoff_t securitylog_compress;
 
     /* ERROR LOG */
     slapi_onoff_t errorlog_logging_enabled;

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -85,6 +85,7 @@ BuildRequires:    icu
 BuildRequires:    libicu-devel
 BuildRequires:    pcre-devel
 BuildRequires:    cracklib-devel
+BuildRequires:    json-c-devel
 %if %{use_clang}
 BuildRequires:    libatomic
 BuildRequires:    clang
@@ -190,6 +191,7 @@ Requires:         perl-sigtrap
 %endif
 # Needed for password dictionary checks
 Requires:         cracklib-dicts
+Requires:         json-c
 # Log compression
 Requires:         zlib-devel
 # Picks up our systemd deps.

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -578,3 +578,9 @@ pre {
     min-height: 250px !important;
     max-height: 250px !important;
 }
+
+.ds-vert-scroll {
+    /* max-height: 100vh !important; */
+    max-height: 75%;
+    overflow-y: auto;
+}

--- a/src/cockpit/389-console/src/lib/monitor/securitylog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/securitylog.jsx
@@ -1,0 +1,182 @@
+import cockpit from "cockpit";
+import React from "react";
+import PropTypes from "prop-types";
+import {
+    Checkbox,
+    FormSelect,
+    FormSelectOption,
+    Grid,
+    GridItem,
+    Spinner,
+    TextArea,
+    Text,
+    TextContent,
+    TextVariants,
+} from "@patternfly/react-core";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faSyncAlt
+} from '@fortawesome/free-solid-svg-icons';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+
+export class SecurityLogMonitor extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            securitylogData: "",
+            securityReloading: false,
+            securitylog_cont_refresh: "",
+            securityRefreshing: false,
+            securityLines: "50",
+        };
+
+        this.refreshSecurityLog = this.refreshSecurityLog.bind(this);
+        this.handleSecurityChange = this.handleSecurityChange.bind(this);
+        this.securityRefreshCont = this.securityRefreshCont.bind(this);
+    }
+
+    componentDidUpdate () {
+        // Set the textarea to be scrolled down to the bottom
+        const textarea = document.getElementById('securitylog-area');
+        textarea.scrollTop = textarea.scrollHeight;
+    }
+
+    componentDidMount() {
+        this.props.enableTree();
+        this.refreshSecurityLog();
+    }
+
+    componentWillUnmount() {
+        // Stop the continuous log refresh interval
+        clearInterval(this.state.securitylog_cont_refresh);
+    }
+
+    securityRefreshCont(e) {
+        if (e.target.checked) {
+            this.state.securitylog_cont_refresh = setInterval(this.refreshSecurityLog, 2000);
+        } else {
+            clearInterval(this.state.securitylog_cont_refresh);
+        }
+        this.setState({
+            securityRefreshing: e.target.checked,
+        });
+    }
+
+    handleSecurityChange(e) {
+        const value = e.target.value;
+        this.setState(() => (
+            {
+                securityLines: value
+            }
+        ), this.refreshSecurityLog);
+    }
+
+    refreshSecurityLog () {
+        this.setState({
+            securityReloading: true
+        });
+        const cmd = ["tail", "-" + this.state.securityLines, this.props.logLocation];
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    this.setState(() => ({
+                        securitylogData: content,
+                        securityReloading: false
+                    }));
+                })
+                .fail(() => {
+                    // Notification of failure (could only be server down)
+                    this.setState({
+                        securityReloading: false,
+                    });
+                });
+    }
+
+    render() {
+        let spinner = "";
+        if (this.state.securityReloading) {
+            spinner =
+                <div>
+                    <Spinner isSVG size="sm" />
+                    Reloading security log...
+                </div>;
+        }
+
+        return (
+            <div id="monitor-log-security-page">
+                <Grid>
+                    <GridItem span={3}>
+                        <TextContent>
+                            <Text component={TextVariants.h3}>
+                                Security Log <FontAwesomeIcon
+                                    size="lg"
+                                    className="ds-left-margin ds-refresh"
+                                    icon={faSyncAlt}
+                                    title="Refresh security log"
+                                    onClick={this.refreshSecurityLog}
+                                />
+                            </Text>
+                        </TextContent>
+                    </GridItem>
+                    <GridItem span={9} className="ds-float-left">
+                        {spinner}
+                    </GridItem>
+                </Grid>
+                <Grid className="ds-margin-top-lg ds-indent">
+                    <GridItem span={2}>
+                        <FormSelect
+                            id="securityLines"
+                            value={this.state.securityLines}
+                            onChange={(value, event) => {
+                                this.handleSecurityChange(event);
+                            }}
+                            aria-label="FormSelect Input"
+                        >
+                            <FormSelectOption key="50" value="50" label="50" />
+                            <FormSelectOption key="100" value="100" label="100" />
+                            <FormSelectOption key="200" value="200" label="200" />
+                            <FormSelectOption key="300" value="300" label="300" />
+                            <FormSelectOption key="400" value="400" label="400" />
+                            <FormSelectOption key="500" value="500" label="500" />
+                            <FormSelectOption key="1000" value="1000" label="1000" />
+                            <FormSelectOption key="2000" value="2000" label="2000" />
+                            <FormSelectOption key="5000" value="5000" label="5000" />
+                            <FormSelectOption key="10000" value="10000" label="10000" />
+                            <FormSelectOption key="50000" value="50000" label="50000" />
+                        </FormSelect>
+                    </GridItem>
+                    <GridItem span={10}>
+                        <div className="ds-float-right">
+                            <Checkbox
+                                id="securityRefreshing"
+                                isChecked={this.state.securityRefreshing}
+                                onChange={(checked, e) => { this.securityRefreshCont(e) }}
+                                label="Continuously Refresh"
+                            />
+                        </div>
+                    </GridItem>
+                    <TextArea
+                        id="securitylog-area"
+                        resizeOrientation="vertical"
+                        className="ds-logarea ds-margin-top-lg"
+                        value={this.state.securitylogData}
+                        aria-label="text area example"
+                    />
+                </Grid>
+            </div>
+        );
+    }
+}
+
+// Props and defaultProps
+
+SecurityLogMonitor.propTypes = {
+    logLocation: PropTypes.string,
+    enableTree: PropTypes.func,
+};
+
+SecurityLogMonitor.defaultProps = {
+    logLocation: "",
+};
+
+export default SecurityLogMonitor;

--- a/src/cockpit/389-console/src/lib/server/securityLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/securityLog.jsx
@@ -1,0 +1,892 @@
+import cockpit from "cockpit";
+import React from "react";
+import { log_cmd } from "../tools.jsx";
+import {
+    Button,
+    Checkbox,
+    ExpandableSection,
+    Form,
+    FormGroup,
+    FormSelect,
+    FormSelectOption,
+    Grid,
+    GridItem,
+    NumberInput,
+    Spinner,
+    Switch,
+    Tab,
+    Tabs,
+    TabTitleText,
+    TextInput,
+    Text,
+    TextContent,
+    TextVariants,
+    TimePicker,
+} from "@patternfly/react-core";
+import {
+    Table,
+    TableHeader,
+    TableBody,
+    TableVariant
+} from '@patternfly/react-table';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faSyncAlt
+} from '@fortawesome/free-solid-svg-icons';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import PropTypes from "prop-types";
+
+const settings_attrs = [
+    'nsslapd-securitylog',
+    'nsslapd-securitylog-level',
+    'nsslapd-securitylog-logbuffering',
+    'nsslapd-securitylog-logging-enabled',
+];
+
+const rotation_attrs = [
+    'nsslapd-securitylog-logrotationsync-enabled',
+    'nsslapd-securitylog-logrotationsynchour',
+    'nsslapd-securitylog-logrotationsyncmin',
+    'nsslapd-securitylog-logrotationtime',
+    'nsslapd-securitylog-logrotationtimeunit',
+    'nsslapd-securitylog-maxlogsize',
+    'nsslapd-securitylog-maxlogsperdir',
+    'nsslapd-securitylog-compress'
+];
+
+const rotation_attrs_no_time = [
+    'nsslapd-securitylog-logrotationsync-enabled',
+    'nsslapd-securitylog-logrotationtime',
+    'nsslapd-securitylog-logrotationtimeunit',
+    'nsslapd-securitylog-maxlogsize',
+    'nsslapd-securitylog-maxlogsperdir',
+    'nsslapd-securitylog-compress'
+];
+
+const exp_attrs = [
+    'nsslapd-securitylog-logexpirationtime',
+    'nsslapd-securitylog-logexpirationtimeunit',
+    'nsslapd-securitylog-logmaxdiskspace',
+    'nsslapd-securitylog-logminfreediskspace',
+];
+
+export class ServerSecurityLog extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: true,
+            loaded: false,
+            activeTabKey: 0,
+            saveSettingsDisabled: true,
+            saveRotationDisabled: true,
+            saveExpDisabled: true,
+            attrs: this.props.attrs,
+            canSelectAll: false,
+            isExpanded: false,
+            rows: [
+                { cells: ['Default Logging'], level: 256, selected: true },
+                { cells: ['Internal Operations'], level: 4, selected: false },
+                { cells: ['Entry Security and Referrals'], level: 512, selected: false }
+            ],
+            columns: [
+                { title: 'Logging Level' },
+            ],
+        };
+
+        // Toggle currently active tab
+        this.handleNavSelect = (event, tabIndex) => {
+            this.setState({
+                activeTabKey: tabIndex
+            });
+        };
+
+        this.onToggle = isExpanded => {
+            this.setState({
+                isExpanded
+            });
+        };
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSwitchChange = this.handleSwitchChange.bind(this);
+        this.handleTimeChange = this.handleTimeChange.bind(this);
+        this.loadConfig = this.loadConfig.bind(this);
+        this.refreshConfig = this.refreshConfig.bind(this);
+        this.saveConfig = this.saveConfig.bind(this);
+        this.onSelect = this.onSelect.bind(this);
+        this.onMinusConfig = (id, nav_tab) => {
+            this.setState({
+                [id]: Number(this.state[id]) - 1
+            }, () => { this.validateSaveBtn(nav_tab, id, Number(this.state[id])) });
+        };
+        this.onConfigChange = (event, id, min, max, nav_tab) => {
+            let maxValue = this.maxValue;
+            if (max !== 0) {
+                maxValue = max;
+            }
+            let newValue = isNaN(event.target.value) ? min : Number(event.target.value);
+            newValue = newValue > maxValue ? maxValue : newValue < min ? min : newValue
+            this.setState({
+                [id]: newValue
+            }, () => { this.validateSaveBtn(nav_tab, id, newValue) });
+        };
+        this.onPlusConfig = (id, nav_tab) => {
+            this.setState({
+                [id]: Number(this.state[id]) + 1
+            }, () => { this.validateSaveBtn(nav_tab, id, Number(this.state[id])) });
+        }
+        this.validateSaveBtn = this.validateSaveBtn.bind(this);
+    }
+
+    componentDidMount() {
+        // Loading config
+        if (!this.state.loaded) {
+            this.loadConfig();
+        } else {
+            this.props.enableTree();
+        }
+    }
+
+    validateSaveBtn(nav_tab, attr, value) {
+        let disableSaveBtn = true;
+        let disableBtnName = "";
+        let config_attrs = [];
+        if (nav_tab == "settings") {
+            config_attrs = settings_attrs;
+            disableBtnName = "saveSettingsDisabled";
+            // Handle the table contents check now
+            for (const row of this.state.rows) {
+                for (const orig_row of this.state._rows) {
+                    if (orig_row.cells[0] == row.cells[0]) {
+                        if (orig_row.selected != row.selected) {
+                            disableSaveBtn = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        } else if (nav_tab == "rotation") {
+            disableBtnName = "saveRotationDisabled";
+            config_attrs = rotation_attrs;
+        } else {
+            config_attrs = exp_attrs;
+            disableBtnName = "saveExpDisabled";
+        }
+
+        // Check if a setting was changed, if so enable the save button
+        for (const config_attr of config_attrs) {
+            if (attr == config_attr && this.state['_' + config_attr] != value) {
+                disableSaveBtn = false;
+                break;
+            }
+        }
+
+        // Now check for differences in values that we did not touch
+        for (const config_attr of config_attrs) {
+            if (attr != config_attr && this.state['_' + config_attr] != this.state[config_attr]) {
+                disableSaveBtn = false;
+                break;
+            }
+        }
+
+        this.setState({
+            [disableBtnName]: disableSaveBtn
+        });
+    }
+
+    handleChange(e, nav_tab) {
+        const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+        const attr = e.target.id;
+
+        this.setState({
+            [attr]: value,
+        }, () => { this.validateSaveBtn(nav_tab, attr, value) } );
+    }
+
+    handleSwitchChange(value) {
+        // log compression
+        this.setState({
+            'nsslapd-securitylog-compress': value
+        }, () => {
+            this.validateSaveBtn('rotation', 'nsslapd-securitylog-compress', value);
+        });
+    }
+
+    handleTimeChange(time_str) {
+        let disableSaveBtn = true;
+        const time_parts = time_str.split(":");
+        let hour = time_parts[0];
+        let min = time_parts[1];
+        if (hour.length == 2 && hour[0] == "0") {
+            hour = hour[1];
+        }
+        if (min.length == 2 && min[0] == "0") {
+            min = min[1];
+        }
+
+        // Start doing the Save button checking
+        for (const config_attr of rotation_attrs_no_time) {
+            if (this.state[config_attr] != this.state['_' + config_attr]) {
+                disableSaveBtn = false;
+                break;
+            }
+        }
+        if (hour != this.state['_nsslapd-securitylog-logrotationsynchour'] ||
+            min != this.state['_nsslapd-securitylog-logrotationsyncmin']) {
+            disableSaveBtn = false;
+        }
+
+        this.setState({
+            'nsslapd-securitylog-logrotationsynchour': hour,
+            'nsslapd-securitylog-logrotationsyncmin': min,
+            saveRotationDisabled: disableSaveBtn,
+        });
+    }
+
+    saveConfig(nav_tab) {
+        let new_level = 0;
+        this.setState({
+            loading: true
+        });
+
+        let config_attrs = [];
+        if (nav_tab == "settings") {
+            config_attrs = settings_attrs;
+        } else if (nav_tab == "rotation") {
+            config_attrs = rotation_attrs;
+        } else {
+            config_attrs = exp_attrs;
+        }
+
+        const cmd = [
+            'dsconf', '-j', "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            'config', 'replace'
+        ];
+
+        for (const attr of config_attrs) {
+            if (this.state['_' + attr] != this.state[attr]) {
+                let val = this.state[attr];
+                if (typeof val === "boolean") {
+                    if (val) {
+                        val = "on";
+                    } else {
+                        val = "off";
+                    }
+                }
+                cmd.push(attr + "=" + val);
+            }
+        }
+
+        for (const row of this.state.rows) {
+            if (row.selected) {
+                new_level += row.level;
+            }
+        }
+        if (new_level.toString() != this.state['_nsslapd-securitylog-level']) {
+            if (new_level == 0) {
+                new_level = 256; // default
+            }
+            cmd.push("nsslapd-securitylog-level" + "=" + new_level.toString());
+        }
+
+        if (cmd.length == 5) {
+            // Nothing to save, just return
+            return;
+        }
+
+        log_cmd("saveConfig", "Saving security log settings", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    this.refreshConfig();
+                    this.props.addNotification(
+                        "success",
+                        "Successfully updated Security Log settings"
+                    );
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.refreshConfig();
+                    this.props.addNotification(
+                        "error",
+                        `Error saving Security Log settings - ${errMsg.desc}`
+                    );
+                });
+    }
+
+    refreshConfig(refesh) {
+        this.setState({
+            loading: true,
+            loaded: false,
+        });
+
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "config", "get"
+        ];
+        log_cmd("refreshConfig", "load Security Log configuration", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const config = JSON.parse(content);
+                    const attrs = config.attrs;
+                    let enabled = false;
+                    let buffering = false;
+                    let compress = false;
+                    const level_val = parseInt(attrs['nsslapd-securitylog-level'][0]);
+                    const rows = [...this.state.rows];
+
+                    if (attrs['nsslapd-securitylog-logging-enabled'][0] == "on") {
+                        enabled = true;
+                    }
+                    if (attrs['nsslapd-securitylog-logbuffering'][0] == "on") {
+                        buffering = true;
+                    }
+                    if (attrs['nsslapd-securitylog-compress'][0] == "on") {
+                        compress = true;
+                    }
+                    for (const row in rows) {
+                        if (rows[row].level & level_val) {
+                            rows[row].selected = true;
+                        } else {
+                            rows[row].selected = false;
+                        }
+                    }
+
+                    this.setState({
+                        loading: false,
+                        loaded: true,
+                        saveSettingsDisabled: true,
+                        saveRotationDisabled: true,
+                        saveExpDisabled: true,
+                        'nsslapd-securitylog': attrs['nsslapd-securitylog'][0],
+                        'nsslapd-securitylog-level': attrs['nsslapd-securitylog-level'][0],
+                        'nsslapd-securitylog-logbuffering': buffering,
+                        'nsslapd-securitylog-logexpirationtime': attrs['nsslapd-securitylog-logexpirationtime'][0],
+                        'nsslapd-securitylog-logexpirationtimeunit': attrs['nsslapd-securitylog-logexpirationtimeunit'][0],
+                        'nsslapd-securitylog-logging-enabled': enabled,
+                        'nsslapd-securitylog-logmaxdiskspace': attrs['nsslapd-securitylog-logmaxdiskspace'][0],
+                        'nsslapd-securitylog-logminfreediskspace': attrs['nsslapd-securitylog-logminfreediskspace'][0],
+                        'nsslapd-securitylog-logrotationsync-enabled': attrs['nsslapd-securitylog-logrotationsync-enabled'][0],
+                        'nsslapd-securitylog-logrotationsynchour': attrs['nsslapd-securitylog-logrotationsynchour'][0],
+                        'nsslapd-securitylog-logrotationsyncmin': attrs['nsslapd-securitylog-logrotationsyncmin'][0],
+                        'nsslapd-securitylog-logrotationtime': attrs['nsslapd-securitylog-logrotationtime'][0],
+                        'nsslapd-securitylog-logrotationtimeunit': attrs['nsslapd-securitylog-logrotationtimeunit'][0],
+                        'nsslapd-securitylog-maxlogsize': attrs['nsslapd-securitylog-maxlogsize'][0],
+                        'nsslapd-securitylog-maxlogsperdir': attrs['nsslapd-securitylog-maxlogsperdir'][0],
+                        'nsslapd-securitylog-compress': compress,
+                        rows: rows,
+                        // Record original values
+                        _rows:  JSON.parse(JSON.stringify(rows)),
+                        '_nsslapd-securitylog': attrs['nsslapd-securitylog'][0],
+                        '_nsslapd-securitylog-level': attrs['nsslapd-securitylog-level'][0],
+                        '_nsslapd-securitylog-logbuffering': buffering,
+                        '_nsslapd-securitylog-logexpirationtime': attrs['nsslapd-securitylog-logexpirationtime'][0],
+                        '_nsslapd-securitylog-logexpirationtimeunit': attrs['nsslapd-securitylog-logexpirationtimeunit'][0],
+                        '_nsslapd-securitylog-logging-enabled': enabled,
+                        '_nsslapd-securitylog-logmaxdiskspace': attrs['nsslapd-securitylog-logmaxdiskspace'][0],
+                        '_nsslapd-securitylog-logminfreediskspace': attrs['nsslapd-securitylog-logminfreediskspace'][0],
+                        '_nsslapd-securitylog-logrotationsync-enabled': attrs['nsslapd-securitylog-logrotationsync-enabled'][0],
+                        '_nsslapd-securitylog-logrotationsynchour': attrs['nsslapd-securitylog-logrotationsynchour'][0],
+                        '_nsslapd-securitylog-logrotationsyncmin': attrs['nsslapd-securitylog-logrotationsyncmin'][0],
+                        '_nsslapd-securitylog-logrotationtime': attrs['nsslapd-securitylog-logrotationtime'][0],
+                        '_nsslapd-securitylog-logrotationtimeunit': attrs['nsslapd-securitylog-logrotationtimeunit'][0],
+                        '_nsslapd-securitylog-maxlogsize': attrs['nsslapd-securitylog-maxlogsize'][0],
+                        '_nsslapd-securitylog-maxlogsperdir': attrs['nsslapd-securitylog-maxlogsperdir'][0],
+                        '_nsslapd-securitylog-compress': compress,
+                    });
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        `Error loading Security Log configuration - ${errMsg.desc}`
+                    );
+                    this.setState({
+                        loading: false,
+                        loaded: true,
+                    });
+                });
+    }
+
+    loadConfig() {
+        const attrs = this.state.attrs;
+        let enabled = false;
+        let buffering = false;
+        let compress = false;
+        const level_val = parseInt(attrs['nsslapd-securitylog-level'][0]);
+        const rows = [...this.state.rows];
+
+        if (attrs['nsslapd-securitylog-logging-enabled'][0] == "on") {
+            enabled = true;
+        }
+        if (attrs['nsslapd-securitylog-logbuffering'][0] == "on") {
+            buffering = true;
+        }
+        if (attrs['nsslapd-securitylog-compress'][0] == "on") {
+            compress = true;
+        }
+        for (const row in rows) {
+            if (rows[row].level & level_val) {
+                rows[row].selected = true;
+            } else {
+                rows[row].selected = false;
+            }
+        }
+
+        this.setState({
+            loading: false,
+            loaded: true,
+            saveSettingsDisabled: true,
+            saveRotationDisabled: true,
+            saveExpDisabled: true,
+            'nsslapd-securitylog': attrs['nsslapd-securitylog'][0],
+            'nsslapd-securitylog-level': attrs['nsslapd-securitylog-level'][0],
+            'nsslapd-securitylog-logbuffering': buffering,
+            'nsslapd-securitylog-logexpirationtime': attrs['nsslapd-securitylog-logexpirationtime'][0],
+            'nsslapd-securitylog-logexpirationtimeunit': attrs['nsslapd-securitylog-logexpirationtimeunit'][0],
+            'nsslapd-securitylog-logging-enabled': enabled,
+            'nsslapd-securitylog-logmaxdiskspace': attrs['nsslapd-securitylog-logmaxdiskspace'][0],
+            'nsslapd-securitylog-logminfreediskspace': attrs['nsslapd-securitylog-logminfreediskspace'][0],
+            'nsslapd-securitylog-logrotationsync-enabled': attrs['nsslapd-securitylog-logrotationsync-enabled'][0],
+            'nsslapd-securitylog-logrotationsynchour': attrs['nsslapd-securitylog-logrotationsynchour'][0],
+            'nsslapd-securitylog-logrotationsyncmin': attrs['nsslapd-securitylog-logrotationsyncmin'][0],
+            'nsslapd-securitylog-logrotationtime': attrs['nsslapd-securitylog-logrotationtime'][0],
+            'nsslapd-securitylog-logrotationtimeunit': attrs['nsslapd-securitylog-logrotationtimeunit'][0],
+            'nsslapd-securitylog-maxlogsize': attrs['nsslapd-securitylog-maxlogsize'][0],
+            'nsslapd-securitylog-maxlogsperdir': attrs['nsslapd-securitylog-maxlogsperdir'][0],
+            'nsslapd-securitylog-compress': compress,
+            rows: rows,
+            // Record original values
+            _rows: JSON.parse(JSON.stringify(rows)),
+            '_nsslapd-securitylog': attrs['nsslapd-securitylog'][0],
+            '_nsslapd-securitylog-level': attrs['nsslapd-securitylog-level'][0],
+            '_nsslapd-securitylog-logbuffering': buffering,
+            '_nsslapd-securitylog-logexpirationtime': attrs['nsslapd-securitylog-logexpirationtime'][0],
+            '_nsslapd-securitylog-logexpirationtimeunit': attrs['nsslapd-securitylog-logexpirationtimeunit'][0],
+            '_nsslapd-securitylog-logging-enabled': enabled,
+            '_nsslapd-securitylog-logmaxdiskspace': attrs['nsslapd-securitylog-logmaxdiskspace'][0],
+            '_nsslapd-securitylog-logminfreediskspace': attrs['nsslapd-securitylog-logminfreediskspace'][0],
+            '_nsslapd-securitylog-logrotationsync-enabled': attrs['nsslapd-securitylog-logrotationsync-enabled'][0],
+            '_nsslapd-securitylog-logrotationsynchour': attrs['nsslapd-securitylog-logrotationsynchour'][0],
+            '_nsslapd-securitylog-logrotationsyncmin': attrs['nsslapd-securitylog-logrotationsyncmin'][0],
+            '_nsslapd-securitylog-logrotationtime': attrs['nsslapd-securitylog-logrotationtime'][0],
+            '_nsslapd-securitylog-logrotationtimeunit': attrs['nsslapd-securitylog-logrotationtimeunit'][0],
+            '_nsslapd-securitylog-maxlogsize': attrs['nsslapd-securitylog-maxlogsize'][0],
+            '_nsslapd-securitylog-maxlogsperdir': attrs['nsslapd-securitylog-maxlogsperdir'][0],
+            '_nsslapd-securitylog-compress': compress,
+        }, this.props.enableTree);
+    }
+
+    onSelect(event, isSelected, rowId) {
+        let disableSaveBtn = true;
+        const rows = JSON.parse(JSON.stringify(this.state.rows));
+
+        // Update the row
+        rows[rowId].selected = isSelected;
+
+        // Handle "save button" state, first check the other config settings
+        for (const config_attr of settings_attrs) {
+            if (this.state['_' + config_attr] != this.state[config_attr]) {
+                disableSaveBtn = false;
+                break;
+            }
+        }
+
+        // Handle the table contents
+        for (const row of rows) {
+            for (const orig_row of this.state._rows) {
+                if (orig_row.cells[0] == row.cells[0]) {
+                    if (orig_row.selected != row.selected) {
+                        disableSaveBtn = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        this.setState({
+            rows,
+            saveSettingsDisabled: disableSaveBtn,
+        });
+    }
+
+    render() {
+        let saveSettingsName = "Save Log Settings";
+        let saveRotationName = "Save Rotation Settings";
+        let saveDeletionName = "Save Deletion Settings";
+        const extraPrimaryProps = {};
+        let rotationTime = "";
+        let hour = this.state['nsslapd-securitylog-logrotationsynchour'] ? this.state['nsslapd-securitylog-logrotationsynchour'] : "00";
+        let min = this.state['nsslapd-securitylog-logrotationsyncmin'] ? this.state['nsslapd-securitylog-logrotationsyncmin'] : "00";
+
+        if (this.state.loading) {
+            saveSettingsName = "Saving settings ...";
+            saveRotationName = "Saving settings ...";
+            saveDeletionName = "Saving settings ...";
+            extraPrimaryProps.spinnerAriaValueText = "Loading";
+        }
+
+        // Adjust time string for TimePicket
+        if (hour.length == 1) {
+            hour = "0" + hour;
+        }
+        if (min.length == 1) {
+            min = "0" + min;
+        }
+        rotationTime = hour + ":" + min;
+
+        let body =
+            <div className="ds-margin-top-lg ds-left-margin">
+                <Tabs className="ds-margin-top-xlg" activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
+                    <Tab eventKey={0} title={<TabTitleText>Settings</TabTitleText>}>
+                        <Checkbox
+                            className="ds-margin-top-xlg"
+                            id="nsslapd-securitylog-logging-enabled"
+                            isChecked={this.state['nsslapd-securitylog-logging-enabled']}
+                            onChange={(checked, e) => {
+                                this.handleChange(e, "settings");
+                            }}
+                            title="Enable security logging (nsslapd-securitylog-logging-enabled)."
+                            label="Enable Security Logging"
+                        />
+                        <Form className="ds-margin-top-lg ds-left-margin-md" isHorizontal autoComplete="off">
+                            <FormGroup
+                                label="Security Log Location"
+                                fieldId="nsslapd-securitylog"
+                                title="Enable security logging (nsslapd-securitylog)."
+                            >
+                                <TextInput
+                                    value={this.state['nsslapd-securitylog']}
+                                    type="text"
+                                    id="nsslapd-securitylog"
+                                    aria-describedby="horizontal-form-name-helper"
+                                    name="nsslapd-securitylog"
+                                    onChange={(str, e) => {
+                                        this.handleChange(e, "settings");
+                                    }}
+                                />
+                            </FormGroup>
+                        </Form>
+                        <Checkbox
+                            className="ds-left-margin-md ds-margin-top-lg"
+                            id="nsslapd-securitylog-logbuffering"
+                            isChecked={this.state['nsslapd-securitylog-logbuffering']}
+                            onChange={(checked, e) => {
+                                this.handleChange(e, "settings");
+                            }}
+                            title="Disable security log buffering for faster troubleshooting, but this will impact server performance (nsslapd-securitylog-logbuffering)."
+                            label="Security Log Buffering Enabled"
+                        />
+
+
+                        <ExpandableSection
+                            className="ds-hidden ds-left-margin-md ds-margin-top-lg ds-font-size-md"
+                            toggleText={this.state.isExpanded ? 'Hide Logging Levels' : 'Show Logging Levels'}
+                            onToggle={this.onToggle}
+                            isExpanded={this.state.isExpanded}
+                        >
+                            <Table
+                                className="ds-left-margin"
+                                onSelect={this.onSelect}
+                                canSelectAll={this.state.canSelectAll}
+                                variant={TableVariant.compact}
+                                aria-label="Selectable Table"
+                                cells={this.state.columns}
+                                rows={this.state.rows}
+                            >
+                                <TableHeader />
+                                <TableBody />
+                            </Table>
+                        </ExpandableSection>
+
+                        <Button
+                            key="save settings"
+                            isDisabled={this.state.saveSettingsDisabled}
+                            variant="primary"
+                            className="ds-margin-top-xlg"
+                            onClick={() => {
+                                this.saveConfig("settings");
+                            }}
+                            isLoading={this.state.loading}
+                            spinnerAriaValueText={this.state.loading ? "Saving" : undefined}
+                            {...extraPrimaryProps}
+                        >
+                            {saveSettingsName}
+                        </Button>
+                    </Tab>
+                    <Tab eventKey={1} title={<TabTitleText>Rotation Policy</TabTitleText>}>
+                        <Form className="ds-margin-top-lg" isHorizontal autoComplete="off">
+                            <Grid
+                                className="ds-margin-top"
+                                title="The maximum number of logs that are archived (nsslapd-securitylog-maxlogsperdir)."
+                            >
+                                <GridItem className="ds-label" span={3}>
+                                    Maximum Number Of Logs
+                                </GridItem>
+                                <GridItem span={3}>
+                                    <NumberInput
+                                        value={this.state['nsslapd-securitylog-maxlogsperdir']}
+                                        min={1}
+                                        max={2147483647}
+                                        onMinus={() => { this.onMinusConfig("nsslapd-securitylog-maxlogsperdir", "rotation") }}
+                                        onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-maxlogsperdir", 1, 2147483647, "rotation") }}
+                                        onPlus={() => { this.onPlusConfig("nsslapd-securitylog-maxlogsperdir", "rotation") }}
+                                        inputName="input"
+                                        inputAriaLabel="number input"
+                                        minusBtnAriaLabel="minus"
+                                        plusBtnAriaLabel="plus"
+                                        widthChars={6}
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="The maximum size of each log file in megabytes (nsslapd-securitylog-maxlogsize).">
+                                <GridItem className="ds-label" span={3}>
+                                    Maximum Log Size (in MB)
+                                </GridItem>
+                                <GridItem span={3}>
+                                    <NumberInput
+                                        value={this.state['nsslapd-securitylog-maxlogsize']}
+                                        min={-1}
+                                        max={2147483647}
+                                        onMinus={() => { this.onMinusConfig("nsslapd-securitylog-maxlogsize", "rotation") }}
+                                        onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-maxlogsize", -1, 2147483647, "rotation") }}
+                                        onPlus={() => { this.onPlusConfig("nsslapd-securitylog-maxlogsize", "rotation") }}
+                                        inputName="input"
+                                        inputAriaLabel="number input"
+                                        minusBtnAriaLabel="minus"
+                                        plusBtnAriaLabel="plus"
+                                        widthChars={6}
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <hr />
+                            <Grid title="Rotate the log based this number of time units (nsslapd-securitylog-logrotationtime).">
+                                <GridItem className="ds-label" span={3}>
+                                    Create New Log Every ...
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <div className="ds-container">
+                                        <NumberInput
+                                            value={this.state['nsslapd-securitylog-logrotationtime']}
+                                            min={-1}
+                                            max={2147483647}
+                                            onMinus={() => { this.onMinusConfig("nsslapd-securitylog-logrotationtime", "rotation") }}
+                                            onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-logrotationtime", -1, 2147483647, "rotation") }}
+                                            onPlus={() => { this.onPlusConfig("nsslapd-securitylog-logrotationtime", "rotation") }}
+                                            inputName="input"
+                                            inputAriaLabel="number input"
+                                            minusBtnAriaLabel="minus"
+                                            plusBtnAriaLabel="plus"
+                                            widthChars={3}
+                                        />
+                                        <GridItem span={2} className="ds-left-indent">
+                                            <FormSelect
+                                                id="nsslapd-securitylog-logrotationtimeunit"
+                                                value={this.state['nsslapd-securitylog-logrotationtimeunit']}
+                                                onChange={(str, e) => {
+                                                    this.handleChange(e, "rotation");
+                                                }}
+                                                aria-label="FormSelect Input"
+                                            >
+                                                <FormSelectOption key="0" value="minute" label="minute" />
+                                                <FormSelectOption key="1" value="hour" label="hour" />
+                                                <FormSelectOption key="2" value="day" label="day" />
+                                                <FormSelectOption key="3" value="week" label="week" />
+                                                <FormSelectOption key="4" value="month" label="month" />
+                                            </FormSelect>
+                                        </GridItem>
+                                    </div>
+                                </GridItem>
+                            </Grid>
+                            <Grid title="The time when the log should be rotated (nsslapd-securitylog-logrotationsynchour, nsslapd-securitylog-logrotationsyncmin).">
+                                <GridItem className="ds-label" span={3}>
+                                    Time Of Day
+                                </GridItem>
+                                <GridItem span={1}>
+                                    <TimePicker
+                                        time={rotationTime}
+                                        onChange={this.handleTimeChange}
+                                        is24Hour
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title="Compress (gzip) the log after it's rotated.">
+                                <GridItem className="ds-label" span={3}>
+                                    Compress Rotated Logs
+                                </GridItem>
+                                <GridItem className="ds-label" span={8}>
+                                    <Switch
+                                        id="nsslapd-securitylog-compress"
+                                        isChecked={this.state['nsslapd-securitylog-compress']}
+                                        onChange={this.handleSwitchChange}
+                                    />
+                                </GridItem>
+                            </Grid>
+                        </Form>
+                        <Button
+                            key="save rot settings"
+                            isDisabled={this.state.saveRotationDisabled}
+                            variant="primary"
+                            className="ds-margin-top-xlg"
+                            onClick={() => {
+                                this.saveConfig("rotation");
+                            }}
+                            isLoading={this.state.loading}
+                            spinnerAriaValueText={this.state.loading ? "Saving" : undefined}
+                            {...extraPrimaryProps}
+                        >
+                            {saveRotationName}
+                        </Button>
+                    </Tab>
+
+                    <Tab eventKey={2} title={<TabTitleText>Deletion Policy</TabTitleText>}>
+                        <Form className="ds-margin-top-lg" isHorizontal autoComplete="off">
+                            <Grid
+                                className="ds-margin-top"
+                                title="The server deletes the oldest archived log when the total of all the logs reaches this amount (nsslapd-securitylog-logmaxdiskspace)."
+                            >
+                                <GridItem className="ds-label" span={3}>
+                                    Log Archive Exceeds (in MB)
+                                </GridItem>
+                                <GridItem span={1}>
+                                    <NumberInput
+                                        value={this.state['nsslapd-securitylog-logmaxdiskspace']}
+                                        min={-1}
+                                        max={2147483647}
+                                        onMinus={() => { this.onMinusConfig("nsslapd-securitylog-logmaxdiskspace", "exp") }}
+                                        onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-logmaxdiskspace", -1, 2147483647, "exp") }}
+                                        onPlus={() => { this.onPlusConfig("nsslapd-securitylog-logmaxdiskspace", "exp") }}
+                                        inputName="input"
+                                        inputAriaLabel="number input"
+                                        minusBtnAriaLabel="minus"
+                                        plusBtnAriaLabel="plus"
+                                        widthChars={6}
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid
+                                title="The server deletes the oldest archived log file when available disk space is less than this amount. (nsslapd-securitylog-logminfreediskspace)."
+                            >
+                                <GridItem className="ds-label" span={3}>
+                                    Free Disk Space (in MB)
+                                </GridItem>
+                                <GridItem span={1}>
+                                    <NumberInput
+                                        value={this.state['nsslapd-securitylog-logminfreediskspace']}
+                                        min={-1}
+                                        max={2147483647}
+                                        onMinus={() => { this.onMinusConfig("nsslapd-securitylog-logminfreediskspace", "exp") }}
+                                        onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-logminfreediskspace", -1, 2147483647, "exp") }}
+                                        onPlus={() => { this.onPlusConfig("nsslapd-securitylog-logminfreediskspace", "exp") }}
+                                        inputName="input"
+                                        inputAriaLabel="number input"
+                                        minusBtnAriaLabel="minus"
+                                        plusBtnAriaLabel="plus"
+                                        widthChars={6}
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid
+                                title="Server deletes an old archived log file when it is older than the specified age. (nsslapd-securitylog-logexpirationtime)."
+                            >
+                                <GridItem className="ds-label" span={3}>
+                                    Log File is Older Than ...
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <div className="ds-container">
+                                        <NumberInput
+                                            value={this.state['nsslapd-securitylog-logexpirationtime']}
+                                            min={-1}
+                                            max={2147483647}
+                                            onMinus={() => { this.onMinusConfig("nsslapd-securitylog-logexpirationtime", "exp") }}
+                                            onChange={(e) => { this.onConfigChange(e, "nsslapd-securitylog-logexpirationtime", -1, 2147483647, "exp") }}
+                                            onPlus={() => { this.onPlusConfig("nsslapd-securitylog-logexpirationtime", "exp") }}
+                                            inputName="input"
+                                            inputAriaLabel="number input"
+                                            minusBtnAriaLabel="minus"
+                                            plusBtnAriaLabel="plus"
+                                            widthChars={3}
+                                        />
+                                        <GridItem span={2} className="ds-left-indent">
+                                            <FormSelect
+                                                id="nsslapd-securitylog-logexpirationtimeunit"
+                                                value={this.state['nsslapd-securitylog-logexpirationtimeunit']}
+                                                onChange={(str, e) => {
+                                                    this.handleChange(e, "exp");
+                                                }}
+                                                aria-label="FormSelect Input"
+                                            >
+                                                <FormSelectOption key="2" value="day" label="day" />
+                                                <FormSelectOption key="3" value="week" label="week" />
+                                                <FormSelectOption key="4" value="month" label="month" />
+                                            </FormSelect>
+                                        </GridItem>
+                                    </div>
+                                </GridItem>
+                            </Grid>
+                        </Form>
+                        <Button
+                            key="save del settings"
+                            isDisabled={this.state.saveExpDisabled}
+                            variant="primary"
+                            className="ds-margin-top-xlg"
+                            onClick={() => {
+                                this.saveConfig("exp");
+                            }}
+                            isLoading={this.state.loading}
+                            spinnerAriaValueText={this.state.loading ? "Saving" : undefined}
+                            {...extraPrimaryProps}
+                        >
+                            {saveDeletionName}
+                        </Button>
+                    </Tab>
+                </Tabs>
+            </div>;
+
+        if (!this.state.loaded) {
+            body =
+                <div className="ds-margin-top-xlg ds-center">
+                    <TextContent>
+                        <Text component={TextVariants.h3}>Loading Security Log Settings ...</Text>
+                    </TextContent>
+                    <Spinner size="xl" />
+                </div>;
+        }
+
+        return (
+            <div id="server-securitylog-page" className={this.state.loading ? "ds-disabled" : ""}>
+                <Grid>
+                    <GridItem span={12}>
+                        <TextContent>
+                            <Text component={TextVariants.h3}>
+                                Security Log Settings <FontAwesomeIcon
+                                    size="lg"
+                                    className="ds-left-margin ds-refresh"
+                                    icon={faSyncAlt}
+                                    title="Refresh log settings"
+                                    onClick={() => {
+                                        this.refreshConfig();
+                                    }}
+                                />
+                            </Text>
+                        </TextContent>
+                    </GridItem>
+                </Grid>
+                {body}
+            </div>
+        );
+    }
+}
+
+// Property types and defaults
+
+ServerSecurityLog.propTypes = {
+    addNotification: PropTypes.func,
+    serverId: PropTypes.string,
+    attrs: PropTypes.object,
+};
+
+ServerSecurityLog.defaultProps = {
+    serverId: "",
+    attrs: {},
+};

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -10,6 +10,7 @@ import AccessLogMonitor from "./lib/monitor/accesslog.jsx";
 import AuditLogMonitor from "./lib/monitor/auditlog.jsx";
 import AuditFailLogMonitor from "./lib/monitor/auditfaillog.jsx";
 import ErrorLogMonitor from "./lib/monitor/errorlog.jsx";
+import SecurityLogMonitor from "./lib/monitor/securitylog.jsx";
 import ReplMonitor from "./lib/monitor/replMonitor.jsx";
 import {
     FormSelect,
@@ -77,6 +78,7 @@ export class Monitor extends React.Component {
             errorlogLocation: "",
             auditlogLocation: "",
             auditfaillogLocation: "",
+            securitylogLocation: "",
         };
 
         // Bindings
@@ -197,6 +199,12 @@ export class Monitor extends React.Component {
                                     name: "Errors Log",
                                     icon: <FontAwesomeIcon size="sm" icon={faBook} />,
                                     id: "error-log-monitor",
+                                    type: "log",
+                                },
+                                {
+                                    name: "Security Log",
+                                    icon: <FontAwesomeIcon size="sm" icon={faBook} />,
+                                    id: "security-log-monitor",
                                     type: "log",
                                 },
                             ]
@@ -364,7 +372,8 @@ export class Monitor extends React.Component {
         }
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "config", "get", "nsslapd-auditlog", "nsslapd-accesslog", "nsslapd-errorlog", "nsslapd-auditfaillog"
+            "config", "get", "nsslapd-auditlog", "nsslapd-accesslog", "nsslapd-errorlog",
+            "nsslapd-auditfaillog", "nsslapd-securitylog"
         ];
         log_cmd("loadLogLocations", "Get log locations", cmd);
         cockpit
@@ -376,6 +385,7 @@ export class Monitor extends React.Component {
                         auditlogLocation: config.attrs['nsslapd-auditlog'][0],
                         auditfaillogLocation: config.attrs['nsslapd-auditfaillog'][0],
                         errorlogLocation: config.attrs['nsslapd-errorlog'][0],
+                        securitylogLocation: config.attrs['nsslapd-securitylog'][0],
                     });
                 }, this.loadReplicatedSuffixes());
     }
@@ -844,6 +854,12 @@ export class Monitor extends React.Component {
                 monitor_element =
                     <ErrorLogMonitor
                         logLocation={this.state.errorlogLocation}
+                        enableTree={this.enableTree}
+                    />;
+            } else if (this.state.node_name === "security-log-monitor") {
+                monitor_element =
+                    <SecurityLogMonitor
+                        logLocation={this.state.securitylogLocation}
                         enableTree={this.enableTree}
                     />;
             } else if (this.state.node_name === "replication-monitor") {

--- a/src/cockpit/389-console/src/plugins.jsx
+++ b/src/cockpit/389-console/src/plugins.jsx
@@ -657,18 +657,16 @@ export class Plugins extends React.Component {
                 </div>
                 <div hidden={this.state.firstLoad} className={this.state.loading ? "ds-disabled" : ""}>
                     <Grid className="ds-margin-top-xlg" hasGutter>
-                        <GridItem span={3}>
-                            <div>
-                                <Nav key={this.state.pluginTableKey} theme="light" onSelect={this.handleSelect}>
-                                    <NavList>
-                                        {Object.entries(selectPlugins).map(([id, item]) => (
-                                            <NavItem key={item.name} itemId={item.name} isActive={this.state.activePlugin === item.name}>
-                                                {item.icon}
-                                            </NavItem>
-                                        ))}
-                                    </NavList>
-                                </Nav>
-                            </div>
+                        <GridItem span={3} className="ds-vert-scroll">
+                            <Nav key={this.state.pluginTableKey} theme="light" onSelect={this.handleSelect}>
+                                <NavList>
+                                    {Object.entries(selectPlugins).map(([id, item]) => (
+                                        <NavItem key={item.name} itemId={item.name} isActive={this.state.activePlugin === item.name}>
+                                            {item.icon}
+                                        </NavItem>
+                                    ))}
+                                </NavList>
+                            </Nav>
                         </GridItem>
                         <GridItem className="ds-indent-md" span={9}>
                             {Object.entries(selectPlugins).filter(plugin => plugin[1].name === this.state.activePlugin)

--- a/src/cockpit/389-console/src/server.jsx
+++ b/src/cockpit/389-console/src/server.jsx
@@ -10,6 +10,7 @@ import { ServerAccessLog } from "./lib/server/accessLog.jsx";
 import { ServerAuditLog } from "./lib/server/auditLog.jsx";
 import { ServerAuditFailLog } from "./lib/server/auditfailLog.jsx";
 import { ServerErrorLog } from "./lib/server/errorLog.jsx";
+import { ServerSecurityLog } from "./lib/server/securityLog.jsx";
 import { Security } from "./security.jsx";
 import {
     Spinner,
@@ -182,6 +183,11 @@ export class Server extends React.Component {
                         name: "Errors Log",
                         icon: <FontAwesomeIcon size="sm" icon={faBook} />,
                         id: "error-log-config",
+                    },
+                    {
+                        name: "Security Log",
+                        icon: <FontAwesomeIcon size="sm" icon={faBook} />,
+                        id: "security-log-config",
                     }
                 ],
                 defaultExpanded: true
@@ -297,6 +303,15 @@ export class Server extends React.Component {
             } else if (this.state.node_name === "error-log-config") {
                 server_element = (
                     <ServerErrorLog
+                        serverId={this.props.serverId}
+                        attrs={this.state.attrs}
+                        enableTree={this.enableTree}
+                        addNotification={this.props.addNotification}
+                    />
+                );
+            } else if (this.state.node_name === "security-log-config") {
+                server_element = (
+                    <ServerSecurityLog
                         serverId={this.props.serverId}
                         attrs={this.state.attrs}
                         enableTree={this.enableTree}

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -43,6 +43,7 @@ class Config(DSLdapObject):
             'nsslapd-auditfaillog',
             'nsslapd-ldifdir',
             'nsslapd-errorlog',
+            'nsslapd-securitylog',
             'nsslapd-instancedir',
             'nsslapd-lockdir',
             'nsslapd-bakdir',

--- a/src/lib389/lib389/paths.py
+++ b/src/lib389/lib389/paths.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2022 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -84,6 +84,7 @@ CONFIG_MAP = {
     'error_log' : ('cn=config', 'nsslapd-errorlog'),
     'access_log' : ('cn=config', 'nsslapd-accesslog'),
     'audit_log' : ('cn=config', 'nsslapd-auditlog'),
+    'security_log' : ('cn=config', 'nsslapd-securitylog'),
     'ldapi': ('cn=config', 'nsslapd-ldapifilepath'),
     'version': ('', 'vendorVersion'),
 }
@@ -104,6 +105,7 @@ DSE_MAP = {
     'nsslapd-errorlog': 'error_log',
     'nsslapd-accesslog': 'access_log',
     'nsslapd-auditlog': 'audit_log',
+    'nsslapd-securitylog': 'security_log',
     'nsslapd-ldapifilepath': 'ldapi',
     'nsslapd-instancedir': 'inst_dir',
 }
@@ -221,7 +223,7 @@ class Paths(object):
         if result is None or desc is None:
             # keep original exception in unusual cases
             return (err)
-        # Lets create a new exception (with same class) to have current stack without the python-ldap internal stack 
+        # Lets create a new exception (with same class) to have current stack without the python-ldap internal stack
         # And to provide more relevant info that are useful for debug
         info = f"{msg}.\nAdditionnal info is: {info}"
         return (err.__class__({ "result":result, "desc":desc, "info":info}))


### PR DESCRIPTION
Description:

Create a new log using a JSON format that captures in a single line all
the relevant info (client, server, bind dn, event type, etc) related to
security events: Failed/success logins, TCP errors, authorization and
account lockout.

https://www.port389.org/docs/389ds/design/security-audit-log-design.html

relates: https://github.com/389ds/389-ds-base/issues/5335

ASAN: passed

