### PR TITLE
Issue 3729 - RFE Extend log of operations statistics in access log

### DIFF
--- a/ldap/servers/slapd/log.h
+++ b/ldap/servers/slapd/log.h
@@ -130,6 +130,7 @@ struct logging_opts
     char *log_accessinfo_file;           /* access log rotation info file */
     LogBufferInfo *log_access_buffer;    /* buffer for access log */
     int log_access_compress;             /* Compress rotated logs */
+    int log_access_stat_level;           /* statistics level in access log file */
 
     /* These are security audit log specific */
     int log_security_state;

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -1059,6 +1059,7 @@ main(int argc, char **argv)
          * changes are replicated as soon as the replication plugin is started.
          */
         pw_exp_init();
+        op_stat_init();
 
         plugin_print_lists();
         plugin_startall(argc, argv, NULL /* specific plugin list */);

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -292,6 +292,7 @@ int config_set_defaultreferral(const char *attrname, struct berval **value, char
 int config_set_timelimit(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_errorlog_level(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesslog_level(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_statlog_level(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_securitylog_level(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditlog(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditfaillog(const char *attrname, char *value, char *errorbuf, int apply);
@@ -514,6 +515,7 @@ long long config_get_pw_minage(void);
 long long config_get_pw_warning(void);
 int config_get_errorlog_level(void);
 int config_get_accesslog_level(void);
+int config_get_statlog_level();
 int config_get_securitylog_level(void);
 int config_get_auditlog_logging_enabled(void);
 int config_get_auditfaillog_logging_enabled(void);
@@ -827,11 +829,15 @@ int lock_fclose(FILE *fp, FILE *lfp);
 #define LDAP_DEBUG_INFO       0x08000000  /* 134217728 */
 #define LDAP_DEBUG_DEBUG      0x10000000  /* 268435456 */
 #define LDAP_DEBUG_ALL_LEVELS 0xFFFFFF
+
+#define LDAP_STAT_READ_INDEX  0x00000001  /*         1 */
+#define LDAP_STAT_FREE_1      0x00000002  /*         2 */
+
 extern int slapd_ldap_debug;
 
 int loglevel_is_set(int level);
 int slapd_log_error_proc(int sev_level, const char *subsystem, const char *fmt, ...);
-
+int slapi_log_stat(int loglevel, const char *fmt, ...);
 int slapi_log_access(int level, const char *fmt, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 2, 3)));
@@ -889,6 +895,7 @@ int check_log_max_size(
 
 
 void g_set_accesslog_level(int val);
+void g_set_statlog_level(int val);
 void g_set_securitylog_level(int val);
 void log__delete_rotated_logs(void);
 

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -355,6 +355,8 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_FE_ERRORLOG_LEVEL_STR "16384"
 #define SLAPD_DEFAULT_ACCESSLOG_LEVEL 256
 #define SLAPD_DEFAULT_ACCESSLOG_LEVEL_STR "256"
+#define SLAPD_DEFAULT_STATLOG_LEVEL 0
+#define SLAPD_DEFAULT_STATLOG_LEVEL_STR "0"
 #define SLAPD_DEFAULT_SECURITYLOG_LEVEL 256
 #define SLAPD_DEFAULT_SECURITYLOG_LEVEL_STR "256"
 
@@ -2106,6 +2108,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_SCHEMAREPLACE_ATTRIBUTE "nsslapd-schemareplace"
 #define CONFIG_LOGLEVEL_ATTRIBUTE "nsslapd-errorlog-level"
 #define CONFIG_ACCESSLOGLEVEL_ATTRIBUTE "nsslapd-accesslog-level"
+#define CONFIG_STATLOGLEVEL_ATTRIBUTE "nsslapd-statlog-level"
 #define CONFIG_SECURITYLOGLEVEL_ATTRIBUTE "nsslapd-securitylog-level"
 #define CONFIG_ACCESSLOG_MODE_ATTRIBUTE "nsslapd-accesslog-mode"
 #define CONFIG_SECURITYLOG_MODE_ATTRIBUTE "nsslapd-securitylog-mode"
@@ -2508,6 +2511,7 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t accesslogbuffering;
     slapi_onoff_t csnlogging;
     slapi_onoff_t accesslog_compress;
+    int statloglevel;
 
     /* SECURITY LOG */
     char *securitylog;

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -454,6 +454,33 @@ int operation_is_flag_set(Slapi_Operation *op, int flag);
 unsigned long operation_get_type(Slapi_Operation *op);
 LDAPMod **copy_mods(LDAPMod **orig_mods);
 
+/* Structures use to collect statistics per operation */
+/* used for LDAP_STAT_READ_INDEX */
+struct component_keys_lookup
+{
+    char *index_type;
+    char *attribute_type;
+    char *key;
+    int id_lookup_cnt;
+    struct component_keys_lookup *next;
+};
+typedef struct op_search_stat
+{
+    struct component_keys_lookup *keys_lookup;
+    struct timespec keys_lookup_start;
+    struct timespec keys_lookup_end;
+} Op_search_stat;
+
+/* structure store in the operation extension */
+typedef struct op_stat
+{
+    Op_search_stat *search_stat;
+} Op_stat;
+
+void op_stat_init(void);
+Op_stat *op_stat_get_operation_extension(Slapi_PBlock *pb);
+void op_stat_set_operation_extension(Slapi_PBlock *pb, Op_stat *op_stat);
+
 /*
  * From ldap.h
  * #define LDAP_MOD_ADD            0x00


### PR DESCRIPTION
Bug description:
	Create a per operation framework to collect/display
	statistics about internal ressource consumption

Fix description:
	The fix contains 2 parts
	The framework registers a per operation object extension
        (op_stat_init). The extension is used to store/retrieve
	collected statistics.
        To reduce the impact of collecting/logging it uses a toggle
        with config attribute 'nsslapd-statlog-level' that is a bit mask.

	An exemple of collected data from the indexes during a search
	filterindex.c (store), retrieve/log (result.c). This path uses
	LDAP_STAT_READ_INDEX=0x1.

relates: #3729

Reviewed by: