### PR TITLE
Issue 5158: entryuuid fixup tasks fails in replicated topology

### DIFF
--- a/dirsrvtests/tests/suites/entryuuid/replicated_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/replicated_test.py
@@ -15,6 +15,8 @@ from lib389.paths import Paths
 from lib389.utils import ds_is_older
 from lib389._constants import *
 from lib389.replica import ReplicationManager
+from lib389.plugins import EntryUUIDPlugin
+from lib389.tasks import EntryUUIDFixupTask
 
 default_paths = Paths()
 
@@ -75,3 +77,77 @@ def test_entryuuid_with_replication(topo_m2):
     assert(len(euuid_c) == 1)
     assert(euuid_c == euuid_a)
 
+@pytest.mark.skipif(not default_paths.rust_enabled or ds_is_older('1.4.2.0'), reason="Entryuuid is not available in older versions")
+def test_entryuuid_fixup_with_replication(topo_m2):
+    """ Check that entryuuid fixup task works with replication
+
+    :id: 4ff25022-2de8-11ed-b393-482ae39447e5
+    :setup: two node mmr
+
+    :steps:
+        1. Disable EntryUUID plugin.
+        2. Create an user entry.
+        3. Enable EntryUUID plugin.
+        4. Check that the user entry does not have an entryuuid attribute
+        5. Run fixup task
+        6. Wait for task completion
+        7. Check that the user entry has an entryuuid attribute
+        8. Wait until changes get replicated
+        9. Check that the user entry on the other supplier has same entryuuid attribute
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Success
+    """
+    server_a = topo_m2.ms["supplier1"]
+    server_b = topo_m2.ms["supplier2"]
+    server_a.config.loglevel(vals=(ErrorLog.DEFAULT,ErrorLog.TRACE))
+    server_b.config.loglevel(vals=(ErrorLog.DEFAULT,ErrorLog.TRACE))
+
+    # 1. Disable EntryUUID plugin.
+    plugin = EntryUUIDPlugin(server_a)
+    plugin.disable()
+    server_a.restart()
+
+    # 2. Create an user entry.
+    # uid must differ than the test test_entryuuid_with_replication one
+    # to avoid conflict between the tests.
+    account_a = nsUserAccounts(server_a, DEFAULT_SUFFIX).create_test_user(uid=3000)
+
+    # 3. Enable EntryUUID plugin.
+    plugin.enable()
+    server_a.restart()
+
+    # 4. Check that the user entry does not have an entryuuid attribute
+    euuid_a = account_a.get_attr_vals_utf8('entryUUID')
+    assert(not euuid_a)
+
+    # 5. Run fixup task
+    task = EntryUUIDFixupTask(server_a).create(properties={
+        'basedn': DEFAULT_SUFFIX,
+        'filter': "objectClass=*"
+    })
+
+    # 6. Wait for task completion
+    task.wait()
+    assert task.is_complete()
+
+    # 7. Check that the user entry has an entryuuid attribute
+    euuid_a = account_a.get_attr_vals_utf8('entryUUID')
+    assert(euuid_a)
+
+    # 8. Wait until changes get replicated
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.wait_for_replication(server_b, server_a)
+
+    # 9. Check that the user entry on the other supplier has same entryuuid attribute
+    account_b = nsUserAccounts(server_b, DEFAULT_SUFFIX).get("test_user_3000")
+    euuid_b = account_b.get_attr_vals_utf8('entryUUID')
+    assert euuid_a == euuid_b

--- a/src/slapi_r_plugin/src/constants.rs
+++ b/src/slapi_r_plugin/src/constants.rs
@@ -6,11 +6,6 @@ pub const LDAP_SUCCESS: i32 = 0;
 pub const PLUGIN_DEFAULT_PRECEDENCE: i32 = 50;
 
 #[repr(i32)]
-pub enum OpFlags {
-    ByassReferrals = 0x0040_0000,
-}
-
-#[repr(i32)]
 /// The set of possible function handles we can register via the pblock. These
 /// values correspond to slapi-plugin.h.
 pub enum PluginFnType {

--- a/src/slapi_r_plugin/src/modify.rs
+++ b/src/slapi_r_plugin/src/modify.rs
@@ -1,4 +1,3 @@
-use crate::constants::OpFlags;
 use crate::dn::SdnRef;
 use crate::error::{LDAPError, PluginError};
 use crate::pblock::Pblock;
@@ -95,7 +94,7 @@ impl Modify {
                 std::ptr::null(),
                 std::ptr::null(),
                 plugin_id.raw_pid,
-                OpFlags::ByassReferrals as i32,
+                0 as i32,
             )
         };
 


### PR DESCRIPTION
Problem: 
 entryuuid plugin fixup task fails in replicated topology because o CSN is generated and the replication plugin aborts the operation.
 This happen because the operation flags are set to 0x400000  which is OP_FLAG_TOMBSTONE_FIXUP
 (a flags that should only be set to handle  replication plugin internal operations)

Solution: 
   Do not any flags 

Issue: [5158](https://github.com/389ds/389-ds-base/pull/5158)

Reviewed by: ?
