### PR TITLE
Issue 5322 - optime & wtime on rejected connections is not properly set

### DIFF
--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -564,6 +564,9 @@ connection_dispatch_operation(Connection *conn, Operation *op, Slapi_PBlock *pb)
         ber_sockbuf_ctrl(conn->c_sb, LBER_SB_OPT_SET_MAX_INCOMING, &maxbersize);
     }
 
+    /* Set the start time */
+    slapi_operation_set_time_started(op);
+
     /* If the minimum SSF requirements are not met, only allow
      * bind and extended operations through.  The bind and extop
      * code will ensure that only SASL binds and startTLS are


### PR DESCRIPTION
Description:  We were not setting the operation start time before
aborting a connection because of minssf or anonymous access being
denied.  This can lead to an overflow and unexpected values for
the wtime & optime keywords in the access log.

relates: https://github.com/389ds/389-ds-base/issues/5322

