### PR TITLE
issue 5833 - dsconf monitor backend fails on lmdb

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
@@ -108,7 +108,6 @@ dbmdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     sprintf(buf, "%" PRId64, maxentries);
     MSET("maxEntryCacheCount");
 
-#if 0
     if (entryrdn_get_switch()) {
         /* fetch cache statistics */
         cache_get_stats(&(inst->inst_dncache), &hits, &tries,
@@ -127,6 +126,17 @@ dbmdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
         MSET("currentDnCacheCount");
         sprintf(buf, "%" PRId64, maxentries);
         MSET("maxDnCacheCount");
+    }
+
+#ifdef DEBUG
+    {
+        /* debugging for hash statistics */
+        char *x = NULL;
+        cache_debug_hash(&(inst->inst_cache), &x);
+        val.bv_val = x;
+        val.bv_len = strlen(x);
+        attrlist_replace(&e->e_attrs, "entrycache-hashtables", vals);
+        slapi_ch_free((void **)&x);
     }
 #endif
 


### PR DESCRIPTION
Problem:  
   On a suffix using lmdb, 'dsconf instance monitor backend userroot' fails because dn normalization cache data are missing. 

Solution: 
 In fact the code was already in mdb_monitor.c but disabled by #if 0 and the fix is simply to remove the #if 
 Also added entrycache-hashtables in debug mode (to be aligned to what is done in bdb case)
 
 Issue: [5833](https://github.com/389ds/389-ds-base/issues/5833)

Reviewed by: @jchapma, @mreynolds389 Thanks!
           