### PR TITLE
Issue 5588 - CI - fix tests

### DIFF
--- a/dirsrvtests/tests/suites/setup_ds/setup_ds_test.py
+++ b/dirsrvtests/tests/suites/setup_ds/setup_ds_test.py
@@ -39,10 +39,11 @@ def create_instance(config_attr):
     standalone.open()
     return standalone
 
+
 # During UI & CLI rebase in 1.4.3 (8abefc754351dac6163c669d3087b8721e6e796c)
 # the use of setup-ds.pl was dropped
 # only support 'false'
-@pytest.mark.parametrize("config_attr", ('false'))
+@pytest.mark.parametrize("config_attr", ['false'])
 def test_slapd_InstScriptsEnabled(config_attr):
     """Tests InstScriptsEnabled attribute with "True" and "False" options
 

--- a/dirsrvtests/tests/suites/tls/ssl_version_test.py
+++ b/dirsrvtests/tests/suites/tls/ssl_version_test.py
@@ -76,7 +76,8 @@ def test_ssl_version_range(topo):
         pass
 
     if not skip:
-        if ds_is_older('1.4.4'):
+        # TLS 1.0 and TLS 1.1 were moved to LEGACY on 1.4.3, adjusting the sanity check
+        if ds_is_older('1.4.3'):
             ssl_versions = [('sslVersionMin', ['TLS1.0', 'TLS1.1', 'TLS1.2', 'TLS1.0']),
                             ('sslVersionMax', ['TLS1.0', 'TLS1.1', 'TLS1.2'])]
         else:


### PR DESCRIPTION
Description:
Small fixes for 1.4.3 branch.
setup_ds_test had wrong brackets for parametrize and instead of 'false' value, it was testing 'f', 'a' etc. values. 
ssl_version_test - adjusting the ds version as TLS 1.0 and TLS 1.1 are on LEGACY policy on RHEL 8.8

Relates: https://github.com/389ds/389-ds-base/issues/5588

Reviewed by: @aadhikar (Thanks!)