### PR TITLE
Issue 5646 - CLI/UI - do not hardcode password storage schemes

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -100,6 +100,7 @@ export class Database extends React.Component {
             BackupRows: [],
             backupRefreshing: false,
             suffixList: [],
+            pwdStorageSchemes: [],
             loaded: false,
         };
 
@@ -111,6 +112,7 @@ export class Database extends React.Component {
         this.loadLDIFs = this.loadLDIFs.bind(this);
         this.loadBackups = this.loadBackups.bind(this);
         this.loadSuffixList = this.loadSuffixList.bind(this);
+        this.loadPwdStorageSchemes = this.loadPwdStorageSchemes.bind(this);
 
         // Suffix
         this.handleShowSuffixModal = this.handleShowSuffixModal.bind(this);
@@ -144,6 +146,7 @@ export class Database extends React.Component {
                     this.loadLDIFs();
                     this.loadBackups();
                     this.loadSuffixList();
+                    this.loadPwdStorageSchemes();
                 }
                 this.loadSuffixTree(false);
             } else {
@@ -166,6 +169,22 @@ export class Database extends React.Component {
                     const suffixList = JSON.parse(content);
                     this.setState(() => (
                         { suffixList: suffixList.items }
+                    ));
+                });
+    }
+
+    loadPwdStorageSchemes () {
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "pwpolicy", "list-schemes"
+        ];
+        log_cmd("loadPwdStorageSchemes", "Get a list of all the password storage sehemes", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const schemes = JSON.parse(content);
+                    this.setState(() => (
+                        { pwdStorageSchemes: schemes.items }
                     ));
                 });
     }
@@ -1222,6 +1241,7 @@ export class Database extends React.Component {
                         serverId={this.props.serverId}
                         addNotification={this.props.addNotification}
                         attrs={this.state.attributes}
+                        pwdStorageSchemes={this.state.pwdStorageSchemes}
                         enableTree={this.enableTree}
                     />;
             } else if (this.state.node_name === LOCAL_PWP_CONFIG) {
@@ -1230,6 +1250,7 @@ export class Database extends React.Component {
                         serverId={this.props.serverId}
                         addNotification={this.props.addNotification}
                         attrs={this.state.attributes}
+                        pwdStorageSchemes={this.state.pwdStorageSchemes}
                         enableTree={this.enableTree}
                     />;
             } else if (this.state.node_name === BACKUP_CONFIG) {

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1364,19 +1364,13 @@ export class GlobalPwPolicy extends React.Component {
                                             }}
                                             aria-label="FormSelect Input"
                                         >
-                                            <FormSelectOption key="0" value="PBKDF2_SHA256" label="PBKDF2_SHA256" />
-                                            <FormSelectOption key="1" value="SSHA512" label="SSHA512" />
-                                            <FormSelectOption key="2" value="SSHA384" label="SSHA384" />
-                                            <FormSelectOption key="3" value="SSHA256" label="SSHA256" />
-                                            <FormSelectOption key="4" value="SSHA" label="SSHA" />
-                                            <FormSelectOption key="5" value="MD5" label="MD5" />
-                                            <FormSelectOption key="6" value="SMD5" label="SMD5" />
-                                            <FormSelectOption key="7" value="CRYPT-MD5" label="CRYPT-MD5" />
-                                            <FormSelectOption key="8" value="CRYPT-SHA512" label="CRYPT-SHA512" />
-                                            <FormSelectOption key="9" value="CRYPT-SHA256" label="CRYPT-SHA256" />
-                                            <FormSelectOption key="10" value="CRYPT" label="CRYPT" />
-                                            <FormSelectOption key="11" value="GOST_YESCRYPT" label="GOST_YESCRYPT" />
-                                            <FormSelectOption key="12" value="CLEAR" label="CLEAR" />
+                                            {this.props.pwdStorageSchemes.map((option, index) => (
+                                                <FormSelectOption
+                                                    key={index}
+                                                    value={option}
+                                                    label={option}
+                                                />
+                                            ))}
                                         </FormSelect>
                                     </GridItem>
                                 </Grid>
@@ -1635,8 +1629,10 @@ export class GlobalPwPolicy extends React.Component {
 
 GlobalPwPolicy.propTypes = {
     attrs: PropTypes.array,
+    pwdStorageSchemes: PropTypes.array,
 };
 
 GlobalPwPolicy.defaultProps = {
     attrs: [],
+    pwdStorageSchemes: []
 };

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -1,12 +1,13 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2018 William Brown <william@blackhats.net.au>
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-from lib389.plugins import Plugin
+from lib389.plugins import Plugin, Plugins
 from lib389._constants import DN_PWDSTORAGE_SCHEMES
 
 
@@ -53,3 +54,12 @@ class CRYPTPlugin(PasswordPlugin):
 class SSHAPlugin(PasswordPlugin):
     def __init__(self, instance, dn=f'cn=SSHA,{DN_PWDSTORAGE_SCHEMES}'):
         super(SSHAPlugin, self).__init__(instance, dn)
+
+
+class PasswordPlugins(Plugins):
+    def __init__(self, instance):
+        super(PasswordPlugins, self).__init__(instance=instance)
+        self._objectclasses = ['nsSlapdPlugin']
+        self._filterattrs = ['cn']
+        self._childobject = PasswordPlugin
+        self._basedn = DN_PWDSTORAGE_SCHEMES


### PR DESCRIPTION
Description:  

Previously all the password storage schemes were hardcoded in the UI.  Now dsconf can list all the current schemes the server supports

relates: https://github.com/389ds/389-ds-base/issues/5636

