### PR TITLE
Issue 5755 - Massive memory leaking on update operations

### DIFF
--- a/ldap/servers/slapd/back-ldbm/idl_set.c
+++ b/ldap/servers/slapd/back-ldbm/idl_set.c
@@ -168,7 +168,6 @@ idl_set_free_idls(IDListSet *idl_set)
 void
 idl_set_destroy(IDListSet *idl_set)
 {
-    idl_free(&idl_set->complement_head);
     slapi_ch_free((void **)&(idl_set));
 }
 
@@ -523,7 +522,7 @@ idl_set_intersect(IDListSet *idl_set, backend *be)
      *
      * NOTE: This is still not optimised yet!
      */
-    if (idl_set->complement_head != NULL && result_list->b_nids > 0) {
+    if (idl_set->complement_head != NULL) {
         IDList *new_result_list = NULL;
         IDList *next_idl = NULL;
         IDList *idl = idl_set->complement_head;


### PR DESCRIPTION
Description: Correction of idl memory leak fix

Fix description: Initial mem leak fix (#5803) causing a SEGV during basic search.

The inital memory leak occurs during idl_set manipulation when a filter type LDAP_FILTER_AND, filter choice LDAP_FILTER_NOT and an empty set is used. The complelement idl is stashed for a later intersection, but is never freed when an empty set is used during set intersection.

The previous fix has been removed and the inital leak corrected.

relates: https://github.com/389ds/389-ds-base/pull/5803

Reviewed by: