### PR TITLE
Issue 5938 - Attribute Names changed to lowercase after adding the Attributes

### DIFF
--- a/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
@@ -760,7 +760,7 @@ class MatchingRulesTable extends React.Component {
             let name = "";
             // Check for matches of all the parts
             if (row.names.length > 0) {
-                name = row.name[0].toLowerCase();
+                name = row.name[0];
             }
             if (val !== "" && name.indexOf(val) === -1 &&
                 row.oid[0].indexOf(val) === -1 &&

--- a/src/lib389/lib389/schema.py
+++ b/src/lib389/lib389/schema.py
@@ -128,10 +128,10 @@ class Schema(DSLdapObject):
             for obj in results:
                 obj_i = vars(object_model(obj))
                 if len(obj_i["names"]) == 1:
-                    obj_i['name'] = obj_i['names'][0].lower()
+                    obj_i['name'] = obj_i['names'][0]
                     obj_i['aliases'] = None
                 elif len(obj_i["names"]) > 1:
-                    obj_i['name'] = obj_i['names'][0].lower()
+                    obj_i['name'] = obj_i['names'][0]
                     obj_i['aliases'] = obj_i['names'][1:]
                 else:
                     obj_i['name'] = ""
@@ -641,7 +641,7 @@ class SchemaLegacy(object):
                 results.getValues('objectClasses')]
             for oc in objectclasses:
                 # Add normalized name for sorting
-                oc['name'] = oc['names'][0].lower()
+                oc['name'] = oc['names'][0]
             objectclasses = sorted(objectclasses, key=itemgetter('name'))
             result = {'type': 'list', 'items': objectclasses}
             return dump_json(result)
@@ -663,7 +663,7 @@ class SchemaLegacy(object):
                 results.getValues('attributeTypes')]
             for attr in attributetypes:
                 # Add normalized name for sorting
-                attr['name'] = attr['names'][0].lower()
+                attr['name'] = attr['names'][0]
             attributetypes = sorted(attributetypes, key=itemgetter('name'))
             result = {'type': 'list', 'items': attributetypes}
             return dump_json(result)
@@ -683,7 +683,7 @@ class SchemaLegacy(object):
             for mr in matchingRules:
                 # Add normalized name for sorting
                 if mr['names']:
-                    mr['name'] = mr['names'][0].lower()
+                    mr['name'] = mr['names'][0]
                 else:
                     mr['name'] = ""
             matchingRules = sorted(matchingRules, key=itemgetter('name'))
@@ -768,7 +768,6 @@ class SchemaLegacy(object):
         # filter our set of all attribute types.
         objectclasses = self.get_objectclasses()
         attributetypes = self.get_attributetypes()
-        attributetypename = attributetypename.lower()
 
         attributetype = [at for at in attributetypes
                          if attributetypename.lower() in
@@ -795,9 +794,9 @@ class SchemaLegacy(object):
             must = [vars(oc) for oc in must]
             # Add normalized 'name' for sorting
             for oc in may:
-                oc['name'] = oc['names'][0].lower()
+                oc['name'] = oc['names'][0]
             for oc in must:
-                oc['name'] = oc['names'][0].lower()
+                oc['name'] = oc['names'][0]
             may = sorted(may, key=itemgetter('name'))
             must = sorted(must, key=itemgetter('name'))
             result = {'type': 'schema',


### PR DESCRIPTION
Bug Description: When working with the web console to edit the attributes
with capital and lowercase letters in their names. The capital letters within
the names of an attribute change whenever the attributes are added
to an object class.

Fix Description: Presevrer the case in both UI and CLI when doing
edit/add/list operations.

Fixes: https://github.com/389ds/389-ds-base/issues/5938

Reviewed by: ?