### PR TITLE
Issue 5647 - Fix unused variable warning from previous commit

### DIFF
--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -250,7 +250,6 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
             if (entry_attr) {
                 log_entry_attr(entry_attr, req_attr, l);
             }
-            charray_free(vals);
         }
     } else {
         /* Return all attributes */

--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -250,6 +250,7 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
             if (entry_attr) {
                 log_entry_attr(entry_attr, req_attr, l);
             }
+            charray_free(vals);
         }
     } else {
         /* Return all attributes */

--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -254,7 +254,6 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
     } else {
         /* Return all attributes */
         for (; entry_attr; entry_attr = entry_attr->a_next) {
-            Slapi_Value **vals = attr_get_present_values(entry_attr);
             char *attr = NULL;
 
             slapi_attr_get_type(entry_attr, &attr);


### PR DESCRIPTION
A simple 1 line commit to remove an useless line.