### PR TITLE
Issue 4577 - Add LMDB pytest github action

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -1,6 +1,10 @@
 name: LMDB Test
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
   workflow_dispatch:
     inputs:
       pytest_tests:
@@ -11,10 +15,6 @@ on:
         description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'     
         required: false
         default: false
-  workflow_run:
-    workflows: [Test]
-    types:
-      - completed
 
 jobs:
   build:

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -1,0 +1,115 @@
+name: LMDB Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      pytest_tests:
+        description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
+        required: false
+        default: false
+      debug_enabled:
+        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
+  workflow_run:
+    workflows: [Test]
+    types:
+      - completed
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    container:
+      image: quay.io/389ds/ci-images:test
+    outputs:
+        matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Get a list of all test suites
+        id: set-matrix
+        run: echo "::set-output name=matrix::$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})"
+
+      - name: Build RPMs
+        run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
+
+      - name: Tar build artifacts
+        run: tar -cvf dist.tar dist/
+
+      - name: Upload RPMs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpms
+          path: dist.tar
+
+  test:
+    name: LMDB Test
+    runs-on: ubuntu-22.04
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.build.outputs.matrix) }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install -y docker.io containerd runc
+        sudo cp .github/daemon.json /etc/docker/daemon.json
+        sudo systemctl unmask docker
+        sudo systemctl start docker
+
+    - name: Download RPMs
+      uses: actions/download-artifact@master
+      with:
+        name: rpms
+    
+    - name: Extract RPMs
+      run: tar xvf dist.tar
+
+    - name: Run pytest in a container
+      run: |
+        set -x
+        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
+        export PASSWD=$(openssl rand -base64 32)
+        sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"
+        sudo docker exec $CID sh -c "systemctl start dbus.service"
+        sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
+        sudo docker exec $CID sh -c "mkdir -p /workspace/assets/cores && chmod 777 /workspace{,/assets{,/cores}}"
+        sudo docker exec $CID sh -c "echo '/workspace/assets/cores/core.%e.%P' > /proc/sys/kernel/core_pattern"
+        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=mdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+
+    - name: Make the results file readable by all
+      if: always()
+      run: |
+        sudo chmod -f -v -R a+r pytest.*ml assets
+        sudo chmod -f -v a+x assets
+    - name: Sanitize filename
+      if: always()
+      run: echo "PYTEST_SUITE=$(echo ${{ matrix.suite }} | sed -e 's#\/#-#g')" >> $GITHUB_ENV
+      
+    - name: Upload pytest test results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest-${{ env.PYTEST_SUITE }}
+        path: |
+          pytest.xml
+          pytest.html
+          assets
+


### PR DESCRIPTION
As @vashirov and @bsimonova discovered in PR [5357,](https://github.com/389ds/389-ds-base/pulls/5357),
 adding a step in the pytest workflow is not working because test are not run 
if a bdb test fails. So I propose to test another approach:
 Duplicate the pytest workflow and it seems to work nicely (The github limit of 20 concurrent jobs prevents that too many tests run at the same time)
 Furthermore as the bdb and lmdb  tests run on different containers it ensure a proper test separations.

Issue [4577](https://github.com/389ds/389-ds-base/issues/4577)

Reviewed by @vashirov, @bsimonova , Thanks !