### PR TITLE
Issue 5883 - Remove connection mutex contention risk on autobind

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1590,7 +1590,13 @@ handle_pr_read_ready(Connection_Table *ct, int list_num, PRIntn num_poll __attri
                 continue;
             }
 
-            pthread_mutex_lock(&(c->c_mutex));
+            /* Try to get connection mutex, if not available just skip the connection and 
+             * process other connections events. May generates cpu load for listening thread
+             * if connection mutex is held for a long time
+             */
+            if (pthread_mutex_trylock(&(c->c_mutex)) == EBUSY) {
+                continue;
+            }
             if (connection_is_active_nolock(c) && c->c_gettingber == 0) {
                 PRInt16 out_flags;
                 short readready;


### PR DESCRIPTION
Problem: A contention on the connection c_mutex is blocking the listener thread when autobind is performed. 

Solution: Let the listener thread skip the connection if the mutex is held by another thread

Issue: [5883](https://github.com/389ds/389-ds-base/issues/5883)

Reviewed by: @mreynolds389 , @droideck Thanks