### PR TITLE
Issue 5462 - RFE - add missing default indexes

### DIFF
--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -995,6 +995,13 @@ nsindextype: pres
 nsindextype: eq
 nsindextype: sub
 
+dn: cn=gidnumber,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+objectclass: top
+objectclass: nsIndex
+cn: gidnumber
+nssystemindex: false
+nsindextype: eq
+
 dn: cn=mail,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsIndex
@@ -1029,6 +1036,13 @@ dn: cn=memberOf,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=con
 objectclass: top
 objectclass: nsIndex
 cn: memberOf
+nssystemindex: false
+nsindextype: eq
+
+dn: cn=memberuid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+objectclass: top
+objectclass: nsIndex
+cn: memberuid
 nssystemindex: false
 nsindextype: eq
 
@@ -1104,6 +1118,13 @@ dn: cn=uid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsIndex
 cn: uid
+nssystemindex: false
+nsindextype: eq
+
+dn: cn=uidnumber,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+objectclass: top
+objectclass: nsIndex
+cn: uidnumber
 nssystemindex: false
 nsindextype: eq
 


### PR DESCRIPTION
Bug Description: Uidnumber and gidnumber are commonly searched by unix related integrations. Memberuid is also used by the less-prefrered legacy style unix group resolution tools. We should index these by default to prevent performance and experience issues.

Fix Description: Add uidnumber, gidnumber and memberuid indexes to the default index set.

fixes: https://github.com/389ds/389-ds-base/issues/5462

Author: William Brown <william@blackhats.net.au>

Review by: ???