### PR TITLE
Issue 5749 - RFE - Allow Account Policy Plugin to handle inactivity and expiration at the same time

### DIFF
--- a/dirsrvtests/tests/suites/plugins/accpol_check_all_state_attrs_test.py
+++ b/dirsrvtests/tests/suites/plugins/accpol_check_all_state_attrs_test.py
@@ -1,0 +1,119 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2023 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import ldap
+import logging
+import pytest
+import os
+import time
+from lib389.topologies import topology_st as topo
+from lib389._constants import DN_CONFIG, DEFAULT_SUFFIX, PLUGIN_ACCT_POLICY, DN_PLUGIN, PASSWORD
+from lib389.idm.user import (UserAccount, UserAccounts)
+from lib389.plugins import (AccountPolicyPlugin, AccountPolicyConfig)
+from lib389.idm.domain import Domain
+
+log = logging.getLogger(__name__)
+
+ACCPOL_DN = "cn={},{}".format(PLUGIN_ACCT_POLICY, DN_PLUGIN)
+ACCP_CONF = "{},{}".format(DN_CONFIG, ACCPOL_DN)
+TEST_ENTRY_NAME = 'actpol_test'
+TEST_ENTRY_DN = 'uid={},{}'.format(TEST_ENTRY_NAME, DEFAULT_SUFFIX)
+NEW_PASSWORD = 'password123'
+USER_SELF_MOD_ACI = '(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)'
+ANON_ACI = "(targetattr=\"*\")(version 3.0; acl \"Anonymous Read access\"; allow (read,search,compare) userdn = \"ldap:///anyone\";)"
+
+
+def test_inactivty_and_expiration(topo):
+    """Test account expiration works when we are checking all state attributes
+
+    :id: 704310de-a2eb-4ee7-baf3-9770c0fbf07c
+    :setup: Standalone Instance
+    :steps:
+        1. Configure instance for password expiration
+        2. Add ACI to allow users to update themselves
+        3. Create test user
+        4. Reset users password to set passwordExpirationtime
+        5. Configure account policy plugin and restart
+        6. Bind as test user to reset lastLoginTime
+        7. Sleep, then bind as user which triggers error
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+    """
+
+    # Configure instance
+    inst = topo.standalone
+    inst.config.set('passwordexp', 'on')
+    inst.config.set('passwordmaxage', '2')
+    inst.config.set('passwordGraceLimit', '5')
+
+    # Add aci so user and update password
+    suffix = Domain(inst, DEFAULT_SUFFIX)
+    suffix.add('aci', USER_SELF_MOD_ACI)
+    suffix.add('aci', ANON_ACI)
+
+    # Create the test user
+    test_user = UserAccount(inst, TEST_ENTRY_DN)
+    test_user.create(properties={
+        'uid': TEST_ENTRY_NAME,
+        'cn': TEST_ENTRY_NAME,
+        'sn': TEST_ENTRY_NAME,
+        'userPassword': PASSWORD,
+        'uidNumber': '1000',
+        'gidNumber': '2000',
+        'homeDirectory': '/home/test',
+    })
+
+    # Reset test user password to reset passwordExpirationtime
+    conn = test_user.bind(PASSWORD)
+    test_user = UserAccount(conn, TEST_ENTRY_DN)
+    test_user.replace('userpassword', NEW_PASSWORD)
+
+    # Sleep a little bit, we'll sleep the remaining 10 seconds later
+    time.sleep(3)
+
+    # Configure account policy plugin
+    plugin = AccountPolicyPlugin(inst)
+    plugin.enable()
+    plugin.set('nsslapd-pluginarg0', ACCP_CONF)
+    accp = AccountPolicyConfig(inst, dn=ACCP_CONF)
+    accp.set('alwaysrecordlogin', 'yes')
+    accp.set('stateattrname', 'lastLoginTime')
+    accp.set('altstateattrname', 'passwordexpirationtime')
+    accp.set('specattrname', 'acctPolicySubentry')
+    accp.set('limitattrname', 'accountInactivityLimit')
+    accp.set('accountInactivityLimit', '10')
+    accp.set('checkAllStateAttrs', 'on')
+    inst.restart()
+
+    # Bind as test user to reset lastLoginTime
+    conn = test_user.bind(NEW_PASSWORD)
+    test_user = UserAccount(conn, TEST_ENTRY_DN)
+
+    # Sleep to exceed passwordexprattiontime over 10 seconds, but less than
+    # 10 seconds for lastLoginTime
+    time.sleep(7)
+
+    # Try to bind, but password expiration should reject this as lastLogintTime
+    # has not exceeded the inactivity limit
+    with pytest.raises(ldap.CONSTRAINT_VIOLATION):
+        test_user.bind(NEW_PASSWORD)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/ldap/servers/plugins/acctpolicy/acct_config.c
+++ b/ldap/servers/plugins/acctpolicy/acct_config.c
@@ -1,5 +1,6 @@
 /******************************************************************************
 Copyright (C) 2009 Hewlett-Packard Development Company, L.P.
+Copyright (C) 2023 Red Hat, Inc.
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -104,6 +105,19 @@ acct_policy_entry2config(Slapi_Entry *e, acctPluginCfg *newcfg)
         slapi_ch_free_string(&newcfg->alt_state_attr_name); /*none - NULL */
     }                                                       /* else use configured value */
 
+    config_val = get_attr_string_val(e, CFG_CHECK_ALL_STATE_ATTRS);
+    if (config_val &&
+        (strcasecmp(config_val, "true") == 0 ||
+         strcasecmp(config_val, "yes") == 0 ||
+         strcasecmp(config_val, "on") == 0 ||
+         strcasecmp(config_val, "1") == 0))
+    {
+        newcfg->check_all_state_attrs = PR_TRUE;
+    } else {
+        newcfg->check_all_state_attrs = PR_FALSE;
+    }
+    slapi_ch_free_string(&config_val);
+
     newcfg->always_record_login_attr = get_attr_string_val(e, CFG_RECORD_LOGIN_ATTR);
     /* What user attribute will store the last login time
      * of a user. If empty, should have the same value as
@@ -148,10 +162,10 @@ acct_policy_entry2config(Slapi_Entry *e, acctPluginCfg *newcfg)
             rc = -1;
             newcfg->inactivitylimit = ULONG_MAX;
         }
+        slapi_ch_free_string(&config_val);
     } else {
         newcfg->inactivitylimit = ULONG_MAX;
     }
-    slapi_ch_free_string(&config_val);
 
     return (rc);
 }

--- a/ldap/servers/plugins/acctpolicy/acct_plugin.c
+++ b/ldap/servers/plugins/acctpolicy/acct_plugin.c
@@ -1,5 +1,6 @@
 /******************************************************************************
 Copyright (C) 2009 Hewlett-Packard Development Company, L.P.
+Copyright (C) 2023 Red Hat, Inc.
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -79,42 +80,99 @@ acct_inact_limit(Slapi_PBlock *pb, const char *dn, Slapi_Entry *target_entry, ac
     int rc = 0; /* Optimistic default */
     acctPluginCfg *cfg;
 
+    cur_t = slapi_current_utc_time();
+
     config_rd_lock();
     cfg = get_config();
-    if ((lasttimestr = get_attr_string_val(target_entry,
-                                           cfg->state_attr_name)) != NULL) {
-        slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
-                      "acct_inact_limit - \"%s\" login timestamp is %s\n", dn, lasttimestr);
-    } else if (cfg->alt_state_attr_name && ((lasttimestr = get_attr_string_val(target_entry,
-                                                                               cfg->alt_state_attr_name)) != NULL)) {
-        slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
-                      "acct_inact_limit - \"%s\" alternate timestamp is %s\n", dn, lasttimestr);
-    } else {
-        /* the primary or alternate attribute might not yet exist eg.
-     * if only lastlogintime is specified and it id the first login
-     */
-        slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
-                      "acct_inact_limit - \"%s\" has no value for stateattr or altstateattr \n", dn);
-        goto done;
-    }
 
-    last_t = gentimeToEpochtime(lasttimestr);
-    cur_t = slapi_current_utc_time();
-    lim_t = policy->inactivitylimit;
+    if (cfg->check_all_state_attrs) {
+        /*
+         * Check both state and alternate state attributes.
+         */
+        if ((lasttimestr = get_attr_string_val(target_entry, cfg->state_attr_name)) != NULL) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" login timestamp is %s (found in attribute '%s')\n",
+                          dn, lasttimestr, cfg->state_attr_name);
+            last_t = gentimeToEpochtime(lasttimestr);
+            lim_t = policy->inactivitylimit;
+            slapi_ch_free_string(&lasttimestr);
 
-    /* Finally do the time comparison */
-    if (cur_t > last_t + lim_t) {
+            /* Finally do the time comparison */
+            if (cur_t > last_t + lim_t) {
+                slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                              "acct_inact_limit - \"%s\" has exceeded inactivity limit  (%ld > (%ld + %ld))\n",
+                              dn, cur_t, last_t, lim_t);
+                rc = 1;
+                goto done;
+            }
+        }
+
+        /* Check alternate state attribute next... */
+        if (cfg->alt_state_attr_name &&
+                ((lasttimestr = get_attr_string_val(target_entry, cfg->alt_state_attr_name)) == NULL))
+        {
+            goto done;
+        }
         slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
-                      "acct_inact_limit - \"%s\" has exceeded inactivity limit  (%ld > (%ld + %ld))\n",
-                      dn, cur_t, last_t, lim_t);
-        rc = 1;
-        goto done;
-    } else {
+                      "acct_inact_limit - \"%s\" alternate timestamp is %s (found in attribute '%s')\n",
+                      dn, lasttimestr, cfg->alt_state_attr_name);
+        last_t = gentimeToEpochtime(lasttimestr);
+        lim_t = policy->inactivitylimit;
+        slapi_ch_free_string(&lasttimestr);
+
+        /* Finally do the time comparison */
+        if (cur_t > last_t + lim_t) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" has exceeded inactivity limit  (%ld > (%ld + %ld))\n",
+                          dn, cur_t, last_t, lim_t);
+            rc = 1;
+            goto done;
+        }
         slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
                       "acct_inact_limit - \"%s\" is within inactivity limit (%ld < (%ld + %ld))\n",
                       dn, cur_t, last_t, lim_t);
