### PR TITLE
Issue 5701 - CLI - Fix referral mode setting

### DIFF
--- a/src/cockpit/389-console/src/lib/database/referrals.jsx
+++ b/src/cockpit/389-console/src/lib/database/referrals.jsx
@@ -272,7 +272,7 @@ export class SuffixReferrals extends React.Component {
                     spinning={this.state.modalSpinning}
                     item={this.state.removeRef}
                     checked={this.state.modalChecked}
-                    mTitle="Delete Refferal"
+                    mTitle="Delete Referral"
                     mMsg="Are you sure you want to delete this referral?"
                     mSpinningMsg="Deleting ..."
                     mBtnName="Delete"

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -1486,9 +1486,17 @@ class CompositeDSLdapObject(DSLdapObject):
         idx = self._find_idx(key)[-1]
         return self._entries[idx].get_attr_vals(key, use_json)
 
+    def get_attr_vals_utf8(self, key, use_json=False):
+        idx = self._find_idx(key)[-1]
+        return self._entries[idx].get_attr_vals_utf8(key, use_json)
+
     def get_attr_val(self, key, use_json=False):
         idx = self._find_idx(key)[-1]
-        return self._entries[idx].get_attr_vals(key, use_json)
+        return self._entries[idx].get_attr_val(key, use_json)
+
+    def get_attr_val_utf8(self, key, use_json=False):
+        idx = self._find_idx(key)[-1]
+        return self._entries[idx].get_attr_val_utf8(key, use_json)
 
     def add_values(self, values):
         raise DeprecationWarning("Not implemented any more.")


### PR DESCRIPTION
Bug Description: Referral mode not working and failing with error: ERROR: Error: 103 - 10 - 53 - Server is unwilling to perform - [] - need to set nsslapd-referral It happens because in CLI, we set nsslapd-referral to the backend when it should be set to "cn=mapping tree".

Fix description: Set the attribute to the correct object. Add get_state and set_state custom functions to BackendSuffixView. Fix minor typos.

Fixes: https://github.com/389ds/389-ds-base/issues/5701

Reviewed by: ?