### PR TITLE
Issue 5960 - Subpackages should have more strict interdependencies

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -373,6 +373,7 @@ SNMP Agent for the 389 Directory Server base package.
 Summary:  A library for accessing, testing, and configuring the 389 Directory Server
 BuildArch:        noarch
 Group:            Development/Libraries
+Requires: %{name} = %{version}-%{release}
 Requires: openssl
 # This is for /usr/bin/c_rehash tool, only needed for openssl < 1.1.0
 Requires: openssl-perl
@@ -400,9 +401,9 @@ This module contains tools and libraries for accessing, testing,
 Summary:          Cockpit UI Plugin for configuring and administering the 389 Directory Server
 BuildArch:        noarch
 Requires:         cockpit
-Requires:         389-ds-base
+Requires:         %{name} = %{version}-%{release}
 Requires:         python%{python3_pkgversion}
-Requires:         python%{python3_pkgversion}-lib389
+Requires:         python%{python3_pkgversion}-lib389 = %{version}-%{release}
 
 %description -n cockpit-389-ds
 A cockpit UI Plugin for configuring and administering the 389 Directory Server


### PR DESCRIPTION
Bug Description:
`cockpit-389-ds` requires `389-ds-base` and `python3-lib389`, but it should require the exact version and release as well. Without this it's possible to update `cockpit-389-ds` without updating other sub-packages, which can lead to incompatibilities between WebUI and underlying lib389 tools used by the WebUI.

Fix Description:
Update Requires for the subpackages to use version and release.

Fixes: https://github.com/389ds/389-ds-base/issues/5960

Reviewed-by: ???