### PR TITLE
Issue 5843 - Fix dscreate create-template issue

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1758,7 +1758,11 @@ def get_default_mdb_max_size(paths):
     # Make sure that there is enough available disk space
     # otherwise decrease the value
     dbdir = paths.db_dir
-    while '{' in dbdir:
+    # dbdir may not exists because:
+    #  - paths instance name has not been expanded 
+    #  - dscreate has not yet created it.
+    # so let use the first existing parent in that case.
+    while not os.path.exists(dbdir):
         dbdir = os.path.dirname(dbdir)
     try:
         statvfs = os.statvfs(dbdir)


### PR DESCRIPTION
Regression with dscreate from-instance before creating first instance:
  the target directory does not exists and a warning is inserted in the template file
  which is then broken.

Fix is pretty trivial:
  Select an existing directory to compute the file system free space.

Issue #5943 

Reviewed by: @droideck (Thanks !)