### PR TITLE
Issue 5658 - CLI - unable to add attribute with matching rule

### DIFF
--- a/dirsrvtests/tests/suites/clu/schema_test.py
+++ b/dirsrvtests/tests/suites/clu/schema_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -97,6 +97,39 @@ def test_origins(topo, name, oid, xorg):
         'no_user_mod': None,
         'equality': None,
         'substr': None,
+        'ordering': None,
+        'usage': None,
+        'sup': None
+    }
+    schema.add_attributetype(parameters)
+
+
+def test_mrs(topo):
+    """Test an attribute can be added with a matching rule
+
+    :id: e4eb06e0-7f80-41fe-8868-08c2bafc7590
+    :setup: Standalone Instance
+    :steps:
+        1. Add an attribute with a matching rule
+    :expectedresults:
+        1. Success
+    """
+    schema = Schema(topo.standalone)
+
+    # Add new attribute
+    parameters = {
+        'names': ['test-mr'],
+        'oid': '99999999',
+        'desc': 'Test matching rule',
+        'syntax': '1.3.6.1.4.1.1466.115.121.1.15',
+        'syntax_len': None,
+        'x_ordered': None,
+        'collective': None,
+        'obsolete': None,
+        'single_value': None,
+        'no_user_mod': None,
+        'equality': None,
+        'substr': 'numericstringsubstringsmatch',
         'ordering': None,
         'usage': None,
         'sup': None

--- a/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
@@ -566,7 +566,7 @@ class AttributeTypeModal extends React.Component {
 
                         <Grid title="An equality matching rule">
                             <GridItem className="ds-label" span={3}>
-                                Equality Matching Rules
+                                Equality Matching Rule
                             </GridItem>
                             <GridItem span={9}>
                                 <Select
@@ -579,7 +579,7 @@ class AttributeTypeModal extends React.Component {
                                     isOpen={isEqualityMROpen}
                                     aria-labelledby="typeAhead-equality-mr"
                                     placeholderText="Type an Equality matching rule..."
-                                    noResultsFoundText="There are no matching entries"
+                                    noResultsFoundText="There are no matching rules"
                                 >
                                     {matchingrules.map((mr, index) => (
                                         <SelectOption
@@ -605,7 +605,7 @@ class AttributeTypeModal extends React.Component {
                                     isOpen={isOrderMROpen}
                                     aria-labelledby="typeAhead-order-mr"
                                     placeholderText="Type an Ordering matching rule.."
-                                    noResultsFoundText="There are no matching entries"
+                                    noResultsFoundText="There are no matching rules"
                                 >
                                     {matchingrules.map((mr, index) => (
                                         <SelectOption
@@ -630,7 +630,7 @@ class AttributeTypeModal extends React.Component {
                                     selections={atSubMr}
                                     isOpen={isSubstringMROpen}
                                     placeholderText="Type a Substring matching rule..."
-                                    noResultsFoundText="There are no matching entries"
+                                    noResultsFoundText="There are no matching rules"
                                 >
                                     {matchingrules.map((mr, index) => (
                                         <SelectOption

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -409,7 +409,7 @@ class FakeArgs(object):
 
 class StdErrFilter(logging.Filter):
     def filter(self, rec):
-        return rec.levelno in (logging.ERROR)
+        return rec.levelno in (logging.ERROR,)
 
 
 def setup_script_logger(name, verbose=False):

--- a/src/lib389/lib389/cli_conf/schema.py
+++ b/src/lib389/lib389/cli_conf/schema.py
@@ -310,14 +310,14 @@ def _add_parser_args(parser, type):
         parser.add_argument('--user-mod', action='store_true',
                             help='True if the attribute is modifiable by a client application (default)'
                                  'Only one of the flags this or --no-user-mode should be specified')
-        parser.add_argument('--equality', nargs='+',
-                            help='NAME or OID of the matching rules used for checking'
+        parser.add_argument('--equality',
+                            help='NAME or OID of the matching rule used for checking'
                                  'whether attribute values are equal')
-        parser.add_argument('--substr', nargs='+',
-                            help='NAME or OID of the matching rules used for checking'
+        parser.add_argument('--substr',
+                            help='NAME or OID of the matching rule used for checking'
                                  'whether an attribute value contains another value')
-        parser.add_argument('--ordering', nargs='+',
-                            help='NAME or OID of the matching rules used for checking'
+        parser.add_argument('--ordering',
+                            help='NAME or OID of the matching rule used for checking'
                                  'whether attribute values are lesser - equal than')
         parser.add_argument('--usage',
                             help='The flag indicates how the attribute type is to be used. Choose from the list: '


### PR DESCRIPTION
Description:  dsconf incorrectly allows for multiple matching rules of the same type (equality, substr, etc).  This causes python-ldap to get upset and error out.  Change arguments to only allow one matching rule per type.

relates: https://github.com/389ds/389-ds-base/issues/5658
