### PR TITLE
Issue 5781 - Bug handling return code of pre-extended operation plugin.

### DIFF
--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -2002,6 +2002,7 @@ plugin_call_func(struct slapdplugin *list, int operation, Slapi_PBlock *pb, int 
                 slapi_plugin_op_finished(list);
                 if (SLAPI_PLUGIN_PREOPERATION == list->plg_type ||
                     SLAPI_PLUGIN_INTERNAL_PREOPERATION == list->plg_type ||
+                    SLAPI_PLUGIN_PREEXTOPERATION == list->plg_type ||
                     SLAPI_PLUGIN_START_FN == operation) {
                     /*
                      * We bail out of plugin processing for preop plugins


### PR DESCRIPTION
Bug Description: The return code of the plugin with the type "pre-extended operation" is not used when processing extended operation.Regardless of the plugin's return code, the operation continues to be processed.

relates: https://github.com/389ds/389-ds-base/issues/5781