### PR TITLE
Issue 5162 - CI - fix error message for invalid pem file

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
@@ -45,7 +45,7 @@ def test_tls_command_returns_error_text(topo):
         assert '255' not in str(e)
         assert 'improperly formatted name' in str(e)
 
-   # dsctl localhost tls remove-cert
+    # dsctl localhost tls remove-cert
     try:
         tls.del_cert("bad")
         assert False
@@ -60,7 +60,7 @@ def test_tls_command_returns_error_text(topo):
         assert False
     except ValueError as e:
         assert '255' not in str(e)
-        assert 'could not decode certificate' in str(e)
+        assert 'Unable to load PEM file' in str(e)
 
     # dsctl localhost tls import-server-cert
     try:


### PR DESCRIPTION
Description:  

With recent changes to certificate validation the error message has changed and the CI needs to be updated.

relates: https://github.com/389ds/389-ds-base/issues/5162

