### PR TITLE
issue 5924 - ASAN server build crash when looping opening/closing connections

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -2420,25 +2420,23 @@ def test_conn_limits(dscreate_with_numlistener):
 
     :id: 7be2eb5c-4d8f-11ee-ae3d-482ae39447e5
     :parametrized: yes
-    :setup: None
+    :setup: Setup an instance then set nsslapd-numlisteners and maximum file descriptors
     :steps:
-        1. Setup an instance then set nsslapd-numlisteners and maximum file descriptors
-        2. Loops on:
+        1. Loops on:
              Open new connection and perform search until timeout expires
-        3. Close one of the previously open connections
-        4. Loops MAX_FDS times on:
+        2. Close one of the previously open connections
+        3. Loops MAX_FDS times on:
               - opening a new connection
               - perform a search
               - close the connection
-        5. Close all open connections
-        6. Remove the instance
+        4. Close all open connections
+        5. Remove the instance
     :expectedresults:
-        1. Should succeeds
-        2. Should get a timeout (because the server has no more any connections)
-        3. Should success
-        4. Should success (otherwise issue #5924 has probably been hit)
+        1. Should get a timeout (because the server has no more any connections)
+        2. Should success
+        3. Should success (otherwise issue #5924 has probably been hit)
+        4. Should success
         5. Should success
-        6. Should success
     """
     inst = dscreate_with_numlistener
 

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -2287,7 +2287,7 @@ def dscreate_with_numlistener(request, dscreate_instance):
     inst = dscreate_instance
     inst_name = inst.serverid
 
-    wrapper_file = "/tmp/dswrapper.sh"
+    wrapper_file = f"{os.getenv("HOME")}/dswrapper.sh"
     wrapper_text = f"""#!/usr/bin/bash
 ulimit -n {maxfds}
 ulimit -H -n {maxfds}

--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -50,11 +50,11 @@
  * contention on the CPU to improve things.
  * Lastly a change was done: Instead of having a sliding windows that tend to get a never used
  * slot for each new connection, it nows reuse last freed one. That has several benefits:
- *  - Fix a bug because the last free list slaots may not be alloced.
+ *  - Fix a bug because the last free list slots may not be alloced.
  *  - Avoid to grow the memory footprint when there is no much load
  *  - Simplify the code (as only a single is needed. )
  *
- * The freelist is a ringbuffer of pointers to the connection table.
+ * The freelist is a stack of pointers to the connection table.
  * It is NULL terminated. On a small scale it looks like:
  *
  *  |--------------------------------------------|
@@ -63,8 +63,8 @@
  *  |--------------------------------------------|
  *        ^- conn_next
  *
- * As we allocate, we shift conn_next through the list, yielding the ptr that was stored (and
- * setting it to NULL as we proceed)
+ * To allocate, we pop one of the stored connection ptr out of the stack (yield the ptr, set
+ * its slot to NULL then increase conn_next)
  *
  *  |--------------------------------------------|
  *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
@@ -72,7 +72,7 @@
  *  |--------------------------------------------|
  *                        ^- conn_next
  *
- * When a connection is "freed" we return it to conn_free, which is then also slid up.
+ * When a connection is "freed" we push it back in the stack after decreasing conn_next
  *
  *  |--------------------------------------------|
  *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
@@ -80,9 +80,7 @@
  *  |--------------------------------------------|
  *              ^- conn_next
  *
- * If all connections are exhausted, frrelist[conn_next] is NULL
- * Or conn_next slot is associated with NULL pointer.
- * (With multiple ct the last freelist slots may not be associated with a connection slots)
+ * If all connections are exhausted, freelist[conn_next] is NULL
  *
  *  |--------------------------------------------|
  *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
@@ -102,7 +100,7 @@
  *
  *
  *  -- invariants
- * * the ring buffer must be as large as conntable.
+ * * the stack must be as large as conntable.
  * * connection_table_move_connection_out_of_active_list is the only function able to return a
  *   connection to the freelist, as it is the function that is called when the event system has
  *   determined all IO's are complete, or unable to complete. This function is what prepares the
@@ -128,7 +126,7 @@ connection_table_new(int table_size)
     ct->c = (Connection **)slapi_ch_calloc(1, ct->size * sizeof(Connection *));
     ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, ct->list_num * sizeof(struct POLL_STRUCT*));
     ct->table_mutex = PR_NewLock();
-    /* Allocate the freelist */
+    /* Allocate the freelist (a slot for each connection plus another slot for the final NULL pointer) */
     ct->c_freelist = (Connection **)slapi_ch_calloc(1, (ct->size+1) * sizeof(Connection *));
     ct->conn_next_offset = 0;
 
@@ -266,6 +264,7 @@ connection_table_get_connection(Connection_Table *ct, int sd)
     Connection *c = ct->c_freelist[ct->conn_next_offset];
     if (c != NULL) {
         /* We allocated it, so now NULL the slot and move forward. */
+        PR_ASSERT(ct->conn_next_offset>=0 && ct->conn_next_offset<ct->size);
         ct->c_freelist[ct->conn_next_offset++] = NULL;
         PR_Unlock(ct->table_mutex);
     } else {

--- a/ldap/servers/slapd/conntable.c
+++ b/ldap/servers/slapd/conntable.c
@@ -48,69 +48,61 @@
  * under the connection table lock. This should move the allocation algorithm from O(n) worst case
  * to O(1) worst case as we always recieve and empty slot *or* ct full. It also reduces lock/atomic
  * contention on the CPU to improve things.
+ * Lastly a change was done: Instead of having a sliding windows that tend to get a never used
+ * slot for each new connection, it nows reuse last freed one. That has several benefits:
+ *  - Fix a bug because the last free list slaots may not be alloced.
+ *  - Avoid to grow the memory footprint when there is no much load
+ *  - Simplify the code (as only a single is needed. )
  *
- * The freelist is a ringbuffer of pointers to the connection table. On a small scale it looks like:
+ * The freelist is a ringbuffer of pointers to the connection table.
+ * It is NULL terminated. On a small scale it looks like:
  *
  *  |--------------------------------------------|
- *  | slot 1 | slot 2 | slot 3 | slot 4 | slot 5 |
- *  | _ ptr  | _ ptr  | _ ptr  | _ ptr  | _ ptr  |
+ *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
+ *  | _ ptr  | _ ptr  | _ ptr  | _ ptr  | NULL   |
  *  |--------------------------------------------|
- *     ^  ^- conn_next
- *     |
- *     \-- conn_free
+ *        ^- conn_next
  *
  * As we allocate, we shift conn_next through the list, yielding the ptr that was stored (and
  * setting it to NULL as we proceed)
  *
  *  |--------------------------------------------|
- *  | slot 1 | slot 2 | slot 3 | slot 4 | slot 5 |
- *  | _NULL  | _NULL  | _ ptr  | _ ptr  | _ ptr  |
+ *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
+ *  | _NULL  | _NULL  | _ ptr  | _ ptr  | NULL   |
  *  |--------------------------------------------|
- *     ^                  ^- conn_next
- *     |
- *     \-- conn_free
+ *                        ^- conn_next
  *
  * When a connection is "freed" we return it to conn_free, which is then also slid up.
  *
  *  |--------------------------------------------|
- *  | slot 1 | slot 2 | slot 3 | slot 4 | slot 5 |
- *  | _ ptr  | _NULL  | _ ptr  | _ ptr  | _ ptr  |
+ *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
+ *  | _NULL  | _ ptr  | _ ptr  | _ ptr  | NULL   |
  *  |--------------------------------------------|
- *              ^         ^- conn_next
- *              |
- *              \-- conn_free
+ *              ^- conn_next
  *
- * If all connections are exhausted, conn_next will == conn_next, as conn_next must have proceeded
- * to the end of the ring, and then wrapped back allocating all previous until we meet with conn_free.
+ * If all connections are exhausted, frrelist[conn_next] is NULL
+ * Or conn_next slot is associated with NULL pointer.
+ * (With multiple ct the last freelist slots may not be associated with a connection slots)
  *
  *  |--------------------------------------------|
- *  | slot 1 | slot 2 | slot 3 | slot 4 | slot 5 |
+ *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
  *  | _NULL  | _NULL  | _NULL  | _NULL  | _NULL  |
  *  |--------------------------------------------|
- *              ^ ^- conn_next
- *              |
- *              \-- conn_free
+ *                                          ^- conn_next
  *
  * This means allocations of conns will keep failing until a connection is returned.
  *
  *  |--------------------------------------------|
- *  | slot 1 | slot 2 | slot 3 | slot 4 | slot 5 |
- *  | _NULL  | _ ptr  | _NULL  | _NULL  | _NULL  |
+ *  | slot 0 | slot 1 | slot 2 | slot 3 | slot 4 |
+ *  | _NULL  | _NULL  | _NULL  | _ ptr  | NULL   |
  *  |--------------------------------------------|
- *             ^- conn_next ^
- *                          |
- *                          \-- conn_free
+ *                                 ^- conn_next
  *
  * And now conn_next can begin to allocate again.
  *
  *
  *  -- invariants
- * * when conn_free is slid back to meet conn_next, there can be no situation where another
- *   connection is returned, as none must allocated  -if they were allocated, conn_free would have
- *   moved_along.
  * * the ring buffer must be as large as conntable.
- * * We do not check conn_next == conn_free (that's the starting state), but we check if the
- *   slot at conn_next is NULL, which must imply that conn_free has nothing to return.
  * * connection_table_move_connection_out_of_active_list is the only function able to return a
  *   connection to the freelist, as it is the function that is called when the event system has
  *   determined all IO's are complete, or unable to complete. This function is what prepares the
@@ -137,10 +129,8 @@ connection_table_new(int table_size)
     ct->fd = (struct POLL_STRUCT **)slapi_ch_calloc(1, ct->list_num * sizeof(struct POLL_STRUCT*));
     ct->table_mutex = PR_NewLock();
     /* Allocate the freelist */
-    ct->c_freelist = (Connection **)slapi_ch_calloc(1, ct->size * sizeof(Connection *));
-    /* NEVER use slot 0, this is a list pointer */
-    ct->conn_next_offset = 1;
-    ct->conn_free_offset = 1;
+    ct->c_freelist = (Connection **)slapi_ch_calloc(1, (ct->size+1) * sizeof(Connection *));
+    ct->conn_next_offset = 0;
 
     slapi_log_err(SLAPI_LOG_INFO, "connection_table_new", "Number of connection sub-tables %d, each containing %d slots.\n",
         ct->list_num, ct->list_size);
@@ -273,22 +263,21 @@ connection_table_get_connection(Connection_Table *ct, int sd)
 {
     PR_Lock(ct->table_mutex);
 
-    PR_ASSERT(ct->conn_next_offset != 0);
     Connection *c = ct->c_freelist[ct->conn_next_offset];
     if (c != NULL) {
         /* We allocated it, so now NULL the slot and move forward. */
-        ct->c_freelist[ct->conn_next_offset] = NULL;
-        /* Handle overflow. */
-        ct->conn_next_offset = (ct->conn_next_offset + 1) % ct->size;
-        if (ct->conn_next_offset == 0) {
-            /* Never use slot 0 */
-            ct->conn_next_offset += 1;
-        }
+        ct->c_freelist[ct->conn_next_offset++] = NULL;
         PR_Unlock(ct->table_mutex);
     } else {
         /* couldn't find a Connection, table must be full */
-        slapi_log_err(SLAPI_LOG_CONNS, "connection_table_get_connection", "Max open connections reached\n");
         PR_Unlock(ct->table_mutex);
+        static time_t last_err_msg_time = 0;
+        time_t curtime = slapi_current_utc_time();
+        /* Logs the message only once per seconds */
+        if (curtime != last_err_msg_time) {
+            slapi_log_err(SLAPI_LOG_ERR, "connection_table_get_connection", "Max open connections reached\n");
+            last_err_msg_time = curtime;
+        }
         return NULL;
     }
 
@@ -461,14 +450,10 @@ connection_table_move_connection_out_of_active_list(Connection_Table *ct, Connec
 
     /* Finally, place the connection back into the freelist for use */
     PR_ASSERT(c->c_refcnt == 0);
-    PR_ASSERT(ct->conn_free_offset != 0);
-    PR_ASSERT(ct->c_freelist[ct->conn_free_offset] == NULL);
-    ct->c_freelist[ct->conn_free_offset] = c;
-    ct->conn_free_offset = (ct->conn_free_offset + 1) % ct->size;
-    if (ct->conn_free_offset == 0) {
-        /* Never use slot 0 */
-        ct->conn_free_offset += 1;
-    }
+    PR_ASSERT(ct->conn_next_offset != 0);
+    ct->conn_next_offset--;
+    PR_ASSERT(ct->c_freelist[ct->conn_next_offset] == NULL);
+    ct->c_freelist[ct->conn_next_offset] = c;
 
     PR_Unlock(ct->table_mutex);
 

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -135,19 +135,25 @@ get_pid_file(void)
 }
 
 static int
-accept_and_configure(int s __attribute__((unused)), PRFileDesc *pr_acceptfd, PRNetAddr *pr_netaddr, int addrlen __attribute__((unused)), int secure, int local, PRFileDesc **pr_clonefd)
+accept_and_configure(int s __attribute__((unused)), PRFileDesc *listenfd, PRNetAddr *pr_netaddr, int addrlen __attribute__((unused)), int secure, int local, PRFileDesc **pr_accepted_fd)
 {
     int ns = 0;
     PRIntervalTime pr_timeout = PR_MillisecondsToInterval(slapd_accept_wakeup_timer);
 
-    (*pr_clonefd) = PR_Accept(pr_acceptfd, pr_netaddr, pr_timeout);
-    if (!(*pr_clonefd)) {
+    (*pr_accepted_fd) = PR_Accept(listenfd, pr_netaddr, pr_timeout);
+    if (!(*pr_accepted_fd)) {
         PRErrorCode prerr = PR_GetError();
-        slapi_log_err(SLAPI_LOG_ERR, "accept_and_configure", "PR_Accept() failed, " SLAPI_COMPONENT_NAME_NSPR " error %d (%s)\n",
-                      prerr, slapd_pr_strerror(prerr));
+        static time_t last_err_msg_time = 0;
+        time_t curtime = slapi_current_utc_time();
+        /* Logs the message only once per seconds */
+        if (curtime != last_err_msg_time) {
+            slapi_log_err(SLAPI_LOG_ERR, "accept_and_configure", "PR_Accept() failed, " SLAPI_COMPONENT_NAME_NSPR " error %d (%s)\n",
+                          prerr, slapd_pr_strerror(prerr));
+            last_err_msg_time = curtime;
+        }
         return (SLAPD_INVALID_SOCKET);
     }
-    ns = configure_pr_socket(pr_clonefd, secure, local);
+    ns = configure_pr_socket(pr_accepted_fd, secure, local);
 
     return ns;
 }
@@ -155,7 +161,7 @@ accept_and_configure(int s __attribute__((unused)), PRFileDesc *pr_acceptfd, PRN
 /*
  * This is the shiny new re-born daemon function, without all the hair
  */
-static int handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *pr_acceptfd, int secure, int local, Connection **newconn);
+static int handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *listenfd, int secure, int local, Connection **newconn);
 static void handle_pr_read_ready(Connection_Table *ct, int list_id, PRIntn num_poll);
 static int clear_signal(struct POLL_STRUCT *fds, int list_id);
 static void unfurl_banners(Connection_Table *ct, daemon_ports_t *ports, PRFileDesc **n_tcps, PRFileDesc **s_tcps, PRFileDesc **i_unix);
@@ -831,6 +837,7 @@ accept_thread(void *vports)
             }
             /* Need a sleep delay here. */
             PR_Sleep(pr_timeout);
+            last_accept_new_connections = accept_new_connections;
             continue;
         } else {
             /* Log that we are now listening again */
@@ -1846,28 +1853,30 @@ handle_closed_connection(Connection *conn)
  * this function returns the connection table list the new connection is in
  */
 static int
-handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *pr_acceptfd, int secure, int local, Connection **newconn)
+handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *listenfd, int secure, int local, Connection **newconn)
 {
     int ns = 0;
     Connection *conn = NULL;
     /*    struct sockaddr_in    from;*/
     PRNetAddr from = {{0}};
-    PRFileDesc *pr_clonefd = NULL;
+    PRFileDesc *pr_accepted_fd = NULL;
     slapdFrontendConfig_t *fecfg = getFrontendConfig();
     ber_len_t maxbersize;
 
     if (newconn) {
         *newconn = NULL;
     }
-    if ((ns = accept_and_configure(tcps, pr_acceptfd, &from,
-                                   sizeof(from), secure, local, &pr_clonefd)) == SLAPD_INVALID_SOCKET) {
+    if ((ns = accept_and_configure(tcps, listenfd, &from,
+                                   sizeof(from), secure, local, &pr_accepted_fd)) == SLAPD_INVALID_SOCKET) {
         return -1;
     }
 
     /* get a new Connection from the Connection Table */
     conn = connection_table_get_connection(ct, ns);
     if (conn == NULL) {
-        PR_Close(pr_acceptfd);
+        if (pr_accepted_fd) {
+            PR_Close(pr_accepted_fd);
+        }
         return -1;
     }
     pthread_mutex_lock(&(conn->c_mutex));
@@ -1879,7 +1888,7 @@ handle_new_connection(Connection_Table *ct, int tcps, PRFileDesc *pr_acceptfd, i
     conn->c_idletimeout = fecfg->idletimeout;
     conn->c_idletimeout_handle = idletimeout_reslimit_handle;
     conn->c_sd = ns;
-    conn->c_prfd = pr_clonefd;
+    conn->c_prfd = pr_accepted_fd;
     conn->c_flags &= ~CONN_FLAG_CLOSING;
 
     /* Set per connection static config */

--- a/ldap/servers/slapd/fe.h
+++ b/ldap/servers/slapd/fe.h
@@ -88,7 +88,6 @@ struct connection_table
     /* An array of free connections awaiting allocation. */;
     Connection **c_freelist;
     size_t conn_next_offset;
-    size_t conn_free_offset;
     struct POLL_STRUCT **fd;
     PRLock *table_mutex;
 };


### PR DESCRIPTION
Issue: Got a crash due to:
      1. Failure to get a connection slot because connection  freelist is misshandled.
      2. A confusion between listening and acceptedfd descriptor leaded to 
          close the listening descriptor while handing the error.
          
Solution: 
      Rename clearly the file descriptor variables
      Close the accepted file descriptor in error handler
      Rewrite the freelist management so that first connection chosen is the last released one.
       (Code is simpler, this fix the end of list issue, and it avoid to spread the open connection over too much memory)

Issue:   #5924 

Reviewed by:  @Firstyear, @vashirov, @droideck,  @tbordaz  (Thanks !) 