### PR TITLE
Issue 5012 - Migrate pcre to pcre2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1993,7 +1993,6 @@ fixupcmd = sed \
 	-e 's,@db_libdir\@,$(db_libdir),g' \
 	-e 's,@db_bindir\@,$(db_bindir),g' \
 	-e 's,@netsnmp_libdir\@,$(netsnmp_libdir),g' \
-	-e 's,@pcre_libdir\@,$(pcre_libdir),g' \
 	-e 's,@propertydir\@,$(propertydir),g' \
 	-e 's,@datadir\@,$(datadir),g' \
 	-e 's,@schemadir\@,$(schemadir),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -847,14 +847,17 @@ if test "$krb5_vendor" = "MIT"; then
     LIBS="$save_LIBS"
 fi
 
-if $PKG_CONFIG --exists pcre; then
-    PKG_CHECK_MODULES([PCRE], [pcre])
-    pcre_libdir=`$PKG_CONFIG --libs-only-L pcre | sed -e s/-L// | sed -e s/\ .*$//`
-else
-    PKG_CHECK_MODULES([PCRE], [libpcre])
-    pcre_libdir=`$PKG_CONFIG --libs-only-L libpcre | sed -e s/-L// | sed -e s/\ .*$//`
-fi
-AC_SUBST(pcre_libdir)
+PKG_CHECK_MODULES(
+    [PCRE],
+    [libpcre2-8],
+    [
+        AC_DEFINE(
+            [PCRE2_CODE_UNIT_WIDTH],
+            8,
+            [Define libpcre2 unit size]
+        )
+    ]
+)
 
 m4_include(m4/selinux.m4)
 m4_include(m4/systemd.m4)

--- a/dirsrvtests/tests/suites/automember_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/basic_test.py
@@ -914,6 +914,8 @@ def test_automemtask_re_build_task(topo, _create_all_entries, _startuptask, _fix
         'basedn': auto_mem_scope,
         'filter': "objectClass=posixAccount"
     })
+    time.sleep(10)
+
     # Search for any error logs
     assert not supplier.searchErrorsLog(error_string)
     for grp in (managers_grp, contract_grp):
@@ -1042,6 +1044,7 @@ def test_automemtask_re_build(topo, _create_all_entries, _startuptask, _fixture_
         'basedn': auto_mem_scope,
         'filter': "objectClass=inetOrgPerson"
     })
+    time.sleep(10)
     with pytest.raises(AssertionError):
         bulk_check_groups(supplier, managers_grp, "member", 10)
 
@@ -1121,7 +1124,7 @@ def test_automemtask_run_re_build(topo, _create_all_entries, _startuptask, _fixt
     AutomemberRebuildMembershipTask(supplier).create(properties={
         'basedn': auto_mem_scope,
         'filter': "objectClass=inetOrgPerson"})
-    time.sleep(2)
+    time.sleep(10)
     bulk_check_groups(supplier, managers_grp, "member", 10)
     AutoMembershipDefinition(supplier,
                              f'cn=userGroups,{PLUGIN_AUTO}').replace('autoMemberFilter',

--- a/ldap/servers/plugins/automember/automember.c
+++ b/ldap/servers/plugins/automember/automember.c
@@ -1168,7 +1168,7 @@ automember_parse_regex_rule(char *rule_string)
     struct automemberRegexRule *rule = NULL;
     char *attr = NULL;
     Slapi_Regex *regex = NULL;
-    const char *recomp_result = NULL;
+    char *recomp_result = NULL;
     char *p = NULL;
     char *p2 = NULL;
 
@@ -1223,6 +1223,7 @@ automember_parse_regex_rule(char *rule_string)
                       "automember_parse_regex_rule - Unable to parse "
                       "regex rule (invalid regex).  Error \"%s\".\n",
                       recomp_result ? recomp_result : "unknown");
+        slapi_ch_free_string(&recomp_result);
         goto bail;
     }
 

--- a/ldap/servers/plugins/syntaxes/string.c
+++ b/ldap/servers/plugins/syntaxes/string.c
@@ -197,7 +197,7 @@ string_filter_sub(Slapi_PBlock *pb, char *initial, char **any, char * final, Sla
     struct timespec expire_time = {0};
     Operation *op = NULL;
     Slapi_Regex *re = NULL;
-    const char *re_result = NULL;
+    char *re_result = NULL;
     char *alt = NULL;
     int filter_normalized = 0;
     int free_re = 1;
@@ -313,6 +313,7 @@ string_filter_sub(Slapi_PBlock *pb, char *initial, char **any, char * final, Sla
             slapi_log_err(SLAPI_LOG_ERR, SYNTAX_PLUGIN_SUBSYSTEM,
                           "string_filter_sub - re_comp (%s) failed (%s): %s\n",
                           pat, p, re_result ? re_result : "unknown");
+            slapi_ch_free_string(&re_result);
             rc = LDAP_OPERATIONS_ERROR;
             goto bailout;
         } else if (slapi_is_loglevel_set(SLAPI_LOG_TRACE)) {

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -208,7 +208,7 @@ ldbm_search_compile_filter(Slapi_Filter *f, void *arg __attribute__((unused)))
         char *p, *end, *bigpat = NULL;
         size_t size = 0;
         Slapi_Regex *re = NULL;
-        const char *re_result = NULL;
+        char *re_result = NULL;
         int i = 0;
 
         PR_ASSERT(NULL == f->f_un.f_un_sub.sf_private);
@@ -262,6 +262,7 @@ ldbm_search_compile_filter(Slapi_Filter *f, void *arg __attribute__((unused)))
         if (NULL == re) {
             slapi_log_err(SLAPI_LOG_ERR, "ldbm_search_compile_filter", "re_comp (%s) failed (%s): %s\n",
                           pat, p, re_result ? re_result : "unknown");
+            slapi_ch_free_string(&re_result);
             rc = SLAPI_FILTER_SCAN_ERROR;
         } else {
             char ebuf[BUFSIZ];

--- a/ldap/servers/slapd/getfilelist.c
+++ b/ldap/servers/slapd/getfilelist.c
@@ -122,7 +122,7 @@ matches(const char *filename, const char *pattern)
 {
     Slapi_Regex *re = NULL;
     int match = 0;
-    const char *error = NULL;
+    char *error = NULL;
 
     if (!pattern)
         return 1; /* null pattern matches everything */
@@ -133,6 +133,8 @@ matches(const char *filename, const char *pattern)
         /* Matches the compiled pattern against the filename */
         match = slapi_re_exec_nt(re, filename);
         slapi_re_free(re);
+    } else {
+        slapi_ch_free_string(&error);
     }
 
     return match;

--- a/ldap/servers/slapd/sasl_map.c
+++ b/ldap/servers/slapd/sasl_map.c
@@ -581,7 +581,7 @@ sasl_map_check(sasl_map_data *dp, char *sasl_user_and_realm, char **ldap_search_
     Slapi_Regex *re = NULL;
     int ret = 0;
     int matched = 0;
-    const char *recomp_result = NULL;
+    char *recomp_result = NULL;
 
     slapi_log_err(SLAPI_LOG_TRACE, "sasl_map_check", "=>\n");
     /* Compiles the regex */
@@ -590,6 +590,7 @@ sasl_map_check(sasl_map_data *dp, char *sasl_user_and_realm, char **ldap_search_
         slapi_log_err(SLAPI_LOG_ERR,
                       "sasl_map_check", "slapi_re_comp failed for expression (%s): %s\n",
                       dp->regular_expression, recomp_result ? recomp_result : "unknown");
+        slapi_ch_free_string(&recomp_result);
     } else {
         /* Matches the compiled regex against sasl_user_and_realm */
         matched = slapi_re_exec_nt(re, sasl_user_and_realm);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -7527,7 +7527,7 @@ typedef struct slapi_regex_handle Slapi_Regex;
  * the compiled pattern. NULL if the compile fails.
  * \warning The regex handler should be released by slapi_re_free().
  */
-Slapi_Regex *slapi_re_comp(const char *pat, const char **error);
+Slapi_Regex *slapi_re_comp(const char *pat, char **error);
 /**
  * Matches a compiled regular expression pattern against a given string.
  * A thin wrapper of pcre_exec.

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -83,7 +83,7 @@ BuildRequires:    lmdb-devel
 BuildRequires:    cyrus-sasl-devel
 BuildRequires:    icu
 BuildRequires:    libicu-devel
-BuildRequires:    pcre-devel
+BuildRequires:    pcre2-devel
 BuildRequires:    cracklib-devel
 BuildRequires:    json-c-devel
 %if %{use_clang}
@@ -120,6 +120,7 @@ BuildRequires: rust
 BuildRequires:    pkgconfig
 BuildRequires:    pkgconfig(systemd)
 BuildRequires:    pkgconfig(krb5)
+BuildRequires:    pkgconfig(libpcre2-8)
 # Needed to support regeneration of the autotool artifacts.
 BuildRequires:    autoconf
 BuildRequires:    automake


### PR DESCRIPTION
Description:  PCRE is deprecated and is being removed, need to use the
new PCRE2 lkbrary

fixes: https://github.com/389ds/389-ds-base/issues/5012