### PR TITLE
dscontainer bugfix: add ca certs as a ca type certificate

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -138,7 +138,7 @@ def _begin_setup_pem_tls():
     # Import the ca's
     for ca_path in [os.path.join(CONTAINER_TLS_SERVER_CADIR, ca) for ca in cas]:
         log.info("Enrolling -> %s" % ca_path)
-        tls.add_cert(nickname=ca_path, input_file=ca_path)
+        tls.add_cert(nickname=ca_path, input_file=ca_path, ca=True)
         tls.edit_cert_trust(ca_path, "C,,")
     # Import the new server-cert
     tls.add_server_key_and_cert(CONTAINER_TLS_SERVER_KEY, CONTAINER_TLS_SERVER_CERT)


### PR DESCRIPTION
Adding a ca certificate to the container image 389ds/dirsrv:2.4 results in the following error:

```
INFO: The 389 Directory Server Container Bootstrap
INFO: Inspired by works of: ITS, The University of Adelaide
INFO: 389 Directory Server Version: 2.4.0
INFO: Checking for PEM TLS files ...
INFO: Found -> ['ca.crt']
INFO: Have /data/tls/server.key -> True
INFO: Have /data/tls/server.crt -> True
INFO: Have /data/tls/ca -> True
INFO: Have /data/config/pwdfile.txt -> True
INFO: TLS PEM requirements met - configuring NSSDB ...
DEBUG: Allocate local instance <class 'lib389.DirSrv'> with None
DEBUG: del_cert cmd: /usr/bin/certutil -D -d /data/config -n Server-Cert -f /data/config/pwdfile.txt
INFO: Enrolling -> /data/tls/ca/ca.crt
Traceback (most recent call last):
  File "/usr/lib/dirsrv/dscontainer", line 467, in <module>
    begin_magic()
  File "/usr/lib/dirsrv/dscontainer", line 300, in begin_magic
    _begin_setup_pem_tls()
  File "/usr/lib/dirsrv/dscontainer", line 141, in _begin_setup_pem_tls
    tls.add_cert(nickname=ca_path, input_file=ca_path)
  File "/usr/lib/python3.10/site-packages/lib389/nss_ssl.py", line 1187, in add_cert
    raise ValueError(f"Certificate ({nickname}) is not a server certificate")
 ValueError: Certificate (/data/tls/ca/ca.crt) is not a server certificate
```

Changes committed with [Issue 5162 - Lib389 - verify certificate type before adding](https://github.com/389ds/389-ds-base/commit/c69f2691bb9c3933c1ff3f81139011fc7d66b0aa) causes the failure now (error condition was probably present before, but had no impact, at least for the v2.2 container and my environment).

We should flag all CA certificates as CA "type" in dscontainer.