### PR TITLE
Issue 5853 - Revert MSRV check

### DIFF
--- a/src/librnsslapd/Cargo.toml
+++ b/src/librnsslapd/Cargo.toml
@@ -2,7 +2,6 @@
 name = "librnsslapd"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 build = "build.rs"
 

--- a/src/librslapd/Cargo.toml
+++ b/src/librslapd/Cargo.toml
@@ -2,7 +2,6 @@
 name = "librslapd"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 build = "build.rs"
 

--- a/src/plugins/entryuuid/Cargo.toml
+++ b/src/plugins/entryuuid/Cargo.toml
@@ -2,7 +2,6 @@
 name = "entryuuid"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plugins/entryuuid_syntax/Cargo.toml
+++ b/src/plugins/entryuuid_syntax/Cargo.toml
@@ -2,7 +2,6 @@
 name = "entryuuid_syntax"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plugins/pwdchan/Cargo.toml
+++ b/src/plugins/pwdchan/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pwdchan"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/slapd/Cargo.toml
+++ b/src/slapd/Cargo.toml
@@ -2,7 +2,6 @@
 name = "slapd"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/slapi_r_plugin/Cargo.toml
+++ b/src/slapi_r_plugin/Cargo.toml
@@ -2,7 +2,6 @@
 name = "slapi_r_plugin"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
-rust-version = "1.70"
 edition = "2018"
 build = "build.rs"
 


### PR DESCRIPTION
Description: We should be careful with the rust-version manifest field on older 389-ds-base versions as it's harder to predict at which point in time Rust was updated in some older environments.

Related: https://github.com/389ds/389-ds-base/issues/5861

Reviewed by: ?