### PR TITLE
Issue 5399 - UI - LDAP Editor is not updated when we switch instances

### DIFF
--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -60,6 +60,7 @@ export class LDAPEditor extends React.Component {
 
         this.state = {
             activeTabKey: 0,
+            firstLoad: true,
             keyIndex: 0,
             suffixList: [],
             changeLayout: false,
@@ -250,6 +251,12 @@ export class LDAPEditor extends React.Component {
             addNotification: this.props.addNotification,
         };
 
+        if (this.state.firstLoad) {
+            this.setState({
+                firstLoad: false
+            });
+        }
+
         this.setState({
             searching: true,
             loading: refresh
@@ -361,6 +368,18 @@ export class LDAPEditor extends React.Component {
                 allObjectclasses: ocs,
             }, () => { this.getAttributes(this.showSuffixes) });
         });
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.wasActiveList.includes(7)) {
+            if (this.state.firstLoad) {
+                this.handleReload(true);
+            } else {
+                if (this.props.serverId !== prevProps.serverId) {
+                    this.handleReload(true);
+                }
+            }
+        }
     }
 
     getPageData (page, perPage) {

--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -765,6 +765,7 @@ export class DSInstance extends React.Component {
                                     key="ldap-editor"
                                     addNotification={this.addNotification}
                                     serverId={this.state.serverId}
+                                    wasActiveList={this.state.wasActiveList}
                                     setPageSectionVariant={this.setPageSectionVariant}
                                 />
                             </Tab>


### PR DESCRIPTION
Description: We don't refresh LDAP Editor when we switch instances.
It may lead to unpleasant errors.

Add componentDidUpdate function with the appropriate processing and
properties.

Fixes: https://github.com/389ds/389-ds-base/issues/5399

Reviewed by: ?