### PR TITLE
Issue 6015 - Fix typo remeber

### DIFF
--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -333,7 +333,7 @@ class Encryption(DSLdapObject):
         :type ciphers: list of str
         """
         self.set('nsSSL3Ciphers', ','.join(ciphers))
-        self._log.info('Remeber to restart the server to apply the new cipher set.')
+        self._log.info('Remember to restart the server to apply the new cipher set.')
         self._log.info('Some ciphers may be disabled anyway due to allowWeakCipher attribute.')
 
     def _get_listed_ciphers(self, attr):


### PR DESCRIPTION
In the logs of my ldap instance when running `dsconf slapd-localhost security ciphers set` command, I saw this typo which I want to fix with this PR.

Issue: #6015 

Reviewed by: @progier389 