### PR TITLE
Issue 5867 - lib389 should use filter for tarfile as written in PEP 706

### DIFF
--- a/dirsrvtests/tests/tickets/ticket47988_test.py
+++ b/dirsrvtests/tests/tickets/ticket47988_test.py
@@ -82,6 +82,7 @@ def _install_schema(server, tarFile):
 
     os.chdir(tmpSchema)
     tar = tarfile.open(tarFile, 'r:gz')
+    tar.extraction_filter = (lambda member, path: member)
     for member in tar.getmembers():
         tar.extract(member.name)
 

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1378,6 +1378,7 @@ class DirSrv(SimpleLDAPObject, object):
         name = "backup_%s_%s.tar.gz" % (self.serverid, time.strftime("%m%d%Y_%H%M%S"))
         backup_file = os.path.join(backup_dir, name)
         tar = tarfile.open(backup_file, "w:gz")
+        tar.extraction_filter = (lambda member, path: member)
 
         for name in listFilesToBackup:
             tar.add(name)
@@ -1451,6 +1452,7 @@ class DirSrv(SimpleLDAPObject, object):
             os.chdir(prefix_pattern)
 
         tar = tarfile.open(backup_file)
+        tar.extraction_filter = (lambda member, path: member)
         for member in tar.getmembers():
             if os.path.isfile(member.name):
                 #

--- a/src/lib389/lib389/tools.py
+++ b/src/lib389/lib389/tools.py
@@ -301,6 +301,7 @@ class DirSrvTools(object):
         name = "backup_%s.tar.gz" % (time.strftime("%m%d%Y_%H%M%S"))
         backup_file = os.path.join(backup_dir, name)
         tar = tarfile.open(backup_file, "w:gz")
+        tar.extraction_filter = (lambda member, path: member)
 
         for name in listFilesToBackup:
             if os.path.isfile(name):
@@ -359,6 +360,7 @@ class DirSrvTools(object):
         os.chdir(dirsrv.prefix)
 
         tar = tarfile.open(backup_file)
+        tar.extraction_filter = (lambda member, path: member)
         for member in tar.getmembers():
             if os.path.isfile(member.name):
                 #


### PR DESCRIPTION
**Problem:** 
tarfile interface evolved after CVE-2007-4559 and using object generated by tarfile.open without setting explicitly a filter  has been obsoleted.

**Solution:**
Add an  extraction_filter after every tarfile.open call

**Issue:** [5867](https://github.com/389ds/389-ds-base/issues/5867)

**Reviewed by:**  @droideck  Thanks !
