### PR TITLE
Issue 5012 - Migrate pcre to pcre2 - remove match limit

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1941,10 +1941,18 @@ delete_search_result_set(Slapi_PBlock *pb, back_search_result_set **sr)
     rc = slapi_filter_apply((*sr)->sr_norm_filter, ldbm_search_free_compiled_filter,
                             NULL, &filt_errs);
     if (rc != SLAPI_FILTER_SCAN_NOMORE) {
-        slapi_log_err(SLAPI_LOG_ERR,
-                      "delete_search_result_set", "Could not free the pre-compiled regexes in the search filter - error %d %d\n",
+        slapi_log_err(SLAPI_LOG_ERR, "delete_search_result_set",
+                      "Could not free the pre-compiled regexes in the search filter - error %d %d\n",
                       rc, filt_errs);
     }
+
+    rc = slapi_filter_apply((*sr)->sr_norm_filter_intent, ldbm_search_free_compiled_filter, NULL, &filt_errs);
+    if (rc != SLAPI_FILTER_SCAN_NOMORE) {
+        slapi_log_err(SLAPI_LOG_ERR, "delete_search_result_set",
+                      "Could not free the pre-compiled regexes in the intent search filter - error %d %d\n",
+                      rc, filt_errs);
+    }
+
     slapi_filter_free((*sr)->sr_norm_filter, 1);
     slapi_filter_free((*sr)->sr_norm_filter_intent, 1);
     memset(*sr, 0, sizeof(back_search_result_set));

--- a/ldap/servers/slapd/regex.c
+++ b/ldap/servers/slapd/regex.c
@@ -21,7 +21,6 @@ struct slapi_regex_handle
 {
     pcre2_code *re_pcre;
     pcre2_match_data *match_data; /* Contains the output vector */
-    pcre2_match_context *mcontext; /* Stores the max element limit */
 };
 
 /**
@@ -88,19 +87,13 @@ slapi_re_exec(Slapi_Regex *re_handle, const char *subject, time_t time_up)
     }
     re_handle->match_data = pcre2_match_data_create_from_pattern(re_handle->re_pcre, NULL);
 
-    if (re_handle->mcontext == NULL) {
-        re_handle->mcontext = pcre2_match_context_create(NULL);
-        pcre2_set_match_limit(re_handle->mcontext, OVEC_MATCH_LIMIT);
-    }
-
-
     rc = pcre2_match(re_handle->re_pcre,    /* the compiled pattern */
                      (PCRE2_SPTR)subject,   /* the subject string */
                      strlen(subject),       /* the length of the subject */
                      0,                     /* start at offset 0 in the subject */
                      0,                     /* default options */
                      re_handle->match_data, /* contains the resulting output vector */
-                     re_handle->mcontext);  /* stores the max element limit */
+                     NULL);                 /* stores the match context */
 
     if (rc >= 0) {
         return 1; /* matched */
@@ -138,17 +131,13 @@ slapi_re_exec_nt(Slapi_Regex *re_handle, const char *subject)
     }
     re_handle->match_data = pcre2_match_data_create_from_pattern(re_handle->re_pcre, NULL);
 
-    if (re_handle->mcontext == NULL) {
-        re_handle->mcontext = pcre2_match_context_create(NULL);
-        pcre2_set_match_limit(re_handle->mcontext, OVEC_MATCH_LIMIT);
-    }
     rc = pcre2_match(re_handle->re_pcre,    /* the compiled pattern */
                      (PCRE2_SPTR)subject,   /* the subject string */
                      strlen(subject),       /* the length of the subject */
                      0,                     /* start at offset 0 in the subject */
                      0,                     /* default options */
                      re_handle->match_data, /* contains the resulting output vector */
-                     re_handle->mcontext);  /* stores the max element limit */
+                     NULL);                 /* stores the match context */
 
     if (rc >= 0) {
         return 1; /* matched */
@@ -255,9 +244,6 @@ slapi_re_free(Slapi_Regex *re_handle)
         }
         if (re_handle->match_data) {
             pcre2_match_data_free(re_handle->match_data);
-        }
-        if (re_handle->mcontext) {
-            pcre2_match_context_free(re_handle->mcontext);
         }
         slapi_ch_free((void **)&re_handle);
     }


### PR DESCRIPTION
Description: 

During the migration a match limit was incorrectly applied when in was not actually needed.  This broke regexes where the source target matched more than 30 characters.

relates: https://github.com/389ds/389-ds-base/issues/5012

