### PR TITLE
Issue 5786 - CLI - register tools for bash completion

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -495,6 +495,12 @@ autoreconf -fiv
   sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' %{_builddir}/%{name}-%{version}%{?prerel}/wrappers/*.service.in
 %endif
 
+# Register CLI tools for bash completion
+for clitool in dsconf dsctl dsidm dscreate ds-replcheck
+do
+  register-python-argcomplete "${clitool}" > "/usr/share/bash-completion/completions/${clitool}"
+done
+
 %if 0%{?rhel} > 7 || 0%{?fedora}
 # lib389
 pushd ./src/lib389


### PR DESCRIPTION
Description:

In newer versions of Fedora you need to register the CLI tools for bash completion.  Previously it worked out of the box, but now this registration is required

relates: https://github.com/389ds/389-ds-base/issues/5785

