### PR TITLE
Issue 5729 - Memory leak in factory_create_extension

### DIFF
--- a/ldap/servers/plugins/sync/sync_persist.c
+++ b/ldap/servers/plugins/sync/sync_persist.c
@@ -1084,7 +1084,7 @@ done:
 
     slapi_ch_free((void **)&req->req_orig_base);
     slapi_filter_free(req->req_filter, 1);
-    sync_cookie_free(&req->req_cookie);
+
     for (qnode = req->ps_eq_head; qnode; qnode = qnodenext) {
         qnodenext = qnode->sync_next;
         sync_node_free(&qnode);

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -626,6 +626,12 @@ slapi_connection_remove_operation(Slapi_PBlock *pb __attribute__((unused)), Slap
             rc = 0;
         }
     }
+
+    /* Call the plugin extension destructor */
+    if (op) {
+        factory_destroy_extension(get_operation_object_type(), op, conn, &((op)->o_extension));
+    }
+
     pthread_mutex_unlock(&(conn->c_mutex));
     return (rc);
 }


### PR DESCRIPTION
Bug description: Mem leak in sync repl operation extension code. In syn persist when we release the connection, the operation extension is not free'd.

Fix description: In syn persist when we release the connection, free the operation extension if it exists.

relates: https://github.com/389ds/389-ds-base/issues/5729

Reviewed by: