### PR TITLE
Issue 5600 - buffer overflow when enabling sync repl plugin when dyna…

### DIFF
--- a/ldap/servers/plugins/acl/acleffectiverights.c
+++ b/ldap/servers/plugins/acl/acleffectiverights.c
@@ -327,6 +327,7 @@ _ger_new_gerpb(
     struct acl_cblock *conn_aclcb;
     Acl_PBlock *geraclpb;
     Operation *gerop;
+    int32_t ext_count = 0;
     int rc = LDAP_SUCCESS;
 
     *save_aclcb = NULL;
@@ -377,7 +378,8 @@ _ger_new_gerpb(
          * conn is a no-use parameter in the functions
          * chained down from factory_create_extension
          */
-        gerop->o_extension = factory_create_extension(get_operation_object_type(), (void *)gerop, (void *)conn);
+        gerop->o_extension = factory_create_extension(get_operation_object_type(), (void *)gerop, (void *)conn, &ext_count);
+        gerop->o_extension_count = ext_count;
         slapi_pblock_set(*gerpb, SLAPI_OPERATION, gerop);
         slapi_sdn_set_ndn_byval(&gerop->o_sdn, subjectndn);
         geraclpb = acl_get_ext(ACL_EXT_OPERATION, (void *)gerop);

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2072,6 +2072,7 @@ connection_add_operation(Connection *conn, Operation *op)
     Operation **olist = &conn->c_ops;
     int id = conn->c_opsinitiated++;
     PRUint64 connid = conn->c_connid;
+    int32_t ext_count = 0;
     Operation **tmp;
 
     /* slapi_ch_stop_recording(); */
@@ -2083,7 +2084,8 @@ connection_add_operation(Connection *conn, Operation *op)
     op->o_opid = id;
     op->o_connid = connid;
     /* Call the plugin extension constructors */
-    op->o_extension = factory_create_extension(get_operation_object_type(), op, conn);
+    op->o_extension = factory_create_extension(get_operation_object_type(), op, conn, &ext_count);
+    op->o_extension_count = ext_count;
 }
 
 /*

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1820,7 +1820,9 @@ daemon_register_connection()
          * that it may call the constructors or destructors registered
          * with it.
          */
-        connection_type = factory_register_type(SLAPI_EXT_CONNECTION, offsetof(Connection, c_extension));
+        connection_type = factory_register_type(SLAPI_EXT_CONNECTION,
+                                                offsetof(Connection, c_extension),
+                                                offsetof(Connection, c_extension_count));
     }
 }
 
@@ -1844,6 +1846,7 @@ handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *pr_acceptfd, i
     PRFileDesc *pr_clonefd = NULL;
     slapdFrontendConfig_t *fecfg = getFrontendConfig();
     ber_len_t maxbersize;
+    int32_t ext_count = 0;
 
     if (newconn) {
         *newconn = NULL;
@@ -1924,7 +1927,8 @@ handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *pr_acceptfd, i
     connection_reset(conn, ns, &from, sizeof(from), secure);
 
     /* Call the plugin extension constructors */
-    conn->c_extension = factory_create_extension(connection_type, conn, NULL /* Parent */);
+    conn->c_extension = factory_create_extension(connection_type, conn, NULL /* Parent */, &ext_count);
+    conn->c_extension_count = ext_count;
 
 #if defined(ENABLE_LDAPI)
     /* ldapi */

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -1825,7 +1825,10 @@ get_entry_object_type()
          * that it may call the constructors or destructors registered
          * with it.
          */
-        entry_type = factory_register_type(SLAPI_EXT_ENTRY, offsetof(Slapi_Entry, e_extension));
+        entry_type = factory_register_type(SLAPI_EXT_ENTRY,
+                                           offsetof(Slapi_Entry, e_extension),
+                                           offsetof(Slapi_Entry, e_extension_count)
+        );
     }
     return entry_type;
 }
@@ -1849,10 +1852,12 @@ Slapi_Entry *
 slapi_entry_alloc()
 {
     Slapi_Entry *e = (Slapi_Entry *)slapi_ch_calloc(1, sizeof(struct slapi_entry));
+    int32_t ext_count = 0;
     slapi_sdn_init(&e->e_sdn);
     slapi_rdn_init(&e->e_srdn);
 
-    e->e_extension = factory_create_extension(get_entry_object_type(), e, NULL);
+    e->e_extension = factory_create_extension(get_entry_object_type(), e, NULL, &ext_count);
+    e->e_extension_count = ext_count;
     if (!counters_created) {
         PR_CREATE_COUNTER(slapi_entry_counter_created, "Slapi_Entry", "created", "");
         PR_CREATE_COUNTER(slapi_entry_counter_deleted, "Slapi_Entry", "deleted", "");

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -102,7 +102,9 @@ get_operation_object_type()
          * that it may call the constructors or destructors registered
          * with it.
          */
-        operation_type = factory_register_type(SLAPI_EXT_OPERATION, offsetof(Operation, o_extension));
+        operation_type = factory_register_type(SLAPI_EXT_OPERATION,
+                                               offsetof(Operation, o_extension),
+                                               offsetof(Operation, o_extension_count));
     }
     return operation_type;
 }

--- a/ldap/servers/slapd/plugin_internal_op.c
+++ b/ldap/servers/slapd/plugin_internal_op.c
@@ -123,10 +123,14 @@ Slapi_Operation *
 internal_operation_new(unsigned long op_type, int flags)
 {
     Slapi_Operation *op = operation_new(flags | OP_FLAG_INTERNAL /*Internal*/);
+    int32_t ext_count = 0;
     /* set operation type: add, delete, etc */
     operation_set_type(op, op_type);
     /* Call the plugin extension constructors */
-    op->o_extension = factory_create_extension(get_operation_object_type(), op, NULL /* Parent */);
+    op->o_extension = factory_create_extension(get_operation_object_type(),
+                                               op, NULL /* Parent */,
+                                               &ext_count);
+    op->o_extension_count = ext_count;
     return op;
 }
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1366,8 +1366,8 @@ void g_set_global_mrl(struct matchingRuleList *newglobalmrl);
  * factory.c
  */
 
-int factory_register_type(const char *name, size_t offset);
-void *factory_create_extension(int type, void *object, void *parent);
+int factory_register_type(const char *name, size_t offset, size_t count_offset);
+void *factory_create_extension(int type, void *object, void *parent, int32_t *count);
 void factory_destroy_extension(int type, void *object, void *parent, void **extension);
 
 /*

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -835,6 +835,7 @@ struct slapi_entry
                                      to global watermark */
     Slapi_RWLock *e_virtual_lock; /* for access to cached vattrs */
     void *e_extension;            /* A list of entry object extensions */
+    int32_t e_extension_count;    /* factory extension count */
     unsigned char e_flags;
     Slapi_Attr *e_aux_attrs;      /* Attr list used for upgrade */
 };
@@ -1591,6 +1592,7 @@ typedef struct op
     char **o_searchattrs; /* original attr names requested  */ /* JCM - Search Param */
     unsigned long o_flags;                                     /* flags for this operation      */
     void *o_extension;                                         /* plugins are able to extend the Operation object */
+    int32_t o_extension_count;                                 /* The number of factory extensions */
     Slapi_DN *o_target_spec;                                   /* used to decide which plugins should be called for the operation */
     void *o_target_entry;                                      /* Only used for SEARCH operation
                                                                 * reference of search target entry (base search) in the entry cache
@@ -1701,6 +1703,7 @@ typedef struct conn
     struct conn *c_prev;             /* active connections in the table*/
     Slapi_Backend *c_bi_backend;     /* which backend is doing the import */
     void *c_extension;               /* plugins are able to extend the Connection object */
+    int32_t c_extension_count;      /* factory extension count */
     void *c_sasl_conn;               /* sasl library connection sasl_conn_t */
     int c_local_ssf;                 /* flag to tell us the local SSF */
     int c_sasl_ssf;                  /* flag to tell us the SASL SSF */


### PR DESCRIPTION
…mic plugins is enabled

Description:

Our factory extension code was not designed to work with dynamic plugins.  It assumes all extensions are regiestered at startup.  If extensions are added after startup (when dynamic plgun is is enabled) then this breaks.  The fix is to keep track in each "object" how many extensions were allocated, instead of relying on the global extension count.

relates: https://github.com/389ds/389-ds-base/issues/5600
