### PR TITLE
Issue 5768 - CLI/UI - cert checks are too strict, and other issues

### DIFF
--- a/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
+++ b/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
@@ -48,7 +48,6 @@ export class CertificateManagement extends React.Component {
             showExportModal: false,
             certName: "",
             certFile: "",
-            certText: "",
             csrContent: "",
             csrName: "",
             csrAltNames: [],
@@ -74,9 +73,8 @@ export class CertificateManagement extends React.Component {
             exportDERFormat: false,
             exportFileName: "",
             certRadioFile: false,
-            certRadioText: false,
-            certRadioSelect: true,
-            certRadioUpload: false,
+            certRadioSelect: false,
+            certRadioUpload: true,
             availCertNames: [],
             selectCertName: "",
             isSelectCertOpen: false,
@@ -95,8 +93,8 @@ export class CertificateManagement extends React.Component {
         };
         this.handleTextOrDataChange = (value) => {
             this.setState({
-                uploadValue: value
-            });
+                uploadValue: value.trim()
+            }, () => this.validateCertText());
         };
         this.handleFileReadStarted = () => {
             this.setState({
@@ -110,8 +108,8 @@ export class CertificateManagement extends React.Component {
         };
         this.handleClear = () => {
             this.setState({
-                certText: "",
-                uploadFile: "",
+                uploadValue: "",
+                uploadFileName: "",
                 uploadIsRejected: false,
             });
         };
@@ -212,15 +210,13 @@ export class CertificateManagement extends React.Component {
             showAddModal: true,
             certFile: "",
             certName: "",
-            certText: "",
             uploadFile: "",
             uploadValue: "",
             uploadIsRejected: false,
             uploadIsLoading: false,
             certRadioFile: false,
-            certRadioText: false,
-            certRadioSelect: true,
-            certRadioUpload: false,
+            certRadioSelect: false,
+            certRadioUpload: true,
             isSelectCertOpen: false,
             modalSpinning: false,
         });
@@ -237,15 +233,13 @@ export class CertificateManagement extends React.Component {
             showAddCAModal: true,
             certFile: "",
             certName: "",
-            certText: "",
             uploadFile: "",
             uploadValue: "",
             uploadIsRejected: false,
             uploadIsLoading: false,
             certRadioFile: false,
-            certRadioText: false,
-            certRadioSelect: true,
-            certRadioUpload: false,
+            certRadioSelect: false,
+            certRadioUpload: true,
             isSelectCertOpen: false,
             modalSpinning: false,
         });
@@ -260,20 +254,17 @@ export class CertificateManagement extends React.Component {
     handleRadioChange(_, e) {
         // Handle the add cert options
         let certRadioFile = false;
-        let certRadioText = false;
+
         let certRadioSelect = false;
         let certRadioUpload = false;
         if (e.target.id === "certRadioFile") {
             certRadioFile = true;
-        } else if (e.target.id === "certRadioText") {
-            certRadioText = true;
         } else if (e.target.id === "certRadioSelect") {
             certRadioSelect = true;
         } else if (e.target.id === "certRadioUpload") {
             certRadioUpload = true;
         }
         this.setState({
-            certRadioText,
             certRadioFile,
             certRadioSelect,
             certRadioUpload
@@ -468,10 +459,10 @@ export class CertificateManagement extends React.Component {
             certType = "ca-certificate";
         }
 
-        if ((this.state.certRadioText && this.state.certText !== "") || (this.state.certRadioUpload && this.state.uploadValue)) {
-            // Certificate was copied and pasted.  Need to create a file for import
-            const certFile = this.props.certDir + "/" + this.state.certName + ".tmp";
-            const certText = this.state.certRadioUpload ? this.state.uploadValue : this.state.certText;
+        if (this.state.certRadioUpload && this.state.uploadValue) {
+            // Certificate was copied and pasted.  Need to create a tmp file for import
+            const certFile = this.props.certDir + "/tmp-cert-" + Date.now() + ".tmp";
+            const certText = this.state.uploadValue;
             const create_cert_cmd = [
                 '/bin/sh', '-c',
                 '/usr/bin/echo -e \'' + certText  + '\' > ' + certFile
@@ -919,18 +910,17 @@ export class CertificateManagement extends React.Component {
                 });
     }
 
-    validateCertText (id) {
-        if (id === "certText" && this.state.certText !== "") {
-            if (!this.state.certText.startsWith("-----BEGIN CERTIFICATE-----") ||
-                !this.state.certText.endsWith("-----END CERTIFICATE-----")) {
-                this.setState({
-                    badCertText: true
-                });
-            } else {
-                this.setState({
-                    badCertText: false
-                });
-            }
+    validateCertText () {
+        const value = this.state.uploadValue;
+        if (!value.startsWith("-----BEGIN CERTIFICATE-----") ||
+            !value.endsWith("-----END CERTIFICATE-----")) {
+            this.setState({
+                badCertText: true
+            });
+        } else {
+            this.setState({
+                badCertText: false
+            });
         }
     }
 
@@ -946,7 +936,7 @@ export class CertificateManagement extends React.Component {
         this.setState({
             [e.target.id]: value,
             errObj: errObj
-        }, () => { this.validateCertText(e.target.id) });
+        });
     }
 
     handleCSRChange (e) {
@@ -1261,6 +1251,7 @@ export class CertificateManagement extends React.Component {
                             />
                             <Button
                                 variant="primary"
+                                className="ds-margin-top-lg"
                                 onClick={() => {
                                     this.showAddCAModal();
                                 }}
@@ -1280,6 +1271,7 @@ export class CertificateManagement extends React.Component {
                             />
                             <Button
                                 variant="primary"
+                                className="ds-margin-top-lg"
                                 onClick={() => {
                                     this.showAddModal();
                                 }}
@@ -1298,6 +1290,7 @@ export class CertificateManagement extends React.Component {
                             />
                             <Button
                                 variant="primary"
+                                className="ds-margin-top-lg"
                                 onClick={() => {
                                     this.showAddCSRModal();
                                 }}
@@ -1347,7 +1340,6 @@ export class CertificateManagement extends React.Component {
                     handleChange={this.handleChange}
                     saveHandler={this.addCert}
                     spinning={this.state.modalSpinning}
-                    certText={this.state.certText}
                     certFile={this.state.certFile}
                     certName={this.state.certName}
                     certNames={this.state.availCertNames}
@@ -1355,7 +1347,6 @@ export class CertificateManagement extends React.Component {
                     isSelectCertOpen={this.state.isSelectCertOpen}
                     handleCertSelect={this.handleCertSelect}
                     certRadioFile={this.state.certRadioFile}
-                    certRadioText={this.state.certRadioText}
                     certRadioSelect={this.state.certRadioSelect}
                     certRadioUpload={this.state.certRadioUpload}
                     handleRadioChange={this.handleRadioChange}
@@ -1378,7 +1369,6 @@ export class CertificateManagement extends React.Component {
                     handleChange={this.handleChange}
                     saveHandler={this.addCert}
                     spinning={this.state.modalSpinning}
-                    certText={this.state.certText}
                     certFile={this.state.certFile}
                     certName={this.state.certName}
                     certNames={this.state.availCertNames}
@@ -1386,7 +1376,6 @@ export class CertificateManagement extends React.Component {
                     isSelectCertOpen={this.state.isSelectCertOpen}
                     handleCertSelect={this.handleCertSelect}
                     certRadioFile={this.state.certRadioFile}
-                    certRadioText={this.state.certRadioText}
                     certRadioSelect={this.state.certRadioSelect}
                     certRadioUpload={this.state.certRadioUpload}
                     handleRadioChange={this.handleRadioChange}

--- a/src/cockpit/389-console/src/lib/security/securityTables.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityTables.jsx
@@ -28,6 +28,7 @@ class KeyTable extends React.Component {
             value: '',
             sortBy: {},
             rows: [],
+            hasRows: false,
             columns: [
                 { title: 'Cipher', transforms: [sortable] },
                 { title: 'Key Identifier', transforms: [sortable] },
@@ -51,6 +52,7 @@ class KeyTable extends React.Component {
     componentDidMount() {
         let rows = [];
         let columns = this.state.columns;
+        let hasRows = true;
 
         for (const ServerKey of this.props.ServerKeys) {
             rows.push(
@@ -64,10 +66,13 @@ class KeyTable extends React.Component {
         if (rows.length == 0) {
             rows = [{ cells: ['No Orphan keys'] }];
             columns = [{ title: 'Orphan keys' }];
+            hasRows = false;
         }
+
         this.setState({
             rows: rows,
-            columns: columns
+            columns: columns,
+            hasRows
         });
     }
 
@@ -85,7 +90,7 @@ class KeyTable extends React.Component {
     }
 
     render() {
-        const { perPage, page, sortBy, rows, columns } = this.state;
+        const { perPage, page, sortBy, rows, columns, hasRows } = this.state;
 
         return (
             <div className="ds-margin-top-lg">
@@ -114,22 +119,24 @@ class KeyTable extends React.Component {
                     variant={TableVariant.compact}
                     sortBy={sortBy}
                     onSort={this.onSort}
-                    actions={rows.length > 0 ? this.actions() : null}
+                    actions={hasRows? this.actions() : null}
                     dropdownPosition="right"
                     dropdownDirection="bottom"
                 >
                     <TableHeader />
                     <TableBody />
                 </Table>
-                <Pagination
-                    itemCount={this.state.rows.length}
-                    widgetId="pagination-options-menu-bottom"
-                    perPage={this.state.perPage}
-                    page={page}
-                    variant={PaginationVariant.bottom}
-                    onSetPage={this.onSetPage}
-                    onPerPageSelect={this.onPerPageSelect}
-                />
+                {hasRows &&
+                    <Pagination
+                        itemCount={this.state.rows.length}
+                        widgetId="pagination-options-menu-bottom"
+                        perPage={this.state.perPage}
+                        page={page}
+                        variant={PaginationVariant.bottom}
+                        onSetPage={this.onSetPage}
+                        onPerPageSelect={this.onPerPageSelect}
+                    />
+                }
             </div>
         );
     }
@@ -185,6 +192,7 @@ class CSRTable extends React.Component {
     componentDidMount() {
         let rows = [];
         let columns = this.state.columns;
+        let hasRows = true;
 
         for (const ServerCSR of this.props.ServerCSRs) {
             rows.push(
@@ -200,10 +208,12 @@ class CSRTable extends React.Component {
         if (rows.length == 0) {
             rows = [{ cells: ['No Certificate Signing Requests'] }];
             columns = [{ title: 'Certificate Signing Requests' }];
+            hasRows = false;
         }
         this.setState({
             rows: rows,
             columns: columns,
+            hasRows,
         });
     }
 
@@ -265,16 +275,18 @@ class CSRTable extends React.Component {
     }
 
     render() {
-        const { perPage, page, sortBy, rows, columns } = this.state;
+        const { perPage, page, sortBy, rows, columns, hasRows } = this.state;
 
         return (
             <div className="ds-margin-top-lg">
-                <SearchInput
-                    placeholder='Search CSRs'
-                    value={this.state.value}
-                    onChange={this.onSearchChange}
-                    onClear={(evt) => this.onSearchChange('', evt)}
-                />
+                {hasRows &&
+                    <SearchInput
+                        placeholder='Search CSRs'
+                        value={this.state.value}
+                        onChange={this.onSearchChange}
+                        onClear={(evt) => this.onSearchChange('', evt)}
+                    />
+                }
                 <Table
                     className="ds-margin-top"
                     aria-label="csr table"
@@ -284,22 +296,24 @@ class CSRTable extends React.Component {
                     variant={TableVariant.compact}
                     sortBy={sortBy}
                     onSort={this.onSort}
-                    actions={rows.length > 0 ? this.actions() : null}
+                    actions={hasRows ? this.actions() : null}
                     dropdownPosition="right"
                     dropdownDirection="bottom"
                 >
                     <TableHeader />
                     <TableBody />
                 </Table>
-                <Pagination
-                    itemCount={this.state.rows.length}
-                    widgetId="pagination-options-menu-bottom"
-                    perPage={perPage}
-                    page={page}
-                    variant={PaginationVariant.bottom}
-                    onSetPage={this.onSetPage}
-                    onPerPageSelect={this.onPerPageSelect}
-                />
+                {hasRows &&
+                    <Pagination
+                        itemCount={rows.length}
+                        widgetId="pagination-options-menu-bottom"
+                        perPage={perPage}
+                        page={page}
+                        variant={PaginationVariant.bottom}
+                        onSetPage={this.onSetPage}
+                        onPerPageSelect={this.onPerPageSelect}
+                    />
+                }
             </div>
         );
     }
@@ -316,6 +330,7 @@ class CertTable extends React.Component {
             sortBy: {},
             rows: [],
             dropdownIsOpen: false,
+            hasRows: false,
             columns: [
                 {
                     title: 'Nickname',
@@ -407,6 +422,7 @@ class CertTable extends React.Component {
         let rows = [];
         let columns = this.state.columns;
         let count = 0;
+        let hasRows = true;
 
         for (const cert of this.props.certs) {
             rows.push(
@@ -428,10 +444,12 @@ class CertTable extends React.Component {
         if (rows.length == 0) {
             rows = [{ cells: ['No Certificates'] }];
             columns = [{ title: 'Certificates' }];
+            hasRows = false;
         }
         this.setState({
             rows: rows,
-            columns: columns
+            columns: columns,
+            hasRows,
         });
     }
 
@@ -508,7 +526,7 @@ class CertTable extends React.Component {
     }
 
     render() {
-        const { perPage, page, sortBy, rows, columns } = this.state;
+        const { perPage, page, sortBy, rows, columns, hasRows } = this.state;
         const origRows = [...rows];
         const startIdx = ((perPage * page) - perPage) * 2;
         const tableRows = origRows.splice(startIdx, perPage * 2);
@@ -520,12 +538,14 @@ class CertTable extends React.Component {
 
         return (
             <div className="ds-margin-top-lg">
-                <SearchInput
-                    placeholder='Search Certificates'
-                    value={this.state.value}
-                    onChange={this.onSearchChange}
-                    onClear={(evt) => this.onSearchChange('', evt)}
-                />
+                {hasRows &&
+                    <SearchInput
+                        placeholder='Search Certificates'
+                        value={this.state.value}
+                        onChange={this.onSearchChange}
+                        onClear={(evt) => this.onSearchChange('', evt)}
+                    />
+                }
                 <Table
                     className="ds-margin-top"
                     aria-label="cert table"
@@ -536,22 +556,24 @@ class CertTable extends React.Component {
                     sortBy={sortBy}
                     onSort={this.onSort}
                     onCollapse={this.onCollapse}
-                    actions={tableRows.length > 0 ? this.actions() : null}
+                    actions={hasRows ? this.actions() : null}
                     dropdownPosition="right"
                     dropdownDirection="bottom"
                 >
                     <TableHeader />
                     <TableBody />
                 </Table>
-                <Pagination
-                    itemCount={this.state.rows.length / 2}
-                    widgetId="pagination-options-menu-bottom"
-                    perPage={perPage}
-                    page={page}
-                    variant={PaginationVariant.bottom}
-                    onSetPage={this.onSetPage}
-                    onPerPageSelect={this.onPerPageSelect}
-                />
+                {hasRows &&
+                    <Pagination
+                        itemCount={this.state.rows.length / 2}
+                        widgetId="pagination-options-menu-bottom"
+                        perPage={perPage}
+                        page={page}
+                        variant={PaginationVariant.bottom}
+                        onSetPage={this.onSetPage}
+                        onPerPageSelect={this.onPerPageSelect}
+                    />
+                }
             </div>
         );
     }
@@ -569,6 +591,7 @@ class CRLTable extends React.Component {
             sortBy: {},
             rows: [],
             dropdownIsOpen: false,
+            hasRows: false,
             columns: [
                 { title: 'Issued By', transforms: [sortable] },
                 { title: 'Effective Date', transforms: [sortable] },
@@ -675,6 +698,7 @@ class CRLTable extends React.Component {
             rows: rows,
             value: value,
             page: 1,
+            hasRows: rows.length === 0 ? false : true,
         });
     }
 
@@ -694,7 +718,6 @@ class CRLTable extends React.Component {
     }
 
     render() {
-        const has_rows = false; // TODO
         return (
             <div className="ds-margin-top">
                 <SearchInput
@@ -714,15 +737,17 @@ class CRLTable extends React.Component {
                     <TableHeader />
                     <TableBody />
                 </Table>
-                <Pagination
-                    itemCount={this.state.rows.length}
-                    widgetId="pagination-options-menu-bottom"
-                    perPage={this.state.perPage}
-                    page={this.state.page}
-                    variant={PaginationVariant.bottom}
-                    onSetPage={this.onSetPage}
-                    onPerPageSelect={this.onPerPageSelect}
-                />
+                {this.state.hasRows &&
+                    <Pagination
+                        itemCount={this.state.rows.length}
+                        widgetId="pagination-options-menu-bottom"
+                        perPage={this.state.perPage}
+                        page={this.state.page}
+                        variant={PaginationVariant.bottom}
+                        onSetPage={this.onSetPage}
+                        onPerPageSelect={this.onPerPageSelect}
+                    />
+                }
             </div>
         );
     }

--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -58,6 +58,7 @@ from lib389.idm.directorymanager import DirectoryManager
 # is always available!
 log = setup_script_logger("container-init", True)
 
+
 # Handle any dead child process signals we receive. Wait for them to terminate, or
 # if they are not found, move on.
 #
@@ -67,15 +68,18 @@ def _sigchild_handler(*args, **kwargs):
     # log.debug("Received SIGCHLD ...")
     os.waitpid(-1, os.WNOHANG)
 
+
 # Start the exit process.
 def _sigterm_handler(*args, **kwargs):
     exit()
+
 
 def _gen_instance():
     inst = DirSrv(verbose=True)
     inst.local_simple_allocate("localhost")
     inst.setup_ldapi()
     return inst
+
 
 def _begin_environment_config():
     inst = _gen_instance()
@@ -103,6 +107,7 @@ def _begin_environment_config():
             ldbmconfig.set("nsslapd-cache-autosize", str(autotune_pct))
 
     inst.close()
+
 
 def _begin_setup_pem_tls():
     # If we have the needed files, we can use them.
@@ -138,18 +143,20 @@ def _begin_setup_pem_tls():
     # Import the ca's
     for ca_path in [os.path.join(CONTAINER_TLS_SERVER_CADIR, ca) for ca in cas]:
         log.info("Enrolling -> %s" % ca_path)
-        tls.add_cert(nickname=ca_path, input_file=ca_path)
+        tls.add_cert(nickname=ca_path, input_file=ca_path, ca=True)
         tls.edit_cert_trust(ca_path, "C,,")
     # Import the new server-cert
     tls.add_server_key_and_cert(CONTAINER_TLS_SERVER_KEY, CONTAINER_TLS_SERVER_CERT)
     # Done!
     log.info("TLS PEM configuration complete.")
 
+
 def _begin_check_reindex():
     if os.getenv('DS_REINDEX', None) is not None:
         log.info("Reindexing database. This may take a while ...")
         inst = _gen_instance()
         inst.db2index()
+
 
 def begin_magic():
     log.info("The 389 Directory Server Container Bootstrap")

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -1069,7 +1069,6 @@ only.
         except subprocess.CalledProcessError as e:
             raise ValueError(e.output.decode('utf-8').rstrip())
 
-
     def display_cert_details(self, nickname):
         cmd = [
             '/usr/bin/certutil',
@@ -1086,7 +1085,6 @@ only.
             raise ValueError(e.output.decode('utf-8').rstrip())
 
         return ensure_str(result)
-
 
     def get_cert_details(self, nickname):
         """Get the trust flags, subject DN, issuer, and expiration date

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -49,6 +49,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 import lib389
 from pathlib import Path
+from subprocess import check_output
 from lib389.paths import ( Paths, DEFAULTS_PATH )
 from lib389.dseldif import DSEldif
 from lib389._constants import (
@@ -1863,6 +1864,25 @@ def is_cert_der(file_name):
         return True
 
 
+def check_cert_info(cert_file_name, search_text):
+    # Use openssl to get cert details
+    cmd = [
+        'openssl',
+        'x509',
+        '-in', cert_file_name,
+        '-text',
+        '-noout',
+    ]
+    log.debug("get_cert_details cmd: %s", format_cmd_list(cmd))
+    try:
+        result = check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        raise ValueError(e.output.decode('utf-8').rstrip())
+
+    cert_text = ensure_str(result)
+    return search_text.lower() in cert_text.lower()
+
+
 def cert_is_ca(cert_file_name):
     with open(cert_file_name, "rb") as f:
         if is_cert_der(cert_file_name):
@@ -1870,18 +1890,20 @@ def cert_is_ca(cert_file_name):
         else:
             cert = x509.load_pem_x509_certificate(f.read(), default_backend())
 
-    key_usage = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.KEY_USAGE)
-    if not key_usage.value.key_cert_sign:
-        return False
-
-    basic_constraints = cert.extensions.get_extension_for_oid(
-        x509.oid.ExtensionOID.BASIC_CONSTRAINTS
-    )
-    if not basic_constraints.value.ca:
-        return False
-
-    # This is a CA cert
-    return True
+    try:
+        key_usage = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.KEY_USAGE)
+        if not key_usage.value.key_cert_sign:
+            return False
+        basic_constraints = cert.extensions.get_extension_for_oid(
+            x509.oid.ExtensionOID.BASIC_CONSTRAINTS
+        )
+        if not basic_constraints.value.ca:
+            return False
+        else:
+            return True
+    except x509.ExtensionNotFound:
+        # No extensions, check the cert info directly
+        return check_cert_info(cert_file_name, "CA:TRUE")
 
 
 def get_passwd_from_file(passwd_file):


### PR DESCRIPTION
Description:

THe certificate type checks for CA/server break if there are no certificate extensions set (use openssl in that case to gather the info instead). dscontainter needed to be updated for new cert checks, and UI adding certs improvements.

relates: https://github.com/389ds/389-ds-base/issues/5768
