### PR TITLE
Issue 3527 - Fix HAProxy x390x compatibility and compiler warnings

### DIFF
--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1187,10 +1187,8 @@ connection_read_operation(Connection *conn, Operation *op, ber_tag_t *tag, int *
     char str_ip[INET6_ADDRSTRLEN + 1] = {0};
     char str_haproxy_ip[INET6_ADDRSTRLEN + 1] = {0};
     char str_haproxy_destip[INET6_ADDRSTRLEN + 1] = {0};
-    PRStatus status = PR_SUCCESS;
     struct berval **bvals = NULL;
     int proxy_connection = 0;
-    int restrict_access = 0;
 
     pthread_mutex_lock(&(conn->c_mutex));
     /*

--- a/ldap/servers/slapd/haproxy.c
+++ b/ldap/servers/slapd/haproxy.c
@@ -368,7 +368,7 @@ int haproxy_receive(int fd, int *proxy_connection, PRNetAddr *pr_netaddr_from, P
     if (hdr_len < sizeof(hdr)) {
         hdr[hdr_len] = 0;
     } else {
-        slapi_log_err(SLAPI_LOG_CONNS, "haproxy_receive", "Recieved header is too long: %d\n", hdr_len);
+        slapi_log_err(SLAPI_LOG_CONNS, "haproxy_receive", "Recieved header is too long: %ld\n", hdr_len);
         rc = HAPROXY_NOT_A_HEADER;
         return rc;
     }

--- a/test/libslapd/haproxy/parse.c
+++ b/test/libslapd/haproxy/parse.c
@@ -26,62 +26,81 @@ test_input test_cases[] = {
         .expected_result = HAPROXY_HEADER_PARSED,
         .expected_len = 39,
         .expected_proxy_connection = 1,
+
+/* We need to support both big-endian (x390x) and little-endian (x86) architectures,
+ * it's better to dynamically adjust the byte order in our test cases based on
+ * the architecture of the system executing the tests.*/
+#ifdef __s390x__
+        .expected_pr_netaddr_from = { .inet = { .family = PR_AF_INET, .ip = 0xC0A80001, .port = 0x3039 }},
+        .expected_pr_netaddr_dest = { .inet = { .family = PR_AF_INET, .ip = 0xC0A80002, .port = 0x0185 }}
+#else
         .expected_pr_netaddr_from = { .inet = { .family = PR_AF_INET, .ip = 0x0100A8C0, .port = 0x3930 }},
         .expected_pr_netaddr_dest = { .inet = { .family = PR_AF_INET, .ip = 0x0200A8C0, .port = 0x8501 }}
+#endif
     },
     {
         .input_str = "PROXY TCP6 2001:db8::1 2001:db8::2 12345 389\r\n",
         .expected_result = HAPROXY_HEADER_PARSED,
         .expected_len = 46,
         .expected_proxy_connection = 1,
-        .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, .port = 0x3930 }},
-        .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}, .port = 0x8501 }},
+#ifdef __s390x__
+        .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}}}, .port = 0x3039 }},
+        .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}}}, .port = 0x0185 }}
+#else
+        .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}}}, .port = 0x3930 }},
+        .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}}}, .port = 0x8501 }}
+#endif
     },
     {
-    .input_str = "PROXY TCP6 ::ffff:192.168.0.1 ::ffff:192.168.0.2 12345 389\r\n",
-    .expected_result = HAPROXY_HEADER_PARSED,
-    .expected_len = 54,
-    .expected_proxy_connection = 1,
-    .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01}, .port = 0x3930 }},
-    .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x02}, .port = 0x8501 }},
+        .input_str = "PROXY TCP6 ::ffff:192.168.0.1 ::ffff:192.168.0.2 12345 389\r\n",
+        .expected_result = HAPROXY_HEADER_PARSED,
+        .expected_len = 54,
+        .expected_proxy_connection = 1,
+#ifdef __s390x__
+        .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01}}}, .port = 0x3039 }},
+        .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x02}}}, .port = 0x0185 }}
+#else
+        .expected_pr_netaddr_from = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01}}}, .port = 0x3930 }},
+        .expected_pr_netaddr_dest = { .ipv6 = { .family = PR_AF_INET6, .ip = {{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x02}}}, .port = 0x8501 }}
+#endif
     },
-    // Invalid IP
+    /* Invalid IP */
     {
         .input_str = "PROXY TCP4 256.168.0.1 192.168.0.2 12345 389\r\n",
         .expected_result = HAPROXY_ERROR,
         .expected_proxy_connection = 0,
     },
-    // Invalid port
+    /* Invalid port */
     {
         .input_str = "PROXY TCP4 192.168.0.1 192.168.0.2 123456 389\r\n",
         .expected_result = HAPROXY_ERROR,
         .expected_proxy_connection = 0,
     },
-    // One port
+    /* One port */
     {
         .input_str = "PROXY TCP4 192.168.0.1 192.168.0.2 12345\r\n",
         .expected_result = HAPROXY_ERROR,
         .expected_proxy_connection = 0,
     },
-    // No ports
+    /* No ports */
     {
         .input_str = "PROXY TCP4 192.168.0.1 192.168.0.2\r\n",
         .expected_result = HAPROXY_ERROR,
         .expected_proxy_connection = 0,
     },
-    // Empty string
+    /* Empty string */
     {
         .input_str = "",
         .expected_result = HAPROXY_NOT_A_HEADER,
         .expected_proxy_connection = 0,
     },
-    // Invalid protocol
+    /* Invalid protocol */
     {
         .input_str = "PROXY TCP3 192.168.0.1 192.168.0.2 12345 389\r\n",
         .expected_result = HAPROXY_ERROR,
         .expected_proxy_connection = 0,
     },
-    // Missing protocol
+    /* Missing protocol */
     {
         .input_str = "PROXY 192.168.0.1 192.168.0.2 12345 389\r\n",
         .expected_result = HAPROXY_ERROR,


### PR DESCRIPTION
Description: We need to support both big-endian (x390x) and little-endian (x86) architectures, it's better to dynamically adjust the byte order in our test cases based on the architecture of the system executing the tests. Define the values depending on the architecture.

Fix minor compiler warnings.

Related: https://github.com/389ds/389-ds-base/issues/3527

Reviewed by: ?