### PR TITLE
Issue 6011 - Backport 'Release' GitHub Action to 1.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "389-ds-base-*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Specify tag to generate a tarball
+        required: true
+      skip-audit-ci:
+        description: Skip npm audit-ci
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  packages: read
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/389ds/ci-images:test
+    steps:
+      - name: Get the version
+        id: get_version
+        run: |
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ github.event.inputs.version || github.ref_name }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.get_version.outputs.version }}
+
+      - name: Create tarball
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if [ "${{ github.event.inputs.skip-audit-ci }}" = "true" ]; then
+              export SKIP_AUDIT_CI=1
+          fi
+          TAG=${{ steps.get_version.outputs.version }} make -f rpm.mk dist-bz2
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.get_version.outputs.version }}.tar.bz2
+          path: ${{ steps.get_version.outputs.version }}.tar.bz2
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          files: |
+            ${{ steps.get_version.outputs.version }}.tar.bz2


### PR DESCRIPTION
Bug Description:
GitHub Action to cut release tarballs is missing in 1.4.3 branch, as a result, tarball releases from that branch are not created automatically.

Fix Description:
Backport 'Release' action.

Fixes: https://github.com/389ds/389-ds-base/issues/6011

Reviewed by: ???