### PR TITLE
Issue 5607, 5351, 5611 - UI/CLI - fix various issues

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -1043,7 +1043,7 @@ export function showCertificate (certificate, showCertCallback) {
 export function b64DecodeUnicode (str) {
   // Going backwards: from bytestream, to percent-encoding, to original string.
   try {
-      result = decodeURIComponent(atob(str).split('').map(c => {
+      let result = decodeURIComponent(atob(str).split('').map(c => {
           return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       }).join(''));
       return result;

--- a/src/lib389/lib389/cli_ctl/cockpit.py
+++ b/src/lib389/lib389/cli_ctl/cockpit.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -9,21 +9,11 @@
 import os
 import subprocess
 
-def cockpit_present():
-    rpm_handle = os.popen('rpm -qa --qf "%{NAME}\n"')
-    rpm_list = rpm_handle.read().splitlines()
-    if 'cockpit' in rpm_list:
-        return True
-    else:
-        return False
-
 
 def enable_cockpit(inst, log, args):
     """
     Enable Cockpit socket
     """
-    if not cockpit_present():
-        raise ValueError("The 'cockpit' package is not installed on this system")
 
     ENABLE_CMD = ['sudo', 'systemctl', 'enable', '--now', 'cockpit.socket']
     try:


### PR DESCRIPTION
Description:

5607 - Ldap Editor failed to decode base64 values
5351 - CLI - Cockpit enable check for cockpit package was not portable
       (just removed this check)
5611 - Security page had a lot of issues when trying to change the Server
       Certificate.  Save didn't work, and "Security Enable" modal would
       crash

relates: https://github.com/389ds/389-ds-base/issues/5607 
relates: https://github.com/389ds/389-ds-base/issues/5351 
relates: https://github.com/389ds/389-ds-base/issues/5611

