### PR TITLE
Issue 5598 - In 2.x, SRCH throughput drops by 10% because of handling…

### DIFF
--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -8,13 +8,18 @@
 #
 from decimal import *
 import os
+import time
 import logging
 import pytest
 import subprocess
+from lib389.backend import Backend
+from lib389.mappingTree import MappingTrees
+from lib389.idm.domain import Domain
+from lib389.configurations.sample import create_base_domain
 from lib389._mapped_object import DSLdapObject
 from lib389.topologies import topology_st
 from lib389.plugins import AutoMembershipPlugin, ReferentialIntegrityPlugin, AutoMembershipDefinitions, MemberOfPlugin
-from lib389.idm.user import UserAccounts
+from lib389.idm.user import UserAccounts, UserAccount
 from lib389.idm.group import Groups
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389._constants import DEFAULT_SUFFIX, LOG_ACCESS_LEVEL, PASSWORD
@@ -209,6 +214,32 @@ def disable_access_log_buffering(topology_st, request):
     request.addfinalizer(fin)
 
     return disable_access_log_buffering
+
+def create_backend(inst, rdn, suffix):
+    # We only support dc= in this test.
+    assert suffix.startswith('dc=')
+    be1 = Backend(inst)
+    be1.create(properties={
+            'cn': rdn,
+            'nsslapd-suffix': suffix,
+        },
+        create_mapping_tree=False
+    )
+
+    # Now we temporarily make the MT for this node so we can add the base entry.
+    mts = MappingTrees(inst)
+    mt = mts.create(properties={
+        'cn': suffix,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': rdn,
+    })
+
+    # Create the domain entry
+    create_base_domain(inst, suffix)
+    # Now delete the mt
+    mt.delete()
+
+    return be1
 
 @pytest.mark.bz1273549
 def test_check_default(topology_st):
@@ -1339,6 +1370,310 @@ def test_stat_internal_op(topology_st, request):
         log.info('Deleting user/group')
         user.delete()
         group.delete()
+
+    request.addfinalizer(fin)
+
+def test_referral_check(topology_st, request):
+    """Check that referral detection mechanism works
+
+    :id: ff9b4247-d1fd-4edc-ba74-6ad61e65c0a4
+    :setup: Standalone Instance
+    :steps:
+        1. Set nsslapd-referral-check-period=7 to accelerate test
+        2. Add a test entry
+        3. Remove error log file
+        4. Check that no referral entry exist
+        5. Create a referral entry
+        6. Check that the server detects the referral
+        7. Delete the referral entry
+        8. Check that the server detects the deletion of the referral
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+    """
+
+    inst = topology_st.standalone
+
+    # Step 1 reduce nsslapd-referral-check-period to accelerate test
+    REFERRAL_CHECK=7
+    topology_st.standalone.config.set("nsslapd-referral-check-period", str(REFERRAL_CHECK))
+    topology_st.standalone.restart()
+
+    # Step 2 Add a test entry
+    users = UserAccounts(inst, DEFAULT_SUFFIX, rdn=None)
+    user = users.create(properties={'uid': 'test_1',
+                                    'cn': 'test_1',
+                                    'sn': 'test_1',
+                                    'description': 'member',
+                                    'uidNumber': '1000',
+                                    'gidNumber': '2000',
+                                    'homeDirectory': '/home/testuser'})
+
+    # Step 3 Remove error log file
+    topology_st.standalone.stop()
+    lpath = topology_st.standalone.ds_error_log._get_log_path()
+    os.unlink(lpath)
+    topology_st.standalone.start()
+
+    # Step 4 Check that no referral entry is found (on regular deployment)
+    entries = topology_st.standalone.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "uid=test_1")
+    time.sleep(REFERRAL_CHECK + 1)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected.*')
+
+    # Step 5 Create a referral entry
+    REFERRAL_DN = "cn=my_ref,%s" % DEFAULT_SUFFIX
+    properties = ({'cn': 'my_ref',
+                   'uid': 'my_ref',
+                   'sn': 'my_ref',
+                   'uidNumber': '1000',
+                   'gidNumber': '2000',
+                   'homeDirectory': '/home/testuser',
+                   'description': 'referral entry',
+                   'objectclass': "top referral extensibleObject".split(),
+                   'ref': 'ref: ldap://remote/%s' % REFERRAL_DN})
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.create(properties=properties)
+
+    # Step 6 Check that the server detected the referral
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % DEFAULT_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % DEFAULT_SUFFIX)
+
+    # Step 7 Delete the referral entry
+    referral.delete()
+
+    # Step 8 Check that the server detected the deletion of the referral
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % DEFAULT_SUFFIX)
+
+    def fin():
+        log.info('Deleting user/referral')
+        try:
+            user.delete()
+            referral.delete()
+        except:
+            pass
+
+    request.addfinalizer(fin)
+
+def test_referral_subsuffix(topology_st, request):
+    """Test the results of an inverted parent suffix definition in the configuration.
+
+    For more details see:
+    https://www.port389.org/docs/389ds/design/mapping_tree_assembly.html
+
+    :id: 4faf210a-4fde-4e4f-8834-865bdc8f4d37
+    :setup: Standalone instance
+    :steps:
+        1. First create two Backends, without mapping trees.
+        2. create the mapping trees for these backends
+        3. reduce nsslapd-referral-check-period to accelerate test
+        4. Remove error log file
+        5. Create a referral entry on parent suffix
+        6. Check that the server detected the referral
+        7. Delete the referral entry
+        8. Check that the server detected the deletion of the referral
+        9. Remove error log file
+        10. Create a referral entry on child suffix
+        11. Check that the server detected the referral on both parent and child suffixes
+        12. Delete the referral entry
+        13. Check that the server detected the deletion of the referral on both parent and child suffixes
+        14. Remove error log file
+        15. Create a referral entry on parent suffix
+        16. Check that the server detected the referral on both parent and child suffixes
+        17. Delete the child referral entry
+        18. Check that the server detected the deletion of the referral on child suffix but not on parent suffix
+        19. Delete the parent referral entry
+        20. Check that the server detected the deletion of the referral parent suffix
+
+    :expectedresults:
+        all steps succeeds
+    """
+    inst = topology_st.standalone
+    # Step 1 First create two Backends, without mapping trees.
+    PARENT_SUFFIX='dc=parent,dc=com'
+    CHILD_SUFFIX='dc=child,%s' % PARENT_SUFFIX
+    be1 = create_backend(inst, 'Parent', PARENT_SUFFIX)
+    be2 = create_backend(inst, 'Child', CHILD_SUFFIX)
+    # Step 2 create the mapping trees for these backends
+    mts = MappingTrees(inst)
+    mt1 = mts.create(properties={
+        'cn': PARENT_SUFFIX,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': 'Parent',
+    })
+    mt2 = mts.create(properties={
+        'cn': CHILD_SUFFIX,
+        'nsslapd-state': 'backend',
+        'nsslapd-backend': 'Child',
+        'nsslapd-parent-suffix': PARENT_SUFFIX,
+    })
+
+    dc_ex = Domain(inst, dn=PARENT_SUFFIX)
+    assert dc_ex.exists()
+
+    dc_st = Domain(inst, dn=CHILD_SUFFIX)
+    assert dc_st.exists()
+
+    # Step 3 reduce nsslapd-referral-check-period to accelerate test
+    # requires a restart done on step 4
+    REFERRAL_CHECK=7
+    topology_st.standalone.config.set("nsslapd-referral-check-period", str(REFERRAL_CHECK))
+
+    # Check that if we create a referral at parent level
+    #  - referral is detected at parent backend
+    #  - referral is not detected at child backend
+
+    # Step 3 Remove error log file
+    topology_st.standalone.stop()
+    lpath = topology_st.standalone.ds_error_log._get_log_path()
+    os.unlink(lpath)
+    topology_st.standalone.start()
+
+    # Step 4 Create a referral entry on parent suffix
+    REFERRAL_DN = "cn=my_ref,%s" % PARENT_SUFFIX
+    properties = ({'cn': 'my_ref',
+                   'uid': 'my_ref',
+                   'sn': 'my_ref',
+                   'uidNumber': '1000',
+                   'gidNumber': '2000',
+                   'homeDirectory': '/home/testuser',
+                   'description': 'referral entry',
+                   'objectclass': "top referral extensibleObject".split(),
+                   'ref': 'ref: ldap://remote/%s' % REFERRAL_DN})
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.create(properties=properties)
+
+    # Step 5 Check that the server detected the referral
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % PARENT_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % CHILD_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % PARENT_SUFFIX)
+
+    # Step 6 Delete the referral entry
+    referral.delete()
+
+    # Step 7 Check that the server detected the deletion of the referral
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % PARENT_SUFFIX)
+
+    # Check that if we create a referral at child level
+    #  - referral is detected at parent backend
+    #  - referral is detected at child backend
+
+    # Step 8 Remove error log file
+    topology_st.standalone.stop()
+    lpath = topology_st.standalone.ds_error_log._get_log_path()
+    os.unlink(lpath)
+    topology_st.standalone.start()
+
+    # Step 9 Create a referral entry on child suffix
+    REFERRAL_DN = "cn=my_ref,%s" % CHILD_SUFFIX
+    properties = ({'cn': 'my_ref',
+                   'uid': 'my_ref',
+                   'sn': 'my_ref',
+                   'uidNumber': '1000',
+                   'gidNumber': '2000',
+                   'homeDirectory': '/home/testuser',
+                   'description': 'referral entry',
+                   'objectclass': "top referral extensibleObject".split(),
+                   'ref': 'ref: ldap://remote/%s' % REFERRAL_DN})
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.create(properties=properties)
+
+    # Step 10 Check that the server detected the referral on both parent and child suffixes
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % PARENT_SUFFIX)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % CHILD_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % CHILD_SUFFIX)
+
+    # Step 11 Delete the referral entry
+    referral.delete()
+
+    # Step 12 Check that the server detected the deletion of the referral on both parent and child suffixes
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % PARENT_SUFFIX)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % CHILD_SUFFIX)
+
+    # Check that if we create a referral at child level and parent level
+    #  - referral is detected at parent backend
+    #  - referral is detected at child backend
+
+    # Step 13 Remove error log file
+    topology_st.standalone.stop()
+    lpath = topology_st.standalone.ds_error_log._get_log_path()
+    os.unlink(lpath)
+    topology_st.standalone.start()
+
+    # Step 14 Create a referral entry on parent suffix
+    #         Create a referral entry on child suffix
+    REFERRAL_DN = "cn=my_ref,%s" % PARENT_SUFFIX
+    properties = ({'cn': 'my_ref',
+                   'uid': 'my_ref',
+                   'sn': 'my_ref',
+                   'uidNumber': '1000',
+                   'gidNumber': '2000',
+                   'homeDirectory': '/home/testuser',
+                   'description': 'referral entry',
+                   'objectclass': "top referral extensibleObject".split(),
+                   'ref': 'ref: ldap://remote/%s' % REFERRAL_DN})
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.create(properties=properties)
+    REFERRAL_DN = "cn=my_ref,%s" % CHILD_SUFFIX
+    properties = ({'cn': 'my_ref',
+                   'uid': 'my_ref',
+                   'sn': 'my_ref',
+                   'uidNumber': '1000',
+                   'gidNumber': '2000',
+                   'homeDirectory': '/home/testuser',
+                   'description': 'referral entry',
+                   'objectclass': "top referral extensibleObject".split(),
+                   'ref': 'ref: ldap://remote/%s' % REFERRAL_DN})
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.create(properties=properties)
+
+    # Step 15 Check that the server detected the referral on both parent and child suffixes
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % PARENT_SUFFIX)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - New referral entries are detected under %s.*' % CHILD_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % CHILD_SUFFIX)
+
+    # Step 16 Delete the child referral entry
+    REFERRAL_DN = "cn=my_ref,%s" % CHILD_SUFFIX
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.delete()
+
+    # Step 17 Check that the server detected the deletion of the referral on child suffix but not on parent suffix
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % CHILD_SUFFIX)
+    assert not topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % PARENT_SUFFIX)
+
+    # Step 18 Delete the parent referral entry
+    REFERRAL_DN = "cn=my_ref,%s" % PARENT_SUFFIX
+    referral = UserAccount(inst, REFERRAL_DN)
+    referral.delete()
+
+    # Step 19 Check that the server detected the deletion of the referral parent suffix
+    time.sleep(REFERRAL_CHECK + 1)
+    assert topology_st.standalone.ds_error_log.match('.*slapd_daemon - No more referral entry under %s' % PARENT_SUFFIX)
+
+    def fin():
+        log.info('Deleting referral')
+        try:
+            REFERRAL_DN = "cn=my_ref,%s" % PARENT_SUFFIX
+            referral = UserAccount(inst, REFERRAL_DN)
+            referral.delete()
+            REFERRAL_DN = "cn=my_ref,%s" % CHILD_SUFFIX
+            referral = UserAccount(inst, REFERRAL_DN)
+            referral.delete()
+        except:
+            pass
 
     request.addfinalizer(fin)
 

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -259,6 +259,11 @@ ldbm_instance_start(backend *be)
     }
 
     rc = dblayer_instance_start(be, DBLAYER_NORMAL_MODE);
+    if (slapi_exist_referral(be)) {
+        slapi_be_set_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
+    } else {
+        slapi_be_unset_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
+    }
     be->be_state = BE_STATE_STARTED;
 
     PR_Unlock(be->be_state_lock);

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1002,6 +1002,7 @@ build_candidate_list(Slapi_PBlock *pb, backend *be, struct backentry *e, const c
     int err = 0;
     int r = 0;
     char logbuf[1024] = {0};
+    Slapi_Operation *operation;
 
     slapi_pblock_get(pb, SLAPI_SEARCH_FILTER, &filter);
     if (NULL == filter) {
@@ -1036,8 +1037,18 @@ build_candidate_list(Slapi_PBlock *pb, backend *be, struct backentry *e, const c
     case LDAP_SCOPE_SUBTREE:
         /* Now optimise the filter for use */
         slapi_filter_optimise(filter);
-        /* make (|(originalfilter)(objectclass=referral)) */
-        filter_exec = create_subtree_filter(filter, managedsait);
+
+        slapi_pblock_get(pb, SLAPI_OPERATION, &operation);
+        if (!slapi_be_is_flag_set(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL) || (operation && operation_is_flag_set(operation, OP_FLAG_INTERNAL))) {
+            /* For performance reason, skip adding (objectclass=referral) in case
+             *  - there is no referral on the server
+             *  - this is an internal SRCH
+             */
+            filter_exec = slapi_filter_dup(filter);
+        } else {
+            /* make (|(originalfilter)(objectclass=referral)) */
+            filter_exec = create_subtree_filter(filter, managedsait);
+        }
 
         slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_search", "Optimised SUB filter to - %s\n",
              slapi_filter_to_string(filter_exec, logbuf, sizeof(logbuf)));

--- a/ldap/servers/slapd/backend.c
+++ b/ldap/servers/slapd/backend.c
@@ -17,6 +17,7 @@
 #include "nspr.h"
 
 static PRMonitor *global_backend_mutex = NULL;
+static Slapi_Eq_Context referral_check_ctx = NULL;
 
 void
 be_init(Slapi_Backend *be, const char *type, const char *name, int isprivate, int logchanges, int sizelimit, int timelimit)
@@ -202,6 +203,111 @@ slapi_be_gettype(Slapi_Backend *be)
         r = be->be_type;
     }
     return r;
+}
+
+int
+slapi_exist_referral(Slapi_Backend *be)
+{
+    Slapi_PBlock *search_pb = NULL;
+    const char *suffix;
+    Slapi_Entry **entries = NULL;
+    char **referrals = NULL;
+    char *filter;
+    int rc = 0; /* assume there is no referral */
+    int exist_referral = 0;
+    LDAPControl **server_ctrls;
+
+    filter = "(objectclass=referral)";
+    if (!slapi_be_is_flag_set(be, SLAPI_BE_FLAG_REMOTE_DATA) && (be->be_state == BE_STATE_STARTED)) {
+        suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be, 0));
+
+        /* ignore special backends */
+        if ((strcmp(suffix, "cn=schema") == 0) ||
+            (strcmp(suffix, "cn=config") == 0)) {
+            return 0; /* it does not mean anything having a referral in those backends */
+        }
+
+        /* search for ("smart") referral entries */
+        search_pb = slapi_pblock_new();
+        server_ctrls = (LDAPControl **) slapi_ch_calloc(2, sizeof (LDAPControl *));
+        server_ctrls[0] = (LDAPControl *) slapi_ch_malloc(sizeof (LDAPControl));
+        server_ctrls[0]->ldctl_oid = slapi_ch_strdup(LDAP_CONTROL_MANAGEDSAIT);
+        server_ctrls[0]->ldctl_value.bv_val = NULL;
+        server_ctrls[0]->ldctl_value.bv_len = 0;
+        server_ctrls[0]->ldctl_iscritical = '\0';
+        slapi_search_internal_set_pb(search_pb, suffix, LDAP_SCOPE_SUBTREE,
+                filter, NULL, 0, server_ctrls, NULL,
+                (void *) plugin_get_default_component_id(), 0);
+        slapi_search_internal_pb(search_pb);
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+        if (LDAP_SUCCESS != rc) { /* plugin is not available */
+            exist_referral = 1; /* be safe, assume there is a referral somewhere */
+        }
+
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_REFERRALS, &referrals);
+        if ((entries && entries[0]) || referrals) {
+            exist_referral = 1;
+        }
+        slapi_free_search_results_internal(search_pb);
+        slapi_pblock_destroy(search_pb);
+    }
+    if (exist_referral) {
+        if (!slapi_be_is_flag_set(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL)) {
+            /* it existed no referral on that backend but now it exists at least a new referral entry */
+            slapi_be_set_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
+            slapi_log_err(SLAPI_LOG_INFO, "slapd_daemon",
+                          "New referral entries are detected under %s (returned to SRCH req)\n",
+                          slapi_sdn_get_ndn(be->be_suffix));
+        }
+    } else if (slapi_be_is_flag_set(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL)) {
+        /* now there is no more referral */
+        slapi_be_unset_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
+        slapi_log_err(SLAPI_LOG_INFO, "slapd_daemon",
+                      "No more referral entry under %s\n",
+                      slapi_sdn_get_ndn(be->be_suffix));
+    }
+    return exist_referral;
+}
+
+/*
+ * This function periodically checks if it exists referrals entries
+ * in the server.
+ * This is used to accelerate SRCH request as the lookup for referrals
+ * has a negative impact on SRCH throughput
+ */
+static void
+referral_check(time_t start_time __attribute__((unused)), void *arg __attribute__((unused)))
+{
+    Slapi_Backend *be;
+    char *cookie;
+
+    /* loop over the backends to check if a it exists a "smart" referral */
+    be = slapi_get_first_backend(&cookie);
+    while (be) {
+        slapi_exist_referral(be);
+
+        /* next backend */
+        be = slapi_get_next_backend(cookie);
+    }
+    slapi_ch_free((void **) &cookie);
+}
+
+/* schedule periodic call to referral_check */
+void
+slapi_referral_check_init(void)
+{
+    referral_check_ctx = slapi_eq_repeat_rel(referral_check,
+                                             NULL, (time_t)0,
+                                             config_get_referral_check_period() * 1000);
+}
+void
+slapi_referral_check_stop(void)
+{
+    if (referral_check_ctx) {
+        slapi_eq_cancel_rel(referral_check_ctx);
+        referral_check_ctx = NULL;
+    }
 }
 
 Slapi_DN *

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1027,6 +1027,7 @@ slapd_daemon(daemon_ports_t *ports)
             }
         }
     }
