### PR TITLE
Issue 5870 - ns-slapd crashes at startup if a backend has no suffix

### DIFF
--- a/ldap/servers/slapd/backend.c
+++ b/ldap/servers/slapd/backend.c
@@ -222,7 +222,8 @@ slapi_exist_referral(Slapi_Backend *be)
         suffix = slapi_sdn_get_dn(slapi_be_getsuffix(be, 0));
 
         /* ignore special backends */
-        if ((strcmp(suffix, "cn=schema") == 0) ||
+        if ((suffix == NULL) ||
+            (strcmp(suffix, "cn=schema") == 0) ||
             (strcmp(suffix, "cn=config") == 0)) {
             return 0; /* it does not mean anything having a referral in those backends */
         }


### PR DESCRIPTION
Bug description:
	With $5598, the server checks at startup if it exists
	some referrals entries in the various backends/suffixes.
	If a backend has no defined suffix (not clear how it
	occurs except crafting dse.ldif) the checking
	triggers a sigsev

Fix description:
	Check it exists a suffix before using it

relates: #5870

Reviewed by: @progier389  Thanks !