### PR TITLE
Issue 5412 - lib389 - do not set backend name to lowercase

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -25,6 +25,8 @@ from lib389.rootdse import RootDSE
 from ....conftest import get_rpm_version
 from lib389._mapped_object import DSLdapObjects
 from lib389.replica import Replicas, Changelog
+from lib389.backend import Backends
+from lib389.idm.domain import Domain
 
 
 pytestmark = pytest.mark.tier0
@@ -1475,6 +1477,36 @@ def test_ldbm_modification_audit_log(topology_st):
         assert conn.searchAuditLog('replace: %s' % attr)
         assert conn.searchAuditLog('%s: %s' % (attr, VALUE))
 
+
+def test_suffix_case(topology_st):
+    """Test that the suffix case is preserved when creating a new backend
+
+    :id: 4eff15be-6cde-4312-b492-c88941876bda
+    :setup: Standalone Instance
+    :steps:
+        1. Create backend with uppercase characters
+        2. Create root node entry
+        3. Search should return suffix with upper case characters
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    # Start with a clean slate
+    topology_st.standalone.restart()
+
+    TEST_SUFFIX = 'dc=UPPER_CASE'
+
+    backends = Backends(topology_st.standalone)
+    backends.create(properties={'nsslapd-suffix': TEST_SUFFIX,
+                                'name': 'upperCaseRoot',
+                                'sample_entries': '001004002'})
+                           
+    domain = Domain(topology_st.standalone, TEST_SUFFIX)
+    assert domain.dn == TEST_SUFFIX
+
+    
 def test_dscreate(request):
     """Test that dscreate works
 

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -608,8 +608,7 @@ class Backend(DSLdapObject):
             dn = ",".join(dn_comps)
 
         if properties is not None:
-            suffix_dn = properties['nsslapd-suffix'].lower()
-            dn_comps = ldap.dn.explode_dn(suffix_dn)
+            dn_comps = ldap.dn.explode_dn(properties['nsslapd-suffix'])
             ndn = ",".join(dn_comps)
             properties['nsslapd-suffix'] = ndn
             sample_entries = properties.pop(BACKEND_SAMPLE_ENTRIES, False)


### PR DESCRIPTION
Description:

There is no reason to set a new suffix to lowercase.  The server
will correctly handle the case, and some customers, especially
with migrations, want to have the base suffix a certain case.

relates: https://github.com/389ds/389-ds-base/issues/5412
