### PR TITLE
Issue 5356 - For RUST build update the default password storage scheme

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -78,7 +78,7 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
         2. Configure an insecure passwordStorageScheme (as SHA) for the instance
         3. Use HealthCheck without --json option
         4. Use HealthCheck with --json option
-        5. Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256
+        5. Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512
         6. Use HealthCheck without --json option
         7. Use HealthCheck with --json option
     :expectedresults:
@@ -106,9 +106,9 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
         standalone.config.set('passwordStorageScheme', 'SSHA512')
         standalone.config.set('nsslapd-rootpwstoragescheme', 'SSHA512')
     else:
-        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256')
-        standalone.config.set('passwordStorageScheme', 'PBKDF2_SHA256')
-        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2_SHA256')
+        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512')
+        standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)

--- a/dirsrvtests/tests/suites/password/pwp_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_test.py
@@ -27,7 +27,7 @@ else:
     if is_fips():
         DEFAULT_PASSWORD_STORAGE_SCHEME = 'SSHA512'
     else:
-        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2_SHA256'
+        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2-SHA512'
 
 
 def _create_user(topo, uid, cn, uidNumber, userpassword):

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -283,7 +283,11 @@ pw_name2scheme(char *name)
             p = plugin_get_pwd_storage_scheme(ssha, strlen(ssha), PLUGIN_LIST_PWD_STORAGE_SCHEME);
         } else {
             /* if not, let's setup pbkdf2 */
+#ifdef RUST_ENABLE
+            char *pbkdf = "PBKDF2-SHA512";
+#else
             char *pbkdf = "PBKDF2_SHA256";
+#endif
             p = plugin_get_pwd_storage_scheme(pbkdf, strlen(pbkdf), PLUGIN_LIST_PWD_STORAGE_SCHEME);
         }
     } else {

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -209,7 +209,7 @@ class Config(DSLdapObject):
             yield report
 
     def _lint_passwordscheme(self):
-        allowed_schemes = ['SSHA512', 'PBKDF2_SHA256', 'GOST_YESCRYPT']
+        allowed_schemes = ['SSHA512', 'PBKDF2-SHA512', 'GOST_YESCRYPT']
         u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
         u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
         if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -94,7 +94,7 @@ designed to be *fast* to validate. This is the opposite of what we desire for pa
 storage. In the unlikely event of a disclosure, you want hashes to be *difficult* to
 verify, as this adds a cost of work to an attacker.
 
-In Directory Server, we offer one hash suitable for this (PBKDF2_SHA256) and one hash
+In Directory Server, we offer one hash suitable for this (PBKDF2-SHA512) and one hash
 for "legacy" support (SSHA512).
 
 Your configuration does not use these for password storage or the root password storage
@@ -110,7 +110,7 @@ is started, they will use the server provided defaults that are secure.
 
 You can also use 'dsconf' to replace these values.  Here is an example:
 
-    # dsconf slapd-YOUR_INSTANCE config replace passwordStorageScheme=PBKDF2_SHA256 nsslapd-rootpwstoragescheme=PBKDF2_SHA256"""
+    # dsconf slapd-YOUR_INSTANCE config replace passwordStorageScheme=PBKDF2-SHA512 nsslapd-rootpwstoragescheme=PBKDF2-SHA512"""
 }
 
 # Security checks

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -31,7 +31,7 @@ class PasswordPlugin(Plugin):
         self._protected = True
 
 class PBKDF2Plugin(PasswordPlugin):
-    def __init__(self, instance, dn="cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config"):
+    def __init__(self, instance, dn="cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config"):
         super(PBKDF2Plugin, self).__init__(instance, dn)
 
 


### PR DESCRIPTION
Description:

If Rust is enabled use PBKDF2-SHA512 as the default password storage
scheme

relates: 389ds#5356

