### PR TITLE
Issue 5778 - UI - Remove error message if .dsrc is missing

### DIFF
--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -414,7 +414,10 @@ class ReportCredentialsModal extends React.Component {
                         key="save"
                         variant="primary"
                         onClick={newEntry ? addConfig : editConfig}
-                        isDisabled={hostname === "" || binddn === "" || bindpw === ""}
+                        isDisabled={
+                            hostname === "" || binddn === "" ||
+                            (bindpw === "" && !pwInputInterractive)
+                        }
                     >
                         Save
                     </Button>,
@@ -549,7 +552,10 @@ class ReportConnectionModal extends React.Component {
                         key="save"
                         variant="primary"
                         onClick={addConn}
-                        isDisabled={name ==="" || hostname === "" || port === "" || binddn === "" || bindpw === ""}
+                        isDisabled={
+                            name ==="" || hostname === "" || port === "" ||
+                            binddn === "" || (bindpw === "" && !pwInputInterractive)
+                        }
                     >
                         Save
                     </Button>,

--- a/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
@@ -234,10 +234,7 @@ export class ReplMonitor extends React.Component {
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.props.addNotification(
-                        "error",
-                        `Failed to get .dsrc information: ${errMsg.desc}`
-                    );
+                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg.desc}`);
                     this.setState({
                         loadingDSRC: false,
                     });
@@ -262,7 +259,9 @@ export class ReplMonitor extends React.Component {
                                     credsBindpw: "",
                                     pwInputInterractive: true
                                 }
-                            ]
+                            ],
+                            credRows: [...this.props.credRows],
+                            aliasRows: [...this.props.aliasRows],
                         }));
                         if ('replAgmts' in this.props.data) {
                             for (const agmt of this.props.data.replAgmts) {

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -713,8 +713,8 @@ export class Monitor extends React.Component {
                             glues: config.items,
 
                         },
+                        replInitLoaded: true,
                         replLoading: false,
-                        replInitLoaded: true
                     });
                 })
                 .fail(() => {
@@ -756,16 +756,13 @@ export class Monitor extends React.Component {
                     this.setState({
                         credRows,
                         aliasRows,
-                        replLoading: false,
                         replInitLoaded: true
                     });
                 })
                 .fail(err => {
+                    // No dsrc file, thats ok
                     const errMsg = JSON.parse(err);
-                    this.props.addNotification(
-                        "error",
-                        `Failed to get .dsrc information: ${errMsg.desc}`
-                    );
+                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg.desc}`);
                     this.setState({
                         replLoading: false,
                     });
@@ -862,6 +859,7 @@ export class Monitor extends React.Component {
                     .spawn(cmd, { superuser: true, err: "message" })
                     .done(content => {
                         const config = JSON.parse(content);
+                        this.loadDSRC();
                         this.setState({
                             [treeViewItem.suffix]: {
                                 ...this.state[treeViewItem.suffix],
@@ -883,7 +881,7 @@ export class Monitor extends React.Component {
                         // Notification of failure (could only be server down)
                         this.setState({
                             replLoading: false,
-                        });
+                        }, this.loadDSRC);
                     });
         } else {
             // We should enable it here because ReplMonitor never will be mounted


### PR DESCRIPTION
Description:  

Having a .dsrc file is not required, so the UI should not report an error if it's not present

relates: https://github.com/389ds/389-ds-base/issues/5778

