### PR TITLE
Issue 5162 - Lib389 - verify certificate type before adding

### DIFF
--- a/dirsrvtests/tests/suites/export/export_test.py
+++ b/dirsrvtests/tests/suites/export/export_test.py
@@ -63,7 +63,7 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
     topo.standalone.stop()
 
     log.info("Performing an offline export to a non accessible ldif file path - should fail properly")
-    expected_output="db2ldif failed"
+    expected_output="The LDIF file location does not exist"
     with pytest.raises(ValueError) as e:
         run_db2ldif_and_clear_logs(topo, topo.standalone, DEFAULT_BENAME, export_ldif, expected_output)
     assert "The LDIF file location does not exist" in str(e.value)

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -232,6 +232,7 @@ BuildRequires:    python%{python3_pkgversion}-argcomplete
 BuildRequires:    python%{python3_pkgversion}-argparse-manpage
 BuildRequires:    python%{python3_pkgversion}-policycoreutils
 BuildRequires:    python%{python3_pkgversion}-libselinux
+BuildRequires:    python%{python3_pkgversion}-cryptography
 
 # For cockpit
 %if %{use_cockpit}
@@ -386,6 +387,7 @@ Requires: python%{python3_pkgversion}-dateutil
 Requires: python%{python3_pkgversion}-argcomplete
 Requires: python%{python3_pkgversion}-libselinux
 Requires: python%{python3_pkgversion}-setuptools
+Requires: python%{python3_pkgversion}-cryptography
 Recommends: bash-completion
 %{?python_provide:%python_provide python%{python3_pkgversion}-lib389}
 

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -16,15 +16,15 @@ import socket
 import time
 import shutil
 import logging
-# from nss import nss
 import subprocess
+import uuid
 from datetime import datetime, timedelta
 from subprocess import check_output, run, PIPE
 from lib389.passwd import password_generate
 from lib389._mapped_object_lint import DSLint
 from lib389.lint import DSCERTLE0001, DSCERTLE0002
-from lib389.utils import ensure_str, format_cmd_list, DSVersion
-import uuid
+from lib389.utils import ensure_str, format_cmd_list, DSVersion, cert_is_ca
+
 
 KEYBITS = 4096
 CA_NAME = 'Self-Signed-CA'
@@ -1149,8 +1149,14 @@ only.
             self._assert_not_chain(input_file)
 
         if ca:
+            # Verify this is a CA cert
+            if not cert_is_ca(input_file):
+                raise ValueError(f"Certificate ({nickname}) is not a CA certificate")
             trust_flags = "CT,,"
         else:
+            # Verify this is a server cert
+            if cert_is_ca(input_file):
+                raise ValueError(f"Certificate ({nickname}) is not a server certificate")
             trust_flags = ",,"
 
         cmd = [
@@ -1271,6 +1277,13 @@ only.
                                 names_len = len(nicknames)
                                 if names_len > ca_count:
                                     if nicknames[ca_count].lower() == CERT_NAME.lower() or nicknames[ca_count].lower() == CA_NAME.lower():
+                                        # cleanup
+                                        try:
+                                            for tmp_file in ca_files_to_cleanup:
+                                                os.remove(tmp_file)
+                                        except IOError as e:
+                                            # failed to remove tmp cert
+                                            log.debug("Failed to remove tmp cert file: " + str(e))
                                         raise ValueError(f"You may not import a CA with the nickname {CERT_NAME} or {CA_NAME}")
                                     ca_cert_name = nicknames[ca_count]
                                 else:
@@ -1290,21 +1303,36 @@ only.
                                     try:
                                         for tmp_file in ca_files_to_cleanup:
                                             os.remove(tmp_file)
-                                    except IOError:
+                                    except IOError as e:
                                         # failed to remove tmp cert
-                                        log.debug("Failed to remove tmp cert file")
-                                        pass
+                                        log.debug("Failed to remove tmp cert file: " + str(e))
                                     raise ValueError(f"Certificate already exists with the same name ({ca_cert_name})")
+
+                                # Verify this is a CA cert
+                                if not cert_is_ca(ca_file_name):
+                                    raise ValueError(f"Certificate ({ca_cert_name}) is not a CA certificate")
 
                                 # Add this CA certificate
                                 self.add_cert(ca_cert_name, ca_file_name, ca=True)
                                 ca_count += 1
                                 log.info(f"Successfully added CA certificate ({ca_cert_name})")
+
+                    # All done, cleanup
+                    try:
+                        for tmp_file in ca_files_to_cleanup:
+                            os.remove(tmp_file)
+                    except IOError as e:
+                        # failed to remove tmp cert
+                        log.debug("Failed to remove tmp cert file: " + str(e))
                 except IOError as e:
                     # Some failure, remove all the tmp files
                     ca_file.close()
-                    for tmp_file in ca_file_to_cleanup:
-                        os.remove(tmp_file)
+                    try:
+                        for tmp_file in ca_files_to_cleanup:
+                            os.remove(tmp_file)
+                    except IOError as e:
+                        # failed to remove tmp cert
+                        log.debug("Failed to remove tmp cert file: " + str(e))
                     raise e
         except EnvironmentError as e:
             raise e

--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -6,3 +6,4 @@ argparse-manpage
 python-ldap
 setuptools
 distro
+cryptography

--- a/src/lib389/setup.py
+++ b/src/lib389/setup.py
@@ -32,7 +32,7 @@ with open(path.join(here, 'README.md'), 'r') as f:
     long_description = f.read()
 
 #
-# For some historical reason when using prefix install 
+# For some historical reason when using prefix install
 #  files that should be in /usr/sbin/, /usr/share/ are
 #  in $PREFIX/sbin, $PREFIX/share
 # So lets mimick this behavior
@@ -100,6 +100,7 @@ setup(
         'python-ldap',
         'setuptools',
         'distro',
+        'cryptography'
         ],
 
     cmdclass={


### PR DESCRIPTION
Description: 

Verify that when importing a certificate that is the correct type.  Also cleanup temporary certs that are created when processing a bundle of certs in a PEM file.

relates: https://github.com/389ds/389-ds-base/issues/5162

