### PR TITLE
Issue 5902 - Fix previous commit regression

### DIFF
--- a/src/lib389/lib389/schema.py
+++ b/src/lib389/lib389/schema.py
@@ -567,7 +567,7 @@ class SchemaLegacy(object):
         """return a list of the schema files in the instance schemadir"""
         file_list = []
         file_list += glob.glob(self.conn.schemadir + "/*.ldif")
-        if ds_is_newer('1.3.6.0', instance=self._instance):
+        if ds_is_newer('1.3.6.0', instance=self.conn):
             file_list += glob.glob(self.conn.ds_paths.system_schema_dir + "/*.ldif")
         return file_list
 


### PR DESCRIPTION
Fix previous commit regression:
CI test test_schema_comparewithfiles fails with: AttributeError: SchemaLegacy object has no attribute _instance
Because SchemaLegacy is not a DSLdapObject and the instance is stored in conn instead of in _instance

Issue: 5902

Reviewed by: @tbodaz, (Thanks!)
