### PR TITLE
Issue 5554 - Add more tests to security_basic_test suite

### DIFF
--- a/dirsrvtests/tests/suites/config/config_delete_attr_test.py
+++ b/dirsrvtests/tests/suites/config/config_delete_attr_test.py
@@ -75,6 +75,7 @@ def test_reset_attributes(topology_st):
         'nsslapd-defaultnamingcontext',
         'nsslapd-accesslog',
         'nsslapd-auditlog',
+        'nsslapd-securitylog',
         'nsslapd-errorlog',
         'nsslapd-tmpdir',
         'nsslapd-rundir',


### PR DESCRIPTION
Description: Add tests for ANONYMOUS_BIND and TLSCLIENTAUTH cases
(including CERT_MAP_FAILED).
Fix minor test structure issues.

Fixes: https://github.com/389ds/389-ds-base/issues/5554

Reviewed by: ?