### PR TITLE
Issue 6037 - Server crash at startup in vlvIndex_delete

### DIFF
--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -475,6 +475,7 @@ vlvIndex_delete(struct vlvIndex **ppvs)
 {
     if (ppvs != NULL && *ppvs != NULL) {
         slapi_ch_free((void **)&((*ppvs)->vlv_sortspec));
+        if ((*ppvs)->vlv_sortkey != NULL)
         {
             int n;
             for (n = 0; (*ppvs)->vlv_sortkey[n] != NULL; n++) {


### PR DESCRIPTION
Server crash at startup because of a corrupted dse.ldif: The vlv initialization code error handling generates a SIGSEV.
Fix: Avoid dereferencing a null pointer while freeing vlvIndex.

Issue: #6037 

Reviewed by: @tbordaz
