### PR TITLE
Issue 5418 - Sync_repl may crash while managing invalid cookie

### DIFF
--- a/ldap/servers/plugins/sync/sync_util.c
+++ b/ldap/servers/plugins/sync/sync_util.c
@@ -775,6 +775,8 @@ sync_cookie_parse(char *cookie, PRBool *cookie_refresh, PRBool *allow_openldap_c
             } else {
                 goto error_return;
             }
+        } else {
+            goto error_return;
         }
     }
     return (sc);


### PR DESCRIPTION
Bug description:
	If the servers receives an invalid cookie without separator '#',
	it parses it into an empty cookie (Sync_Cookie) instead of a NULL
	cookie (failure).
	Later it sigsegv when using the empty cookie.

Fix description:
	If the parsing fails return NULL

relates: #5418

Reviewed by: Viktor Ashirov, Mark Reynolds