### PR TITLE
Issue 5630 - CLI - error messages should goto stderr

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -71,7 +71,7 @@ export function getUserSuffixes (serverId, suffixCallback) {
   ];
   log_cmd("getUserSuffixes", "list suffixes", suffixCmd);
   cockpit
-    .spawn(suffixCmd, { superuser: true })
+    .spawn(suffixCmd, { superuser: true, err: "message" })
     .done(content => {
       const suffList = JSON.parse(content);
       suffixCallback(suffList.items)

--- a/src/lib389/cli/dsconf
+++ b/src/lib389/cli/dsconf
@@ -90,6 +90,7 @@ cli_repl_conflicts.create_parser(subparsers)
 
 argcomplete.autocomplete(parser)
 
+
 # handle a control-c gracefully
 def signal_handler(signal, frame):
     print('\n\nExiting...')

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -407,6 +407,11 @@ class FakeArgs(object):
         return len(self.__dict__.keys())
 
 
+class StdErrFilter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno in (logging.ERROR)
+
+
 def setup_script_logger(name, verbose=False):
     """Reset the python logging system for STDOUT, and attach a new
     console logger with cli expected formatting.
@@ -430,6 +435,12 @@ def setup_script_logger(name, verbose=False):
 
     log_handler.setFormatter(logging.Formatter(log_format))
     root.addHandler(log_handler)
+
+    log_handler_err = logging.StreamHandler(sys.stderr)
+    log_handler_err.setLevel(logging.ERROR)
+    log_handler_err.addFilter(StdErrFilter())
+    log_handler_err.setFormatter(logging.Formatter(log_format))
+    log.addHandler(log_handler_err)
 
     return log
 


### PR DESCRIPTION
Description:  

Previously all CLI output (error not not) was sent to stdout when it should really goto stderr.

 Add new handle/filter for stderr messages

relates: https://github.com/389ds/389-ds-base/issues/5630

