### PR TITLE
Issue 5397 - Fix various memory leaks

### DIFF
--- a/ldap/servers/plugins/replication/repl5_connection.c
+++ b/ldap/servers/plugins/replication/repl5_connection.c
@@ -249,6 +249,7 @@ conn_delete_internal(Repl_Connection *conn)
     slapi_ch_free_string(&conn->last_ldap_errmsg);
     slapi_ch_free((void **)&conn->hostname);
     slapi_ch_free((void **)&conn->binddn);
+    slapi_ch_free((void **)&conn->creds);
     slapi_ch_free((void **)&conn->plain);
 }
 

--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -395,6 +395,7 @@ slapi_exists_or_add_internal(
     if (search_result == LDAP_SUCCESS) {
         slapi_pblock_get(search_pb, SLAPI_NENTRIES, &search_nentries);
     }
+    slapi_free_search_results_internal(search_pb);
     slapi_pblock_destroy(search_pb);
 
     slapi_log_error(SLAPI_LOG_DEBUG, "slapi_exists_or_add_internal", "search_internal result -> %d, %d\n", search_result, search_nentries);

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1945,6 +1945,7 @@ delete_search_result_set(Slapi_PBlock *pb, back_search_result_set **sr)
                       rc, filt_errs);
     }
     slapi_filter_free((*sr)->sr_norm_filter, 1);
+    slapi_filter_free((*sr)->sr_norm_filter_intent, 1);
     memset(*sr, 0, sizeof(back_search_result_set));
     slapi_ch_free((void **)sr);
     return;


### PR DESCRIPTION
Description:

Fixed memory leaks in:

- Upgrade code when we check if an expected plugin is present, we didn't
  free the search results.
- Filter optimizer introduced sr_norm_filter_intent which dupped a filter
  but never freed it.
- Replication connections would leak the replication manager's
  credentials.

relates: https://github.com/389ds/389-ds-base/issues/5397

