### PR TITLE
Issue 5465 - Fix dbscan linking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1786,7 +1786,7 @@ libwhoami_plugin_la_LDFLAGS = -avoid-version
 dbscan_SOURCES = ldap/servers/slapd/tools/dbscan.c
 
 dbscan_CPPFLAGS = $(NSPR_INCLUDES) $(AM_CPPFLAGS)
-dbscan_LDADD = $(NSPR_LINK) $(DB_IMPL)
+dbscan_LDADD = $(NSPR_LINK) $(DB_IMPL) libslapd.la
 
 #------------------------
 # ldap-agent


### PR DESCRIPTION
Bug Description:

Linking of dbscan fails with:
ld: ./.libs/libback-ldbm.so: undefined reference to symbol 'slapi_ch_free' ld: ./.libs/libslapd.so.0: error adding symbols: DSO missing from command line

Fix Description:

Add the missing libslapd.so to the command line.

relates: https://github.com/389ds/389-ds-base/issues/5465

Author: Stanislav Levin

Reviewed by: Mark Reynolds (thanks)