### PR TITLE
Issue 5428 - Fix regression with nscpEntryWsi computation

### DIFF
--- a/dirsrvtests/tests/suites/state/mmt_state_test.py
+++ b/dirsrvtests/tests/suites/state/mmt_state_test.py
@@ -36,12 +36,17 @@ def _check_user_oper_attrs(topo, tuser, attr_name, attr_value, oper_type, exp_va
     log.info('Checking if operational attrs vucsn, adcsn and vdcsn present for: {}'.format(tuser))
     entry = topo.ms["supplier1"].search_s(tuser.dn, ldap.SCOPE_BASE, 'objectclass=*',['nscpentrywsi'])
     if oper_attr:
+        match = False
         for line in str(entry).split('\n'):
-            if attr_name + ';' in line:
+            if attr_name.lower() + ';' in line.lower():
+                match = True
                 if not 'DELETE' in oper_type:
                     assert any(attr in line for attr in exp_values) and oper_attr in line
                 else:
-                    assert 'deleted' in line and oper_attr in line and attr_value in line
+                    assert 'deleted' in line and oper_attr in line
+
+        # If we didn't look at a single attribute then something went wrong
+        assert match
 
 
 @pytest.mark.parametrize("attr_name, attr_value, oper_type, exp_values, oper_attr",

--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -1735,4 +1735,5 @@ void dup_ldif_line(struct berval *copy, const char *line, const char *endline)
         pt += 2;        /* Skip \n and continuation line space */
     }
     buf[pos] = 0;
+    copy->bv_len = copylen;
 }


### PR DESCRIPTION
Description: We were not resetting the length of copied value when
computing the nscpEntryWsi value.  This led to value corruption in the
output.

relates: https://github.com/389ds/389-ds-base/issues/5428
