### PR TITLE
Issue 5848 - dsconf should prevent setting the replicaID for hub and consumer roles

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_test.py
@@ -8,17 +8,20 @@
 #
 """Test dsconf CLI with LDAPS"""
 
-import ldap
-import logging
-import pytest
 import subprocess
+import logging
 import os
-from lib389._constants import DEFAULT_SUFFIX, DN_DM
-from lib389.topologies import topology_st
+from lib389.cli_base import LogCapture
+import pytest
+import ldap
+from lib389._constants import DEFAULT_SUFFIX, DN_DM, ReplicaRole
+from lib389.topologies import create_topology
+
 
 pytestmark = pytest.mark.tier1
 
 log = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope="function")
 def enable_config(request, topology_st, config_type):
@@ -43,6 +46,15 @@ def enable_config(request, topology_st, config_type):
 
     request.addfinalizer(fin)
 
+
+@pytest.fixture(scope="function")
+def topology_st(request):
+    """Create DS standalone instance"""
+
+    topology = create_topology({ReplicaRole.STANDALONE: 1})
+
+    topology.logcap = LogCapture()
+    return topology
 
 def test_backend_referral(topology_st):
     """Test setting and deleting referral in backend
@@ -167,3 +179,36 @@ def test_dsconf_with_ldaps(topology_st, enable_config, config_type):
     msg = proc.communicate()
     log.info(f'output message : {msg[0]}')
     assert proc.returncode == 0
+
+
+@pytest.mark.parametrize('instance_role', ('consumer', 'hub'))
+def test_check_replica_id_rejected (instance_role):
+    """Test dsconf CLI does not accept replica-id parameter for comsumer and hubs
+
+    :id: 274b47f8-111a-11ee-8321-98fa9ba19b65
+    :parametrized: yes
+    :customerscenario: True
+    :setup: Create DS instance
+    :steps:
+        1. Create ldap instance
+        2. Use dsconf cli to create replica and specify replica id for a consumer
+        3. Verify dsconf command rejects replica_id for consumers
+        4. Repeat for a hub use dsconf to create a replica w replica id
+        5. Verify dsconf command rejects replica_id for hubs
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Setting the "replica-id" manually for consumers not allowed.
+        4. Success
+        5. Setting the "replica-id" manually for hubs is not allowed.
+    """
+    print("DN_DM {}".format(DN_DM))
+    cmdline = ['/usr/sbin/dsconf', 'standalone1', '-D', DN_DM, '-w', 'password', 'replication', 'enable', '--suffix', DEFAULT_SUFFIX, '--role', instance_role, '--replica-id=1']
+    log.info(f'Command used : {cmdline}')
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+
+    msg = proc.communicate()
+    msg = msg[0].decode('utf-8')
+    log.info(f'output message : {msg}')
+    assert "Replication successfully enabled for" not in msg, f"Test Failed: --replica-id option is accepted....It shouldn't for {instance_role}"
+    log.info(f"Test PASSED: --replica-id option is NOT accepted for {instance_role}.")

--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -183,6 +183,13 @@ def enable_replication(inst, basedn, log, args):
         # rid is good add it to the props
         repl_properties['nsDS5ReplicaId'] = args.replica_id
 
+    # Validate consumer and hub settings
+    elif role == "consumer" or role == "hub":
+        # Check Replica ID
+        if args.replica_id is not None or args.replica_id != 65535:
+            # Error, Replica ID cannot be specified for consumer and hub roles
+            raise ValueError('Replica ID cannot be specified for consumer and hub roles')
+
     # Bind DN or Bind DN Group?
     if args.bind_group_dn:
         repl_properties['nsDS5ReplicaBindDNGroup'] = args.bind_group_dn


### PR DESCRIPTION

Bug Description:

dsconf accepts the "replica-id" option when setting a hub or a consumer. The replica configuration entry is correctly created ( replicaID is set to 65535 ). we should  prevent users setting the replicaID for hub and consumer roles because the value is set automatically anyway.

Fix Description:
Check if role is "consumer" or "hub" and if so deny option to set the ReplicaID

relates: https://github.com/389ds/389-ds-base/issues/5848

Author: Gilbert Kimetto

Reviewed by: ?? Simon Pichugi