### PR TITLE
Issue 5648 - Covscan - Compiler warnings

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl_trim.c
+++ b/ldap/servers/plugins/retrocl/retrocl_trim.c
@@ -423,7 +423,7 @@ retrocl_init_trimming(void)
     const char *cl_maxage;
     time_t ageval = 0; /* Don't trim, by default */
     const char *cl_trim_interval;
-    int trim_interval;
+    int trim_interval = DEFAULT_CHANGELOGDB_TRIM_INTERVAL;
 
     cl_maxage = retrocl_get_config_str(CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE);
     if (cl_maxage) {


### PR DESCRIPTION
Description: A covscan report on 389-ds-base=-2.2.4 reported two compiler warnings.

Defect type: COMPILER_WARNING
389-ds-base-2.2.4/ldap/servers/plugins/retrocl/retrocl_trim.c:458:27: warning[-Wmaybe-uninitialized]: 'trim_interval' may be used uninitialized in this function

Defect type: COMPILER_WARNING
389-ds-base-2.2.4/ldap/servers/plugins/retrocl/retrocl_trim.c:26:40: warning[-Wint-conversion]: initialization of 'int' from 'void *' makes integer from pointer without a cast

One has since been fixed, this is for the remaining one.

relates: https://github.com/389ds/389-ds-base/issues/5648

Reviewed by: