### PR TITLE
Issue 5561 - Nightly tests are still failing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -92,6 +92,8 @@ jobs:
         sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
         sudo docker exec $CID sh -c "mkdir -p /workspace/assets/cores && chmod 777 /workspace{,/assets{,/cores}}"
         sudo docker exec $CID sh -c "echo '/workspace/assets/cores/core.%e.%P' > /proc/sys/kernel/core_pattern"
+        sudo docker exec $CID sh -c "dnf install -y python-slugify python3-wheel"
+        sudo docker exec $CID sh -c "python3 -m pip install -t /usr/lib/python3.11/site-packages pytest pytest-playwright pytest-custom-exit-code pytest-html"
         sudo docker exec -e WEBUI=1 -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
 
     - name: Make the results file readable by all


### PR DESCRIPTION
Some python modules are missing to be able to run py.test CI
Added them back in .github/workflows/pytest.yml using dnf and pip

Issue: [5561](https://github.com/389ds/389-ds-base/issues/5561)

Reviewed by: