### PR TITLE
Issue 5032 - Fix older version compatibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2221,7 +2221,7 @@ ldclt_LDADD = $(NSPR_LINK) $(NSS_LINK) $(LDAPSDK_LINK) $(SASL_LINK) $(LIBNSL) $(
 ldif_SOURCES = ldap/servers/slapd/tools/ldif.c
 
 ldif_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS)
-ldif_LDADD = $(NSPR_LINK) $(NSS_LINK) $(LDAPSDK_LINK_NOTHR) $(SASL_LINK)
+ldif_LDADD = $(NSPR_LINK) $(NSS_LINK) $(LDAPSDK_LINK) $(SASL_LINK)
 
 #------------------------
 # migratecred
@@ -2238,7 +2238,7 @@ migratecred_DEPENDENCIES = libslapd.la
 mmldif_SOURCES = ldap/servers/slapd/tools/mmldif.c
 
 mmldif_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS)
-mmldif_LDADD = libslapd.la libsvrcore.la $(NSPR_LINK) $(NSS_LINK) $(LDAPSDK_LINK_NOTHR) $(SASL_LINK)
+mmldif_LDADD = libslapd.la libsvrcore.la $(NSPR_LINK) $(NSS_LINK) $(LDAPSDK_LINK) $(SASL_LINK)
 mmldif_DEPENDENCIES = libslapd.la
 
 #------------------------

--- a/Makefile.am
+++ b/Makefile.am
@@ -166,7 +166,7 @@ PROFILING_LINKS = @profiling_links@
 NSPR_LINK = $(NSPR_LIBS)
 NSS_LINK = $(NSS_LIBS)
 
-# OpenLDAP 2.6 and newer versions don't have libldap_r shared library (only libldap)
+# OpenLDAP 2.5 and newer versions don't have libldap_r shared library (only libldap)
 # For the older versions we should compile with libldap_r
 if WITH_LIBLDAP_R
 LDAPSDK_LINK = @openldap_lib@ -lldap_r@ol_libver@ @ldap_lib_ldif@ -llber@ol_libver@

--- a/configure.ac
+++ b/configure.ac
@@ -912,9 +912,9 @@ AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use lldap_r shared lib
     AC_SUBST(with_libldap_r)
   fi
 ],
-OPENLDAP_VERSION=`ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([0-9]\+\.[0-9]\+\.[0-9]\+\) .*/\1/p')`
-AC_MSG_RESULT([$OPENLDAP_VERSION])
-AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.5], [ with_libldap_r=no ], [ with_libldap_r=yes ]))
+OPENLDAP_VERSION=`ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([[[0-9]]]\+\.[[[0-9]]]\+\.[[[0-9]]]\+\) .*/\1/p')`
+AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.5], [ with_libldap_r=yes ], [ with_libldap_r=no ])
+AC_MSG_RESULT($with_libldap_r))
 
 AM_CONDITIONAL([WITH_LIBLDAP_R],[test "$with_libldap_r" = yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -902,7 +902,7 @@ AM_CONDITIONAL(OPENLDAP,test "$with_openldap" = "yes")
 
 # check for --with-libldap-r
 AC_MSG_CHECKING(for --with-libldap-r)
-AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so shared library (default: if OpenLDAP version is less than 2.6, then libldap_r.so will be used, else - libldap.so)]),
+AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use lldap_r shared library (default: if OpenLDAP version is less than 2.5, then lldap_r will be used, else - lldap)]),
 [
   if test "$withval" = "no"; then
     AC_MSG_RESULT(no)
@@ -914,7 +914,7 @@ AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use libldap_r.so share
 ],
 OPENLDAP_VERSION=`ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([0-9]\+\.[0-9]\+\.[0-9]\+\) .*/\1/p')`
 AC_MSG_RESULT([$OPENLDAP_VERSION])
-AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.6], [ with_libldap_r=no ], [ with_libldap_r=yes ]))
+AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.5], [ with_libldap_r=no ], [ with_libldap_r=yes ]))
 
 AM_CONDITIONAL([WITH_LIBLDAP_R],[test "$with_libldap_r" = yes])
 


### PR DESCRIPTION
Description: Some of the legacy libraries are still built with LDAPSDK_LINK_NOTHR.
Change them to be built with LDAPSDK_LINK instead.
Backport older commits from #5032.

Fixes: https://github.com/389ds/389-ds-base/issues/5032

Reviewed by: ?