### PR TITLE
Issue 5752 - RFE - Provide a history for LastLoginTime

### DIFF
--- a/ldap/schema/60acctpolicy.ldif
+++ b/ldap/schema/60acctpolicy.ldif
@@ -20,6 +20,12 @@
 #
 dn: cn=schema
 ##
+## lastLoginHistory holds successful logins in an entry (GeneralizedTime syntax)
+attributeTypes: ( 2.16.840.1.113730.3.1.2394 NAME 'lastLoginHistory'
+  DESC 'History of successful logins'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 USAGE directoryOperation
+  X-ORIGIN 'Account Policy Plugin' )
+##
 ## lastLoginTime holds login state in user entries (GeneralizedTime syntax)
 attributeTypes: ( 2.16.840.1.113719.1.1.4.1.35 NAME 'lastLoginTime'
   DESC 'Last login time'

--- a/ldap/servers/plugins/acctpolicy/acct_config.c
+++ b/ldap/servers/plugins/acctpolicy/acct_config.c
@@ -135,6 +135,16 @@ acct_policy_entry2config(Slapi_Entry *e, acctPluginCfg *newcfg)
     }
     slapi_ch_free_string(&config_val);
 
+    if (newcfg->always_record_login) {
+        char *hist_size = NULL;
+        newcfg->login_history_attr = slapi_ch_strdup(LASTLOGIN_HISTORY_ATTR);
+        if (has_attr(e, LASTLOGIN_HISTORY_SIZE_ATTR, &hist_size)) {
+            newcfg->login_history_size = atoi(hist_size);
+        } else {
+            newcfg->login_history_size = DEFAULT_LASTLOGIN_HISTORY_SIZE;
+        }
+    }
+
     /* the default limit if not set in the acctPolicySubentry */
     config_val = get_attr_string_val(e, newcfg->limit_attr_name);
     if (config_val) {
@@ -174,4 +184,5 @@ free_config()
     slapi_ch_free_string(&globalcfg.spec_attr_name);
     slapi_ch_free_string(&globalcfg.limit_attr_name);
     slapi_ch_free_string(&globalcfg.always_record_login_attr);
+    slapi_ch_free_string(&globalcfg.login_history_attr);
 }

--- a/ldap/servers/plugins/acctpolicy/acct_plugin.c
+++ b/ldap/servers/plugins/acctpolicy/acct_plugin.c
@@ -141,7 +141,7 @@ acct_update_login_history(const char *dn, char *timestr)
 {
     void *plugin_id = NULL;
     int rc = -1;
-    int num_entrys = 0;
+    int num_entries = 0;
     size_t i = 0;
     char **login_hist = NULL;
     Slapi_PBlock *entry_pb = NULL;
@@ -157,24 +157,24 @@ acct_update_login_history(const char *dn, char *timestr)
     sdn = slapi_sdn_new_normdn_byref(dn);
     slapi_search_get_entry(&entry_pb, sdn, NULL, &e, plugin_id);
 
-    config_rd_lock();
-    cfg = get_config();
-
     if (!timestr) {
         return (rc);
     }
 
+    config_rd_lock();
+    cfg = get_config();
+
     /* get login history */
-    login_hist = slapi_entry_attr_get_charray_ext(e, cfg->login_history_attr, &num_entrys);
+    login_hist = slapi_entry_attr_get_charray_ext(e, cfg->login_history_attr, &num_entries);
 
     /* first time round */
-    if (!login_hist || !num_entrys) {
+    if (!login_hist || !num_entries) {
         login_hist = (char **)slapi_ch_calloc(2, sizeof(char *));
     }
 
     /* Do we need to resize login_hist array */
-    if (num_entrys >= cfg->login_history_size) {
-        int diff = (num_entrys - cfg->login_history_size);
+    if (num_entries >= cfg->login_history_size) {
+        int diff = (num_entries - cfg->login_history_size);
         /* free times we dont need */
         for (i = 0; i <= diff; i++) {
             slapi_ch_free_string(&login_hist[i]);
@@ -189,9 +189,9 @@ acct_update_login_history(const char *dn, char *timestr)
         login_hist[i + 1] = NULL;
     } else {
         /* expand array and add current time string at the end */
-        login_hist = (char **)slapi_ch_realloc((char *)login_hist, sizeof(char *) * (num_entrys + 2));
-        login_hist[num_entrys] = slapi_ch_smprintf("%s", timestr);
-        login_hist[num_entrys + 1] = NULL;
+        login_hist = (char **)slapi_ch_realloc((char *)login_hist, sizeof(char *) * (num_entries + 2));
+        login_hist[num_entries] = slapi_ch_smprintf("%s", timestr);
+        login_hist[num_entries + 1] = NULL;
     }
 
     /* modify the attribute */

--- a/ldap/servers/plugins/acctpolicy/acct_plugin.c
+++ b/ldap/servers/plugins/acctpolicy/acct_plugin.c
@@ -27,6 +27,9 @@ Hewlett-Packard Development Company, L.P.
 #include "acctpolicy.h"
 #include "slapi-plugin.h"
 
+static int
+acct_update_login_history(const char *, char *);
+
 /*
  * acct_policy_dn_is_config()
  *
@@ -131,8 +134,96 @@ done:
 }
 
 /*
+  Preserve bind time stamps in virtual attribute
+*/
+int
+acct_update_login_history(const char *dn, char *timestr)
+{
+    void *plugin_id = NULL;
+    int rc = -1;
+    int num_entrys = 0;
+    size_t i = 0;
+    char **login_hist = NULL;
+    Slapi_PBlock *entry_pb = NULL;
+    Slapi_PBlock *mod_pb;
+    Slapi_Entry *e = NULL;
+    Slapi_DN *sdn = NULL;
+    acctPluginCfg *cfg;
+    LDAPMod attribute;
+    LDAPMod *list_of_mods[2];
+
+    plugin_id = get_identity();
+
+    sdn = slapi_sdn_new_normdn_byref(dn);
+    slapi_search_get_entry(&entry_pb, sdn, NULL, &e, plugin_id);
+
+    config_rd_lock();
+    cfg = get_config();
+
+    if (!timestr) {
+        return (rc);
+    }
+
+    /* get login history */
+    login_hist = slapi_entry_attr_get_charray_ext(e, cfg->login_history_attr, &num_entrys);
+
+    /* first time round */
+    if (!login_hist || !num_entrys) {
+        login_hist = (char **)slapi_ch_calloc(2, sizeof(char *));
+    }
+
+    /* Do we need to resize login_hist array */
+    if (num_entrys >= cfg->login_history_size) {
+        int diff = (num_entrys - cfg->login_history_size);
+        /* free times we dont need */
+        for (i = 0; i <= diff; i++) {
+            slapi_ch_free_string(&login_hist[i]);
+        }
+        /* remap array*/
+        for (i = 0; i < (cfg->login_history_size - 1); i++) {
+            login_hist[i] = login_hist[(diff + 1) + i];
+        }
+        /* expand array and add current time string at the end */
+        login_hist = (char **)slapi_ch_realloc((char *)login_hist, sizeof(char *) * (cfg->login_history_size + 1));
+        login_hist[i] = slapi_ch_smprintf("%s", timestr);
+        login_hist[i + 1] = NULL;
+    } else {
+        /* expand array and add current time string at the end */
+        login_hist = (char **)slapi_ch_realloc((char *)login_hist, sizeof(char *) * (num_entrys + 2));
+        login_hist[num_entrys] = slapi_ch_smprintf("%s", timestr);
+        login_hist[num_entrys + 1] = NULL;
+    }
+
+    /* modify the attribute */
+    attribute.mod_type = cfg->login_history_attr;
+    attribute.mod_op = LDAP_MOD_REPLACE;
+    attribute.mod_values = login_hist;
+
+    list_of_mods[0] = &attribute;
+    list_of_mods[1] = NULL;
+
+    mod_pb = slapi_pblock_new();
+    slapi_modify_internal_set_pb(mod_pb, dn, list_of_mods, NULL, NULL, plugin_id, 0);
+    slapi_modify_internal_pb(mod_pb);
+    slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+    if (rc != LDAP_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_ERR, "acct_update_login_history", "Modify error %d on entry '%s'\n", rc, dn);
+    }
+
+    config_unlock();
+
+    slapi_ch_array_free(login_hist);
+    slapi_search_get_entry_done(&entry_pb);
+    slapi_sdn_free(&sdn);
+    slapi_pblock_destroy(mod_pb);
+    slapi_pblock_destroy(entry_pb);
+
+    return (rc);
+}
+
+/*
   This is called after binds, it updates an attribute in the account
-  with the current time.
+  and the login time history.
 */
 static int
 acct_record_login(const char *dn)
@@ -193,6 +284,9 @@ acct_record_login(const char *dn)
     } else {
         slapi_log_err(SLAPI_LOG_PLUGIN, POST_PLUGIN_NAME,
                       "acct_record_login - Recorded %s=%s on \"%s\"\n", cfg->always_record_login_attr, timestr, dn);
+
+        /* update login history */
+        acct_update_login_history(dn, timestr);
     }
 
 done:

--- a/ldap/servers/plugins/acctpolicy/acctpolicy.h
+++ b/ldap/servers/plugins/acctpolicy/acctpolicy.h
@@ -28,12 +28,15 @@ Hewlett-Packard Development Company, L.P.
 #define CFG_INACT_LIMIT_ATTR "limitAttrName"
 #define CFG_RECORD_LOGIN "alwaysRecordLogin"
 #define CFG_RECORD_LOGIN_ATTR "alwaysRecordLoginAttr"
+#define LASTLOGIN_HISTORY_ATTR "lastLoginHistory"
+#define LASTLOGIN_HISTORY_SIZE_ATTR "lastLoginHistorySize"
 
 #define DEFAULT_LASTLOGIN_STATE_ATTR "lastLoginTime"
 #define DEFAULT_ALT_LASTLOGIN_STATE_ATTR "createTimestamp"
 #define DEFAULT_SPEC_ATTR "acctPolicySubentry"
 #define DEFAULT_INACT_LIMIT_ATTR "accountInactivityLimit"
 #define DEFAULT_RECORD_LOGIN 1
+#define DEFAULT_LASTLOGIN_HISTORY_SIZE 5
 
 #define PLUGIN_VENDOR "Hewlett-Packard Company"
 #define PLUGIN_VERSION "1.0"
@@ -58,6 +61,8 @@ typedef struct acct_plugin_cfg
     char *limit_attr_name;
     int always_record_login;
     char *always_record_login_attr;
+    char *login_history_attr;
+    int login_history_size;
     unsigned long inactivitylimit;
 } acctPluginCfg;
 

--- a/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
+++ b/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
@@ -20,7 +20,9 @@ arg_to_attr_config = {
     'always_record_login_attr': 'alwaysRecordLoginAttr',
     'limit_attr': 'limitattrname',
     'spec_attr': 'specattrname',
-    'state_attr': 'stateattrname'
+    'state_attr': 'stateattrname',
+    'login_history': 'lastLoginHistory',
+    'login_history_size': 'lastLoginHistorySize'
 }
 
 
@@ -95,7 +97,8 @@ def _add_parser_args(parser):
                              'are account policy configuration entries (specAttrName)')
     parser.add_argument('--state-attr',
                         help='Specifies the primary time attribute used to evaluate an account policy (stateAttrName)')
-
+    parser.add_argument('--login-history-size',
+                        help='Specifies the number of login timestamps to store (lastLoginHistSize) )')
 
 def create_parser(subparsers):
     accountpolicy = subparsers.add_parser('account-policy', help='Manage and configure Account Policy plugin')


### PR DESCRIPTION
Description: When a user did a successfully bind, the "LastLoginTime" attribute is updated. We have now a request from our security department to display the users last successful bind before the current one. When we just read out this attribute the value is already updated, so that the user did not see his real last successful
login, in fact he sees the current login date and time.

Fix description: Create a new Acount Policy attribute to store the login time stamps for a successful bind.

relates: https://github.com/389ds/389-ds-base/issues/5752

Reviewed by: