### PR TITLE
Issue 6028 - vlv index keys inconsistencies

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
@@ -157,7 +157,6 @@ int dbmdb_run_ldif2db(Slapi_PBlock *pb);
 
 
 /* mdb_import_threads.c */
-const char *attr_in_list(const char *search, char **list);
 void safe_cond_wait(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex);
 
 struct backentry *dbmdb_import_make_backentry(Slapi_Entry *e, ID id);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
@@ -157,6 +157,7 @@ int dbmdb_run_ldif2db(Slapi_PBlock *pb);
 
 
 /* mdb_import_threads.c */
+const char *attr_in_list(const char *search, char **list);
 void safe_cond_wait(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex);
 
 struct backentry *dbmdb_import_make_backentry(Slapi_Entry *e, ID id);


### PR DESCRIPTION
The issue is that reindexed vlv database are not cleared, so old keys remains
Solution: truncate the reindexed vlv sub database and its cache before starting the import engine.
Note: this is tested by:  dirsrvtests/tests/suites/vlv/regression_test.py::test_vlv_cache_subdb_names CI test

Issue #6028 

Reviewed by: @droideck (Thanks!)

