### PR TITLE
issue 5647 - covscan: memory leak in audit log when adding entries

### DIFF
--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -228,6 +228,7 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
                 addlenstr(l, log_val);
                 addlenstr(l, "\n");
             }
+            charray_free(vals);
         }
     } else {
         /* Return all attributes */


### PR DESCRIPTION
covscan reported an issue about "vals" variable in auditlog.c:231 and indeed a charray_free is missing.

Issue: [5647](https://github.com/389ds/389-ds-base/issues/5647)

Reviewed by: @mreynolds389, @droideck 