### PR TITLE
Issue 5567 - CLI - make ldifgen use the same default ldif name for all options

### DIFF
--- a/src/lib389/lib389/cli_ctl/dbgen.py
+++ b/src/lib389/lib389/cli_ctl/dbgen.py
@@ -17,8 +17,8 @@ from lib389.dbgen import (
 )
 from lib389.utils import is_a_dn
 
-DEFAULT_LDIF = "/tmp/ldifgen.ldif"
-USERS_LDIF_NAME = "/users.ldif"
+DEFAULT_LDIF = "/ldifgen.ldif"
+
 ignore_args = [
     "ldif_file",
     "func",
@@ -29,14 +29,12 @@ ignore_args = [
     "remove_all",
 ]
 
+
 def get_ldif_dir(instance):
     """
-    Get the server's LDIF directory.  This is only used for user & nested LDIFs
+    Get the server's LDIF directory.
     """
-    server_dir = instance.get_ldif_dir()
-    if server_dir is not None:
-        return server_dir
-    return DEFAULT_LDIF
+    return instance.get_ldif_dir()
 
 
 def adjust_ldif_name(instance, ldif_name):
@@ -186,7 +184,7 @@ def dbgen_create_users(inst, log, args):
         args.localize = get_input(log, "Do you want to localize the LDIF data (yes/no)", False, "bool")
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + USERS_LDIF_NAME)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         args.ldif_file = adjust_ldif_name(inst, args.ldif_file)
         validate_ldif_file(args.ldif_file)
@@ -230,7 +228,7 @@ def dbgen_create_groups(inst, log, args):
             args.member_parent = get_input(log, "Enter the parent entry to add the users under", args.suffix, "dn")
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         validate_ldif_file(args.ldif_file)
 
@@ -285,7 +283,7 @@ def dbgen_create_cos_def(inst, log, args):
             args.cos_attr.append(val)
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         validate_ldif_file(args.ldif_file)
 
@@ -324,7 +322,7 @@ def dbgen_create_cos_tmp(inst, log, args):
         args.cos_attr_val = get_input(log, "Enter the attribute and value pair.  Use this format: \"ATTRIBUTE:VALUE\"", "postalcode:19605")
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         validate_ldif_file(args.ldif_file)
 
@@ -373,7 +371,7 @@ def dbgen_create_role(inst, log, args):
                 args.role_dn.append(val)
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         validate_ldif_file(args.ldif_file)
 
@@ -444,7 +442,7 @@ def dbgen_create_mods(inst, log, args):
         args.randomize = get_input(log, "Randomly perform the specified add, mod, delete, and modrdn operations (yes/no)", True, "bool")
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         validate_ldif_file(args.ldif_file)
 
@@ -484,7 +482,7 @@ def dbgen_create_nested(inst, log, args):
         args.suffix = get_input(log, "Enter the suffix", "dc=example,dc=com", "dn")
 
         # Get the output LDIF file name
-        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + USERS_LDIF_NAME)
+        args.ldif_file = get_ldif_file_input(log, default_name=get_ldif_dir(inst) + DEFAULT_LDIF)
     else:
         args.ldif_file = adjust_ldif_name(inst, args.ldif_file)
         validate_ldif_file(args.ldif_file)
@@ -514,7 +512,7 @@ def create_parser(subparsers):
     dbgen_users_parser.add_argument('--start-idx', default=0, help="For generic LDIF's you can choose the starting index for the user entries.  The default is \"0\".")
     dbgen_users_parser.add_argument('--rdn-cn', action='store_true', help="Use the attribute \"cn\" as the RDN attribute in the DN instead of \"uid\"")
     dbgen_users_parser.add_argument('--localize', action='store_true', help="Localize the LDIF data")
-    dbgen_users_parser.add_argument('--ldif-file', default="users.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'users.ldif'")
+    dbgen_users_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create static groups
     dbgen_groups_parser = subcommands.add_parser('groups', help='Generate a LDIF containing groups and members')
@@ -527,7 +525,7 @@ def create_parser(subparsers):
     dbgen_groups_parser.add_argument('--create-members', action='store_true', help="Create the member user entries.")
     dbgen_groups_parser.add_argument('--member-parent', help="The entry DN that the members should be created under.  The default is the suffix entry.")
     dbgen_groups_parser.add_argument('--member-attr', default="uniquemember", help="The membership attribute to use in the group.  Default is \"uniquemember\".")
-    dbgen_groups_parser.add_argument('--ldif-file', default=DEFAULT_LDIF, help=f"The LDIF file name.  Default is \"{DEFAULT_LDIF}\"")
+    dbgen_groups_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create a COS definition
     dbgen_cos_def_parser = subcommands.add_parser('cos-def', help='Generate a LDIF containing a COS definition (classic, pointer, or indirect)')
@@ -539,7 +537,7 @@ def create_parser(subparsers):
     dbgen_cos_def_parser.add_argument('--cos-specifier', help="Used in a classic COS definition, this attribute located in the user entry is used to select which COS template to use.")
     dbgen_cos_def_parser.add_argument('--cos-template', help="The DN of the COS template entry, only used for \"classic\" and \"pointer\" COS definitions.")
     dbgen_cos_def_parser.add_argument('--cos-attr', nargs='*', default=[], help="A list of attributes which defines which attribute the COS generates values for.")
-    dbgen_cos_def_parser.add_argument('--ldif-file', default=DEFAULT_LDIF, help=f"The LDIF file name.  Default is \"{DEFAULT_LDIF}\"")
+    dbgen_cos_def_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create a COS Template
     dbgen_cos_tmp_parser = subcommands.add_parser('cos-template', help='Generate a LDIF containing a COS template')
@@ -549,7 +547,7 @@ def create_parser(subparsers):
     dbgen_cos_tmp_parser.add_argument('--create-parent', action='store_true', help="Create the parent entry")
     dbgen_cos_tmp_parser.add_argument('--cos-priority', type=int, help="Sets the priority of this conflicting/competing COS templates.")
     dbgen_cos_tmp_parser.add_argument('--cos-attr-val', help="defines the attribute and value that the template provides.")
-    dbgen_cos_tmp_parser.add_argument('--ldif-file', default=DEFAULT_LDIF, help=f"The LDIF file name.  Default is \"{DEFAULT_LDIF}\"")
+    dbgen_cos_tmp_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create Role entries
     dbgen_roles_parser = subcommands.add_parser('roles', help='Generate a LDIF containing a role entry (managed, filtered, or indirect)')
@@ -560,7 +558,7 @@ def create_parser(subparsers):
     dbgen_roles_parser.add_argument('--create-parent', action='store_true', help="Create the parent entry")
     dbgen_roles_parser.add_argument('--filter', help="A search filter for gathering Role members.  Required for a \"filtered\" role.")
     dbgen_roles_parser.add_argument('--role-dn', nargs='*', default=[], help="A DN of a role entry that should be included in this role.  Used for \"nested\" roles only.")
-    dbgen_roles_parser.add_argument('--ldif-file', default=DEFAULT_LDIF, help=f"The LDIF file name.  Default is \"{DEFAULT_LDIF}\"")
+    dbgen_roles_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create a modification LDIF
     dbgen_mod_load_parser = subcommands.add_parser('mod-load', help='Generate a LDIF containing modify operations.  This is intended to be consumed by ldapmodify.')
@@ -576,7 +574,7 @@ def create_parser(subparsers):
     dbgen_mod_load_parser.add_argument('--mod-users', default=100, help="The number of entries to modify.")
     dbgen_mod_load_parser.add_argument('--mod-attrs', nargs="*", default=['description'], help="List of attributes the script will randomly choose from when modifying an entry.  The default is \"description\".")
     dbgen_mod_load_parser.add_argument('--randomize', action='store_true', help="Randomly perform the specified add, mod, delete, and modrdn operations")
-    dbgen_mod_load_parser.add_argument('--ldif-file', default=DEFAULT_LDIF, help=f"The LDIF file name.  Default is \"{DEFAULT_LDIF}\"")
+    dbgen_mod_load_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")
 
     # Create a heavily nested LDIF
     dbgen_nested_parser = subcommands.add_parser('nested', help='Generate a heavily nested database LDIF in a cascading/fractal tree design')
@@ -584,4 +582,4 @@ def create_parser(subparsers):
     dbgen_nested_parser.add_argument('--num-users', help="The total number of user entries to create in the entire LDIF (does not include the container entries).")
     dbgen_nested_parser.add_argument('--node-limit', help="The total number of user entries to create under each node/subtree")
     dbgen_nested_parser.add_argument('--suffix', help="The suffix DN for the LDIF")
-    dbgen_nested_parser.add_argument('--ldif-file', default="nested-users.ldif",  help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'users.ldif'")
+    dbgen_nested_parser.add_argument('--ldif-file', default="ldifgen.ldif", help=f"The LDIF file name.  Default location is the server's LDIF directory using the name 'ldifgen.ldif'")


### PR DESCRIPTION
Description:  

For consistency just use the server's ldif directory for all the default ldif locations

relates: https://github.com/389ds/389-ds-base/issues/5667

