### PR TITLE
Issue 5786 - Set minimal permissions on GitHub Workflows

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,6 +3,11 @@ on:
   - pull_request
   - push
 
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
 
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   npm-audit-ci:
     name: npm-audit-ci

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
 
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         type: boolean
         default: false
 
+permissions:
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set minimal permissions on our GitHub Workflows.
Defining minimal permissions secures you against erroneous or malicious behavior from external jobs you call from your workflow. It's especially important in case they get compromised.

Fixes: https://github.com/389ds/389-ds-base/issues/5786

Reviewed by: ?