### PR TITLE
Issue 843 - Add a warning to slapi_valueset_add_value_ext

### DIFF
--- a/ldap/servers/slapd/valueset.c
+++ b/ldap/servers/slapd/valueset.c
@@ -889,6 +889,14 @@ slapi_valueset_add_value(Slapi_ValueSet *vs, const Slapi_Value *addval)
 void
 slapi_valueset_add_value_ext(Slapi_ValueSet *vs, const Slapi_Value *addval, unsigned long flags)
 {
+    // Check if both SLAPI_VALUE_FLAG_DUPCHECK and SLAPI_VALUE_FLAG_PASSIN flags are used together
+    if ((flags & SLAPI_VALUE_FLAG_DUPCHECK) && (flags & SLAPI_VALUE_FLAG_PASSIN)) {
+        slapi_log_err(SLAPI_LOG_WARNING, "slapi_valueset_add_value_ext",
+            "The combination of SLAPI_VALUE_FLAG_DUPCHECK and SLAPI_VALUE_FLAG_PASSIN flags is not recommended. "
+            "Using this combination could result in undefined behavior related to memory management. "
+            "If you need both of the flags, please, use slapi_valueset_add_attr_value_ext function instead "
+            "and ensure proper cleanup if there's an error.\n");
+    }
     Slapi_Value *oneval[2];
     oneval[0] = (Slapi_Value *)addval;
     oneval[1] = NULL;


### PR DESCRIPTION
Description: The combination of SLAPI_VALUE_FLAG_DUPCHECK and SLAPI_VALUE_FLAG_PASSIN flags is not recommended for slapi_valueset_add_value_ext.

Using this combination could result in undefined behaviour related to memory management. If you need both flags, please use the slapi_valueset_add_attr_value_ext function instead and ensure proper cleanup if there's an error.

We don't use the function with the above flag combination, but someone in the community might (even though it's highly unlikely). Hence, as of now, it isn't worth investing more time into this, and the documentation should be updated with this change.

Related: https://github.com/389ds/389-ds-base/issues/843

Reviewed by: ?