### PR TITLE
Issue 5373 - dsidm user get_dn fails with search_ext() 

### DIFF
--- a/src/lib389/cli/dsidm
+++ b/src/lib389/cli/dsidm
@@ -147,7 +147,10 @@ if __name__ == '__main__':
         if args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
-            log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
+            if 'desc' in msg:
+                log.error(f"Error: {msg['desc']}")
+            else:
+                log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
         result = False
 
     disconnect_instance(inst)

--- a/src/lib389/lib389/cli_idm/user.py
+++ b/src/lib389/lib389/cli_idm/user.py
@@ -34,7 +34,7 @@ def get(inst, basedn, log, args):
     _generic_get(inst, basedn, log.getChild('_generic_get'), MANY, rdn, args)
 
 def get_dn(inst, basedn, log, args):
-    dn = lambda args: _get_arg( args.dn, msg="Enter dn to retrieve")
+    dn = _get_arg( args.dn, msg="Enter dn to retrieve")
     _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY, dn, args)
 
 def create(inst, basedn, log, args):


### PR DESCRIPTION
Description:  The _get_arg() function was not being properly called when
a DN is not provided.  Also improved the overall error handling when
things go wrong.

relates: https://github.com/389ds/389-ds-base/issues/5373

