### PR TITLE
Issue 5643 - Memory leak in entryrdn during delete

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -2826,6 +2826,7 @@ bail:
     dblayer_value_free(be, &key);
     dblayer_value_free(be, &data);
     slapi_ch_free((void **)&elem);
+    slapi_ch_free((void **)&keybuf);
     slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_delete_key",
                   "<-- entryrdn_delete_key\n");
     return rc;

--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -2826,7 +2826,7 @@ bail:
     dblayer_value_free(be, &key);
     dblayer_value_free(be, &data);
     slapi_ch_free((void **)&elem);
-    slapi_ch_free((void **)&keybuf);
+    slapi_ch_free_string(&keybuf);
     slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_delete_key",
                   "<-- entryrdn_delete_key\n");
     return rc;


### PR DESCRIPTION
Bug description: Failure to delete temp key buffer

Fix description: Delete temp key buffer on exit

Fixes: https://github.com/389ds/389-ds-base/issues/5643

Reviewed by: