### PR TITLE
Issue 5415 - Hostname when set to localhost causing failures in other…

### DIFF
--- a/dirsrvtests/tests/suites/acl/keywords_part2_test.py
+++ b/dirsrvtests/tests/suites/acl/keywords_part2_test.py
@@ -20,6 +20,7 @@ from lib389._constants import DEFAULT_SUFFIX, PW_DM
 from lib389.idm.domain import Domain
 from lib389.idm.organizationalunit import OrganizationalUnit
 from lib389.idm.user import UserAccount
+from lib389.utils import *
 
 pytestmark = pytest.mark.tier1
 
@@ -39,7 +40,7 @@ NIGHTWORKER_KEY = "uid=NIGHTWORKER_KEY,{}".format(TIMEOFDAY_OU_KEY)
 NOWORKER_KEY = "uid=NOWORKER_KEY,{}".format(TIMEOFDAY_OU_KEY)
 
 
-def test_access_from_certain_network_only_ip(topo, add_user, aci_of_user):
+def test_access_from_certain_network_only_ip(topo, add_user, aci_of_user, request):
     """
     User can access the data when connecting from certain network only as per the ACI.
 
@@ -95,8 +96,14 @@ def test_access_from_certain_network_only_ip(topo, add_user, aci_of_user):
     with pytest.raises(ldap.INSUFFICIENT_ACCESS):
         org.replace("seeAlso", "cn=1")
 
+    def fin():
+        log.info('Setting the hostname back to orginal')
+        socket.sethostname(old_hostname)
 
-def test_connection_from_an_unauthorized_network(topo, add_user, aci_of_user):
+    request.addfinalizer(fin)
+
+
+def test_connection_from_an_unauthorized_network(topo, add_user, aci_of_user, request):
     """
     User cannot access the data when connectin from an unauthorized network as per the ACI.
 
@@ -144,6 +151,12 @@ def test_connection_from_an_unauthorized_network(topo, add_user, aci_of_user):
 
     # now user can access data
     org.replace("seeAlso", "cn=1")
+
+    def fin():
+        log.info('Setting the hostname back to orginal')
+        socket.sethostname(old_hostname)
+
+    request.addfinalizer(fin)
 
 
 def test_ip_keyword_test_noip_cannot(topo, add_user, aci_of_user):

--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -72,6 +72,7 @@ def create_user(topology_st, request):
     def fin():
         log.info('Deleting user simplepaged_test')
         user.delete()
+        socket.sethostname(OLD_HOSTNAME)
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
… tests

Description: When the hostname is set to localhost it is causing failures
in other test suites like replication

Fixes: https://github.com/389ds/389-ds-base/issues/5415

Reviewed by: @bsimonova, @tbordaz (Thanks!)