### PR TITLE
Issue 5973 - Fix fedora cop RawHide builds

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -18,7 +18,10 @@
 
 #if defined(HPUX11) || defined(OS_solaris) || defined(linux)
 /* built-in 64-bit file I/O support */
+#if ! defined(__LP64__)
+/* But not on 64-bit arch: It is needless and build fails since gcc 13.2.1-4 */
 #define DB_USE_64LFS
+#endif
 #endif
 
 /* needed by at least HPUX and Solaris, to define off64_t */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -7,14 +7,14 @@
  * END COPYRIGHT BLOCK **/
 
 
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
 #include "bdb_layer.h"
 #include <prthread.h>
 #include <prclist.h>
-#include <sys/types.h>
-#include <sys/statvfs.h>
 #include <glob.h>
 
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -6,6 +6,8 @@
  * See LICENSE for details.
  * END COPYRIGHT BLOCK **/
 
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -13,7 +15,6 @@
 /* dbmdb_ctx_t.c - Handles configuration information that is specific to a MDB backend instance. */
 
 #include "mdb_layer.h"
-#include <sys/statvfs.h>
 
 
 /* Forward declarations */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -7,6 +7,8 @@
  * END COPYRIGHT BLOCK **/
 
 
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -15,8 +17,6 @@
 #include <prthread.h>
 #include <assert.h>
 #include <prclist.h>
-#include <sys/types.h>
-#include <sys/statvfs.h>
 #include <glob.h>
 
 Slapi_ComponentId *dbmdb_componentid;

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -26,6 +26,8 @@
  *   are in dblayer.c ( All function defined during phase 2 )
  */
 
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -34,8 +36,6 @@
 #include "dblayer.h"
 #include <prthread.h>
 #include <prclist.h>
-#include <sys/types.h>
-#include <sys/statvfs.h>
 
 
 static inline dblayer_private *dblayer_get_priv(Slapi_Backend *be)

--- a/ldap/servers/slapd/back-ldbm/dblayer.c
+++ b/ldap/servers/slapd/back-ldbm/dblayer.c
@@ -57,6 +57,8 @@
  *  dblayer_release_index_file()
  */
 
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -64,8 +66,6 @@
 #include "dblayer.h"
 #include <prthread.h>
 #include <prclist.h>
-#include <sys/types.h>
-#include <sys/statvfs.h>
 
 #define NEWDIR_MODE 0755
 #define DB_REGION_PREFIX "__db."


### PR DESCRIPTION
Problem: @389ds/389-ds-base-nightly copr nigthly builds faild on
 fedora-rawhide-s390x and fedora-rawhide-x86_64

Solution:
   [1] Work around a gcc cpp bug by moving stavfs.h include line
       before ldbm-backend.h include line
   [2] Do not use large file API on LP64 architecture

Issue:  @5973

Reviewed by:  @tbordaz , @droideck (Thanks !)