### PR TITLE
Issue 5534 - Add copyright text to the repository files

### DIFF
--- a/dirsrvtests/check_for_duplicate_ids.py
+++ b/dirsrvtests/check_for_duplicate_ids.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import subprocess
 import sys

--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import subprocess
 import logging
 import pytest

--- a/dirsrvtests/create_test.py
+++ b/dirsrvtests/create_test.py
@@ -12,6 +12,7 @@
 
 import argparse, argcomplete
 import argcomplete
+import datetime
 import optparse
 import os
 import re
@@ -34,7 +35,7 @@ def display_usage():
           '-s|--suite <suite name> ' +
           '[ i|--instances <number of standalone instances> ' +
           '[ -m|--suppliers <number of suppliers> -h|--hubs <number of hubs> ' +
-          '-c|--consumers <number of consumers> ] -o|--outputfile ]\n')
+          '-c|--consumers <number of consumers> ] -o|--outputfile -C|--copyright <name of the entity>]\n')
     print('If only "-t" is provided then a single standalone instance is ' +
           'created. Or you can create a test suite script using ' +
           '"-s|--suite" instead of using "-t|--ticket". The "-i" option ' +
@@ -158,6 +159,7 @@ if len(sys.argv) > 0:
     parser.add_argument('-o', '--filename', default=None, help="Custom test script file name")
     parser.add_argument('-u', '--uuid', action='store_true',
                         help="Display a test case uuid to used for new test functions in script")
+    parser.add_argument('-C', '--copyright', default="Red Hat, Inc.", help="Add a copyright section in the beginning of the file")
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
@@ -241,6 +243,20 @@ if len(sys.argv) > 0:
     except IOError:
         print("Can\'t open file:", filename)
         exit(1)
+
+    # Write the copyright section
+    if args.copyright:
+        today = datetime.date.today()
+        current_year = today.year
+
+        TEST.write('# --- BEGIN COPYRIGHT BLOCK ---\n')
+        TEST.write('# Copyright (C) {} {}\n'.format(current_year, args.copyright))
+        TEST.write('# All rights reserved.\n')
+        TEST.write('#\n')
+        TEST.write('# License: GPL (version 3 or any later version).\n')
+        TEST.write('# See LICENSE for details.\n')
+        TEST.write('# --- END COPYRIGHT BLOCK ---\n')
+        TEST.write('#\n')
 
     # Write the imports
     if my_topology[0]:

--- a/dirsrvtests/tests/stress/reliabilty/reliab_conn_test.py
+++ b/dirsrvtests/tests/stress/reliabilty/reliab_conn_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/dirsrvtests/tests/stress/replication/mmr_01_4m-2h-4c_test.py
+++ b/dirsrvtests/tests/stress/replication/mmr_01_4m-2h-4c_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/dirsrvtests/tests/stress/replication/mmr_01_4m_test.py
+++ b/dirsrvtests/tests/stress/replication/mmr_01_4m_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/dirsrvtests/tests/suites/automember_plugin/automember_abort_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/automember_abort_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/automember_plugin/automember_mod_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/automember_mod_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/automember_plugin/automember_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/automember_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2017 alisha17 <anejaalisha@yahoo.com>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/backups/backup_test.py
+++ b/dirsrvtests/tests/suites/backups/backup_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import ssl

--- a/dirsrvtests/tests/suites/clu/dsrc_test.py
+++ b/dirsrvtests/tests/suites/clu/dsrc_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/clu/schema_test.py
+++ b/dirsrvtests/tests/suites/clu/schema_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -5,7 +5,11 @@
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
+<<<<<<< HEAD
 
+=======
+#
+>>>>>>> 4a5f6a8c2 (Issue 5534 - Add copyright text to the repository files)
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/get_effective_rights/acceptance_test.py
+++ b/dirsrvtests/tests/suites/get_effective_rights/acceptance_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import logging
 from ldap.controls import GetEffectiveRightsControl

--- a/dirsrvtests/tests/suites/ldapi/ldapi_test.py
+++ b/dirsrvtests/tests/suites/ldapi/ldapi_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/lib389/config_compare_test.py
+++ b/dirsrvtests/tests/suites/lib389/config_compare_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2019 William Brown <william@blackhats.net.au>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import pytest
 

--- a/dirsrvtests/tests/suites/lib389/idm/user_compare_i2_test.py
+++ b/dirsrvtests/tests/suites/lib389/idm/user_compare_i2_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import pytest
 from lib389._constants import DEFAULT_SUFFIX

--- a/dirsrvtests/tests/suites/lib389/idm/user_compare_m2Repl_test.py
+++ b/dirsrvtests/tests/suites/lib389/idm/user_compare_m2Repl_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2019 William Brown <william@blackhats.net.au>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import pytest
 from lib389._constants import DEFAULT_SUFFIX

--- a/dirsrvtests/tests/suites/lib389/idm/user_compare_st_test.py
+++ b/dirsrvtests/tests/suites/lib389/idm/user_compare_st_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import pytest
 from lib389._constants import DEFAULT_SUFFIX

--- a/dirsrvtests/tests/suites/logging/logging_config_test.py
+++ b/dirsrvtests/tests/suites/logging/logging_config_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/mapping_tree/be_del_and_default_naming_attr_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/be_del_and_default_naming_attr_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import ldap
 import logging
 import pytest

--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/password/pw_expired_access_test.py
+++ b/dirsrvtests/tests/suites/password/pw_expired_access_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import ldap
 import logging
 import pytest

--- a/dirsrvtests/tests/suites/password/pwdPolicy_controls_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_controls_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/password/pwdPolicy_logging_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_logging_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import ldap
 import logging
 import pytest

--- a/dirsrvtests/tests/suites/password/pwdPolicy_token_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_token_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/plugins/deref_aci_test.py
+++ b/dirsrvtests/tests/suites/plugins/deref_aci_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import logging
 import pytest

--- a/dirsrvtests/tests/suites/replication/changelog_encryption_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_encryption_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/replication/multiple_changelogs_test.py
+++ b/dirsrvtests/tests/suites/replication/multiple_changelogs_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import ldap
 import logging
 import pytest

--- a/dirsrvtests/tests/suites/replication/promote_demote_test.py
+++ b/dirsrvtests/tests/suites/replication/promote_demote_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/replication/repl_agmt_bootstrap_test.py
+++ b/dirsrvtests/tests/suites/replication/repl_agmt_bootstrap_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/replication/replica_config_test.py
+++ b/dirsrvtests/tests/suites/replication/replica_config_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import copy

--- a/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
+++ b/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/retrocl/retrocl_indexing_test.py
+++ b/dirsrvtests/tests/suites/retrocl/retrocl_indexing_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/rewriters/adfilter_test.py
+++ b/dirsrvtests/tests/suites/rewriters/adfilter_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import glob
 import base64

--- a/dirsrvtests/tests/suites/rewriters/basic_test.py
+++ b/dirsrvtests/tests/suites/rewriters/basic_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import glob
 from lib389.tasks import *

--- a/dirsrvtests/tests/suites/state/mmt_state_test.py
+++ b/dirsrvtests/tests/suites/state/mmt_state_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import logging
 import ldap

--- a/dirsrvtests/tests/suites/tls/cipher_test.py
+++ b/dirsrvtests/tests/suites/tls/cipher_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import os
 from lib389.config import Encryption

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/tls/ssl_version_test.py
+++ b/dirsrvtests/tests/suites/tls/ssl_version_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/suites/upgrade/upgrade_repl_plugin_test.py
+++ b/dirsrvtests/tests/suites/upgrade/upgrade_repl_plugin_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import ldap
 import logging
 import pytest

--- a/dirsrvtests/tests/tickets/ticket47931_test.py
+++ b/dirsrvtests/tests/tickets/ticket47931_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import threading
 import time
 import pytest

--- a/dirsrvtests/tests/tickets/ticket47976_test.py
+++ b/dirsrvtests/tests/tickets/ticket47976_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48212_test.py
+++ b/dirsrvtests/tests/tickets/ticket48212_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48214_test.py
+++ b/dirsrvtests/tests/tickets/ticket48214_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 
 import pytest

--- a/dirsrvtests/tests/tickets/ticket48233_test.py
+++ b/dirsrvtests/tests/tickets/ticket48233_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.topologies import topology_st

--- a/dirsrvtests/tests/tickets/ticket48266_test.py
+++ b/dirsrvtests/tests/tickets/ticket48266_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48270_test.py
+++ b/dirsrvtests/tests/tickets/ticket48270_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48272_test.py
+++ b/dirsrvtests/tests/tickets/ticket48272_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48312_test.py
+++ b/dirsrvtests/tests/tickets/ticket48312_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48325_test.py
+++ b/dirsrvtests/tests/tickets/ticket48325_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.tasks import *

--- a/dirsrvtests/tests/tickets/ticket48342_test.py
+++ b/dirsrvtests/tests/tickets/ticket48342_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48354_test.py
+++ b/dirsrvtests/tests/tickets/ticket48354_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.topologies import topology_st

--- a/dirsrvtests/tests/tickets/ticket48370_test.py
+++ b/dirsrvtests/tests/tickets/ticket48370_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48383_test.py
+++ b/dirsrvtests/tests/tickets/ticket48383_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import random
 import string
 

--- a/dirsrvtests/tests/tickets/ticket48497_test.py
+++ b/dirsrvtests/tests/tickets/ticket48497_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48637_test.py
+++ b/dirsrvtests/tests/tickets/ticket48637_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48665_test.py
+++ b/dirsrvtests/tests/tickets/ticket48665_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.topologies import topology_st

--- a/dirsrvtests/tests/tickets/ticket48745_test.py
+++ b/dirsrvtests/tests/tickets/ticket48745_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48746_test.py
+++ b/dirsrvtests/tests/tickets/ticket48746_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48798_test.py
+++ b/dirsrvtests/tests/tickets/ticket48798_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 from subprocess import check_output
 
 import pytest

--- a/dirsrvtests/tests/tickets/ticket48799_test.py
+++ b/dirsrvtests/tests/tickets/ticket48799_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48808_test.py
+++ b/dirsrvtests/tests/tickets/ticket48808_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 from random import sample
 
 import pytest

--- a/dirsrvtests/tests/tickets/ticket48844_test.py
+++ b/dirsrvtests/tests/tickets/ticket48844_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48893_test.py
+++ b/dirsrvtests/tests/tickets/ticket48893_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.topologies import topology_st

--- a/dirsrvtests/tests/tickets/ticket48916_test.py
+++ b/dirsrvtests/tests/tickets/ticket48916_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket48956_test.py
+++ b/dirsrvtests/tests/tickets/ticket48956_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import subprocess
 from lib389.tasks import *

--- a/dirsrvtests/tests/tickets/ticket48973_test.py
+++ b/dirsrvtests/tests/tickets/ticket48973_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/dirsrvtests/tests/tickets/ticket49008_test.py
+++ b/dirsrvtests/tests/tickets/ticket49008_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket49020_test.py
+++ b/dirsrvtests/tests/tickets/ticket49020_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49039_test.py
+++ b/dirsrvtests/tests/tickets/ticket49039_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49073_test.py
+++ b/dirsrvtests/tests/tickets/ticket49073_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.tasks import *
 from lib389.utils import *

--- a/dirsrvtests/tests/tickets/ticket49076_test.py
+++ b/dirsrvtests/tests/tickets/ticket49076_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49095_test.py
+++ b/dirsrvtests/tests/tickets/ticket49095_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49122_test.py
+++ b/dirsrvtests/tests/tickets/ticket49122_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49184_test.py
+++ b/dirsrvtests/tests/tickets/ticket49184_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49192_test.py
+++ b/dirsrvtests/tests/tickets/ticket49192_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49227_test.py
+++ b/dirsrvtests/tests/tickets/ticket49227_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import time
 import ldap

--- a/dirsrvtests/tests/tickets/ticket49249_test.py
+++ b/dirsrvtests/tests/tickets/ticket49249_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49386_test.py
+++ b/dirsrvtests/tests/tickets/ticket49386_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49412_test.py
+++ b/dirsrvtests/tests/tickets/ticket49412_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49441_test.py
+++ b/dirsrvtests/tests/tickets/ticket49441_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49460_test.py
+++ b/dirsrvtests/tests/tickets/ticket49460_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49463_test.py
+++ b/dirsrvtests/tests/tickets/ticket49463_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import time
 import ldap
 import logging

--- a/dirsrvtests/tests/tickets/ticket49471_test.py
+++ b/dirsrvtests/tests/tickets/ticket49471_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49540_test.py
+++ b/dirsrvtests/tests/tickets/ticket49540_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49658_test.py
+++ b/dirsrvtests/tests/tickets/ticket49658_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import pytest
 import os

--- a/dirsrvtests/tests/tickets/ticket49788_test.py
+++ b/dirsrvtests/tests/tickets/ticket49788_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2018 Dj Padzensky <djpadz@padz.net>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 import time
 

--- a/dirsrvtests/tests/tickets/ticket50078_test.py
+++ b/dirsrvtests/tests/tickets/ticket50078_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 from lib389.utils import *
 from lib389.topologies import topology_m1h1c1

--- a/src/lib389/lib389/_mapped_object_lint.py
+++ b/src/lib389/lib389/_mapped_object_lint.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 from abc import ABC, abstractmethod
 from functools import partial
 from inspect import signature

--- a/src/lib389/lib389/cli_ctl/tls.py
+++ b/src/lib389/lib389/cli_ctl/tls.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 from lib389.nss_ssl import NssSsl, CERT_NAME, CA_NAME
 from lib389.cli_base import _warn

--- a/src/lib389/lib389/tests/aci_parse_test.py
+++ b/src/lib389/lib389/tests/aci_parse_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 from lib389._entry import EntryAci
 from lib389.utils import *
 import pytest

--- a/src/lib389/lib389/tests/cli/conf_plugins/automember_test.py
+++ b/src/lib389/lib389/tests/cli/conf_plugins/automember_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2017 alisha17 <anejaalisha@yahoo.com>
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import pytest
 import ldap
 

--- a/src/lib389/lib389/tests/cli/conf_pwpolicy_test.py
+++ b/src/lib389/lib389/tests/cli/conf_pwpolicy_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import io
 import sys
 import pytest

--- a/src/lib389/lib389/tests/config.py
+++ b/src/lib389/lib389/tests/config.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import logging
 
 logging.basicConfig(level=logging.DEBUG)

--- a/src/lib389/lib389/tests/idm/services_test.py
+++ b/src/lib389/lib389/tests/idm/services_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/src/lib389/lib389/tests/idm/user_and_group_test.py
+++ b/src/lib389/lib389/tests/idm/user_and_group_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 import os
 import sys
 import time

--- a/src/lib389/lib389/tests/mapped_object_lint_test.py
+++ b/src/lib389/lib389/tests/mapped_object_lint_test.py
@@ -1,3 +1,11 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
 from typing import List
 
 import pytest

--- a/src/lib389/setup.py
+++ b/src/lib389/setup.py
@@ -52,7 +52,7 @@ setup(
     long_description=long_description,
     url='http://www.port389.org/docs/389ds/FAQ/upstream-test-framework.html',
 
-    author='Red Hat Inc., and William Brown',
+    author='Red Hat, Inc., and William Brown',
     author_email='389-devel@lists.fedoraproject.org',
 
     classifiers=[


### PR DESCRIPTION
Description: We need to have copyright texts around our files and
some of it is missing. This commit adds the copyright to tests and
lib389.
Also, add an automatic generator in the create_test.py script.

Fixes: https://github.com/389ds/389-ds-base/issues/5534

Reviewed by: ?