### PR TITLE
Issue 5909 - Multi listener hang with 20k connections

### DIFF
--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -154,7 +154,7 @@ connection_table_new(int table_size)
         /* We rely on the fact that we called calloc, which zeros the block, so we don't
         * init any structure element unless a zero value is troublesome later
         */
-        for (i = 0; i < ct->list_size; i++) {
+        for (i = 1; i < ct->list_size; i++) {
             /*
             * Technically this is a no-op due to calloc, but we should always be
             * careful with things like this ....


### PR DESCRIPTION
Bug Description: When the server is configured with multiple listeners, the connection table is divided into multiple sub tables. These sub tables are then mapped to a single freelist to enable efficient allocation of new connections. Each sub table is a double linked list with element 0 used as the head of the list. During the mapping of sub tables to freelist the head of each sub table is incorrectly mapped to the freelist, creating a "hole" in the freelist.

Fix Description: Skip element 0 of each sub table when mapping to the single freelist.

Fixes: https//github.com/389ds/389-ds-base/issues/5909

Reviewed by: