### PR TITLE
Allow empty export path for db2ldif

### DIFF
--- a/dirsrvtests/tests/suites/export/export_test.py
+++ b/dirsrvtests/tests/suites/export/export_test.py
@@ -55,7 +55,7 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
         1. Operation successful
         2. Operation properly fails, without crashing
         3. An error code different from 139 (segmentation fault) should be reported
-        4. "The LDIF file location does not exist" is returned
+        4. "location does not exist" is returned
     """
     export_ldif = '/tmp/nonexistent/export.ldif'
 
@@ -63,10 +63,10 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
     topo.standalone.stop()
 
     log.info("Performing an offline export to a non accessible ldif file path - should fail properly")
-    expected_output="The LDIF file location does not exist"
+    expected_output="location does not exist"
     with pytest.raises(ValueError) as e:
         run_db2ldif_and_clear_logs(topo, topo.standalone, DEFAULT_BENAME, export_ldif, expected_output)
-    assert "The LDIF file location does not exist" in str(e.value)
+    assert "location does not exist" in str(e.value)
 
     log.info("Restarting the instance...")
     topo.standalone.start()

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -56,11 +56,13 @@ def dbtasks_bak2db(inst, log, args):
 
 
 def dbtasks_db2ldif(inst, log, args):
-    # Check if file path exists
-    path = Path(args.ldif)
-    parent = path.parent.absolute()
-    if not parent.exists():
-        raise ValueError("The LDIF file location does not exist: " + args.ldif)
+    # If export filename is provided, check if file path exists
+    if args.ldif:
+        path = Path(args.ldif)
+        parent = path.parent.absolute()
+        if not parent.exists():
+            raise ValueError("The LDIF export location does not exist: "
+                             + args.ldif)
 
     # Export backend
     if not inst.db2ldif(bename=args.backend, encrypt=args.encrypted, repl_data=args.replication,


### PR DESCRIPTION
Until recently, `db2ldif` did not require an export path to be specified and would use a specified default location to create a timestamped file.

See [the `else` statement in
`__init__.py`](https://github.com/389ds/389-ds-base/blob/a30a9e0d6f74774e3c5a0bbe11347d13dc37ddb4/src/lib389/lib389/__init__.py#L2759)

Commit cee276d which was merged in #5641 introduced
[a check](https://github.com/389ds/389-ds-base/commit/cee276d3983aafe6459b4b6545b4d01200a9b892#diff-0df3612e00b94edc2072af211e8c3bacaec694cdfa0f84b0b42a84066f119957R60) to ensure the targeted export file's parent actually exists. This check is fine if a target filename *is* provided, but it fails when no filename is provided; a use case that was supported before.

Therefore, the check should only be done *iff* a filename for the export is provided.