### PR TITLE
Issue 5551 - Almost empty and not loaded ns-slapd high cpu load

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1119,7 +1119,7 @@ slapd_daemon(daemon_ports_t *ports)
     /* The meat of the operation is in a loop on a call to select */
     while (!g_get_shutdown()) {
 
-        usleep(1000);
+        usleep(500 * 1000);
     }
     /* We get here when the server is shutting down */
     /* Do what we have to do before death */


### PR DESCRIPTION
Bug Description: stracing the ns-slapd process one can see nanosleep gets called a lot as we only sleep for 1ms

Fix Description: Increasing the sleep time from 1ms to 500ms and the cpu usage will drop drop a few percent and strace will be more usable

relates: https://github.com/389ds/389-ds-base/issues/5551

Reviewd by: @mreynolds389