### PR TITLE
Issue 5550 - dsconf monitor crashes with Error math domain error

### DIFF
--- a/dirsrvtests/tests/suites/clu/dbmon_test.py
+++ b/dirsrvtests/tests/suites/clu/dbmon_test.py
@@ -9,12 +9,16 @@
 import time
 import subprocess
 import pytest
+import json
+import glob
 
 from lib389.tasks import *
 from lib389.utils import *
-from lib389.topologies import topology_st
+from lib389.topologies import topology_st, topology_m2
 from lib389.cli_conf.monitor import db_monitor
-from lib389.cli_base import FakeArgs
+from lib389.monitor import MonitorLDBM
+from lib389.cli_base import FakeArgs, LogCapture
+from lib389.backend import Backends
 
 pytestmark = pytest.mark.tier1
 
@@ -134,6 +138,33 @@ def clear_log(inst):
     inst.logcap.flush()
 
 
+def _set_dbsizes(inst, dbpagesize, dbcachesize):
+    backends = Backends(inst)
+    backend = backends.get(DEFAULT_BENAME)
+    dir = backend.get_attr_val_utf8('nsslapd-directory')
+    inst.stop()
+    # Export the db to ldif
+    ldif_file = f'{inst.get_ldif_dir()}/db.ldif'
+    inst.db2ldif(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX],
+               excludeSuffixes=None, repl_data=False,
+               outputfile=ldif_file, encrypt=False)
+    # modify dse.ldif
+    dse_ldif = DSEldif(inst, serverid=inst.serverid)
+    bdb = 'cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config'
+    dse_ldif.replace(bdb, 'nsslapd-db-page-size', str(dbpagesize))
+    dse_ldif.replace(bdb, 'nsslapd-cache-autosize', '0')
+    dse_ldif.replace(bdb, 'nsslapd-cache-autosize-split', '0')
+    dse_ldif.replace(bdb, 'nsslapd-dbcachesize', str(dbcachesize))
+    # remove the database files and the database environment files
+    for d in (dir, inst.ds_paths.db_home_dir):
+        for f in glob.glob(f'{d}/*'):
+            if os.path.isfile(f):
+                os.remove(f)
+    # Reimport the db
+    inst.ldif2db(DEFAULT_BENAME, None, None, None, ldif_file)
+    inst.start()
+
+
 @pytest.mark.ds50545
 @pytest.mark.bz1795943
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
@@ -184,6 +215,63 @@ def test_dsconf_dbmon(topology_st):
         assert topology_st.logcap.contains(json_item)
 
     clear_log(topology_st)
+
+
+
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
+def test_dbmon_mp_pagesize(topology_st):
+    """Test dbmon tool, that was ported from legacy tools to dsconf
+
+    :id: 20c1e5b0-75a0-11ed-91de-482ae39447e5
+    :setup: Standalone instance
+    :steps:
+         1. Set bdb parameters (pagesize and cachesize)
+         2. Query ldbm database statistics and extract dbpages and dbcachesize values
+         3. Capture dsconf monitor dbmon output and extract dbcache free_percentage value
+         4. Check that free_percentage is computed rightly
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Success
+         4. free_percentage computation should be based on file system prefered block size
+            rather than on db page size.
+
+    """
+
+    inst = topology_st.standalone
+    fspath = inst.ds_paths.db_home_dir
+    os.makedirs(fspath, mode=0o750, exist_ok=True)
+    fs_pagesize = os.statvfs(fspath).f_bsize
+    db_pagesize = 1024*64 # Maximum value supported by bdb
+    if fs_pagesize == db_pagesize:
+        fs_pagesize = db_pagesize / 2;
+    _set_dbsizes(inst, db_pagesize, 80960)
+
+    # Now lets check that we are really in the condition
+    # needed to reproduce RHBZ 2034407
+    ldbm_mon = MonitorLDBM(inst).get_status()
+    dbcachesize = int(ldbm_mon['nsslapd-db-cache-size-bytes'][0])
+    dbpages = int(ldbm_mon['nsslapd-db-pages-in-use'][0])
+
+    args = FakeArgs()
+    args.backends = DEFAULT_BENAME
+    args.indexes = False
+    args.json = True
+    lc = LogCapture()
+    db_monitor(inst, DEFAULT_SUFFIX, lc.log, args)
+    db_mon_as_str = "".join( ( str(rec) for rec in lc.outputs ) )
+    db_mon_as_str = re.sub("^[^{]*{", "{", db_mon_as_str)[:-2]
+    db_mon = json.loads(db_mon_as_str);
+
+    dbmon_free_percentage = int(10 * float(db_mon['dbcache']['free_percentage']))
+    real_free_percentage = int(1000 * ( dbcachesize - dbpages * fs_pagesize ) / dbcachesize)
+    log.info(f'dbcachesize: {dbcachesize}')
+    log.info(f'dbpages: {dbpages}')
+    log.info(f'db_pagesize: {db_pagesize}')
+    log.info(f'fs_pagesize: {fs_pagesize}')
+    log.info(f'dbmon_free_percentage: {dbmon_free_percentage}')
+    log.info(f'real_free_percentage: {real_free_percentage}')
+    assert real_free_percentage == dbmon_free_percentage
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -743,6 +743,38 @@ def test_retrochangelog_trimming_crash(topo, changelog_init):
     topo.ms["supplier1"].log.info("ticket 50736 was successfully verified.")
 
 
+@pytest.mark.bz2034407
+@pytest.mark.skipif(not os.path.isfile("/usr/bin/db_stat"), reason="libdb-utils package is not installed")
+def test_changelog_pagesize(topo):
+    """Test that changelog page size is set properly
+
+    :id: 584a9a82-756d-11ed-8b38-482ae39447e5
+    :setup: Replication with two suppliers
+    :steps:
+         1. Check that file system preferred block size is 4K
+         2. Run db_stat -e -h db_home_dir
+         3. Check for 4K page size in db_stat output
+    :expectedresults:
+         1. Mark the test as skipped if block size is not 4K
+         2. Success
+         3. Should not have any 4K page size in db_stat output
+    """
+
+    s1=topo.ms["supplier1"]
+    fs_pagesize = os.statvfs(s1.ds_paths.db_home_dir).f_bsize
+    if fs_pagesize != 4096:
+        pytest.skip("This test requires that database filesystem prefered block size is 4K.")
+        return
+    try:
+        cmd = ["/usr/bin/db_stat", "-h", s1.ds_paths.db_home_dir, "-e"]
+        log.debug(f"DEBUG: Running {cmd}")
+        output = subprocess.check_output(cmd, universal_newlines=True, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        self.log.error(f'Failed to gather db statistics {cmd}: "{e.output.decode()}')
+        self.log.error(e)
+        raise e
+    assert not re.match("^4096 *Page size", output, flags=re.MULTILINE)
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -1426,6 +1426,37 @@ bdb_check_and_set_import_cache(struct ldbminfo *li)
     return 0;
 }
 
+/*
+ * Creates the db handler with the proper pagesize.
+ * This function should be systematically used instead of db_create when the handler
+ * is used to open a database.
+ * ( db_create may still be used when removing or renaming a database )
+ */
+int
+dbbdb_create_db_for_open(backend *be, const char *funcname, int open_flags, DB **dbp, DB_ENV *dbenv)
+{
+    struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
+    bdb_config *conf = (bdb_config *)li->li_dblayer_config;
+    int rval;
+
+    rval = db_create(dbp, dbenv, 0);
+    if (rval) {
+        slapi_log_err(SLAPI_LOG_ERR, funcname, "Unable to create db handler! %d\n", rval);
+        return rval;
+    }
+
+    if (open_flags & DB_CREATE) {
+        unsigned pagesize = (conf->bdb_page_size == 0) ? DBLAYER_PAGESIZE : conf->bdb_page_size;
+        rval = (*dbp)->set_pagesize(*dbp, pagesize);
+        if (rval) {
+            slapi_log_err(SLAPI_LOG_ERR,
+                          funcname, "dbp->set_pagesize(%" PRIu32 ") failed %d\n", pagesize, rval);
+            return rval;
+        }
+    }
+    return rval;
+}
+
 
 /* mode is one of
  * DBLAYER_NORMAL_MODE,
@@ -1663,24 +1694,12 @@ bdb_instance_start(backend *be, int mode)
         }
 
         inst->inst_id2entry = NULL;
-        return_value = db_create((DB**)&inst->inst_id2entry, mypEnv->bdb_DB_ENV, 0);
+        return_value = dbbdb_create_db_for_open(be, "bdb_instance_start", open_flags,
+                                                (DB**)&inst->inst_id2entry, mypEnv->bdb_DB_ENV);
         if (0 != return_value) {
-            slapi_log_err(SLAPI_LOG_ERR,
-                          "bdb_instance_start", "Unable to create id2entry db file! %d\n",
-                          return_value);
             goto out;
         }
         dbp = inst->inst_id2entry;
-
-        return_value = dbp->set_pagesize(dbp,
-                                         (conf->bdb_page_size == 0) ? DBLAYER_PAGESIZE : conf->bdb_page_size);
-        if (0 != return_value) {
-            slapi_log_err(SLAPI_LOG_ERR,
-                          "bdb_instance_start", "dbp->set_pagesize(%" PRIu32 " or %" PRIu32 ") failed %d\n",
-                          conf->bdb_page_size, DBLAYER_PAGESIZE,
-                          return_value);
-            goto out;
-        }
 
         if ((charray_get_index(conf->bdb_data_directories,
                                inst->inst_parent_dir_name) != 0) &&
@@ -1694,20 +1713,11 @@ bdb_instance_start(backend *be, int mode)
                     dbp, NULL /* txnid */, abs_id2entry_file, subname, DB_BTREE,
                     open_flags, priv->dblayer_file_mode, return_value);
             dbp->close(dbp, 0);
