### PR TITLE
Issue 5385 - LMDB - import crash in rdncache_add_elem

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_rdncache.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_rdncache.c
@@ -94,11 +94,11 @@ rdncache_elem_release(RDNcacheElem_t **elem)
 RDNcache_t *
 rdncache_init(ImportCtx_t *ctx)
 {
-	RDNcache_t *cache = CALLOC(RDNcache_t);
+    RDNcache_t *cache = CALLOC(RDNcache_t);
     cache->ctx = ctx;
     pthread_mutex_init(&cache->mutex, NULL);
     pthread_cond_init(&cache->condvar, NULL);
-	cache->cur = rdncache_new_head(cache);
+    cache->cur = rdncache_new_head(cache);
     cache->prev = rdncache_new_head(cache);
     return cache;
 }
@@ -180,8 +180,8 @@ rdncache_index_lookup_by_id(RDNcache_t *cache,  ID entryid)
     RDNcacheElem_t *elem = NULL;
     ImportCtx_t *ctx = cache->ctx;
     backend *be = ctx->job->inst->inst_be;
-	MDB_val key = {0};
-	MDB_val data = {0};
+    MDB_val key = {0};
+    MDB_val data = {0};
     dbmdb_cursor_t cur = {0};
     char key_str[10];
     int nrdnlen = 0;
@@ -225,8 +225,8 @@ rdncache_index_lookup_by_rdn(RDNcache_t *cache,  ID parentid, int _nrdnlen, cons
     backend *be = ctx->job->inst->inst_be;
     char *elem2search = NULL;
     dbmdb_cursor_t cur = {0};
-	MDB_val data = {0};
-	MDB_val key = {0};
+    MDB_val data = {0};
+    MDB_val key = {0};
     char *nrdn = NULL;
     char *rdn = NULL;
     char key_str[10];
@@ -388,7 +388,7 @@ rdncache_add_elem(RDNcache_t *cache, WorkerQueueData_t *slot, ID entryid, ID par
     rdncache_wait4older_slots(cache, slot);
     elem = rdncache_new_elem(cache->cur, entryid, parentid, nrdnlen, nrdn, rdnlen, rdn, slot);
     elem = rdncache_elem_get(elem);
-	RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
+    RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
     return elem;
 }
 
@@ -429,7 +429,7 @@ RDNcacheElem_t *rdncache_id_lookup(RDNcache_t *cache,  WorkerQueueData_t *slot, 
     RDNcacheElem_t *elem = NULL;
     int idx;
 
-	RDNCACHE_MUTEX_LOCK(&cache->mutex);
+    RDNCACHE_MUTEX_LOCK(&cache->mutex);
     idx = rdncache_lookup_by_id(cache->cur, entryid);
     if (idx >= 0) {
         elem = cache->cur->head_per_id[idx];
@@ -457,7 +457,7 @@ RDNcacheElem_t *rdncache_id_lookup(RDNcache_t *cache,  WorkerQueueData_t *slot, 
     }
     /* increase refcount while still holding the lock */
     elem = rdncache_elem_get(elem);
-	RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
+    RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
     return elem;
 }
 
@@ -507,7 +507,7 @@ RDNcacheElem_t *rdncache_rdn_lookup(RDNcache_t *cache,  WorkerQueueData_t *slot,
     }
     /* increase refcount while still holding the lock */
     elem = rdncache_elem_get(elem);
-	RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
+    RDNCACHE_MUTEX_UNLOCK(&cache->mutex);
     return elem;
 }
 


### PR DESCRIPTION
Problem: 
   The mutex that protects against rdn cache rotation is released within rdncache_add_elem by a call to
     safe_cond_wait within rdncache_new_elem function, so in case of cache rotation the variable set before  safe_cond_wait may
     reference freed data. 
Solution:
    assertion are added around the mutex lock/unlock (because at first I suspected a problem of reentrance)
    The code that wait that entryrdn of parent entries get computed has been separated from the rdncache_new_elem
    and called before calling rdncache_new_elem so there is no reference toward the cached data while releasing the mutex
    (note: there was no issue in the other function that used safe_cond_wait because they are lookup function 
        without reference to the cached data when releasing the mutex) but I replaced the waiting code anyway (for consistency))

Issue: [5385](https://github.com/389ds/389-ds-base/issues/5385)

Reviewed by: @mreynolds389 
