### PR TITLE
Issue 5425 - CLI - add confirmation arg when deleting backend

### DIFF
--- a/src/cockpit/389-console/src/lib/database/suffix.jsx
+++ b/src/cockpit/389-console/src/lib/database/suffix.jsx
@@ -742,7 +742,7 @@ export class Suffix extends React.Component {
         })
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "delete", this.props.suffix
+            "backend", "delete", this.props.suffix, "--do-it"
         ];
         log_cmd("doDelete", "Delete database", cmd);
         cockpit

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -236,14 +236,17 @@ def backend_delete(inst, basedn, log, args, warn=True):
     dn = _search_backend_dn(inst, args.be_name)
     if dn is None:
         raise ValueError("Unable to find a backend with the name: ({})".format(args.be_name))
-    if warn and args.json is False:
-        _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
+    if not args.ack:
+        log.info("""Not removing backend: if you are really sure add: --do-it""")
+    else:
+        if warn and args.json is False:
+            _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
 
-    be = _get_backend(inst, args.be_name)
-    _recursively_del_backends(be)
-    be.delete()
+        be = _get_backend(inst, args.be_name)
+        _recursively_del_backends(be)
+        be.delete()
 
-    log.info("The database, and any sub-suffixes, were sucessfully deleted")
+        log.info("The database, and any sub-suffixes, were successfully deleted")
 
 
 def backend_import(inst, basedn, log, args):
@@ -1152,6 +1155,9 @@ def create_parser(subparsers):
     delete_parser = subcommands.add_parser('delete', help='Delete a backend database')
     delete_parser.set_defaults(func=backend_delete)
     delete_parser.add_argument('be_name', help='The backend name or suffix')
+    delete_parser.add_argument('--do-it', dest="ack",
+                               help="Remove backend and its subsuffixes",
+                               action='store_true', default=False)
 
     #######################################################
     # Get Suffix Tree (for use in web console)


### PR DESCRIPTION
Description:  Add "--do-it" CLI argument when deleting a backend and its subsuffixes

fixes: https://github.com/389ds/389-ds-base/issues/5425
