### PR TITLE
Issue 5718 - Memory leak in connection table

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -133,7 +133,6 @@ connection_table_new(int table_size)
     ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
     ct->size = table_size - (table_size % ct->list_num);
     ct->list_size = ct->size/ct->list_num;
-    ct->num_active = (int *)slapi_ch_calloc(1, ct->list_num * sizeof(int));
     ct->c = (Connection **)slapi_ch_calloc(1, ct->size * sizeof(Connection *));
     ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, ct->list_num * sizeof(struct POLL_STRUCT*));
     ct->table_mutex = PR_NewLock();


### PR DESCRIPTION
Bug description: duplicate mem allocation causes mem leak

Fix description: remove duplicate allocation

Fixes: https://github.com/389ds/389-ds-base/issues/5718

Reviewed by: