### PR TITLE
Issue 5490 - tombstone in entryrdn index with lmdb but not with bdb

### DIFF
--- a/dirsrvtests/tests/suites/entryuuid/replicated_test.py
+++ b/dirsrvtests/tests/suites/entryuuid/replicated_test.py
@@ -145,7 +145,7 @@ def test_entryuuid_fixup_with_replication(topo_m2):
 
     # 8. Wait until changes get replicated
     repl = ReplicationManager(DEFAULT_SUFFIX)
-    repl.wait_for_replication(server_b, server_a)
+    repl.wait_for_replication(server_a, server_b)
 
     # 9. Check that the user entry on the other supplier has same entryuuid attribute
     account_b = nsUserAccounts(server_b, DEFAULT_SUFFIX).get("test_user_3000")

--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -269,6 +269,8 @@ def test_healthcheck_MO_plugin_missing_indexes(topology_st):
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    # Restart the intsnce after changing the plugin to avoid breaking the other tests
+    standalone.restart()
 
 
 @pytest.mark.ds50873

--- a/dirsrvtests/tests/suites/indexes/entryrdn_test.py
+++ b/dirsrvtests/tests/suites/indexes/entryrdn_test.py
@@ -1,0 +1,149 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import time
+import os
+import pytest
+import ldap
+import logging
+from lib389._constants import DEFAULT_BENAME, DEFAULT_SUFFIX
+from lib389.backend import Backends
+from lib389.idm.user import UserAccounts
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.topologies import topology_m2 as topo_m2
+from lib389.agreement import Agreements
+from lib389.utils import ds_is_older
+from lib389.tasks import Tasks,ExportTask, ImportTask
+from lib389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+
+OUNAME = 'NewOU'
+OUDN = f'ou={OUNAME},ou=people,{DEFAULT_SUFFIX}'
+OUPROPERTIES = { 'ou' : OUNAME }
+USERNAME = 'NewUser'
+USERID = '100'
+USERSDN = f'uid={USERNAME},{OUDN}'
+USERPROPERTIES = {
+        'uid': USERNAME,
+        'sn': USERNAME,
+        'cn': USERNAME,
+        'uidNumber': USERID,
+        'gidNumber': USERID,
+        'homeDirectory': f'/home/{USERNAME}'
+    }
+
+# 2 tombstone entry + 1 RUV have 2 records in entryrdn index
+# Each record have 1 rdn + 1 normalized rdn both containing nsuniqueid
+# So 3 * 2 * 2 nsuniqueid substrings are expected
+EXPECTED_NB_NSNIQUEID = 12
+
+logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def test_tombstone(topo_m2):
+    """
+    An internal unindexed search was able to crash the server due to missing logging function.
+
+    :id: a12eacac-4e35-11ed-8625-482ae39447e5
+    :setup: 2 Suplier instances
+    :steps:
+        1. Add an OrganizationalUnit
+        2. Add an User as child of the new OrganizationalUnit
+        3. Modify User's description
+        4. Delele User
+        5. Delete OrganizationalUnit
+        6. Dump supplier1 entryrdn index
+        7. Check that nsuniqueid appears three times in the dump result
+        8. Export supplier1 with replication data
+        9. Import supplier2 with previously exported ldif file
+        10. Dump entryrdn index
+        11. Check that nsuniqueid appears three times in the dump result
+        12. Reindex entryrdn on supplier1
+        13. Dump entryrdn index on supplier
+        14. Check that nsuniqueid appears three times in the dump result
+        15. Perform bulk import from supplier1 to supplier2
+        16. Wait until bulk import is completed
+        17. Dump entryrdn index on supplier
+        18. Check that nsuniqueid appears three times in the dump result
+    :expectedresults:
+        1. Should succeed
+        2. Should succeed
+        3. Should succeed
+        4. Should succeed
+        5. Should succeed
+        6. Should succeed
+        7. Should succeed
+        8. Should succeed
+        9. Should succeed
+        10. Should succeed
+        11. Should succeed
+        12. Should succeed
+        13. Should succeed
+        14. Should succeed
+        15. Should succeed
+        16. Should succeed
+        17. Should succeed
+        18. Should succeed
+    """
+    s1 = topo_m2.ms["supplier1"]
+    s2 = topo_m2.ms["supplier2"]
+    ldif_dir = s1.get_ldif_dir()
+
+    log.info("Create tombstones...")
+    ous = OrganizationalUnits(s1, DEFAULT_SUFFIX)
+    ou = ous.create(properties=OUPROPERTIES)
+    users = UserAccounts(s1, DEFAULT_SUFFIX, rdn=None)
+    user = users.create(properties=USERPROPERTIES)
+    user.replace('description', 'New Description')
+    user.delete()
+    ou.delete()
+    time.sleep(2)
+    dbscanOut = s1.dbscan(args=['-f', f'{s1.dbdir}/{DEFAULT_BENAME}/entryrdn.db', '-A'], stopping=False)
+    assert dbscanOut.count('nsuniqueid') == EXPECTED_NB_NSNIQUEID
+
+    log.info("Exporting LDIF online...")
+    export_ldif = ldif_dir + '/export.ldif'
+    export_task = Backends(s1).export_ldif(be_names=DEFAULT_BENAME, ldif=export_ldif, replication=True)
+    export_task.wait()
+
+    log.info("Importing LDIF online...")
+    import_task = ImportTask(s2)
+    import_task.import_suffix_from_ldif(ldiffile=export_ldif, suffix=DEFAULT_SUFFIX)
+    import_task.wait()
+    time.sleep(2)
+    dbscanOut = s2.dbscan(args=['-f', f'{s2.dbdir}/{DEFAULT_BENAME}/entryrdn.db', '-A'], stopping=False)
+    assert dbscanOut.count('nsuniqueid') == EXPECTED_NB_NSNIQUEID
+
+    log.info("Reindex online...")
+    task = Tasks(s2)
+    task.reindex(suffix=DEFAULT_SUFFIX, args={'wait': True})
+    time.sleep(2)
+    dbscanOut = s2.dbscan(args=['-f', f'{s2.dbdir}/{DEFAULT_BENAME}/entryrdn.db', '-A'], stopping=False)
+    assert dbscanOut.count('nsuniqueid') == EXPECTED_NB_NSNIQUEID
+
+    log.info("Bulk import...")
+    agmt = Agreements(s1).list()[0]
+    agmt.begin_reinit()
+    (done, error) = agmt.wait_reinit()
+    assert done is True
+    assert error is False
+    time.sleep(2)
+    dbscanOut = s2.dbscan(args=['-f', f'{s2.dbdir}/{DEFAULT_BENAME}/entryrdn.db', '-A'], stopping=False)
+    assert dbscanOut.count('nsuniqueid') == EXPECTED_NB_NSNIQUEID
+
+
+
+
+if __name__ == "__main__":
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
@@ -27,21 +27,25 @@ typedef enum { IM_UNKNOWN, IM_IMPORT, IM_INDEX, IM_UPGRADE, IM_BULKIMPORT } Impo
 
 typedef struct importctx ImportCtx_t;
 
+#define DNRC_IS_ENTRY(dnrc)  (((dnrc) & DNRC_ERROR) == 0)
+
 typedef enum {
-    DNRC_OK,          /* Regular entry */
-    DNRC_BADDN,       /* Invalid DN syntax */
-    DNRC_BAD_SUFFIX_ID, /* DN is the backend suffix and the entry ID != 1 */
-    DNRC_DUP,         /* DN already exist in the private database */
-    DNRC_ERROR,       /* Some lmdb error occured */
-    DNRC_NODN,        /* No dn: in entry string */
-    DNRC_NOPARENT_DN, /* Entry DN has a single rdn */
-    DNRC_NOPARENT_ID, /* Parent info record is not found or no parenid: in entry */
-    DNRC_NORDN,       /* No rdn: in entry string */
-    DNRC_RUV,         /* RUV entry */
-    DNRC_SUFFIX,      /* Suffix entry */
-    DNRC_TOMBSTONE,   /* Tombstone entry */
-    DNRC_VERSION,     /* Not an entry but initial ldif version string */
-    DNRC_WAIT,        /* Parent id not yet in private db */
+    DNRC_OK,              /* Regular entry */
+    DNRC_RUV,             /* RUV entry */
+    DNRC_SUFFIX,          /* Suffix entry */
+    DNRC_TOMBSTONE,       /* Tombstone entry */
+    DNRC_ERROR = 0x100,   /* Some lmdb error occured */
+    DNRC_BADDN,           /* Invalid DN syntax */
+    DNRC_BAD_SUFFIX_ID,   /* DN is the backend suffix and the entry ID != 1 */
+    DNRC_DUP,             /* DN already exist in the private database */
+    DNRC_NODN,            /* No dn: in entry string */
+    DNRC_NOPARENT_DN,     /* Entry DN has a single rdn */
+    DNRC_NOPARENT_ID,     /* Parent info record is not found or no parenid: in entry */
+    DNRC_NORDN,           /* No rdn: in entry string */
+    DNRC_VERSION,         /* Not an entry but initial ldif version string */
+    DNRC_WAIT,            /* Parent id not yet in private db */
+    DNRC_POSPONE_RUV,     /* RUV entry is before suffix entry */
+    DNRC_BAD_TOMBSTONE,   /* Invalid tombstone entry */
 } dnrc_t;
 
 /******************** Queues ********************/

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -292,7 +292,7 @@ add_index_dbi(struct attrinfo *ai, dbi_open_ctx_t *octx)
     int flags = octx->ctx->readonly ? MDB_RDONLY: MDB_CREATE;
     char *rcdbname = NULL;
 
-    slapi_log_error(SLAPI_LOG_DBGMDB, "add_index_dbi", "ai_type = %s ai_indexmask=0x%x.\n", ai->ai_type, ai->ai_indexmask);
+    dbg_log(__FILE__,__LINE__,__FUNCTION__, DBGMDB_LEVEL_OTHER, "ai_type = %s ai_indexmask=0x%x.\n", ai->ai_type, ai->ai_indexmask);
     octx->ai = ai;
 
     if (ai->ai_indexmask & INDEX_VLV) {

--- a/ldap/servers/slapd/back-ldbm/idl_new.c
+++ b/ldap/servers/slapd/back-ldbm/idl_new.c
@@ -445,7 +445,7 @@ idl_new_range_fetch(
     }
 
     /* Make a cursor */
-    ret = dblayer_new_cursor(be, db, txn, &cursor);
+    ret = dblayer_new_cursor(be, db, s_txn.back_txn_txn, &cursor);
     if (0 != ret) {
         ldbm_nasty("idl_new_range_fetch - idl_new.c", index_id, 1, ret);
         goto error;

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -2362,14 +2362,14 @@ task_fixup_tombstone_thread(void *arg)
     slapi_task_begin(task, 1);
     slapi_task_log_notice(task, "Beginning tombstone fixup task...\n");
     slapi_log_err(SLAPI_LOG_REPL, TASK_TOMBSTONE_FIXUP,
-                  "fixup_tombstone_task_thread: Beginning tombstone fixup task...\n");
+                  "fixup_tombstone_task_thread: Beginning tombstone fixup task with strip mode: %d...\n", task_data->stripcsn);
 
     if (task_data->stripcsn) {
         /* find tombstones with nsTombstoneCSN */
-        filter = "(&(nstombstonecsn=*)(objectclass=nsTombstone)(|(objectclass=*)(objectclass=ldapsubentry)))";
+        filter = "(&(nstombstonecsn=*)(objectclass=nsTombstone)(!(nsuniqueid=ffffffff-ffffffff-ffffffff-ffffffff))(|(objectclass=*)(objectclass=ldapsubentry)))";
     } else {
-        /* find tombstones missing nsTombstoneCSN */
-        filter = "(&(!(nstombstonecsn=*))(objectclass=nsTombstone)(|(objectclass=*)(objectclass=ldapsubentry)))";
+        /* find tombstones missing nsTombstoneCSN and ignore the RUV (that should never be purged) */
+        filter = "(&(!(nstombstonecsn=*))(objectclass=nsTombstone)(!(nsuniqueid=ffffffff-ffffffff-ffffffff-ffffffff))(|(objectclass=*)(objectclass=ldapsubentry)))";
     }
 
     /* Okay check the specified backends only */

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -415,6 +415,8 @@ class DirSrv(SimpleLDAPObject, object):
         # Set the default systemd status. This MAY be overidden in the setup utils
         # as required, generally for containers.
         self.systemd_override = None
+        # Status telling whether dbscan supports '-D libdb' option ?
+        self._dbisupport = None
 
         # Reset the args (py.test reuses the args_instance for each test case)
         # We allocate a "default" prefix here which allows an un-allocate or
@@ -2981,10 +2983,11 @@ class DirSrv(SimpleLDAPObject, object):
         os.remove(del_file)
 
     def is_dbi_supported(self):
+        if self._dbisupport is not None:
+            return self._dbisupport
         # check if -D and -L options are supported
         try:
-            cmd = ["%s/dbscan" % self.get_bin_dir(),
-                    "--help"]
+            cmd = ["%s/dbscan" % self.get_bin_dir(), "--help"]
             self.log.debug("DEBUG: checking dbscan supported options %s" % cmd)
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         except subprocess.CalledProcessError:
@@ -2992,27 +2995,29 @@ class DirSrv(SimpleLDAPObject, object):
         output, stderr = p.communicate()
         self.log.debug("is_dbi_supported output " + output.decode())
         if "-D <dbimpl>" in output.decode() and "-L <dbhome>" in output.decode():
-            return True
+            self._dbisupport = True
         else:
-            return False
+            self._dbisupport = False
+        return self._dbisupport
 
     def is_dbi(self, dbipattern):
-        try:
-            cmd = ["%s/dbscan" % self.get_bin_dir(),
-                    "-D",
-                    self.get_db_lib(),
-                    "-L",
-                    self.ds_paths.db_dir],
-            self.log.debug("DEBUG: starting with %s" % cmd)
-            output = subprocess.check_output(*cmd, text=True, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
-            self.log.error('Failed to run dbscan: "%s"' % output)
-            raise ValueError('Failed to run dbscan')
-        self.log.debug("is_dbi output is: " + output)
+        if self.is_dbi_supported():
+            # Use dbscan to determine whether the database instance exists.
+            output = self.dbscan(args=['-L', self.ds_paths.db_dir], stopping=False)
+            self.log.debug("is_dbi output is: " + output)
+            return dbipattern.lower() in output.lower()
+        else:
+            # lmdb is not supported. Check if the database instance file exists.
+            if '.db' in dbipattern:
+                indexfile = os.path.join(self.dbdir, bename, index)
+            else:
+                indexfile = os.path.join(self.dbdir, bename, index + '.db')
+            # (we should also accept a version number for .db suffix)
+            for f in glob.glob(f'{indexfile}*'):
+                return True
+            return False
 
-        return dbipattern.lower() in output.lower()
-
-    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False):
+    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False, args=None, stopping=True):
         """Wrapper around dbscan tool that analyzes and extracts information
         from an import Directory Server database file
 
@@ -3022,50 +3027,55 @@ class DirSrv(SimpleLDAPObject, object):
         :param id: Entry id to dump
         :param width: Entry truncate size (bytes)
         :param isRaw: Dump as a raw data
-        :returns: A dumped string
+        :param args: use args as parameters instead of using bename, index, key
+        :param stopping: stop then restart the instance (if started)
+        :returns: dbscan output as a string
         """
 
         DirSrvTools.lib389User(user=DEFAULT_USER)
         prog = os.path.join(self.ds_paths.bin_dir, DBSCAN)
