### PR TITLE
Issue 5558 - non-root instance fails to start on creation

### DIFF
--- a/src/lib389/lib389/cli_ctl/instance.py
+++ b/src/lib389/lib389/cli_ctl/instance.py
@@ -227,9 +227,7 @@ def prepare_ds_root(inst, log, args):
         log.debug(f'Copying {bin} into {destbin}')
         os.makedirs(os.path.dirname(destbin), 0o755, True)
         copyfile(bin, destbin)
-    # And finally, update the template files
-    for dse in ('/usr/share/dirsrv/data/template-dse-minimal.ldif', '/usr/share/dirsrv/data/template-dse.ldif'):
-        copy_and_skip_entry(dse, ('libpwdchan-plugin',))
+    # And finally, update the template file
     # Use PO and PF to escape { } in formatted strings
     PO = '{'
     PF = '}'


### PR DESCRIPTION
issue: non root installation fails to start after the default storage scheme change.
The solution is to avoid removing the RUST storage scheme from dse.ldif templates while preparing the non root user installation.

Issue:  [5558](https://github.com/progier389/389-ds-base/issues/5558)

Reviewed by: @mreynolds389 