### PR TITLE
Issue 5413 - Allow only one MemberOf fixup task at a time

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
@@ -1,0 +1,74 @@
+import ldap
+import logging
+import pytest
+import os
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.topologies import topology_st as topo
+from lib389.plugins import MemberOfPlugin
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups
+
+
+log = logging.getLogger(__name__)
+
+
+def test_fixup_task_limit(topo):
+    """Test only one fixup task is allowed at one time
+
+    :id: 2bb49a10-fca9-4d89-9a7a-34c2ba4baadc
+    :setup: Standalone Instance
+    :steps:
+        1. Add some users and groups
+        2. Enable memberOf Plugin
+        3. Add fixup task
+        4. Add second task
+        5. Add a third task after first task completes
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Second task should fail
+        5. Success
+    """
+
+    # Create group with members
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    group = groups.create(properties={'cn': 'test'})
+
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    for idx in range(400):
+        user = users.create(properties={
+            'uid': 'testuser%s' % idx,
+            'cn' : 'testuser%s' % idx,
+            'sn' : 'user%s' % idx,
+            'uidNumber' : '%s' % (1000 + idx),
+            'gidNumber' : '%s' % (1000 + idx),
+            'homeDirectory' : '/home/testuser%s' % idx
+        })
+        group.add('member', user.dn)
+
+    # Configure memberOf plugin
+    memberof = MemberOfPlugin(topo.standalone)
+    memberof.enable()
+    topo.standalone.restart()
+
+    # Add first task
+    task = memberof.fixup(DEFAULT_SUFFIX)
+
+    # Add second task which should fail
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        memberof.fixup(DEFAULT_SUFFIX)
+
+    # Wait for first task to complete
+    task.wait()
+
+    # Add new task which should be allowed now
+    memberof.fixup(DEFAULT_SUFFIX)
+     
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/plugins/memberof/memberof.h
+++ b/ldap/servers/plugins/memberof/memberof.h
@@ -66,6 +66,7 @@ typedef struct memberofconfig
     char *auto_add_oc;
     PLHashTable *ancestors_cache;
     PLHashTable *fixup_cache;
+    Slapi_Task *task;
 } MemberOfConfig;
 
 /* The key to access the hash table is the normalized DN

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1561,15 +1561,7 @@ def get_task_status(inst, log, taskObj, dn=None, show_log=False, watch=False, us
                 all_finished = False
                 task_ended = ""
                 exitcode = "Not finished ..."
-
-                # Calc elapsed time for running task
-                curr_time = int(time.time())  # Use the current time
-                time_tuple = (int(task_created[:4]), int(task_created[4:6]), int(task_created[6:8]),
-                              int(task_created[8:10]), int(task_created[10:12]), int(task_created[12:14]),
-                              0, 0, 0)
-                start_time = int(time.mktime(time_tuple))
-                elapsed_secs = curr_time - start_time
-                elapsed_time_str = str(timedelta(seconds=elapsed_secs))
+                elapsed_time_str = ""
             else:
                 # Task is finished, use start and end times to calc elapsed time
                 elapsed_time_str = elapsed_time(task_created, task_ended)


### PR DESCRIPTION
Description:  only allow one fixup task to run at a time, and improve the task logging

relates: https://github.com/389ds/389-ds-base/issues/5413