### PR TITLE
Issue 5407 - sync_repl crashes if enabled while dynamic plugin is ena…

### DIFF
--- a/ldap/servers/plugins/sync/sync_persist.c
+++ b/ldap/servers/plugins/sync/sync_persist.c
@@ -154,6 +154,17 @@ ignore_op_pl(Slapi_PBlock *pb)
      * This is the same for ident
      */
     prim_op = get_thread_primary_op();
+    if (prim_op == NULL) {
+        /* This can happen if the PRE_OP (sync_update_persist_betxn_pre_op) was not called.
+         * The only known case it happens is with dynamic plugin enabled and an
+         * update that enable the sync_repl plugin. In such case sync_repl registers
+         * the postop (sync_update_persist_op) that is called while the preop was not called
+         */
+        slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM,
+              "ignore_op_pl - Operation without primary op set (0x%lx)\n",
+              (ulong) op);
+        return;
+    }
     ident = sync_persist_get_operation_extension(pb);
 
     if (ident) {
@@ -230,8 +241,18 @@ sync_update_persist_op(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eprev, ber
 
 
     prim_op = get_thread_primary_op();
+    if (prim_op == NULL) {
+        /* This can happen if the PRE_OP (sync_update_persist_betxn_pre_op) was not called.
+         * The only known case it happens is with dynamic plugin enabled and an
+         * update that enable the sync_repl plugin. In such case sync_repl registers
+         * the postop (sync_update_persist_op) that is called while the preop was not called
+         */
+        slapi_log_err(SLAPI_LOG_PLUGIN, SYNC_PLUGIN_SUBSYSTEM,
+                      "sync_update_persist_op - Operation without primary op set (0x%lx)\n",
+                      (ulong) pb_op);
+        return;
+    }
     ident = sync_persist_get_operation_extension(pb);
-    assert(prim_op);
 
     if ((ident == NULL) && operation_is_flag_set(pb_op, OP_FLAG_NOOP)) {
         /* This happens for URP (add cenotaph, fixup rename, tombstone resurrect)


### PR DESCRIPTION
…bled

Bug description:
	When dynamic plugin is enabled, if a MOD enables sync_repl plugin
	then sync_repl init function registers the postop callback
        that will be called for the MOD itself while the preop
        has not been called.
        postop expects preop to be called and so primary operation
        to be set. When it is not set it crashes

Fix description:
	If the primary operation is not set, just return

relates: #5407

Reviewed by: