### PR TITLE
Issue 6049 - lmdb - changelog is wrongly recreated by reindex task

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -736,7 +736,11 @@ dbmdb_import_all_done(ImportJob *job, int ret)
             ldbm_set_last_usn(inst->inst_be);
 
             /* bring backend online again */
-            slapi_mtn_be_enable(inst->inst_be);
+            if (job->flags & FLAG_REINDEXING) {
+                instance_set_not_busy(inst);
+            } else {
+                slapi_mtn_be_enable(inst->inst_be);
+            }
             slapi_log_err(SLAPI_LOG_INFO, "dbmdb_import_all_done",
                           "Backend %s is now online.\n",
                           slapi_be_get_name(inst->inst_be));

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -735,7 +735,17 @@ dbmdb_import_all_done(ImportJob *job, int ret)
             /* Reset USN slapi_counter with the last key of the entryUSN index */
             ldbm_set_last_usn(inst->inst_be);
 
-            /* bring backend online again */
+            /* Bring backend online again:
+             * In lmdb case, the import framework is also used for reindexing
+             * while in bdb case reindexing uses its own code.
+             * So dbmdb_import_all_done is called either after 
+             * dbmdb_ldif2db or after dbmdb_db2index while
+             * bdb_import_all_done is only called after bdb_ldif2db.
+             *
+             * dbmdb_db2index uses instance_set_busy_and_readonly 
+             * while dbmdb_ldif2db uses slapi_mtn_be_disable
+             * and these functions have to be reverted accordingly.
+             */
             if (job->flags & FLAG_REINDEXING) {
                 instance_set_not_busy(inst);
             } else {


### PR DESCRIPTION
dbmdb_import_all_done called at the end of import, bulk import and reindex is reenabling the backend
 which trigger the replication plugin to check if data were not reloaded, but in the reindex case, the backend was not disabled (so the db ruv is not up to date) and changelog is then discarded .
 The solution is to set back the backend in not busy mode when doing a reindex.

Issue:  #6049 

Reviewed by: @tbordaz (Thanks!)