### PR TITLE
update replication.py

### DIFF
--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -633,6 +633,8 @@ def create_repl_manager(inst, basedn, log, args):
     if args.passwd is not None:
         repl_manager_password = args.passwd
     elif args.passwd_file is not None:
+        repl_manager_password = get_passwd_from_file(args.passwd_file)
+    elif args.bind_passwd_file is not None:
         repl_manager_password = get_passwd_from_file(args.bind_passwd_file)
     elif repl_manager_password == "":
         repl_manager_password = _get_arg(None, msg=f"Enter replication manager password for \"{manager_dn}\"",
@@ -1348,7 +1350,8 @@ def create_parser(subparsers):
                                                         "entry's DN would be \"cn=replication manager,cn=config\".")
     repl_add_manager_parser.add_argument('--passwd', help="Sets the password for replication manager. If not provided, "
                                                           "you will be prompted for the password")
-    repl_add_manager_parser.add_argument('--passwd-file', help="File containing the password")
+    repl_add_manager_parser.add_argument('--passwd-file', help="File containing the password for back compatibility")
+    repl_add_manager_parser.add_argument('--bind-passwd-file', help="File containing the password")
     repl_add_manager_parser.add_argument('--suffix', help='The DN of the replication suffix whose replication ' +
                                                           'configuration you want to add this new manager to (OPTIONAL)')
 


### PR DESCRIPTION
Fix a dsconf fails because a naming mismatch between argparse parameters and args attribute) 
Solved by using consistent naming while keeping old name for compatibility

Issue: #5935 

Reviewer: @tbordaz @progier389 @droideck 