### PR TITLE
Issue 5605 - Adding a slapi_log_backtrace function in libslapd

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
@@ -12,7 +12,6 @@
 #endif
 #include "mdb_layer.h"
 
-#include <execinfo.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -143,23 +142,10 @@ void dbmdb_format_dbslist_info(char *info, dbmdb_dbi_t *dbi)
 }
 
 
-void log_stack(int loglvl)
+static inline void log_stack(int loglvl)
 {
-    /* Log stack (1 error message per frame to avoid log framework buffer overflow) */
-    void *frames[100];
-    char **symbols;
-    int nbframes;
-    int i;
-
     if (loglvl & dbgmdb_level) {
-        nbframes = backtrace(frames, (sizeof frames)/sizeof frames[0]);
-        symbols = backtrace_symbols(frames, nbframes);
-        if (symbols) {
-            for (i=0; i<nbframes; i++) {
-               slapi_log_err(SLAPI_LOG_DBGMDB, "log_stack", "\t[%d]\t%s\n", i, symbols[i]);
-            }
-            free(symbols);
-        }
+        slapi_log_backtrace(SLAPI_LOG_DBGMDB);
     }
 }
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.h
@@ -23,7 +23,6 @@ void dbmdb_format_dbslist_info(char *info, dbmdb_dbi_t *dbi);
 extern int dbgmdb_level; /* defined in mdb_debug.c */
 void dbg_log(const char *file, int lineno, const char *funcname, int loglevel, char *fmt, ...);
 void dbgval2str(char *buff, size_t bufsiz, MDB_val *val);
-void log_stack(int loglvl);
 void dbmdb_dbg_set_dbi_slots(dbmdb_dbi_t *slots);
 
 /* #define DBMDB_DEBUG 1 */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -1190,7 +1190,7 @@ int dbmdb_open_dbi_from_filename(dbmdb_dbi_t **dbi, backend *be, const char *fil
              * online import/bulk import/reindex failed and suffix database was cleared)
              */
             slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_open_dbi_from_filename", "Attempt to open to open dbi %s/%s while txn is already pending. The only case this message is expected is after a failed import or reindex.\n", be->be_name, filename);
-            log_stack(SLAPI_LOG_WARNING);
+            slapi_log_backtrace(SLAPI_LOG_WARNING);
             return MDB_NOTFOUND;
         }
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -1545,7 +1545,7 @@ dbi_error_t dbmdb_map_error(const char *funcname, int err)
             }
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_map_error",
                 "%s failed with db error %d : %s\n", funcname, err, msg);
-            log_stack(SLAPI_LOG_ERR);
+            slapi_log_backtrace(SLAPI_LOG_ERR);
             return DBI_RC_OTHER;
     }
 }
@@ -2550,11 +2550,11 @@ int dbmdb_public_new_cursor(dbi_db_t *db,  dbi_cursor_t *cursor)
            rc = MDB_NOTFOUND;
         } else if (rc==EINVAL) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_public_new_cursor", "Invalid dbi =%d (%s) while opening cursor in txn= %p\n", dbi->dbi, dbi->dbname, TXN(cursor->txn));
-            log_stack(SLAPI_LOG_ERR);
+            slapi_log_backtrace(SLAPI_LOG_ERR);
         } else {
             rc = EINVAL;
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_public_new_cursor", "Failed to open cursor dbi =%d (%s) in txn= %p\n", dbi->dbi, dbi->dbname, TXN(cursor->txn));
-            log_stack(SLAPI_LOG_ERR);
+            slapi_log_backtrace(SLAPI_LOG_ERR);
          }
     }
     if (rc && cursor->islocaltxn)

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_txn.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_txn.c
@@ -140,7 +140,7 @@ int dbmdb_start_txn(const char *funcname, dbi_txn_t *parent_txn, int flags, dbi_
              */
              slapi_log_error(SLAPI_LOG_CRIT, "dbmdb_start_txn",
                     "Code issue: Trying to handle a db instance in a thread that is already holding a txn.\n");
-            log_stack(SLAPI_LOG_CRIT);
+            slapi_log_backtrace(SLAPI_LOG_CRIT);
             abort();
         }
 

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1508,6 +1508,8 @@ void slapi_pblock_set_task_warning(Slapi_PBlock *pb, task_warning warning);
 
 int slapi_exists_or_add_internal(Slapi_DN *dn, const char *filter, const char *entry, const char *modifier_name);
 
+void slapi_log_backtrace(int loglevel);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Moving log_stack out of db-mdb code to libslapd and renaming it as slapi_log_backtrace.

Issue: [5605](https://github.com/389ds/389-ds-base/issues/5605)

Reviewed by: @mreynolds389