### PR TITLE
Issue 6010 - 389 ds ignores nsslapd-maxdescriptors 

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -815,7 +815,7 @@ accept_thread(void *vports)
     PRErrorCode prerr;
     int last_accept_new_connections = -1;
     PRIntervalTime pr_timeout = PR_MillisecondsToInterval(slapd_accept_wakeup_timer);
-    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    //slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     PRFileDesc **n_tcps = NULL;
     PRFileDesc **s_tcps = NULL;
     PRFileDesc **i_unix = NULL;
@@ -829,7 +829,7 @@ accept_thread(void *vports)
 
     while (!g_get_shutdown()) {
         /* Do we need to accept new connections? */
-        int accept_new_connections = ((ct->size - g_get_current_conn_count()) > slapdFrontendConfig->reservedescriptors);
+        int accept_new_connections = (ct->size > g_get_current_conn_count());
         if (!accept_new_connections) {
             if (last_accept_new_connections) {
                 slapi_log_err(SLAPI_LOG_ERR, "accept_thread",
@@ -2038,7 +2038,7 @@ unfurl_banners(Connection_Table *ct, daemon_ports_t *ports, PRFileDesc **n_tcps,
     char addrbuf[256];
     int isfirsttime = 1;
 
-    if (ct->size <= slapdFrontendConfig->reservedescriptors) {
+    if (ct->size > (slapdFrontendConfig->maxdescriptors - slapdFrontendConfig->reservedescriptors)) {
         slapi_log_err(SLAPI_LOG_ERR, "slapd_daemon",
                       "Not enough descriptors to accept any connections. "
                       "This may be because the maxdescriptors configuration "

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -815,7 +815,6 @@ accept_thread(void *vports)
     PRErrorCode prerr;
     int last_accept_new_connections = -1;
     PRIntervalTime pr_timeout = PR_MillisecondsToInterval(slapd_accept_wakeup_timer);
-    //slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     PRFileDesc **n_tcps = NULL;
     PRFileDesc **s_tcps = NULL;
     PRFileDesc **i_unix = NULL;


### PR DESCRIPTION
Bug description: During server startup the connection table size is assumed
to be lower than or equal to the number of configured reserve file descriptors.
This prevents the server from starting whem the number of reserve descriptors
is high.

Fix description: Change the check to make sure the connection table size is
not greater than (max descriptors - reserve descriptors).

Also, the number of reserve descriptors is used to determine if the server can
accept a new connection. This has been changed to compare the connection table
size against the current number of connections.

Relates: https://github.com/389ds/389-ds-base/issues/6010