### PR TITLE
issue 5890 part 2 - Need a tester for testing multiple listening thread feature

### DIFF
--- a/dirsrvtests/tests/perf/ltest.py
+++ b/dirsrvtests/tests/perf/ltest.py
@@ -45,7 +45,7 @@ for i in range(args.nbconn):
         raise ex
 print (f'{args.nbconn} connections are open. Starting the latency test using {args} as parameters')
 
-now = time.time()
+now = int(time.time())
 end_time = None
 if args.test_duration:
     print(f'{now}')
@@ -55,12 +55,12 @@ ltime = now
 sum = 0
 nbops = 0
 while True:
-    now = time.time()
+    now = int(time.time())
     if now != ltime and nbops > 0:
         print(f"Performed {nbops} operations. Average operation time is: {sum/nbops/1000000} ms.")
         sum = 0
         nbops = 0
-    if end_time and time.time() >= end_time:
+    if end_time and int(time.time()) >= end_time:
         break
     ltime = now
     time.sleep(args.wait_time/1000.0)


### PR DESCRIPTION
**Problem:** after latest commit --amend: elapsed time is now written every operation
       instead of getting aggregated every seconds

**Cause:** I forgot that time.time() is returning a float instead of an int as in C

**Fix:** Convert time.time() result to int

**Issue:** [5890](https://github.com/389ds/389-ds-base/issues/5890)

**Reviewed by:** ?