### PR TITLE
Issue 5944 - Reversion of the entry cache should be limited to BETXN …

### DIFF
--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -556,7 +556,12 @@ flush_hash(struct cache *cache, struct timespec *start_time, int32_t type)
 {
     Hashtable *ht = cache->c_idtable; /* start with the ID table as it's in both ENTRY and DN caches */
     void *e, *laste = NULL;
+    char flush_etime[ETIME_BUFSIZ] = {0};
+    struct timespec duration;
+    struct timespec flush_start;
+    struct timespec flush_end;
 
+    clock_gettime(CLOCK_MONOTONIC, &flush_start);
     cache_lock(cache);
 
     for (size_t i = 0; i < ht->size; i++) {
@@ -638,6 +643,11 @@ flush_hash(struct cache *cache, struct timespec *start_time, int32_t type)
     }
 
     cache_unlock(cache);
+
+    clock_gettime(CLOCK_MONOTONIC, &flush_end);
+    slapi_timespec_diff(&flush_end, &flush_start, &duration);
+    snprintf(flush_etime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)duration.tv_sec, (int64_t)duration.tv_nsec);
+    slapi_log_err(SLAPI_LOG_WARNING, "flush_hash", "Upon BETXN callback failure, entry cache is flushed during %s\n", flush_etime);
 }
 
 void

--- a/ldap/servers/slapd/back-ldbm/ldbm_delete.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_delete.c
@@ -80,6 +80,7 @@ ldbm_back_delete(Slapi_PBlock *pb)
     int result_sent = 0;
     Connection *pb_conn;
     int32_t parent_op = 0;
+    int32_t betxn_callback_fails = 0; /* if a BETXN fails we need to revert entry cache */
     struct timespec parent_time;
 
     if (slapi_pblock_get(pb, SLAPI_CONN_ID, &conn_id) < 0) {
@@ -434,6 +435,9 @@ replace_entry:
                                           &ldap_result_code : &retval );
                     }
                     slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+                    if (retval) {
+                        betxn_callback_fails = 1;
+                    }
                     goto error_return;
                 }
             }
@@ -717,6 +721,9 @@ replace_entry:
                                      ldap_result_code ? &ldap_result_code : &retval);
                 }
                 slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+                if (retval) {
+                    betxn_callback_fails = 1;
+                }
                 goto error_return;
             }
         }
@@ -746,6 +753,9 @@ replace_entry:
                 }
                 /* retval is -1 */
                 slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+                if (rc) {
+                    betxn_callback_fails = 1;
+                }
                 goto error_return;
             }
             slapi_pblock_set(pb, SLAPI_DELETE_BEPREOP_ENTRY, orig_entry);
@@ -1266,6 +1276,7 @@ replace_entry:
             slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &retval);
         }
         slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+        betxn_callback_fails = 1;
         goto error_return;
     }
     if (parent_found) {
@@ -1281,6 +1292,7 @@ replace_entry:
 
     retval = plugin_call_mmr_plugin_postop(pb, NULL,SLAPI_PLUGIN_BE_TXN_POST_DELETE_FN);
     if (retval) {
+        betxn_callback_fails = 1;
         ldbm_set_error(pb, retval, &ldap_result_code, &ldap_result_message);
         goto error_return;
     }
@@ -1416,8 +1428,12 @@ error_return:
                 slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
             }
             slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+            betxn_callback_fails = 1;
         }
         retval = plugin_call_mmr_plugin_postop(pb, NULL,SLAPI_PLUGIN_BE_TXN_POST_DELETE_FN);
+        if (retval) {
+            betxn_callback_fails = 1;
+        }
 
         /* Release SERIAL LOCK */
         dblayer_txn_abort(be, &txn); /* abort crashes in case disk full */
@@ -1437,7 +1453,7 @@ error_return:
     }
 
     /* Revert the caches if this is the parent operation */
-    if (parent_op) {
+    if (parent_op && betxn_callback_fails) {
         revert_cache(inst, &parent_time);
     }
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -522,6 +522,7 @@ ldbm_back_modify(Slapi_PBlock *pb)
     int ec_locked = 0;
     int result_sent = 0;
     int32_t parent_op = 0;
+    int32_t betxn_callback_fails = 0; /* if a BETXN fails we need to revert entry cache */
     struct timespec parent_time;
     Slapi_Mods *smods_add_rdn = NULL;
 
@@ -817,6 +818,9 @@ ldbm_back_modify(Slapi_PBlock *pb)
                 slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
             }
             slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+            if (retval) {
+                betxn_callback_fails = 1;
+            }
             goto error_return;
         }
 
