### PR TITLE
Issue 4324 - Change entry monitor to recursive pthread mutex

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -337,7 +337,7 @@ struct backentry
     void *ep_dn_link;               /* linkage for the 3 hash */
     void *ep_id_link;               /*     tables used for */
     void *ep_uuid_link;             /*     looking up entries */
-    PRMonitor *ep_mutexp;           /* protection for mods; make it reentrant */
+    pthread_mutex_t *ep_mutexp __attribute__((__aligned__(64))); /* protection for mods; make it reentrant */
 };
 
 /* From ep_type through ep_create_time MUST be identical to backcommon */

--- a/ldap/servers/slapd/back-ldbm/backentry.c
+++ b/ldap/servers/slapd/back-ldbm/backentry.c
@@ -29,7 +29,7 @@ backentry_free(struct backentry **bep)
         slapi_entry_free(ep->ep_entry);
     }
     if (ep->ep_mutexp != NULL) {
-        PR_DestroyMonitor(ep->ep_mutexp);
+        slapi_pthread_mutex_free(&ep->ep_mutexp);
     }
     slapi_ch_free((void **)&ep);
     *bep = NULL;


### PR DESCRIPTION
Description: We've changed the entry cache monitor from PR_Monitor
to pthread recursive mutex. The entry lock is also protected
with with recursive mutex, which is implemented using PR_Monitor (NSPR).
Now, when we try to lock entry in cache_lock_entry we may stumble on
another bottleneck as entry lock still uses NSPR while entry cache
mutex uses a more performant pthread recursive mutex.

Fix Description:
Change the ep_mutexp from PR_Monitor to pthread recursive mutex.

Related: https://github.com/389ds/389-ds-base/issues/4324

Reviewed by: ?