### PR TITLE
Issue 4592: dscreate error with custom dir_path

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -866,58 +866,6 @@ class DirSrv(SimpleLDAPObject, object):
         # Now the instance is created but DirSrv is not yet connected to it
         self.state = DIRSRV_STATE_OFFLINE
 
-    def _deleteDirsrv(self):
-        '''
-            Deletes the instance with the parameters sets in dirsrv
-            The state changes  -> DIRSRV_STATE_ALLOCATED
-
-            @param self
-
-            @return None
-
-            @raise None
-        '''
-
-        # Grab all the instances now, before we potentially remove the last one
-        insts = self.list(all=True)
-
-        if self.state == DIRSRV_STATE_ONLINE:
-            self.close()
-
-        if not self.exists():
-            raise ValueError("Error can not find instance %s[%s:%d]" %
-                             (self.serverid, self.host, self.port))
-
-        # Now time to remove the instance
-        prog = os.path.join(self.ds_paths.sbin_dir, 'dsctl')
-        if (not self.ds_paths.prefix or self.ds_paths.prefix == '/') and os.geteuid() != 0:
-            raise ValueError("Error: without prefix deployment it is required to be root user")
-        cmd = "%s slapd-%s remove --do-it" % (prog, self.serverid)
-        self.log.debug("running: %s ", cmd)
-        try:
-            os.system(cmd)
-        except:
-            self.log.exception("error executing %r", cmd)
-
-        # If this was the last instance being deleted, remove the DEFAULT_USER
-        # if lib389 created the default user
-        if os.getuid() == 0:
-            # Only the root user could of added the entry
-            if len(insts) == 1:
-                # No more instances (this was the last one)
-                if pwd.getpwnam(DEFAULT_USER).pw_gecos == DEFAULT_USER_COMMENT:
-                    # We created this user, so we will delete it
-                    cmd = ['/usr/sbin/userdel', DEFAULT_USER]
-                    try:
-                        subprocess.call(cmd)
-                    except subprocess.CalledProcessError as e:
-                        self.log.exception(
-                                'Failed to delete default user ',
-                                      '(%s): error %s' % (DEFAULT_USER,
-                                                          e.output))
-
-        self.state = DIRSRV_STATE_ALLOCATED
-
     def get_db_lib(self):
         with suppress(AttributeError):
             return self._db_lib

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -46,6 +46,7 @@ from lib389.utils import (
     socket_check_open,
     selinux_label_file,
     selinux_label_port,
+    resolve_selinux_path,
     selinux_restorecon,
     selinux_present)
 
@@ -945,7 +946,7 @@ class SetupDs(object):
                 selinux_label_port(slapd['secure_port'])
 
         # Do selinux fixups
-        if general['selinux']:
+        if general['selinux'] and selinux_present():
             self.log.info("Perform SELinux labeling ...")
             # Since there may be some custom path, we must explicitly set the labels
             selinux_labels = {
@@ -961,11 +962,8 @@ class SetupDs(object):
                                 'schema_dir': 'dirsrv_config_t',
                                 'tmp_dir': 'tmp_t',
             }
-            # Lets sort the paths to avoid overriding the labels if path are nested.
-            selinux_sorted_labels = sorted( ( (slapd[key], label) for key, label in selinux_labels.items() ) )
-            for path, label in selinux_sorted_labels:
-                selinux_label_file(path, label)
-                selinux_restorecon(path)
+            for k, label in selinux_labels.items():
+                selinux_label_file(resolve_selinux_path(slapd[k]), label)
 
             selinux_label_port(slapd['port'])
 

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -478,7 +478,7 @@ only.
             raise ValueError(e.output.decode('utf-8').rstrip())
         lines = result.split('\n')[1:-1]
         for line in lines:
-            m = re.match('\<(?P<id>.*)\> (?P<type>\w+)\s+(?P<hash>\w+).*:(?P<name>.+)', line)
+            m = re.match(r'\<(?P<id>.*)\> (?P<type>\w+)\s+(?P<hash>\w+).*:(?P<name>.+)', line)
             if name == m.group('name'):
                 return True
         return False


### PR DESCRIPTION
Problem:
When creating an instance with a custom dir_path and if seLinux is enabled then the instance creation fails:
Instance fails to start because database cannot be created due to seLinux permission error.
    
Solution:
The solution is to set the right seLinux label for the instance directories by deleting current context 
and adding new one 
but there are some pitfalls to avoid:
   - Make sure that the right path is used (otherwise semanage fails)
   - Make sure that we do not explicity try to overrule a record explicity set by the seLinux policy
     ( for example trying to set db_dir as /tmp ( and tmp_dir as something else )
The idea is to parse the semanage fcontext -l [-C] output to get the:
    path equivalence rules (about symbolic link)
    local file context path and labels
    global policy file context path and labels
And use them to compute the right path, and to decide what must be done 
  (nothing, delete existing local context, raise an error or add new context)

Also made sure that the selinux labels stored in the local policy get cleaned
  when removing and instance (and that all labels set by ds get cleaned when removing all instances)  
    
Note: also fixed some lib389 warning about obsolete escape sequences
 and also removed _deleteDirsrv private function (dead code) to avoid that 
 someone else waste time trying to "fix" it.
    
Issue: [4592](https://github.com/389ds/389-ds-base/issues/4592)
    
Reviewd by:
