### PR TITLE
Issue 5517 - Replication conflict CI test sometime fails

### DIFF
--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -1054,8 +1054,7 @@ keys2idl(
     int allidslimit)
 {
     IDList *idl = NULL;
-    Op_stat *op_stat;
-    PRBool collect_stat = PR_FALSE;
+    Op_stat *op_stat = NULL;
 
     slapi_log_err(SLAPI_LOG_TRACE, "keys2idl", "=> type %s indextype %s\n", type, indextype);
 
@@ -1063,8 +1062,9 @@ keys2idl(
     if (LDAP_STAT_READ_INDEX & config_get_statlog_level()) {
         op_stat = op_stat_get_operation_extension(pb);
         if (op_stat->search_stat) {
-            collect_stat = PR_TRUE;
             clock_gettime(CLOCK_MONOTONIC, &(op_stat->search_stat->keys_lookup_start));
+        } else {
+            op_stat = NULL;
         }
     }
 
@@ -1074,7 +1074,7 @@ keys2idl(
         int key_len;
 
         idl2 = index_read_ext_allids(pb, be, type, indextype, slapi_value_get_berval(ivals[i]), txn, err, unindexed, allidslimit);
-        if (collect_stat) {
+        if (op_stat) {
             /* gather the index lookup statistics */
             key_stat = (struct component_keys_lookup *) slapi_ch_calloc(1, sizeof (struct component_keys_lookup));
 
@@ -1139,7 +1139,7 @@ keys2idl(
     }
 
     /* All the keys have been fetch, time to take the completion time */
-    if (collect_stat) {
+    if (op_stat) {
         clock_gettime(CLOCK_MONOTONIC, &(op_stat->search_stat->keys_lookup_end));
     }
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
@@ -1126,9 +1126,10 @@ ldbm_back_modrdn(Slapi_PBlock *pb)
          */
         if (entryrdn_get_switch()) /* subtree-rename: on */
         {
+            const Slapi_DN *oldsdn = slapi_entry_get_sdn_const(e->ep_entry);
             Slapi_RDN newsrdn;
             slapi_rdn_init_sdn(&newsrdn, (const Slapi_DN *)&dn_newdn);
-            retval = entryrdn_rename_subtree(be, (const Slapi_DN *)sdn, &newsrdn,
+            retval = entryrdn_rename_subtree(be, oldsdn, &newsrdn,
                                              (const Slapi_DN *)dn_newsuperiordn,
                                              e->ep_id, &txn, is_tombstone);
             slapi_rdn_done(&newsrdn);


### PR DESCRIPTION
replication conflict test failure (both in bdb and mdb mode):
Several causes:
  - Test issues:
      - Cleanup issues
      - Timing issues
  - A server bug about MODRDN conflict resolution that triggered "entryrdn_rename_subtree failed - Failed to read the target element ..." message.
  
Fix: 
   - Test case:
       - Fixed the test cleanup to avoid alarming error messages in the error logs  
       - Replacing the sleep in test case by  Replicationmanager().test_replication
       - Increasing number of attempt when testing for entry from 10 to 60 (i.e having a ! minute timeout)
   - Modrdn operation:
       - Used correct dn (i.e The target entry one) rather than the MODRDN operation one to rename the subtree in
        entryrdn index (They are different when handling renaming conflict)
   - Search operation: 
       - Fixed a compilation warning in keys2idl about new search statistics
   - Entry cache:
       - Fix debug mode issues
       - Add a test about entry pointer validation when walking the hash table.

Note:  There are some other server bugs that the  Replication conflict CI test could triggers:
     - [Issue 5620](https://github.com/389ds/389-ds-base/issues/5620)
     - A SIGSEGV triggered by a corruption of the entry cache (I added code to help diagnose that we hit these bug)
     but something changed that last week (either the test machine dynamic changed or code rebase 
      somehow fixed the issue) and I was no more able to see that bug this week while it triggered in most than 30% of
      the tests before 

Issue: [5517](https://github.com/389ds/389-ds-base/issues/5517)

Reviewed by:  @tbordaz, thanks