### PR TITLE
Issue 5278 - CLI - dsidm asks for the old password on password reset

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -65,7 +65,8 @@ from lib389.utils import (
     format_cmd_list,
     get_default_db_lib,
     selinux_present,
-    selinux_label_port)
+    selinux_label_port,
+    get_user_is_root)
 from lib389.paths import Paths
 from lib389.nss_ssl import NssSsl
 from lib389.tasks import BackupTask, RestoreTask
@@ -3484,3 +3485,20 @@ class DirSrv(SimpleLDAPObject, object):
         task.create(properties=task_properties)
 
         return task
+
+    def is_rootdn_bound(self):
+        # Return True if root DN is authenticated for this DirSrv instance
+        if self.state != DIRSRV_STATE_ONLINE:
+            return False
+
+        if self.binddn is None and get_user_is_root():
+            # ldapi
+            return True
+
+        if self.binddn is not None:
+            # Bind DN provided, is it the root DN?
+            rootdn = self.config.get_attr_val_utf8_l('nsslapd-rootdn')
+            if self.binddn.lower() == rootdn:
+                return True
+
+        return False

--- a/src/lib389/lib389/cli_idm/account.py
+++ b/src/lib389/lib389/cli_idm/account.py
@@ -145,11 +145,18 @@ def reset_password(inst, basedn, log, args):
 
 def change_password(inst, basedn, log, args):
     dn = _get_dn_arg(args.dn, msg="Enter dn to change password")
-    cur_password = _get_arg(args.current_password, hidden=True, confirm=False, msg="Enter current password for %s" % dn)
-    new_password = _get_arg(args.new_password, hidden=True, confirm=True, msg="Enter new password for %s" % dn)
     accounts = Accounts(inst, basedn)
     acct = accounts.get(dn=dn)
-    acct.change_password(cur_password, new_password)
+
+    if not inst.is_rootdn_bound():
+        cur_password = _get_arg(args.current_password, hidden=True, confirm=False, msg="Enter current password for %s" % dn)
+        new_password = _get_arg(args.new_password, hidden=True, confirm=True, msg="Enter new password for %s" % dn)
+        acct.change_password(cur_password, new_password)
+    if inst.is_rootdn_bound():
+        # is root/rootdn do not prompt for old password
+        new_password = _get_arg(args.new_password, hidden=True, confirm=True, msg="Enter new password for %s" % dn)
+        acct.reset_password(new_password)
+
     log.info('changed password for %s' % dn)
 
 


### PR DESCRIPTION
Description:  If we are chaning a password as Root DN we don't need the old password

relates: https://github.com/389ds/389-ds-base/issues/5278

Reviewed by: ?