### PR TITLE
Issue 5941 - Switch default backend to lmdb and change version to 3.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
           path: dist.tar
 
   test:
-    name: Test
+    name: BDB Test
     runs-on: ubuntu-22.04
     needs: build
     strategy:
@@ -97,7 +97,7 @@ jobs:
         sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
         sudo docker exec $CID sh -c "mkdir -p /workspace/assets/cores && chmod 777 /workspace{,/assets{,/cores}}"
         sudo docker exec $CID sh -c "echo '/workspace/assets/cores/core.%e.%P' > /proc/sys/kernel/core_pattern"
-        sudo docker exec -e WEBUI=1 -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=bdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
 
     - name: Make the results file readable by all
       if: always()

--- a/VERSION.sh
+++ b/VERSION.sh
@@ -8,8 +8,8 @@ capbrand=389
 vendor="389 Project"
 
 # PACKAGE_VERSION is constructed from these
-VERSION_MAJOR=2
-VERSION_MINOR=5
+VERSION_MAJOR=3
+VERSION_MINOR=0
 VERSION_MAINT=0
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -1262,8 +1262,18 @@ main(int argc, char **argv)
     int ret = 0;
     char *find_key = NULL;
     uint32_t entry_id = 0xffffffff;
-    char *dbimpl_name = (char*) "bdb";
+    char *defdbimpl = getenv("NSSLAPD_DB_LIB");
+    char *dbimpl_name = (char*) "mdb";
     int c;
+
+    if (defdbimpl) {
+        if (strcasecmp(defdbimpl, "bdb") == 0) {
+            dbimpl_name = (char*) "bdb";
+        }
+        if (strcasecmp(defdbimpl, "mdb") == 0) {
+            dbimpl_name = (char*) "mdb";
+        }
+    }
 
     while ((c = getopt(argc, argv, "Af:RL:S:l:nG:srk:K:hvt:D:X:I:d")) != EOF) {
         switch (c) {

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -120,7 +120,7 @@ DEFAULT_INST_HEAD = 'slapd-'
 DEFAULT_ENV_HEAD = 'dirsrv-'
 DEFAULT_CHANGELOG_NAME = "changelog5"
 DEFAULT_CHANGELOG_DB = 'changelogdb'
-DEFAULT_DB_LIB = 'bdb'
+DEFAULT_DB_LIB = 'mdb'
 
 # CONF_DIR = 'etc/dirsrv'
 # ENV_SYSCONFIG_DIR = '/etc/sysconfig'


### PR DESCRIPTION
Changes:
   [1] use lmdb by default 
   [2] Change version number to 3.0.0
   
Issue: #5941 

Reviewed by: @droideck, @tbordaz (Thanks!)