### PR TITLE
Issue i5846 - Crash when lmdb import is aborted

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -4052,13 +4052,7 @@ void dbmdb_dup_writer_slot(struct importqueue *q, void *from_slot, void *to_slot
 void
 free_writer_queue_item(WriterQueueData_t **q)
 {
-    WriterQueueData_t *n = *q, *f = NULL;
-    *q = NULL;
-    while (n) {
-        f = n;
-        n = n->next;
-        slapi_ch_free((void**)&f);
-   }
+    slapi_ch_free((void**)q);
 }
 
 WriterQueueData_t *


### PR DESCRIPTION
Problem: Double free occurs in  the writer thread queue when an import over lmdb aborts

Solution: fix the double free

Issue: [5846](https://github.com/389ds/389-ds-base/issues/5846)

Reviewed by: @jchapma (Thanks!)