-            return_value = db_create((DB**)&inst->inst_id2entry,
-                                     mypEnv->bdb_DB_ENV, 0);
+            return_value = dbbdb_create_db_for_open(be, "bdb_instance_start", open_flags,
+                                                    (DB**)&inst->inst_id2entry, mypEnv->bdb_DB_ENV);
             if (0 != return_value)
                 goto out;
             dbp = inst->inst_id2entry;
-            return_value = dbp->set_pagesize(dbp,
-                                             (conf->bdb_page_size == 0) ? DBLAYER_PAGESIZE : conf->bdb_page_size);
-            if (0 != return_value) {
-                slapi_log_err(SLAPI_LOG_ERR,
-                              "bdb_instance_start", "dbp->set_pagesize(%" PRIu32 " or %" PRIu32 ") failed %d\n",
-                              conf->bdb_page_size, DBLAYER_PAGESIZE,
-                              return_value);
-                goto out;
-            }
 
             slapi_ch_free_string(&abs_id2entry_file);
         }
@@ -1914,18 +1924,8 @@ bdb_get_aux_id2entry_ext(backend *be, DB **ppDB, DB_ENV **ppEnv, char **path, in
         }
         *ppEnv = mypEnv->bdb_DB_ENV;
     }
-    rval = db_create(&dbp, *ppEnv, 0);
+    rval = dbbdb_create_db_for_open(be, "dblayer_get_aux_id2entry_ext", dbflags, &dbp, *ppEnv);
     if (rval) {
-        slapi_log_err(SLAPI_LOG_ERR,
-                      "dblayer_get_aux_id2entry_ext", "Unable to create id2entry db handler! %d\n", rval);
-        goto err;
-    }
-
-    rval = dbp->set_pagesize(dbp, (conf->bdb_page_size == 0) ? DBLAYER_PAGESIZE : conf->bdb_page_size);
-    if (rval) {
-        slapi_log_err(SLAPI_LOG_ERR,
-                      "dblayer_get_aux_id2entry_ext", "dbp->set_pagesize(%" PRIu32 " or %" PRIu32 ") failed %d\n",
-                      conf->bdb_page_size, DBLAYER_PAGESIZE, rval);
         goto err;
     }
 
@@ -2381,7 +2381,7 @@ bdb_get_db(backend *be, char *indexname, int open_flag, struct attrinfo *ai, dbi
 
     if (!ppDB)
         goto out;
-    return_value = db_create((DB**)ppDB, pENV->bdb_DB_ENV, 0);
+    return_value = dbbdb_create_db_for_open(be, "dblayer_open_file", open_flags, (DB**)ppDB, pENV->bdb_DB_ENV);
     if (0 != return_value)
         goto out;
 
@@ -2418,7 +2418,7 @@ bdb_get_db(backend *be, char *indexname, int open_flag, struct attrinfo *ai, dbi
                 dbp, NULL /* txnid */, abs_file_name, subname, DB_BTREE,
                 open_flags, priv->dblayer_file_mode, return_value);
         dbp->close(dbp, 0);
-        return_value = db_create((DB**)ppDB, pENV->bdb_DB_ENV, 0);
+        return_value = dbbdb_create_db_for_open(be, "dblayer_open_file", open_flags,(DB**)ppDB, pENV->bdb_DB_ENV);
         if (0 != return_value) {
             goto out;
         }
@@ -6910,7 +6910,7 @@ bdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_t 
     }
 
     if (rc == 0) {
-        rc = db_create((DB**)db, bdb_env, 0);
+        rc = dbbdb_create_db_for_open(be, "bdb_public_private_open", DB_CREATE | DB_THREAD, (DB**)db, bdb_env);
         bdb_db = *db;
     }
     if (rc == 0) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.c
@@ -153,6 +153,7 @@ bdb_perfctrs_update(perfctrs_private *priv, DB_ENV *db_env)
             perf->longest_chain_length = mpstat->st_hash_longest;
             perf->hash_elements_examine_rate = mpstat->st_hash_examined;
             perf->pages_in_use = mpstat->st_page_dirty + mpstat->st_page_clean;
+            perf->mp_pagesize = mpstat->st_pagesize;
             perf->dirty_pages = mpstat->st_page_dirty;
             perf->clean_pages = mpstat->st_page_clean;
             perf->page_trickle_rate = mpstat->st_page_trickle;
@@ -246,6 +247,8 @@ static SlapiLDBMPerfctrATMap bdb_perfctr_at_map[] = {
      offsetof(performance_counters, page_write_rate)},
     {SLAPI_LDBM_PERFCTR_AT_PREFIX "pages-in-use",
      offsetof(performance_counters, pages_in_use)},
+    {SLAPI_LDBM_PERFCTR_AT_PREFIX "mp-pagesize",
+     offsetof(performance_counters, mp_pagesize)},
     {SLAPI_LDBM_PERFCTR_AT_PREFIX "txn-region-wait-rate",
      offsetof(performance_counters, txn_region_wait_rate)},
 };

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.h
@@ -53,6 +53,7 @@ struct _performance_counters
     uint64_t commit_rate;
     uint64_t abort_rate;
     uint64_t txn_region_wait_rate;
+    uint64_t mp_pagesize;
 };
 typedef struct _performance_counters performance_counters;
 

--- a/src/lib389/lib389/cli_conf/monitor.py
+++ b/src/lib389/lib389/cli_conf/monitor.py
@@ -9,6 +9,7 @@
 
 import datetime
 import json
+import os
 from lib389.monitor import (Monitor, MonitorLDBM, MonitorSNMP, MonitorDiskSpace)
 from lib389.chaining import (ChainingLinks)
 from lib389.backend import Backends
@@ -126,15 +127,21 @@ def db_monitor(inst, basedn, log, args):
     ldbm_mon = ldbm_monitor.get_status()
     dbcachesize = int(ldbm_mon['nsslapd-db-cache-size-bytes'][0])
     if 'nsslapd-db-page-size' in ldbm_mon:
-        pagesize = int(ldbm_mon['nsslapd-db-page-size'][0])
+        pagesize = int(ldbm_mon['nsslapd-db-mp-pagesize'][0])
     else:
-        pagesize = 8 * 1024  # Taken from DBLAYER_PAGESIZE
+        try:
+            pagesize = os.statvfs(inst.ds_paths.db_home_dir).f_bsize
+        except OSError:
+            # let use the usual default file system preferred block size
+            pagesize = 4096
+    log.debug(f'DB mempool pagesize: {pagesize}')
+    log.debug(f'ldbm_mon: {ldbm_mon}')
     dbhitratio = ldbm_mon['dbcachehitratio'][0]
     dbcachepagein = ldbm_mon['dbcachepagein'][0]
     dbcachepageout = ldbm_mon['dbcachepageout'][0]
     dbroevict = ldbm_mon['nsslapd-db-page-ro-evict-rate'][0]
     dbpages = int(ldbm_mon['nsslapd-db-pages-in-use'][0])
-    dbcachefree = int(dbcachesize - (pagesize * dbpages))
+    dbcachefree = max(int(dbcachesize - (pagesize * dbpages)), 0)
     dbcachefreeratio = dbcachefree/dbcachesize
     ndnratio = ldbm_mon['normalizeddncachehitratio'][0]
     ndncursize = int(ldbm_mon['currentnormalizeddncachesize'][0])

--- a/src/lib389/lib389/monitor.py
+++ b/src/lib389/lib389/monitor.py
@@ -161,6 +161,7 @@ class MonitorLDBM(DSLdapObject):
             'nsslapd-db-page-write-rate',
             'nsslapd-db-pages-in-use',
             'nsslapd-db-txn-region-wait-rate',
+            'nsslapd-db-mp-pagesize',
         ]
         if not ds_is_older("1.4.0", instance=instance):
             self._backend_keys.extend([


### PR DESCRIPTION
Two issues around bdb pagesize handling:
1.  changelog database use the default page size instead of the configured page size because a
2. Exception in dsconf monitor dbconf is the dbcache is used at more than 50% because the "free space" is wrongly computed:  Using the configured page size while bdb mempool always used the file system preferred block size as page size.  
The Solution is:
1.  systematically set the page size after creating the db file handling before an db->open with  DB_CREATE flags
2. Add the mempool pagesize amongs the other monitoring statistics and use this value to compute dbmon dbcache statistics.  Otherwise use the file system preferred block size  

Issue: [5550](https://github.com/389ds/389-ds-base/issues/5550)

Reviewed by: ?