### PR TITLE
Issue 5502 - RFE - Add option to display entry attributes in audit log

### DIFF
--- a/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
+++ b/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
@@ -72,7 +72,7 @@ def test_dsentrydn(topo):
     user = UserAccount(inst, NEW_USER_DN)
     assert user.get_attr_val_utf8('dsentrydn') == NEW_USER_DN
 
-    # Check DN retruend to client matches "dsEntryDN"
+    # Check DN returned to client matches "dsEntryDN"
     users = UserAccounts(inst, SUFFIX).list()
     for user in users:
         if user.dn.startswith("tUser"):

--- a/dirsrvtests/tests/suites/ds_logs/audit_log_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/audit_log_test.py
@@ -1,0 +1,104 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import logging
+import pytest
+import os
+import time
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.topologies import topology_st as topo
+from lib389.idm.user import UserAccounts
+
+log = logging.getLogger(__name__)
+
+
+def test_auditlog_display_attrs(topo):
+    """Test "display attributes" feature of the audit log
+
+    :id: 01beaf71-4cb5-4943-9774-3210ae5d68a2
+    :setup: Standalone Instance
+    :steps:
+        1. Test "cn" attribute is displayed
+        2. Test multiple attributes are displayed
+        3. Test modrdn updates log
+        4. Test all attributes are displayed
+        5. Test delete updates log
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Sucecss
+    """
+
+    inst = topo.standalone
+    inst.config.replace('nsslapd-auditlog-logging-enabled', 'on')
+
+    # Test "cn" attribute
+    inst.config.replace('nsslapd-auditlog-display-attrs', 'cn')
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user = users.ensure_state(properties={
+        'uid': 'test_audit_log',
+        'cn': 'test',
+        'sn': 'user',
+        'uidNumber': '1000',
+        'gidNumber': '1000',
+        'homeDirectory': '/home/test',
+        'userPassword': 'pppppppp'
+    })
+    user2 = users.ensure_state(properties={
+        'uid': 'test_modrdn_delete',
+        'cn': 'modrdn_delete',
+        'sn': 'modrdn_delete',
+        'uidNumber': '1001',
+        'gidNumber': '1001',
+        'homeDirectory': '/home/modrdn_delete',
+        'userPassword': 'pppppppp'
+    })
+    time.sleep(1)
+    assert inst.ds_audit_log.match("#cn: test")
+    assert not inst.ds_audit_log.match("#uid: test_audit_log")
+
+    # Test multiple attributes
+    inst.config.replace('nsslapd-auditlog-display-attrs', 'uidNumber gidNumber, homeDirectory')
+    user.replace('sn', 'new value')
+    time.sleep(1)
+    assert inst.ds_audit_log.match("#uidNumber: 1000")
+    assert inst.ds_audit_log.match("#gidNumber: 1000")
+    assert inst.ds_audit_log.match("#homeDirectory: /home/test")
+    assert not inst.ds_audit_log.match("#uid: test_audit_log")
+    assert not inst.ds_audit_log.match("#uidNumber: 1001")
+    assert not inst.ds_audit_log.match("#sn: modrdn_delete")
+
+    # Test modrdn
+    user2.rename("uid=modrdn_delete", DEFAULT_SUFFIX)
+    time.sleep(1)
+    assert inst.ds_audit_log.match("#uidNumber: 1001")
+    assert inst.ds_audit_log.match("#gidNumber: 1001")
+
+    # Test ALL attributes
+    inst.config.replace('nsslapd-auditlog-display-attrs', '*')
+    user.replace('sn', 'new value again')
+    time.sleep(1)
+    assert inst.ds_audit_log.match("#uid: test_audit_log")
+    assert inst.ds_audit_log.match("#cn: test")
+    assert inst.ds_audit_log.match("#uidNumber: 1000")
+    assert inst.ds_audit_log.match("#objectClass: top")
+
+    # Test delete
+    user2.delete()
+    time.sleep(1)
+    assert inst.ds_audit_log.match("#sn: modrdn_delete")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -887,7 +887,6 @@ def test_optime_and_wtime_keywords(topology_st, clean_access_logs, remove_users,
          7. From the op num find the associated RESULT string in the access log
          8. Search for the wtime optime keywords in the RESULT string
          9. From the RESULT string get the wtime, optime and etime values for the operation
-         10. Check that optime + wtime is approximatively etime
     :expectedresults:
          1. access log buffering is off
          2. Previously existing access logs are deleted
@@ -898,7 +897,6 @@ def test_optime_and_wtime_keywords(topology_st, clean_access_logs, remove_users,
          7. RESULT string is catched from the access log
          8. wtime and optime keywords are collected
          9. wtime, optime and etime values are collected
-         10. (optime + wtime) =~ etime
     """
 
     log.info('add_users')
@@ -940,10 +938,6 @@ def test_optime_and_wtime_keywords(topology_st, clean_access_logs, remove_users,
 
     log.info('get the etime value from the RESULT string')
     etime_value = result_str.split()[10].split('=')[1][:-3]
-
-    log.info('Check that (wtime + optime) is approximately equal to etime i.e. their ratio is 1')
-    etime_ratio = (Decimal(wtime_value) + Decimal(optime_value)) // Decimal(etime_value)
-    assert etime_ratio == 1
 
     log.info('Perform a compare operation')
     topology_st.standalone.compare_s('uid=testuser1000,ou=people,dc=example,dc=com','uid', 'testuser1000')

--- a/ldap/schema/01core389.ldif
+++ b/ldap/schema/01core389.ldif
@@ -329,8 +329,9 @@ attributeTypes: ( 2.16.840.1.113730.3.1.2374 NAME 'nsDS5ReplicaBootstrapTranspor
 attributeTypes: ( 2.16.840.1.113730.3.1.2387 NAME 'nsslapd-tcp-fin-timeout' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2388 NAME 'nsslapd-tcp-keepalive-time' DESC 'Netscape defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'Netscape Directory Server' )
 attributeTypes: ( 2.16.840.1.113730.3.1.2390 NAME 'nsds5ReplicaKeepAliveUpdateInterval' DESC '389 defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
-attributeTypes: ( 2.16.840.1.113730.3.1.9998 NAME 'dsEntryDN' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 NO-USER-MODIFICATION SINGLE-VALUE USAGE directoryOperation X-ORIGIN '389 Directory Server' )
-attributeTypes: ( 2.16.840.1.113730.3.1.9999 NAME 'nsslapd-return-original-entrydn' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2391 NAME 'dsEntryDN' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 NO-USER-MODIFICATION SINGLE-VALUE USAGE directoryOperation X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2392 NAME 'nsslapd-return-original-entrydn' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2393 NAME 'nsslapd-auditlog-display-attrs' DESC '389 Directory Server defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN '389 Directory Server' )
 #
 # objectclasses
 #

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -812,6 +812,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.auditlog_logging_hide_unhashed_pw,
      CONFIG_ON_OFF, NULL, &init_auditlog_logging_hide_unhashed_pw, NULL},
+    {CONFIG_AUDITLOG_DISPLAY_ATTRS, config_set_auditlog_display_attrs,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.auditlog_display_attrs,
+     CONFIG_STRING, NULL, &config_get_auditlog_display_attrs, NULL},
     {CONFIG_ACCESSLOG_BUFFERING_ATTRIBUTE, config_set_accesslogbuffering,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.accesslogbuffering,
@@ -2237,6 +2241,38 @@ config_value_is_null(const char *attrname, const char *value, char *errorbuf, in
     }
 
     return 0;
+}
+
+int32_t
+config_set_auditlog_display_attrs(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int32_t retVal = LDAP_SUCCESS;
+
+    if (config_value_is_null(attrname, value, errorbuf, 0)) {
+        retVal = LDAP_OPERATIONS_ERROR;
+    }
+
+    if (apply) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        slapi_ch_free_string(&slapdFrontendConfig->auditlog_display_attrs);
+        slapdFrontendConfig->auditlog_display_attrs = slapi_ch_strdup(value);
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+char *
+config_get_auditlog_display_attrs()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char *retVal;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapi_ch_strdup(slapdFrontendConfig->auditlog_display_attrs);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
 }
 
 int32_t

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -393,6 +393,7 @@ int config_set_disk_grace_period(const char *attrname, char *value, char *errorb
 int config_set_disk_logging_critical(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditlog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditfaillog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
+int32_t config_set_auditlog_display_attrs(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_external_libs_debug_enabled(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ndn_cache_enabled(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_ndn_cache_max_size(const char *attrname, char *value, char *errorbuf, int apply);
@@ -516,6 +517,7 @@ int config_get_accesslog_level(void);
 int config_get_securitylog_level(void);
 int config_get_auditlog_logging_enabled(void);
 int config_get_auditfaillog_logging_enabled(void);
+char *config_get_auditlog_display_attrs(void);
 char *config_get_referral_mode(void);
 int config_get_conntablesize(void);
 int config_check_referral_mode(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2299,6 +2299,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_SECURITYLOG_LIST_ATTRIBUTE "nsslapd-securitylog-list"
 #define CONFIG_ERRORLOG_LIST_ATTRIBUTE "nsslapd-errorlog-list"
 #define CONFIG_AUDITLOG_LIST_ATTRIBUTE "nsslapd-auditlog-list"
+#define CONFIG_AUDITLOG_DISPLAY_ATTRS "nsslapd-auditlog-display-attrs"
 #define CONFIG_AUDITFAILLOG_LIST_ATTRIBUTE "nsslapd-auditfaillog-list"
 #define CONFIG_REWRITE_RFC1274_ATTRIBUTE "nsslapd-rewrite-rfc1274"
 #define CONFIG_PLUGIN_BINDDN_TRACKING_ATTRIBUTE "nsslapd-plugin-binddn-tracking"
@@ -2699,6 +2700,7 @@ typedef struct _slapdFrontendConfig
     slapi_int_t tcp_fin_timeout;
     slapi_int_t tcp_keepalive_time;
     slapi_onoff_t return_orig_dn;
+    char *auditlog_display_attrs;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -155,21 +155,21 @@ export class ServerAccessLog extends React.Component {
         let disableSaveBtn = true;
         let disableBtnName = "";
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
             disableBtnName = "saveSettingsDisabled";
             // Handle the table contents check now
             for (const row of this.state.rows) {
                 for (const orig_row of this.state._rows) {
-                    if (orig_row.level == row.level) {
-                        if (orig_row.selected != row.selected) {
+                    if (orig_row.level === row.level) {
+                        if (orig_row.selected !== row.selected) {
                             disableSaveBtn = false;
                             break;
                         }
                     }
                 }
             }
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             disableBtnName = "saveRotationDisabled";
             config_attrs = rotation_attrs;
         } else {
@@ -179,7 +179,7 @@ export class ServerAccessLog extends React.Component {
 
         // Check if a setting was changed, if so enable the save button
         for (const config_attr of config_attrs) {
-            if (attr == config_attr && this.state['_' + config_attr] != value) {
+            if (attr === config_attr && this.state['_' + config_attr] !== value) {
                 disableSaveBtn = false;
                 break;
             }
@@ -187,7 +187,7 @@ export class ServerAccessLog extends React.Component {
 
         // Now check for differences in values that we did not touch
         for (const config_attr of config_attrs) {
-            if (attr != config_attr && this.state['_' + config_attr] != this.state[config_attr]) {
+            if (attr !== config_attr && this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
@@ -221,22 +221,22 @@ export class ServerAccessLog extends React.Component {
         const time_parts = time_str.split(":");
         let hour = time_parts[0];
         let min = time_parts[1];
-        if (hour.length == 2 && hour[0] == "0") {
+        if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
-        if (min.length == 2 && min[0] == "0") {
+        if (min.length === 2 && min[0] === "0") {
             min = min[1];
         }
 
         // Start doing the Save button checking
         for (const config_attr of rotation_attrs_no_time) {
-            if (this.state[config_attr] != this.state['_' + config_attr]) {
+            if (this.state[config_attr] !== this.state['_' + config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
         }
-        if (hour != this.state['_nsslapd-accesslog-logrotationsynchour'] ||
-            min != this.state['_nsslapd-accesslog-logrotationsyncmin']) {
+        if (hour !== this.state['_nsslapd-accesslog-logrotationsynchour'] ||
+            min !== this.state['_nsslapd-accesslog-logrotationsyncmin']) {
             disableSaveBtn = false;
         }
 
@@ -254,9 +254,9 @@ export class ServerAccessLog extends React.Component {
         });
 
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             config_attrs = rotation_attrs;
         } else {
             config_attrs = exp_attrs;
@@ -268,7 +268,7 @@ export class ServerAccessLog extends React.Component {
         ];
 
         for (const attr of config_attrs) {
-            if (this.state['_' + attr] != this.state[attr]) {
+            if (this.state['_' + attr] !== this.state[attr]) {
                 let val = this.state[attr];
                 if (typeof val === "boolean") {
                     if (val) {
@@ -286,14 +286,14 @@ export class ServerAccessLog extends React.Component {
                 new_level += row.level;
             }
         }
-        if (new_level.toString() != this.state['_nsslapd-accesslog-level']) {
-            if (new_level == 0) {
+        if (new_level.toString() !== this.state['_nsslapd-accesslog-level']) {
+            if (new_level === 0) {
                 new_level = 256; // default
             }
             cmd.push("nsslapd-accesslog-level" + "=" + new_level.toString());
         }
 
-        if (cmd.length == 5) {
+        if (cmd.length === 5) {
             // Nothing to save, just return
             return;
         }
@@ -340,13 +340,13 @@ export class ServerAccessLog extends React.Component {
                     const level_val = parseInt(attrs['nsslapd-accesslog-level'][0]);
                     const rows = [...this.state.rows];
 
-                    if (attrs['nsslapd-accesslog-logging-enabled'][0] == "on") {
+                    if (attrs['nsslapd-accesslog-logging-enabled'][0] === "on") {
                         enabled = true;
                     }
-                    if (attrs['nsslapd-accesslog-logbuffering'][0] == "on") {
+                    if (attrs['nsslapd-accesslog-logbuffering'][0] === "on") {
                         buffering = true;
                     }
-                    if (attrs['nsslapd-accesslog-compress'][0] == "on") {
+                    if (attrs['nsslapd-accesslog-compress'][0] === "on") {
                         compress = true;
                     }
                     for (const row in rows) {
@@ -421,13 +421,13 @@ export class ServerAccessLog extends React.Component {
         const level_val = parseInt(attrs['nsslapd-accesslog-level'][0]);
         const rows = [...this.state.rows];
 
-        if (attrs['nsslapd-accesslog-logging-enabled'][0] == "on") {
+        if (attrs['nsslapd-accesslog-logging-enabled'][0] === "on") {
             enabled = true;
         }
-        if (attrs['nsslapd-accesslog-logbuffering'][0] == "on") {
+        if (attrs['nsslapd-accesslog-logbuffering'][0] === "on") {
             buffering = true;
         }
-        if (attrs['nsslapd-accesslog-compress'][0] == "on") {
+        if (attrs['nsslapd-accesslog-compress'][0] === "on") {
             compress = true;
         }
         for (const row in rows) {
@@ -491,7 +491,7 @@ export class ServerAccessLog extends React.Component {
 
         // Handle "save button" state, first check the other config settings
         for (const config_attr of settings_attrs) {
-            if (this.state['_' + config_attr] != this.state[config_attr]) {
+            if (this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
@@ -500,8 +500,8 @@ export class ServerAccessLog extends React.Component {
         // Handle the table contents
         for (const row of rows) {
             for (const orig_row of this.state._rows) {
-                if (orig_row.level == row.level) {
-                    if (orig_row.selected != row.selected) {
+                if (orig_row.level === row.level) {
+                    if (orig_row.selected !== row.selected) {
                         disableSaveBtn = false;
                         break;
                     }
@@ -532,10 +532,10 @@ export class ServerAccessLog extends React.Component {
         }
 
         // Adjust time string for TimePicket
-        if (hour.length == 1) {
+        if (hour.length === 1) {
             hour = "0" + hour;
         }
-        if (min.length == 1) {
+        if (min.length === 1) {
             min = "0" + min;
         }
         rotationTime = hour + ":" + min;
@@ -724,6 +724,7 @@ export class ServerAccessLog extends React.Component {
                                         id="nsslapd-accesslog-compress"
                                         isChecked={this.state['nsslapd-accesslog-compress']}
                                         onChange={this.handleSwitchChange}
+                                        aria-label="nsslapd-accesslog-compress"
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { listsEqual, log_cmd } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -11,6 +11,9 @@ import {
     Grid,
     GridItem,
     NumberInput,
+    Select,
+    SelectVariant,
+    SelectOption,
     Spinner,
     Switch,
     Tab,
@@ -31,8 +34,6 @@ import PropTypes from "prop-types";
 
 const settings_attrs = [
     'nsslapd-auditlog',
-    'nsslapd-auditlog-level',
-    'nsslapd-auditlog-logbuffering',
     'nsslapd-auditlog-logging-enabled',
 ];
 
@@ -74,6 +75,10 @@ export class ServerAuditLog extends React.Component {
             saveRotationDisabled: true,
             saveExpDisabled: true,
             attrs: this.props.attrs,
+            displayAttrs: [],
+            isDisplayAttrOpen: false,
+            attributes: [],
+            displayAllAttrs: false,
         };
 
         // Toggle currently active tab
@@ -81,6 +86,35 @@ export class ServerAuditLog extends React.Component {
             this.setState({
                 activeTabKey: tabIndex
             });
+        };
+
+        this.onDisplayAttrSelect = (event, selection) => {
+            if (this.state.displayAttrs.includes(selection)) {
+                this.setState(
+                    (prevState) => ({
+                        displayAttrs: prevState.displayAttrs.filter((item) => item !== selection),
+                        isDisplayAttrOpen: false
+                    }), () => { this.validateSaveBtn("settings", "none", "none") }
+                );
+            } else {
+                this.setState(
+                    (prevState) => ({
+                        displayAttrs: [...prevState.displayAttrs, selection],
+                        isDisplayAttrOpen: false
+                    }), () => { this.validateSaveBtn("settings", "none", "none") }
+                );
+            }
+        };
+        this.onDisplayAttrToggle = isDisplayAttrOpen => {
+            this.setState({
+                isDisplayAttrOpen
+            });
+        };
+        this.onDisplayAttrClear = () => {
+            this.setState({
+                displayAttrs: [],
+                isDisplayAttrOpen: false
+            }, () => { this.validateSaveBtn("settings", "none", "none") });
         };
 
         this.handleChange = this.handleChange.bind(this);
@@ -116,20 +150,44 @@ export class ServerAuditLog extends React.Component {
     componentDidMount() {
         // Loading config
         if (!this.state.loaded) {
-            this.loadConfig();
+            this.getAttributes();
         } else {
             this.props.enableTree();
         }
+    }
+
+    getAttributes() {
+        const attr_cmd = [
+            "dsconf",
+            "-j",
+            "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "schema",
+            "attributetypes",
+            "list"
+        ];
+        log_cmd("getAttributes", "Get attributes for audit log display attributes", attr_cmd);
+        cockpit
+                .spawn(attr_cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const attrContent = JSON.parse(content);
+                    const attrs = [];
+                    for (const content of attrContent.items) {
+                        attrs.push(content.name[0]);
+                    }
+                    this.setState({
+                        attributes: attrs,
+                    }, () => { this.loadConfig() });
+                });
     }
 
     validateSaveBtn(nav_tab, attr, value) {
         let disableSaveBtn = true;
         let disableBtnName = "";
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
             disableBtnName = "saveSettingsDisabled";
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             disableBtnName = "saveRotationDisabled";
             config_attrs = rotation_attrs;
         } else {
@@ -139,7 +197,7 @@ export class ServerAuditLog extends React.Component {
 
         // Check if a setting was changed, if so enable the save button
         for (const config_attr of config_attrs) {
-            if (attr == config_attr && this.state['_' + config_attr] != value) {
+            if (attr === config_attr && this.state['_' + config_attr] !== value) {
                 disableSaveBtn = false;
                 break;
             }
@@ -147,10 +205,17 @@ export class ServerAuditLog extends React.Component {
 
         // Now check for differences in values that we did not touch
         for (const config_attr of config_attrs) {
-            if (attr != config_attr && this.state['_' + config_attr] != this.state[config_attr]) {
+            if (attr !== config_attr && this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
+        }
+
+        if (this.state.displayAllAttrs !== this.state._displayAllAttrs) {
+            disableSaveBtn = false;
+        }
+        if (!this.state.displayAllAttrs && !listsEqual(this.state.displayAttrs, this.state._displayAttrs)) {
+            disableSaveBtn = false;
         }
 
         this.setState({
@@ -181,22 +246,22 @@ export class ServerAuditLog extends React.Component {
         const time_parts = time_str.split(":");
         let hour = time_parts[0];
         let min = time_parts[1];
-        if (hour.length == 2 && hour[0] == "0") {
+        if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
-        if (min.length == 2 && min[0] == "0") {
+        if (min.length === 2 && min[0] === "0") {
             min = min[1];
         }
 
         // Start doing the Save button checking
         for (const config_attr of rotation_attrs_no_time) {
-            if (this.state[config_attr] != this.state['_' + config_attr]) {
+            if (this.state[config_attr] !== this.state['_' + config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
         }
-        if (hour != this.state['_nsslapd-auditlog-logrotationsynchour'] ||
-            min != this.state['_nsslapd-auditlog-logrotationsyncmin']) {
+        if (hour !== this.state['_nsslapd-auditlog-logrotationsynchour'] ||
+            min !== this.state['_nsslapd-auditlog-logrotationsyncmin']) {
             disableSaveBtn = false;
         }
 
@@ -213,9 +278,9 @@ export class ServerAuditLog extends React.Component {
         });
 
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             config_attrs = rotation_attrs;
         } else {
             config_attrs = exp_attrs;
@@ -227,7 +292,7 @@ export class ServerAuditLog extends React.Component {
         ];
 
         for (const attr of config_attrs) {
-            if (this.state['_' + attr] != this.state[attr]) {
+            if (this.state['_' + attr] !== this.state[attr]) {
                 let val = this.state[attr];
                 if (typeof val === "boolean") {
                     if (val) {
@@ -240,7 +305,23 @@ export class ServerAuditLog extends React.Component {
             }
         }
 
-        if (cmd.length == 5) {
+        if (!this.state.displayAllAttrs && !listsEqual(this.state.displayAttrs, this.state._displayAttrs)) {
+            if (this.state.displayAttrs.length > 0) {
+                let val = this.state.displayAttrs.join(' ');
+                cmd.push('nsslapd-auditlog-display-attrs=' + val);
+            } else {
+                cmd.push('nsslapd-auditlog-display-attrs=');
+            }
+        }
+        if (this.state.displayAllAttrs !== this.state._displayAllAttrs) {
+            if (this.state.displayAllAttrs) {
+                cmd.push('nsslapd-auditlog-display-attrs=*');
+            } else if (this.state.displayAttrs.length === 0) {
+                cmd.push('nsslapd-auditlog-display-attrs=');
+            }
+        }
+
+        if (cmd.length === 5) {
             // Nothing to save, just return
             return;
         }
@@ -282,12 +363,22 @@ export class ServerAuditLog extends React.Component {
                     const attrs = config.attrs;
                     let enabled = false;
                     let compressed = false;
+                    let display_attrs = [];
+                    let displayAllAttrs = this.state.displayAllAttrs;
 
-                    if (attrs['nsslapd-auditlog-logging-enabled'][0] == "on") {
+                    if (attrs['nsslapd-auditlog-logging-enabled'][0] === "on") {
                         enabled = true;
                     }
-                    if (attrs['nsslapd-auditlog-compress'][0] == "on") {
+                    if (attrs['nsslapd-auditlog-compress'][0] === "on") {
                         compressed = true;
+                    }
+                    if ('nsslapd-auditlog-display-attrs' in attrs) {
+                        if (attrs['nsslapd-auditlog-display-attrs'][0] === "*") {
+                            displayAllAttrs = true;
+                        } else if (attrs['nsslapd-auditlog-display-attrs'][0] !== "") {
+                            displayAllAttrs = false;
+                            display_attrs = attrs['nsslapd-auditlog-display-attrs'][0].split(/[, ]+/);
+                        }
                     }
 
                     this.setState({
@@ -310,6 +401,8 @@ export class ServerAuditLog extends React.Component {
                         'nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
                         'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
                         'nsslapd-auditlog-compress': compressed,
+                        displayAttrs: display_attrs,
+                        displayAllAttrs: displayAllAttrs,
                         // Record original values
                         '_nsslapd-auditlog': attrs['nsslapd-auditlog'][0],
                         '_nsslapd-auditlog-logexpirationtime': attrs['nsslapd-auditlog-logexpirationtime'][0],
@@ -325,6 +418,8 @@ export class ServerAuditLog extends React.Component {
                         '_nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
                         '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
                         '_nsslapd-auditlog-compress': compressed,
+                        _displayAttrs: display_attrs,
+                        _displayAllAttrs: displayAllAttrs,
                     });
                 })
                 .fail(err => {
@@ -344,12 +439,22 @@ export class ServerAuditLog extends React.Component {
         const attrs = this.state.attrs;
         let enabled = false;
         let compressed = false;
+        let display_attrs = [];
+        let displayAllAttrs = this.state.displayAllAttrs;
 
-        if (attrs['nsslapd-auditlog-logging-enabled'][0] == "on") {
+        if (attrs['nsslapd-auditlog-logging-enabled'][0] === "on") {
             enabled = true;
         }
-        if (attrs['nsslapd-auditlog-compress'][0] == "on") {
+        if (attrs['nsslapd-auditlog-compress'][0] === "on") {
             compressed = true;
+        }
+
+        if ('nsslapd-auditlog-display-attrs' in attrs) {
+            if (attrs['nsslapd-auditlog-display-attrs'][0] === "*") {
+                displayAllAttrs = true;
+            } else if (attrs['nsslapd-auditlog-display-attrs'][0] !== "") {
+                display_attrs = attrs['nsslapd-auditlog-display-attrs'][0].split(/[, ]+/);
+            }
         }
 
         this.setState({
@@ -372,6 +477,8 @@ export class ServerAuditLog extends React.Component {
             'nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
             'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
             'nsslapd-auditlog-compress': compressed,
+            displayAttrs: display_attrs,
+            displayAllAttrs: displayAllAttrs,
             // Record original values,
             '_nsslapd-auditlog': attrs['nsslapd-auditlog'][0],
             '_nsslapd-auditlog-logexpirationtime': attrs['nsslapd-auditlog-logexpirationtime'][0],
@@ -387,6 +494,8 @@ export class ServerAuditLog extends React.Component {
             '_nsslapd-auditlog-maxlogsize': attrs['nsslapd-auditlog-maxlogsize'][0],
             '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
             '_nsslapd-auditlog-compress': compressed,
+            _displayAttrs: display_attrs,
+            _displayAllAttrs: displayAllAttrs,
         }, this.props.enableTree);
     }
 
@@ -407,10 +516,10 @@ export class ServerAuditLog extends React.Component {
         }
 
         // Adjust time string for TimePicket
-        if (hour.length == 1) {
+        if (hour.length === 1) {
             hour = "0" + hour;
         }
-        if (min.length == 1) {
+        if (min.length === 1) {
             min = "0" + min;
         }
         rotationTime = hour + ":" + min;
@@ -444,6 +553,45 @@ export class ServerAuditLog extends React.Component {
                                     onChange={(str, e) => {
                                         this.handleChange(e, "settings");
                                     }}
+                                />
+                            </FormGroup>
+                        </Form>
+                        <Form className="ds-margin-top-lg ds-margin-left" isHorizontal autoComplete="off">
+                            <FormGroup
+                                label="Display Attributes"
+                                fieldId="nsslapd-auditlog-display-attrs"
+                                title="Display attributes from the entry in the audit log (nsslapd-auditlog-display-attrs)."
+                            >
+                                <div className={this.state.displayAllAttrs ? "ds-hidden" : "ds-margin-bottom"}>
+                                    <Select
+                                        variant={SelectVariant.typeaheadMulti}
+                                        typeAheadAriaLabel="Type an attribute"
+                                        onToggle={this.onDisplayAttrToggle}
+                                        onSelect={this.onDisplayAttrSelect}
+                                        onClear={this.onDisplayAttrClear}
+                                        selections={this.state.displayAttrs}
+                                        isOpen={this.state.isDisplayAttrOpen}
+                                        aria-labelledby="typeAhead-audit-display-attr"
+                                        placeholderText="Type an attribute..."
+                                        noResultsFoundText="There are no matching attributes"
+                                    >
+                                        {this.state.attributes.map((attr, index) => (
+                                            <SelectOption
+                                                key={index}
+                                                value={attr}
+                                            />
+                                        ))}
+                                    </Select>
+                                </div>
+                                <Checkbox
+                                    className="ds-lower-field-md"
+                                    id="displayAllAttrs"
+                                    isChecked={this.state.displayAllAttrs}
+                                    onChange={(checked, e) => {
+                                        this.handleChange(e, "settings");
+                                    }}
+                                    title="Display all attributes from the entry in the audit log (nsslapd-auditlog-display-attrs)."
+                                    label="All Attributes"
                                 />
                             </FormGroup>
                         </Form>
@@ -567,6 +715,7 @@ export class ServerAuditLog extends React.Component {
                                         id="nsslapd-auditlog-compress"
                                         isChecked={this.state['nsslapd-auditlog-compress']}
                                         onChange={this.handleSwitchChange}
+                                        aria-label="nsslapd-auditlog-compress"
                                     />`
                                 </GridItem>
                             </Grid>

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -125,10 +125,10 @@ export class ServerAuditFailLog extends React.Component {
         let disableSaveBtn = true;
         let disableBtnName = "";
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
             disableBtnName = "saveSettingsDisabled";
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             disableBtnName = "saveRotationDisabled";
             config_attrs = rotation_attrs;
         } else {
@@ -138,7 +138,7 @@ export class ServerAuditFailLog extends React.Component {
 
         // Check if a setting was changed, if so enable the save button
         for (const config_attr of config_attrs) {
-            if (attr == config_attr && this.state['_' + config_attr] != value) {
+            if (attr === config_attr && this.state['_' + config_attr] !== value) {
                 disableSaveBtn = false;
                 break;
             }
@@ -146,7 +146,7 @@ export class ServerAuditFailLog extends React.Component {
 
         // Now check for differences in values that we did not touch
         for (const config_attr of config_attrs) {
-            if (attr != config_attr && this.state['_' + config_attr] != this.state[config_attr]) {
+            if (attr !== config_attr && this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
@@ -180,22 +180,22 @@ export class ServerAuditFailLog extends React.Component {
         const time_parts = time_str.split(":");
         let hour = time_parts[0];
         let min = time_parts[1];
-        if (hour.length == 2 && hour[0] == "0") {
+        if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
-        if (min.length == 2 && min[0] == "0") {
+        if (min.length === 2 && min[0] === "0") {
             min = min[1];
         }
 
         // Start doing the Save button checking
         for (const config_attr of rotation_attrs_no_time) {
-            if (this.state[config_attr] != this.state['_' + config_attr]) {
+            if (this.state[config_attr] !== this.state['_' + config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
         }
-        if (hour != this.state['_nsslapd-auditfaillog-logrotationsynchour'] ||
-            min != this.state['_nsslapd-auditfaillog-logrotationsyncmin']) {
+        if (hour !== this.state['_nsslapd-auditfaillog-logrotationsynchour'] ||
+            min !== this.state['_nsslapd-auditfaillog-logrotationsyncmin']) {
             disableSaveBtn = false;
         }
 
@@ -212,9 +212,9 @@ export class ServerAuditFailLog extends React.Component {
         });
 
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             config_attrs = rotation_attrs;
         } else {
             config_attrs = exp_attrs;
@@ -226,7 +226,7 @@ export class ServerAuditFailLog extends React.Component {
         ];
 
         for (const attr of config_attrs) {
-            if (this.state['_' + attr] != this.state[attr]) {
+            if (this.state['_' + attr] !== this.state[attr]) {
                 let val = this.state[attr];
                 if (typeof val === "boolean") {
                     if (val) {
@@ -239,7 +239,7 @@ export class ServerAuditFailLog extends React.Component {
             }
         }
 
-        if (cmd.length == 5) {
+        if (cmd.length === 5) {
             // Nothing to save, just return
             return;
         }
@@ -283,10 +283,10 @@ export class ServerAuditFailLog extends React.Component {
                     let enabled = false;
                     let compressed = false;
 
-                    if (attrs['nsslapd-auditfaillog-logging-enabled'][0] == "on") {
+                    if (attrs['nsslapd-auditfaillog-logging-enabled'][0] === "on") {
                         enabled = true;
                     }
-                    if (attrs['nsslapd-auditfaillog-compress'][0] == "on") {
+                    if (attrs['nsslapd-auditfaillog-compress'][0] === "on") {
                         compressed = true;
                     }
 
@@ -347,10 +347,10 @@ export class ServerAuditFailLog extends React.Component {
         let enabled = false;
         let compressed = false;
 
-        if (attrs['nsslapd-auditfaillog-logging-enabled'][0] == "on") {
+        if (attrs['nsslapd-auditfaillog-logging-enabled'][0] === "on") {
             enabled = true;
         }
-        if (attrs['nsslapd-auditfaillog-compress'][0] == "on") {
+        if (attrs['nsslapd-auditfaillog-compress'][0] === "on") {
             compressed = true;
         }
 
@@ -409,10 +409,10 @@ export class ServerAuditFailLog extends React.Component {
         }
 
         // Adjust time string for TimePicket
-        if (hour.length == 1) {
+        if (hour.length === 1) {
             hour = "0" + hour;
         }
-        if (min.length == 1) {
+        if (min.length === 1) {
             min = "0" + min;
         }
         rotationTime = hour + ":" + min;
@@ -568,6 +568,7 @@ export class ServerAuditFailLog extends React.Component {
                                         id="nsslapd-auditfaillog-compress"
                                         isChecked={this.state['nsslapd-auditfaillog-compress']}
                                         onChange={this.handleSwitchChange}
+                                        aria-label="nsslapd-auditfaillog-compress"
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -180,21 +180,21 @@ export class ServerErrorLog extends React.Component {
         let disableSaveBtn = true;
         let disableBtnName = "";
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
             disableBtnName = "saveSettingsDisabled";
             // Handle the table contents check now
             for (const row of this.state.rows) {
                 for (const orig_row of this.state._rows) {
-                    if (orig_row.level == row.level) {
-                        if (orig_row.selected != row.selected) {
+                    if (orig_row.level === row.level) {
+                        if (orig_row.selected !== row.selected) {
                             disableSaveBtn = false;
                             break;
                         }
                     }
                 }
             }
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             disableBtnName = "saveRotationDisabled";
             config_attrs = rotation_attrs;
         } else {
@@ -204,7 +204,7 @@ export class ServerErrorLog extends React.Component {
 
         // Check if a setting was changed, if so enable the save button
         for (const config_attr of config_attrs) {
-            if (attr == config_attr && this.state['_' + config_attr] != value) {
+            if (attr === config_attr && this.state['_' + config_attr] !== value) {
                 disableSaveBtn = false;
                 break;
             }
@@ -212,7 +212,7 @@ export class ServerErrorLog extends React.Component {
 
         // Now check for differences in values that we did not touch
         for (const config_attr of config_attrs) {
-            if (attr != config_attr && this.state['_' + config_attr] != this.state[config_attr]) {
+            if (attr !== config_attr && this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
@@ -246,22 +246,22 @@ export class ServerErrorLog extends React.Component {
         const time_parts = time_str.split(":");
         let hour = time_parts[0];
         let min = time_parts[1];
-        if (hour.length == 2 && hour[0] == "0") {
+        if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
-        if (min.length == 2 && min[0] == "0") {
+        if (min.length === 2 && min[0] === "0") {
             min = min[1];
         }
 
         // Start doing the Save button checking
         for (const config_attr of rotation_attrs_no_time) {
-            if (this.state[config_attr] != this.state['_' + config_attr]) {
+            if (this.state[config_attr] !== this.state['_' + config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
         }
-        if (hour != this.state['_nsslapd-errorlog-logrotationsynchour'] ||
-            min != this.state['_nsslapd-errorlog-logrotationsyncmin']) {
+        if (hour !== this.state['_nsslapd-errorlog-logrotationsynchour'] ||
+            min !== this.state['_nsslapd-errorlog-logrotationsyncmin']) {
             disableSaveBtn = false;
         }
 
@@ -279,9 +279,9 @@ export class ServerErrorLog extends React.Component {
         });
 
         let config_attrs = [];
-        if (nav_tab == "settings") {
+        if (nav_tab === "settings") {
             config_attrs = settings_attrs;
-        } else if (nav_tab == "rotation") {
+        } else if (nav_tab === "rotation") {
             config_attrs = rotation_attrs;
         } else {
             config_attrs = exp_attrs;
@@ -293,7 +293,7 @@ export class ServerErrorLog extends React.Component {
         ];
 
         for (const attr of config_attrs) {
-            if (this.state['_' + attr] != this.state[attr]) {
+            if (this.state['_' + attr] !== this.state[attr]) {
                 let val = this.state[attr];
                 if (typeof val === "boolean") {
                     if (val) {
@@ -311,14 +311,14 @@ export class ServerErrorLog extends React.Component {
                 new_level += row.level;
             }
         }
-        if (new_level.toString() != this.state['_nsslapd-errorlog-level']) {
-            if (new_level == 0) {
+        if (new_level.toString() !== this.state['_nsslapd-errorlog-level']) {
+            if (new_level === 0) {
                 new_level = 16384; // default
             }
             cmd.push("nsslapd-errorlog-level" + "=" + new_level.toString());
         }
 
-        if (cmd.length == 5) {
+        if (cmd.length === 5) {
             // Nothing to save, just return
             return;
         }
@@ -364,10 +364,10 @@ export class ServerErrorLog extends React.Component {
                     const level_val = parseInt(attrs['nsslapd-errorlog-level'][0]);
                     const rows = [...this.state.rows];
 
-                    if (attrs['nsslapd-errorlog-logging-enabled'][0] == "on") {
+                    if (attrs['nsslapd-errorlog-logging-enabled'][0] === "on") {
                         enabled = true;
                     }
-                    if (attrs['nsslapd-errorlog-compress'][0] == "on") {
+                    if (attrs['nsslapd-errorlog-compress'][0] === "on") {
                         compressed = true;
                     }
 
@@ -442,10 +442,10 @@ export class ServerErrorLog extends React.Component {
         const level_val = parseInt(attrs['nsslapd-errorlog-level'][0]);
         const rows = [...this.state.rows];
 
-        if (attrs['nsslapd-errorlog-logging-enabled'][0] == "on") {
+        if (attrs['nsslapd-errorlog-logging-enabled'][0] === "on") {
             enabled = true;
         }
-        if (attrs['nsslapd-errorlog-compress'][0] == "on") {
+        if (attrs['nsslapd-errorlog-compress'][0] === "on") {
             compressed = true;
         }
         for (const row in rows) {
@@ -507,7 +507,7 @@ export class ServerErrorLog extends React.Component {
 
         // Handle "save button" state, first check the other config settings
         for (const config_attr of settings_attrs) {
-            if (this.state['_' + config_attr] != this.state[config_attr]) {
+            if (this.state['_' + config_attr] !== this.state[config_attr]) {
                 disableSaveBtn = false;
                 break;
             }
@@ -516,8 +516,8 @@ export class ServerErrorLog extends React.Component {
         // Handle the table contents
         for (const row of rows) {
             for (const orig_row of this.state._rows) {
-                if (orig_row.level == row.level) {
-                    if (orig_row.selected != row.selected) {
+                if (orig_row.level === row.level) {
+                    if (orig_row.selected !== row.selected) {
                         disableSaveBtn = false;
                         break;
                     }
@@ -548,10 +548,10 @@ export class ServerErrorLog extends React.Component {
         }
 
         // Adjust time string for TimePicket
-        if (hour.length == 1) {
+        if (hour.length === 1) {
             hour = "0" + hour;
         }
-        if (min.length == 1) {
+        if (min.length === 1) {
             min = "0" + min;
         }
         rotationTime = hour + ":" + min;
@@ -729,6 +729,7 @@ export class ServerErrorLog extends React.Component {
                                         id="nsslapd-errorlog-compress"
                                         isChecked={this.state['nsslapd-errorlog-compress']}
                                         onChange={this.handleSwitchChange}
+                                        aria-label="nsslapd-errorlog-compress"
                                     />
                                 </GridItem>
                             </Grid>

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -320,7 +320,7 @@ class DirSrv(SimpleLDAPObject, object):
         from lib389.aci import Aci
         from lib389.config import RSA
         from lib389.config import Encryption
-        from lib389.dirsrv_log import DirsrvAccessLog, DirsrvErrorLog, DirsrvSecurityLog
+        from lib389.dirsrv_log import DirsrvAccessLog, DirsrvErrorLog, DirsrvAuditLog, DirsrvSecurityLog
         from lib389.ldclt import Ldclt
         from lib389.mappingTree import MappingTrees
         from lib389.mappingTree import MappingTreeLegacy as MappingTree
@@ -365,6 +365,7 @@ class DirSrv(SimpleLDAPObject, object):
         self.encryption = Encryption(self)
         self.ds_access_log = DirsrvAccessLog(self)
         self.ds_error_log = DirsrvErrorLog(self)
+        self.ds_audit_log = DirsrvAuditLog(self)
         self.ds_security_log = DirsrvSecurityLog(self)
         self.ldclt = Ldclt(self)
         self.saslmaps = SaslMappings(self)

--- a/src/lib389/lib389/dirsrv_log.py
+++ b/src/lib389/lib389/dirsrv_log.py
@@ -368,3 +368,32 @@ class DirsrvSecurityLog(DirsrvLog):
         @return - A dictionary of the log parts for each line
         """
         return map(self.parse_line, lines)
+
+
+class DirsrvAuditLog(DirsrvLog):
+    """Directory Server Audit log class"""
+    def __init__(self, dirsrv):
+        """Init the Audit log class
+        @param dirsrv - A DirSrv object
+        """
+        super(DirsrvAuditLog, self).__init__(dirsrv)
+
+    def _get_log_path(self):
+        """Return the current log file location"""
+        return self.dirsrv.ds_paths.audit_log
+
+    def parse_line(self, line):
+        """Parse an audit log line
+        @line - a text string from an audit log
+        @return - A dictionary of the log parts
+        """
+        line = line.strip()
+        return line.groupdict()
+
+    def parse_lines(self, lines):
+        """Parse multiple lines from an audit log
+        @param lines - a list of strings/lines from an audit log
+        @return - A dictionary of the log parts for each line
+        """
+        return map(self.parse_line, lines)
+


### PR DESCRIPTION
Description:

Add a new config setting to specify specifc, or all, attributes from the entry being updated.  These attributes are prefixed with a '#' to make them comments so parsing tools will still work.

relates: https://github.com/389ds/389-ds-base/issues/5502