-    }
+    } else {
+        /*
+         * Check state attribute, if not present in entry only then try
+         * alternate state attribute
+         */
+        if ((lasttimestr = get_attr_string_val(target_entry, cfg->state_attr_name)) != NULL) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" login timestamp is %s (found in attribute '%s')\n",
+                          dn, lasttimestr, cfg->state_attr_name);
+        } else if (cfg->alt_state_attr_name &&
+            ((lasttimestr = get_attr_string_val(target_entry, cfg->alt_state_attr_name)) != NULL))
+        {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" alternate timestamp is %s (found in attribute '%s')\n",
+                          dn, lasttimestr, cfg->alt_state_attr_name);
+        } else {
+            /*
+             * The primary or alternate attribute might not yet exist eg.
+             * if only lastlogintime is specified and it is the first login
+             */
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" has no value for stateattr or altstateattr \n", dn);
+            goto done;
+        }
 
+        last_t = gentimeToEpochtime(lasttimestr);
+        lim_t = policy->inactivitylimit;
+        slapi_ch_free_string(&lasttimestr);
+
+        /* Finally do the time comparison */
+        if (cur_t > last_t + lim_t) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" has exceeded inactivity limit  (%ld > (%ld + %ld))\n",
+                          dn, cur_t, last_t, lim_t);
+            rc = 1;
+            goto done;
+        } else {
+            slapi_log_err(SLAPI_LOG_PLUGIN, PRE_PLUGIN_NAME,
+                          "acct_inact_limit - \"%s\" is within inactivity limit (%ld < (%ld + %ld))\n",
+                          dn, cur_t, last_t, lim_t);
+        }
+    }
 done:
     config_unlock();
     /* Deny bind; the account has exceeded the inactivity limit */
@@ -124,8 +182,6 @@ done:
                                " Contact system administrator to reset.",
                                0, NULL);
     }
-
-    slapi_ch_free_string(&lasttimestr);
 
     return (rc);
 }
@@ -336,8 +392,7 @@ acct_bind_postop(Slapi_PBlock *pb)
             rc = -1;
             goto done;
         } else {
-            if (target_entry && has_attr(target_entry,
-                                         cfg->spec_attr_name, NULL)) {
+            if (target_entry && has_attr(target_entry, cfg->spec_attr_name, NULL)) {
                 tracklogin = 1;
             }
         }

--- a/ldap/servers/plugins/acctpolicy/acctpolicy.h
+++ b/ldap/servers/plugins/acctpolicy/acctpolicy.h
@@ -1,5 +1,6 @@
 /******************************************************************************
 Copyright (C) 2009 Hewlett-Packard Development Company, L.P.
+Copyright (C) 2023 Red Hat, Inc.
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -24,6 +25,7 @@ Hewlett-Packard Development Company, L.P.
 
 #define CFG_LASTLOGIN_STATE_ATTR "stateAttrName"
 #define CFG_ALT_LASTLOGIN_STATE_ATTR "altStateAttrName"
+#define CFG_CHECK_ALL_STATE_ATTRS "checkAllStateAttrs"
 #define CFG_SPEC_ATTR "specAttrName"
 #define CFG_INACT_LIMIT_ATTR "limitAttrName"
 #define CFG_RECORD_LOGIN "alwaysRecordLogin"
@@ -59,6 +61,7 @@ typedef struct acct_plugin_cfg
     int always_record_login;
     char *always_record_login_attr;
     unsigned long inactivitylimit;
+    PRBool check_all_state_attrs;
 } acctPluginCfg;
 
 typedef struct accountpolicy

--- a/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
+++ b/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -20,7 +20,8 @@ arg_to_attr_config = {
     'always_record_login_attr': 'alwaysRecordLoginAttr',
     'limit_attr': 'limitattrname',
     'spec_attr': 'specattrname',
-    'state_attr': 'stateattrname'
+    'state_attr': 'stateattrname',
+    'check_all_state_attrs': 'checkallstateattrs',
 }
 
 
@@ -95,6 +96,8 @@ def _add_parser_args(parser):
                              'are account policy configuration entries (specAttrName)')
     parser.add_argument('--state-attr',
                         help='Specifies the primary time attribute used to evaluate an account policy (stateAttrName)')
+    parser.add_argument('--check-all-state-attrs', choices=['yes', 'no'], type=str.lower,
+                        help="Check both state and alternate state attributes for account state")
 
 
 def create_parser(subparsers):


### PR DESCRIPTION
Description:

Currently Account Policy Plugin as a state attribute and alternate state attribute. If the main state attribute is NOT present in the entry then it fails back to the alternate state attribute.

This RFE adds a new setting that tells the plugin to check both state attributes. The purpose of this is for expiration and inactivity, so this is meant to be used when the alternate state attribute is 'passwordExpirationtime'.  So if the main state attribute is OK, it will then check the alternate state attribute for inactivity.

relates: https://github.com/389ds/389-ds-base/issues/5749

