### PR TITLE
Issue 4308 - checking if an entry is a referral is expensive

### DIFF
--- a/ldap/servers/plugins/replication/repl5_total.c
+++ b/ldap/servers/plugins/replication/repl5_total.c
@@ -705,7 +705,7 @@ decode_total_update_extop(Slapi_PBlock *pb, Slapi_Entry **ep)
         bv.bv_val = "ldapsubentry";
         bv.bv_len = strlen(bv.bv_val);
         if (slapi_attr_value_find(attr, &bv) == 0) {
-            slapi_entry_set_flag(e, SLAPI_ENTRY_LDAPSUBENTRY);
+            slapi_entry_set_flag(e, SLAPI_ENTRY_FLAG_LDAPSUBENTRY);
         }
         bv.bv_val = SLAPI_ATTR_VALUE_TOMBSTONE;
         bv.bv_len = strlen(bv.bv_val);

--- a/ldap/servers/plugins/replication/urp.c
+++ b/ldap/servers/plugins/replication/urp.c
@@ -1369,7 +1369,7 @@ urp_add_new_entry_to_conflict (Slapi_PBlock *pb, char *sessionid, Slapi_Entry *a
                 slapi_value_init_berval(new_v, &bv);
                 slapi_attr_add_value(attr, new_v);
                 slapi_value_free(&new_v);
-                slapi_entry_set_flag(addentry, SLAPI_ENTRY_LDAPSUBENTRY);
+                slapi_entry_set_flag(addentry, SLAPI_ENTRY_FLAG_LDAPSUBENTRY);
             }
         }
         /* add or replace the conflict csn */

--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -1060,7 +1060,7 @@ check_oc_subentry(Slapi_Entry *e, struct berval **vals, char *normtype)
     PRBool subentry = PR_TRUE;
     for (n = 0; vals != NULL && vals[n] != NULL; n++) {
         if ((strcasecmp(normtype, "objectclass") == 0) && (strncasecmp((const char *)vals[n]->bv_val, "ldapsubentry", vals[n]->bv_len) == 0)) {
-            e->e_flags |= SLAPI_ENTRY_LDAPSUBENTRY;
+            e->e_flags |= SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
             subentry = PR_FALSE;
             break;
         }

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -1115,6 +1115,7 @@ entrycache_replace(struct cache *cache, struct backentry *olde, struct backentry
 #endif
     size_t entry_size = 0;
     struct backentry *alte = NULL;
+    Slapi_Attr *attr = NULL;
 
     LOG("=> entrycache_replace (%s) -> (%s)\n", backentry_get_ndn(olde),
         backentry_get_ndn(newe));
@@ -1130,6 +1131,14 @@ entrycache_replace(struct cache *cache, struct backentry *olde, struct backentry
 #endif
     newndn = slapi_sdn_get_ndn(backentry_get_sdn(newe));
     entry_size = cache_entry_size(newe);
+
+    /* Might have added/removed a referral */
+    if (slapi_entry_attr_find(newe->ep_entry, "ref", &attr) && attr) {
+        slapi_entry_set_flag(newe->ep_entry, SLAPI_ENTRY_FLAG_REFERRAL);
+    } else {
+        slapi_entry_clear_flag(newe->ep_entry, SLAPI_ENTRY_FLAG_REFERRAL);
+    }
+
     cache_lock(cache);
 
     /*
@@ -1424,6 +1433,7 @@ entrycache_add_int(struct cache *cache, struct backentry *e, int state, struct b
     struct backentry *my_alt;
     size_t entry_size = 0;
     int already_in = 0;
+    Slapi_Attr *attr = NULL;
 
     LOG("=> entrycache_add_int( \"%s\", %ld )\n", backentry_get_ndn(e),
         (long int)e->ep_id);
@@ -1436,6 +1446,13 @@ entrycache_add_int(struct cache *cache, struct backentry *e, int state, struct b
         entry_size = cache_entry_size(e);
     } else {
         entry_size = e->ep_size;
+    }
+    /* Check for referrals now so we don't have to do it for every base
+     * search in the future */
+    if (slapi_entry_attr_find(e->ep_entry, "ref", &attr) && attr) {
+        slapi_entry_set_flag(e->ep_entry, SLAPI_ENTRY_FLAG_REFERRAL);
+    } else {
+        slapi_entry_clear_flag(e->ep_entry, SLAPI_ENTRY_FLAG_REFERRAL);
     }
 
     cache_lock(cache);

--- a/ldap/servers/slapd/back-ldbm/findentry.c
+++ b/ldap/servers/slapd/back-ldbm/findentry.c
@@ -32,8 +32,13 @@ check_entry_for_referral(Slapi_PBlock *pb, Slapi_Entry *entry, char *matched, co
     struct berval **url = NULL;
 
     /* if the entry is a referral send the referral */
+    if (!slapi_entry_flag_is_set(entry, SLAPI_ENTRY_FLAG_REFERRAL)) {
+        return 0;
+    }
+
     if (slapi_entry_attr_find(entry, "ref", &attr)) {
-        // ref attribute not found
+        // ref attribute not found (should not happen)
+        PR_ASSERT(0);
         goto out;
     }
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -395,10 +395,10 @@ modify_apply_check_expand(
                     switch ( mods[i]->mod_op & ~LDAP_MOD_BVALUES ) {
                     case LDAP_MOD_ADD:
                     case LDAP_MOD_REPLACE:
-                        ec->ep_entry->e_flags |= SLAPI_ENTRY_LDAPSUBENTRY;
+                        ec->ep_entry->e_flags |= SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
                         break;
                     case LDAP_MOD_DELETE:
-                        ec->ep_entry->e_flags &= ~SLAPI_ENTRY_LDAPSUBENTRY;
+                        ec->ep_entry->e_flags &= ~SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
                         break;
                     }
                     break;

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1695,7 +1695,7 @@ ldbm_back_next_search_entry(Slapi_PBlock *pb)
                  * because whereas the former should be read as 'no entry must be returned', the latter
                  * might still lead to return an empty entry. */
 
-                if (slapi_entry_flag_is_set(e->ep_entry, SLAPI_ENTRY_LDAPSUBENTRY)) {
+                if (slapi_entry_flag_is_set(e->ep_entry, SLAPI_ENTRY_FLAG_LDAPSUBENTRY)) {
                     /* If the entry is an LDAP subentry and RFC 3672 Subentries control is present
                      * and its value is set to false OR filter don't filter subentries
                      */

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -428,7 +428,7 @@ str2entry_fast(const char *rawdn, const Slapi_RDN *srdn, const char *s, int flag
 
         if (value_state == VALUE_PRESENT && type.bv_len >= SLAPI_ATTR_OBJECTCLASS_LENGTH && PL_strncasecmp(type.bv_val, SLAPI_ATTR_OBJECTCLASS, type.bv_len) == 0) {
             if (value.bv_len >= SLAPI_ATTR_VALUE_SUBENTRY_LENGTH && PL_strncasecmp(value.bv_val, SLAPI_ATTR_VALUE_SUBENTRY, value.bv_len) == 0)
-                e->e_flags |= SLAPI_ENTRY_LDAPSUBENTRY;
+                e->e_flags |= SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
             if (value.bv_len >= SLAPI_ATTR_VALUE_TOMBSTONE_LENGTH && PL_strncasecmp(value.bv_val, SLAPI_ATTR_VALUE_TOMBSTONE, value.bv_len) == 0)
                 e->e_flags |= SLAPI_ENTRY_FLAG_TOMBSTONE;
         }
@@ -949,7 +949,7 @@ str2entry_dupcheck(const char *rawdn, const char *s, int flags, int read_statein
 
         if (strcasecmp(type, "objectclass") == 0) {
             if (strcasecmp(valuecharptr, "ldapsubentry") == 0)
-                e->e_flags |= SLAPI_ENTRY_LDAPSUBENTRY;
+                e->e_flags |= SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
             if (strcasecmp(valuecharptr, SLAPI_ATTR_VALUE_TOMBSTONE) == 0)
                 e->e_flags |= SLAPI_ENTRY_FLAG_TOMBSTONE;
         }
@@ -3604,7 +3604,7 @@ entry_apply_mod(Slapi_Entry *e, const LDAPMod *mod)
     case LDAP_MOD_ADD:
         slapi_log_err(SLAPI_LOG_ARGS, "entry_apply_mod", "add: %s\n", mod->mod_type);
         if (sawsubentry)
-            e->e_flags |= SLAPI_ENTRY_LDAPSUBENTRY;
+            e->e_flags |= SLAPI_ENTRY_FLAG_LDAPSUBENTRY;
         err = slapi_entry_add_values(e, mod->mod_type, mod->mod_bvalues);
         break;
 
@@ -4055,7 +4055,6 @@ slapi_entries_diff(Slapi_Entry **old_entries, Slapi_Entry **curr_entries, int te
     char *my_logging_prestr = "";
     Slapi_Entry **oep, **cep;
     int rval = 0;
-#define SLAPI_ENTRY_FLAG_DIFF_IN_BOTH 0x80
 
     if (NULL != logging_prestr && '\0' != *logging_prestr) {
         my_logging_prestr = slapi_ch_smprintf("%s ", logging_prestr);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -2248,7 +2248,10 @@ int slapi_entry_rename(Slapi_Entry *e, const char *newrdn, int deleteoldrdn, Sla
  * \see slapi_entry_set_flag()
  * \see slapi_entry_clear_flag()
  */
-#define SLAPI_ENTRY_FLAG_TOMBSTONE 1
+#define SLAPI_ENTRY_FLAG_TOMBSTONE    0x1
+#define SLAPI_ENTRY_FLAG_LDAPSUBENTRY 0x2
+#define SLAPI_ENTRY_FLAG_DIFF_IN_BOTH 0x4
+#define SLAPI_ENTRY_FLAG_REFERRAL     0x8
 
 /**
  * Determines if certain flags are set for a specified entry.

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -61,9 +61,6 @@ typedef enum _slapi_filter_flags_t {
     SLAPI_FILTER_INVALID_ATTR_WARN = 64,
 } slapi_filter_flags;
 
-#define SLAPI_ENTRY_LDAPSUBENTRY 2
-
-
 /*
     Optimized filter path. For example the following code was lifted from int.c (syntaxes plugin):
 


### PR DESCRIPTION
Description:

When updating the entry cache check if the entry has a smart referral, if
so set a flag so we don't have to do the referral check for future
searches.

relates: https://github.com/389ds/389-ds-base/issues/4308

