### PR TITLE
Issue 5386 - BUG - Update sudoers schema to correctly support UTF-8

### DIFF
--- a/ldap/schema/60sudo.ldif
+++ b/ldap/schema/60sudo.ldif
@@ -9,9 +9,9 @@ attributeTypes: (
   1.3.6.1.4.1.15953.9.1.1
   NAME 'sudoUser'
   DESC 'User(s) who may  run sudo'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  EQUALITY caseExactMatch
+  SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   X-ORIGIN 'SUDO' )
 #
 ################################################################################
@@ -60,8 +60,8 @@ attributeTypes: (
 attributeTypes: ( 1.3.6.1.4.1.15953.9.1.6
   NAME 'sudoRunAsUser'
   DESC 'User(s) impersonated by sudo'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   X-ORIGIN 'SUDO' )
 #
 ################################################################################
@@ -69,8 +69,8 @@ attributeTypes: ( 1.3.6.1.4.1.15953.9.1.6
 attributeTypes: ( 1.3.6.1.4.1.15953.9.1.7
   NAME 'sudoRunAsGroup'
   DESC 'Group(s) impersonated by sudo'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   X-ORIGIN 'SUDO' )
 #
 ################################################################################


### PR DESCRIPTION
Bug Description: It was found by a SUSE customer, that an inconsistency between ldap core schemas
and sudoers existed. This was due to items like uid and cn being UTF-8, but sudoUser and other
types were IA5 only. This created a scenario where sudo rules in ldap were failing due to incorrect
matching being applied (trying to match a UTF8 type with IA5 rules.).

Fix Description: Since UTF-8 is a superset of IA5 the sudoers schema can be expanded to support
UTF-8 without any other changes. This was discussed with the sudo maintainers at SUSE, and the sudo
project itself accepted the changes to the schema. Since we ship a copy of the schema, we should
update to be in line.

fixes: https://github.com/389ds/389-ds-base/issues/5386

Author: William Brown <william@blackhats.net.au>

Review by: ???