### PR TITLE
Issue 5947 - CI test_vlv_recreation_reindex fails on LMDB

### DIFF
--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -788,7 +788,8 @@ do_vlv_update_index(back_txn *txn, struct ldbminfo *li, Slapi_PBlock *pb, struct
     } else {
         /* Very bad idea to do this outside of a transaction */
     }
-    if (priv->dblayer_clear_vlv_cache_fn) {
+    if (txn && !txn->back_special_handling_fn && priv->dblayer_clear_vlv_cache_fn) {
+        /* If there is a txn and it is not an import pseudo txn then clear the vlv cache */
         priv->dblayer_clear_vlv_cache_fn(be, db_txn, db);
     }
     data.size = sizeof(entry->ep_id);


### PR DESCRIPTION
There are a few problems about vlv and lmdb:
 [1] Crash while reindexing a vlv index while trying to clear the vlv cache
 [2] Crash when VLV search fails because target entry is released twice
 [3] Confusion about db interface and recno (recno is in the key rather than the data)
 [4] dbscan fails to dump vlv cache database

Fix:
  [1] Do not clear the vlv cache when having a pseudo txn (i.e: in import/reindex)
  [2] Do not release the target entry in ldbm_back_search_cleanup
  [3] Use the key to set the recno
  [4] Do not try change the "vlv db name to vlv cache name" if the name
      is already a cache name (i.e starting with ~)

Issue: #5947 

Reviewed by: @droideck (Thanks!)