### PR TITLE
Issue 5510 - remove twalk_r dependency to build on RHEL8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,6 @@ AC_CHECK_FUNCS([endpwent ftruncate getcwd getaddrinfo inet_pton inet_ntop localt
 
 # These functions are *required* without option.
 AC_CHECK_FUNCS([clock_gettime], [], AC_MSG_ERROR([unable to locate required symbol clock_gettime]))
-AC_CHECK_FUNCS([twalk_r], [], AC_MSG_ERROR([cannot locate required symbol twalk_r: use glibc-2.30 or higher ]))
 
 # This will detect if we need to add the LIBADD_DL value for us.
 LT_LIB_DLLOAD

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -91,6 +91,28 @@ static dbmdb_dbi_t *dbi_slots;    /* The alloced slots */
 static int dbi_nbslots;           /* Number of available slots in dbi_slots */
 
 /*
+ * twalk_r is not available before glibc-2.30 so lets replace it by twalk
+ * and a global variable (it is possible because there is a single call
+ *   and it is protected by global mutex dbmdb_ctx->dbis_lock )
+ */
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 30)
+
+static struct {
+    void *closure;
+    void (*cb)(const void *nodep, VISIT which, void *closure);
+} twalk_ctx;
+
+static void twalk_cb(const void *nodep, VISIT which, int depth)
+{
+    twalk_ctx.cb(nodep, which, twalk_ctx.closure);
+}
+
+#define twalk_r(_tree, _cb, _closure) { twalk_ctx.cb = (_cb); twalk_ctx.closure = (_closure); twalk(_tree, twalk_cb); }
+
+#endif
+
+
+/*
  * Rules:
  * NULL comes before anything else.
  * Otherwise, strcasecmp(elem_a->rdn_elem_nrdn_rdn - elem_b->rdn_elem_nrdn_rdn) is

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -173,8 +173,6 @@ Requires:         cyrus-sasl-plain
 # this is needed for backldbm
 Requires:         libdb
 Requires:         lmdb
-# twalk_r is only available in glibc-2.30 or higher
-Requires:         glibc => 2.30
 # This picks up libperl.so as a Requires, so we add this versioned one
 Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 # Needed by logconv.pl


### PR DESCRIPTION
Bug Description
Since version 2.1 we use twalk_r function that is available in glibc-2.30 and newer. This prevents building 389-ds on platforms with older glibc such as EL8.

Fix Description
Replace twalk_r by twalk if glibc version is < 2.30

Fixes: #5510

Reviewed by: