### PR TITLE
Issue 5447 - UI - add NDN max cache size to UI

### DIFF
--- a/src/cockpit/389-console/package-lock.json
+++ b/src/cockpit/389-console/package-lock.json
@@ -2012,13 +2012,13 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.224.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.224.1.tgz",
-      "integrity": "sha512-v8wGGNoMGndAScAoE5jeOA5jVgymlLSwttPjQk/Idr0k7roSpOrsM39oXUR5DEgkZee45DW00WKTgmg50PP3FQ==",
+      "version": "4.235.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.235.7.tgz",
+      "integrity": "sha512-I26IE75kI2P3kIfPsw0N4/pUSzXxWw2dinGw50fDN0qBMTnSCwwiJnyCFImF0f7YF30QWOO4VPs45zdM4iiQeg==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.75.1",
-        "@patternfly/react-styles": "^4.74.1",
-        "@patternfly/react-tokens": "^4.76.1",
+        "@patternfly/react-icons": "^4.86.7",
+        "@patternfly/react-styles": "^4.85.7",
+        "@patternfly/react-tokens": "^4.87.7",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -2030,18 +2030,18 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.75.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.75.1.tgz",
-      "integrity": "sha512-1ly8SVi/kcc0zkiViOjUd8D5BEr7GeqWGmDPuDSBtD60l1dYf3hZc44IWFVkRM/oHZML/musdrJkLfh4MDqX9w==",
+      "version": "4.86.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.86.7.tgz",
+      "integrity": "sha512-QYurZzfjOKqHWRI8zeUweXy583C11NVeRAWbxVhOhPT/aFtgkd75iZNlLpv6XI1EN/uLpa9WdkZzyuLY1txYnA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.74.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.74.1.tgz",
-      "integrity": "sha512-9eWvKrjtrJ3qhJkhY2GQKyYA13u/J0mU1befH49SYbvxZtkbuHdpKmXBAeQoHmcx1hcOKtiYXeKb+dVoRRNx0A=="
+      "version": "4.85.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.85.7.tgz",
+      "integrity": "sha512-XSa8Loaouj1XEmbJmEeURXxKu5ub1VCRV0yN5YOnRo7j7XI4Yw9QarSHODzhkquI3AhkD0dPyMOaefz4P6lJKw=="
     },
     "node_modules/@patternfly/react-table": {
       "version": "4.93.1",
@@ -2061,9 +2061,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.76.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.76.1.tgz",
-      "integrity": "sha512-gLEezRSzQeflaPu3SCgYmWtuiqDIRtxNNFP1+ES7P2o56YHXJ5o1Pki7LpNCPk/VOzHy2+vRFE/7l+hBEweugw=="
+      "version": "4.87.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.87.7.tgz",
+      "integrity": "sha512-07A7Ya4zIAYyYn3mOCG82wMC3/Y8mtTw95a//Onu/H0oDPMJ5oT7Vd14YN7pHexCAtWvc36Mp46iZ1osIQ7yVQ=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -9953,13 +9953,13 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.224.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.224.1.tgz",
-      "integrity": "sha512-v8wGGNoMGndAScAoE5jeOA5jVgymlLSwttPjQk/Idr0k7roSpOrsM39oXUR5DEgkZee45DW00WKTgmg50PP3FQ==",
+      "version": "4.235.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.235.7.tgz",
+      "integrity": "sha512-I26IE75kI2P3kIfPsw0N4/pUSzXxWw2dinGw50fDN0qBMTnSCwwiJnyCFImF0f7YF30QWOO4VPs45zdM4iiQeg==",
       "requires": {
-        "@patternfly/react-icons": "^4.75.1",
-        "@patternfly/react-styles": "^4.74.1",
-        "@patternfly/react-tokens": "^4.76.1",
+        "@patternfly/react-icons": "^4.86.7",
+        "@patternfly/react-styles": "^4.85.7",
+        "@patternfly/react-tokens": "^4.87.7",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -9967,15 +9967,15 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.75.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.75.1.tgz",
-      "integrity": "sha512-1ly8SVi/kcc0zkiViOjUd8D5BEr7GeqWGmDPuDSBtD60l1dYf3hZc44IWFVkRM/oHZML/musdrJkLfh4MDqX9w==",
+      "version": "4.86.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.86.7.tgz",
+      "integrity": "sha512-QYurZzfjOKqHWRI8zeUweXy583C11NVeRAWbxVhOhPT/aFtgkd75iZNlLpv6XI1EN/uLpa9WdkZzyuLY1txYnA==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.74.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.74.1.tgz",
-      "integrity": "sha512-9eWvKrjtrJ3qhJkhY2GQKyYA13u/J0mU1befH49SYbvxZtkbuHdpKmXBAeQoHmcx1hcOKtiYXeKb+dVoRRNx0A=="
+      "version": "4.85.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.85.7.tgz",
+      "integrity": "sha512-XSa8Loaouj1XEmbJmEeURXxKu5ub1VCRV0yN5YOnRo7j7XI4Yw9QarSHODzhkquI3AhkD0dPyMOaefz4P6lJKw=="
     },
     "@patternfly/react-table": {
       "version": "4.93.1",
@@ -9991,9 +9991,9 @@
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.76.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.76.1.tgz",
-      "integrity": "sha512-gLEezRSzQeflaPu3SCgYmWtuiqDIRtxNNFP1+ES7P2o56YHXJ5o1Pki7LpNCPk/VOzHy2+vRFE/7l+hBEweugw=="
+      "version": "4.87.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.87.7.tgz",
+      "integrity": "sha512-07A7Ya4zIAYyYn3mOCG82wMC3/Y8mtTw95a//Onu/H0oDPMJ5oT7Vd14YN7pHexCAtWvc36Mp46iZ1osIQ7yVQ=="
     },
     "@trysound/sax": {
       "version": "0.2.0",

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -587,7 +587,7 @@ export class Backups extends React.Component {
         return (
             <div>
                 <TextContent>
-                    <Text className="ds-config-header" component={TextVariants.h3}>
+                    <Text className="ds-config-header" component={TextVariants.h2}>
                         Database Backups & LDIFs
                     </Text>
                 </TextContent>

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/ldapNavigator.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/ldapNavigator.jsx
@@ -524,6 +524,7 @@ class LdapNavigator extends React.Component {
                 }
                 <div className={this.props.isDisabled ? "ds-disabled ds-editor-tree" : "ds-editor-tree"}>
                     <TreeView
+                        hasSelectableNodes
                         data={allItems}
                         onSelect={this.treeOnClick}
                         activeItems={activeItems}

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -199,7 +199,7 @@ export function numToCommas(num) {
 
 export function displayBytes(bytes) {
     // Convert bytes into a more human readable value/unit
-    if (bytes === 0) {
+    if (bytes === 0 || isNaN(bytes)) {
         return '0 Bytes';
     }
     const k = 1024;
@@ -211,7 +211,7 @@ export function displayBytes(bytes) {
 
 export function displayKBytes(kbytes) {
     // Convert kilobytes into a more human readable value/unit
-    if (kbytes === 0) {
+    if (kbytes === 0 || isNaN(kbytes)) {
         return '0 KB';
     }
     const k = 1024;

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -972,6 +972,7 @@ export class Monitor extends React.Component {
                             <div className="ds-tree">
                                 <div className={disabled} id="monitor-tree">
                                     <TreeView
+                                        hasSelectableNodes
                                         data={nodes}
                                         activeItems={this.state.activeItems}
                                         onSelect={this.handleTreeClick}


### PR DESCRIPTION
Descripion:

Add NDD cache max size to UI.  Also rewored "Database Global Config" page as it was getting crowded, so it's now a Tabs form.  Also updated patternfly to pick up enhancements to the TreeView (previously selecting a node label would expand/collapse the node which was very annoying), now you must click on the "icon" to expand/collapse it.

relates: https://github.com/389ds/389-ds-base/issues/5447

Reviewed by: ?