### PR TITLE
Issue 3729 - (cont) RFE Extend log of operations statistics in access…

### DIFF
--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -515,7 +515,7 @@ long long config_get_pw_minage(void);
 long long config_get_pw_warning(void);
 int config_get_errorlog_level(void);
 int config_get_accesslog_level(void);
-int config_get_statlog_level();
+int config_get_statlog_level(void);
 int config_get_securitylog_level(void);
 int config_get_auditlog_logging_enabled(void);
 int config_get_auditfaillog_logging_enabled(void);


### PR DESCRIPTION
… log

Bug description:
	This is a continuation of the #3729
	The previous fix did not manage internal SRCH, so
	statistics of internal SRCH were not logged

Fix description:
	For internal operation log_op_stat uses
	connid/op_id/op_internal_id/op_nested_count that have been
	computed log_result

	For direct operation log_op_stat uses info from the
	operation itself (o_connid and o_opid)

	log_op_stat relies on operation_type rather than
	o_tag that is not available for internal operation

relates: #3729

Reviewed by: