### PR TITLE
RFE - store full DN in database record 

### DIFF
--- a/dirsrvtests/create_test.py
+++ b/dirsrvtests/create_test.py
@@ -198,14 +198,14 @@ if len(sys.argv) > 0:
               'can not be greater than 99')
         display_usage()
 
-    if args.inst:
-        if not args.inst.isdigit() or \
-            int(args.inst) > 99 or \
-            int(args.inst) < 0:
+    if args.instances:
+        if not args.instances.isdigit() or \
+            int(args.instances) > 99 or \
+            int(args.instances) < 0:
             print('Invalid value for "--instances", it must be a number ' +
                   'greater than 0 and not greater than 99')
             display_usage()
-        if int(args.inst) > 0:
+        if int(args.instances) > 0:
             if int(args.suppliers) > 0 or \
                             int(args.hubs) > 0 or \
                             int(args.consumers) > 0:
@@ -216,12 +216,12 @@ if len(sys.argv) > 0:
     ticket = args.ticket
     suite = args.suite
 
-    if args.inst == '0' and args.suppliers == '0' and args.hubs == '0' \
+    if args.instances == '0' and args.suppliers == '0' and args.hubs == '0' \
        and args.consumers == '0':
         instances = 1
         my_topology = [True, 'topology_st', "Standalone Instance"]
     else:
-        instances = int(args.inst)
+        instances = int(args.instances)
         suppliers = int(args.suppliers)
         hubs = int(args.hubs)
         consumers = int(args.consumers)

--- a/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
+++ b/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
@@ -1,0 +1,96 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import logging
+import pytest
+import os
+import time
+from lib389.topologies import topology_st as topo
+from lib389.idm.user import UserAccount, UserAccounts
+from lib389.idm.organizationalunit import OrganizationalUnit
+
+log = logging.getLogger(__name__)
+
+SUFFIX = "dc=Example,DC=COM"
+SUBTREE = "ou=People,dc=Example,DC=COM"
+NEW_SUBTREE = "ou=humans,dc=Example,DC=COM"
+USER_DN = "uid=tUser,ou=People,dc=Example,DC=COM"
+NEW_USER_DN = "uid=tUser,ou=humans,dc=Example,DC=COM"
+NEW_USER_NORM_DN = "uid=tUser,ou=humans,dc=example,dc=com"
+
+
+def test_dsentrydn(topo):
+    """Test that the dsentrydn attribute is properly maintained and preserves the case of the DN
+
+    :id: f0f2fe6b-c70d-4de1-a9a9-06dda74e7c30
+    :setup: Standalone Instance
+    :steps:
+        1. Create user and make sure dsentrydn is set to the correct value/case
+        2. Moddn of "ou=people" and check dsentrydn is correct for parent and the children
+        3. Check the DN matches dsEntryDN
+        4. Disable nsslapd-return-original-entrydn
+        5. Check the DN matches normalized DN
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+
+    inst = topo.standalone
+    inst.config.replace('nsslapd-return-original-entrydn', 'on')
+
+    # Create user and makes sure "dsEntryDN" is set correctly
+    users = UserAccounts(inst, SUFFIX)
+    user_properties = {
+        'uid': 'tUser',
+        'givenname': 'test',
+        'cn': 'Test User',
+        'sn': 'user',
+        'userpassword': 'password',
+        'uidNumber': '1000',
+        'gidNumber': '2000',
+        'homeDirectory': '/home/tUser'
+    }
+    user = users.create(properties=user_properties)
+    assert user.get_attr_val_utf8('dsentrydn') == USER_DN
+
+    # Move subtree ou=people to ou=humans
+    ou = OrganizationalUnit(inst, SUBTREE)
+    ou.rename("ou=humans", SUFFIX)  # NEW_SUBTREE
+
+    # check dsEntryDN is properly updated to new subtree
+    ou = OrganizationalUnit(inst, NEW_SUBTREE)
+    assert ou.get_attr_val_utf8('dsentrydn') == NEW_SUBTREE
+
+    user = UserAccount(inst, NEW_USER_DN)
+    assert user.get_attr_val_utf8('dsentrydn') == NEW_USER_DN
+
+    # Check DN retruend to client matches "dsEntryDN"
+    users = UserAccounts(inst, SUFFIX).list()
+    for user in users:
+        if user.dn.startswith("tUser"):
+            assert user.dn == NEW_USER_DN
+            break
+
+    # Disable 'nsslapd-return-original-entrydn' andcheck DN is normalized
+    inst.config.replace('nsslapd-return-original-entrydn', 'on')
+    users = UserAccounts(inst, SUFFIX).list()
+    for user in users:
+        if user.dn.startswith("tUser"):
+            assert user.dn == NEW_USER_NORM_DN
+            break
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -656,7 +656,7 @@ def test_internal_log_level_516(topology_st, add_user_log_level_516, disable_acc
                                     r'SRCH base="cn=group,ou=Groups,dc=example,dc=com".*')
     # (Internal) op=10(1)(2) ENTRY dn="cn=group,ou=Groups,dc=example,dc=com"
     assert topo.ds_access_log.match(r'.*\(Internal\) op=[0-9]+\([0-9]+\)\([0-9]+\) '
-                                    r'ENTRY dn="cn=group,ou=groups,dc=example,dc=com".*')
+                                    r'ENTRY dn="cn=group,ou=Groups,dc=example,dc=com".*')
     # (Internal) op=10(1)(2) RESULT err=0 tag=48 nentries=1*')
     assert topo.ds_access_log.match(r'.*\(Internal\) op=[0-9]+\([0-9]+\)\([0-9]+\) RESULT err=0 tag=48 nentries=1*')
     # (Internal) op=10(1)(1) RESULT err=0 tag=48

--- a/dirsrvtests/tests/suites/filter/filter_cert_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_cert_test.py
@@ -57,11 +57,11 @@ def test_positive(topo):
     assert Accounts(topo.standalone, DEFAULT_SUFFIX).filter("(userCertificate;binary=*)")
     user1_cert = users_people.list()[0].get_attr_val("userCertificate;binary")
     assert Accounts(topo.standalone, DEFAULT_SUFFIX).filter(
-        f'(userCertificate;binary={search_filter_escape_bytes(user1_cert)})')[0].dn == \
+        f'(userCertificate;binary={search_filter_escape_bytes(user1_cert)})')[0].dn.lower() == \
            'uid=test_user_1,ou=people,dc=example,dc=com'
     user2_cert = users_people.list()[1].get_attr_val("userCertificate;binary")
     assert Accounts(topo.standalone, DEFAULT_SUFFIX).filter(
-        f'(userCertificate;binary={search_filter_escape_bytes(user2_cert)})')[0].dn == \
+        f'(userCertificate;binary={search_filter_escape_bytes(user2_cert)})')[0].dn.lower() == \
            'uid=test_user_2,ou=people,dc=example,dc=com'
 
 

--- a/dirsrvtests/tests/suites/filter/filter_logic_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_logic_test.py
@@ -74,7 +74,7 @@ def _check_filter(topology_st_f, filt, expect_len, expect_dns):
     # print("checking %s" % filt)
     results = topology_st_f.search_s("ou=people,%s" % DEFAULT_SUFFIX, ldap.SCOPE_ONELEVEL, filt, ['uid',])
     assert len(results) == expect_len
-    result_dns = [result.dn for result in results]
+    result_dns = [result.dn.lower() for result in results]
     assert set(expect_dns) == set(result_dns)
 
 

--- a/dirsrvtests/tests/suites/filter/rfc3673_all_oper_attrs_test.py
+++ b/dirsrvtests/tests/suites/filter/rfc3673_all_oper_attrs_test.py
@@ -45,21 +45,22 @@ TEST_PARAMS = [(DN_ROOT, False, [
                (DN_PEOPLE, False, [
                 'aci', 'createTimestamp', 'creatorsName', 'entrydn',
                 'entryid', 'modifiersName', 'modifyTimestamp',
-                'nsUniqueId', 'numSubordinates', 'parentid'
+                'nsUniqueId', 'numSubordinates', 'parentid', 'dsEntryDN'
                ]),
                (DN_PEOPLE, True, [
                 'createTimestamp', 'creatorsName', 'entrydn',
                 'entryid', 'modifyTimestamp', 'nsUniqueId',
-                'numSubordinates', 'parentid'
+                'numSubordinates', 'parentid', 'dsEntryDN'
                ]),
                (TEST_USER_DN, False, [
                 'createTimestamp', 'creatorsName', 'entrydn',
                 'entryid', 'modifiersName', 'modifyTimestamp',
-                'nsUniqueId', 'parentid', 'entryUUID'
+                'nsUniqueId', 'parentid', 'entryUUID', 'dsEntryDN'
                ]),
                (TEST_USER_DN, True, [
                 'createTimestamp', 'creatorsName', 'entrydn',
-                'entryid', 'modifyTimestamp', 'nsUniqueId', 'parentid', 'entryUUID'
+                'entryid', 'modifyTimestamp', 'nsUniqueId', 'parentid',
+                'entryUUID', 'dsEntryDN'
                ]),
                (DN_CONFIG, False, [
                 'numSubordinates', 'passwordHistory',  'modifyTimestamp',

--- a/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
@@ -319,7 +319,7 @@ def test_scheme_violation_errors_logged(topo_m2):
     assert user_memberof_attr
     log.info('memberOf attr value - {}'.format(user_memberof_attr))
 
-    pattern = ".*oc_check_allowed_sv.*{}.*memberOf.*not allowed.*".format(testuser.dn.lower())
+    pattern = ".*oc_check_allowed_sv.*{}.*memberOf.*not allowed.*".format(testuser.dn)
     log.info("pattern = %s" % pattern)
     assert inst.ds_error_log.match(pattern)
 

--- a/dirsrvtests/tests/suites/psearch/psearch_test.py
+++ b/dirsrvtests/tests/suites/psearch/psearch_test.py
@@ -65,7 +65,7 @@ def test_psearch(topology_st):
     # Now run the result again and see what's there.
     results = _run_psearch(topology_st.standalone, msg_id)
     # assert our group is in the changeset.
-    assert(group.dn.lower() == results[0])
+    assert(group.dn == results[0])
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -15,13 +15,12 @@ import ldap
 import pytest
 import subprocess
 import time
-from lib389.idm.user import TEST_USER_PROPERTIES, UserAccounts
+from lib389.idm.user import TEST_USER_PROPERTIES, UserAccount, UserAccounts
 from lib389.pwpolicy import PwPolicyManager
 from lib389.utils import *
 from lib389._constants import *
 from lib389.idm.domain import Domain
 from lib389.idm.organizationalunit import OrganizationalUnits
-from lib389.idm.user import UserAccount
 from lib389.idm.group import Groups, Group
 from lib389.idm.domain import Domain
 from lib389.idm.directorymanager import DirectoryManager

--- a/ldap/schema/01core389.ldif
+++ b/ldap/schema/01core389.ldif
@@ -329,6 +329,8 @@ attributeTypes: ( 2.16.840.1.113730.3.1.2374 NAME 'nsDS5ReplicaBootstrapTranspor
 attributeTypes: ( 2.16.840.1.113730.3.1.2387 NAME 'nsslapd-tcp-fin-timeout' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2388 NAME 'nsslapd-tcp-keepalive-time' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2390 NAME 'nsds5ReplicaKeepAliveUpdateInterval' DESC '389 defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.9998 NAME 'dsEntryDN' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 NO-USER-MODIFICATION SINGLE-VALUE USAGE directoryOperation X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.9999 NAME 'nsslapd-return-original-entrydn' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 #
 # objectclasses
 #

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -265,6 +265,7 @@ slapi_onoff_t init_ignore_vattrs;
 slapi_onoff_t init_enable_upgrade_hash;
 slapi_special_filter_verify_t init_verify_filter_schema;
 slapi_onoff_t init_enable_ldapssotoken;
+slapi_onoff_t init_return_orig_dn;
 
 static int
 isInt(ConfigVarType type)
@@ -1401,6 +1402,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.tcp_keepalive_time, CONFIG_INT,
      (ConfigGetFunc)config_get_tcp_keepalive_time, SLAPD_DEFAULT_TCP_KEEPALIVE_TIME_STR, NULL},
+    {CONFIG_RETURN_ENTRY_DN, config_set_return_orig_dn,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.return_orig_dn,
+     CONFIG_ON_OFF, (ConfigGetFunc)config_get_return_orig_dn, &init_return_orig_dn, NULL},
     /* End config */
     };
 
@@ -1953,6 +1958,7 @@ FrontendConfig_init(void)
 #endif
 #endif
     init_extract_pem = cfg->extract_pem = LDAP_ON;
+    init_return_orig_dn = cfg->return_orig_dn = LDAP_ON;
     /*
      * Default upgrade hash to on - this is an important security step, meaning that old
      * or legacy hashes are upgraded on bind. It means we are proactive in securing accounts
@@ -8448,6 +8454,31 @@ config_get_verify_filter_schema()
     }
     /* Should be unreachable ... */
     return FILTER_POLICY_OFF;
+}
+
+int32_t
+config_get_return_orig_dn()
+{
+    int32_t retVal;
+
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapdFrontendConfig->return_orig_dn;
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+int32_t
+config_set_return_orig_dn(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int32_t retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    retVal = config_set_onoff(attrname, value,
+                              &(slapdFrontendConfig->return_orig_dn),
+                              errorbuf, apply);
+    return retVal;
 }
 
 int32_t

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -1130,27 +1130,27 @@ process_entry(Slapi_PBlock *pb, Slapi_Entry *e, int send_result)
 static void
 send_entry(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Operation *operation, char **attrs, int attrsonly, int *pnentries)
 {
-                /*
-             * It's a regular entry, or it's a referral and
-             * managedsait control is on.  In either case, send
-             * the entry.
-             */
-                switch (send_ldap_search_entry(pb, e, NULL, attrs, attrsonly)) {
-                case 0: /* entry sent ok */
-                    (*pnentries)++;
-                    slapi_pblock_set(pb, SLAPI_NENTRIES, pnentries);
-                    break;
-                case 1: /* entry not sent */
-                    break;
-                case -1: /* connection closed */
-                    /*
-                     * mark the operation as abandoned so the backend
-                     * next entry function gets called again and has
-                     * a chance to clean things up.
-                     */
-                    operation->o_status = SLAPI_OP_STATUS_ABANDONED;
-                    break;
-                }
+    /*
+     * It's a regular entry, or it's a referral and
+     * managedsait control is on.  In either case, send
+     * the entry.
+     */
+    switch (send_ldap_search_entry(pb, e, NULL, attrs, attrsonly)) {
+    case 0: /* entry sent ok */
+        (*pnentries)++;
+        slapi_pblock_set(pb, SLAPI_NENTRIES, pnentries);
+        break;
+    case 1: /* entry not sent */
+        break;
+    case -1: /* connection closed */
+        /*
+         * mark the operation as abandoned so the backend
+         * next entry function gets called again and has
+         * a chance to clean things up.
+         */
+        operation->o_status = SLAPI_OP_STATUS_ABANDONED;
+        break;
+    }
 }
 
 /* Loops through search entries and sends them to the client.

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -625,6 +625,9 @@ int32_t config_set_ldapssotoken_secret(const char *attrname, char *value, char *
 int32_t config_set_ldapssotoken_ttl(const char *attrname, char *value, char *errorbuf, int apply);
 int32_t config_get_ldapssotoken_ttl(void);
 
+int32_t config_get_return_orig_dn(void);
+int32_t config_set_return_orig_dn(const char *attrname, char *value, char *errorbuf, int apply);
+
 int config_set_tcp_fin_timeout(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_tcp_fin_timeout(void);
 int config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -831,11 +831,11 @@ struct slapi_entry
     Slapi_Attr *e_deleted_attrs;  /* deleted list of attributes and values */
     Slapi_Vattr *e_virtual_attrs; /* cache of virtual attributes */
     uint32_t e_virtual_watermark; /* indicates cache consistency when compared
-                                    to global watermark */
+                                     to global watermark */
     Slapi_RWLock *e_virtual_lock; /* for access to cached vattrs */
     void *e_extension;            /* A list of entry object extensions */
     unsigned char e_flags;
-    Slapi_Attr *e_aux_attrs; /* Attr list used for upgrade */
+    Slapi_Attr *e_aux_attrs;      /* Attr list used for upgrade */
 };
 
 struct attrs_in_extension
@@ -2345,6 +2345,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_LISTEN_BACKLOG_SIZE "nsslapd-listen-backlog-size"
 #define CONFIG_DYNAMIC_PLUGINS "nsslapd-dynamic-plugins"
 #define CONFIG_RETURN_DEFAULT_OPATTR "nsslapd-return-default-opattr"
+#define CONFIG_RETURN_ENTRY_DN "nsslapd-return-original-entrydn"
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
 
@@ -2697,6 +2698,7 @@ typedef struct _slapdFrontendConfig
 
     slapi_int_t tcp_fin_timeout;
     slapi_int_t tcp_keepalive_time;
+    slapi_onoff_t return_orig_dn;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -403,6 +403,7 @@ PR_fprintf(struct PRFileDesc *fd, const char *fmt, ...) __ATTRIBUTE__((format(pr
 #define SLAPI_ATTR_NSCP_ENTRYDN          "nscpEntryDN"
 #define SLAPI_ATTR_ENTRYUSN              "entryusn"
 #define SLAPI_ATTR_ENTRYDN               "entrydn"
+#define SLAPI_ATTR_DS_ENTRYDN            "dsEntryDN"
 #define SLAPI_ATTR_DN                    "dn"
 #define SLAPI_ATTR_RDN                   "rdn"
 #define SLAPI_ATTR_PARENTID              "parentid"

--- a/wrappers/systemd.template.service.xsan.conf.in
+++ b/wrappers/systemd.template.service.xsan.conf.in
@@ -5,7 +5,7 @@ Description=@capbrand@ Directory Server with @SANITIZER@ %i.
 
 [Service]
 # We can't symbolize here, as llvm symbolize crashes when it goes near systemd.
-Environment=ASAN_OPTIONS=log_path=/run/@package_name@/ns-slapd-%i.asan:print_stacktrace=1
+Environment=ASAN_OPTIONS=log_path=/run/@package_name@/ns-slapd-%i.asan:print_stacktrace=1:fast_unwind_on_malloc=0
 Environment=TSAN_OPTIONS=log_path=/run/@package_name@/ns-slapd-%i.tsan:print_stacktrace=1:second_deadlock_stack=1:history_size=7
 Environment=MSAN_OPTIONS=log_path=/run/@package_name@/ns-slapd-%i.msan:print_stacktrace=1
 Environment=UBSAN_OPTIONS=log_path=/run/@package_name@/ns-slapd-%i.ubsan:print_stacktrace=1


### PR DESCRIPTION
While testing "nsslapd-subtree-rename-switch=off" there was noticeable performance improvement. The current implementation generates the DN dynamically by using the entryrdn attribute in the database record, and then obtaining the parent portion of the DN from other database indexes.

Disabling subtree-rename (nsslapd-subtree-rename-switch=off) improves throughput/response_time performance especially when the number of clients increases.

The range of improvement on highest load (high number of clients) ranges up to ~10%

-------------------------------------------------------------------------------------------------------------------

This PR brings in the short-cut of already having a DN, and not needing to call entryrdn_lookup_dn() which is very expensive.   This shows a 35% improvement when moving entries from disk into the entry cache, There is also an improvement once the cache is primed, but a full performance test run is needed.  Regardless this definitely provides a nice perf boost...

Note - this new attribute "dsEntryDN" stores the DN in the exact case that was used when the entry was added.  This helps with migrations from ODSEE.

https://github.com/389ds/389-ds-base/issues/5267