### PR TITLE
Issue 5872 - `dbscan()` in lib389 can return bytes

### DIFF
--- a/dirsrvtests/tests/suites/indexes/entryrdn_test.py
+++ b/dirsrvtests/tests/suites/indexes/entryrdn_test.py
@@ -17,7 +17,7 @@ from lib389.idm.user import UserAccounts
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.topologies import topology_m2 as topo_m2
 from lib389.agreement import Agreements
-from lib389.utils import ds_is_older
+from lib389.utils import ds_is_older, ensure_bytes
 from lib389.tasks import Tasks,ExportTask, ImportTask
 from lib389.topologies import topology_st as topo
 
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
 def checkdbscancount(inst, pattern, expected_count):
     inst.restart()
     dbscanOut = inst.dbscan(args=['-f', f'{inst.dbdir}/{DEFAULT_BENAME}/entryrdn.db', '-A'], stopping=False)
-    count = dbscanOut.count(pattern)
+    count = dbscanOut.count(ensure_bytes(pattern))
     if count != expected_count:
         log.info(f"dbscan output is: {dbscanOut}")
     assert count == expected_count

--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -13,7 +13,7 @@ from lib389._constants import SUFFIX, PASSWORD, DN_DM, DN_CONFIG, PLUGIN_RETRO_C
 from lib389 import Entry
 from lib389.topologies import topology_m1 as topo_supplier
 from lib389.idm.user import UserAccounts
-from lib389.utils import ldap, os, logging, ds_is_newer, ds_supports_new_changelog
+from lib389.utils import ldap, os, logging, ensure_bytes, ds_is_newer, ds_supports_new_changelog
 from lib389.topologies import topology_st as topo
 from lib389.idm.organizationalunit import OrganizationalUnits
 
@@ -52,12 +52,12 @@ def _check_unhashed_userpw(inst, user_dn, is_present=False):
             log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
             dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
 
-    for entry in dbscanOut.split('dbid: '):
-        if 'operation: modify' in entry and user_dn in entry and 'userPassword' in entry:
+    for entry in dbscanOut.split(b'dbid: '):
+        if ensure_bytes('operation: modify') in entry and ensure_bytes(user_dn) in entry and ensure_bytes('userPassword') in entry:
             if is_present:
-                assert unhashed_pwd_attribute in entry
+                assert ensure_bytes(unhashed_pwd_attribute) in entry
             else:
-                assert unhashed_pwd_attribute not in entry
+                assert ensure_bytes(unhashed_pwd_attribute) not in entry
 
 @pytest.fixture(scope="module")
 def passw_policy(topo, request):

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3020,7 +3020,7 @@ class DirSrv(SimpleLDAPObject, object):
                 return True
             return False
 
-    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False, args=None, stopping=True):
+    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False, args=None, stopping=True) -> bytes:
         """Wrapper around dbscan tool that analyzes and extracts information
         from an import Directory Server database file
 
@@ -3032,7 +3032,7 @@ class DirSrv(SimpleLDAPObject, object):
         :param isRaw: Dump as a raw data
         :param args: use args as parameters instead of using bename, index, key
         :param stopping: stop then restart the instance (if started)
-        :returns: dbscan output as a string
+        :returns: dbscan output as bytes
         """
 
         DirSrvTools.lib389User(user=DEFAULT_USER)
@@ -3071,7 +3071,7 @@ class DirSrv(SimpleLDAPObject, object):
             self.stop()
         self.log.info('Running script: %s', cmd)
         try:
-            result = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             result.check_returncode();
         except subprocess.CalledProcessError:
             self.log.error('Failed to run dbscan: "%s"' % result)


### PR DESCRIPTION
Bug Description:
When attribute encryption or changelog encryption is used, `dbscan()` can return bytes instead of a string.

Fix Description:
* Update subprocess call to expect bytes instead of string.
* Revert changes to the tests done in 8bf7829ce3e3a8990fccd2fdbe7ae15ca1c8f0e7.
* Update entryrdn_test to expect output from dbscan as bytes.

Fixes: https://github.com/389ds/389-ds-base/issues/5872
Relates: https://github.com/389ds/389-ds-base/issues/5859

Reviewed-by: