### PR TITLE
Issue 5734 - RFE - Exclude pwdFailureTime and ContextCSN

### DIFF
--- a/src/lib389/lib389/migrate/plan.py
+++ b/src/lib389/lib389/migrate/plan.py
@@ -662,6 +662,7 @@ class Migration(object):
             [
                 # Core openldap attrs that we can't use, and don't matter.
                 'entrycsn',
+                'contextcsn',
                 'structuralobjectclass',
                 # pwd attributes from ppolicy which are not supported.
                 'pwdattribute',
@@ -669,6 +670,8 @@ class Migration(object):
                 'pwdsafemodify',
                 'pwdcheckmodule',
                 'pwdmaxrecordedfailure',
+                # ppolicy attr that isn't in schema that isn't supported.
+                'pwdfailuretime',
                 # dds attributes we don't support
                 'dgidentity',
                 'dgauthz'


### PR DESCRIPTION
Bug Description: A customer reported an issue with openldap to 389ds migration. This was due to their openldap instance using a number of openldap attributes that I had not encountered in other migrations.

These attributes are operational to openldap only and can be safely excluded.

Fix Description: Exclude pwdFailureTime and ContextCSN

fixes: https://github.com/389ds/389-ds-base/issues/5734

Author: William Brown <william@blackhats.net.au>

Review by: ???