### PR TITLE
Issue 5856 - SyntaxWarning: invalid escape sequence '\,'

### DIFF
--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -1679,7 +1679,7 @@ def create_parser(subparsers):
     winsync_agmt_add_parser.add_argument('--sync-interval', help="Sets the interval that DS checks AD for changes in entries")
     winsync_agmt_add_parser.add_argument('--one-way-sync',
                                          help="Sets which direction to perform synchronization: \"toWindows\", or "
-                                              "\"fromWindows\,.  By default sync occurs in both directions.")
+                                              "\"fromWindows\".  By default sync occurs in both directions.")
     winsync_agmt_add_parser.add_argument('--move-action',
                                          help="Sets instructions on how to handle moved or deleted entries: "
                                               "\"none\", \"unsync\", or \"delete\"")


### PR DESCRIPTION
Bug Description:
An error is logged during rpm build:

/usr/lib/python3.12/site-packages/lib389/cli_conf/replication.py:1682: SyntaxWarning: invalid escape sequence '\,'

Fix Description:
Fix the typo.

Fixes: https://github.com/389ds/389-ds-base/issues/5856

Reviewed-by: ???