### PR TITLE
Issue 5786 - Update permissions for Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   actions: read
   packages: read
-  contents: read
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Description:
Release workflow needs write access to create releases.

Fixes: https://github.com/389ds/389-ds-base/issues/5786

Reviewed by: ???