### PR TITLE
Issue 4776 - Fix entryuuid fixup task

### DIFF
--- a/src/plugins/entryuuid/src/lib.rs
+++ b/src/plugins/entryuuid/src/lib.rs
@@ -144,11 +144,17 @@ impl SlapiPlugin3 for EntryUuid {
         // Error if the first filter is empty?
 
         // Now, to make things faster, we wrap the filter in a exclude term.
+
+        // 2021 - #4877 because we allow entryuuid to be strings, on import these may
+        // be invalid. As a result, we DO need to allow the fixup to check the entryuuid
+        // value is correct, so we can not exclude these during the search.
+        /*
         let raw_filter = if !raw_filter.starts_with('(') && !raw_filter.ends_with('(') {
             format!("(&({})(!(entryuuid=*)))", raw_filter)
         } else {
             format!("(&{}(!(entryuuid=*)))", raw_filter)
         };
+        */
 
         Ok(FixupData { basedn, raw_filter })
     }
@@ -213,14 +219,20 @@ pub fn entryuuid_fixup_mapfn(e: &EntryRef, _data: &()) -> Result<(), PluginError
     /* Supply a modification to the entry. */
     let sdn = e.get_sdnref();
 
-    /* Sanity check that entryuuid doesn't already exist */
-    if e.contains_attr("entryUUID") {
-        log_error!(
-            ErrorLevel::Plugin,
-            "skipping fixup for -> {}",
-            sdn.to_dn_string()
-        );
-        return Ok(());
+    /* Check that entryuuid doesn't already exist, and is valid */
+    if let Some(valueset) = e.get_attr("entryUUID") {
+        if valueset.iter().all(|v| {
+            let u: Result<Uuid, _> = (&v).try_into();
+            u.is_ok()
+        }) {
+            // All values were valid uuid, move on!
+            log_error!(
+                ErrorLevel::Plugin,
+                "skipping fixup for -> {}",
+                sdn.to_dn_string()
+            );
+            return Ok(());
+        }
     }
 
     // Setup the modifications


### PR DESCRIPTION
Description: Bring back the the entryuuid validation in fixup task.
The part of the code was removed during the cherry-pick to the older
branch (389-ds-base-2.0), and its tests start to fail.

Related: https://github.com/389ds/389-ds-base/pull/4878
Related: https://github.com/389ds/389-ds-base/issues/4877
Related: https://github.com/389ds/389-ds-base/pull/4776
Related: https://github.com/389ds/389-ds-base/issues/4775

Reviewed by: ?