### PR TITLE
Issue 6041 - dscreate ds-root - accepts relative path

### DIFF
--- a/src/lib389/lib389/cli_ctl/instance.py
+++ b/src/lib389/lib389/cli_ctl/instance.py
@@ -234,7 +234,7 @@ def prepare_ds_root(inst, log, args):
     PO = '{'
     PF = '}'
     copy_and_substitute('/usr/share/dirsrv/inf/defaults.inf', (
-            ('WORD', ' /', f' {args.root_dir}/'),
+            ('WORD', ' /', f' {os.path.abspath(args.root_dir)}/'),
             ('LINE', 'with_selinux', 'no'),
             ('LINE', 'with_systemd', '0'),
             ('LINE', 'user', user),


### PR DESCRIPTION
Bug Description: When dscreate ds-root is invoked with a relative path to root_dir, the relative path is written to defaults.inf, causing instance creation failure.

Fix Description: Use abs path when writing root_dir to defaults.inf

Fixes: https://github.com/389ds/389-ds-base/issues/6041

Reviewed by: