### PR TITLE
Issue 5751 - Cleanallruv task crashes on consumer

### DIFF
--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -390,7 +390,7 @@ cl5GetUpperBoundRUV(Replica *r, RUV **ruv)
     int rc = CL5_SUCCESS;
     cldb_Handle *cldb = replica_get_cl_info(r);
 
-    if (r == NULL || ruv == NULL) {
+    if (r == NULL || ruv == NULL || cldb == NULL) {
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
                       "cl5GetUpperBoundRUV - Invalid parameters\n");
         return CL5_BAD_DATA;
@@ -437,7 +437,7 @@ cl5ExportLDIF(const char *ldifFile, Replica *replica)
     cldb_Handle *cldb = replica_get_cl_info(replica);
     int rc;
 
-    if (ldifFile == NULL) {
+    if (ldifFile == NULL || cldb == NULL) {
         slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
                       "cl5ExportLDIF - null ldif file name\n");
         return CL5_BAD_DATA;
@@ -537,6 +537,12 @@ cl5ImportLDIF(const char *clDir, const char *ldifFile, Replica *replica)
     }
 
     cldb = replica_get_cl_info(replica);
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "cl5ImportLDIF - This replica has no changelog\n");
+        return CL5_BAD_DATA;
+    }
+
     if (cldb->dbState != CL5_STATE_OPEN) {
         slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
                       "cl5ImportLDIF - Changelog is not initialized\n");
@@ -1165,7 +1171,9 @@ cl5DestroyReplayIterator(CL5ReplayIterator **iterator, Replica *replica)
 
     /* this thread no longer holds a db reference, release it */
     cldb = replica_get_cl_info(replica);
-    slapi_counter_decrement(cldb->clThreads);
+    if (cldb) {
+        slapi_counter_decrement(cldb->clThreads);
+    }
 }
 
 /* Name: cl5GetOperationCount
@@ -1182,7 +1190,7 @@ cl5GetOperationCount(Replica *replica)
     int count = 0;
     cldb_Handle *cldb = replica_get_cl_info(replica);
 
-    if (replica == NULL) /* compute total entry count */
+    if (replica == NULL || cldb == NULL) /* compute total entry count */
     {
         /* TBD (LK) get count for all backends
         file_obj = objset_first_obj(s_cl5Desc.dbFiles);
@@ -1395,6 +1403,11 @@ cldb_StopTrimming(Replica *replica, void *arg)
 {
     cldb_Handle *cldb = replica_get_cl_info(replica);
 
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "cldb_StopTrimming - Changelog info was NULL - is your replication configuration valid?\n");
+        return 0;
+    }
     /* we need to stop the changelog threads - trimming or purging */
     pthread_mutex_lock(&(cldb->clLock));
     pthread_cond_broadcast(&(cldb->clCvar));
@@ -1410,6 +1423,11 @@ cldb_StopThreads(Replica *replica, void *arg)
     PRIntervalTime interval;
     uint64_t threads;
 
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "cldb_StopThreads - Changelog info was NULL - is your replication configuration valid?\n");
+        return 0;
+    }
     /* we need to stop the changelog threads - trimming or purging */
     pthread_mutex_lock(&(cldb->clLock));
     pthread_cond_broadcast(&(cldb->clCvar));
@@ -2538,6 +2556,11 @@ _cl5DoPurging(cleanruv_purge_data *purge_data)
     const Slapi_DN *suffix_sdn = purge_data->suffix_sdn;
     cldb_Handle *cldb = replica_get_cl_info(purge_data->replica);
 
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "_cl5DoPurging - Changelog info was NULL - is your replication configuration valid?\n");
+        return;
+    }
     pthread_mutex_lock(&(cldb->clLock));
     _cl5PurgeRID (cldb, rid);
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name_cl,
@@ -2777,6 +2800,11 @@ _cl5TrimReplica(Replica *r)
     int rc = CL5_SUCCESS;
 
     cldb_Handle *cldb = replica_get_cl_info(r);
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "_cl5TrimReplica - Changelog info was NULL - is your replication configuration valid?\n");
+        return;
+    }
     if (!_cl5CanTrim ((time_t)0, &dblcictx.numToTrim, r, &cldb->clConf) ) {
         return;
     }
@@ -3856,6 +3884,11 @@ _cl5PositionCursorForReplay(ReplicaId consumerRID, const RUV *consumerRuv, Repli
     cldb_Handle *cldb = replica_get_cl_info(replica);
     PR_ASSERT (consumerRuv && replica && iterator);
 
+    if (cldb == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                      "_cl5PositionCursorForReplay - Changelog info was NULL - is your replication configuration valid?\n");
+        return CL5_UNKNOWN_ERROR;
+    }
     csnStr[0] = '\0';
 
     /* get supplier's RUV */
@@ -4410,6 +4443,10 @@ trigger_cl_purging_thread(void *arg)
     cleanruv_purge_data *purge_data = (cleanruv_purge_data *)arg;
     Replica *replica = purge_data->replica;
     cldb_Handle *cldb = replica_get_cl_info(replica);
+
+    if (cldb == NULL) {
+        return;
+    }
 
     pthread_mutex_lock(&(cldb->stLock));
     /* Make sure we have a change log, and we aren't closing it */


### PR DESCRIPTION
Bug description:
	During CL refactoring (changelog DB was integrated into the main DB #2621)
	several parts of code (removed DB, export/import CL,
	cleanallRUV,..) calls replica_get_cl_info to retrieve the
	changelog of a replica. If the replica does not contain a
	changelog (consumer) the returned pointer is NULL.
	Some code assume the pointer is not NULL and derefence it.

Fix description:
	For all calls to replica_get_cl_info, check the pointer
	before referencing it

relates: #5751

Reviewed by: