### PR TITLE
Issue 5858 - WebUI monitoring test fails to run

### DIFF
--- a/dirsrvtests/tests/suites/webui/monitoring/__init__.py
+++ b/dirsrvtests/tests/suites/webui/monitoring/__init__.py
@@ -1,0 +1,3 @@
+"""
+   :Requirement: WebUI: Monitoring
+"""


### PR DESCRIPTION
Description:
The WebUI monitoring test on 2.2 branch is causing import failures because of missing __init__.py file.

Relates: https://github.com/389ds/389-ds-base/issues/5858

Reviewed by: @mreynolds389, @vashirov (Thanks!)