### PR TITLE
Issue 5637 - Covscan - fix Buffer Overflows

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -134,7 +134,7 @@ connection_table_new(int table_size)
     ct->list_size = (table_size+ct->list_num-1)/ct->list_num; /* to avoid rounding issue */
     ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
     ct->c = (Connection **)slapi_ch_calloc(1, table_size * sizeof(Connection *));
-    ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, table_size * sizeof(struct POLL_STRUCT));
+    ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, ct->list_num * sizeof(struct POLL_STRUCT*));
     ct->table_mutex = PR_NewLock();
     /* Allocate the freelist */
     ct->c_freelist = (Connection **)slapi_ch_calloc(1, table_size * sizeof(Connection *));


### PR DESCRIPTION
Covscan reports:
`. 389-ds-base-2.2.4/ldap/servers/slapd/conntable.c:138: suspicious_sizeof: Passing argument "table_size * 16UL /* sizeof (struct PRPollDesc) */" to function "slapi_ch_calloc" and then casting the return value to "struct PRPollDesc **" is suspicious.`
And indeed memory space is wasted because a buffer larger than the expected one is allocated in connection table code: it should be: `ct->list_num *sizeof(struct PRPollDesc*)`.

Issue: [5637](https://github.com/389ds/389-ds-base/issues/5637)

Reviewed by: @mreynolds389, @jchapma. Thanks !