### PR TITLE
Issue 5591 - BUG - Segfault in cl5configtrim with invalid config

### DIFF
--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -696,6 +696,12 @@ cl5ConfigTrimming(Replica *replica, int maxEntries, const char *maxAge, int trim
     int isTrimmingEnabledAfter = 0;
     cldb_Handle *cldb = replica_get_cl_info(replica);
 
+    if (!cldb) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "cl5ConfigTrimming - Changelog info was NULL - is your replication configuration valid?\n");
+        return CL5_BAD_STATE;
+    }
+
     if (cldb->dbState == CL5_STATE_CLOSED) {
         slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
                       "cl5ConfigTrimming - Changelog is not initialized\n");


### PR DESCRIPTION
Bug Description: When an invalid replication config exists, replica_get_cl_info can return null. The lack of a null check in cl5configtrim can lead to a SIGSEGV

Fix Description: Check for the NULL case.

fixes: https://github.com/389ds/389-ds-base/issues/5591

Author: William Brown <william@blackhats.net.au>

Review by: ???