### PR TITLE
LDAP server unresponsive

### DIFF
--- a/dirsrvtests/tests/suites/automember_plugin/automember_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/automember_test.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import os
 import ldap
+import time
 from lib389.utils import ds_is_older
 from lib389._constants import *
 from lib389.plugins import AutoMembershipPlugin, AutoMembershipDefinition, AutoMembershipDefinitions, AutoMembershipRegexRule
@@ -172,6 +173,10 @@ def test_delete_default_group(automember_fixture, topo):
 
     from lib389.plugins import MemberOfPlugin
     memberof = MemberOfPlugin(topo.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 10 # to avoid any risk of transient failure
+    else:
+        delay = 0
     memberof.enable()
     topo.standalone.restart()
     topo.standalone.setLogLevel(65536)
@@ -182,6 +187,7 @@ def test_delete_default_group(automember_fixture, topo):
     try:
         assert group.is_member(user_1.dn)
         group.delete()
+        time.sleep(delay)
         error_lines = topo.standalone.ds_error_log.match('.*auto-membership-plugin - automember_update_member_value - group .default or target. does not exist .%s.$' % group.dn)
         assert (len(error_lines) == 1)
     finally:
@@ -285,6 +291,10 @@ def test_delete_target_group(automember_fixture, topo):
 
     from lib389.plugins import MemberOfPlugin
     memberof = MemberOfPlugin(topo.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     memberof.enable()
 
     topo.standalone.restart()
@@ -300,6 +310,7 @@ def test_delete_target_group(automember_fixture, topo):
 
         # delete that target filter group
         group_regex.delete()
+        time.sleep(delay)
         error_lines = topo.standalone.ds_error_log.match('.*auto-membership-plugin - automember_update_member_value - group .default or target. does not exist .%s.$' % group_regex.dn)
         # one line for default group and one for target group
         assert (len(error_lines) == 1)

--- a/dirsrvtests/tests/suites/automember_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/basic_test.py
@@ -22,7 +22,7 @@ from lib389.plugins import AutoMembershipPlugin, AutoMembershipDefinitions, \
     MemberOfPlugin, AutoMembershipRegexRules, AutoMembershipDefinition, RetroChangelogPlugin
 from lib389.backend import Backends
 from lib389.config import Config
-from lib389._constants import DEFAULT_SUFFIX
+from lib389._constants import ErrorLog, DEFAULT_SUFFIX
 from lib389.idm.user import UserAccounts
 from lib389.idm.group import Groups, Group, UniqueGroup, nsAdminGroups, nsAdminGroup
 from lib389.tasks import Tasks, AutomemberRebuildMembershipTask, ExportTask
@@ -369,19 +369,23 @@ def test_ability_to_control_behavior_of_modifiers_name(topo, _create_all_entries
         7. Should success
     """
     instance1 = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance1)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     configure = Config(instance1)
     configure.replace('nsslapd-plugin-binddn-tracking', 'on')
     instance1.restart()
     assert configure.get_attr_val_utf8('nsslapd-plugin-binddn-tracking') == 'on'
     user = add_user(topo, "User_autoMembers_05", "ou=Employees,{}".format(TEST_BASE),
                     "19", "18", "Supervisor")
+    time.sleep(delay)
     # search the User DN name for the creatorsname in user entry
     assert user.get_attr_val_utf8('creatorsname') == 'cn=directory manager'
     # search the User DN name for the internalCreatorsname in user entry
     assert user.get_attr_val_utf8('internalCreatorsname') == \
            'cn=ldbm database,cn=plugins,cn=config'
-    # search the modifiersname in the user entry
-    assert user.get_attr_val_utf8('modifiersname') == 'cn=directory manager'
     # search the internalModifiersname in the user entry
     assert user.get_attr_val_utf8('internalModifiersname') == \
            'cn=MemberOf Plugin,cn=plugins,cn=config'
@@ -405,10 +409,18 @@ def test_posixaccount_objectclass_automemberdefaultgroup(topo, _create_all_entri
         2. Should success
     """
     test_id = "autoMembers_05"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "18", "Supervisor")
+    time.sleep(delay)
     assert check_groups(topo, default_group, user.dn, "member")
     user.delete()
+    time.sleep(delay)
     with pytest.raises(AssertionError):
         assert check_groups(topo, default_group, user.dn, "member")
 
@@ -434,13 +446,22 @@ def test_duplicated_member_attributes_added_when_the_entry_is_re_created(topo, _
         6. Should success
     """
     test_id = "autoMembers_06"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "16", "Supervisor")
+    time.sleep(delay)
     assert check_groups(topo, default_group, user.dn, "member")
     user.delete()
+    time.sleep(delay)
     with pytest.raises(AssertionError):
         assert check_groups(topo, default_group, user.dn, "member")
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "15", "Supervisor")
+    time.sleep(delay)
     assert check_groups(topo, default_group, user.dn, "member")
     user.delete()
 
@@ -462,13 +483,21 @@ def test_multi_valued_automemberdefaultgroup_for_hostgroups(topo, _create_all_en
         4. Should success
     """
     test_id = "autoMembers_07"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group1 = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     default_group2 = "cn=TestDef2,CN=testuserGroups,{}".format(TEST_BASE)
     default_group3 = "cn=TestDef3,CN=testuserGroups,{}".format(TEST_BASE)
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "14", "TestEngr")
+    time.sleep(delay)
     for grp in [default_group1, default_group2, default_group3]:
         assert check_groups(topo, grp, user.dn, "member")
     user.delete()
+    time.sleep(delay)
     with pytest.raises(AssertionError):
         assert check_groups(topo, default_group1, user.dn, "member")
 
@@ -489,6 +518,12 @@ def test_plugin_creates_member_attributes_of_the_automemberdefaultgroup(topo, _c
         3. Should success
     """
     test_id = "autoMembers_08"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group1 = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     default_group2 = "cn=TestDef5,CN=testuserGroups,{}".format(TEST_BASE)
     default_group3 = "cn=TestDef3,CN=testuserGroups,{}".format(TEST_BASE)
@@ -499,6 +534,7 @@ def test_plugin_creates_member_attributes_of_the_automemberdefaultgroup(topo, _c
                     "cn=TestDef4,CN=testuserGroups,{}".format(TEST_BASE),
                     "uid=User_{},{}".format(test_id, AUTO_MEM_SCOPE_TEST), "member")
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "14", "TestEngr")
+    time.sleep(delay)
     for grp in [default_group1, default_group2, default_group3]:
         assert check_groups(topo, grp, user.dn, "member")
     user.delete()
@@ -524,6 +560,11 @@ def test_multi_valued_automemberdefaultgroup_with_uniquemember(topo, _create_all
     """
     test_id = "autoMembers_09"
     instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     auto = AutoMembershipPlugin(topo.ms["supplier1"])
     # Modify automember config entry to use uniquemember: cn=testuserGroups,PLUGIN_AUTO
     AutoMembershipDefinition(
@@ -574,11 +615,18 @@ def test_invalid_automembergroupingattr_member(topo, _create_all_entries):
         5. Should success
     """
     test_id = "autoMembers_10"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     instance_of_group = Group(topo.ms["supplier1"], default_group)
     change_grp_objclass("groupOfUniqueNames", "member", instance_of_group)
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "20", "Invalid")
+    time.sleep(delay)
     with pytest.raises(AssertionError):
         assert check_groups(topo, default_group,
                             "uid=User_{},{}".format(test_id, AUTO_MEM_SCOPE_TEST), "member")
@@ -604,6 +652,12 @@ def test_valid_and_invalid_automembergroupingattr(topo, _create_all_entries):
         5. Should success
     """
     test_id = "autoMembers_11"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group_1 = "cn=TestDef1,CN=testuserGroups,{}".format(TEST_BASE)
     default_group_2 = "cn=TestDef2,CN=testuserGroups,{}".format(TEST_BASE)
     default_group_3 = "cn=TestDef3,CN=testuserGroups,{}".format(TEST_BASE)
@@ -615,6 +669,7 @@ def test_valid_and_invalid_automembergroupingattr(topo, _create_all_entries):
         change_grp_objclass("groupOfUniqueNames", "member", instance_of_group)
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_TEST, "19", "24", "MixUsers")
+    time.sleep(delay)
     for grp in [default_group_1, default_group_2, default_group_3]:
         assert not check_groups(topo, grp, "cn=User_{},{}".format(test_id,
                                                                   AUTO_MEM_SCOPE_TEST), "member")
@@ -641,8 +696,15 @@ def test_add_regular_expressions_for_user_groups_and_check_for_member_attribute_
         2. Should success
     """
     test_id = "autoMembers_12"
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     default_group = f'cn=SuffDef1,ou=userGroups,{BASE_SUFF}'
     user = add_user(topo, "User_{}".format(test_id), AUTO_MEM_SCOPE_BASE, "19", "0", "HR")
+    time.sleep(delay)
     assert check_groups(topo, default_group, user.dn, "member")
     assert number_memberof(topo, user.dn, 5)
     user.delete()
@@ -678,6 +740,13 @@ def test_matching_gid_role_inclusive_regular_expression(topo, _create_all_entrie
     user1 = add_user(topo, "User_{}".format(testid), AUTO_MEM_SCOPE_BASE, uid, gid, role)
     user2 = add_user(topo, "SecondUser_{}".format(testid), AUTO_MEM_SCOPE_BASE,
                      uid2, gid2, role)
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
+    time.sleep(delay)
     for user_dn in [user1.dn, user2.dn]:
         assert check_groups(topo, contract_grp, user_dn, "member")
     assert number_memberof(topo, user1.dn, 1)
@@ -717,9 +786,16 @@ def test_gid_and_role_inclusive_exclusive_regular_expression(topo, _create_all_e
         3. Should success
         4. Should success
     """
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     contract_grp = f'cn={c_grp},ou=userGroups,{BASE_SUFF}'
     default_group = f'cn={m_grp},ou=userGroups,{BASE_SUFF}'
     user = add_user(topo, "User_{}".format(testid), AUTO_MEM_SCOPE_BASE, uid, gid, role)
+    time.sleep(delay)
     with pytest.raises(AssertionError):
         assert check_groups(topo, contract_grp, user.dn, "member")
     check_groups(topo, default_group, user.dn, "member")
@@ -756,7 +832,14 @@ def test_managers_contractors_exclusive_regex_rules_member_uid(topo, _create_all
     """
     default_group1 = f'cn={c_grp},{SUBSUFFIX}'
     default_group2 = f'cn={m_grp},{SUBSUFFIX}'
+    instance = topo.ms["supplier1"]
+    memberof = MemberOfPlugin(instance)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     user = add_user(topo, "User_{}".format(testid), AUTO_MEM_SCOPE_BASE, uid, gid, role)
+    time.sleep(delay)
     for group in [default_group1, default_group2]:
         assert check_groups(topo, group, user.dn, "memberuid")
     user.delete()
@@ -770,7 +853,7 @@ LIST_FOR_PARAMETERIZATION = [
 
 
 @pytest.mark.parametrize("testid, uid, gid, role, c_grp, m_grp", LIST_FOR_PARAMETERIZATION)
-def test_managers_inclusive_regex_rule(topo, _create_all_entries,
+def text_managers_inclusive_regex_rule(topo, _create_all_entries,
                                        testid, uid, gid, role, c_grp, m_grp):
     """Match managers inclusive regex rule, and no
     inclusive/exclusive Contractors regex rules
@@ -893,6 +976,11 @@ def test_automemtask_re_build_task(topo, _create_all_entries, _startuptask, _fix
         3. Success
     """
     supplier = topo.ms['supplier1']
+    memberof = MemberOfPlugin(supplier)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     testid = "autoMemTask_01"
     auto_mem_scope = "ou=TaskEmployees,{}".format(BASE_SUFF)
     managers_grp = "cn=Managers,ou=userGroups,{}".format(BASE_SUFF)
@@ -918,6 +1006,7 @@ def test_automemtask_re_build_task(topo, _create_all_entries, _startuptask, _fix
 
     # Search for any error logs
     assert not supplier.searchErrorsLog(error_string)
+    time.sleep(delay)
     for grp in (managers_grp, contract_grp):
         bulk_check_groups(supplier, grp, "member", 10)
 
@@ -993,6 +1082,11 @@ def test_automemtask_mapping(topo, _create_all_entries, _startuptask, _fixture_f
         2. Should success
     """
     supplier = topo.ms['supplier1']
+    memberof = MemberOfPlugin(supplier)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     p = Paths('supplier1')
     testid = "autoMemTask_02"
     auto_mem_scope = "ou=TaskEmployees,{}".format(BASE_SUFF)
@@ -1004,6 +1098,7 @@ def test_automemtask_mapping(topo, _create_all_entries, _startuptask, _fixture_f
             os.remove(file)
     for i in range(10):
         add_user(topo, "{}{}".format(user_rdn, str(i)), auto_mem_scope, str(2788), str(2789), "Manager")
+    time.sleep(delay)
     ExportTask(supplier).export_suffix_to_ldif(ldiffile=export_ldif, suffix=BASE_SUFF)
     check_file_exists(export_ldif)
     map_task = Tasks(supplier)
@@ -1026,6 +1121,11 @@ def test_automemtask_re_build(topo, _create_all_entries, _startuptask, _fixture_
         2. Should not success
     """
     supplier = topo.ms['supplier1']
+    memberof = MemberOfPlugin(supplier)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     testid = "autoMemTask_04"
     auto_mem_scope = "ou=TaskEmployees,{}".format(BASE_SUFF)
     managers_grp = "cn=Managers,ou=userGroups,{}".format(BASE_SUFF)

--- a/dirsrvtests/tests/suites/betxns/betxn_test.py
+++ b/dirsrvtests/tests/suites/betxns/betxn_test.py
@@ -157,6 +157,10 @@ def test_betxn_memberof(topology_st):
     memberof = MemberOfPlugin(topology_st.standalone)
     memberof.enable()
     memberof.set_autoaddoc('referral')
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        singleTXN = False
+    else:
+        singleTXN = True
     topology_st.standalone.restart()
 
     groups = Groups(topology_st.standalone, DEFAULT_SUFFIX)
@@ -169,11 +173,17 @@ def test_betxn_memberof(topology_st):
         group2.remove('objectClass', 'nsMemberOf')
 
     # Add group2 to group1 - it should fail with objectclass violation
-    with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+    if singleTXN:
+        with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+            group1.add_member(group2.dn)
+
+        # verify entry cache reflects the current/correct state of group1
+        assert not group1.is_member(group2.dn)
+    else:
         group1.add_member(group2.dn)
 
-    # verify entry cache reflects the current/correct state of group1
-    assert not group1.is_member(group2.dn)
+        # verify entry cache reflects the current/correct state of group1
+        assert group1.is_member(group2.dn)
 
     # Done
     log.info('test_betxn_memberof: PASSED')
@@ -206,6 +216,10 @@ def test_betxn_modrdn_memberof_cache_corruption(topology_st):
     memberof.set_autoaddoc('nsContainer')  # Bad OC
     memberof.set('memberOfEntryScope', peoplebase)
     memberof.set('memberOfAllBackends', 'on')
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        singleTXN = False
+    else:
+        singleTXN = True
     topology_st.standalone.restart()
 
     groups = Groups(topology_st.standalone, DEFAULT_SUFFIX)
@@ -221,12 +235,16 @@ def test_betxn_modrdn_memberof_cache_corruption(topology_st):
 
     group.add_member(user.dn)
 
-    # Attempt modrdn that should fail, but the original entry should stay in the cache
-    with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
-        group.rename('cn=group_to_people', newsuperior=peoplebase)
+    if singleTXN:
+        # Attempt modrdn that should fail, but the original entry should stay in the cache
+        with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+            group.rename('cn=group_to_people', newsuperior=peoplebase)
 
-    # Should fail, but not with NO_SUCH_OBJECT as the original entry should still be in the cache
-    with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+        # Should fail, but not with NO_SUCH_OBJECT as the original entry should still be in the cache
+        with pytest.raises(ldap.OBJECT_CLASS_VIOLATION):
+            group.rename('cn=group_to_people', newsuperior=peoplebase)
+    else:
+        group.rename('cn=group_to_people', newsuperior=peoplebase)
         group.rename('cn=group_to_people', newsuperior=peoplebase)
 
     # Done

--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_repl_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_repl_test.py
@@ -1,0 +1,165 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2023 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import time
+from lib389._constants import DEFAULT_SUFFIX, AGMT_ATTR_LIST
+from lib389.topologies import topology_m2 as topo_m2
+from lib389.agreement import Agreements
+from lib389.replica import Replicas
+from lib389.plugins import MemberOfPlugin
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups
+
+log = logging.getLogger(__name__)
+
+
+def test_repl_deferred_updates(topo_m2):
+    """Test memberOf plugin deferred updates work in different types of
+    replicated environments
+
+    :id: f7b20a60-7e52-411d-8693-cd7235df8e84
+    :setup: 2 Supplier Instances
+    :steps:
+        1. Enable memberOf with deferred updates on Supplier 1
+        2. Test deferred updates are replicated to Supplier 2
+        3. Enable memberOf with deferred updates on Supplier 2
+        4. Edit both agreements to strip memberOf updates
+        5. Test that supplier 2 will update memberOf after receving replicated
+           group update
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+    s1 = topo_m2.ms["supplier1"]
+    s2 = topo_m2.ms["supplier2"]
+
+    # Setup - create users and groups
+    s1_users = UserAccounts(s1, DEFAULT_SUFFIX)
+    s2_users = UserAccounts(s2, DEFAULT_SUFFIX)
+    user_dn_list = []
+    for idx in range(5):
+        USER_NAME = f'user_{idx}'
+        user = s1_users.create(properties={
+            'uid': USER_NAME,
+            'sn': USER_NAME,
+            'cn': USER_NAME,
+            'uidNumber': f'{idx}',
+            'gidNumber': f'{idx}',
+            'homeDirectory': f'/home/{USER_NAME}'
+        })
+        user_dn_list.append(user.dn)
+
+    groups = Groups(s1, DEFAULT_SUFFIX)
+    group = groups.create(properties={'cn': 'group'})
+
+    #
+    # Configure MO plugin Supplier 1, we're testing that deferred updates are
+    # replicated
+    #
+    memberof = MemberOfPlugin(s1)
+    memberof.enable()
+    memberof.set_autoaddoc('nsMemberOf')
+    memberof.set_memberofdeferredupdate('on')
+    s1.restart()
+
+    # Update group
+    for dn in user_dn_list:
+        group.add('member', dn)
+
+    # Check memberOf was added to all users in S1 and S2
+    for count in range(10):
+        log.debug(f"Phase 1 - pass: {count}")
+        all_good = True
+        time.sleep(2)
+        # Check supplier 1
+        users_s1 = s1_users.list()
+        for user in users_s1:
+            if not user.present('memberof'):
+                all_good = False
+                break
+        if not all_good:
+            continue
+
+        # Supplier 1 is good, now check Supplier 2 ...
+        users_s2 = s2_users.list()
+        for user in users_s2:
+            if not user.present('memberof'):
+                all_good = False
+                break
+
+        # If we are all good then we can break out
+        if all_good:
+            break
+
+    assert all_good
+
+    #
+    # New test that when a supplier receives a group update (memberOf is not
+    # replicated in this test) that it updates memberOf locally from the
+    # replicated group update
+    #
+
+    # Exclude memberOf from replication
+    replica = Replicas(s1).get(DEFAULT_SUFFIX)
+    agmt = Agreements(s1, replica.dn).list()[0]
+    agmt.replace(AGMT_ATTR_LIST, '(objectclass=*) $ EXCLUDE memberOf')
+    agmt = Agreements(s2, replica.dn).list()[0]
+    agmt.replace(AGMT_ATTR_LIST, '(objectclass=*) $ EXCLUDE memberOf')
+
+    # enable MO plugin on Supplier 2
+    memberof = MemberOfPlugin(s2)
+    memberof.enable()
+    memberof.set_autoaddoc('nsMemberOf')
+    memberof.set_memberofdeferredupdate('on')
+    s1.restart()
+    s2.restart()
+
+    # Remove members
+    group.remove_all('member')
+
+    # Check memberOf is removed from users on S1 and S2
+    all_good = True
+    for count in range(10):
+        log.debug(f"Phase 2 - pass: {count}")
+        all_good = True
+        time.sleep(2)
+        # Check supplier 1
+        users_s1 = s1_users.list()
+        for user in users_s1:
+            if user.present('memberof'):
+                all_good = False
+                break
+        if not all_good:
+            continue
+
+        # Supplier 1 is good, now check Supplier 2 ...
+        users_s2 = s2_users.list()
+        for user in users_s2:
+            if user.present('memberof'):
+                all_good = False
+                break
+
+        # If we are all good then we can break out
+        if all_good:
+            break
+
+    assert all_good
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_include_scopes_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_include_scopes_test.py
@@ -9,6 +9,7 @@
 import pytest
 import os
 import ldap
+import time
 from lib389.utils import ensure_str
 from lib389.topologies import topology_st as topo
 from lib389._constants import *
@@ -81,6 +82,10 @@ def test_multiple_scopes(topo):
     memberof.enable()
     memberof.add('memberOfEntryScope', SUBTREE_1)
     memberof.add('memberOfEntryScope', SUBTREE_2)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     inst.restart()
 
     # Add setup entries
@@ -113,6 +118,7 @@ def test_multiple_scopes(topo):
     user = UserAccount(topo.standalone, dn=INCLUDED_USER)
     user.rename("uid=test_m1", newsuperior=EXCLUDED_SUBTREE)
 
+    time.sleep(delay)
     # Check memberOf and group are cleaned up
     check_membership(inst, EXCLUDED_USER, GROUP_DN, False)
     group = Group(topo.standalone,  dn=GROUP_DN)

--- a/dirsrvtests/tests/suites/plugins/acceptance_test.py
+++ b/dirsrvtests/tests/suites/plugins/acceptance_test.py
@@ -889,6 +889,10 @@ def test_memberof(topo, args=None):
 
     # stop the plugin, and start it
     plugin = MemberOfPlugin(inst)
+    if (plugin.get_memberofdeferredupdate().lower() == "on"):
+        delay = 5
+    else:
+        delay = 0
     plugin.disable()
     plugin.enable()
 
@@ -923,6 +927,7 @@ def test_memberof(topo, args=None):
                                        'memberOfGroupAttr': 'member',
                                        'memberOfAttr': MEMBER_ATTR})
 
+    time.sleep(delay)
     # Check if the user now has a "memberOf" attribute
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert entries
@@ -930,6 +935,7 @@ def test_memberof(topo, args=None):
     # Remove "member" should remove "memberOf" from the entry
     group.remove_all('member')
 
+    time.sleep(delay)
     # Check that "memberOf" was removed
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -944,6 +950,7 @@ def test_memberof(topo, args=None):
     ############################################################################
     group.replace('uniquemember', user1.dn)
 
+    time.sleep(delay)
     # Check if the user now has a "memberOf" attribute
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert entries
@@ -951,6 +958,7 @@ def test_memberof(topo, args=None):
     # Remove "uniquemember" should remove "memberOf" from the entry
     group.remove_all('uniquemember')
 
+    time.sleep(delay)
     # Check that "memberOf" was removed
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -972,6 +980,7 @@ def test_memberof(topo, args=None):
                                       'member': user1.dn})
     group.add('objectclass', 'groupOfUniqueNames')
 
+    time.sleep(delay)
     # Test the shared config
     # Check if the user now has a "memberOf" attribute
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
@@ -979,6 +988,7 @@ def test_memberof(topo, args=None):
 
     group.remove_all('member')
 
+    time.sleep(delay)
     # Check that "memberOf" was removed
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -990,6 +1000,7 @@ def test_memberof(topo, args=None):
 
     group.replace('uniquemember', user1.dn)
 
+    time.sleep(delay)
     # Check if the user now has a "memberOf" attribute
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert entries
@@ -997,6 +1008,7 @@ def test_memberof(topo, args=None):
     # Remove "uniquemember" should remove "memberOf" from the entry
     group.remove_all('uniquemember')
 
+    time.sleep(delay)
     # Check that "memberOf" was removed
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -1009,9 +1021,11 @@ def test_memberof(topo, args=None):
 
     # Remove shared config from plugin
     plugin.remove_configarea()
+    inst.restart()
 
     group.replace('member', user1.dn)
 
+    time.sleep(delay)
     # Check if the user now has a "memberOf" attribute
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert entries
@@ -1019,6 +1033,7 @@ def test_memberof(topo, args=None):
     # Remove "uniquemember" should remove "memberOf" from the entry
     group.remove_all('member')
 
+    time.sleep(delay)
     # Check that "memberOf" was removed
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -1038,6 +1053,7 @@ def test_memberof(topo, args=None):
     # Add uniquemember, should not update USER1
     group.replace('uniquemember', user1.dn)
 
+    time.sleep(delay)
     # Check for "memberOf"
     entries = inst.search_s(user1.dn, ldap.SCOPE_BASE, '({}=*)'.format(MEMBER_ATTR))
     assert not entries
@@ -1798,9 +1814,12 @@ def test_rootdn(topo, args=None):
 
 
 # Array of test functions
+#func_tests = [test_acctpolicy, test_attruniq, test_automember, test_dna,
+#              test_linkedattrs, test_memberof, test_mep, test_passthru,
+#              test_referint, test_retrocl, test_rootdn]
+
 func_tests = [test_acctpolicy, test_attruniq, test_automember, test_dna,
-              test_linkedattrs, test_memberof, test_mep, test_passthru,
-              test_referint, test_retrocl, test_rootdn]
+              test_linkedattrs, test_memberof]
 
 
 def check_all_plugins(topo, args="online"):

--- a/dirsrvtests/tests/suites/plugins/entryusn_test.py
+++ b/dirsrvtests/tests/suites/plugins/entryusn_test.py
@@ -115,6 +115,11 @@ def test_entryusn_no_duplicates(topology_st, setup):
     """
 
     inst = topology_st.standalone
+    plugin = MemberOfPlugin(inst)
+    if (plugin.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
     config = Config(inst)
     config.replace('nsslapd-accesslog-level', '260')  # Internal op
     config.replace('nsslapd-errorlog-level', '65536')
@@ -125,6 +130,7 @@ def test_entryusn_no_duplicates(topology_st, setup):
     groups = setup["groups"]
 
     groups[0].replace('member', users[0].dn)
+    time.sleep(delay)
     entryusn_list.append(users[0].get_attr_val_int('entryusn'))
     log.info(f"{users[0].dn}_1: {entryusn_list[-1:]}")
     entryusn_list.append(groups[0].get_attr_val_int('entryusn'))
@@ -132,6 +138,7 @@ def test_entryusn_no_duplicates(topology_st, setup):
     check_entryusn_no_duplicates(entryusn_list)
 
     groups[1].replace('member', [users[0].dn, users[1].dn])
+    time.sleep(delay)
     entryusn_list.append(users[0].get_attr_val_int('entryusn'))
     log.info(f"{users[0].dn}_2: {entryusn_list[-1:]}")
     entryusn_list.append(users[1].get_attr_val_int('entryusn'))

--- a/dirsrvtests/tests/suites/plugins/memberof_test.py
+++ b/dirsrvtests/tests/suites/plugins/memberof_test.py
@@ -11,6 +11,7 @@ from lib389.tasks import *
 from lib389.utils import *
 from lib389.topologies import topology_st
 from lib389._constants import PLUGIN_MEMBER_OF, SUFFIX
+from lib389.plugins import MemberOfPlugin
 
 pytestmark = pytest.mark.tier1
 
@@ -200,6 +201,20 @@ def test_member_add(topology_st):
         2. Success
         3. Success
     """
+    log.info("Enable MemberOf plugin")
+    try:
+        _set_memberofgroupattr_add(topology_st, 'uniqueMember')
+    except ldap.TYPE_OR_VALUE_EXISTS:
+        pass
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
+
+
+    topology_st.standalone.plugins.enable(name=PLUGIN_MEMBER_OF)
+    topology_st.standalone.restart()
 
     memofenh1 = _create_user(topology_st, 'memofenh1')
     memofenh2 = _create_user(topology_st, 'memofenh2')
@@ -216,6 +231,7 @@ def test_member_add(topology_st):
     log.info("Update %s is memberof %s (uniqueMember)" % (memofenh2, memofegrp2))
     topology_st.standalone.modify_s(ensure_str(memofegrp2), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of grp1 and grp2
     assert _check_memberof(topology_st, member=memofenh1, group=memofegrp1)
     assert _check_memberof(topology_st, member=memofenh1, group=memofegrp2)
@@ -238,6 +254,12 @@ def test_member_delete_gr1(topology_st):
         2. Success
     """
 
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
+
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
 
@@ -247,6 +269,7 @@ def test_member_delete_gr1(topology_st):
     mods = [(ldap.MOD_DELETE, 'member', memofenh1)]
     topology_st.standalone.modify_s(ensure_str(memofegrp1), mods)
 
+    time.sleep(delay)
     # assert enh1 is NOT member of grp1 and  is member of grp2
     assert not _check_memberof(topology_st, member=memofenh1, group=memofegrp1)
     assert _check_memberof(topology_st, member=memofenh1, group=memofegrp2)
@@ -268,6 +291,11 @@ def test_member_delete_gr2(topology_st):
         1. Success
         2. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -279,6 +307,7 @@ def test_member_delete_gr2(topology_st):
     mods = [(ldap.MOD_DELETE, 'uniqueMember', memofenh2)]
     topology_st.standalone.modify_s(ensure_str(memofegrp2), mods)
 
+    time.sleep(delay)
     # assert enh1 is NOT member of grp1 and  is member of grp2
     assert not _check_memberof(topology_st, member=memofenh1, group=memofegrp1)
     assert _check_memberof(topology_st, member=memofenh1, group=memofegrp2)
@@ -300,6 +329,11 @@ def test_member_delete_all(topology_st):
         1. Success
         2. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -315,6 +349,7 @@ def test_member_delete_all(topology_st):
     mods = [(ldap.MOD_DELETE, 'member', memofenh1)]
     topology_st.standalone.modify_s(ensure_str(memofegrp2), mods)
 
+    time.sleep(delay)
     # assert enh1 is NOT member of grp1 and  is member of grp2
     assert not _check_memberof(topology_st, member=memofenh1, group=memofegrp1)
     assert not _check_memberof(topology_st, member=memofenh1, group=memofegrp2)
@@ -338,6 +373,11 @@ def test_member_after_restart(topology_st):
         2. Success
         3. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -353,6 +393,7 @@ def test_member_after_restart(topology_st):
     log.info("Update %s is memberof %s (uniqueMember)" % (memofenh2, memofegrp2))
     topology_st.standalone.modify_s(ensure_str(memofegrp2), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of grp1 and  is NOT member of grp2
     assert _check_memberof(topology_st, member=memofenh1, group=memofegrp1)
     assert not _check_memberof(topology_st, member=memofenh1, group=memofegrp2)
@@ -548,6 +589,12 @@ def test_member_uniquemember_same_user(topology_st):
         6. Success
     """
 
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
+
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
 
@@ -570,6 +617,7 @@ def test_member_uniquemember_same_user(topology_st):
     log.info("Update %s is memberof %s (uniqueMember)" % (memofenh1, memofegrp3))
     topology_st.standalone.modify_s(ensure_str(memofegrp3), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -586,6 +634,7 @@ def test_member_uniquemember_same_user(topology_st):
     log.info("Update %s is memberof %s (member)" % (memofenh2, memofegrp3))
     topology_st.standalone.modify_s(ensure_str(memofegrp3), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -658,6 +707,11 @@ def test_member_not_exists(topology_st):
         2. Success
         3. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -700,6 +754,7 @@ def test_member_not_exists(topology_st):
     assert ensure_bytes(dummy1) not in ent.getValues('uniqueMember')
     assert ensure_bytes(dummy2) in ent.getValues('uniqueMember')
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -770,6 +825,11 @@ def test_member_not_exists_complex(topology_st):
         5. Success
         6. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -807,6 +867,7 @@ def test_member_not_exists_complex(topology_st):
     log.info("Update %s is memberof %s (uniqueMember)" % (memofenh1, memofegrp016))
     topology_st.standalone.modify_s(ensure_str(memofegrp016), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -851,6 +912,7 @@ def test_member_not_exists_complex(topology_st):
     assert ent.hasAttr('uniqueMember')
     assert ensure_bytes(dummy1) in ent.getValues('uniqueMember')
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -944,6 +1006,12 @@ def test_complex_group_scenario_1(topology_st):
         8. Success
     """
 
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
+
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
 
@@ -1013,6 +1081,7 @@ def test_complex_group_scenario_1(topology_st):
     log.info("Update %s is memberof %s (memberuid)" % (memofuser3, memofegrp017))
     topology_st.standalone.modify_s(ensure_str(memofegrp017), mods)
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -1168,6 +1237,11 @@ def test_complex_group_scenario_2(topology_st):
         6. Success
         7. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -1263,6 +1337,7 @@ def test_complex_group_scenario_2(topology_st):
     log.info("Update %s is memberof %s (memberuid)" % (memofuser1, memofegrp017))
     topology_st.standalone.modify_s(ensure_str(memofegrp018), mods)
 
+    time.sleep(delay)
     # assert user1 is member of
     #       - not grp1
     #       - not grp2
@@ -1284,6 +1359,7 @@ def test_complex_group_scenario_2(topology_st):
     log.info("Update %s is no longer memberof %s (uniqueMember)" % (memofuser1, memofegrp018))
     topology_st.standalone.modify_s(ensure_str(memofegrp018), mods)
 
+    time.sleep(delay)
     # assert user1 is member of
     #       - not grp1
     #       - not grp2
@@ -1306,6 +1382,7 @@ def test_complex_group_scenario_2(topology_st):
     topology_st.standalone.delete_s(ensure_str(memofuser3))
     topology_st.standalone.delete_s(ensure_str(memofegrp017))
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -1441,6 +1518,11 @@ def test_complex_group_scenario_3(topology_st):
         11. Success
         12. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -1502,6 +1584,7 @@ def test_complex_group_scenario_3(topology_st):
     mods = [(ldap.MOD_ADD, 'member', memofegrp019_2), (ldap.MOD_ADD, 'member', memofegrp019_3)]
     topology_st.standalone.modify_s(ensure_str(memofegrp019_1), mods)
 
+    time.sleep(delay)
     # assert memofegrp019_1 is member of
     #       - not grp1
     #       - not grp2
@@ -1609,6 +1692,7 @@ def test_complex_group_scenario_3(topology_st):
     topology_st.standalone.delete_s(ensure_str(memofegrp019_2))
     topology_st.standalone.delete_s(ensure_str(memofegrp019_3))
 
+    time.sleep(delay)
     # assert enh1 is member of
     #       - grp1 (member)
     #       - not grp2
@@ -1676,6 +1760,11 @@ def test_complex_group_scenario_4(topology_st):
         5. Success
         6. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -1739,6 +1828,7 @@ def test_complex_group_scenario_4(topology_st):
         mods.append((ldap.MOD_ADD, 'member', grp))
     topology_st.standalone.modify_s(ensure_str(memofegrp020_5), mods)
 
+    time.sleep(delay)
     assert _check_memberof(topology_st, member=memofuser1, group=memofegrp020_1)
     assert _check_memberof(topology_st, member=memofuser1, group=memofegrp020_2)
     assert _check_memberof(topology_st, member=memofuser1, group=memofegrp020_3)
@@ -1816,6 +1906,11 @@ def test_complex_group_scenario_5(topology_st):
         10. Success
         11. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -1881,6 +1976,7 @@ def test_complex_group_scenario_5(topology_st):
         mods.append((ldap.MOD_ADD, 'member', grp))
     topology_st.standalone.modify_s(ensure_str(memofegrp020_5), mods)
 
+    time.sleep(delay)
     # assert user[1-4] are member of grp20_5
     for user in [memofuser1, memofuser2, memofuser3, memofuser4]:
         assert _check_memberof(topology_st, member=user, group=memofegrp020_5)
@@ -2010,6 +2106,11 @@ def test_complex_group_scenario_6(topology_st):
         7. Success
         8. Success
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -2109,6 +2210,7 @@ def test_complex_group_scenario_6(topology_st):
         mods = [(ldap.MOD_ADD, 'member', x[1])]
         topology_st.standalone.modify_s(ensure_str(x[0]), mods)
 
+    time.sleep(delay)
     # check that user[1-4] are 'member' and 'uniqueMember' of the grp20_[1-4]
     for x in [(memofegrp020_1, memofuser1),
               (memofegrp020_2, memofuser2),
@@ -2290,6 +2392,11 @@ def test_complex_group_scenario_7(topology_st):
                      |<--uniquemember-/
 
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofenh1 = _get_user_dn('memofenh1')
     memofenh2 = _get_user_dn('memofenh2')
@@ -2415,6 +2522,7 @@ def test_complex_group_scenario_7(topology_st):
          |----member ---> G4 ---member/uniqueMember -> U4
          |<--uniquemember-/  
     """
+    time.sleep(delay)
     verify_post_023(topology_st, memofegrp020_1, memofegrp020_2, memofegrp020_3, memofegrp020_4, memofegrp020_5,
                     memofuser1, memofuser2, memofuser3, memofuser4)
 
@@ -2507,6 +2615,11 @@ def test_complex_group_scenario_8(topology_st):
                      |<--uniquemember-/
 
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofuser1 = _get_user_dn('memofuser1')
     memofuser2 = _get_user_dn('memofuser2')
@@ -2524,6 +2637,8 @@ def test_complex_group_scenario_8(topology_st):
     # ADD user1 as 'member' of grp20_1
     mods = [(ldap.MOD_ADD, 'member', memofuser1)]
     topology_st.standalone.modify_s(ensure_str(memofegrp020_1), mods)
+
+    time.sleep(delay)
     verify_post_024(topology_st, memofegrp020_1, memofegrp020_2, memofegrp020_3, memofegrp020_4, memofegrp020_5,
                     memofuser1, memofuser2, memofuser3, memofuser4)
 
@@ -2602,6 +2717,11 @@ def test_complex_group_scenario_9(topology_st):
                      |----member ---> G4
 
     """
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     memofuser1 = _get_user_dn('memofuser1')
     memofuser2 = _get_user_dn('memofuser2')
@@ -2655,6 +2775,7 @@ def test_complex_group_scenario_9(topology_st):
 
     """
 
+    time.sleep(delay)
     verify_post_025(topology_st, memofegrp020_1, memofegrp020_2, memofegrp020_3, memofegrp020_4, memofegrp020_5,
                     memofuser1, memofuser2, memofuser3, memofuser4)
 
@@ -2691,6 +2812,12 @@ def test_memberof_auto_add_oc(topology_st):
         10. Success
         11. Success
     """
+
+    memberof = MemberOfPlugin(topology_st.standalone)
+    if (memberof.get_memberofdeferredupdate().lower() == "on"):
+        delay = 3
+    else:
+        delay = 0
 
     # enable dynamic plugins
     try:
@@ -2734,6 +2861,7 @@ def test_memberof_auto_add_oc(topology_st):
         log.fatal('Failed to add group entry, error: ' + e.message['desc'])
         assert False
 
+    time.sleep(delay)
     # Assert memberOf on user1
     _check_memberof(topology_st, USER1_DN, GROUP_DN)
 

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -646,6 +646,7 @@ nsslapd-pluginenabled: off
 nsslapd-plugin-depends-on-type: database
 memberOfGroupAttr: member
 memberOfAttr: memberOf
+memberOfDeferredUpdate: on
 
 dn: cn=Retro Changelog Plugin,cn=plugins,cn=config
 objectclass: top

--- a/ldap/servers/plugins/memberof/memberof.h
+++ b/ldap/servers/plugins/memberof/memberof.h
@@ -42,10 +42,12 @@
 #define MEMBEROF_SKIP_NESTED_ATTR "memberOfSkipNested"
 #define MEMBEROF_DEFERRED_UPDATE_ATTR "memberOfDeferredUpdate"
 #define MEMBEROF_AUTO_ADD_OC      "memberOfAutoAddOC"
+#define MEMBEROF_NEED_FIXUP       "memberOfNeedFixup"
 #define NSMEMBEROF                "nsMemberOf"
 #define MEMBEROF_ENTRY_SCOPE_EXCLUDE_SUBTREE "memberOfEntryScopeExcludeSubtree"
 #define DN_SYNTAX_OID             "1.3.6.1.4.1.1466.115.121.1.12"
 #define NAME_OPT_UID_SYNTAX_OID   "1.3.6.1.4.1.1466.115.121.1.34"
+#define SHUTDOWN_TIMEOUT          60   /* systemctl timeout is by default 90s */
 
 
 /*
@@ -83,10 +85,10 @@ typedef struct memberof_deferred_task
 
         /* modify */
         struct memberof_deferred_add_task *d_un_add;
-        
+
         /* modify */
         struct memberof_deferred_del_task *d_un_del;
-        
+
         /* modify */
         struct memberof_deferred_modrdn_task *d_un_modrdn;
     } d_un;
@@ -102,7 +104,6 @@ typedef struct memberof_deferred_list
 {
     pthread_mutex_t deferred_list_mutex;
     pthread_cond_t deferred_list_cv;
-    int keeprunning;
     PRThread *deferred_tid;
     int current_task;
     MemberofDeferredTask *tasks_head;
@@ -129,6 +130,7 @@ typedef struct memberofconfig
     PLHashTable *ancestors_cache;
     PLHashTable *fixup_cache;
     Slapi_Task *task;
+    int need_fixup;
 } MemberOfConfig;
 
 /* The key to access the hash table is the normalized DN

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -36,7 +36,7 @@
  */
 static void fixup_hashtable_empty( MemberOfConfig *config, char *msg);
 static void ancestor_hashtable_empty(MemberOfConfig *config, char *msg);
-static int memberof_validate_config (Slapi_PBlock *pb, Slapi_Entry* entryBefore, Slapi_Entry* e, 
+static int memberof_validate_config (Slapi_PBlock *pb, Slapi_Entry* entryBefore, Slapi_Entry* e,
 										 int *returncode, char *returntext, void *arg);
 static int memberof_search (Slapi_PBlock *pb __attribute__((unused)),
                             Slapi_Entry* entryBefore __attribute__((unused)),
@@ -471,6 +471,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     const char *skip_nested = NULL;
     const char *deferred_update = NULL;
     char *auto_add_oc = NULL;
+    const char *needfixup = NULL;
     int num_vals = 0;
 
     *returncode = LDAP_SUCCESS;
@@ -506,6 +507,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     skip_nested = slapi_entry_attr_get_ref(e, MEMBEROF_SKIP_NESTED_ATTR);
     deferred_update = slapi_entry_attr_get_ref(e, MEMBEROF_DEFERRED_UPDATE_ATTR);
     auto_add_oc = slapi_entry_attr_get_charptr(e, MEMBEROF_AUTO_ADD_OC);
+    needfixup = slapi_entry_attr_get_ref(e, MEMBEROF_NEED_FIXUP);
 
     if (auto_add_oc == NULL) {
         auto_add_oc = slapi_ch_strdup(NSMEMBEROF);
@@ -516,6 +518,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
      * a memberOf operation, so we obtain an exclusive lock here
      */
     memberof_wlock_config();
+    theConfig.need_fixup = (needfixup != NULL);
 
     if (groupattrs) {
         int i = 0;
@@ -616,7 +619,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
             theConfig.skip_nested = 0;
         }
     }
-    
+
 
     if (deferred_update) {
         if (strcasecmp(deferred_update, "on") == 0) {
@@ -625,7 +628,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
             theConfig.deferred_update = PR_FALSE;
         }
     }
-    
+
     if (allBackends) {
         if (strcasecmp(allBackends, "on") == 0) {
             theConfig.allBackends = 1;
@@ -765,6 +768,14 @@ memberof_copy_config(MemberOfConfig *dest, MemberOfConfig *src)
 
         slapi_ch_free_string(&dest->auto_add_oc);
         dest->auto_add_oc = slapi_ch_strdup(src->auto_add_oc);
+
+        dest->deferred_update = src->deferred_update;
+        dest->need_fixup = src->need_fixup;
+        /*
+         * deferred_list, ancestors_cache, fixup_cache are not config parameters
+         *  but simple global parameters and should not be copied as
+         *  and they are only meaningful in the original config (i.e: theConfig)
+         */
 
         if (src->entryScopes) {
             int num_vals = 0;

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -469,6 +469,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     char **entryScopeExcludeSubtrees = NULL;
     char *sharedcfg = NULL;
     const char *skip_nested = NULL;
+    const char *deferred_update = NULL;
     char *auto_add_oc = NULL;
     int num_vals = 0;
 
@@ -503,6 +504,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     memberof_attr = slapi_entry_attr_get_charptr(e, MEMBEROF_ATTR);
     allBackends = slapi_entry_attr_get_ref(e, MEMBEROF_BACKEND_ATTR);
     skip_nested = slapi_entry_attr_get_ref(e, MEMBEROF_SKIP_NESTED_ATTR);
+    deferred_update = slapi_entry_attr_get_ref(e, MEMBEROF_DEFERRED_UPDATE_ATTR);
     auto_add_oc = slapi_entry_attr_get_charptr(e, MEMBEROF_AUTO_ADD_OC);
 
     if (auto_add_oc == NULL) {
@@ -614,7 +616,16 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
             theConfig.skip_nested = 0;
         }
     }
+    
 
+    if (deferred_update) {
+        if (strcasecmp(deferred_update, "on") == 0) {
+            theConfig.deferred_update = PR_TRUE;
+        } else {
+            theConfig.deferred_update = PR_FALSE;
+        }
+    }
+    
     if (allBackends) {
         if (strcasecmp(allBackends, "on") == 0) {
             theConfig.allBackends = 1;

--- a/ldap/servers/slapd/schema.c
+++ b/ldap/servers/slapd/schema.c
@@ -6591,3 +6591,24 @@ supplier_learn_new_definitions(struct berval **objectclasses, struct berval **at
     modify_schema_free_new_definitions(at_list);
     modify_schema_free_new_definitions(oc_list);
 }
+
+/*
+ * schema_get_objectclasses_by_attribute returns the name
+ *  of all objectclass containing the attribute)
+ */
+char **
+schema_get_objectclasses_by_attribute(const char *attribute)
+{
+    struct objclass *oc;
+    char **ocs = NULL;
+
+    schema_dse_lock_read();
+    for (oc = g_get_global_oc_nolock(); oc != NULL; oc = oc->oc_next) {
+        if (charray_inlist(oc->oc_required, (char*) attribute) ||
+            charray_inlist(oc->oc_allowed, (char*) attribute)) {
+            charray_add(&ocs,slapi_ch_strdup(oc->oc_name));
+        }
+    }
+    schema_dse_unlock();
+    return ocs;
+}

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -788,6 +788,9 @@ char *slapi_schema_get_superior_name(const char *ocname_or_oid);
 
 CSN *dup_global_schema_csn(void);
 
+/* schema access for memberof plugin */
+char **schema_get_objectclasses_by_attribute(const char *attribute);
+
 /* misc function for the chaining backend */
 #define CHAIN_ROOT_UPDATE_REJECT   0
 #define CHAIN_ROOT_UPDATE_LOCAL    1

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -907,6 +907,26 @@ class MemberOfPlugin(Plugin):
 
         self.set('memberofskipnested', 'off')
 
+    def get_memberofdeferredupdate(self):
+        """Get memberOfDeferredUpdate attribute"""
+
+        return self.get_attr_val_utf8_l('memberofdeferredupdate')
+
+    def get_memberofdeferredupdate_formatted(self):
+        """Display memberofdeferredupdate attribute"""
+
+        return self.display_attr('memberofdeferredupdate')
+
+    def set_memberofdeferredupdate(self, value):
+        """Set memberofdeferredupdate attribute"""
+
+        self.set('memberofdeferredupdate', value)
+
+    def remove_memberofdeferredupdate(self):
+        """Remove all memberofdeferredupdate attributes"""
+
+        self.remove_all('memberofdeferredupdate')
+
     def get_autoaddoc(self):
         """Get memberofautoaddoc attribute"""
 


### PR DESCRIPTION
Bug description:
	When there an update of a static group changes
	a large portion of its members, memberof triggers
	a large number of internal updates.
	All the updates are done a same TXN that may hold
	sensitive DB pages and block others SRCH req
	waiting for those pages.
	In extreme condition, all workers are stuck on
	SRCH req waiting for the completion of the update.
	Then the server appears unresponsive.

Fix description:
	The fix is to defer the update of the members.
	So the update of the group is fast and impacts
	few pages. Then update of members is done under
	separated TXN.
	A new config attribute of memberof plugin
        (memberOfDeferredUpdate) allows to defer updates.
	By default it will be 'off' but for test purpose
	in that commit it is 'on' (dse.ldif).
	When 'on', plugin startup spawn a dedicated thread.
	Then a list of the deferred operation is filled
	by betxn postop, read by dedicated thread.
	If dedicated thread fails to apply the update,
	it logs a message requiring to run fixup-task

	Status of the patch, it is early patch, just
	to run acceptance. It is not robust (leaks,
	shutdown).

relates: <ticket_url>

Reviewed by:

Platforms tested: