### PR TITLE
Issue #5610 - Build failure on Debian

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1166,7 +1166,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	$(libavl_a_SOURCES)
 
 libslapd_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(DB_INC) $(KERBEROS_CFLAGS) $(PCRE_CFLAGS) $(SVRCORE_INCLUDES)
-libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KERBEROS_LIBS) $(PCRE_LIBS) $(THREADLIB) $(SYSTEMD_LIBS) libsvrcore.la $(RSLAPD_LIB)
+libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KERBEROS_LIBS) $(PCRE_LIBS) $(THREADLIB) $(SYSTEMD_LIBS) libsvrcore.la $(RSLAPD_LIB) $(OPENSSL_LIBS)
 # If asan is enabled, it creates special libcrypt interceptors. However, they are
 # detected by the first load of libasan at runtime, and what is in the linked lib
 # so we need libcrypt to be present as soon as libasan is loaded for the interceptors
@@ -1175,7 +1175,7 @@ libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KER
 if enable_asan
 libslapd_la_LIBADD += $(LIBCRYPT)
 endif
-libslapd_la_LDFLAGS = $(AM_LDFLAGS) $(SLAPD_LDFLAGS) -lssl -lcrypto
+libslapd_la_LDFLAGS = $(AM_LDFLAGS) $(SLAPD_LDFLAGS)
 
 #////////////////////////////////////////////////////////////////
 #
@@ -1868,7 +1868,7 @@ ns_slapd_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(SVRCORE
 # We need our libraries to come first, then our externals libraries second.
 ns_slapd_LDADD = libslapd.la libldaputil.la libsvrcore.la $(RNSSLAPD_LIB)
 
-ns_slapd_LDADD += $(LDAPSDK_LINK) $(NSS_LINK) $(LIBADD_DL) -lssl -lcrypto \
+ns_slapd_LDADD += $(LDAPSDK_LINK) $(NSS_LINK) $(LIBADD_DL) $(OPENSSL_LIBS) \
        $(NSPR_LINK) $(SASL_LINK) $(LIBNSL) $(LIBSOCKET) $(THREADLIB) $(SYSTEMD_LIBS) $(EVENT_LINK)
 
 ns_slapd_DEPENDENCIES = libslapd.la libldaputil.la

--- a/configure.ac
+++ b/configure.ac
@@ -97,8 +97,6 @@ AC_SUBST([rust_vendor_sources])
 if test "$enable_rust_offline" = yes; then
     AC_CHECK_PROG(CARGO, [cargo], [yes], [no])
     AC_CHECK_PROG(RUSTC, [rustc], [yes], [no])
-    # Since fernet uses the openssl lib.
-    PKG_CHECK_MODULES([OPENSSL], [openssl])
 
     AS_IF([test "$CARGO" != "yes" -o "$RUSTC" != "yes"], [
       AC_MSG_FAILURE("Rust based plugins cannot be built cargo=$CARGO rustc=$RUSTC")
@@ -819,6 +817,8 @@ else
     nss_libdir=`$PKG_CONFIG --libs-only-L dirsec-nss | sed -e s/-L// | sed -e s/\ .*$//`
 fi
 AC_SUBST(nss_libdir)
+
+PKG_CHECK_MODULES([OPENSSL], [openssl])
 
 m4_include(m4/openldap.m4)
 m4_include(m4/db.m4)


### PR DESCRIPTION
Bug Description:
On Debian libslapd.so is not getting linked with libcrypto.so, which results in `undefined reference` link errors.

Fix Description:
Move -lssl and -lcrypto for libslapd.so from LDFLAGS to LIBADD.

Fixes: https://github.com/389ds/389-ds-base/issues/5610

Reviewed by: ???