### PR TITLE
Issue 5859 - dbscan fails with AttributeError: 'list' object has no a…

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3054,7 +3054,7 @@ class DirSrv(SimpleLDAPObject, object):
             # (we should also accept a version number for .db suffix)
             for f in glob.glob(f'{indexfile}*'):
                 indexfile = f
-            cmd.extends(['-f', indexfile])
+            cmd.extend(['-f', indexfile])
             if 'id2entry' in index:
                 if key and key.isdigit():
                     cmd.extend(['-K', key])


### PR DESCRIPTION
…ttribute 'extends'

Bug Description:
There is a typo in dbscan:
```
>           cmd.extends(['-f', indexfile])
E           AttributeError: 'list' object has no attribute 'extends'

src/lib389/lib389/__init__.py:3057: AttributeError
```

Fix Description:
Fix the typo and fix the test test
dirsrvtests/tests/suites/password/regression_test.py::test_unhashed_pw_switch

Fixes: https://github.com/389ds/389-ds-base/issues/5859

Reviewed-by: ???