### PR TITLE
Issue 5356 - Make Rust non-optional and update default password storage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,9 +56,6 @@ SYSTEMTAP_DEFINES = @systemtap_defs@
 NSPR_INCLUDES = $(NSPR_CFLAGS)
 
 # Rust inclusions.
-if RUST_ENABLE
-# Rust enabled
-RUST_ON = 1
 CARGO_FLAGS = @cargo_defs@
 
 if CLANG_ENABLE
@@ -76,14 +73,6 @@ if RUST_ENABLE_OFFLINE
 RUST_OFFLINE = --locked --offline
 else
 RUST_OFFLINE =
-endif
-else
-# Rust disabled
-RUST_ON = 0
-CARGO_FLAGS =
-RUSTC_FLAGS =
-RUST_LDFLAGS =
-RUST_DEFINES =
 endif
 
 if CLANG_ENABLE
@@ -250,12 +239,8 @@ SLAPD_LDFLAGS = -version-info 1:0:1
 #------------------------
 # Generated Sources
 #------------------------
-BUILT_SOURCES = dberrstrs.h \
+BUILT_SOURCES = dberrstrs.h rust-slapi-private.h rust-nsslapd-private.h \
 	$(POLICY_FC)
-
-if RUST_ENABLE
-BUILT_SOURCES += rust-slapi-private.h rust-nsslapd-private.h
-endif
 
 if enable_posix_winsync
 LIBPOSIX_WINSYNC_PLUGIN = libposix-winsync-plugin.la
@@ -270,20 +255,14 @@ CLEANFILES =  dberrstrs.h ns-slapd.properties \
 	ldap/ldif/template-ldapi.ldif ldap/ldif/template-locality.ldif ldap/ldif/template-org.ldif \
 	ldap/ldif/template-orgunit.ldif ldap/ldif/template-pampta.ldif ldap/ldif/template-sasl.ldif \
 	ldap/ldif/template-state.ldif ldap/ldif/template-suffix-db.ldif \
-	doxyfile.stamp \
+	doxyfile.stamp rust-slapi-private.h\
 	$(NULL)
-
-if RUST_ENABLE
-CLEANFILES += rust-slapi-private.h
-endif
 
 clean-local:
 	-rm -rf dist
 	-rm -rf $(abs_top_builddir)/html
 	-rm -rf $(abs_top_builddir)/man/man3
-if RUST_ENABLE
 	-rm -rf $(abs_top_builddir)/rs
-endif
 
 dberrstrs.h: Makefile $(srcdir)/ldap/servers/slapd/mkDBErrStrs.py  $(srcdir)/ldap/servers/slapd/back-ldbm/dbimpl.h
 	$(srcdir)/ldap/servers/slapd/mkDBErrStrs.py -i $(srcdir)/ldap/servers/slapd/back-ldbm -o .
@@ -382,13 +361,8 @@ serverplugin_LTLIBRARIES = libacl-plugin.la \
 	libacctusability-plugin.la librootdn-access-plugin.la \
 	libwhoami-plugin.la $(LIBACCTPOLICY_PLUGIN) \
 	$(LIBPAM_PASSTHRU_PLUGIN) $(LIBDNA_PLUGIN) \
-	$(LIBBITWISE_PLUGIN) $(LIBPRESENCE_PLUGIN) $(LIBPOSIX_WINSYNC_PLUGIN)
-
-if RUST_ENABLE
-serverplugin_LTLIBRARIES += libentryuuid-plugin.la libentryuuid-syntax-plugin.la \
-	libpwdchan-plugin.la
-endif
-
+	$(LIBBITWISE_PLUGIN) $(LIBPRESENCE_PLUGIN) $(LIBPOSIX_WINSYNC_PLUGIN) \
+	libentryuuid-plugin.la libentryuuid-syntax-plugin.la libpwdchan-plugin.la
 
 noinst_LIBRARIES = libavl.a
 
@@ -683,11 +657,8 @@ systemschema_DATA = $(srcdir)/ldap/schema/00core.ldif \
 	$(srcdir)/ldap/schema/60sudo.ldif \
 	$(srcdir)/ldap/schema/60trust.ldif \
 	$(srcdir)/ldap/schema/60nss-ldap.ldif \
+	$(srcdir)/ldap/schema/03entryuuid.ldif \
 	$(LIBACCTPOLICY_SCHEMA)
-
-if RUST_ENABLE
-systemschema_DATA += $(srcdir)/ldap/schema/03entryuuid.ldif
-endif
 
 schema_DATA = $(srcdir)/ldap/schema/99user.ldif
 
@@ -845,8 +816,6 @@ libsvrcore_la_SOURCES = \
 libsvrcore_la_LDFLAGS = $(AM_LDFLAGS)
 libsvrcore_la_CPPFLAGS = $(AM_CPPFLAGS) $(SVRCORE_INCLUDES) $(DSPLUGIN_CPPFLAGS)
 libsvrcore_la_LIBADD = $(NSS_LINK) $(NSPR_LINK)
-
-if RUST_ENABLE
 
 noinst_LTLIBRARIES = librslapd.la librnsslapd.la libentryuuid.la libentryuuid_syntax.la \
 	libpwdchan.la
@@ -1034,9 +1003,6 @@ check-local:
 endif
 endif
 
-# End if RUST_ENABLE
-endif
-
 #------------------------
 # libns-dshttpd
 #------------------------
@@ -1200,7 +1166,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	$(libavl_a_SOURCES)
 
 libslapd_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(DB_INC) $(KERBEROS_CFLAGS) $(PCRE_CFLAGS) $(SVRCORE_INCLUDES)
-libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KERBEROS_LIBS) $(PCRE_LIBS) $(THREADLIB) $(SYSTEMD_LIBS) libsvrcore.la
+libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KERBEROS_LIBS) $(PCRE_LIBS) $(THREADLIB) $(SYSTEMD_LIBS) libsvrcore.la $(RSLAPD_LIB)
 # If asan is enabled, it creates special libcrypt interceptors. However, they are
 # detected by the first load of libasan at runtime, and what is in the linked lib
 # so we need libcrypt to be present as soon as libasan is loaded for the interceptors
@@ -1209,14 +1175,7 @@ libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KER
 if enable_asan
 libslapd_la_LIBADD += $(LIBCRYPT)
 endif
-libslapd_la_LDFLAGS = $(AM_LDFLAGS) $(SLAPD_LDFLAGS)
-
-if RUST_ENABLE
-libslapd_la_LIBADD += $(RSLAPD_LIB)
-libslapd_la_LDFLAGS += -lssl -lcrypto
-endif
-
-
+libslapd_la_LDFLAGS = $(AM_LDFLAGS) $(SLAPD_LDFLAGS) -lssl -lcrypto
 
 #////////////////////////////////////////////////////////////////
 #
@@ -1481,7 +1440,6 @@ libderef_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSPR_LINK)
 libderef_plugin_la_DEPENDENCIES = libslapd.la
 libderef_plugin_la_LDFLAGS = -avoid-version
 
-if RUST_ENABLE
 #------------------------
 # libentryuuid-syntax-plugin
 #-----------------------
@@ -1505,7 +1463,6 @@ libpwdchan_plugin_la_SOURCES = src/slapi_r_plugin/src/init.c
 libpwdchan_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSPR_LINK) -lpwdchan
 libpwdchan_plugin_la_DEPENDENCIES = libslapd.la $(PWDCHAN_LIB)
 libpwdchan_plugin_la_LDFLAGS = -avoid-version
-endif
 
 #------------------------
 # libpbe-plugin
@@ -1910,23 +1867,13 @@ ns_slapd_SOURCES = ldap/servers/slapd/abandon.c \
 
 ns_slapd_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(SVRCORE_INCLUDES) $(CFI_CFLAGS)
 # We need our libraries to come first, then our externals libraries second.
-ns_slapd_LDADD = libslapd.la libldaputil.la libsvrcore.la
-if RUST_ENABLE
-ns_slapd_LDADD += $(RNSSLAPD_LIB)
-endif
-ns_slapd_LDADD += $(LDAPSDK_LINK) $(NSS_LINK) $(LIBADD_DL) \
+ns_slapd_LDADD = libslapd.la libldaputil.la libsvrcore.la $(RNSSLAPD_LIB)
+
+ns_slapd_LDADD += $(LDAPSDK_LINK) $(NSS_LINK) $(LIBADD_DL) -lssl -lcrypto \
        $(NSPR_LINK) $(SASL_LINK) $(LIBNSL) $(LIBSOCKET) $(THREADLIB) $(SYSTEMD_LIBS) $(EVENT_LINK)
-if RUST_ENABLE
-ns_slapd_LDADD += -lssl -lcrypto
-endif
+
 ns_slapd_DEPENDENCIES = libslapd.la libldaputil.la
-# We need to link ns-slapd with the C++ compiler on HP-UX since we load
-# some C++ shared libraries (such as icu).
-if HPUX
-ns_slapd_LINK = $(CXXLINK)
-else
 ns_slapd_LINK = $(LINK)
-endif
 
 
 #------------------------
@@ -2023,7 +1970,6 @@ fixupcmd = sed \
 	-e 's,@enable_tsan\@,$(TSAN_ON),g' \
 	-e 's,@enable_ubsan\@,$(UBSAN_ON),g' \
 	-e 's,@SANITIZER\@,$(SANITIZER),g' \
-	-e 's,@enable_rust\@,@enable_rust@,g' \
 	-e 's,@ECHO_N\@,$(ECHO_N),g' \
 	-e 's,@ECHO_C\@,$(ECHO_C),g' \
 	-e 's,@brand\@,$(brand),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -95,12 +95,7 @@ AS_IF([test "$enable_rust_offline" = yes],
     [rust_vendor_sources="replace-with = \"vendored-sources\""],
     [rust_vendor_sources=""])
 AC_SUBST([rust_vendor_sources])
-
-AC_MSG_CHECKING(for --enable-rust)
-AC_ARG_ENABLE(rust, AS_HELP_STRING([--enable-rust], [Enable rust language features (default: no)]),
-              [], [ enable_rust=no ])
-AC_MSG_RESULT($enable_rust)
-if test "$enable_rust" = yes -o "$enable_rust_offline" = yes; then
+if test "$enable_rust_offline" = yes; then
     AC_CHECK_PROG(CARGO, [cargo], [yes], [no])
     AC_CHECK_PROG(RUSTC, [rustc], [yes], [no])
     # Since fernet uses the openssl lib.
@@ -110,8 +105,6 @@ if test "$enable_rust" = yes -o "$enable_rust_offline" = yes; then
       AC_MSG_FAILURE("Rust based plugins cannot be built cargo=$CARGO rustc=$RUSTC")
     ])
 fi
-AC_SUBST([enable_rust])
-AM_CONDITIONAL([RUST_ENABLE],[test "$enable_rust" = yes -o "$enable_rust_offline" = yes])
 
 # Optional cockpit support (enabled by default)
 AC_MSG_CHECKING(for --enable-cockpit)

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -78,7 +78,7 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
         2. Configure an insecure passwordStorageScheme (as SHA) for the instance
         3. Use HealthCheck without --json option
         4. Use HealthCheck with --json option
-        5. Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256
+        5. Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA512
         6. Use HealthCheck without --json option
         7. Use HealthCheck with --json option
     :expectedresults:
@@ -106,9 +106,9 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
         standalone.config.set('passwordStorageScheme', 'SSHA512')
         standalone.config.set('nsslapd-rootpwstoragescheme', 'SSHA512')
     else:
-        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256')
-        standalone.config.set('passwordStorageScheme', 'PBKDF2_SHA256')
-        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2_SHA256')
+        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512')
+        standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)

--- a/dirsrvtests/tests/suites/password/pwp_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_test.py
@@ -27,7 +27,7 @@ else:
     if is_fips():
         DEFAULT_PASSWORD_STORAGE_SCHEME = 'SSHA512'
     else:
-        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2_SHA256'
+        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2-SHA512'
 
 
 def _create_user(topo, uid, cn, uidNumber, userpassword):

