### PR TITLE
Issue 5843 - dsconf / dscreate should be able to handle lmdb parameters

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -44,7 +44,7 @@ def init_user(topo_m2, request):
     def fin():
         try:
             test_user.delete()
-        except ldap.NO_SUCH_OBJECT:
+        except (ldap.NO_SUCH_OBJECT, ldap.SERVER_DOWN):
             pass
 
     request.addfinalizer(fin)

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -45,7 +45,7 @@
 #define DBMDB_DB_MINSIZE             ( 4LL * MEGABYTE )
 #define DBMDB_DISK_RESERVE(disksize) ((disksize)*2ULL/1000ULL)
 #define DBMDB_READERS_MARGIN         10
-#define DBMDB_READERS_DEFAULT        50
+#define DBMDB_READERS_DEFAULT        126  /* default value as described in mdb_env_set_maxreaders */
 #define DBMDB_DBS_MARGIN             10
 #define DBMDB_DBS_DEFAULT            128
 

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -241,6 +241,8 @@ VALGRIND_LEAK_STR = " blocks are definitely lost in loss record "
 VALGRIND_INVALID_STR = " Invalid (free|read|write)"
 DISORDERLY_SHUTDOWN = ('Detected Disorderly Shutdown last time Directory '
                        'Server was running, recovering database')
+DEFAULT_LMDB_SIZE = 20.0
+GIGABYTE = 1024*1024*1024
 
 #
 # LOG: see https://access.redhat.com/documentation/en-US/Red_Hat_Directory

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -241,8 +241,7 @@ VALGRIND_LEAK_STR = " blocks are definitely lost in loss record "
 VALGRIND_INVALID_STR = " Invalid (free|read|write)"
 DISORDERLY_SHUTDOWN = ('Detected Disorderly Shutdown last time Directory '
                        'Server was running, recovering database')
-DEFAULT_LMDB_SIZE = 20.0
-GIGABYTE = 1024*1024*1024
+DEFAULT_LMDB_SIZE = '20Gb'
 
 #
 # LOG: see https://access.redhat.com/documentation/en-US/Red_Hat_Directory

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -151,6 +151,9 @@ class DSLdapObject(DSLogging, DSLint):
     def __str__(self):
         return self.__unicode__()
 
+    def __repr__(self):
+        return f'{type(self)}(instance_name="{self._instance.serverid}", dn="{self.__unicode__()}")'
+
     def _unsafe_raw_entry(self):
         """Get an Entry object
 

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -65,8 +65,7 @@ arg_to_attr = {
         'deadlock_policy': 'nsslapd-db-deadlock-policy',
         'db_home_directory': 'nsslapd-db-home-directory',
         'db_lib': 'nsslapd-backend-implement',
-        'lmdb_size': 'nsslapd-mdb-max-size',    # For dscreate (unit is Gb)
-        'mdb_max_size': 'nsslapd-mdb-max-size', # For dsconf (unit is bytes)
+        'mdb_max_size': 'nsslapd-mdb-max-size',
         'mdb_max_readers': 'nsslapd-mdb-max-readers',
         'mdb_max_dbs': 'nsslapd-mdb-max-dbs',
         # VLV attributes

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -65,6 +65,10 @@ arg_to_attr = {
         'deadlock_policy': 'nsslapd-db-deadlock-policy',
         'db_home_directory': 'nsslapd-db-home-directory',
         'db_lib': 'nsslapd-backend-implement',
+        'lmdb_size': 'nsslapd-mdb-max-size',    # For dscreate (unit is Gb)
+        'mdb_max_size': 'nsslapd-mdb-max-size', # For dsconf (unit is bytes)
+        'mdb_max_readers': 'nsslapd-mdb-max-readers',
+        'mdb_max_dbs': 'nsslapd-mdb-max-dbs',
         # VLV attributes
         'search_base': 'vlvbase',
         'search_scope': 'vlvscope',
@@ -1081,6 +1085,10 @@ def create_parser(subparsers):
     set_db_config_parser.add_argument('--deadlock-policy', help='Adjusts the backend database deadlock policy (Advanced setting)')
     set_db_config_parser.add_argument('--db-home-directory', help='Sets the directory for the database mmapped files (Advanced setting)')
     set_db_config_parser.add_argument('--db-lib', help='Sets which db lib is used. Valid values are: bdb or mdb')
+    set_db_config_parser.add_argument('--mdb-max-size', help='Sets the lmdb database maximum size (in bytes).')
+    set_db_config_parser.add_argument('--mdb-max-readers', help='Sets the lmdb database maximum number of readers (Advanced setting)')
+    set_db_config_parser.add_argument('--mdb-max-dbs', help='Sets the lmdb database maximum number of sub databases (Advanced setting)')
+
 
     #######################################################
     # Database & Suffix Monitor

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -15,7 +15,8 @@ import re
 import glob
 import shutil
 from lib389.dseldif import DSEldif
-from lib389._constants import DEFAULT_LMDB_SIZE, GIGABYTE
+from lib389._constants import DEFAULT_LMDB_SIZE
+from lib389.utils import parse_size
 import subprocess
 
 
@@ -236,7 +237,7 @@ def dblib_bdb2mdb(inst, log, args):
         total_dbi += be['dbi']
 
     # Round up dbmap size
-    dbmap_size = DEFAULT_LMDB_SIZE * GIGABYTE
+    dbmap_size = parse_size(DEFAULT_LMDB_SIZE)
     while (total_dbsize * DBSIZE_MARGIN > dbmap_size):
         dbmap_size *= 1.25
 

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -15,11 +15,11 @@ import re
 import glob
 import shutil
 from lib389.dseldif import DSEldif
+from lib389._constants import DEFAULT_LMDB_SIZE, GIGABYTE
 import subprocess
 
 
 DBLIB_LDIF_PREFIX = "__dblib-"
-DEFAULT_DBMAP_SIZE = 2 * 1024 * 1024 * 1024
 DBSIZE_MARGIN = 1.2
 DBI_MARGIN = 60
 
@@ -236,7 +236,7 @@ def dblib_bdb2mdb(inst, log, args):
         total_dbi += be['dbi']
 
     # Round up dbmap size
-    dbmap_size = DEFAULT_DBMAP_SIZE
+    dbmap_size = DEFAULT_LMDB_SIZE * GIGABYTE
     while (total_dbsize * DBSIZE_MARGIN > dbmap_size):
         dbmap_size *= 1.25
 

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -16,8 +16,9 @@ import glob
 import shutil
 from lib389.dseldif import DSEldif
 from lib389._constants import DEFAULT_LMDB_SIZE
-from lib389.utils import parse_size
+from lib389.utils import parse_size, format_size
 import subprocess
+from errno import ENOSPC
 
 
 DBLIB_LDIF_PREFIX = "__dblib-"
@@ -143,14 +144,6 @@ def get_mdb_dbis(dbdir):
     return result
 
 
-def size_fmt(num):
-    for unit in ["B", "KB", "MB", "GB", "TB"]:
-        if (num < 1024):
-            return f"{num:3.1f} {unit}"
-        num /= 1024
-    return f"{num:.1f} TB"
-
-
 def run_dbscan(args):
     prefix = os.environ.get('PREFIX', "")
     prog = f'{prefix}/bin/dbscan'
@@ -236,18 +229,20 @@ def dblib_bdb2mdb(inst, log, args):
         total_entrysize += be['entrysize']
         total_dbi += be['dbi']
 
-    # Round up dbmap size
+    required_dbsize = round(total_dbsize * DBSIZE_MARGIN)
+
+    # Compute a dbmap size greater than required_dbsize
     dbmap_size = parse_size(DEFAULT_LMDB_SIZE)
-    while (total_dbsize * DBSIZE_MARGIN > dbmap_size):
-        dbmap_size *= 1.25
+    while (required_dbsize > dbmap_size):
+        dbmap_size = round(dbmap_size * 1.25)
 
     # Round up number of dbis
     nbdbis = 1
     while nbdbis < total_dbi + DBI_MARGIN:
         nbdbis *= 2
 
-    log.info(f"Required space for LDIF files is about {size_fmt(total_entrysize)}")
-    log.info(f"Required space for DBMAP files is about {size_fmt(dbmap_size)}")
+    log.info(f"Required space for LDIF files is about {format_size(total_entrysize)}")
+    log.info(f"Required space for DBMAP files is about {format_size(required_dbsize)}")
     log.info(f"Required number of dbi is {nbdbis}")
 
     # Generate the info file (so dbscan could generate the map)
@@ -261,20 +256,29 @@ def dblib_bdb2mdb(inst, log, args):
         f.write(f'MAXDBS={nbdbis}\n')
     os.chown(f'{dbmapdir}/{MDB_INFO}', uid, gid)
 
-    if os.stat(dbmapdir).st_dev == os.stat(tmpdir).st_dev:
-        total, used, free = shutil.disk_usage(dbmapdir)
-        if free < total_entrysize + dbmap_size:
-            log.error(f"Not enough space on {dbmapdir} to migrate to lmdb (Need {size_fmt(total_entrysize + dbmap_size)}, Have {size_fmt(free)})")
-            return
-    else:
-        total, used, free = shutil.disk_usage(dbmapdir)
-        if free < dbmap_size:
-            log.error(f"Not enough space on {dbmapdir} to migrate to lmdb (Need {size_fmt(dbmap_size)}, Have {size_fmt(free)})")
-            return
+    total, used, free = shutil.disk_usage(dbmapdir)
+    if os.stat(dbmapdir).st_dev != os.stat(tmpdir).st_dev:
+        # Ldif and db are on different filesystems
+        # Let check that we have enough space in tmpdir for ldif files
         total, used, free = shutil.disk_usage(tmpdir)
         if free < total_entrysize:
-            log.error("Not enough space on {tmpdir} to migrate to lmdb (Need {size_fmt(total_entrysize)}, Have {size_fmt(free)})")
-            return
+            raise OSError(ENOSPC, "Not enough space on {tmpdir} to migrate to lmdb " +
+                                  "(In {tmpdir}, {format_size(total_entrysize)} is "+
+                                  "needed but only {format_size(free)} is available)")
+        total_entrysize = 0    # do not count total_entrysize when checking dbmapdir size
+
+    # Let check that we have enough space in dbmapdir for the db and ldif files
+    total, used, free = shutil.disk_usage(dbmapdir)
+    size = required_dbsize + total_entrysize
+    if free < required_dbsize + total_entrysize:
+            raise OSError(ENOSPC, "Not enough space on {tmpdir} to migrate to lmdb " +
+                                  "(In {dbmapdir}, " +
+                                  "{format_size(required_dbsize + total_entrysize)} is "
+                                  "needed but only {format_size(free)} is available)")
+    # Lets use dbmap_size if possible, otherwise use required_dbsize
+    if free < dbmap_size + total_entrysize:
+        dbmap_size = required_dbsize
+
     progress = 0
     encrypt = False       # Should maybe be a args param
     for bename, be in backends.items():
@@ -377,23 +381,26 @@ def dblib_mdb2bdb(inst, log, args):
     # Clearly over evaluated (but better than nothing )
     total_entrysize = dbmap_size
 
-    log.info(f"Required space for LDIF files is about {size_fmt(total_entrysize)}")
-    log.info(f"Required space for bdb files is about {size_fmt(dbmap_size)}")
+    log.info(f"Required space for LDIF files is about {format_size(total_entrysize)}")
+    log.info(f"Required space for bdb files is about {format_size(dbmap_size)}")
 
-    if os.stat(dbmapdir).st_dev == os.stat(tmpdir).st_dev:
-        total, used, free = shutil.disk_usage(dbmapdir)
-        if free < total_entrysize + dbmap_size:
-            log.error(f"Not enough space on {dbmapdir} to migrate to bdb (Need {size_fmt(total_entrysize + dbmap_size)}, Have {size_fmt(free)})")
-            return
-    else:
-        total, used, free = shutil.disk_usage(dbmapdir)
-        if free < dbmap_size:
-            log.error(f"Not enough space on {dbmapdir} to migrate to bdb (Need {size_fmt(dbmap_size)}, Have {size_fmt(free)})")
-            return
+    if os.stat(dbmapdir).st_dev != os.stat(tmpdir).st_dev:
+        # Ldif and db are on different filesystems
+        # Let check that we have enough space for ldif files
         total, used, free = shutil.disk_usage(tmpdir)
         if free < total_entrysize:
-            log.error("Not enough space on {tmpdir} to migrate to bdb (Need {size_fmt(total_entrysize)}, Have {size_fmt(free)})")
-            return
+            raise OSError(ENOSPC, "Not enough space on {tmpdir} to migrate to bdb " +
+                                  "(In {tmpdir}, {format_size(total_entrysize)} bytes "+
+                                  "are needed but only {format_size(free)} are available)")
+        total_entrysize = 0    # do not count total_entrysize when checking dbmapdir size
+
+    # Let check that we have enough space for the db and ldif files
+    total, used, free = shutil.disk_usage(dbmapdir)
+    if free < dbmap_size + total_entrysize:
+            raise OSError(ENOSPC, "Not enough space on {tmpdir} to migrate to bdb " +
+                                  "(In {dbmapdir}, {format_size(dbmap_size+total_entrysize)} "+
+                                  "is needed but only {format_size(free)} is available)")
+
     progress = 0
     encrypt = False       # Should maybe be a args param
     total_dbsize = 0

--- a/src/lib389/lib389/instance/options.py
+++ b/src/lib389/lib389/instance/options.py
@@ -12,7 +12,7 @@ import os
 import random
 from lib389.paths import Paths
 from lib389._constants import INSTALL_LATEST_CONFIG
-from lib389.utils import get_default_db_lib, get_default_lmdb_max_size, socket_check_bind
+from lib389.utils import get_default_db_lib, get_default_mdb_max_size, socket_check_bind
 
 MAJOR, MINOR, _, _, _ = sys.version_info
 
@@ -38,7 +38,7 @@ format_keys = [
     'db_lib',
     'ldapi',
     'ldif_dir',
-    'lmdb_size',
+    'mdb_max_size',
     'lock_dir',
     'log_dir',
     'run_dir',
@@ -115,8 +115,6 @@ class Options2(object):
                     v = config.getint(self._section, k)
                 elif self._type[k] == bool:
                     v = config.getboolean(self._section, k)
-                elif self._type[k] == float:
-                    v = config.getfloat(self._section, k)
                 elif self._type[k] == str:
                     v = config.get(self._section, k)
                 # How does this handle wrong types?
@@ -327,10 +325,10 @@ class Slapd2Base(Options2):
         self._helptext['db_lib'] = "Select the database implementation library (bdb or mdb)."
         self._advanced['db_lib'] = False
 
-        self._options['lmdb_size'] = get_default_lmdb_max_size(ds_paths)
-        self._type['lmdb_size'] = float
-        self._helptext['lmdb_size'] = "Select the lmdb database maximum size (gb)."
-        self._advanced['lmdb_size'] = False
+        self._options['mdb_max_size'] = get_default_mdb_max_size(ds_paths)
+        self._type['mdb_max_size'] = str
+        self._helptext['mdb_max_size'] = "Select the lmdb database maximum size."
+        self._advanced['mdb_max_size'] = False
 
         self._options['ldif_dir'] = ds_paths.ldif_dir
         self._type['ldif_dir'] = str

--- a/src/lib389/lib389/instance/options.py
+++ b/src/lib389/lib389/instance/options.py
@@ -12,7 +12,7 @@ import os
 import random
 from lib389.paths import Paths
 from lib389._constants import INSTALL_LATEST_CONFIG
-from lib389.utils import get_default_db_lib, socket_check_bind
+from lib389.utils import get_default_db_lib, get_default_lmdb_max_size, socket_check_bind
 
 MAJOR, MINOR, _, _, _ = sys.version_info
 
@@ -38,6 +38,7 @@ format_keys = [
     'db_lib',
     'ldapi',
     'ldif_dir',
+    'lmdb_size',
     'lock_dir',
     'log_dir',
     'run_dir',
@@ -114,6 +115,8 @@ class Options2(object):
                     v = config.getint(self._section, k)
                 elif self._type[k] == bool:
                     v = config.getboolean(self._section, k)
+                elif self._type[k] == float:
+                    v = config.getfloat(self._section, k)
                 elif self._type[k] == str:
                     v = config.get(self._section, k)
                 # How does this handle wrong types?
@@ -322,7 +325,12 @@ class Slapd2Base(Options2):
         self._options['db_lib'] = get_default_db_lib()
         self._type['db_lib'] = str
         self._helptext['db_lib'] = "Select the database implementation library (bdb or mdb)."
-        self._advanced['db_lib'] = True
+        self._advanced['db_lib'] = False
+
+        self._options['lmdb_size'] = get_default_lmdb_max_size(ds_paths)
+        self._type['lmdb_size'] = float
+        self._helptext['lmdb_size'] = "Select the lmdb database maximum size (gb)."
+        self._advanced['lmdb_size'] = False
 
         self._options['ldif_dir'] = ds_paths.ldif_dir
         self._type['ldif_dir'] = str

--- a/src/lib389/lib389/properties.py
+++ b/src/lib389/lib389/properties.py
@@ -27,6 +27,7 @@ SER_LDAPI_ENABLED = 'ldapi_enabled'
 SER_LDAPI_SOCKET = 'ldapi_socket'
 SER_LDAPI_AUTOBIND = 'ldapi_autobind'
 SER_INST_SCRIPTS_ENABLED = 'InstScriptsEnabled'
+SER_DB_LIB = 'db_lib'
 
 SER_PROPNAME_TO_ATTRNAME = {SER_HOST: 'nsslapd-localhost',
                             SER_PORT: 'nsslapd-port',
@@ -38,6 +39,7 @@ SER_PROPNAME_TO_ATTRNAME = {SER_HOST: 'nsslapd-localhost',
                             SER_LDAPI_ENABLED: 'nsslapd-ldapilisten',
                             SER_LDAPI_SOCKET: 'nsslapd-ldapifilepath',
                             SER_LDAPI_AUTOBIND: 'nsslapd-ldapiautobind',
+                            SER_DB_LIB: 'nsslapd-backend-implement',
                             }
 #
 # Those WITHOUT related attribute name
@@ -47,6 +49,7 @@ SER_GROUP_ID = 'group-id'
 SER_DEPLOYED_DIR = 'deployed-dir'
 SER_BACKUP_INST_DIR = 'inst-backupdir'
 SER_STRICT_HOSTNAME_CHECKING = 'strict_hostname_checking'
+SER_LMDB_SIZE = 'lmdb_size'
 
 ####################################
 #

--- a/src/lib389/lib389/properties.py
+++ b/src/lib389/lib389/properties.py
@@ -49,7 +49,6 @@ SER_GROUP_ID = 'group-id'
 SER_DEPLOYED_DIR = 'deployed-dir'
 SER_BACKUP_INST_DIR = 'inst-backupdir'
 SER_STRICT_HOSTNAME_CHECKING = 'strict_hostname_checking'
-SER_LMDB_SIZE = 'lmdb_size'
 
 ####################################
 #

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -54,7 +54,8 @@ from lib389.paths import ( Paths, DEFAULTS_PATH )
 from lib389.dseldif import DSEldif
 from lib389._constants import (
         DEFAULT_USER, VALGRIND_WRAPPER, DN_CONFIG, CFGSUFFIX, LOCALHOST,
-        ReplicaRole, CONSUMER_REPLICAID, SENSITIVE_ATTRS, DEFAULT_DB_LIB
+        ReplicaRole, CONSUMER_REPLICAID, SENSITIVE_ATTRS, DEFAULT_DB_LIB,
+        DEFAULT_LMDB_SIZE
     )
 from lib389.properties import (
         SER_HOST, SER_USER_ID, SER_GROUP_ID, SER_STRICT_HOSTNAME_CHECKING, SER_PORT,
@@ -1703,6 +1704,21 @@ def is_valid_hostname(hostname):
 
 def get_default_db_lib():
     return os.getenv('NSSLAPD_DB_LIB', default=DEFAULT_DB_LIB)
+
+
+def get_default_lmdb_max_size(paths):
+    if paths is None:
+        paths = Paths()
+    lmdb_max_size = DEFAULT_LMDB_SIZE
+    try:
+        statvfs = os.statvfs(paths.db_dir)
+        avail = statvfs.f_frsize * statvfs.f_bavail / GIGABYTE
+        avail *= 0.8 # Reserve 20% as margin
+        if lmdb_max_size > avail:
+            lmdb_max_size =  avail
+    except Exception as e:
+        pass
+    return lmdb_max_size
 
 
 def is_fips():

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1724,6 +1724,20 @@ def parse_size(size):
         raise ValueError(f'Unable to parse "{size}" as a size.')
 
 
+def format_size(size):
+    """
+    Return a string representing a size (like "5 kb" or "2.5Gb")
+    :param size: The size int bytes to format
+    :type size: int:
+    :return str:
+    """
+    for unit in ["B", "KB", "MB", "GB",]:
+        if (size < 1024):
+            return f"{size:3.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
 def get_default_db_lib():
     """
     Get the default value for the database implementation


### PR DESCRIPTION
Description:

  **`dscreate` changes:**
    - make db_lib a standard option instead of an advanced one
    - add mdb_max_size as standard option 
  **`dsconf instance backend config set` changes:** 
     - add --mdb_max_size option associated with nsslapd-mdb-max-size
     - add --mdb_max_readers option associated with nsslapd-mdb_max_readers
     - add --mdb_max_dbs option associated with nsslapd-mdb_max_dbs

Issue: #5843 

Reviewed by: @Firstyear and @droideck  ( Thanks ! )