+    slapi_referral_check_init();
 
     /* We are now ready to accept incoming connections */
     if (n_tcps != NULL) {
@@ -1136,6 +1137,7 @@ slapd_daemon(daemon_ports_t *ports)
     ct_thread_cleanup();
     housekeeping_stop(); /* Run this after op_thread_cleanup() logged sth */
     disk_monitoring_stop();
+    slapi_referral_check_stop();
 
     /*
      * Now that they are abandonded, we need to mark them as done.

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1406,6 +1406,11 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.tcp_keepalive_time, CONFIG_INT,
      (ConfigGetFunc)config_get_tcp_keepalive_time, SLAPD_DEFAULT_TCP_KEEPALIVE_TIME_STR, NULL},
+    {CONFIG_REFERRAL_CHECK_PERIOD, config_set_referral_check_period,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.referral_check_period,
+     CONFIG_INT, (ConfigGetFunc)config_set_referral_check_period,
+     SLAPD_DEFAULT_REFERRAL_CHECK_PERIOD_STR, NULL},
     {CONFIG_RETURN_ENTRY_DN, config_set_return_orig_dn,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.return_orig_dn,
@@ -1955,6 +1960,7 @@ FrontendConfig_init(void)
 #endif
 #endif
     init_extract_pem = cfg->extract_pem = LDAP_ON;
+    cfg->referral_check_period = SLAPD_DEFAULT_REFERRAL_CHECK_PERIOD;
     init_return_orig_dn = cfg->return_orig_dn = LDAP_ON;
     /*
      * Default upgrade hash to on - this is an important security step, meaning that old
@@ -8472,6 +8478,40 @@ config_get_verify_filter_schema()
     }
     /* Should be unreachable ... */
     return FILTER_POLICY_OFF;
+}
+
+int32_t
+config_get_referral_check_period()
+{
+    int32_t retVal;
+
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapdFrontendConfig->referral_check_period;
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+int32_t
+config_set_referral_check_period(const char *attrname, char *value, char *errorbuf, int apply __attribute__((unused)))
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int32_t min = 5;
+    int32_t max = 3600;
+    int32_t referral_check_period;
+    char *endp = NULL;
+
+    errno = 0;
+    referral_check_period = strtol(value, &endp, 10);
+    if ((*endp != '\0') || (errno == ERANGE) || (referral_check_period < min) || (referral_check_period > max)) {
+        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "limit \"%s\" is invalid, %s must range from %d to %d",
+                              value, CONFIG_REFERRAL_CHECK_PERIOD, min, max);
+        return LDAP_OPERATIONS_ERROR;
+    }
+    slapi_atomic_store_32(&(slapdFrontendConfig->referral_check_period), referral_check_period, __ATOMIC_RELEASE);
+
+    return LDAP_SUCCESS;
 }
 
 int32_t

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -629,6 +629,9 @@ int32_t config_set_ldapssotoken_secret(const char *attrname, char *value, char *
 int32_t config_set_ldapssotoken_ttl(const char *attrname, char *value, char *errorbuf, int apply);
 int32_t config_get_ldapssotoken_ttl(void);
 
+int32_t config_get_referral_check_period();
+int32_t config_set_referral_check_period(const char *attrname, char *value, char *errorbuf, int apply);
+
 int32_t config_get_return_orig_dn(void);
 int32_t config_set_return_orig_dn(const char *attrname, char *value, char *errorbuf, int apply);
 

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -431,6 +431,9 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_TCP_KEEPALIVE_TIME 300
 #define SLAPD_DEFAULT_TCP_KEEPALIVE_TIME_STR "300"
 
+#define SLAPD_DEFAULT_REFERRAL_CHECK_PERIOD 300
+#define SLAPD_DEFAULT_REFERRAL_CHECK_PERIOD_STR "300"
+
 #define MIN_THREADS 16
 #define MAX_THREADS 512
 
@@ -2348,6 +2351,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_LISTEN_BACKLOG_SIZE "nsslapd-listen-backlog-size"
 #define CONFIG_DYNAMIC_PLUGINS "nsslapd-dynamic-plugins"
 #define CONFIG_RETURN_DEFAULT_OPATTR "nsslapd-return-default-opattr"
+#define CONFIG_REFERRAL_CHECK_PERIOD "nsslapd-referral-check-period"
 #define CONFIG_RETURN_ENTRY_DN "nsslapd-return-original-entrydn"
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
@@ -2702,6 +2706,7 @@ typedef struct _slapdFrontendConfig
 
     slapi_int_t tcp_fin_timeout;
     slapi_int_t tcp_keepalive_time;
+    int32_t referral_check_period;
     slapi_onoff_t return_orig_dn;
     char *auditlog_display_attrs;
 } slapdFrontendConfig_t;

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6406,6 +6406,9 @@ Slapi_DN *slapi_get_next_suffix_ext(void **node, int show_private);
 int slapi_is_root_suffix(Slapi_DN *dn);
 const Slapi_DN *slapi_get_suffix_by_dn(const Slapi_DN *dn);
 const char *slapi_be_gettype(Slapi_Backend *be);
+int slapi_exist_referral(Slapi_Backend *be);
+void slapi_referral_check_init(void);
+void slapi_referral_check_stop(void);
 
 /**
  * Start database transaction
@@ -6459,6 +6462,7 @@ void slapi_be_unset_flag(Slapi_Backend *be, int flag);
 #define SLAPI_BE_FLAG_DONT_BYPASS_FILTERTEST  0x10  /* force to call filter_test (search only) */
 #define SLAPI_BE_FLAG_POST_IMPORT            0x100  /* backend was imported */
 #define SLAPI_BE_FLAG_POST_RESTORE           0x200  /* startup after restore */
+#define SLAPI_BE_FLAG_CONTAINS_REFERRAL      0x400  /* Used to flag that the backend contains a referral entry */
 
 
 /* These functions allow a plugin to register for callback when


### PR DESCRIPTION
… of referral

Bug description:
	A part of the fix #5170 append '(objectclass=referral)' to
	the original filter (in subtree scope) in order to conform
        smart referral support https://www.ietf.org/rfc/rfc3296.txt
	This triggers a drop on SRCH throughput (10%).
	#5598 limits the case when '(objectclass=referral)' is added
         - Most of the time a server does not contain smart referral.
           So most of the time it is useless to  add that subfilter
         - It should not be added for internal searches

Fix description:
	A mechanism periodically (each 30s) checks if there are
	smart referral entries (referral_check).
	When a first smart referral is detected or no more smart
	referral is detected it logs a information message.
	During a direct subtree search, 'objectclass=referral' is
	append at the condition it exists at least a referral

relates:  #5598

Reviewed by: