### PR TITLE
Issue 5984 - Crash when page search are abandonned - Fix minor merge issue in 1.4.3

### DIFF
--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -7,11 +7,7 @@
 # --- END COPYRIGHT BLOCK ---
 #
 import socket
-<<<<<<< HEAD
-from random import sample
-=======
 from random import sample, randrange
->>>>>>> 06bd08629 (Issue 5984 - Crash when paged result search are abandoned (#5985))
 
 import pytest
 from ldap.controls import SimplePagedResultsControl, GetEffectiveRightsControl


### PR DESCRIPTION
Fix a merge issue that impacted CI test in 1.4.3 cherry-pick

Issue: #5984

Reviewed by @jchapma (Thanks!)