### PR TITLE
Issue 5864 - Server fails to start after reboot because it's unable t…

### DIFF
--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -4,8 +4,9 @@
 [Unit]
 Description=@capbrand@ Directory Server %i.
 PartOf=@systemdgroupname@
-After=chronyd.service ntpd.service network-online.target
+After=chronyd.service ntpd.service network-online.target systemd-tmpfiles-setup.service
 Before=radiusd.service
+Wants=systemd-tmpfiles-setup.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
…o access nsslapd-rundir

Bug Description:
Sometimes after reboot dirsrv service fails to start:

EMERG - main - Unable to access nsslapd-rundir: No such file or directory EMERG - main - Ensure that user "dirsrv" has read and write permissions on /run/dirsrv EMERG - main - Shutting down.

We rely on systemd-tmpfiles for /run/dirsrv creation. But dirsrv service doesn't explicitly wait for systemd-tmpfiles-setup.service to start. This creates a race condition.

Fix Description:
dirsrv service should start only after systemd-tmpfiles-setup.service is finished.