### PR TITLE
Issue 5872 - part 2 - fix is_dbi regression of dbscan() in lib389 can return bytes

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3006,7 +3006,7 @@ class DirSrv(SimpleLDAPObject, object):
     def is_dbi(self, dbipattern):
         if self.is_dbi_supported():
             # Use dbscan to determine whether the database instance exists.
-            output = self.dbscan(args=['-L', self.ds_paths.db_dir], stopping=False)
+            output = self.dbscan(args=['-L', self.ds_paths.db_dir], stopping=False).decode()
             self.log.debug("is_dbi output is: " + output)
             return dbipattern.lower() in output.lower()
         else:


### PR DESCRIPTION
A one liner fix to handle a regression in  nightly tests about is_dbi function (need to convert dbscan output back into string):

Issue: [5272 part 2](https://github.com/389ds/389-ds-base/issues/5872)

Reviewed by: @mreynolds389  Thanks!
