### PR TITLE
Issue 5755 - The Massive memory leaking on update operations

### DIFF
--- a/dirsrvtests/tests/suites/memory_leaks/allids_search_test.py
+++ b/dirsrvtests/tests/suites/memory_leaks/allids_search_test.py
@@ -1,0 +1,70 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2023 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import pytest
+from lib389.dbgen import dbgen_groups
+from lib389.tasks import ImportTask
+from lib389.utils import *
+from lib389.paths import Paths
+from lib389.topologies import topology_st as topo
+from lib389._constants import *
+
+pytestmark = pytest.mark.tier2
+
+logging.getLogger(__name__).setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+ds_paths = Paths()
+
+
+@pytest.mark.skipif(not ds_paths.asan_enabled, reason="Don't run if ASAN is not enabled")
+def test_allids_search(topo):
+    """Add 100 groups, and run a search with a special filter that triggers a memleak.
+
+    :id: 8aeca831-e671-4203-9d50-2bfe9567bec7
+    :setup: Standalone instance
+    :steps:
+        1. Add 100 test groups
+        2. Issue a search with a special filter
+        3. There should be no leak
+    :expectedresults:
+        1. 100 test groups should be added
+        2. Search should be successful
+        3. Success
+    """
+
+    inst = topo.standalone
+
+    import_ldif = inst.ldifdir + '/import_100_users.ldif'
+    props = {
+        "name": "grp",
+        "suffix": DEFAULT_SUFFIX,
+        "parent": DEFAULT_SUFFIX,
+        "number": 100,
+        "numMembers": 0,
+        "createMembers": False,
+        "memberParent": DEFAULT_SUFFIX,
+        "membershipAttr": "member",
+    }
+    dbgen_groups(inst, import_ldif, props)
+
+    task = ImportTask(inst)
+    task.import_suffix_from_ldif(ldiffile=import_ldif, suffix=DEFAULT_SUFFIX)
+    task.wait()
+
+    inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+                            '(&(objectClass=groupOfNames)(!(objectClass=nsTombstone))(member=doesnt_exist))')
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)
+
+

--- a/ldap/servers/slapd/back-ldbm/idl_set.c
+++ b/ldap/servers/slapd/back-ldbm/idl_set.c
@@ -168,6 +168,9 @@ idl_set_free_idls(IDListSet *idl_set)
 void
 idl_set_destroy(IDListSet *idl_set)
 {
+    if (idl_set->complement_head) {
+        idl_free(&idl_set->complement_head);
+    }
     slapi_ch_free((void **)&(idl_set));
 }
 

--- a/ldap/servers/slapd/back-ldbm/idl_set.c
+++ b/ldap/servers/slapd/back-ldbm/idl_set.c
@@ -168,9 +168,7 @@ idl_set_free_idls(IDListSet *idl_set)
 void
 idl_set_destroy(IDListSet *idl_set)
 {
-    if (idl_set->complement_head) {
-        idl_free(&idl_set->complement_head);
-    }
+    idl_free(&idl_set->complement_head);
     slapi_ch_free((void **)&(idl_set));
 }
 


### PR DESCRIPTION
Bug description: Memory leak with creation, modification and deletion operations.

Fix description: When multiple search filters are used we use set manipulation to construct the final idl results. In this corner case we set the idl_set->compliment_head pointer which is never freed.

relates: https://github.com/389ds/389-ds-base/issues/5755

Reviewed by: ?