### PR TITLE
Issue 5375 - CI - disable TLS hostname checking

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -707,7 +707,6 @@ def backend_list_vlv(inst, basedn, log, args):
                     log.info(' - dn: ' + idx.dn)
                     for k, v in list(entry.items()):
                         log.info(' - {}: {}'.format(ensure_str(k), ensure_str(v[0])))
-                    log.info()
 
     if args.json:
         log.info(json.dumps({"type": "list", "items": results}, indent=4))

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -19,6 +19,7 @@ from lib389.nss_ssl import NssSsl
 from lib389._constants import *
 from lib389.cli_base import LogCapture
 
+TLS_HOSTNAME_CHECK = os.getenv('TLS_HOSTNAME_CHECK', default=True)
 DEBUGGING = os.getenv('DEBUGGING', default=False)
 if DEBUGGING:
     logging.getLogger(__name__).setLevel(logging.DEBUG)
@@ -107,6 +108,10 @@ def _create_instances(topo_dict, suffix):
             # configured in a FIPS compliant way
             if is_fips():
                 instance.enable_tls()
+
+            # Disable strict hostname checking for TLS
+            if not TLS_HOSTNAME_CHECK:
+                instance.config.set('nsslapd-ssl-check-hostname', 'off')
             if DEBUGGING:
                 instance.config.set('nsslapd-errorlog-level','8192')
                 instance.config.set('nsslapd-accesslog-level','260')


### PR DESCRIPTION
Description:  
For CI tests we should disable TLS hostname checking
because our testing environments are fragile and TLS issues occur often.

relates: https://github.com/389ds/389-ds-base/issues/5375