@@ -1017,10 +1021,12 @@ ldbm_back_modify(Slapi_PBlock *pb)
             slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
         }
         slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+        betxn_callback_fails = 1;
         goto error_return;
     }
     retval = plugin_call_mmr_plugin_postop(pb, NULL,SLAPI_PLUGIN_BE_TXN_POST_MODIFY_FN);
     if (retval) {
+        betxn_callback_fails = 1;
         ldbm_set_error(pb, retval, &ldap_result_code, &ldap_result_message);
         goto error_return;
     }
@@ -1083,8 +1089,12 @@ error_return:
                 if (!opreturn) {
                     slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
                 }
+                betxn_callback_fails = 1;
             }
             retval = plugin_call_mmr_plugin_postop(pb, NULL,SLAPI_PLUGIN_BE_TXN_POST_MODIFY_FN);
+            if (retval) {
+                betxn_callback_fails = 1;
+            }
 
             /* It is safer not to abort when the transaction is not started. */
             /* Release SERIAL LOCK */
@@ -1096,7 +1106,7 @@ error_return:
             rc = SLAPI_FAIL_GENERAL;
         }
         /* Revert the caches if this is the parent operation */
-        if (parent_op) {
+        if (parent_op && betxn_callback_fails) {
             revert_cache(inst, &parent_time);
         }
     }

--- a/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
@@ -101,6 +101,7 @@ ldbm_back_modrdn(Slapi_PBlock *pb)
     int result_sent = 0;
     Connection *pb_conn = NULL;
     int32_t parent_op = 0;
+    int32_t betxn_callback_fails = 0; /* if a BETXN fails we need to revert entry cache */
     struct timespec parent_time;
     Slapi_Mods *smods_add_rdn = NULL;
 
@@ -999,6 +1000,9 @@ ldbm_back_modrdn(Slapi_PBlock *pb)
                 slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
             }
             slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+            if (retval) {
+                betxn_callback_fails = 1;
+            }
             goto error_return;
         }
 
@@ -1250,10 +1254,12 @@ ldbm_back_modrdn(Slapi_PBlock *pb)
             slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, ldap_result_code ? &ldap_result_code : &retval);
         }
         slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
+        betxn_callback_fails = 1;
         goto error_return;
     }
     retval = plugin_call_mmr_plugin_postop(pb, NULL,SLAPI_PLUGIN_BE_TXN_POST_MODRDN_FN);
     if (retval) {
+        betxn_callback_fails = 1;
         ldbm_set_error(pb, retval, &ldap_result_code, &ldap_result_message);
         goto error_return;
     }
@@ -1319,7 +1325,7 @@ ldbm_back_modrdn(Slapi_PBlock *pb)
 
 error_return:
     /* Revert the caches if this is the parent operation */
-    if (parent_op) {
+    if (parent_op && betxn_callback_fails) {
         revert_cache(inst, &parent_time);
     }
 
@@ -1401,7 +1407,9 @@ error_return:
                 }
                 slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &ldap_result_message);
 
-                /* Revert the caches if this is the parent operation */
+                /* As it is a BETXN plugin failure then
+                 * revert the caches if this is the parent operation
+                 */
                 if (parent_op) {
                     revert_cache(inst, &parent_time);
                 }


### PR DESCRIPTION
…plugin failures

Bug description:
	During an update if an BETXN plugin fails the full TXN is aborted and
	the DB returns to the previous state. However potential internal
	updates, done by BETXN plugins, are also applied on the entry cache.
	Some entries in the entry cache are left in a state that does not
	reflect the DB state. To prevent this mismatch, upon BETXN failure,
	the fix https://pagure.io/389-ds-base/issue/50260 reverts some entries
	in the entry cache .

	The problem is that reversion is not limited to the cases of BETXN
	failures that was the initial goal. So a "regular" error like schema
	violation could trigger revert_cache

Fix description:
	The fix flags if the failure is due to BETXN failures and
	trigger revert_cache only in that case

relates: #5944

Reviewed by: