### PR TITLE
Issue 5653 - covscan - fix invalid dereference

### DIFF
--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2021 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -2014,14 +2014,16 @@ log_op_stat(Slapi_PBlock *pb, uint64_t connid, int32_t op_id, int32_t op_interna
     if (config_get_statlog_level() == 0) {
         return;
     }
-
     slapi_pblock_get(pb, SLAPI_OPERATION, &op);
-    internal_op = operation_is_flag_set(op, OP_FLAG_INTERNAL);
-    op_stat = op_stat_get_operation_extension(pb);
-
-    if (op == NULL || op_stat == NULL) {
+    if (op == NULL) {
         return;
     }
+    internal_op = operation_is_flag_set(op, OP_FLAG_INTERNAL);
+    op_stat = op_stat_get_operation_extension(pb);
+    if (op_stat == NULL) {
+        return;
+    }
+
     /* process the operation */
     switch (operation_get_type(op)) {
         case SLAPI_OPERATION_BIND:
@@ -2380,7 +2382,7 @@ encode_read_entry(Slapi_PBlock *pb, Slapi_Entry *e, char **attrs, int alluseratt
 
     if (conn == NULL || op == NULL) {
         slapi_log_err(SLAPI_LOG_ERR, "encode_read_entry",
-                      "NULL param error: conn (0x%p) op (0x%p)\n", conn, op);
+                      "NULL param error: conn (%p) op (%p)\n", conn, op);
         rc = -1;
         goto cleanup;
     }

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2021 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1108,13 +1108,20 @@ _read_line(FILE *file, int *keyword, dbi_val_t *val)
 int
 importdb(const char *dbimpl_name, const char *filename, const char *dump_name)
 {
-    FILE *dump = fopen(dump_name, "r");
+    FILE *dump = NULL;
     dbi_val_t key = {0}, data = {0};
     struct back_txn txn = {0};
     dbi_env_t *env = NULL;
     dbi_db_t *db = NULL;
     int keyword = 0;
     int ret = 0;
+
+    if (dump_name == NULL) {
+        printf("Error: dump_name can not be NULL\n");
+        return 1;
+    }
+
+    dump = fopen(dump_name, "r");
 
     dblayer_init_pvt_txn();
 


### PR DESCRIPTION
Description:

389-ds-base-2.2.4/ldap/servers/slapd/tools/dbscan.c:1111: var_deref_model: Passing null pointer "dump" to "fclose", which dereferences it.

389-ds-base-2.2.4/ldap/servers/slapd/result.c:2022: check_after_deref: Null-checking "op" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.

389-ds-base-2.2.4/ldap/servers/slapd/result.c:2019: var_deref_model: Passing null pointer "op" to "operation_is_flag_set", which dereferences it.

relates: https://github.com/389ds/389-ds-base/issues/5653

