### PR TITLE
Issue 6047 - Add a check for tagged commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,19 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.get_version.outputs.version }}
 
+      - name: Check if the tagged commit belongs to a valid branch
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          COMMIT=$(git rev-parse HEAD)
+          BRANCHES=$(git branch -a --contains $COMMIT | grep -v 'HEAD detached at')
+          if [ -n "$BRANCHES" ]; then
+              echo "Tagged commit $COMMIT belongs to the following branch(es):"
+              echo "$BRANCHES"
+          else
+              echo "Tagged commit $COMMIT does not belong to any branch."
+              exit 1
+          fi
+
       - name: Create tarball
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
Bug Description:
Release on GitHub can be created from a tag that points to a branch-less commit.

Fix Description:
Add an additional check to Release action to ensure that the tagged commit belongs to a valid branch.

Reviewed by:

Fixes: https://github.com/389ds/389-ds-base/issues/6047