### PR TITLE
Issue 5495 - BUG - Minor fix to dds skip, inconsistent attrs caused e…

### DIFF
--- a/src/lib389/lib389/migrate/plan.py
+++ b/src/lib389/lib389/migrate/plan.py
@@ -220,20 +220,21 @@ class SchemaAttributeInconsistent(MigrationAction):
         log.info(f" * Schema Skip Inconsistent Attribute -> {self.attr.names[0]} ({self.attr.oid})")
 
     def display_post(self, log):
-        log.info(f" * [ ] - Review Schema Inconsistent Attribute -> {self.obj.names[0]} ({self.obj.oid})")
+        log.info(f" * [ ] - Review Schema Inconsistent Attribute -> {self.attr.names[0]} ({self.attr.oid})")
 
 class SchemaAttributeAmbiguous(MigrationAction):
-    def __init__(self, attr):
+    def __init__(self, attr, overlaps):
         self.attr = attr
+        self.overlaps = overlaps
 
     def __unicode__(self):
         return f"SchemaAttributeAmbiguous -> {self.attr.__unicode__()}"
 
     def display_plan(self, log):
-        log.info(f" * Schema Skip Abmiguous Attribute -> {self.attr.names[0]} ({self.attr.oid})")
+        log.info(f" * Schema Skip Abmiguous Attribute -> {self.attr.names[0]} ({self.attr.oid}) overlaps {self.overlaps}")
 
     def display_post(self, log):
-        log.info(f" * [ ] - Review Schema Ambiguous Attribute -> {self.obj.names[0]} ({self.obj.oid})")
+        log.info(f" * [ ] - Review Schema Ambiguous Attribute -> {self.attr.names[0]} ({self.attr.oid}) overlaps {self.overlaps}")
 
 class SchemaAttributeInvalid(MigrationAction):
     def __init__(self, attr, reason):


### PR DESCRIPTION
…rrors

Bug Description: Incorrect variables were used in the inconsistent attribute logs.

Fix Description: Fix the variable names and reporting.

fixes: https://github.com/389ds/389-ds-base/issues/5495

Author: William Brown <william@blackhats.net.au>

Review by: ???