### PR TITLE
Issue 5403 - Memory leak in conntection table mulit list

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -214,6 +214,9 @@ connection_table_free(Connection_Table *ct)
             Connection *c = &(ct->c[ct_list][i]);
             connection_done(c);
         }
+
+        slapi_ch_free((void **)&ct->c[ct_list]);
+        slapi_ch_free((void **)&ct->fd[ct_list]);
     }
     slapi_ch_free((void **)&ct->c);
     slapi_ch_free((void **)&ct->fd);


### PR DESCRIPTION
Bug description: Memory leaks were introduced as part of the
connection table multi list feature.

Fixes: https://github.com/389ds/389-ds-base/issues/5403

Reviewed by: ?