### PR TITLE
Pass instance correctly to ds_is_older for PosixGroups

### DIFF
--- a/src/lib389/lib389/idm/group.py
+++ b/src/lib389/lib389/idm/group.py
@@ -36,7 +36,7 @@ class Group(DSLdapObject):
             'top',
             'groupOfNames',
         ]
-        if not ds_is_older('1.3.7'):
+        if not ds_is_older('1.3.7', instance=instance):
             self._create_objectclasses.append('nsMemberOf')
         self._protected = False
 
@@ -122,7 +122,7 @@ class UniqueGroup(DSLdapObject):
             'top',
             'groupOfUniqueNames',
         ]
-        if not ds_is_older('1.3.7'):
+        if not ds_is_older('1.3.7', instance=instance):
             self._create_objectclasses.append('nsMemberOf')
         self._protected = False
 
@@ -175,11 +175,11 @@ class nsAdminGroup(DSLdapObject):
             'top',
             'nsAdminGroup'
         ]
-        if ds_is_older('1.3.7'):
+        if ds_is_older('1.3.7', instance=instance):
             self._create_objectclasses.append('inetUser')
         else:
             self._create_objectclasses.append('nsMemberOf')
-        if not ds_is_older('1.4.0'):
+        if not ds_is_older('1.4.0', instance=instance):
             self._create_objectclasses.append('nsAccount')
         user_compare_exclude = [
             'nsUniqueId',

--- a/src/lib389/lib389/idm/posixgroup.py
+++ b/src/lib389/lib389/idm/posixgroup.py
@@ -38,7 +38,7 @@ class PosixGroup(DSLdapObject):
             'groupOfNames',
             'posixGroup',
         ]
-        if not ds_is_older('1.3.7'):
+        if not ds_is_older('1.3.7', instance=instance):
             self._create_objectclasses.append('nsMemberOf')
         self._protected = False
 

--- a/src/lib389/lib389/idm/services.py
+++ b/src/lib389/lib389/idm/services.py
@@ -38,7 +38,7 @@ class ServiceAccount(Account):
             'top',
             'applicationProcess',
         ]
-        if ds_is_older('1.4.0'):
+        if ds_is_older('1.4.0', instance=instance):
             # This is a HORRIBLE HACK for older versions that DON'T have
             # correct updated schema!
             #

--- a/src/lib389/lib389/monitor.py
+++ b/src/lib389/lib389/monitor.py
@@ -298,7 +298,7 @@ class MonitorBackend(DSLdapObject):
                 'currentdncachecount',
                 'maxdncachecount',
             ]
-            if ds_is_older("1.4.0"):
+            if ds_is_older("1.4.0", instance=self._instance):
                 self._backend_keys.extend([
                     'normalizeddncachetries',
                     'normalizeddncachehits',

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1140,7 +1140,7 @@ class Changelog5(DSLdapObject):
             'top',
             'nsChangelogConfig',
         ]
-        if ds_is_older('1.4.0'):
+        if ds_is_older('1.4.0', instance=instance):
             self._create_objectclasses = [
                 'top',
                 'extensibleobject',
@@ -1217,7 +1217,7 @@ class Replica(DSLdapObject):
             'top',
             'nsds5Replica'
         ]
-        if ds_is_older('1.4.0'):
+        if ds_is_older('1.4.0', instance=instance):
             self._create_objectclasses.append('extensibleobject')
         self._protected = False
         self._suffix = None
@@ -1906,7 +1906,7 @@ class BootstrapReplicationManager(DSLdapObject):
             'netscapeServer',  # for cn
             'nsAccount',  # for authentication attributes
             ]
-        if ds_is_older('1.4.0'):
+        if ds_is_older('1.4.0', instance=instance):
             self._create_objectclasses.remove('nsAccount')
         self._protected = False
         self.common_name = 'replication manager'

--- a/src/lib389/lib389/schema.py
+++ b/src/lib389/lib389/schema.py
@@ -295,7 +295,7 @@ class Schema(DSLdapObject):
 
         file_list = []
         file_list += glob.glob(os.path.join(self.conn.schemadir, "*.ldif"))
-        if ds_is_newer('1.3.6.0'):
+        if ds_is_newer('1.3.6.0', instance=self._instance):
             file_list += glob.glob(os.path.join(self.conn.ds_paths.system_schema_dir, "*.ldif"))
         return file_list
 
@@ -567,7 +567,7 @@ class SchemaLegacy(object):
         """return a list of the schema files in the instance schemadir"""
         file_list = []
         file_list += glob.glob(self.conn.schemadir + "/*.ldif")
-        if ds_is_newer('1.3.6.0'):
+        if ds_is_newer('1.3.6.0', instance=self._instance):
             file_list += glob.glob(self.conn.ds_paths.system_schema_dir + "/*.ldif")
         return file_list
 


### PR DESCRIPTION
Correctly pass instance to instance to ds_is_older  when initializing PosixGroups class.

Currently this results in an error when connecting to a remote 389ds instance.

Fixes #5902