### PR TITLE
Issue 5394 - configure doesn't check for lmdb and json-c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,8 @@ AC_CHECK_HEADERS([arpa/inet.h errno.h fcntl.h malloc.h netdb.h netinet/in.h stdl
 # These are *required* headers without option.
 AC_CHECK_HEADERS([inttypes.h], [], AC_MSG_ERROR([unable to locate required header inttypes.h]))
 AC_CHECK_HEADERS([crack.h], [], AC_MSG_ERROR([unable to locate required header crack.h]))
+AC_CHECK_HEADERS([lmdb.h], [], AC_MSG_ERROR([unable to locate required header lmdb.h]))
+AC_CHECK_HEADERS([json-c/json.h], [], AC_MSG_ERROR([unable to locate required header json-c/json.h]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT


### PR DESCRIPTION
Description:
After a successful ./configure with no options, build fails with:

```
In file included from ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c:15:
ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h:13:10: fatal error: lmdb.h: No such file or directory
   13 | #include <lmdb.h>
      |          ^~~~~~~~
compilation terminated.
make[1]: *** [Makefile:7679: ldap/servers/slapd/back-ldbm/db-mdb/libback_ldbm_la-mdb_config.lo] Error 1
make[1]: Leaving directory '/home/debian/ds'
make: *** [Makefile:4013: all] Error 2
```

and then with

```
ldap/servers/slapd/log.c:34:10: fatal error: json-c/json.h: No such file or directory
   34 | #include <json-c/json.h>
      |          ^~~~~~~~~~~~~~~

```

Fix Description:
We should check for presence of lmdb.h and json-c/json.h

Fixes: https://github.com/389ds/389-ds-base/issues/5394

Reviewed by: ???