### PR TITLE
Issue 4169 - UI - Fix retrochangelog and schema Typeaheads

### DIFF
--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -425,7 +425,7 @@ textarea {
     margin-left: 80px;
 }
 
-@media screen and (max-width: 1300px) {
+@media screen and (max-width >= 1300px) {
     .ds-plugin-spinner {
         margin-left: 0;
     }
@@ -453,7 +453,7 @@ textarea {
     top: -16px;
 }
 
-@media screen and (max-width: 770px) {
+@media screen and (max-width >= 770px) {
     .ds-plugin-tab-header {
         margin-top: 0;
         margin-bottom: 0;

--- a/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
@@ -46,6 +46,7 @@ class RetroChangelog extends React.Component {
             maxAgeUnit: "w",
             trimInterval: 300,
             excludeSuffix: [],
+            excludeSuffixOptions: [],
             excludeAttrs: [],
             // original values
             _isReplicated: false,
@@ -152,10 +153,10 @@ class RetroChangelog extends React.Component {
                 isExcludeSuffixOpen: false
             }, () => { this.validate() });
         };
-        this.onExcludeSuffixCreateOption = newValue => {
-            if (!this.state.excludeSuffix.includes(newValue)) {
+        this.handleOnExcludeSuffixCreateOption = newValue => {
+            if (!this.state.excludeSuffixOptions.includes(newValue)) {
                 this.setState({
-                    excludeSuffix: [...this.state.excludeSuffix, newValue],
+                    excludeSuffixOptions: [...this.state.excludeSuffixOptions, newValue],
                     isExcludeSuffixOpen: false
                 }, () => { this.validate() });
             }
@@ -388,7 +389,7 @@ class RetroChangelog extends React.Component {
                                     placeholderText="Type a suffix..."
                                     noResultsFoundText="There are no matching entries"
                                     isCreatable
-                                    onCreateOption={this.handleSubtreeScopeCreateOption}
+                                    onCreateOption={this.handleOnExcludeSuffixCreateOption}
                                     validated={error.excludeSuffix ? ValidatedOptions.error : ValidatedOptions.default}
                                 >
                                     {[""].map((attr, index) => (

--- a/src/cockpit/389-console/src/schema.jsx
+++ b/src/cockpit/389-console/src/schema.jsx
@@ -223,7 +223,8 @@ export class Schema extends React.Component {
         this.handleAliasNameCreateOption = newValue => {
             if (!this.state.atAliasOptions.includes(newValue)) {
                 this.setState({
-                    atAliasOptions: [...this.state.atAliasOptions, { value: newValue }]
+                    atAliasOptions: [...this.state.atAliasOptions, { value: newValue }],
+                    isAliasNameOpen: false
                 });
             }
         };
@@ -291,7 +292,8 @@ export class Schema extends React.Component {
         this.handleRequiredAttrsCreateOption = newValue => {
             if (!this.state.ocMustOptions.includes(newValue)) {
                 this.setState({
-                    ocMustOptions: [...this.state.ocParentocMustOptionsOptions, { value: newValue }]
+                    ocMustOptions: [...this.state.ocMustOptions, { value: newValue }],
+                    isRequiredAttrsOpen: false
                 });
             }
         };
@@ -329,7 +331,8 @@ export class Schema extends React.Component {
         this.handleAllowedAttrsCreateOption = newValue => {
             if (!this.state.ocMayOptions.includes(newValue)) {
                 this.setState({
-                    ocMayOptions: [...this.state.ocMayOptions, { value: newValue }]
+                    ocMayOptions: [...this.state.ocMayOptions, { value: newValue }],
+                    isAllowedAttrsOpen: false
                 });
             }
         };


### PR DESCRIPTION
Description: During PF4 Migration, a few typeaheads got broken.
Fix retroChangelog and schema typeahead selects.

Related: https://github.com/389ds/389-ds-base/issues/4169

Reviewed by: ?