### PR TITLE
Issue 5697 - Obsolete nsslapd-ldapimaprootdn attribute

### DIFF
--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -23,7 +23,6 @@ nsslapd-rootpw: %ds_passwd%
 nsslapd-ldapilisten: %ldapi_enabled%
 nsslapd-ldapifilepath: %ldapi%
 nsslapd-ldapiautobind: %ldapi_autobind%
-nsslapd-ldapimaprootdn: %rootdn%
 
 dn: cn=auto_bind,cn=config
 objectclass: top

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -24,7 +24,6 @@ nsslapd-rootpw: %ds_passwd%
 nsslapd-ldapilisten: %ldapi_enabled%
 nsslapd-ldapifilepath: %ldapi%
 nsslapd-ldapiautobind: %ldapi_autobind%
-nsslapd-ldapimaprootdn: %rootdn%
 
 dn: cn=encryption,cn=config
 objectClass: top

--- a/ldap/ldif/template-ldapi-autobind.ldif.in
+++ b/ldap/ldif/template-ldapi-autobind.ldif.in
@@ -3,9 +3,6 @@ changetype: modify
 replace: nsslapd-ldapiautobind
 nsslapd-ldapiautobind: on
 -
-replace: nsslapd-ldapimaprootdn
-nsslapd-ldapimaprootdn: %rootdn%
--
 replace: nsslapd-ldapimaptoentries
 nsslapd-ldapimaptoentries: off
 -

--- a/ldap/servers/slapd/ldapi.c
+++ b/ldap/servers/slapd/ldapi.c
@@ -321,7 +321,7 @@ slapd_bind_local_user(Connection *conn)
 
         if (ret && (0 == uid || proc_uid == uid || proc_gid == gid)) {
             /* map unix root (uidNumber:0)? */
-            char *root_dn = config_get_ldapi_root_dn();
+            char *root_dn = config_get_rootdn();
 
             if (root_dn) {
                 Slapi_PBlock *entry_pb = NULL;

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -2775,6 +2775,9 @@ config_set_ldapi_root_dn(const char *attrname, char *value, char *errorbuf, int 
     }
 
     if (apply) {
+        slapi_log_err(SLAPI_LOG_WARNING, "config_set_ldapi_root_dn",
+                "The \"nsslapd-ldapimaprootdn\" setting is obsolete and kept for compatibility reasons. "
+                "For LDAPI configuration, \"nsslapd-rootdn\" is used instead.\n");
         CFG_LOCK_WRITE(slapdFrontendConfig);
 
         slapi_ch_free((void **)&(slapdFrontendConfig->ldapi_root_dn));

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2628,7 +2628,7 @@ typedef struct _slapdFrontendConfig
     char *ldapi_filename;                 /* filename for ldapi socket */
     slapi_onoff_t ldapi_switch;           /* switch to turn ldapi on/off */
     slapi_onoff_t ldapi_bind_switch;      /* switch to turn ldapi auto binding on/off */
-    char *ldapi_root_dn;                  /* DN to map root to over LDAPI */
+    char *ldapi_root_dn;                  /* DN to map root to over LDAPI. Obsolete setting. rootds is used instead */
     slapi_onoff_t ldapi_map_entries;      /* turns ldapi entry bind mapping on/off */
     char *ldapi_uidnumber_type;           /* type that contains uid number */
     char *ldapi_gidnumber_type;           /* type that contains gid number */

--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -73,7 +73,7 @@ const staticStates = {
         <TextContent>
             <Text className="ds-margin-top-xlg ds-indent-md" component={TextVariants.h2}>
                 Problem accessing required server configuration. Check LDAPI is properly
-                configured for the current Root DN (nsslapd-rootdn & nsslapd-ldapimaprootdn).
+                configured on this instance.
             </Text>
         </TextContent>
     )

--- a/src/cockpit/389-console/src/lib/server/ldapi.jsx
+++ b/src/cockpit/389-console/src/lib/server/ldapi.jsx
@@ -340,7 +340,7 @@ export class ServerLDAPI extends React.Component {
                             />
                         </GridItem>
                     </Grid>
-                    <Grid title="Map the Unix root entry to this Directory Manager DN (nsslapd-ldapimaprootdn).  The UI requires this to be set to the current root DN so it is a read-only setting.">
+                    <Grid title="Map the Unix root entry to this Directory Manager DN (nsslapd-ldapimaprootdn).  The UI requires this to be set to the current root DN so it is a read-only setting. The attribute is obsolete. Current root DN is used.">
                         <GridItem className="ds-label" span={3}>
                             LDAPI Map To Root DN
                         </GridItem>

--- a/src/lib389/lib389/cli_conf/config.py
+++ b/src/lib389/lib389/cli_conf/config.py
@@ -16,6 +16,15 @@ from lib389.cli_base import (
     )
 
 
+def _config_display_ldapimaprootdn_warning(log, args):
+    """If we update the rootdn we need to update the ldapi settings too"""
+
+    for attr in args.attr:
+        if attr.lower().startswith('nsslapd-ldapimaprootdn='):
+            log.warning("The \"nsslapd-ldapimaprootdn\" setting is obsolete and kept for compatibility reasons. "
+                        "For LDAPI configuration, \"nsslapd-rootdn\" is used instead.")
+
+
 def config_get(inst, basedn, log, args):
     if args and args.attrs:
         _generic_get_attr(inst, basedn, log.getChild('config_get'), Config, args)
@@ -27,17 +36,14 @@ def config_get(inst, basedn, log, args):
 def config_add_attr(inst, basedn, log, args):
     _generic_add_attr(inst, basedn, log.getChild('config_add_attr'), Config, args)
 
+    _config_display_ldapimaprootdn_warning(log, args)
+
 
 def config_replace_attr(inst, basedn, log, args):
     _generic_replace_attr(inst, basedn, log.getChild('config_replace_attr'), Config, args)
 
-    # If we update the rootdn we need to update the ldapi settings too
-    for attr in args.attr:
-        if attr.startswith('nsslapd-rootdn='):
-            [rootdn_attr, rootdn_val] = attr.split("=", 1)
-            args.attr = ['nsslapd-ldapimaprootdn=' + rootdn_val]
-            _generic_replace_attr(inst, basedn, log.getChild('config_get'),
-                                  Config, args)
+    _config_display_ldapimaprootdn_warning(log, args)
+
 
 def config_del_attr(inst, basedn, log, args):
     _generic_del_attr(inst, basedn, log.getChild('config_del_attr'), Config, args)


### PR DESCRIPTION
Description: LDAPI code uses nsslapd-ldapimaprootdn to map Unix root entry to a Root DN entry. It usually has the same value as nsslapd-rootdn. Changing one attribute but not changing the other leads to a non-functional autobind configuration that breaks dsconf and WebUI.

LDAPI code should use nsslapd-rootdn value instead of having two separate entries that should be kept in sync. This should make changing Root DN simpler and without fear that it will break dsconf or WebUI access.

Fixes: https://github.com/389ds/389-ds-base/issues/5697

Reviewed by: ?