### PR TITLE
Issue 5236 - UI - add specialized group edit modal

### DIFF
--- a/src/cockpit/389-console/README.md
+++ b/src/cockpit/389-console/README.md
@@ -162,7 +162,7 @@ To test changes to the 389-console plugin, you can set up links from your worksp
 
 - Create cockpit directory under user's home directory
 
-    mkdir ~/.local/share/cockpit/389-console
+    mkdir ~/.local/share/cockpit
 
 - Link your workspace directory
 

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -88,6 +88,10 @@ td {
     color: #f0ab00 !important;
 }
 
+.ds-pf-green-color {
+    color: green !important;
+}
+
 .ds-editor-tree {
     max-height: 70vh;
     overflow: auto;
@@ -110,6 +114,10 @@ td {
 
 .ds-right-align {
     text-align: right;
+}
+
+.ds-left-align {
+    text-align: left !important;
 }
 
 .ds-label {
@@ -244,11 +252,11 @@ textarea {
 }
 
 .ds-float-right {
-    float: right;
+    float: right !important;
 }
 
 .ds-float-left {
-    float: left;
+    float: left !important;
 }
 
 .ds-config-header {

--- a/src/cockpit/389-console/src/lib/database/databaseTables.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseTables.jsx
@@ -54,13 +54,15 @@ class ReferralTable extends React.Component {
 
     getDeleteButton(name) {
         return (
-            <TrashAltIcon
-                className="ds-center"
-                onClick={() => {
-                    this.props.deleteRef(name);
-                }}
-                title="Delete this referral"
-            />
+            <a>
+                <TrashAltIcon
+                    className="ds-center"
+                    onClick={() => {
+                        this.props.deleteRef(name);
+                    }}
+                    title="Delete this referral"
+                />
+            </a>
         );
     }
 
@@ -317,13 +319,15 @@ class EncryptedAttrTable extends React.Component {
 
     getDeleteButton(name) {
         return (
-            <TrashAltIcon
-                className="ds-center"
-                onClick={() => {
-                    this.props.deleteAttr(name);
-                }}
-                title="Delete this attribute"
-            />
+            <a>
+                <TrashAltIcon
+                    className="ds-center"
+                    onClick={() => {
+                        this.props.deleteAttr(name);
+                    }}
+                    title="Delete this attribute"
+                />
+            </a>
         );
     }
 

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/editableTable.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/editableTable.jsx
@@ -451,19 +451,17 @@ class EditableTable extends React.Component {
                         }
                     },
                     {
-
                         title: (value, rowIndex, cellIndex, props) => (
                             <React.Fragment>
                                 <EditableTextCell
                                     // isDisabled={myData.isDisabled}
-                                    value={value !== "" ? "********" : ""}
+                                    value={value !== "" ? "********" : <Label color="red" icon={<InfoCircleIcon />}> Empty value! </Label>}
                                     rowIndex={rowIndex}
                                     cellIndex={cellIndex}
                                     props={props}
                                     handleTextInputChange={this.handleTextInputChange}
                                     inputAriaLabel={'_' + value} // To avoid empty property when value is empty.
                                 />
-                                { value === '' && <Label color="red" icon={<InfoCircleIcon />}> Empty value! </Label> }
                             </React.Fragment>
                         ),
                         props: {
@@ -521,14 +519,13 @@ class EditableTable extends React.Component {
                             <React.Fragment>
                                 <EditableTextCell
                                     // isDisabled={myData.isDisabled}
-                                    value={value}
+                                    value={value === "" ? <Label color="red" icon={<InfoCircleIcon />}> Empty value! </Label> : value}
                                     rowIndex={rowIndex}
                                     cellIndex={cellIndex}
                                     props={props}
                                     handleTextInputChange={this.handleTextInputChange}
                                     inputAriaLabel={'_' + value} // To avoid empty property when value is empty.
                                 />
-                                { value === '' && <Label color="red" icon={<InfoCircleIcon />}> Empty value! </Label> }
                             </React.Fragment>
                         ),
                         props: {

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -1250,3 +1250,12 @@ export function isValidLDAPUrl (url) {
     }
     return false;
 }
+
+export function getBaseDNFromTree (entrydn, treeViewRootSuffixes) {
+    for (const suffixObj of treeViewRootSuffixes) {
+        if (entrydn.toLowerCase().indexOf(suffixObj.name.toLowerCase()) !== -1) {
+            return suffixObj.name;
+        }
+    }
+    return "";
+}

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/genericWizard.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/genericWizard.jsx
@@ -19,40 +19,37 @@ class GenericWizard extends React.Component {
             setWizardOperationInfo: this.props.setWizardOperationInfo,
             onReload: this.props.onReload,
             onModrdnReload: this.props.onModrdnReload,
-            addNotification: this.props.addNotification
+            addNotification: this.props.addNotification,
+            // LDAP Data
+            treeViewRootSuffixes: this.props.treeViewRootSuffixes,
+            allObjectclasses: this.props.allObjectclasses,
         };
 
         switch (this.props.wizardName) {
             case ENTRY_MENU.acis:
                 return <AciWizard
                     {...wizardProps }
-                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />;
             case ENTRY_MENU.new:
                 return <NewEntryWizard
                     {...wizardProps }
-                    allObjectclasses={this.props.allObjectclasses}
-                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />;
             case ENTRY_MENU.edit:
                 return <EditLdapEntry
                     {...wizardProps}
-                    allObjectclasses={this.props.allObjectclasses}
                 />;
             case ENTRY_MENU.rename:
                 return <RenameEntry
                     {...wizardProps}
-                    allObjectclasses={this.props.allObjectclasses}
-                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />;
             case ENTRY_MENU.cos:
                 return <CoSEntryWizard
                     {...wizardProps}
-                    allObjectclasses={this.props.allObjectclasses}
-                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />;
             case ENTRY_MENU.delete:
-                return <DeleteOperationWizard {...wizardProps } />;
+                return <DeleteOperationWizard
+                    {...wizardProps }
+                />;
             default:
                 console.log(`Unknown Wizard in GenericWizard class: ${this.props.wizardName}`);
                 return null;

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
@@ -13,8 +13,6 @@ import {
     Form, FormHelperText, FormSelect, FormSelectOption,
     Grid, GridItem,
     HelperText, HelperTextItem,
-    InputGroup,
-    Label,
     Modal, ModalVariant,
     SearchInput,
     Select, SelectOption, SelectVariant,
@@ -892,10 +890,19 @@ class AddNewAci extends React.Component {
                     />
                 }
                 <div className="ds-margin-bottom-md" />
-                <Label onClick={this.onUsersDrawerClick} href="#" variant="outline" color="blue" icon={<InfoCircleIcon />}>
-                    Search Base DN
-                </Label>
-                <strong>&nbsp;&nbsp;{usersSearchBaseDn}</strong>
+                <TextContent>
+                    <Text>
+                        Search Base:
+                        <Text
+                            className="ds-left-margin"
+                            component={TextVariants.a}
+                            onClick={this.onUsersDrawerClick}
+                            href="#"
+                        >
+                            {usersSearchBaseDn}
+                        </Text>
+                    </Text>
+                </TextContent>
 
                 <Drawer className="ds-margin-top" isExpanded={isUsersDrawerExpanded} onExpand={this.onDrawerExpand}>
                     <DrawerContent panelContent={usersPanelContent}>

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addCosDefinition.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addCosDefinition.jsx
@@ -345,7 +345,7 @@ class AddCoS extends React.Component {
             this.setState({
                 cosAttrRows,
                 attributeList,
-                tableModificationTime 
+                tableModificationTime
             });
         });
         this.setState({
@@ -910,10 +910,19 @@ class AddCoS extends React.Component {
                             </TextContent>
                         </GridItem>
                         <GridItem span={9} className="ds-margin-top-xlg">
-                            <Label onClick={this.openLDAPNavModal} href="#" variant="outline" color="blue" icon={<InfoCircleIcon />}>
-                                Search Base DN
-                            </Label>
-                            <strong>&nbsp;&nbsp;{cosSearchBaseDn}</strong>
+                            <TextContent>
+                                <Text>
+                                    Search Base:
+                                    <Text
+                                        className="ds-left-margin"
+                                        component={TextVariants.a}
+                                        onClick={this.openLDAPNavModal}
+                                        href="#"
+                                    >
+                                        {cosSearchBaseDn}
+                                    </Text>
+                                </Text>
+                            </TextContent>
                         </GridItem>
                         <GridItem span={3} className="ds-margin-top-xlg ds-right-align">
                             <Button
@@ -937,7 +946,7 @@ class AddCoS extends React.Component {
                             CoS Template Selected: <strong>&nbsp;&nbsp;{cosTemplateDNSelected}</strong>
                         </GridItem>
                         <GridItem span={12} className="ds-margin-top-xlg">
-                            {(cosAvailableOptions.length !== 0) ? 
+                            {(cosAvailableOptions.length !== 0) ?
                                 <SimpleList onSelect={this.onSelectTemplate}>
                                     {cosAvailableOptions}
                                 </SimpleList>

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
@@ -30,7 +30,8 @@ import {
 import LdapNavigator from '../../lib/ldapNavigator.jsx';
 import {
     createLdapEntry,
-    runGenericSearch
+    runGenericSearch,
+    decodeLine
 } from '../../lib/utils.jsx';
 import {
     InfoCircleIcon
@@ -478,10 +479,19 @@ class AddGroup extends React.Component {
                             </TextContent>
                         </GridItem>
                         <GridItem span={12} className="ds-margin-top-xlg">
-                            <Label onClick={this.openLDAPNavModal} href="#" variant="outline" color="blue" icon={<InfoCircleIcon />}>
-                                Search Base DN
-                            </Label>
-                            <strong>&nbsp;&nbsp;{usersSearchBaseDn}</strong>
+                            <TextContent>
+                                <Text>
+                                    Search Base:
+                                    <Text
+                                        className="ds-left-margin"
+                                        component={TextVariants.a}
+                                        onClick={this.openLDAPNavModal}
+                                        href="#"
+                                    >
+                                        {usersSearchBaseDn}
+                                    </Text>
+                                </Text>
+                            </TextContent>
                         </GridItem>
                         <GridItem span={12} className="ds-margin-top">
                             <SearchInput

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
@@ -754,10 +754,19 @@ class AddRole extends React.Component {
                             </TextContent>
                         </GridItem>
                         <GridItem span={12} className="ds-margin-top-xlg">
-                            <Label onClick={this.openLDAPNavModal} href="#" variant="outline" color="blue" icon={<InfoCircleIcon />}>
-                                Search Base DN
-                            </Label>
-                            <strong>&nbsp;&nbsp;{rolesSearchBaseDn}</strong>
+                            <TextContent>
+                                <Text>
+                                    Search Base:
+                                    <Text
+                                        className="ds-left-margin"
+                                        component={TextVariants.a}
+                                        onClick={this.openLDAPNavModal}
+                                        href="#"
+                                    >
+                                        {rolesSearchBaseDn}
+                                    </Text>
+                                </Text>
+                            </TextContent>
                         </GridItem>
                         <GridItem span={12} className="ds-margin-top">
                             <SearchInput

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/editGroup.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/editGroup.jsx
@@ -1,0 +1,606 @@
+import React from 'react';
+import {
+    Button,
+    Card,
+    CardBody,
+    Divider,
+    DualListSelector,
+    Form,
+    Grid,
+    GridItem,
+    Modal,
+    ModalVariant,
+    SearchInput,
+    Tab,
+    Tabs,
+    TabTitleText,
+    Text,
+    TextContent,
+    TextInput,
+    TextVariants,
+} from '@patternfly/react-core';
+import {
+    UsersIcon
+} from '@patternfly/react-icons';
+import LdapNavigator from '../../lib/ldapNavigator.jsx';
+import {
+    runGenericSearch,
+    decodeLine,
+    getBaseDNFromTree,
+    modifyLdapEntry,
+    getBaseLevelEntryAttributes,
+} from '../../lib/utils.jsx';
+import { DoubleConfirmModal } from "../../../notifications.jsx";
+import GroupTable from './groupTable.jsx';
+
+class EditGroup extends React.Component {
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            activeTabKey: 0,
+            saving: false,
+            isTreeLoading: false,
+            members: [],
+            searching: false,
+            searchPattern: "",
+            showLDAPNavModal: false,
+            usersSearchBaseDn: "",
+            usersAvailableOptions: [],
+            usersChosenOptions: [],
+            ldifArray: [],
+            showConfirmMemberDelete: false,
+            showConfirmBulkDelete: false,
+            modalOpen: true,
+            modalSpinning: false,
+            modalChecked: false,
+            delMember: "",
+            bulkDeleting: false,
+            delMemberList: [],
+            showViewEntry: false,
+        };
+
+        // Toggle currently active tab
+        this.handleNavSelect = (event, tabIndex) => {
+            event.preventDefault();
+            this.setState({
+                activeTabKey: tabIndex
+            });
+        };
+
+        this.handleBaseDnSelection = (treeViewItem) => {
+            this.setState({
+                usersSearchBaseDn: treeViewItem.dn
+            });
+        }
+
+        this.showTreeLoadingState = (isTreeLoading) => {
+            this.setState({
+                isTreeLoading,
+                searching: isTreeLoading ? true : false
+            });
+        }
+
+        this.openLDAPNavModal = () => {
+            this.setState({
+                showLDAPNavModal: true
+            });
+        };
+
+        this.closeLDAPNavModal = () => {
+            this.setState({
+                showLDAPNavModal: false
+            });
+        };
+
+        this.closeModal = () => {
+            this.setState({
+                modalOpen: false
+            });
+        };
+
+        this.handleSearchClick = () => {
+            this.setState({
+                isSearchRunning: true,
+                usersAvailableOptions: []
+            }, () => { this.getEntries () });
+        };
+
+        this.handleSearchPattern = searchPattern => {
+            this.setState({ searchPattern });
+        };
+
+        this.getEntries = () => {
+            const baseDn = this.state.usersSearchBaseDn;
+            const pattern = this.state.searchPattern;
+            const filter = pattern === '' || pattern === '*'
+                ? '(|(objectClass=person)(objectClass=nsPerson)(objectClass=nsAccount)(objectClass=nsOrgPerson)(objectClass=posixAccount))'
+                : `(&(|(objectClass=person)(objectClass=nsPerson)(objectClass=nsAccount)(objectClass=nsOrgPerson)(objectClass=posixAccount))(|(cn=*${pattern}*)(uid=*${pattern}*)))`;
+            const attrs = 'dn';
+
+            const params = {
+                serverId: this.props.editorLdapServer,
+                baseDn: baseDn,
+                scope: 'sub',
+                filter: filter,
+                attributes: attrs
+            };
+            runGenericSearch(params, (resultArray) => {
+                const newOptionsArray = resultArray.map(result => {
+                    const lines = result.split('\n');
+                    const dnEncoded = lines[0].indexOf(':: ');
+                    let dnLine = lines[0];
+                    if (dnEncoded > 0) {
+                        const decoded = decodeLine(dnLine);
+                        dnLine = decoded[1];
+                    } else {
+                        dnLine = dnLine.substring(4);
+                    }
+
+                    // Is this dn already chosen?
+                    for (const cOption of this.state.usersChosenOptions) {
+                        if (cOption.props.title === dnLine) {
+                            return "skip";
+                        }
+                    }
+
+                    // Check here is member is already in the group
+                    if (this.props.members.includes(dnLine)) {
+                        return (
+                            <span className="ds-pf-green-color" title={dnLine + " (ALREADY A MEMBER)"}>
+                                {dnLine}
+                            </span>
+                        );
+                    } else {
+                        return (
+                            <span title={dnLine}>
+                                {dnLine}
+                            </span>
+                        );
+                    }
+                }).filter(member_option => member_option !== "skip");
+
+                newOptionsArray.sort((a, b) => (a.props.children > b.props.children ? 1 : -1));
+                this.setState({
+                    usersAvailableOptions: newOptionsArray,
+                    isSearchRunning: false
+                });
+            });
+        }
+
+        this.usersOnListChange = (newAvailableOptions, newChosenOptions) => {
+            let newNewAvailOptions = [...newAvailableOptions];
+            let newNewChosenOptions = []
+
+            for (const option of newChosenOptions) {
+                if ('className' in option.props && option.props.className.indexOf("ds-pf-green-color") !== -1) {
+                    // This member is in the group already(green), put it back
+                    newNewAvailOptions.push(option);
+                } else {
+                    // This member is not in the group, allow it
+                    newNewChosenOptions.push(option);
+                }
+            }
+
+            this.setState({
+                usersAvailableOptions: newNewAvailOptions.sort((a, b) => (a.props.children > b.props.children ? 1 : -1)),
+                usersChosenOptions: newNewChosenOptions.sort((a, b) => (a.props.children > b.props.children ? 1 : -1))
+            });
+        };
+
+        this.showConfirmMemberDelete = this.showConfirmMemberDelete.bind(this);
+        this.closeConfirmMemberDelete = this.closeConfirmMemberDelete.bind(this);
+        this.showConfirmBulkDelete = this.showConfirmBulkDelete.bind(this);
+        this.closeConfirmBulkDelete = this.closeConfirmBulkDelete.bind(this);
+        this.addMembers = this.addMembers.bind(this);
+        this.delMember = this.delMember.bind(this);
+        this.onSelectMember = this.onSelectMember.bind(this);
+        this.delBulkMembers = this.delBulkMembers.bind(this);
+        this.handleModalChange = this.handleModalChange.bind(this);
+        this.switchEditor = this.switchEditor.bind(this);
+        this.editEntry = this.editEntry.bind(this);
+        this.viewEntry = this.viewEntry.bind(this);
+        this.closeViewEntry = this.closeViewEntry.bind(this);
+    };
+
+    componentDidMount() {
+        this.setState({
+            members: [...this.props.members],
+            _members: [...this.props.members],
+            usersSearchBaseDn: getBaseDNFromTree(this.props.groupdn, this.props.treeViewRootSuffixes)
+        });
+    }
+
+    switchEditor () {
+        this.setState({
+            modalOpen: false,
+        }, () => {
+            this.props.onReload(1);
+            this.props.useGenericEditor();
+        });
+    }
+
+    editEntry (memberdn) {
+        this.setState({
+            modalOpen: false,
+        });
+        this.props.openEditEntry(memberdn);
+    }
+
+    viewEntry (memberdn) {
+        getBaseLevelEntryAttributes(this.props.editorLdapServer,
+            memberdn,
+            (entryDetails) => {
+                let ldifArray = [];
+                entryDetails
+                .filter(data => (data.attribute + data.value !== '' && // Filter out empty lines
+                data.attribute !== '???: ')) // and data for empty suffix(es) and in case of failure.
+                .map((line, index) => {
+                    if (index === 1000) {
+                        ldifArray.push({
+                            'attribute': '... Truncated',
+                            'value': " - Entry too large to display ..."
+                        });
+                        return;
+                    } else if (index > 1000) {
+                        return;
+                    }
+                    ldifArray.push(line);
+                });
+                this.setState({
+                    showViewEntry: true,
+                    ldifArray: ldifArray,
+                });
+        });
+    }
+
+    closeViewEntry () {
+        this.setState({
+            showViewEntry: false,
+            ldifArray: [],
+        });
+    }
+
+    handleModalChange(e) {
+        const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+        this.setState({
+            [e.target.id]: value
+        });
+    }
+
+    showConfirmMemberDelete (name) {
+        let ldifArray = [];
+        let memberAttr = "uniquemember";
+
+        if (this.props.isGroupOfNames) {
+            memberAttr = "member";
+        }
+        ldifArray.push(`dn: ${this.props.groupdn}`);
+        ldifArray.push('changetype: modify');
+        ldifArray.push(`delete:  ${memberAttr}`);
+        ldifArray.push(`${memberAttr}: ${name}`);
+
+        this.setState({
+            showConfirmMemberDelete: true,
+            delMember: name,
+            modalChecked: false,
+            modalSpinning: false,
+            ldifArray: ldifArray,
+        });
+    }
+
+    closeConfirmMemberDelete() {
+        this.setState({
+            showConfirmMemberDelete: false,
+            modalSpinning: false,
+            modalChecked: false,
+            delMember: "",
+        });
+    }
+
+    addMembers () {
+        const params = { serverId: this.props.editorLdapServer };
+        let ldifArray = [];
+        let memberAttr = "uniquemember";
+        let memCount = 0;
+
+        this.setState({
+            saving: true,
+        });
+
+        if (this.props.isGroupOfNames) {
+            memberAttr = "member";
+        }
+        ldifArray.push(`dn: ${this.props.groupdn}`);
+        ldifArray.push('changetype: modify');
+
+        // Loop of dual select list
+        for (const user of this.state.usersChosenOptions) {
+            ldifArray.push(`add:  ${memberAttr}`);
+            ldifArray.push(`${memberAttr}: ${user.props.title}`);
+            ldifArray.push('-');
+            memCount += 1;
+        }
+
+        modifyLdapEntry(params, ldifArray, (result) => {
+            if (result.errorCode === 0) {
+                this.props.addNotification(
+                    "success",
+                    "Successfully added " + memCount + " member" + (memCount > 1 ? "s" : "")
+                );
+            } else {
+                this.props.addNotification(
+                    "error",
+                    "Failed to update group, error code: " + result.errorCode
+                );
+            }
+            this.setState({
+                saving: false,
+                usersChosenOptions: [],
+            }, () => { this.props.onReload(1) });
+        });
+    }
+
+    delMember () {
+        const params = { serverId: this.props.editorLdapServer };
+        modifyLdapEntry(params, this.state.ldifArray, (result) => {
+            if (result.errorCode === 0) {
+                this.props.addNotification(
+                    "success",
+                    "Successfully updated group"
+                );
+            } else {
+                this.props.addNotification(
+                    "error",
+                    "Failed to update group, error code: " + result.errorCode
+                );
+            }
+            this.setState({
+                showConfirmMemberDelete: false,
+                showConfirmBulkDelete: false,
+                bulkDeleting: false,
+            }, () => { this.props.onReload(1) });
+        });
+    }
+
+    onSelectMember(memberdn, isSelected) {
+        let delMemList = [...this.state.delMemberList];
+        if (isSelected) {
+            if (!delMemList.includes(memberdn)) {
+                // Add member to delete
+                delMemList.push(memberdn);
+            }
+        } else {
+            let idx = delMemList.indexOf(memberdn);
+            if (idx !== -1) {
+                // Remove member from delete list
+                delMemList.splice(idx, 1);
+            }
+        }
+
+        this.setState({
+            delMemberList: delMemList
+        });
+    };
+
+    showConfirmBulkDelete () {
+        this.setState({
+            showConfirmBulkDelete: true,
+            modalChecked: false,
+            modalSpinning: false,
+        });
+    }
+
+    closeConfirmBulkDelete () {
+        this.setState({
+            showConfirmBulkDelete: false,
+        });
+    }
+
+    delBulkMembers () {
+        if (this.state.delMemberList.length === 0) {
+            return;
+        }
+        this.setState({
+            bulkDeleting: true,
+        });
+        let ldifArray = [];
+        let memberAttr = "uniquemember";
+
+        if (this.props.isGroupOfNames) {
+            memberAttr = "member";
+        }
+        ldifArray.push(`dn: ${this.props.groupdn}`);
+        ldifArray.push('changetype: modify');
+        for (const member of this.state.delMemberList) {
+            ldifArray.push(`delete:  ${memberAttr}`);
+            ldifArray.push(`${memberAttr}: ${member}`);
+            ldifArray.push(`-`);
+        }
+        this.setState({
+            ldifArray: ldifArray,
+        }, () => this.delMember() );
+    }
+
+    render () {
+        const {
+            usersSearchBaseDn, usersAvailableOptions,
+            usersChosenOptions, showLDAPNavModal, members, modalOpen,
+            saving, delMemberList, showViewEntry, ldifArray,
+        } = this.state;
+        const title = <><UsersIcon />&nbsp;&nbsp;{this.props.groupdn}</>;
+        const extraPrimaryProps = {};
+        let saveBtnName = "Add Members";
+        if (saving) {
+            saveBtnName = "Saving ...";
+            extraPrimaryProps.spinnerAriaValueText = "Saving";
+        }
+
+        const delMemList = this.state.delMemberList.map((member) =>
+            <div key={member} className="ds-left-margin ds-left-align">{member}</div>);
+
+        return (
+            <div>
+                <Modal
+                    className="ds-modal-select-tall"
+                    variant={ModalVariant.large}
+                    title={title}
+                    isOpen={modalOpen}
+                    onClose={this.closeModal}
+                    actions={[
+                        <Button
+                            key="switch"
+                            variant="secondary"
+                            onClick={this.switchEditor}
+                            className="ds-float-right"
+                        >
+                            Switch To Generic Editor
+                        </Button>,
+                    ]}
+                >
+                    <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
+                        <Tab
+                            eventKey={0}
+                            title={<TabTitleText>Current Members <font size="2">({this.props.members.length})</font></TabTitleText>}
+                        >
+                            <GroupTable
+                                key={members + delMemberList}
+                                rows={members}
+                                removeMember={this.showConfirmMemberDelete}
+                                onSelectMember={this.onSelectMember}
+                                showConfirmBulkDelete={this.showConfirmBulkDelete}
+                                delMemberList={delMemberList}
+                                viewEntry={this.viewEntry}
+                                editEntry={this.props.openEditEntry}
+                                saving={this.state.bulkDeleting}
+                            />
+                        </Tab>
+                        <Tab eventKey={1} title={<TabTitleText>Find New Members</TabTitleText>}>
+                            <Form autoComplete="off">
+                                <Grid className="ds-indent">
+                                    <GridItem span={12} className="ds-margin-top-xlg">
+                                        <TextContent>
+                                            <Text>
+                                                Search Base:
+                                                <Text
+                                                    className="ds-left-margin"
+                                                    component={TextVariants.a}
+                                                    onClick={this.openLDAPNavModal}
+                                                    href="#"
+                                                >
+                                                    {usersSearchBaseDn}
+                                                </Text>
+                                            </Text>
+                                        </TextContent>
+                                    </GridItem>
+                                    <GridItem span={12} className="ds-margin-top-lg">
+                                        <SearchInput
+                                          placeholder="Find members..."
+                                          value={this.state.searchPattern}
+                                          onChange={this.handleSearchPattern}
+                                          onSearch={this.handleSearchClick}
+                                          onClear={() => { this.handleSearchPattern('') }}
+                                        />
+                                    </GridItem>
+                                    <GridItem span={12} className="ds-margin-top-xlg">
+                                        <DualListSelector
+                                            availableOptions={usersAvailableOptions}
+                                            chosenOptions={usersChosenOptions}
+                                            availableOptionsTitle="Available Members"
+                                            chosenOptionsTitle="Chosen Members"
+                                            onListChange={this.usersOnListChange}
+                                            id="usersSelector"
+                                        />
+                                        <Button
+                                            className="ds-margin-top"
+                                            isDisabled={usersChosenOptions.length === 0 || this.state.saving}
+                                            variant="primary"
+                                            onClick={this.addMembers}
+                                            isLoading={this.state.saving}
+                                            spinnerAriaValueText={this.state.saving ? "Saving" : undefined}
+                                            {...extraPrimaryProps}
+                                        >
+                                            {saveBtnName}
+                                        </Button>
+                                    </GridItem>
+                                    <Modal
+                                        variant={ModalVariant.medium}
+                                        title="Choose A Branch To Search"
+                                        isOpen={showLDAPNavModal}
+                                        onClose={this.closeLDAPNavModal}
+                                        actions={[
+                                            <Button
+                                                key="confirm"
+                                                variant="primary"
+                                                onClick={this.closeLDAPNavModal}
+                                            >
+                                                Done
+                                            </Button>
+                                        ]}
+                                    >
+                                        <Card isSelectable className="ds-indent ds-margin-bottom-md">
+                                            <CardBody>
+                                                <LdapNavigator
+                                                    treeItems={[...this.props.treeViewRootSuffixes]}
+                                                    editorLdapServer={this.props.editorLdapServer}
+                                                    skipLeafEntries={true}
+                                                    handleNodeOnClick={this.handleBaseDnSelection}
+                                                    showTreeLoadingState={this.showTreeLoadingState}
+                                                />
+                                            </CardBody>
+                                        </Card>
+                                    </Modal>
+                                    <Divider
+                                        className="ds-margin-top-lg"
+                                    />
+                                </Grid>
+                            </Form>
+                        </Tab>
+                    </Tabs>
+                    <Modal
+                        variant={ModalVariant.medium}
+                        title="View Entry"
+                        isOpen={showViewEntry}
+                        onClose={this.closeViewEntry}
+                    >
+                        <Card isSelectable className="ds-indent ds-margin-bottom-md">
+                            <CardBody className="ds-textarea">
+                                {ldifArray.map((line) => (
+                                    <h6 key={line.attribute+line.value}>{line.attribute}{line.value}</h6>
+                                ))}
+                            </CardBody>
+                        </Card>
+                    </Modal>
+                    <DoubleConfirmModal
+                        showModal={this.state.showConfirmMemberDelete}
+                        closeHandler={this.closeConfirmMemberDelete}
+                        handleChange={this.handleModalChange}
+                        actionHandler={this.delMember}
+                        spinning={this.state.modalSpinning}
+                        item={this.state.delMember}
+                        checked={this.state.modalChecked}
+                        mTitle="Remove Member From Group"
+                        mMsg="Are you sure you want to remove this member?"
+                        mSpinningMsg="Deleting ..."
+                        mBtnName="Delete"
+                    />
+                    <DoubleConfirmModal
+                        showModal={this.state.showConfirmBulkDelete}
+                        closeHandler={this.closeConfirmBulkDelete}
+                        handleChange={this.handleModalChange}
+                        actionHandler={this.delBulkMembers}
+                        spinning={this.state.modalSpinning}
+                        item={delMemList}
+                        checked={this.state.modalChecked}
+                        mTitle="Remove Members From Group"
+                        mMsg="Are you sure you want to remove these members?"
+                        mSpinningMsg="Deleting ..."
+                        mBtnName="Delete Members"
+                    />
+                </Modal>
+            </div>
+        );
+    }
+}
+
+export default EditGroup;

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/groupTable.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/groupTable.jsx
@@ -1,0 +1,209 @@
+import React from "react";
+import {
+    Button,
+    Divider,
+    Pagination,
+    PaginationVariant,
+    SearchInput,
+} from '@patternfly/react-core';
+import {
+    expandable,
+    Table,
+    TableHeader,
+    TableBody,
+    TableVariant,
+    sortable,
+    SortByDirection,
+} from '@patternfly/react-table';
+import PropTypes from "prop-types";
+
+class GroupTable extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            page: 1,
+            perPage: 10,
+            value: '',
+            sortBy: {},
+            rows: [],
+            columns: [
+                { title: 'Member DN', transforms: [sortable] },
+            ],
+        };
+        this.selectedCount = 0;
+
+        this.onSetPage = (_event, pageNumber) => {
+            this.setState({
+                page: pageNumber
+            });
+        };
+
+        this.onPerPageSelect = (_event, perPage) => {
+            this.setState({
+                perPage: perPage
+            });
+        };
+
+        this.onSort = this.onSort.bind(this);
+        this.onSearchChange = this.onSearchChange.bind(this);
+    }
+
+    componentDidMount() {
+        let rows = [];
+        let columns = this.state.columns;
+
+        for (const attrRow of this.props.rows) {
+            let selected = false;
+            if (this.props.delMemberList.includes(attrRow)) {
+                selected = true;
+            }
+            rows.push({
+                cells: [attrRow],
+                selected: selected,
+            });
+        }
+        if (rows.length == 0) {
+            rows = [{ cells: ['No Members'], disableSelection: true }];
+        }
+        this.setState({
+            rows: rows,
+            columns: columns
+        });
+    }
+
+    onSearchChange(value, event) {
+        let rows = [];
+        const val = value.toLowerCase();
+        for (const row of this.props.rows) {
+            if (val !== "" && val != "*" && row.indexOf(val) === -1 ) {
+                // Not a match, skip it
+                continue;
+            }
+            rows.push({
+                cells: [row]
+            });
+        }
+        if (rows.length == 0) {
+            rows = [{ cells: ['No Members'], disableSelection: true }];
+        }
+
+        this.setState({
+            rows: rows,
+            value: value,
+            page: 1,
+        });
+    }
+
+    onSort(_event, index, direction) {
+        const rows = [];
+        const sortedAttrs = [...this.props.rows];
+
+        // Sort the referrals and build the new rows
+        sortedAttrs.sort();
+        if (direction !== SortByDirection.asc) {
+            sortedAttrs.reverse();
+        }
+        for (const attrRow of sortedAttrs) {
+            rows.push({ cells: [attrRow] });
+        }
+
+        this.setState({
+            sortBy: {
+                index,
+                direction
+            },
+            rows: rows,
+            page: 1,
+        });
+    }
+
+    actions() {
+        return [
+            {
+                title: 'View Entry',
+                onClick: (event, rowId, rowData, extra) =>
+                    this.props.viewEntry(rowData.cells[0])
+            },
+            {
+                title: 'Edit Entry',
+                onClick: (event, rowId, rowData, extra) =>
+                    this.props.editEntry(rowData.cells[0])
+            },
+            {
+                isSeparator: true
+            },
+            {
+                title: 'Remove Entry',
+                onClick: (event, rowId, rowData, extra) =>
+                    this.props.removeMember(rowData.cells[0])
+            }
+        ];
+    }
+
+    render() {
+        const { columns, rows, perPage, page, sortBy } = this.state;
+        const extraPrimaryProps = {};
+        const canSelectAll = false;
+        let deleteBtnName = "Remove Selected Members";
+        if (this.props.saving) {
+            deleteBtnName = "Updating group ...";
+            extraPrimaryProps.spinnerAriaValueText = "Updating";
+        }
+
+        return (
+            <div className="ds-margin-top-xlg ds-indent">
+                <SearchInput
+                    className="ds-margin-top"
+                    placeholder='Search Members'
+                    value={this.state.value}
+                    onChange={this.onSearchChange}
+                    onClear={(evt) => this.onSearchChange('', evt)}
+                />
+                <Table
+                    className="ds-margin-top"
+                    canSelectAll={canSelectAll}
+                    onSelect={(_event, isSelecting, rowIndex) => {
+                        if (rowIndex !== -1) {
+                            this.props.onSelectMember(this.state.rows[rowIndex].cells[0], isSelecting)
+                        }
+                    }}
+                    aria-label="group table"
+                    cells={columns}
+                    rows={rows}
+                    variant={TableVariant.compact}
+                    sortBy={sortBy}
+                    onSort={this.onSort}
+                    actions={rows.length > 0 ? this.actions() : null}
+                >
+                    <TableHeader />
+                    <TableBody />
+                </Table>
+                <Pagination
+                    itemCount={this.props.rows.length}
+                    widgetId="pagination-options-menu-bottom"
+                    perPage={perPage}
+                    page={page}
+                    variant={PaginationVariant.bottom}
+                    onSetPage={this.onSetPage}
+                    onPerPageSelect={this.onPerPageSelect}
+                />
+                <Button
+                    isDisabled={this.props.delMemberList.length === 0 || this.props.saving}
+                    variant="primary"
+                    onClick={this.props.showConfirmBulkDelete}
+                    isLoading={this.props.saving}
+                    spinnerAriaValueText={this.state.saving ? "Updating group ..." : undefined}
+                    {...extraPrimaryProps}
+                >
+                    {deleteBtnName}
+                </Button>
+                <Divider
+                    className="ds-margin-top-lg"
+                />
+            </div>
+        );
+    }
+}
+
+export default GroupTable;

--- a/src/cockpit/389-console/src/lib/notifications.jsx
+++ b/src/cockpit/389-console/src/lib/notifications.jsx
@@ -73,8 +73,8 @@ export class DoubleConfirmModal extends React.Component {
                         </Text>
                     </TextContent>
                     <TextContent>
-                        <Text className="ds-center ds-margin-top-xlg" component={TextVariants.h4}>
-                            {item}
+                        <Text className="ds-center ds-margin-top" component={TextVariants.h4}>
+                            <i>{item}</i>
                         </Text>
                     </TextContent>
                     <Grid className="ds-margin-top-xlg">
@@ -101,7 +101,6 @@ DoubleConfirmModal.propTypes = {
     handleChange: PropTypes.func,
     actionHandler: PropTypes.func,
     spinning: PropTypes.bool,
-    item: PropTypes.string,
     checked: PropTypes.bool,
     mTitle: PropTypes.string,
     mMsg: PropTypes.string,

--- a/src/cockpit/389-console/src/lib/replication/replTables.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replTables.jsx
@@ -226,13 +226,15 @@ class ManagerTable extends React.Component {
 
     getDeleteButton(name) {
         return (
-            <TrashAltIcon
-                className="ds-center"
-                onClick={() => {
-                    this.props.confirmDelete(name);
-                }}
-                title="Delete Replication Manager"
-            />
+            <a>
+                <TrashAltIcon
+                    className="ds-center"
+                    onClick={() => {
+                        this.props.confirmDelete(name);
+                    }}
+                    title="Delete Replication Manager"
+                />
+            </a>
         );
     }
 


### PR DESCRIPTION
Description:

Added a modal for handling groups: viewing, adding and removing members

Revised overall project:

- "Search Base" handling using a label button was not intuitive.  Changed it to a more recognizable href.

- Made table "trash Can" icons visibly clickable

- Edit/add entry wizard, the big red "Empty Value!" label is no longer displayed while you edit the value

relates: https://github.com/389ds/389-ds-base/issues/5236
