### PR TITLE
Issue 5966 - CLI - Custom schema object is removed on a failed edit

### DIFF
--- a/src/lib389/lib389/schema.py
+++ b/src/lib389/lib389/schema.py
@@ -275,7 +275,11 @@ class Schema(DSLdapObject):
             raise ValueError('Schema is already in the required state. Nothing to change')
 
         self.remove(attr_name, schema_object_str_old)
-        return self.add(attr_name, schema_object_str)
+        try:
+            return self.add(attr_name, schema_object_str)
+        except ldap.LDAPError:
+            self.add(attr_name, schema_object_str_old)
+            raise
 
     def reload(self, schema_dir=None):
         """Reload the schema"""


### PR DESCRIPTION
Description: When the failure happens during a custom schema edit operation in both CLI and UI (because it uses the CLI command), we first remove the old schema object and only then do we add the new one (edited).

Bring the old schema object on the failed attempt.

Resolves: https://github.com/389ds/389-ds-base/issues/5966

Reviewed by: ?