### PR TITLE
Issue 5541 - Fix typo in `lib389.cli_conf.backend._get_backend`

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -107,7 +107,7 @@ def _get_backend(inst, be_name):
         if (is_a_dn(be_name) and str2dn(be_suffix) == str2dn(be_name)) or (not is_a_dn(be_name) and cn == be_name):
             return be
 
-    raise ValueError('Could not find backend suffix: {}'.format(name))
+    raise ValueError('Could not find backend suffix: {}'.format(be_name))
 
 
 def _get_index(inst, be_name, attr):


### PR DESCRIPTION
Fix Description:
Replace `name` with `be_name`.

relates: https://github.com/389ds/389-ds-base/issues/5541