### PR TITLE
Issue 4812 - Listener thread does not scale with a high num of established connections

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -129,8 +129,8 @@ connection_table_new(int table_size)
     int free_idx = 0;
     ber_len_t maxbersize = config_get_maxbersize();
     ct = (Connection_Table *)slapi_ch_calloc(1, sizeof(Connection_Table));
-    ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
     ct->list_num = config_get_num_listeners();
+    ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
     ct->size = table_size - (table_size % ct->list_num);
     ct->list_size = ct->size/ct->list_num;
     ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));


### PR DESCRIPTION
Bug description: Latest commit introduced zero alloc bug.

Fix description: Memory allocation of a buffer that tracks the number of 
                            active connections per list is attempted before we retrieve 
                            the number of lists value from config. Copy and paste error 
                            introduced during rework. 

relates:  https://github.com/389ds/389-ds-base/issues/4812

Reviewed by: