### PR TITLE
Issue 5700 - SRCH performance drop 2.0 vs 1.4

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -804,7 +804,8 @@ typedef struct _back_search_result_set
     Slapi_Filter *sr_norm_filter; /* search filter pre-normalized */
     Slapi_Filter *sr_norm_filter_intent; /* intended search filter pre-normalized */
 } back_search_result_set;
-#define SR_FLAG_MUST_APPLY_FILTER_TEST 1 /* If set in sr_flags, means that we MUST apply the filter test */
+#define SR_FLAG_CAN_SKIP_FILTER_TEST 1 /* If set in sr_flags, means that we can safely skip the filter test */
+#define SR_FLAG_MUST_APPLY_FILTER_TEST 2 /* If set in sr_flags, means that we MUST apply the filter test */
 
 #include "proto-back-ldbm.h"
 #include "ldbm_config.h"

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -902,7 +902,7 @@ list_candidates(
              * and allids - we should not process anymore, and fallback to full
              * table scan at this point.
              */
-                slapi_log_err(SLAPI_LOG_TRACE, "list_candidates", "OR shortcut condition - must apply filter test\n");
+            slapi_log_err(SLAPI_LOG_FILTER, "list_candidates", "OR shortcut condition - must apply filter test\n");
             sr->sr_flags |= SR_FLAG_MUST_APPLY_FILTER_TEST;
             goto apply_set_op;
         }
@@ -912,7 +912,7 @@ list_candidates(
              * If we encounter a zero length idl, we bail now because this can never
              * result in a meaningful result besides zero.
              */
-            slapi_log_err(SLAPI_LOG_TRACE, "list_candidates", "AND shortcut condition - must apply filter test\n");
+            slapi_log_err(SLAPI_LOG_FILTER, "list_candidates", "AND shortcut condition - must apply filter test\n");
             sr->sr_flags |= SR_FLAG_MUST_APPLY_FILTER_TEST;
             goto apply_set_op;
         }

--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -770,12 +770,6 @@ slapi_vattr_filter_test_ext(
     int rc = 0; /* a no op request succeeds */
     int access_check_done = 0;
 
-    if (only_check_access != 0) {
-        slapi_log_err(SLAPI_LOG_ERR, "slapi_vattr_filter_test_ext",
-            "⚠️  DANGER ⚠️  - only_check_access mode is BROKEN!!! YOU MUST CHECK ACCESS WITH FILTER MATCHING");
-    }
-    PR_ASSERT(only_check_access == 0);
-
     /* Fix for ticket 48275
      * If we want to handle or components which can contain nonmatching components without access propoerly
      * always filter verification and access check have to be done together for each component
@@ -1028,6 +1022,8 @@ vattr_test_filter_list_or(
                 continue;
             }
         }
+        if (only_check_access)
+            continue;
         /* now check if filter matches */
         /*
          * We can NOT skip this because we need to know if the item we matched on


### PR DESCRIPTION
Bug description:
	The commit 40563667e12da3042ea5a0e3771c1e1db1dafa06
	force the evaluation of the filter before returning
	entries. This evaluation can be skipped in case
	of indexed search and filter syntax without OR
	(sr_flags ~SR_FLAG_MUST_APPLY_FILTER_TEST).
	The consequence of the fix is a severe drop of
	search performance.
	The testcase provided with the commit are PASS
	without part of the original fix

Fix description:
	Revert parts of the fix.
	This patch intend to identify new testcase
	that confirm the need to force the evaluation
	of the filter

relates: #5700

Reviewed by: