### PR TITLE
Issue 5539 - Make logger's parameter name unified

### DIFF
--- a/src/lib389/lib389/cli_conf/security.py
+++ b/src/lib389/lib389/cli_conf/security.py
@@ -76,7 +76,7 @@ RSA_ATTRS_MAP = OrderedDict([
 ])
 
 
-def _security_generic_get(inst, basedn, logs, args, attrs_map):
+def _security_generic_get(inst, basedn, log, args, attrs_map):
     result = {}
     for attr, props in attrs_map.items():
         val = props.cls(inst).get_attr_val_utf8(props.attr)
@@ -89,7 +89,7 @@ def _security_generic_get(inst, basedn, logs, args, attrs_map):
         print('\n'.join([f'{attr}: {value or ""}' for attr, value in result.items()]))
 
 
-def _security_generic_set(inst, basedn, logs, args, attrs_map):
+def _security_generic_set(inst, basedn, log, args, attrs_map):
     for attr, props in attrs_map.items():
         arg = getattr(args, attr.replace('-', '_'))
         if arg is None:


### PR DESCRIPTION
Description: Some of the functions of `lib389.cli_conf.security` used `log` as logger's parameter name while another ones - `logs`. This lead to regression like #5539.

Fix Description:
Replace `logs` with `log`.

relates: https://github.com/389ds/389-ds-base/issues/5539

Reviewed by: mreynolds389  (Thanks)