### PR TITLE
Issue 1338 - nsslapd-changelogtrim-interval is not applied immediately

### DIFF
--- a/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
@@ -8,6 +8,7 @@ from lib389.properties import *
 from lib389.topologies import topology_m1 as topo
 from lib389.replica import Changelog5
 from lib389.idm.domain import Domain
+from lib389.utils import ds_supports_new_changelog
 
 pytestmark = pytest.mark.tier1
 


### PR DESCRIPTION
Description:
Fixed import statement in branch 1.4.3 so we don't have these tests failing

Relates: https://github.com/389ds/389-ds-base/issues/1338

Reviewed by: aadhikar (Thanks!)