### PR TITLE
Issue 6022 - lmdb inconsistency between vlv index and vlv cache names

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2846,7 +2846,7 @@ out:
 int
 dbmdb_public_clear_vlv_cache(Slapi_Backend *be, dbi_txn_t *txn, dbi_db_t *db)
 {
-    char *rcdbname = slapi_ch_smprintf("%s%s", RECNOCACHE_PREFIX, ((dbmdb_dbi_t*)db)->dbname);
+    char *rcdbname = dbmdb_recno_cache_get_dbname(((dbmdb_dbi_t*)db)->dbname);
     dbmdb_dbi_t *rcdbi = NULL;
     MDB_val ok = { 0 };
     int rc = 0;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -498,6 +498,7 @@ int dbmdb_dbi_remove(dbmdb_ctx_t *conf, dbi_db_t **db);
 int dbmdb_dbi_rmdir(backend *be);
 int dbmdb_clear_dirty_flags(backend *be);
 int dbmdb_recno_cache_get_mode(dbmdb_recno_cache_ctx_t *rcctx);
+char *dbmdb_recno_cache_get_dbname(const char *vlvdbiname);
 int dbmdb_cmp_vals(MDB_val *v1, MDB_val *v2);
 dbmdb_stats_t *dbdmd_gather_stats(dbmdb_ctx_t *conf, backend *be);
 void dbmdb_free_stats(dbmdb_stats_t **stats);


### PR DESCRIPTION
Problem: dbstat -L shows two vlv cache db for a single vlv index db. 
There should only have a single one. 

Fix: 
 Added a CI Test
 Using a single dbmdb_recno_cache_get_dbname function to get the cache db name.
 Fix dbmdb_build_dbname to also append the backend name if the name is a vlv cache

Also fixed some issue found while creating the CI test:
  Fixed an error message that puzzled me to make it clearer.
  Fixed a race condition in lmdb bulk import that logged crappy data in error logs and crashed the CI tests.
  
Issue: #6022 

Reviewed by: @droideck (Thanks !)
   