### PR TITLE
Issue 4588 - Gost yescrypt may fail to build on some older versions o…

### DIFF
--- a/dirsrvtests/tests/suites/attr_encryption/attr_encryption_test.py
+++ b/dirsrvtests/tests/suites/attr_encryption/attr_encryption_test.py
@@ -47,7 +47,7 @@ def enable_user_attr_encryption(topo, request):
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     test_user = users.create(properties=TEST_USER_PROPERTIES)
     test_user.replace('employeeNumber', '1000')
-    test_user.replace('telephonenumber', '1234567890')
+    test_user.replace('telephoneNumber', '1234567890')
 
     def fin():
         log.info("Remove attribute encryption for various attributes")
@@ -137,8 +137,8 @@ def test_export_import_ciphertext(topo, enable_user_attr_encryption):
     log.info("Check that the encrypted value of attribute is not present in the exported file")
     with open(export_ldif, 'r') as ldif_file:
         ldif = ldif_file.read()
-        assert 'telephonenumber' in ldif
-        assert 'telephonenumber: 1234567890' not in ldif
+        assert 'telephoneNumber' in ldif
+        assert 'telephoneNumber: 1234567890' not in ldif
 
     log.info("Delete the test user entry with encrypted data")
     enable_user_attr_encryption.delete()

--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -136,6 +136,9 @@ def test_pwd_algo_test(topology_st, algo):
     if algo == 'DEFAULT':
         if ds_is_older('1.4.0'):
             pytest.skip("Not implemented")
+    if algo == 'GOST_YESCRYPT':
+        if ds_is_older('2.0.1'):
+            pytest.skip("Not Supported")
     _test_algo(topology_st.standalone, algo)
     log.info('Test %s PASSED' % algo)
 


### PR DESCRIPTION
…f glibc

Description: Fixed the test case for older version, also fixed another test
case which had wrong attribute name: telephonenumber

Relates: https://github.com/389ds/389-ds-base/issues/4588

Reviewed by: bsimonova (Thanks!)