### PR TITLE
Truncated certificate encoded values

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -396,8 +396,9 @@ export function getBaseLevelEntryAttributes (serverId, baseDn, entryAttributesCa
                 const lines = data.split('\n');
                 lines.map(currentLine => {
                     if (currentLine !== '') {
+                        // Never truncate values for certificate
                         if (currentLine.length < 1000 || currentLine.substring(0, 9).toLowerCase()
-                                .startsWith("jpegphoto")) {
+                                .startsWith("jpegphoto") || currentLine.match(/.*certificate.*/i)) {
                             entryArray.push(splitAttributeValue(currentLine));
                         } else {
                             const myTruncatedValue = (


### PR DESCRIPTION
Base64 encoded certificate value must be kept even if they are longer than 1000 characters.