--- a/ldap/servers/slapd/config.c
+++ b/ldap/servers/slapd/config.c
@@ -40,16 +40,15 @@ char *rel2abspath(char *);
  * see fedse.c instead!
  */
 static char *bootstrap_plugins[] = {
-    "dn: cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+    "dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config\n"
     "objectclass: top\n"
     "objectclass: nsSlapdPlugin\n"
-    "cn: PBKDF2_SHA256\n"
-    "nsslapd-pluginpath: libpwdstorage-plugin\n"
-    "nsslapd-plugininitfunc: pbkdf2_sha256_pwd_storage_scheme_init\n"
+    "cn: PBKDF2-SHA512\n"
+    "nsslapd-pluginpath: libpwdchan-plugin\n"
+    "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init\n"
     "nsslapd-plugintype: pwdstoragescheme\n"
-    "nsslapd-pluginenabled: on",
+    "nsslapd-pluginenabled: on\n",
 
-#ifdef RUST_ENABLE
     "dn: cn=entryuuid_syntax,cn=plugins,cn=config\n"
     "objectclass: top\n"
     "objectclass: nsSlapdPlugin\n"
@@ -62,7 +61,6 @@ static char *bootstrap_plugins[] = {
     "nsslapd-pluginVersion: none\n"
     "nsslapd-pluginVendor: 389 Project\n"
     "nsslapd-pluginDescription: entryuuid_syntax\n",
-#endif
 
     NULL
 };

--- a/ldap/servers/slapd/extendop.c
+++ b/ldap/servers/slapd/extendop.c
@@ -15,11 +15,8 @@
 
 #include <stdio.h>
 #include "slap.h"
-
-/* If available, expose rust types. */
-#ifdef RUST_ENABLE
 #include <rust-nsslapd-private.h>
-#endif
+
 
 static const char *extended_op_oid2string(const char *oid);
 
@@ -206,8 +203,6 @@ extop_handle_import_done(Slapi_PBlock *pb, char *extoid __attribute__((unused)),
     return;
 }
 
-
-#ifdef RUST_ENABLE
 static void
 extop_handle_ldapssotoken_request(Slapi_PBlock *pb, char *extoid __attribute__((unused)), struct berval *extval) {
     BerElement *ber = NULL;
@@ -258,8 +253,6 @@ extop_handle_ldapssotoken_request(Slapi_PBlock *pb, char *extoid __attribute__((
     ber_bvfree(bvp);
     return;
 }
-#endif
-
 
 void
 do_extended(Slapi_PBlock *pb)
@@ -411,7 +404,6 @@ do_extended(Slapi_PBlock *pb)
      * Auth tokens are generated outside of transactions, and are just part of the
      * main server, so we do it now before consulting plugins - WB
      */
-#ifdef RUST_ENABLE
     if (strcmp(extoid, EXTOP_LDAPSSOTOKEN_REQUEST_OID) == 0 && config_get_enable_ldapssotoken()) {
         /*
          * We want to generate an auth token for this user.
@@ -433,7 +425,6 @@ do_extended(Slapi_PBlock *pb)
             goto free_and_return;
         }
     }
-#endif
 
     rc = plugin_determine_exop_plugins(extoid, &p);
     slapi_log_err(SLAPI_LOG_TRACE, "do_extended", "Plugin_determine_exop_plugins rc %d\n", rc);

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -119,7 +119,6 @@ static const char *internal_entries[] =
         "cn:SNMP\n"
         "nsSNMPEnabled: on\n",
 
-#ifdef RUST_ENABLE
         "dn: cn=entryuuid_syntax,cn=plugins,cn=config\n"
         "objectclass: top\n"
         "objectclass: nsSlapdPlugin\n"
@@ -145,7 +144,6 @@ static const char *internal_entries[] =
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
         "nsslapd-pluginDescription: entryuuid\n",
-#endif
 
         "dn: cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"
@@ -217,7 +215,6 @@ static const char *internal_entries[] =
         "nsslapd-pluginVendor: 389 Project\n"
         "nsslapd-pluginDescription: GOST_YESCRYPT\n",
 
-#ifdef RUST_ENABLE
         "dn: cn=PBKDF2,cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"
         "objectclass: nsSlapdPlugin\n"
@@ -256,20 +253,6 @@ static const char *internal_entries[] =
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
         "nsslapd-pluginDescription: PBKDF2-SHA256\n",
-
-        "dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config\n"
-        "objectclass: top\n"
-        "objectclass: nsSlapdPlugin\n"
-        "cn: PBKDF2-SHA512\n"
-        "nsslapd-pluginpath: libpwdchan-plugin\n"
-        "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init\n"
-        "nsslapd-plugintype: pwdstoragescheme\n"
-        "nsslapd-pluginenabled: on\n"
-        "nsslapd-pluginId: PBKDF2-SHA512\n"
-        "nsslapd-pluginVersion: none\n"
-        "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: PBKDF2-SHA512\n",
-#endif
 };
 
 static int NUM_INTERNAL_ENTRIES = sizeof(internal_entries) / sizeof(internal_entries[0]);

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -2952,7 +2952,7 @@ slapd_do_all_nss_ssl_init(int slapd_exemode, int importexport_encrypt, int s_por
         slapi_log_err(SLAPI_LOG_WARNING, "slapd_do_all_nss_ssl_init",
                       "ERROR: TLS is not enabled, and the machine is in FIPS mode. "
                       "Some functionality won't work correctly (for example, "
-                      "users with PBKDF2_SHA256 password scheme won't be able to log in). "
+                      "users with PBKDF2-SHA256 password scheme won't be able to log in). "
                       "It's highly advisable to enable TLS on this instance.\n");
     }
 

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -274,18 +274,9 @@ pw_name2scheme(char *name)
     typedef char *(*ENCFP)(char *);
 
     if (name == NULL || strcmp(DEFAULT_PASSWORD_SCHEME_NAME, name) == 0) {
-        /*
-         * If the name is DEFAULT, we need to get a scheme based on env and others.
-         */
-        if (slapd_pk11_isFIPS()) {
-            /* Are we in fips mode? This limits algos we have */
-            char *ssha = "SSHA512";
-            p = plugin_get_pwd_storage_scheme(ssha, strlen(ssha), PLUGIN_LIST_PWD_STORAGE_SCHEME);
-        } else {
-            /* if not, let's setup pbkdf2 */
-            char *pbkdf = "PBKDF2_SHA256";
-            p = plugin_get_pwd_storage_scheme(pbkdf, strlen(pbkdf), PLUGIN_LIST_PWD_STORAGE_SCHEME);
-        }
+         /* default scheme */
+         char *pbkdf = "PBKDF2-SHA512";
+         p = plugin_get_pwd_storage_scheme(pbkdf, strlen(pbkdf), PLUGIN_LIST_PWD_STORAGE_SCHEME);
     } else {
         /*
          * Else, get the scheme "as named".

--- a/ldap/servers/slapd/pw_verify.c
+++ b/ldap/servers/slapd/pw_verify.c
@@ -25,10 +25,8 @@
 #endif
 #include "slap.h"
 #include "fe.h"
-
-#ifdef RUST_ENABLE
 #include <rust-nsslapd-private.h>
-#endif
+
 
 int
 pw_verify_root_dn(const char *dn, const Slapi_Value *cred)
@@ -100,7 +98,6 @@ pw_verify_be_dn(Slapi_PBlock *pb, Slapi_Entry **referral)
 int32_t
 pw_verify_token_dn(Slapi_PBlock *pb) {
     int rc = SLAPI_BIND_FAIL;
-#ifdef RUST_ENABLE
     struct berval *cred = NULL;
     Slapi_DN *sdn = NULL;
 
@@ -122,7 +119,7 @@ pw_verify_token_dn(Slapi_PBlock *pb) {
         rc = SLAPI_BIND_SUCCESS;
     }
     slapi_ch_free_string(&key);
-#endif
+
     return rc;
 }
 

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -22,12 +22,9 @@
  * or altered.
  */
 
-#ifdef RUST_ENABLE
 static char *modifier_name = "cn=upgrade internal,cn=config";
-#endif
 static char *old_repl_plugin_name = NULL;
 
-#ifdef RUST_ENABLE
 static upgrade_status
 upgrade_entry_exists_or_create(char *upgrade_id, char *filter, char *dn, char *entry)
 {
@@ -46,7 +43,6 @@ upgrade_entry_exists_or_create(char *upgrade_id, char *filter, char *dn, char *e
     slapi_sdn_free(&base_sdn);
     return uresult;
 }
-#endif
 
 /*
  * Add the new replication bootstrap bind DN password attribute to the AES
@@ -102,7 +98,6 @@ upgrade_AES_reverpwd_plugin(void)
     return uresult;
 }
 
-#ifdef RUST_ENABLE
 static upgrade_status
 upgrade_143_entryuuid_exists(void)
 {
@@ -126,7 +121,6 @@ upgrade_143_entryuuid_exists(void)
         entry
     );
 }
-#endif
 
 static upgrade_status
 upgrade_144_remove_http_client_presence(void)
@@ -288,11 +282,9 @@ upgrade_205_fixup_repl_dep(void)
 upgrade_status
 upgrade_server(void)
 {
-#ifdef RUST_ENABLE
     if (upgrade_143_entryuuid_exists() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
-#endif
 
     if (upgrade_AES_reverpwd_plugin() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;

--- a/rpm.mk
+++ b/rpm.mk
@@ -25,8 +25,6 @@ TSAN_ON = 0
 # Undefined Behaviour Sanitizer
 UBSAN_ON = 0
 
-RUST_ON = 1
-
 COCKPIT_ON = 1
 
 clean:
@@ -101,7 +99,6 @@ rpmroot:
 	mkdir -p $(RPMBUILD)/SRPMS
 	sed -e s/__VERSION__/$(RPM_VERSION)/ -e s/__RELEASE__/$(RPM_RELEASE)/ \
 	-e s/__VERSION_PREREL__/$(VERSION_PREREL)/ \
-	-e s/__RUST_ON__/$(RUST_ON)/ \
 	-e s/__ASAN_ON__/$(ASAN_ON)/ \
 	-e s/__MSAN_ON__/$(MSAN_ON)/ \
 	-e s/__TSAN_ON__/$(TSAN_ON)/ \

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -25,9 +25,6 @@
 %global use_tsan __TSAN_ON__
 %global use_ubsan __UBSAN_ON__
 
-# This enables rust in the build.
-%global use_rust __RUST_ON__
-
 %if %{use_asan} || %{use_msan} || %{use_tsan} || %{use_ubsan}
 %global variant base-xsan
 %endif
@@ -112,11 +109,8 @@ BuildRequires:    openssl-devel
 BuildRequires:    pam-devel
 BuildRequires:    systemd-units
 BuildRequires:    systemd-devel
-# If rust is enabled
-%if %{use_rust}
-BuildRequires: cargo
-BuildRequires: rust
-%endif
+BuildRequires:    cargo
+BuildRequires:    rust
 BuildRequires:    pkgconfig
 BuildRequires:    pkgconfig(systemd)
 BuildRequires:    pkgconfig(krb5)
@@ -352,9 +346,7 @@ TSAN_FLAGS="--enable-tsan --enable-debug"
 UBSAN_FLAGS="--enable-ubsan --enable-debug"
 %endif
 
-%if %{use_rust}
 RUST_FLAGS="--enable-rust --enable-rust-offline"
-%endif
 
 %if !%{use_cockpit}
 COCKPIT_FLAGS="--disable-cockpit"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "librnsslapd"
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "openssl"
@@ -479,9 +479,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "scopeguard"
@@ -570,18 +570,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -629,9 +629,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "once_cell",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-width"
@@ -780,9 +780,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/src/lib389/doc/source/passwd.rst
+++ b/src/lib389/doc/source/passwd.rst
@@ -16,6 +16,7 @@ Usage example
         'SSHA256',
         'SSHA512',
         'PBKDF2_SHA256',
+        'PBKDF2-SHA256',
     ]
      
     # Generate password

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -210,7 +210,7 @@ class Config(DSLdapObject):
             yield report
 
     def _lint_passwordscheme(self):
-        allowed_schemes = ['SSHA512', 'PBKDF2_SHA256', 'GOST_YESCRYPT']
+        allowed_schemes = ['SSHA512', 'PBKDF2-SHA512', 'GOST_YESCRYPT']
         u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
         u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
         if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -94,7 +94,7 @@ designed to be *fast* to validate. This is the opposite of what we desire for pa
 storage. In the unlikely event of a disclosure, you want hashes to be *difficult* to
 verify, as this adds a cost of work to an attacker.
 
-In Directory Server, we offer one hash suitable for this (PBKDF2_SHA256) and one hash
+In Directory Server, we offer one hash suitable for this (PBKDF2-SHA512) and one hash
 for "legacy" support (SSHA512).
 
 Your configuration does not use these for password storage or the root password storage
@@ -110,7 +110,7 @@ is started, they will use the server provided defaults that are secure.
 
 You can also use 'dsconf' to replace these values.  Here is an example:
 
-    # dsconf slapd-YOUR_INSTANCE config replace passwordStorageScheme=PBKDF2_SHA256 nsslapd-rootpwstoragescheme=PBKDF2_SHA256"""
+    # dsconf slapd-YOUR_INSTANCE config replace passwordStorageScheme=PBKDF2-SHA512 nsslapd-rootpwstoragescheme=PBKDF2-SHA512"""
 }
 
 # Security checks

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -31,7 +31,7 @@ class PasswordPlugin(Plugin):
         self._protected = True
 
 class PBKDF2Plugin(PasswordPlugin):
-    def __init__(self, instance, dn="cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config"):
+    def __init__(self, instance, dn="cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config"):
         super(PBKDF2Plugin, self).__init__(instance, dn)
 
 


### PR DESCRIPTION
Make Rust non-optional and update default password storage scheme

Description:

We need a stronger default storage scheme which comes from our Rust
plugins, but to do this  Rust needs to be non-optional.  It will be
a requirement moving forward.

relates: https://github.com/389ds/389-ds-base/issues/5356

Reviewed by: ?