### PR TITLE
Issue 6061 - Certificate lifetime displayed as NaN

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -998,7 +998,7 @@ export function showCertificate (certificate, showCertCallback) {
         'echo ' + certificate +
     ' | base64 --decode | openssl x509 -inform DER -noout -subject -issuer -dates -serial ;' +
     // ' echo HOST_TIME_GMT=`TZ=GMT date "+%Y-%m-%d %H:%M:%S %Z"` ' // Issue with Firefox and Safari.
-    ' echo HOST_TIME_GMT=`TZ=GMT date`'
+    ' echo HOST_TIME_GMT=`date -Iminutes`'
     ];
 
     let result = {};


### PR DESCRIPTION
Bug Description:
HOST_TIME_GMT content depends on user locale. On french version (maybe others too) date calculation doesn't work 

Fix Description:
Add "LANG=C" before date comand to ensure format will be correct.

Author: Adadov
Relates: #6061