### PR TITLE
Issue 5701 - CI - Add more tests for referral mode fix

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_test.py
@@ -8,6 +8,7 @@
 #
 """Test dsconf CLI with LDAPS"""
 
+import ldap
 import logging
 import pytest
 import subprocess
@@ -41,6 +42,91 @@ def enable_config(request, topology_st, config_type):
             os.remove(f'{os.environ.get("HOME")}/.dsrc')
 
     request.addfinalizer(fin)
+
+
+def test_backend_referral(topology_st):
+    """Test setting and deleting referral in backend
+
+    :id: e65fa6c3-da7c-49f8-be0c-738be46a1180
+    :setup: Standalone Instance
+    :steps:
+        1. Set referral using dsconf command
+        2. Verify that referral is set correctly
+        3. Set nsslapd-state to referral and verify
+        4. Test a referral error
+        5. Restart the server
+        6. Cleanup - delete referral and set nsslapd-state to 'backend'
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+    dsconf_cmd= ['/usr/sbin/dsconf', topology_st.standalone.serverid, '-D', DN_DM, '-w', 'password']
+    # Set referral
+    log.info("Use dsconf to set referral")
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'set', '--add-referral', 'ldap://localhost.localdomain:389/o%3dnetscaperoot', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    msg = proc.communicate()
+    log.info('output message : %s' % msg[0])
+    assert proc.returncode == 0
+
+    # Check referral
+    log.info("Verify referral is set correctly")
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'get', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    log.info('output message : %s' % out[0])
+    assert 'referral: ldap://localhost.localdomain:389/o%3dnetscaperoot' in out.decode('utf-8')
+
+    # Set nsslapd-state to referral
+    log.info("Use dsconf to set nsslapd-state to referral")
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'set', '--state', 'referral', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    msg = proc.communicate()
+    log.info('output message : %s' % msg[0])
+    assert proc.returncode == 0
+
+    # Verify nsslapd-state
+    log.info("Verify nsslapd-state is set to referral")
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'get', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    log.info('output message : %s' % out[0])
+    assert 'state: referral' in out.decode('utf-8')
+
+    # Test a referral error
+    topology_st.standalone.set_option(ldap.OPT_REFERRALS, 0)  # Do not follow referral
+    with pytest.raises(ldap.REFERRAL):
+        topology_st.standalone.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, 'objectclass=top')
+
+    # Restart the server
+    log.info('Restarting the server...')
+    topology_st.standalone.restart(timeout=10)
+
+    # Cleanup
+    log.info('Cleaning up...')
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'set', '--state', 'backend', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    log.info('output message : %s' % out[0])
+    assert proc.returncode == 0
+
+    cmdline = dsconf_cmd + ['backend', 'suffix', 'set', '--del-referral', 'ldap://localhost.localdomain:389/o%3dnetscaperoot', 'userRoot']
+    log.info(f'Command used: %{cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    log.info('output message : %s' % out[0])
+    assert proc.returncode == 0
+    topology_st.standalone.set_option(ldap.OPT_REFERRALS, 1)
+
 
 @pytest.mark.parametrize('config_type', ('ldapfile','dsrfile'))
 def test_dsconf_with_ldaps(topology_st, enable_config, config_type):

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -883,7 +883,7 @@ def create_parser(subparsers):
     set_backend_parser.add_argument('--cache-size', help='Sets the maximum number of entries to keep in the entry cache')
     set_backend_parser.add_argument('--cache-memsize', help='Sets the maximum size in bytes that the entry cache can grow to')
     set_backend_parser.add_argument('--dncache-memsize', help='Sets the maximum size in bytes that the DN cache can grow to')
-    set_backend_parser.add_argument('--state', help='Changes the backend state to: "database", "disabled", "referral", or "referral on update"')
+    set_backend_parser.add_argument('--state', help='Changes the backend state to: "backend", "disabled", "referral", or "referral on update"')
     set_backend_parser.add_argument('be_name', help='The backend name or suffix')
 
     #########################################


### PR DESCRIPTION
Description: Refactor basic referral state test to be correct according to the current lib389 implementation.
Add more tests to the clu/dsconf_test.py suite, which covers CLI referral state logic.

Related: https://github.com/389ds/389-ds-base/issues/5701

Reviewed by: ?