### PR TITLE
Issue 5585 - lib389 password policy DN handling is incorrect

### DIFF
--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -102,7 +102,10 @@ def list_policies(inst, basedn, log, args):
         attr_list = list(pwp_manager.arg_to_attr.values())
 
         for pwp_entry in pwp_entries.list():
-            dn_comps = ldap.dn.explode_dn(pwp_entry.get_attr_val_utf8_l('cn'))
+            # Sometimes, the cn value includes quotes (for example, after migration from pre-CLI version).
+            # We need to strip them as python-ldap doesn't expect them
+            dn_comps_str = pwp_entry.get_attr_val_utf8_l('cn').strip("\'").strip("\"")
+            dn_comps = ldap.dn.explode_dn(dn_comps_str)
             dn_comps.pop(0)
             entrydn = ",".join(dn_comps)
             policy_type = _get_policy_type(inst, entrydn)

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -211,7 +211,10 @@ class PwPolicyManager(object):
         policies = pwp_entries.list()
 
         for policy in policies:
-            dn_comps = ldap.dn.explode_dn(policy.get_attr_val_utf8_l('cn'))
+            # Sometimes, the cn value includes quotes (for example, after migration from pre-CLI version).
+            # We need to strip them as python-ldap doesn't expect them
+            dn_comps_str = policy.get_attr_val_utf8_l('cn').strip("\'").strip("\"")
+            dn_comps = ldap.dn.explode_dn(dn_comps_str)
             dn_comps.pop(0)
             pwp_dn = ",".join(dn_comps)
             if pwp_dn == dn.lower():


### PR DESCRIPTION
Description: After a migration between major DS versions, it can happen that already existing password policies will have 'cn' that contains a valid DN in double quote "". We need to strip the quotes before processing the DN with python-ldap.

Fixes: https://github.com/389ds/389-ds-base/issues/5585

Reviewed by: ?