### PR TITLE
Issue 5598 - (3rd) In 2.x, SRCH throughput drops by 10% because of ha…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -259,11 +259,6 @@ ldbm_instance_start(backend *be)
     }
 
     rc = dblayer_instance_start(be, DBLAYER_NORMAL_MODE);
-    if (slapi_exist_referral(be)) {
-        slapi_be_set_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
-    } else {
-        slapi_be_unset_flag(be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
-    }
     be->be_state = BE_STATE_STARTED;
 
     PR_Unlock(be->be_state_lock);
@@ -318,6 +313,11 @@ ldbm_instance_startall(struct ldbminfo *li)
             ldbm_instance_register_modify_callback(inst);
             vlv_init(inst);
             slapi_mtn_be_started(inst->inst_be);
+        }
+        if (slapi_exist_referral(inst->inst_be)) {
+            slapi_be_set_flag(inst->inst_be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
+        } else {
+            slapi_be_unset_flag(inst->inst_be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);
         }
         inst_obj = objset_next_obj(li->li_instance_set, inst_obj);
     }


### PR DESCRIPTION
…ndling of referral

Bug description:
        The first fix 5598 logs a single and useless message (INFO)
	when configuring a backend/mapping tree.
	"INFO - slapd_daemon - New referral entries are detected under
        dc=example,dc=com (returned to SRCH req)"
	The reason is that it checks referral (internal search)
	at the backend level. This is called at startup and config.
	Upon config it should not be called because backend/
	mapping tree are not ready for internal search

Fix description:
	Moving the test from ldbm_instance_start(backend) to
	startup ldbm_instance_startall (after slapi_mtn_be_started)

relates:  #5598

Reviewed by: Mark Reynolds