### PR TITLE
Issue 5956 - After an upgrade the server won't start - conntabledize

### DIFF
--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -4828,7 +4828,7 @@ config_set_conntablesize(const char *attrname, char *value, char *errorbuf, int 
                           "User setting of %s attribute is disabled, server has auto calculated its value to %d.",
                           attrname, slapdFrontendConfig->conntablesize);
 
-    return LDAP_OPERATIONS_ERROR;
+    return LDAP_SUCCESS;
 }
 
 int


### PR DESCRIPTION
Description: A commit, that increased the default connection table size included the deprecation of the attribute nsslapd-conntablesize. An attempt to set the value of this attribute issued a warning message and returned LDAP_OPERATIONS_ERROR. This causes an issue after an upgrade, the server fails to start if nsslapd-conntablesize is present in dse.ldif

Fix: Return LDAP_SUCCESS instead...

Related: https://github.com/389ds/389-ds-base/issues/5956

Reviewed by: