### PR TITLE
Issue 5565 - Change default password stoage scheme

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2022 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -113,9 +113,9 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
         standalone.config.set('passwordStorageScheme', 'SSHA512')
         standalone.config.set('nsslapd-rootpwstoragescheme', 'SSHA512')
     else:
-        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512')
-        standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
-        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
+        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2_SHA256')
+        standalone.config.set('passwordStorageScheme', 'PBKDF2_SHA256')
+        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2_SHA256')
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)

--- a/dirsrvtests/tests/suites/password/pwp_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_test.py
@@ -27,7 +27,7 @@ else:
     if is_fips():
         DEFAULT_PASSWORD_STORAGE_SCHEME = 'SSHA512'
     else:
-        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2-SHA512'
+        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2_SHA256'
 
 
 def _create_user(topo, uid, cn, uidNumber, userpassword):

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -280,7 +280,8 @@ pw_name2scheme(char *name)
         } else {
             /* if not, let's setup pbkdf2 */
 #ifdef RUST_ENABLE
-            char *pbkdf = "PBKDF2-SHA512";
+            /* until 1.3.10 supports Rust hashers we can't use PBKDF2-SHA512 by default */
+            char *pbkdf = "PBKDF2_SHA256";
 #else
             char *pbkdf = "PBKDF2_SHA256";
 #endif

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -209,7 +209,7 @@ class Config(DSLdapObject):
             yield report
 
     def _lint_passwordscheme(self):
-        allowed_schemes = ['SSHA512', 'PBKDF2-SHA512', 'GOST_YESCRYPT']
+        allowed_schemes = ['SSHA512', 'PBKDF2_SHA256', 'GOST_YESCRYPT']
         u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
         u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
         if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:


### PR DESCRIPTION
Descriptrion:  Becuase of replication we need to use a default stoage scheme that works on 389-ds-base-1.3.10

relates: https://github.com/389ds/389-ds-base/issues/5565

