### PR TITLE
Issue 5652 - Libasan crash in replication/cascading_test

### DIFF
--- a/ldap/servers/plugins/replication/repl_extop.c
+++ b/ldap/servers/plugins/replication/repl_extop.c
@@ -483,9 +483,9 @@ free_and_return:
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                 "decode_startrepl_extop - decoded csn: %s\n", *csnstr);
         ruv_dump_to_log(*supplier_ruv, "decode_startrepl_extop");
-        for (size_t i = 0; *extra_referrals && extra_referrals[i]; i++) {
+        for (size_t i = 0; *extra_referrals && (*extra_referrals)[i]; i++) {
             slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "decode_startrepl_extop - "
-                "decoded referral: %s\n", *extra_referrals[i]);
+                "decoded referral: %s\n", (*extra_referrals)[i]);
         }
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                 "decode_startrepl_extop - Finshed decoding payload.\n");


### PR DESCRIPTION
got a crash when running replication/cascading_test on with an asan build. at repl_extop.c:486
And review shows that the code is suspicious.

Issue: [5652](https://github.com/389ds/389-ds-base/issues/5652)

Reviewed by: @mreynolds389 