### PR TITLE
Issue 5443 - UI - disable save button while saving

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -1347,7 +1347,7 @@ class CreateSuffixModal extends React.Component {
                         key="confirm"
                         variant="primary"
                         onClick={saveHandler}
-                        isDisabled={createNotOK}
+                        isDisabled={createNotOK || modalSpinning}
                         isLoading={modalSpinning}
                         spinnerAriaValueText={modalSpinning ? "Creating Suffix" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -421,7 +421,7 @@ export class CreateInstanceModal extends React.Component {
                         key="confirm"
                         variant="primary"
                         onClick={this.handleCreateInstance}
-                        isDisabled={!createOK}
+                        isDisabled={!createOK || loadingCreate}
                         isLoading={loadingCreate}
                         spinnerAriaValueText={loadingCreate ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
+++ b/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
@@ -212,7 +212,7 @@ export class AttrEncryption extends React.Component {
                             variant="primary"
                             onClick={this.addEncryptedAttr}
                             isLoading={saving}
-                            isDisabled={addAttr == ""}
+                            isDisabled={addAttr == "" || saving}
                             spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                             {...extraPrimaryProps}
                         >

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -807,6 +807,7 @@ class ExportModal extends React.Component {
                         onClick={saveHandler}
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Creating ..." : undefined}
+                        isDisabled={spinning}
                         {...extraPrimaryProps}
                     >
                         {createBtnName}
@@ -904,6 +905,7 @@ export class BackupModal extends React.Component {
                         variant="primary"
                         onClick={saveHandler}
                         isLoading={spinning}
+                        isDisabled={spinning}
                         spinnerAriaValueText={spinning ? "Creating ..." : undefined}
                         {...extraPrimaryProps}
                     >

--- a/src/cockpit/389-console/src/lib/database/chaining.jsx
+++ b/src/cockpit/389-console/src/lib/database/chaining.jsx
@@ -854,7 +854,7 @@ export class ChainingDatabaseConfig extends React.Component {
                                 className="ds-margin-top-xlg"
                                 variant="primary"
                                 onClick={this.save_chaining_config}
-                                isDisabled={this.state.saveBtnDisabled}
+                                isDisabled={this.state.saveBtnDisabled || this.state.saving}
                                 isLoading={this.state.saving}
                                 spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                                 {...extraPrimaryProps}
@@ -1793,7 +1793,7 @@ export class ChainingConfig extends React.Component {
                     isLoading={this.state.saving}
                     spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                     {...extraPrimaryProps}
-                    isDisabled={this.state.saveBtnDisabled}
+                    isDisabled={this.state.saveBtnDisabled || this.state.saving}
                 >
                     {saveBtnName}
                 </Button>
@@ -1853,6 +1853,7 @@ export class ChainControlsModal extends React.Component {
                         variant="primary"
                         onClick={saveHandler}
                         isLoading={spinning}
+                        isDisabled={spinning}
                         spinnerAriaValueText={spinning ? "Loading" : undefined}
                         {...extraPrimaryProps}
                     >
@@ -1912,6 +1913,7 @@ export class ChainCompsModal extends React.Component {
                         variant="primary"
                         onClick={saveHandler}
                         isLoading={spinning}
+                        isDisabled={spinning}
                         spinnerAriaValueText={spinning ? "Loading" : undefined}
                         {...extraPrimaryProps}
                     >

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -864,7 +864,7 @@ export class GlobalDatabaseConfig extends React.Component {
                         isLoading={this.state.saving}
                         spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.state.saveBtnDisabled}
+                        isDisabled={this.state.saveBtnDisabled || this.state.saving}
                     >
                         {saveBtnName}
                     </Button>

--- a/src/cockpit/389-console/src/lib/database/databaseModal.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseModal.jsx
@@ -52,7 +52,7 @@ class CreateLinkModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Creating Link" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled}
+                        isDisabled={this.props.saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>,
@@ -270,7 +270,7 @@ class CreateSubSuffixModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Creating Suffix" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled}
+                        isDisabled={this.props.saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>,
@@ -380,7 +380,7 @@ class ExportModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Creating Suffix" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled}
+                        isDisabled={this.props.saveBtnDisabled || spinning}
                     >
                         {saveBtnName}
                     </Button>,

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1420,7 +1420,7 @@ export class GlobalPwPolicy extends React.Component {
                                 </Grid>
                             </Form>
                             <Button
-                                isDisabled={this.state.saveGeneralDisabled}
+                                isDisabled={this.state.saveGeneralDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left-sm"
                                 onClick={this.saveGeneral}
@@ -1448,7 +1448,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwExpirationRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveExpDisabled}
+                                isDisabled={this.state.saveExpDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveExp}
@@ -1476,7 +1476,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwLockoutRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveLockoutDisabled}
+                                isDisabled={this.state.saveLockoutDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveLockout}
@@ -1504,7 +1504,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveSyntaxDisabled}
+                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveSyntax}
@@ -1595,7 +1595,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveTPRDisabled}
+                                isDisabled={this.state.saveTPRDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveTPR}

--- a/src/cockpit/389-console/src/lib/database/indexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/indexes.jsx
@@ -821,7 +821,7 @@ class AddIndexModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Creating" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>,
@@ -1110,7 +1110,7 @@ class EditIndexModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>,

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -1342,7 +1342,7 @@ export class LocalPwPolicy extends React.Component {
                 cmd.push(this.state.attrMap[attr] + "=" + new_val);
             }
         }
-      
+
         log_cmd("createPolicy", "Create a local password policy", cmd);
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
@@ -2860,7 +2860,7 @@ export class LocalPwPolicy extends React.Component {
                                 </Grid>
                             </Form>
                             <Button
-                                isDisabled={this.state.saveGeneralDisabled}
+                                isDisabled={this.state.saveGeneralDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left-sm"
                                 onClick={this.saveGeneral}
@@ -2888,7 +2888,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwExpirationRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveExpDisabled}
+                                isDisabled={this.state.saveExpDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveExp}
@@ -2916,7 +2916,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwLockoutRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveLockoutDisabled}
+                                isDisabled={this.state.saveLockoutDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveLockout}
@@ -2944,7 +2944,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveSyntaxDisabled}
+                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveSyntax}
@@ -3035,7 +3035,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveTPRDisabled}
+                                isDisabled={this.state.saveTPRDisabled || this.state.saving}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.saveTPR}

--- a/src/cockpit/389-console/src/lib/database/referrals.jsx
+++ b/src/cockpit/389-console/src/lib/database/referrals.jsx
@@ -333,7 +333,7 @@ class AddReferralModal extends React.Component {
                         key="confirm"
                         variant="primary"
                         onClick={saveHandler}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/database/suffixConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/suffixConfig.jsx
@@ -71,10 +71,10 @@ export class SuffixConfig extends React.Component {
             cacheInputs =
                 <Form isHorizontal autoComplete="off">
                     <Grid title="The size for the available memory space in bytes for the entry cache (nsslapd-cachememsize).">
-                        <GridItem className="ds-label" span={4}>
+                        <GridItem className="ds-label" span={3}>
                             Entry Cache Size
                         </GridItem>
-                        <GridItem span={8}>
+                        <GridItem span={9}>
                             <TextInput
                                 value={this.props.cachememsize}
                                 type="number"
@@ -88,10 +88,10 @@ export class SuffixConfig extends React.Component {
                         </GridItem>
                     </Grid>
                     <Grid title="The number of entries to keep in the entry cache, use'-1' for unlimited (nsslapd-cachesize).">
-                        <GridItem className="ds-label" span={4}>
+                        <GridItem className="ds-label" span={3}>
                             Entry Cache Max Entries
                         </GridItem>
-                        <GridItem span={8}>
+                        <GridItem span={9}>
                             <TextInput
                                 value={this.props.cachesize}
                                 type="number"
@@ -105,10 +105,10 @@ export class SuffixConfig extends React.Component {
                         </GridItem>
                     </Grid>
                     <Grid title="the available memory space in bytes for the DN cache. The DN cache is similar to the entry cache for a database, only its table stores only the entry ID and the entry DN (nsslapd-dncachememsize).">
-                        <GridItem className="ds-label" span={4}>
+                        <GridItem className="ds-label" span={3}>
                             DN Cache Size
                         </GridItem>
-                        <GridItem span={8}>
+                        <GridItem span={9}>
                             <TextInput
                                 value={this.props.dncachememsize}
                                 type="number"
@@ -192,7 +192,7 @@ export class SuffixConfig extends React.Component {
                         isLoading={this.props.saving}
                         spinnerAriaValueText={this.props.saving ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled}
+                        isDisabled={this.props.saveBtnDisabled || this.props.saving}
                     >
                         {saveBtnName}
                     </Button>

--- a/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
@@ -573,7 +573,7 @@ class AddVLVIndexModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.state.sortValue.length == 0}
+                        isDisabled={this.state.sortValue.length == 0 || saving}
                     >
                         {saveBtnName}
                     </Button>,
@@ -658,7 +658,7 @@ class AddVLVModal extends React.Component {
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled}
+                        isDisabled={this.props.saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>,

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/aci.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/aci.jsx
@@ -502,7 +502,7 @@ class AciWizard extends React.Component {
                             isLoading={modalSpinning}
                             spinnerAriaValueText={modalSpinning ? "Loading" : undefined}
                             {...extraPrimaryProps}
-                            isDisabled={this.state.aciText === this.state.aciTextNew}
+                            isDisabled={this.state.aciText === this.state.aciTextNew || modalSpinning}
                         >
                             {btnName}
                         </Button>,
@@ -544,7 +544,7 @@ class AciWizard extends React.Component {
                             isLoading={modalSpinning}
                             spinnerAriaValueText={modalSpinning ? "Loading" : undefined}
                             {...extraPrimaryProps}
-                            isDisabled={this.state.aciTextNew === ""}
+                            isDisabled={this.state.aciTextNew === "" || modalSpinning}
                         >
                             {btnName}
                         </Button>,

--- a/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
@@ -1376,6 +1376,7 @@ export class ReplMonitor extends React.Component {
                             onClick={this.doFullReport}
                             title="Use the specified credentials and display full topology report"
                             isLoading={this.state.reportLoading}
+                            isDisabled={this.state.reportLoading}
                             spinnerAriaValueText={this.state.reportLoading ? "Generating" : undefined}
                             {...extraPrimaryProps}
                         >

--- a/src/cockpit/389-console/src/lib/notifications.jsx
+++ b/src/cockpit/389-console/src/lib/notifications.jsx
@@ -56,7 +56,7 @@ export class DoubleConfirmModal extends React.Component {
                         spinnerAriaValueText={spinning ? "Loading" : undefined}
                         variant="primary"
                         onClick={actionHandler}
-                        isDisabled={saveDisabled}
+                        isDisabled={saveDisabled || spinning}
                         {...extraPrimaryProps}
                     >
                         {btnName}

--- a/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
@@ -747,7 +747,7 @@ class AccountPolicy extends React.Component {
                     key="save"
                     variant="primary"
                     onClick={this.editConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || savingModal}
                     isLoading={savingModal}
                     spinnerAriaValueText={savingModal ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -764,7 +764,7 @@ class AccountPolicy extends React.Component {
                     key="add"
                     variant="primary"
                     onClick={this.addConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || addingModal}
                     isLoading={addingModal}
                     spinnerAriaValueText={addingModal ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -1002,7 +1002,7 @@ class AccountPolicy extends React.Component {
                         variant="primary"
                         onClick={this.saveConfig}
                         {...extraPrimaryProps}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                     >
                         {saveBtnText}
                     </Button>

--- a/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
@@ -623,7 +623,7 @@ class AttributeUniqueness extends React.Component {
                             key="confirm"
                             variant="primary"
                             onClick={newEntry ? this.addConfig : this.editConfig}
-                            isDisabled={this.state.saveBtnDisabled}
+                            isDisabled={this.state.saveBtnDisabled || this.state.saving}
                             isLoading={this.state.saving}
                             spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                             {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
@@ -1083,7 +1083,7 @@ class AutoMembership extends React.Component {
                             key="confirm"
                             variant="primary"
                             onClick={newDefinitionEntry ? this.addDefinition : this.editDefinition}
-                            isDisabled={saveBtnDisabled}
+                            isDisabled={saveBtnDisabled || saving}
                             isLoading={saving}
                             spinnerAriaValueText={saving ? "Saving" : undefined}
                             {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/dna.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/dna.jsx
@@ -1046,7 +1046,7 @@ class DNAPlugin extends React.Component {
                     actions={[
                         <Button
                             key="saveshared"
-                            isDisabled={saveBtnDisabled}
+                            isDisabled={saveBtnDisabled || saving}
                             variant="primary"
                             onClick={newEntry ? this.addConfig : this.editConfig}
                             isLoading={saving}
@@ -1338,7 +1338,7 @@ class DNAPlugin extends React.Component {
                     actions={[
                         <Button
                             key="confirm"
-                            isDisabled={sharedResult.saveSharedNotOK}
+                            isDisabled={sharedResult.saveSharedNotOK || savingShared}
                             variant="primary"
                             onClick={this.editSharedConfig}
                             isLoading={savingShared}

--- a/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
@@ -449,7 +449,7 @@ class LinkedAttributes extends React.Component {
                             key="confirm"
                             variant="primary"
                             onClick={newEntry ? this.addConfig : this.editConfig}
-                            isDisabled={saveBtnDisabled}
+                            isDisabled={saveBtnDisabled || saving}
                             isLoading={saving}
                             spinnerAriaValueText={saving ? "Saving" : undefined}
                             {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -1152,7 +1152,7 @@ class MemberOf extends React.Component {
                     key="save"
                     variant="primary"
                     onClick={this.editConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || savingModal}
                     isLoading={savingModal}
                     spinnerAriaValueText={savingModal ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -1169,7 +1169,7 @@ class MemberOf extends React.Component {
                     key="add"
                     variant="primary"
                     onClick={this.addConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || savingModal}
                     isLoading={savingModal}
                     spinnerAriaValueText={savingModal ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -1654,7 +1654,7 @@ class MemberOf extends React.Component {
                         variant="primary"
                         onClick={this.saveConfig}
                         {...extraPrimaryProps}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                     >
                         {saveBtnName}
                     </Button>

--- a/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
@@ -1040,7 +1040,7 @@ class PassthroughAuthentication extends React.Component {
                             key="confirm"
                             variant="primary"
                             onClick={newPAMConfigEntry ? this.addPAMConfig : this.editPAMConfig}
-                            isDisabled={this.state.saveBtnDisabledPAM}
+                            isDisabled={this.state.saveBtnDisabledPAM || this.state.savingPAM}
                             isLoading={this.state.savingPAM}
                             spinnerAriaValueText={this.state.savingPAM ? "Saving" : undefined}
                             {...extraPrimaryProps}
@@ -1265,7 +1265,7 @@ class PassthroughAuthentication extends React.Component {
                             key="confirm"
                             variant="primary"
                             onClick={newURLEntry ? this.addURL : this.editURL}
-                            isDisabled={this.state.saveBtnDisabledPassthru}
+                            isDisabled={this.state.saveBtnDisabledPassthru || this.state.savingPassthru}
                             isLoading={this.state.savingPassthru}
                             spinnerAriaValueText={this.state.savingPassthru ? "Saving" : undefined}
                             {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
@@ -811,7 +811,7 @@ class ReferentialIntegrity extends React.Component {
                     key="save"
                     variant="primary"
                     onClick={this.editConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || savingModal}
                     isLoading={savingModal}
                     spinnerAriaValueText={savingModal ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -828,7 +828,7 @@ class ReferentialIntegrity extends React.Component {
                     key="add"
                     variant="primary"
                     onClick={this.addConfig}
-                    isDisabled={saveBtnDisabledModal}
+                    isDisabled={saveBtnDisabledModal || addSpinning}
                     isLoading={addSpinning}
                     spinnerAriaValueText={addSpinning ? "Saving" : undefined}
                     {...extraPrimaryProps}
@@ -1189,7 +1189,7 @@ class ReferentialIntegrity extends React.Component {
                         variant="primary"
                         onClick={this.saveConfig}
                         {...extraPrimaryProps}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                     >
                         {saveBtnText}
                     </Button>

--- a/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
@@ -95,7 +95,7 @@ class RetroChangelog extends React.Component {
                 trimInterval: Number(this.state.trimInterval) + 1
             }, () => { this.validate() });
         };
-        
+
         this.onExcludeAttrSelect = (event, selection) => {
             if (this.state.excludeAttrs.includes(selection)) {
                 this.setState(
@@ -310,7 +310,7 @@ class RetroChangelog extends React.Component {
             } else {
                 cmd = [...cmd, "delete"];
             }
-        } 
+        }
         this.setState({
             saving: true
         });
@@ -504,7 +504,7 @@ class RetroChangelog extends React.Component {
                         className="ds-margin-top-xlg"
                         variant="primary"
                         onClick={this.savePlugin}
-                        isDisabled={this.state.saveBtnDisabled}
+                        isDisabled={this.state.saveBtnDisabled || this.state.saving}
                         isLoading={this.state.saving}
                         spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
@@ -747,7 +747,7 @@ class RootDNAccessControl extends React.Component {
                         className="ds-margin-top-lg"
                         variant="primary"
                         onClick={this.savePlugin}
-                        isDisabled={saveBtnDisabled}
+                        isDisabled={saveBtnDisabled || saving}
                         isLoading={saving}
                         spinnerAriaValueText={saving ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/plugins/winsync.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/winsync.jsx
@@ -313,7 +313,7 @@ class WinSync extends React.Component {
                             key="task"
                             variant="primary"
                             onClick={this.runFixup}
-                            isDisabled={saveBtnDisabledModal}
+                            isDisabled={saveBtnDisabledModal || savingModal}
                             isLoading={savingModal}
                             spinnerAriaValueText={savingModal ? "Saving" : undefined}
                             {...extraPrimaryProps}
@@ -446,7 +446,7 @@ class WinSync extends React.Component {
                     className="ds-margin-top-lg"
                     variant="primary"
                     onClick={this.savePlugin}
-                    isDisabled={saveBtnDisabled}
+                    isDisabled={saveBtnDisabled || saving}
                     isLoading={saving}
                     spinnerAriaValueText={saving ? "Saving" : undefined}
                     {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
@@ -279,7 +279,7 @@ export class Changelog extends React.Component {
                                     widthChars={8}
                                 />
                             </GridItem>
-                            <GridItem span={3}>
+                            <GridItem className="ds-margin-left" span={3}>
                                 <FormSelect
                                     className="ds-margin-left"
                                     id="clMaxAgeUnit"
@@ -318,9 +318,7 @@ export class Changelog extends React.Component {
                                 />
                             </GridItem>
                         </Grid>
-                        <Grid
-                            title="The changelog trimming interval.  Set how often the changelog checks if there are entries that can be purged from the changelog based on the trimming parameters (nsslapd-changelogtrim-interval)."
-                        >
+                        <Grid>
                             <GridItem className="ds-label" span={3}>
                                 Changelog Encryption
                                 <Tooltip
@@ -356,7 +354,7 @@ export class Changelog extends React.Component {
                         className="ds-margin-top-xlg"
                         variant="primary"
                         onClick={this.saveSettings}
-                        isDisabled={this.state.saveBtnDisabled}
+                        isDisabled={this.state.saveBtnDisabled || this.state.saving}
                         isLoading={this.state.saving}
                         spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -338,7 +338,7 @@ export class WinsyncAgmtModal extends React.Component {
                     <Button
                         key="confirm"
                         variant="primary"
-                        isDisabled={saveDisabled}
+                        isDisabled={saveDisabled || spinning}
                         onClick={saveHandler}
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
@@ -1114,7 +1114,7 @@ export class ReplAgmtModal extends React.Component {
                     <Button
                         key="confirm"
                         variant="primary"
-                        isDisabled={saveDisabled}
+                        isDisabled={saveDisabled || spinning}
                         onClick={saveHandler}
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
@@ -1611,7 +1611,7 @@ export class AddManagerModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={error.manager || error.manager_passwd || error.manager_passwd_confirm}
+                        isDisabled={error.manager || error.manager_passwd || error.manager_passwd_confirm || spinning}
                     >
                         {saveBtnName}
                     </Button>,
@@ -1750,7 +1750,7 @@ export class EnableReplModal extends React.Component {
                         key="enable"
                         variant="primary"
                         onClick={saveHandler}
-                        isDisabled={this.props.disabled}
+                        isDisabled={this.props.disabled || spinning}
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
@@ -1994,7 +1994,7 @@ export class ExportCLModal extends React.Component {
                         key="export"
                         variant="primary"
                         onClick={saveHandler}
-                        isDisabled={!saveOK}
+                        isDisabled={!saveOK || spinning}
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
@@ -82,7 +82,7 @@ class ObjectClassModal extends React.Component {
                     variant="primary"
                     onClick={newOcEntry ? addHandler : editHandler}
                     {...extraPrimaryProps}
-                    isDisabled={saveBtnDisabled}
+                    isDisabled={saveBtnDisabled || loading}
                 >
                     {btnText}
                 </Button>
@@ -372,7 +372,7 @@ class AttributeTypeModal extends React.Component {
                     variant="primary"
                     onClick={newAtEntry ? addHandler : editHandler}
                     {...extraPrimaryProps}
-                    isDisabled={saveBtnDisabled}
+                    isDisabled={saveBtnDisabled || loading}
                 >
                     {btnText}
                 </Button>

--- a/src/cockpit/389-console/src/lib/security/ciphers.jsx
+++ b/src/cockpit/389-console/src/lib/security/ciphers.jsx
@@ -480,7 +480,7 @@ export class Ciphers extends React.Component {
                         onClick={() => {
                             this.saveCipherPref();
                         }}
-                        isDisabled={this.state.disableSaveBtn}
+                        isDisabled={this.state.disableSaveBtn || this.state.saving}
                         isLoading={this.state.saving}
                         spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                         {...extraPrimaryProps}

--- a/src/cockpit/389-console/src/lib/security/securityModals.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityModals.jsx
@@ -49,7 +49,7 @@ export class SecurityAddCACertModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={error.certFile || error.certName}
+                        isDisabled={error.certFile || error.certName || spinning}
                     >
                         {saveBtnName}
                     </Button>,
@@ -141,7 +141,7 @@ export class SecurityAddCertModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={error.certFile || error.certName}
+                        isDisabled={error.certFile || error.certName || spinning}
                     >
                         {saveBtnName}
                     </Button>,
@@ -240,6 +240,7 @@ export class SecurityEnableModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
+                        isDisabled={spinning}
                     >
                         {saveBtnName}
                     </Button>,
@@ -398,7 +399,7 @@ export class EditCertModal extends React.Component {
                         isLoading={spinning}
                         spinnerAriaValueText={spinning ? "Saving" : undefined}
                         {...extraPrimaryProps}
-                        isDisabled={this.props.disableSaveBtn}
+                        isDisabled={this.props.disableSaveBtn || spinning}
                     >
                         {saveBtnName}
                     </Button>,

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -606,7 +606,7 @@ export class ServerAccessLog extends React.Component {
 
                         <Button
                             key="save settings"
-                            isDisabled={this.state.saveSettingsDisabled}
+                            isDisabled={this.state.saveSettingsDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -730,7 +730,7 @@ export class ServerAccessLog extends React.Component {
                         </Form>
                         <Button
                             key="save rot settings"
-                            isDisabled={this.state.saveRotationDisabled}
+                            isDisabled={this.state.saveRotationDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -832,7 +832,7 @@ export class ServerAccessLog extends React.Component {
                         </Form>
                         <Button
                             key="save del settings"
-                            isDisabled={this.state.saveExpDisabled}
+                            isDisabled={this.state.saveExpDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -449,7 +449,7 @@ export class ServerAuditLog extends React.Component {
                         </Form>
                         <Button
                             key="save settings"
-                            isDisabled={this.state.saveSettingsDisabled}
+                            isDisabled={this.state.saveSettingsDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -573,7 +573,7 @@ export class ServerAuditLog extends React.Component {
                         </Form>
                         <Button
                             key="save rot settings"
-                            isDisabled={this.state.saveRotationDisabled}
+                            isDisabled={this.state.saveRotationDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -675,7 +675,7 @@ export class ServerAuditLog extends React.Component {
                         </Form>
                         <Button
                             key="save del settings"
-                            isDisabled={this.state.saveExpDisabled}
+                            isDisabled={this.state.saveExpDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -450,7 +450,7 @@ export class ServerAuditFailLog extends React.Component {
                         </Grid>
                         <Button
                             key="save settings"
-                            isDisabled={this.state.saveSettingsDisabled}
+                            isDisabled={this.state.saveSettingsDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -574,7 +574,7 @@ export class ServerAuditFailLog extends React.Component {
                         </Form>
                         <Button
                             key="save rot settings"
-                            isDisabled={this.state.saveRotationDisabled}
+                            isDisabled={this.state.saveRotationDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -676,7 +676,7 @@ export class ServerAuditFailLog extends React.Component {
                         </Form>
                         <Button
                             key="save del settings"
-                            isDisabled={this.state.saveExpDisabled}
+                            isDisabled={this.state.saveExpDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -110,7 +110,7 @@ export class ServerErrorLog extends React.Component {
                 { cells: [{ title: this.aclLevel }], level: 128, selected: false },
                 { cells: [{ title: this.entryLevel }], level: 2048, selected: false },
                 { cells: [{ title: this.houseLevel }], level: 4096, selected: false },
-                { cells: [{ title: this.replLevel }], level: 8291, selected: false },
+                { cells: [{ title: this.replLevel }], level: 8192, selected: false },
                 { cells: [{ title: this.cacheLevel }], level: 32768, selected: false },
                 { cells: [{ title: this.pluginLevel }], level: 65536, selected: false },
                 { cells: [{ title: this.aclSummaryevel }], level: 262144, selected: false },
@@ -609,7 +609,7 @@ export class ServerErrorLog extends React.Component {
 
                         <Button
                             key="save settings"
-                            isDisabled={this.state.saveSettingsDisabled}
+                            isDisabled={this.state.saveSettingsDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -733,7 +733,7 @@ export class ServerErrorLog extends React.Component {
                         </Form>
                         <Button
                             key="save rot settings"
-                            isDisabled={this.state.saveRotationDisabled}
+                            isDisabled={this.state.saveRotationDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -835,7 +835,7 @@ export class ServerErrorLog extends React.Component {
                         </Form>
                         <Button
                             key="save del settings"
-                            isDisabled={this.state.saveExpDisabled}
+                            isDisabled={this.state.saveExpDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/ldapi.jsx
+++ b/src/cockpit/389-console/src/lib/server/ldapi.jsx
@@ -373,7 +373,7 @@ export class ServerLDAPI extends React.Component {
                     {mapUserAttrs}
                 </Form>
                 <Button
-                    isDisabled={this.state.saveDisabled}
+                    isDisabled={this.state.saveDisabled || this.state.loading}
                     variant="primary"
                     className="ds-margin-top-xlg"
                     onClick={this.saveConfig}

--- a/src/cockpit/389-console/src/lib/server/sasl.jsx
+++ b/src/cockpit/389-console/src/lib/server/sasl.jsx
@@ -695,7 +695,7 @@ export class ServerSASL extends React.Component {
                         </Grid>
                     </Form>
                     <Button
-                        isDisabled={this.state.saveDisabled}
+                        isDisabled={this.state.saveDisabled || this.state.configLoading}
                         variant="primary"
                         className="ds-margin-top-xlg"
                         onClick={this.saveConfig}

--- a/src/cockpit/389-console/src/lib/server/securityLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/securityLog.jsx
@@ -601,7 +601,7 @@ export class ServerSecurityLog extends React.Component {
 
                         <Button
                             key="save settings"
-                            isDisabled={this.state.saveSettingsDisabled}
+                            isDisabled={this.state.saveSettingsDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -725,7 +725,7 @@ export class ServerSecurityLog extends React.Component {
                         </Form>
                         <Button
                             key="save rot settings"
-                            isDisabled={this.state.saveRotationDisabled}
+                            isDisabled={this.state.saveRotationDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {
@@ -827,7 +827,7 @@ export class ServerSecurityLog extends React.Component {
                         </Form>
                         <Button
                             key="save del settings"
-                            isDisabled={this.state.saveExpDisabled}
+                            isDisabled={this.state.saveExpDisabled || this.state.loading}
                             variant="primary"
                             className="ds-margin-top-xlg"
                             onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/serverModals.jsx
+++ b/src/cockpit/389-console/src/lib/server/serverModals.jsx
@@ -36,7 +36,7 @@ export class SASLMappingModal extends React.Component {
                 actions={[
                     <Button
                         key="confirm"
-                        isDisabled={this.props.saveDisabled}
+                        isDisabled={this.props.saveDisabled || this.props.spinning}
                         variant="primary"
                         isLoading={this.props.spinning}
                         spinnerAriaValueText={this.props.spinning ? "Loading" : undefined}

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -1127,7 +1127,7 @@ export class ServerSettings extends React.Component {
                                     </Grid>
                                 </Form>
                                 <Button
-                                    isDisabled={this.state.configSaveDisabled}
+                                    isDisabled={this.state.configSaveDisabled || this.state.configReloading}
                                     variant="primary"
                                     className="ds-margin-top-xlg"
                                     onClick={this.saveConfig}
@@ -1223,7 +1223,7 @@ export class ServerSettings extends React.Component {
                                 <Button
                                     variant="primary"
                                     className="ds-margin-top-xlg"
-                                    isDisabled={this.state.rootDNSaveDisabled}
+                                    isDisabled={this.state.rootDNSaveDisabled || this.state.rootDNReloading}
                                     onClick={this.saveRootDN}
                                     isLoading={this.state.rootDNReloading}
                                     spinnerAriaValueText={this.state.rootDNReloading ? "Saving" : undefined}
@@ -1245,7 +1245,7 @@ export class ServerSettings extends React.Component {
                                 </Form>
                                 {diskMonitor}
                                 <Button
-                                    isDisabled={this.state.diskMonSaveDisabled}
+                                    isDisabled={this.state.diskMonSaveDisabled || this.state.diskMonReloading}
                                     variant="primary"
                                     className="ds-margin-top-xlg"
                                     onClick={this.saveDiskMonitoring}
@@ -1428,7 +1428,7 @@ export class ServerSettings extends React.Component {
                                     </Grid>
                                 </Form>
                                 <Button
-                                    isDisabled={this.state.advSaveDisabled}
+                                    isDisabled={this.state.advSaveDisabled || this.state.advReloading}
                                     variant="primary"
                                     className="ds-margin-top-xlg"
                                     onClick={this.saveAdvanced}

--- a/src/cockpit/389-console/src/lib/server/tuning.jsx
+++ b/src/cockpit/389-console/src/lib/server/tuning.jsx
@@ -626,7 +626,7 @@ export class ServerTuning extends React.Component {
                         </div>
                     </ExpandableSection>
                     <Button
-                        isDisabled={this.state.saveDisabled}
+                        isDisabled={this.state.saveDisabled || this.state.loading}
                         variant="primary"
                         className="ds-margin-top-xlg"
                         onClick={this.saveConfig}

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -1015,7 +1015,7 @@ export class Security extends React.Component {
                             onClick={() => {
                                 this.saveSecurityConfig();
                             }}
-                            isDisabled={this.state.disableSaveBtn}
+                            isDisabled={this.state.disableSaveBtn || this.state.saving}
                             isLoading={this.state.saving}
                             spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
                             {...extraPrimaryProps}


### PR DESCRIPTION
Description:

You can click the save button over and over while its spinning and it will trigger the same operation over and over. It should be disabled while it's "working/spinning".

relates: https://github.com/389ds/389-ds-base/issues/5443

Reviewed by: ?