-
-        if not bename:
-            self.log.error("dbscan: missing required backend name")
-            return False
-
-        if not index:
-            self.log.error("dbscan: missing required index name")
-            return False
-        elif '.db' in index:
-            indexfile = os.path.join(self.dbdir, bename, index)
+        if not self.status():
+                stopping = False
+        cmd = [ prog ]
+        if self.is_dbi_supported():
+            cmd.extend(['-D', self.get_db_lib()])
+        if args:
+            cmd.extend(args)
         else:
-            indexfile = os.path.join(self.dbdir, bename, index + '.db')
-        # (we should also accept a version number for .db suffix)
-        for f in glob.glob(f'{indexfile}*'):
-            indexfile = f
-
-        cmd = [prog, '-f', indexfile]
-
-        if 'id2entry' in index:
-            if key and key.isdigit():
-                cmd.extend(['-K', key])
-        else:
-            if key:
-                cmd.extend(['-k', key])
-
+            if not bename:
+                raise ValueError('dbscan: missing required backend name')
+            if not index:
+                raise ValueError('dbscan: missing required index name')
+            if '.db' in index:
+                indexfile = os.path.join(self.dbdir, bename, index)
+            else:
+                indexfile = os.path.join(self.dbdir, bename, index + '.db')
+            # (we should also accept a version number for .db suffix)
+            for f in glob.glob(f'{indexfile}*'):
+                indexfile = f
+            cmd.extends(['-f', indexfile])
+            if 'id2entry' in index:
+                if key and key.isdigit():
+                    cmd.extend(['-K', key])
+                else:
+                    if key:
+                        cmd.extend(['-k', key])
         if width:
             cmd.extend(['-t', width])
-
         if isRaw:
             cmd.append('-R')
-
-        self.stop(timeout=10)
-
+        if stopping:
+            self.stop()
         self.log.info('Running script: %s', cmd)
-        output = subprocess.check_output(cmd)
-
-        self.start(timeout=10)
-
-        return output
+        try:
+            result = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            result.check_returncode();
+        except subprocess.CalledProcessError:
+            self.log.error('Failed to run dbscan: "%s"' % result)
+            raise ValueError('Failed to run dbscan')
+        if stopping:
+            self.start()
+        return result.stdout
 
     def dbverify(self, bename):
         """

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -120,7 +120,7 @@ DEFAULT_INST_HEAD = 'slapd-'
 DEFAULT_ENV_HEAD = 'dirsrv-'
 DEFAULT_CHANGELOG_NAME = "changelog5"
 DEFAULT_CHANGELOG_DB = 'changelogdb'
-DEFAULT_DB_LIB = 'bdb'
+DEFAULT_DB_LIB = 'mdb'
 
 # CONF_DIR = 'etc/dirsrv'
 # ENV_SYSCONFIG_DIR = '/etc/sysconfig'

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -120,7 +120,7 @@ DEFAULT_INST_HEAD = 'slapd-'
 DEFAULT_ENV_HEAD = 'dirsrv-'
 DEFAULT_CHANGELOG_NAME = "changelog5"
 DEFAULT_CHANGELOG_DB = 'changelogdb'
-DEFAULT_DB_LIB = 'mdb'
+DEFAULT_DB_LIB = 'bdb'
 
 # CONF_DIR = 'etc/dirsrv'
 # ENV_SYSCONFIG_DIR = '/etc/sysconfig'

--- a/src/lib389/lib389/perftools.py
+++ b/src/lib389/lib389/perftools.py
@@ -45,7 +45,7 @@ class IdGenerator:
         return self._formatId()
 
     def _formatId(self, id):
-        # Should be overwritten in subclass 
+        # Should be overwritten in subclass
         # Should return an id
         return str(id)
 
@@ -75,7 +75,7 @@ class IdGeneratorWithNames(IdGenerator):
         self._voyelles = [ 'a', 'e', 'i', 'o', 'u', 'ai', 'an', 'au', 'en', 'ei', 'en', 'eu', 'in', 'on', 'ou' ]
         self._consonnes = [ 'b', 'c', 'ch', 'cr', 'd', 'f', 'g', 'j', 'l', 'm', 'n', 'p', 'ph', 'qu', 'r', 's', 't', 'v' ]
         self._syllabs = [c+v for c in self._consonnes for v in self._voyelles]
-        shuffle(self._syllabs) 
+        shuffle(self._syllabs)
         self._level = 0
         self._syllabsLen = len(self._syllabs)
         while (nbids > 0):
@@ -153,7 +153,7 @@ class PerformanceTools:
         perfdir= f"{prefix}/var/log/dirsrv/perfdir"
         print(f"Results and logs are stored in {perfdir} directory.")
         self._options = {
-            'nbUsers' : 10000,                
+            'nbUsers' : 10000,
             'seed' : 'lib389PerfTools',
             'resultDir' : perfdir,
             'suffix' : DEFAULT_SUFFIX,
@@ -163,7 +163,7 @@ class PerformanceTools:
         self._instance = None
         os.makedirs(perfdir, mode=0o755, exist_ok = True)
         self._ldclt_template = self.getFilePath("template.ldclt");
-        # Generate a dummy template anyway we do not plan to create entries 
+        # Generate a dummy template anyway we do not plan to create entries
         with open(self._ldclt_template, "w") as f:
             f.write("objectclass: inetOrgPerson\n");
         self._users_parents_dn = f"ou=People,{self._options['suffix']}"
@@ -243,7 +243,7 @@ class PerformanceTools:
                 csv.nl();
 
     def getFilePath(self, filename):
-        return os.path.join(self._options['resultDir'], filename)   
+        return os.path.join(self._options['resultDir'], filename)
 
     def log(self, filename, msg):
         with open(self.getFilePath(filename), "at") as f:
@@ -274,7 +274,7 @@ class PerformanceTools:
                         need_rebuild = False
                     else:
                         print (f"db is {self._instance.get_db_lib()} instead of {get_default_db_lib()} ==> instance must be rebuild")
-                else:    
+                else:
                     print (f"missing instance ==> instance must be rebuild")
             except Exception:
                 pass
@@ -286,9 +286,9 @@ class PerformanceTools:
             topology = create_topology({ReplicaRole.STANDALONE: 1})
             self._instance = topology.standalone
             #  Adjust db size if needed (i.e about 670 K users)
-            defaultDBsize = 1073741824 
-            entrySize =  1600 # Real size is around 1525 
-            if (self._instance.get_db_lib() == "mdb" and 
+            defaultDBsize = 1073741824
+            entrySize =  2000 # Real size is around 1525 but got error with 1800 (likely due to some recent changes in entries)
+            if (self._instance.get_db_lib() == "mdb" and
                     nb_users * entrySize > defaultDBsize):
                 mdb_config = LMDB_LDBMConfig(self._instance)
                 mdb_config.replace("nsslapd-mdb-max-size", str(nb_users * entrySize))
@@ -299,7 +299,7 @@ class PerformanceTools:
                 uidgen = IdGeneratorWithNumbers(nb_users)
                 cnGen = IdGeneratorWithNames(100)
                 snGen = IdGeneratorWithNames(100)
-        
+
                 for uid in uidgen:
                     cn = cnGen.random()
                     sn = snGen.random()
@@ -317,7 +317,7 @@ class PerformanceTools:
                     super(UserAccounts, useraccounts).create(rdn, properties)
                     f.write(f'{uid}\n')
         return self._instance;
-        
+
     @staticmethod
     def filterMeasures(values, m, ecart):
         # keep values around m
@@ -373,7 +373,7 @@ class PerformanceTools:
         return res
 
     def ldclt(self, measure_name, args, nbThreads=10, nbMes=10):
-        # First ldclt measure is always bad so do 1 measure more 
+        # First ldclt measure is always bad so do 1 measure more
         # and discard it from final result
         nbMes += 1
 
@@ -409,7 +409,7 @@ class PerformanceTools:
         print (" Done.")
         stop_time = time.time()
         # Lets parse the result
-        res = { "measure_name" : measure_name, 
+        res = { "measure_name" : measure_name,
                 "cmd" : cmd,
                 "stdout" : result.stdout,
                 "stderr" : result.stderr,
@@ -435,7 +435,7 @@ class PerformanceTools:
         return self.ldclt(name, args, nbThreads=nb_threads)
 
     # I wish I could make the base dn vary rather than use the dn in filter
-    # but I did not find how to do that (the RDN trick as in modify 
+    # but I did not find how to do that (the RDN trick as in modify
     #  generates the same search than measure_search_by_uid test)
     def measure_search_by_filtering_the_dn(self, name, nb_threads = 1):
         nb_users = self._options['nbUsers']
@@ -473,7 +473,7 @@ class PerformanceTools:
 
     def _do_measure(self, measure_name, measure_cb, nbMes):
         # Perform non ldcltl measure
-        #  
+        #
         first_time = time.time()
         rawres = []
         for m in range(nbMes):
@@ -484,7 +484,7 @@ class PerformanceTools:
                 continue
         last_time = time.time()
         # Lets parse the result
-        res = { "measure_name" : measure_name, 
+        res = { "measure_name" : measure_name,
                 "start_time" : first_time,
                 "stop_time" : last_time,
                 "nb_measures" : nbMes,
@@ -512,7 +512,7 @@ class PerformanceTools:
 
         def argsused(self):
             return [ "nb_threads", "name" ]
-        
+
         def description(self):
             return self._base_description
 
@@ -531,13 +531,13 @@ class PerformanceTools:
     class TesterImportExport(Tester):
         # A special tester for export/import
         def __init__(self):
-            super().__init__("export/import", 
+            super().__init__("export/import",
                 "Measure export rate in entries per seconds then measure import rate.",
                  None)
 
         def argsused(self):
             return []
-        
+
         def run(self, perftools, args=None):
             res = perftools.mesure_export_import()
             for r in res:
@@ -546,7 +546,7 @@ class PerformanceTools:
     @staticmethod
     def listTests():
         # List of test for which args.nb_threads is useful
-        return { t.name() :  t for t in [ 
+        return { t.name() :  t for t in [
             PerformanceTools.Tester("search_uid", "Measure number of searches per seconds using filter with random existing uid.", "measure_search_by_uid"),
             PerformanceTools.Tester("search_uid_in_dn", "Measure number of searches per seconds using filter with random existing uid in dn (i.e: (uid:dn:uid_value)).", "measure_search_by_filtering_the_dn"),
             PerformanceTools.Tester("modify_sn", "Measure number of modify per seconds replacing sn by random value on random entries.", "measure_modify"),


### PR DESCRIPTION
Align mdb behavior on bdb one about tombstone entries and (entryrdn / parentid/ ancestorid ) indexes:
Make sure that entry info are build for tombstone and RUV entry so the indexes get properly updated.
Fix deadlock by insuring that ai is provided when first opening the dbi while reindexing (so that cmp function is rightly set and does not need to be set later on)

[1] Added a test that check the tombstone in entryrdn after import/reindex/bulk import
[2] I found that Tombstone entry should be in the entryrdn index but:
       parent should be looked up with the nsparentuniqueid rather than on the parent dn.
       ==>  entries nsuniqueid should also be a key of the import private database
       And tombstone entry should also be stored in the private database
 [3] Fixed some issue in test case
 [4] removed the cas atomic operation 
 [5] Fixed dsrate issue about full lmdb database  
 [6] Fixed issue around cursor bulk operation
 [7] Improved/fixed entryrdn and lmdb debug   
       
Issue: 5490

Reviewed by: @tbordaz 
