### PR TITLE
Issue 5632 - CLI - improve error handling with db2ldif

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
@@ -60,7 +60,7 @@ def test_tls_command_returns_error_text(topo):
         assert False
     except ValueError as e:
         assert '255' not in str(e)
-        assert 'error converting ascii to binary' in str(e)
+        assert 'could not decode certificate' in str(e)
 
     # dsctl localhost tls import-server-cert
     try:

--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -26,6 +26,8 @@ from lib389.config import LDBMConfig
 from lib389.utils import ds_is_newer, get_default_db_lib
 from lib389.idm.user import UserAccount
 from lib389.idm.account import Accounts
+from lib389.cli_ctl.dbtasks import dbtasks_ldif2db
+from lib389.cli_base import FakeArgs
 
 pytestmark = pytest.mark.tier1
 
@@ -37,15 +39,15 @@ else:
 log = logging.getLogger(__name__)
 
 bdb_values = {
-  'wait30' : 30
+  'wait30': 30
 }
 
 # Note: I still sometime get failure with a 60s timeout so lets use 90s
 mdb_values = {
-  'wait30' : 90
+  'wait30': 90
 }
 
-if get_default_db_lib() is 'bdb':
+if get_default_db_lib() == 'bdb':
     values = bdb_values
 else:
     values = mdb_values
@@ -265,6 +267,7 @@ def test_online_import_with_warning(topo, _import_clean):
     assert import_task.present('nstaskwarning')
     assert TaskWarning.WARN_SKIPPED_IMPORT_ENTRY == import_task.get_task_warn()
 
+
 def test_crash_on_ldif2db(topo, _import_clean):
     """
     Delete the cn=monitor entry for an LDBM backend instance. Doing this will
@@ -379,6 +382,7 @@ def _toggle_private_import_mem(request, topo):
             ('nsslapd-db-private-import-mem', 'off'))
     request.addfinalizer(finofaci)
 
+
 #unstable or unstatus tests, skipped for now
 #@pytest.mark.flaky(max_runs=2, min_passes=1)
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="nsslapd-db-private-import-mem and nsslapd-import-cache-autosize parameters are ignored when usign lmdb")
@@ -441,7 +445,7 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # Measure offline import time duration total_time2
     total_time2 = _import_offline(topo, 1000)
     # total_time1 < total_time2
-    log.info("toral_time1 = %f" % total_time1)
+    log.info("total_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
     assert total_time1 < total_time2
 
@@ -522,9 +526,33 @@ def test_import_perf_after_failure(topo):
     topo.standalone.restart()
 
 
+def test_import_wrong_file_path(topo):
+    """Make an import fail by specifying the wrong LDIF file name
+
+    :id: 6795a3cd-b95e-4777-bc77-25ab864882a3
+    :setup: Standalone Instance
+    :steps:
+        1. Do an import with an invalid file path
+        2. Appropriate error is returned
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    import_ldif = '/nope/perf_import.ldif'
+    args = FakeArgs()
+    args.instance = topo.standalone.serverid
+    args.backend = "userroot"
+    args.encrypted = False
+    args.replication = False
+    args.ldif = import_ldif
+
+    with pytest.raises(ValueError) as e:
+        dbtasks_ldif2db(topo.standalone, log, args)
+    assert "The LDIF file does not exist" in str(e.value)
+
+
 if __name__ == '__main__':
     # Run isolated
     # -s for DEBUG mode
     CURRENT_FILE = os.path.realpath(__file__)
     pytest.main("-s %s" % CURRENT_FILE)
-

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2016 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -7,7 +7,10 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import os
 from lib389._constants import TaskWarning
+from pathlib import Path
+
 
 def dbtasks_db2index(inst, log, args):
     rtn = False
@@ -34,7 +37,6 @@ def dbtasks_db2index(inst, log, args):
         return rtn
 
 
-
 def dbtasks_db2bak(inst, log, args):
     # Needs an output name?
     if not inst.db2bak(args.archive):
@@ -54,6 +56,13 @@ def dbtasks_bak2db(inst, log, args):
 
 
 def dbtasks_db2ldif(inst, log, args):
+    # Check if file path exists
+    path = Path(args.ldif)
+    parent = path.parent.absolute()
+    if not parent.exists():
+        raise ValueError("The LDIF file location does not exist: " + args.ldif)
+
+    # Export backend
     if not inst.db2ldif(bename=args.backend, encrypt=args.encrypted, repl_data=args.replication,
                         outputfile=args.ldif, suffixes=None, excludeSuffixes=None, export_cl=False):
         log.fatal("db2ldif failed")
@@ -63,6 +72,10 @@ def dbtasks_db2ldif(inst, log, args):
 
 
 def dbtasks_ldif2db(inst, log, args):
+    # Check if ldif file exists
+    if not os.path.exists(args.ldif):
+        raise ValueError("The LDIF file does not exist: " + args.ldif)
+
     ret = inst.ldif2db(bename=args.backend, encrypt=args.encrypted, import_file=args.ldif,
                         suffixes=None, excludeSuffixes=None, import_cl=False)
     if not ret:
@@ -156,4 +169,3 @@ def create_parser(subcommands):
     ldifs_parser = subcommands.add_parser('ldifs', help="List all the LDIF files located in the server's LDIF directory")
     ldifs_parser.add_argument('--delete', nargs=1, help="Delete LDIF file")
     ldifs_parser.set_defaults(func=dbtasks_ldifs)
-


### PR DESCRIPTION
Description: 

Have the CLI check if the ldif location exists.  This also prevents the database from getting trashed by skipping the export attempt.

relates: https://github.com/389ds/389-ds-base/issues/5632

