### PR TITLE
Issue 6032 - Replication is broken after backup restore

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -1440,23 +1440,20 @@ dbmdb_back_ctrl(Slapi_Backend *be, int cmd, void *info)
         struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
 
         ldbm_instance *inst = (ldbm_instance *) be->be_instance_info;
-        if (li) {
-            dblayer_private *priv = (dblayer_private *)li->li_dblayer_private;
-            if (priv && priv->dblayer_env) {
-                char *instancedir;
-                dbmdb_dbi_t *dbi = NULL;
+        if (li && MDB_CONFIG(li)) {
+            char *instancedir;
+            dbmdb_dbi_t *dbi = NULL;
 
-                slapi_back_get_info(be, BACK_INFO_INSTANCE_DIR, (void **)&instancedir);
-                rc = dbmdb_open_dbi_from_filename(&dbi, be, BDB_CL_FILENAME, NULL, 0);
-                if (rc == MDB_NOTFOUND) {
-                    /* Nothing to do */
-                    rc = 0;
-                } else if (rc == 0) {
-                    rc = dbmdb_dbi_remove(MDB_CONFIG(li), (dbi_db_t**)&dbi);
-                }
-                inst->inst_changelog = NULL;
-                slapi_ch_free_string(&instancedir);
+            slapi_back_get_info(be, BACK_INFO_INSTANCE_DIR, (void **)&instancedir);
+            rc = dbmdb_open_dbi_from_filename(&dbi, be, BDB_CL_FILENAME, NULL, 0);
+            if (rc == MDB_NOTFOUND) {
+                /* Nothing to do */
+                rc = 0;
+            } else if (rc == 0) {
+                rc = dbmdb_dbi_remove(MDB_CONFIG(li), (dbi_db_t**)&dbi);
             }
+            inst->inst_changelog = NULL;
+            slapi_ch_free_string(&instancedir);
         }
         break;
     }


### PR DESCRIPTION
Replication is broken after doing an offline backup then later on an online or offline restore
Note: with online backup changelog is discarded at restore time (because it has no purge RUV)
In fact there are multiple cause:
  [1] _cl5CICbInit is building wrongly the changelog RUVs so changelog is recreated
  [2] Changelog is not cleared when it is "Recreated because of wrong test in dbmdb_back_ctrl
  [3] Replication keep alive get created before the replica get back in sync. This creates missing csn.
 Solution:
    [1] Fix _cl5CICbInit to get the csn from the changelog record key and store properly the min and max in the context.
    [2] Replace invalid test by a proper one.
    [3] Change keep alive update starting delay from 2 seconds to 10 minutes (i.e twice the maximum backoff timeout)
         To let a chance for the other supplier to replay the missing changes.
  Also added/modified some more data when replication log are enabled
  Note: this is a partial fix as a proper "resync after db reload" is not handled so this left issues (typically because
    of the plugin internal operations like memberof plugin or if there are lots of changes to replay) but at least is is enough for the CI test ...
   
Issue: #6032 

Reviewed by: @droideck, @tbordaz (Thanks!)
 
