### PR TITLE
Issue 5082 - slugify: ModuleNotFoundError when running test cases

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -18,8 +18,10 @@ import gzip
 from .report import getReport
 from lib389.paths import Paths
 from enum import Enum
-from slugify import slugify
-from pathlib import Path
+
+if "WEBUI" in os.environ:
+    from slugify import slugify
+    from pathlib import Path
 
 
 pkgs = ['389-ds-base', 'nss', 'nspr', 'openldap', 'cyrus-sasl']
@@ -139,7 +141,7 @@ def pytest_runtest_makereport(item, call):
             report.extra = extra
 
     # Make a screenshot if WebUI test fails
-    if call.when == "call":
+    if call.when == "call" and "WEBUI" in os.environ:
         if call.excinfo is not None and "page" in item.funcargs:
             page = item.funcargs["page"]
             screenshot_dir = Path(".playwright-screenshots")


### PR DESCRIPTION
Bug Description:
slugify module is used in WebUI tests for creating filenames for screenshots. But it's often not installed by default, since it's not required by lib389. WebUI tests are executed only when a WEBUI environment variable is present, so we should import it under the same condition.

Fix Description:
Import slugify module only when WEBUI environment variable is present and WebUI tests are executed.

Reviewed-by:

Fixes: https://github.com/389ds/389-ds-base/issues/5082