### PR TITLE
Issue 5852 = Remove turbo mode from the code base

### DIFF
--- a/ldap/servers/slapd/configdse.c
+++ b/ldap/servers/slapd/configdse.c
@@ -114,7 +114,9 @@ ignore_attr_type(const char *attr_type)
 static int
 reject_attr_type(const char *attr_type)
 {
-    if (!attr_type || (strcasecmp(attr_type, "cn") == 0)) {
+    if (!attr_type ||
+        (strcasecmp(attr_type, "cn") == 0) ||
+        (strcasecmp(attr_type, "nsslapd-enable-turbo-mode") == 0)) {
         return 1;
     }
     return 0;

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -8394,11 +8394,7 @@ config_get_global_backend_lock()
 int32_t
 config_set_enable_turbo_mode(const char *attrname, char *value, char *errorbuf, int apply)
 {
-    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
-                          "Setting of %s attribute is currently disabled, it will be removed in the future",
-                          attrname);
-
-    return LDAP_OPERATIONS_ERROR;
+    return LDAP_SUCCESS;
 }
 
 int32_t

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1963,7 +1963,7 @@ FrontendConfig_init(void)
     cfg->sasl_max_bufsize = SLAPD_DEFAULT_SASL_MAXBUFSIZE;
     cfg->unhashed_pw_switch = SLAPD_DEFAULT_UNHASHED_PW_SWITCH;
     init_return_orig_type = cfg->return_orig_type = LDAP_OFF;
-    init_enable_turbo_mode = cfg->enable_turbo_mode = LDAP_ON;
+    init_enable_turbo_mode = cfg->enable_turbo_mode = LDAP_OFF;
     init_connection_buffer = cfg->connection_buffer = CONNECTION_BUFFER_ON;
     init_connection_nocanon = cfg->connection_nocanon = LDAP_ON;
     init_plugin_logging = cfg->plugin_logging = LDAP_OFF;
@@ -8394,13 +8394,11 @@ config_get_global_backend_lock()
 int32_t
 config_set_enable_turbo_mode(const char *attrname, char *value, char *errorbuf, int apply)
 {
-    int32_t retVal = LDAP_SUCCESS;
-    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                          "Setting of %s attribute is currently disabled, it will be removed in the future",
+                          attrname);
 
-    retVal = config_set_onoff(attrname, value,
-                              &(slapdFrontendConfig->enable_turbo_mode),
-                              errorbuf, apply);
-    return retVal;
+    return LDAP_OPERATIONS_ERROR;
 }
 
 int32_t

--- a/src/cockpit/389-console/src/lib/server/tuning.jsx
+++ b/src/cockpit/389-console/src/lib/server/tuning.jsx
@@ -559,16 +559,14 @@ export class ServerTuning extends React.Component {
                                     </GridItem>
                                 </Grid>
                                 <Grid
-                                    title="Sets the worker threads to continuously read a connection without passing it back to the polling mechanism. (nsslapd-enable-turbo-mode)."
+                                    title="Sets the worker threads to continuously read a connection without passing it back to the polling mechanism. This attribute is currently disabled and will be removed in the future. (nsslapd-enable-turbo-mode)."
                                 >
                                     <GridItem className="ds-label" span={4}>
                                         <Checkbox
                                             id="nsslapd-enable-turbo-mode"
                                             isChecked={this.state['nsslapd-enable-turbo-mode']}
-                                            onChange={(checked, e) => {
-                                                this.handleChange(e);
-                                            }}
                                             label="Enable Connection Turbo Mode"
+                                            isDisabled
                                         />
                                     </GridItem>
                                 </Grid>


### PR DESCRIPTION
Description: Turbo mode is a feature that improves the search performance for a low number of highly active connections. Since its introduction the deployment model has changed and this feature is no longer required. Turbo mode adds some complexity to the code so removal will simplify connection code.

Fix description: Following investigation into the pros/cons of turbo mode it has been decided that this feature should be removed from the codebase.

Relates: https://github.com/389ds/389-ds-base/issues/5852

Reviewed by: ?