### PR TITLE
Issue 6016 - Pin upload/download artifacts action to v3

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -12,11 +12,11 @@ on:
         required: false
         default: false
       debug_enabled:
-        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -79,10 +79,10 @@ jobs:
         sudo systemctl start docker
 
     - name: Download RPMs
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v3
       with:
         name: rpms
-    
+
     - name: Extract RPMs
       run: tar xvf dist.tar
 
@@ -107,7 +107,7 @@ jobs:
     - name: Sanitize filename
       if: always()
       run: echo "PYTEST_SUITE=$(echo ${{ matrix.suite }} | sed -e 's#\/#-#g')" >> $GITHUB_ENV
-      
+
     - name: Upload pytest test results
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,11 +12,11 @@ on:
         required: false
         default: false
       debug_enabled:
-        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -79,10 +79,10 @@ jobs:
         sudo systemctl start docker
 
     - name: Download RPMs
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v3
       with:
         name: rpms
-    
+
     - name: Extract RPMs
       run: tar xvf dist.tar
 
@@ -107,7 +107,7 @@ jobs:
     - name: Sanitize filename
       if: always()
       run: echo "PYTEST_SUITE=$(echo ${{ matrix.suite }} | sed -e 's#\/#-#g')" >> $GITHUB_ENV
-      
+
     - name: Upload pytest test results
       if: always()
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Bug Description:
After update of actions/download-artifact to v4, our PR CI started to fail.

Fix Description:
A workaround is to pin to the older version v3.

Fixes: https://github.com/389ds/389-ds-base/issues/6016

Reviewed by: @progier389 (Thanks!)