### PR TITLE
Issue 5785 - move bash completion to post section of specfile

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -495,12 +495,6 @@ autoreconf -fiv
   sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts)=/d' %{_builddir}/%{name}-%{version}%{?prerel}/wrappers/*.service.in
 %endif
 
-# Register CLI tools for bash completion
-for clitool in dsconf dsctl dsidm dscreate ds-replcheck
-do
-  register-python-argcomplete "${clitool}" > "/usr/share/bash-completion/completions/${clitool}"
-done
-
 %if 0%{?rhel} > 7 || 0%{?fedora}
 # lib389
 pushd ./src/lib389
@@ -589,6 +583,12 @@ else
     output=/dev/null
     output2=/dev/null
 fi
+
+# Register CLI tools for bash completion
+for clitool in dsconf dsctl dsidm dscreate ds-replcheck
+do
+  register-python-argcomplete "${clitool}" > "/usr/share/bash-completion/completions/${clitool}"
+done
 
 # reload to pick up any changes to systemd files
 /bin/systemctl daemon-reload >$output 2>&1 || :


### PR DESCRIPTION
Description:  Need to move bash completion setup to %post section of specfile. Previously it was done during the build process which is incorrect and breaks builds.

relates: https://github.com/389ds/389-ds-base/issues/5785

Reviewed by: ?