### PR TITLE
Issue 5825 - healthcheck - password storage scheme warning needs more info

### DIFF
--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -215,9 +215,20 @@ class Config(DSLdapObject):
         allowed_schemes = ['PBKDF2-SHA512', 'PBKDF2_SHA256', 'PBKDF2_SHA512', 'GOST_YESCRYPT']
         u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
         u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
-        if u_root_scheme not in allowed_schemes or u_password_scheme not in allowed_schemes:
+        if u_root_scheme not in allowed_schemes:
             report = copy.deepcopy(DSCLE0002)
+            report['detail'] = report['detail'].replace('SCHEME', u_root_scheme)
+            report['detail'] = report['detail'].replace('CONFIG', 'nsslapd-rootpwstoragescheme')
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['fix'] = report['fix'].replace('CONFIG', 'nsslapd-rootpwstoragescheme')
+            report['check'] = "config:passwordscheme"
+            yield report
+        if u_password_scheme not in allowed_schemes:
+            report = copy.deepcopy(DSCLE0002)
+            report['detail'] = report['detail'].replace('SCHEME', u_password_scheme)
+            report['detail'] = report['detail'].replace('CONFIG', 'passwordStorageScheme')
+            report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['fix'] = report['fix'].replace('CONFIG', 'passwordStorageScheme')
             report['check'] = "config:passwordscheme"
             yield report
 

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -97,20 +97,16 @@ verify, as this adds a cost of work to an attacker.
 In Directory Server, we offer one hash suitable for this (PBKDF2-SHA512) and one hash
 for "legacy" support (SSHA512).
 
-Your configuration does not use these for password storage or the root password storage
-scheme.
+Your configured scheme (SCHEME) for 'CONFIG' is not secure
 """,
     'fix': """Perform a configuration reset of the values:
 
-passwordStorageScheme
-nsslapd-rootpwstoragescheme
-
-IE, stop Directory Server, and in dse.ldif delete these two lines. When Directory Server
+IE, stop Directory Server, and in dse.ldif delete this line (CONFIG). When Directory Server
 is started, they will use the server provided defaults that are secure.
 
 You can also use 'dsconf' to replace these values.  Here is an example:
 
-    # dsconf slapd-YOUR_INSTANCE config replace passwordStorageScheme=PBKDF2-SHA512 nsslapd-rootpwstoragescheme=PBKDF2-SHA512"""
+    # dsconf slapd-YOUR_INSTANCE config replace CONFIG=PBKDF2-SHA512"""
 }
 
 DSCLE0003 = {


### PR DESCRIPTION
Description:  

Add the current/insecure scheme to the report, and state which config setting is insecure.

relates: https://github.com/389ds/389-ds-base/issues/5825

