### PR TITLE
Issue 6051 - Drop unused pytest markers

### DIFF
--- a/dirsrvtests/tests/suites/acl/enhanced_aci_modrnd_test.py
+++ b/dirsrvtests/tests/suites/acl/enhanced_aci_modrnd_test.py
@@ -64,7 +64,6 @@ def env_setup(topology_st):
     topology_st.standalone.modify_s(CONTAINER_2, mod)
 
 
-@pytest.mark.ds47553
 def test_enhanced_aci_modrnd(topology_st, env_setup):
     """Tests, that MODRDN operation is allowed,
     if user has ACI right '(all)' under superior entries,

--- a/dirsrvtests/tests/suites/acl/keywords_test.py
+++ b/dirsrvtests/tests/suites/acl/keywords_test.py
@@ -438,8 +438,6 @@ def test_dnsalias_keyword_test_nodns_cannot(topo, add_user, aci_of_user):
 
 #unstable or unstatus tests, skipped for now
 @pytest.mark.flaky(max_runs=2, min_passes=1)
-@pytest.mark.ds50378
-@pytest.mark.bz1710848
 @pytest.mark.parametrize("ip_addr", ['127.0.0.1', "[::1]"])
 def test_user_can_access_from_ipv4_or_ipv6_address(topo, add_user, aci_of_user, ip_addr):
     """User can modify the data when accessing the server from the allowed IPv4 and IPv6 addresses

--- a/dirsrvtests/tests/suites/acl/misc_test.py
+++ b/dirsrvtests/tests/suites/acl/misc_test.py
@@ -124,7 +124,6 @@ def test_accept_aci_in_addition_to_acl(topo, clean, aci_of_user):
         i.delete()
 
 
-@pytest.mark.bz334451
 def test_more_then_40_acl_will_crash_slapd(topo, clean, aci_of_user):
     """bug 334451 : more then 40 acl will crash slapd
     superseded by Bug 772778 - acl cache overflown problem with > 200 acis
@@ -156,7 +155,6 @@ def test_more_then_40_acl_will_crash_slapd(topo, clean, aci_of_user):
     for i in uas.list():
         i.delete()
 
-@pytest.mark.bz345643
 def test_search_access_should_not_include_read_access(topo, clean, aci_of_user):
     """bug 345643
     Misc Test 4 search access should not include read access
@@ -285,7 +283,6 @@ def test_only_allow_some_targetattr_two(topo, clean, aci_of_user, request):
         i.delete()
 
 
-@pytest.mark.bz326000
 def test_memberurl_needs_to_be_normalized(topo, clean, aci_of_user):
     """Non-regression test for BUG 326000: MemberURL needs to be normalized
 
@@ -331,7 +328,6 @@ def test_memberurl_needs_to_be_normalized(topo, clean, aci_of_user):
     for i in uas.list():
         i.delete()
 
-@pytest.mark.bz624370
 def test_greater_than_200_acls_can_be_created(topo, clean, aci_of_user):
     """Misc 10, check that greater than 200 ACLs can be created. Bug 624370
 
@@ -363,7 +359,6 @@ def test_greater_than_200_acls_can_be_created(topo, clean, aci_of_user):
         i.delete()
 
 
-@pytest.mark.bz624453
 def test_server_bahaves_properly_with_very_long_attribute_names(topo, clean, aci_of_user):
     """Make sure the server bahaves properly with very long attribute names. Bug 624453.
 

--- a/dirsrvtests/tests/suites/acl/modrdn_test.py
+++ b/dirsrvtests/tests/suites/acl/modrdn_test.py
@@ -200,7 +200,6 @@ def test_write_access_to_naming_atributes_two(topo, _add_user, aci_of_user, requ
     UserAccount(topo.standalone, SAM_DAMMY_MODRDN).delete()
 
 
-@pytest.mark.bz950351
 def test_access_aci_list_contains_any_deny_rule(topo, _add_user, aci_of_user):
     """RHDS denies MODRDN access if ACI list contains any DENY rule
     Bug description: If you create a deny ACI for some or more attributes there is incorrect behaviour

--- a/dirsrvtests/tests/suites/acl/repeated_ldap_add_test.py
+++ b/dirsrvtests/tests/suites/acl/repeated_ldap_add_test.py
@@ -148,7 +148,6 @@ def check_op_result(server, op, dn, superior, exists, rc):
     log.info('PASSED\n')
 
 
-@pytest.mark.bz1347760
 def test_repeated_ldap_add(topology_st):
     """Prevent revealing the entry info to whom has no access rights.
 

--- a/dirsrvtests/tests/suites/acl/search_real_part3_test.py
+++ b/dirsrvtests/tests/suites/acl/search_real_part3_test.py
@@ -434,7 +434,6 @@ def test_entry_with_lots_100_attributes(topo, add_test_user, aci_of_user):
     assert 103 == len(Accounts(conn, DEFAULT_SUFFIX).filter('(uid=*)'))
 
 
-@pytest.mark.bz301798
 def test_groupdnattr_value_is_another_group(topo):
     """Search Test 42 groupdnattr value is another group test #1
 

--- a/dirsrvtests/tests/suites/acl/selfdn_permissions_test.py
+++ b/dirsrvtests/tests/suites/acl/selfdn_permissions_test.py
@@ -84,7 +84,6 @@ def allow_user_init(topology_st):
             'cn': name})))
 
 
-@pytest.mark.ds47653
 def test_selfdn_permission_add(topology_st, allow_user_init):
     """Check add entry operation with and without SelfDN aci
 
@@ -185,7 +184,6 @@ def test_selfdn_permission_add(topology_st, allow_user_init):
     topology_st.standalone.add_s(entry_with_member)
 
 
-@pytest.mark.ds47653
 def test_selfdn_permission_search(topology_st, allow_user_init):
     """Check search operation with and without SelfDN aci
 
@@ -235,7 +233,6 @@ def test_selfdn_permission_search(topology_st, allow_user_init):
     assert len(ents) == 1
 
 
-@pytest.mark.ds47653
 def test_selfdn_permission_modify(topology_st, allow_user_init):
     """Check modify operation with and without SelfDN aci
 
@@ -294,7 +291,6 @@ def test_selfdn_permission_modify(topology_st, allow_user_init):
     assert ensure_str(ents[0].postalCode) == '1928'
 
 
-@pytest.mark.ds47653
 def test_selfdn_permission_delete(topology_st, allow_user_init):
     """Check delete operation with and without SelfDN aci
 

--- a/dirsrvtests/tests/suites/acl/valueacl_part2_test.py
+++ b/dirsrvtests/tests/suites/acl/valueacl_part2_test.py
@@ -373,7 +373,6 @@ def test_on_modrdn_allow(topo, _add_user, aci_of_user, request):
     assert useraccount.dn == 'cn=engineer,dc=example,dc=com'
 
 
-@pytest.mark.bz979515
 def test_targattrfilters_keyword(topo):
     """Testing the targattrfilters keyword that allows access control based on the value
     of the attributes being added (or deleted))

--- a/dirsrvtests/tests/suites/automember_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/basic_test.py
@@ -344,7 +344,6 @@ def test_custom_config_area(topo, _create_all_entries):
     assert not instance_auto.get_attr_val_utf8("nsslapd-pluginConfigArea")
 
 
-@pytest.mark.bz834053
 def test_ability_to_control_behavior_of_modifiers_name(topo, _create_all_entries):
     """Control behaviour of modifier's name
 

--- a/dirsrvtests/tests/suites/automember_plugin/configuration_test.py
+++ b/dirsrvtests/tests/suites/automember_plugin/configuration_test.py
@@ -15,7 +15,6 @@ from lib389._constants import DEFAULT_SUFFIX
 
 pytestmark = pytest.mark.tier1
 
-@pytest.mark.bz834056
 def test_configuration(topo):
     """Automembership plugin and mixed in the plugin configuration
 

--- a/dirsrvtests/tests/suites/backups/backup_test.py
+++ b/dirsrvtests/tests/suites/backups/backup_test.py
@@ -80,8 +80,6 @@ def test_missing_backend(topo):
     assert restore_task.get_exit_code() != 0
 
 
-@pytest.mark.bz1851967
-@pytest.mark.ds4112
 @pytest.mark.skipif(ds_is_older('1.4.1'), reason="Not implemented")
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 def test_db_home_dir_online_backup(topo):

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1381,8 +1381,6 @@ def test_basic_anonymous_search(topology_st, create_users):
         assert len(entries) != 0
 
 
-@pytest.mark.ds604
-@pytest.mark.bz915801
 def test_search_original_type(topology_st, create_users):
     """Test ldapsearch returning original attributes
        using nsslapd-search-return-original-type-switch
@@ -1418,7 +1416,6 @@ def test_search_original_type(topology_st, create_users):
     assert "objectclass overflow" not in entries[0].getAttrs()
 
 
-@pytest.mark.bz192901
 def test_search_ou(topology_st):
     """Test that DS should not return an entry that does not match the filter
 
@@ -1514,8 +1511,6 @@ def test_bind_entry_missing_passwd(topology_st):
         user.bind("some_password")
 
 
-@pytest.mark.bz1044135
-@pytest.mark.ds47319
 def test_connection_buffer_size(topology_st):
     """Test connection buffer size adjustable with different values(valid values and invalid)
 
@@ -1539,7 +1534,6 @@ def test_connection_buffer_size(topology_st):
             topology_st.standalone.config.replace('nsslapd-connection-buffer', value)
 
 
-@pytest.mark.bz1637439
 def test_critical_msg_on_empty_range_idl(topology_st):
     """Doing a range index lookup should not report a critical message even if IDL is empty
 
@@ -1612,8 +1606,6 @@ def test_critical_msg_on_empty_range_idl(topology_st):
     assert not topology_st.standalone.searchErrorsLog('CRIT - list_candidates - NULL idl was recieved from filter_candidates_ext.')
 
 
-@pytest.mark.bz1870624
-@pytest.mark.ds4379
 @pytest.mark.parametrize("case,value", [('positive', ['cn','','']),
                                         ("positive", ['cn', '', '', '', '', '', '', '', '', '', '']),
                                         ("negative", ['cn', '', '', '', '', '', '', '', '', '', '', ''])])
@@ -1640,8 +1632,6 @@ def test_attr_description_limit(topology_st, case, value):
             DSLdapObjects(topology_st.standalone, basedn='').filter("(objectclass=*)", attrlist=value, scope=0)
 
 
-@pytest.mark.bz1647099
-@pytest.mark.ds50026
 def test_ldbm_modification_audit_log(topology_st):
     """When updating LDBM config attributes, those attributes/values are not listed
     in the audit log
@@ -2255,8 +2245,6 @@ sample_entries = yes
 
 @pytest.mark.skipif(not get_user_is_root() or ds_is_older('1.4.2.0'),
                     reason="This test is only required with new admin cli, and requires root.")
-@pytest.mark.bz1748016
-@pytest.mark.ds50581
 def test_dscreate_ldapi(dscreate_long_instance):
     """Test that an instance with a long name can
     handle ldapi connection using a long socket name
@@ -2277,8 +2265,6 @@ def test_dscreate_ldapi(dscreate_long_instance):
 
 @pytest.mark.skipif(not get_user_is_root() or ds_is_older('1.4.2.0'),
                     reason="This test is only required with new admin cli, and requires root.")
-@pytest.mark.bz1715406
-@pytest.mark.ds50923
 def test_dscreate_multiple_dashes_name(dscreate_long_instance):
     """Test that an instance with a multiple dashes in the name
     can be removed with dsctl --remove-all
@@ -2347,8 +2333,6 @@ suffix = {request.param}
 
 @pytest.mark.skipif(not get_user_is_root() or ds_is_older('1.4.0.0'),
                     reason="This test is only required with new admin cli, and requires root.")
-@pytest.mark.bz1807419
-@pytest.mark.ds50928
 def test_dscreate_with_different_rdn(dscreate_test_rdn_value):
     """Test that dscreate works with different RDN attributes as suffix
 

--- a/dirsrvtests/tests/suites/basic/vlv.py
+++ b/dirsrvtests/tests/suites/basic/vlv.py
@@ -81,7 +81,6 @@ def add_users(topology_st, users_num):
         })
 
 
-@pytest.mark.DS47966
 def test_vlv(topology_st):
     """
     Testing bulk import when the backend with VLV was recreated.

--- a/dirsrvtests/tests/suites/clu/dbgen_test.py
+++ b/dirsrvtests/tests/suites/clu/dbgen_test.py
@@ -73,8 +73,6 @@ def check_value_in_log_and_reset(content_list):
         f.truncate(0)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_users(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create ldif with users
@@ -135,8 +133,6 @@ def test_dsconf_dbgen_users(topology_st, set_log_file_and_ldif):
     assert len(accounts.filter('(uid=*)')) > count_account
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_groups(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create ldif with group
@@ -208,8 +204,6 @@ def test_dsconf_dbgen_groups(topology_st, set_log_file_and_ldif):
     new_group.present('uniquemember', 'uid=group_entry1-0152,ou=people,dc=example,dc=com')
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_cos_classic(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -275,8 +269,6 @@ def test_dsconf_dbgen_cos_classic(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_cos_pointer(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -340,8 +332,6 @@ def test_dsconf_dbgen_cos_pointer(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_cos_indirect(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -405,8 +395,6 @@ def test_dsconf_dbgen_cos_indirect(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_cos_template(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS template
@@ -466,8 +454,6 @@ def test_dsconf_dbgen_cos_template(topology_st, set_log_file_and_ldif):
     assert new_cos.present('postalcode', '12345')
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_managed_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a managed role
@@ -525,8 +511,6 @@ def test_dsconf_dbgen_managed_role(topology_st, set_log_file_and_ldif):
     assert roles.exists(args.NAME)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_filtered_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a filtered role
@@ -587,8 +571,6 @@ def test_dsconf_dbgen_filtered_role(topology_st, set_log_file_and_ldif):
     assert new_role.present('nsRoleFilter', args.filter)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_nested_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a nested role
@@ -648,8 +630,6 @@ def test_dsconf_dbgen_nested_role(topology_st, set_log_file_and_ldif):
     assert new_role.present('nsRoleDN', args.role_dn[0])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_mod_ldif_mixed(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create mixed modification ldif
@@ -721,8 +701,6 @@ def test_dsconf_dbgen_mod_ldif_mixed(topology_st, set_log_file_and_ldif):
     assert len(accounts.filter('(uid=*)')) > count_account
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_dsconf_dbgen_nested_ldif(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create nested ldif

--- a/dirsrvtests/tests/suites/clu/dbgen_test_usan.py
+++ b/dirsrvtests/tests/suites/clu/dbgen_test_usan.py
@@ -91,8 +91,6 @@ def check_value_in_log_and_reset(content_list):
         f.truncate(0)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_users(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create ldif with users
@@ -153,8 +151,6 @@ def test_usandsconf_dbgen_users(topology_st, set_log_file_and_ldif):
     assert len(accounts.filter('(uid=*)')) > count_account
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_groups(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create ldif with group
@@ -226,8 +222,6 @@ def test_usandsconf_dbgen_groups(topology_st, set_log_file_and_ldif):
     new_group.present('uniquemember', 'uid=group_entry1-0152,ou=people,dc=example,dc=com')
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_cos_classic(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -293,8 +287,6 @@ def test_usandsconf_dbgen_cos_classic(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_cos_pointer(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -358,8 +350,6 @@ def test_usandsconf_dbgen_cos_pointer(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_cos_indirect(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS definition
@@ -423,8 +413,6 @@ def test_usandsconf_dbgen_cos_indirect(topology_st, set_log_file_and_ldif):
     assert new_cos.present('cosAttribute', args.cos_attr[1])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_cos_template(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a COS template
@@ -484,8 +472,6 @@ def test_usandsconf_dbgen_cos_template(topology_st, set_log_file_and_ldif):
     assert new_cos.present('postalcode', '12345')
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_managed_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a managed role
@@ -543,8 +529,6 @@ def test_usandsconf_dbgen_managed_role(topology_st, set_log_file_and_ldif):
     assert roles.exists(args.NAME)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_filtered_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a filtered role
@@ -605,8 +589,6 @@ def test_usandsconf_dbgen_filtered_role(topology_st, set_log_file_and_ldif):
     assert new_role.present('nsRoleFilter', args.filter)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_nested_role(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create a nested role
@@ -666,8 +648,6 @@ def test_usandsconf_dbgen_nested_role(topology_st, set_log_file_and_ldif):
     assert new_role.present('nsRoleDN', args.role_dn[0])
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_mod_ldif_mixed(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create mixed modification ldif
@@ -739,8 +719,6 @@ def test_usandsconf_dbgen_mod_ldif_mixed(topology_st, set_log_file_and_ldif):
     assert len(accounts.filter('(uid=*)')) > count_account
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1798394
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_usandsconf_dbgen_nested_ldif(topology_st, set_log_file_and_ldif):
     """Test ldifgen (formerly dbgen) tool to create nested ldif

--- a/dirsrvtests/tests/suites/clu/dbmon_test.py
+++ b/dirsrvtests/tests/suites/clu/dbmon_test.py
@@ -165,8 +165,6 @@ def _set_dbsizes(inst, dbpagesize, dbcachesize):
     inst.start()
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1795943
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 def test_dsconf_dbmon(topology_st):

--- a/dirsrvtests/tests/suites/clu/dbverify_test.py
+++ b/dirsrvtests/tests/suites/clu/dbverify_test.py
@@ -36,8 +36,6 @@ def set_log_file(request):
     request.addfinalizer(fin)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1739718
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsctl_dbverify(topology_st, set_log_file):
     """Test dbverify tool, that was ported from legacy tools to dsctl

--- a/dirsrvtests/tests/suites/clu/dsidm_account_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_test.py
@@ -42,8 +42,6 @@ def create_test_user(topology_st, request):
     request.addfinalizer(fin)
 
 
-@pytest.mark.bz1862971
-@pytest.mark.ds4281
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
     """ Test dsidm account entry-status option with account lock/unlock

--- a/dirsrvtests/tests/suites/clu/dsidm_init_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_init_test.py
@@ -31,7 +31,6 @@ else:
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds4281
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_initialise(topology_no_sample):
     """Check that keep alive entries are created when initializing a master from another one

--- a/dirsrvtests/tests/suites/clu/dsidm_organizational_unit_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_organizational_unit_test.py
@@ -43,8 +43,6 @@ def create_test_ou(topology_st, request):
     request.addfinalizer(fin)
 
 
-@pytest.mark.bz1866294
-@pytest.mark.ds4284
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 @pytest.mark.xfail(ds_is_older("1.4.3.16"), reason="Might fail because of bz1866294")
 def test_dsidm_organizational_unit_delete(topology_st, create_test_ou):

--- a/dirsrvtests/tests/suites/clu/dsidm_services_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_services_test.py
@@ -170,7 +170,6 @@ def test_dsidm_service_get_rdn(topology_st, create_test_service):
     check_value_in_log_and_reset(topology_st, content_list=json_content)
 
 
-@pytest.mark.bz1893667
 @pytest.mark.xfail(reason="Will fail because of bz1893667")
 @pytest.mark.skipif(ds_is_older("2.1.0"), reason="Not implemented")
 def test_dsidm_service_get_dn(topology_st, create_test_service):

--- a/dirsrvtests/tests/suites/clu/dsidm_user_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_test.py
@@ -185,7 +185,6 @@ def test_dsidm_user_get_rdn(topology_st, create_test_user):
     check_value_in_log_and_reset(topology_st, content_list=json_content)
 
 
-@pytest.mark.bz1893667
 @pytest.mark.xfail(reason="Will fail because of bz1893667")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_user_get_dn(topology_st, create_test_user):

--- a/dirsrvtests/tests/suites/clu/fixup_test.py
+++ b/dirsrvtests/tests/suites/clu/fixup_test.py
@@ -47,8 +47,6 @@ def set_log_file_and_ldif(topology_st, request):
     request.addfinalizer(fin)
 
 
-@pytest.mark.ds50545
-@pytest.mark.bz1739718
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_posix_winsync_fixup(topology_st, set_log_file_and_ldif):
     """Test posix-winsync fixup that was ported from legacy tools

--- a/dirsrvtests/tests/suites/clu/repl_monitor_test.py
+++ b/dirsrvtests/tests/suites/clu/repl_monitor_test.py
@@ -92,8 +92,6 @@ def get_hostnames_from_log(port1, port2):
 
 #unstable or unstatus tests, skipped for now
 @pytest.mark.flaky(max_runs=2, min_passes=1)
-@pytest.mark.ds50545
-@pytest.mark.bz1739718
 @pytest.mark.skipif(ds_is_older("1.4.0"), reason="Not implemented")
 def test_dsconf_replication_monitor(topology_m2, set_log_file):
     """Test replication monitor that was ported from legacy tools

--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -118,8 +118,6 @@ def test_compaction_interval_and_time(topo):
     inst.deleteErrorLogs(restart=False)
 
 
-@pytest.mark.ds4778
-@pytest.mark.bz1748441
 @pytest.mark.skipif(ds_is_older("1.4.3.23"), reason="Not implemented")
 def test_no_compaction(topo):
     """Test there is no compaction when nsslapd-db-compactdb-interval is set to 0
@@ -145,8 +143,6 @@ def test_no_compaction(topo):
     inst.deleteErrorLogs(restart=False)
 
 
-@pytest.mark.ds4778
-@pytest.mark.bz1748441
 @pytest.mark.skipif(ds_is_older("1.4.3.23"), reason="Not implemented")
 def test_compaction_interval_invalid(topo):
     """Test that invalid value is rejected for nsslapd-db-compactdb-interval

--- a/dirsrvtests/tests/suites/config/config_delete_attr_test.py
+++ b/dirsrvtests/tests/suites/config/config_delete_attr_test.py
@@ -19,7 +19,6 @@ pytestmark = [pytest.mark.tier2,
               pytest.mark.skipif(ds_is_older('1.3.6'), reason="Not implemented")]
 
 
-@pytest.mark.ds48961
 def test_delete_storagescheme(topology_st):
     """ Test that deletion of passwordStorageScheme is rejected
 
@@ -49,7 +48,6 @@ def test_delete_storagescheme(topology_st):
         assert "deleting the value is not allowed" in str(excinfo.value)
 
 
-@pytest.mark.ds48961
 def test_reset_attributes(topology_st):
     """ Test that we can reset some attributes while others are rejected
 

--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -47,8 +47,6 @@ def big_file():
     return TEMP_BIG_FILE
 
 
-@pytest.mark.bz1897248
-@pytest.mark.ds4315
 @pytest.mark.skipif(ds_is_older('1.4.3.16'), reason="This config setting exists in 1.4.3.16 and higher")
 def test_nagle_default_value(topo):
     """Test that nsslapd-nagle attribute is off by default
@@ -204,8 +202,6 @@ def test_config_deadlock_policy(topology_m2):
     ldbmconfig.replace('nsslapd-db-deadlock-policy', deadlock_policy)
 
 
-@pytest.mark.bz766322
-@pytest.mark.ds26
 def test_defaultnamingcontext(topo):
     """Tests configuration attribute defaultNamingContext in the rootdse
 
@@ -290,7 +286,6 @@ def test_defaultnamingcontext(topo):
     b2.delete()
 
 
-@pytest.mark.bz602456
 def test_allow_add_delete_config_attributes(topo):
     """Tests configuration attributes are allowed to add and delete
 
@@ -332,8 +327,6 @@ def test_allow_add_delete_config_attributes(topo):
     assert not topo.standalone.config.present('invalid-attribute', 'invalid-value')
 
 
-@pytest.mark.bz918705
-@pytest.mark.ds511
 def test_ignore_virtual_attrs(topo):
     """Test nsslapd-ignore-virtual-attrs configuration attribute
 
@@ -442,8 +435,6 @@ def test_ignore_virtual_attrs_after_restart(topo):
     log.info("Check the default value of attribute nsslapd-ignore-virtual-attrs should be OFF")
     assert topo.standalone.config.present('nsslapd-ignore-virtual-attrs', 'off')
 
-@pytest.mark.bz918694
-@pytest.mark.ds408
 def test_ndn_cache_enabled(topo):
     """Test nsslapd-ignore-virtual-attrs configuration attribute
 

--- a/dirsrvtests/tests/suites/config/regression_test.py
+++ b/dirsrvtests/tests/suites/config/regression_test.py
@@ -61,8 +61,6 @@ def get_available_memory():
 
 
 @pytest.mark.skipif(get_available_memory() < (int(CUSTOM_MEM)/1024), reason="available memory is too low")
-@pytest.mark.bz1627512
-@pytest.mark.ds49618
 def test_set_cachememsize_to_custom_value(topo):
     """Test if value nsslapd-cachememsize remains set
      at the custom setting of value above 3805132804 bytes

--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
@@ -50,8 +50,6 @@ def change_config(topology_st):
     topology_st.standalone.config.set('nsslapd-disk-monitoring-readonly-on-threshold', 'on')
 
 
-@pytest.mark.ds4414
-@pytest.mark.bz1890118
 @pytest.mark.skipif(ds_is_older("1.4.3.16"), reason="Might fail because of bz1890118")
 @disk_monitoring_ack
 def test_produce_division_by_zero(topology_st, create_dummy_mount, change_config):

--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_test.py
@@ -650,7 +650,6 @@ def test_go_straight_below_4kb(topo, setup, reset_logs):
 
 
 @disk_monitoring_ack
-@pytest.mark.bz982325
 def test_threshold_to_overflow_value(topo, setup, reset_logs):
     """Overflow in nsslapd-disk-monitoring-threshold
 
@@ -670,7 +669,6 @@ def test_threshold_to_overflow_value(topo, setup, reset_logs):
 
 
 @disk_monitoring_ack
-@pytest.mark.bz970995
 def test_threshold_is_reached_to_half(topo, setup, reset_logs):
     """RHDS not shutting down when disk monitoring threshold is reached to half.
 

--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -243,7 +243,6 @@ def create_backend(inst, rdn, suffix):
 
     return be1
 
-@pytest.mark.bz1273549
 def test_check_default(topology_st):
     """Check the default value of nsslapd-logging-hr-timestamps-enabled,
      it should be ON
@@ -269,7 +268,6 @@ def test_check_default(topology_st):
     log.debug(default)
 
 
-@pytest.mark.bz1273549
 def test_plugin_set_invalid(topology_st):
     """Try to set some invalid values for nsslapd-logging-hr-timestamps-enabled
     attribute
@@ -290,7 +288,6 @@ def test_plugin_set_invalid(topology_st):
         topology_st.standalone.config.set(PLUGIN_TIMESTAMP, 'JUNK')
 
 
-@pytest.mark.bz1273549
 def test_log_plugin_on(topology_st, remove_users):
     """Check access logs for millisecond, when
     nsslapd-logging-hr-timestamps-enabled=ON
@@ -326,7 +323,6 @@ def test_log_plugin_on(topology_st, remove_users):
     assert topology_st.standalone.ds_access_log.match(r'^\[.+\d{9}.+\].+')
 
 
-@pytest.mark.bz1273549
 def test_log_plugin_off(topology_st, remove_users):
     """Milliseconds should be absent from access logs when
     nsslapd-logging-hr-timestamps-enabled=OFF
@@ -377,8 +373,6 @@ def test_log_plugin_off(topology_st, remove_users):
 
 
 @pytest.mark.xfail(ds_is_older('1.4.0'), reason="May fail on 1.3.x because of bug 1358706")
-@pytest.mark.bz1358706
-@pytest.mark.ds49029
 def test_internal_log_server_level_0(topology_st, clean_access_logs, disable_access_log_buffering):
     """Tests server-initiated internal operations
 
@@ -423,8 +417,6 @@ def test_internal_log_server_level_0(topology_st, clean_access_logs, disable_acc
 
 
 @pytest.mark.xfail(ds_is_older('1.4.0'), reason="May fail on 1.3.x because of bug 1358706")
-@pytest.mark.bz1358706
-@pytest.mark.ds49029
 def test_internal_log_server_level_4(topology_st, clean_access_logs, disable_access_log_buffering):
     """Tests server-initiated internal operations
 
@@ -473,8 +465,6 @@ def test_internal_log_server_level_4(topology_st, clean_access_logs, disable_acc
 
 
 @pytest.mark.xfail(ds_is_older('1.4.0'), reason="May fail on 1.3.x because of bug 1358706")
-@pytest.mark.bz1358706
-@pytest.mark.ds49029
 def test_internal_log_level_260(topology_st, add_user_log_level_260, disable_access_log_buffering):
     """Tests client initiated operations when automember plugin is enabled
 
@@ -557,8 +547,6 @@ def test_internal_log_level_260(topology_st, add_user_log_level_260, disable_acc
 
 
 @pytest.mark.xfail(ds_is_older('1.4.0'), reason="May fail on 1.3.x because of bug 1358706")
-@pytest.mark.bz1358706
-@pytest.mark.ds49029
 def test_internal_log_level_131076(topology_st, add_user_log_level_131076, disable_access_log_buffering):
     """Tests client-initiated operations while referential integrity plugin is enabled
 
@@ -642,8 +630,6 @@ def test_internal_log_level_131076(topology_st, add_user_log_level_131076, disab
 
 
 @pytest.mark.xfail(ds_is_older('1.4.0'), reason="May fail on 1.3.x because of bug 1358706")
-@pytest.mark.bz1358706
-@pytest.mark.ds49029
 def test_internal_log_level_516(topology_st, add_user_log_level_516, disable_access_log_buffering):
     """Tests client initiated operations when referential integrity plugin is enabled
 
@@ -734,8 +720,6 @@ def test_internal_log_level_516(topology_st, add_user_log_level_516, disable_acc
 
 
 @pytest.mark.skipif(ds_is_older('1.4.2.0'), reason="Not implemented")
-@pytest.mark.bz1358706
-@pytest.mark.ds49232
 def test_access_log_truncated_search_message(topology_st, clean_access_logs):
     """Tests that the access log message is properly truncated when the message is too long
 
@@ -771,8 +755,6 @@ def test_access_log_truncated_search_message(topology_st, clean_access_logs):
 
 @pytest.mark.skipif(ds_is_newer("1.4.3"), reason="rsearch was removed")
 @pytest.mark.xfail(ds_is_older('1.4.2.0'), reason="May fail because of bug 1732053")
-@pytest.mark.bz1732053
-@pytest.mark.ds50510
 def test_etime_at_border_of_second(topology_st, clean_access_logs):
     """Test that the etime reported in the access log doesn't contain wrong nsec value
 
@@ -824,7 +806,6 @@ def test_etime_at_border_of_second(topology_st, clean_access_logs):
 
 @pytest.mark.flaky(max_runs=2, min_passes=1)
 @pytest.mark.skipif(ds_is_older('1.3.10.1', '1.4.1'), reason="Fail because of bug 1749236")
-@pytest.mark.bz1749236
 def test_etime_order_of_magnitude(topology_st, clean_access_logs, remove_users, disable_access_log_buffering):
     """Test that the etime reported in the access log has a correct order of magnitude
 
@@ -904,8 +885,6 @@ def test_etime_order_of_magnitude(topology_st, clean_access_logs, remove_users, 
 
 
 @pytest.mark.skipif(ds_is_older('1.4.3.8'), reason="Fail because of bug 1850275")
-@pytest.mark.bz1850275
-@pytest.mark.bz1924848
 def test_optime_and_wtime_keywords(topology_st, clean_access_logs, remove_users, disable_access_log_buffering):
     """Test that the new optime and wtime keywords are present in the access log and have correct values
 
@@ -994,9 +973,6 @@ def test_optime_and_wtime_keywords(topology_st, clean_access_logs, remove_users,
 
 
 @pytest.mark.xfail(ds_is_older('1.3.10.1'), reason="May fail because of bug 1662461")
-@pytest.mark.bz1662461
-@pytest.mark.ds50428
-@pytest.mark.ds49969
 def test_log_base_dn_when_invalid_attr_request(topology_st, disable_access_log_buffering):
     """Test that DS correctly logs the base dn when a search with invalid attribute request is performed
 
@@ -1040,8 +1016,6 @@ def test_log_base_dn_when_invalid_attr_request(topology_st, disable_access_log_b
 
 
 @pytest.mark.xfail(ds_is_older('1.3.8', '1.4.2'), reason="May fail because of bug 1676948")
-@pytest.mark.bz1676948
-@pytest.mark.ds50536
 def test_audit_log_rotate_and_check_string(topology_st, clean_access_logs, set_audit_log_config_values_to_rotate):
     """Version string should be logged only once at the top of audit log
     after it is rotated.
@@ -1176,8 +1150,6 @@ def test_enable_external_libs_debug_log(topology_st):
 
 
 @pytest.mark.skipif(ds_is_older('1.4.3'), reason="Might fail because of bug 1895460")
-@pytest.mark.bz1895460
-@pytest.mark.ds4593
 def test_cert_personality_log_help(topology_st, request):
     """Test changing the nsSSLPersonalitySSL attribute will raise help message in log
 

--- a/dirsrvtests/tests/suites/ds_logs/regression_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/regression_test.py
@@ -23,7 +23,6 @@ else:
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.bz1460718
 @pytest.mark.parametrize("log_level", [(LOG_REPLICA + LOG_DEFAULT), (LOG_ACL + LOG_DEFAULT), (LOG_TRACE + LOG_DEFAULT)])
 def test_default_loglevel_stripped(topo, log_level):
     """The default log level 16384 is stripped from the log level returned to a client
@@ -44,7 +43,6 @@ def test_default_loglevel_stripped(topo, log_level):
     assert topo.standalone.config.get_attr_val_int('nsslapd-errorlog-level') == log_level
 
 
-@pytest.mark.bz1460718
 def test_dse_config_loglevel_error(topo):
     """Manually setting nsslapd-errorlog-level to 64 in dse.ldif throws error
 

--- a/dirsrvtests/tests/suites/ds_tools/replcheck_test.py
+++ b/dirsrvtests/tests/suites/ds_tools/replcheck_test.py
@@ -505,8 +505,6 @@ def test_dsreplcheck_with_password_file(topo_tls_ldapi, tmpdir):
     subprocess.Popen(tool_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
 
 
-@pytest.mark.ds51102
-@pytest.mark.bz1836428
 @pytest.mark.skipif(ds_is_older('1.4.1'), reason='Not implemented')
 def test_dsreplcheck_timeout_connection_mechanisms(topo_tls_ldapi):
     """Check that ds-replcheck timeout option works with various connection mechanisms

--- a/dirsrvtests/tests/suites/export/export_test.py
+++ b/dirsrvtests/tests/suites/export/export_test.py
@@ -38,8 +38,6 @@ def run_db2ldif_and_clear_logs(topology, instance, backend, ldif, output_msg, en
     topology.logcap.flush()
 
 
-@pytest.mark.bz1806978
-@pytest.mark.ds51188
 @pytest.mark.skipif(ds_is_older("1.3.10", "1.4.2"), reason="Not implemented")
 def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
     """Export with dsctl db2ldif, giving a ldif file path which can't be accessed by the user (dirsrv by default)
@@ -72,8 +70,6 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path(topo):
     topo.standalone.start()
 
 
-@pytest.mark.bz1806978
-@pytest.mark.ds51188
 @pytest.mark.skipif(ds_is_older("1.4.3.8"), reason="bz1806978 not fixed")
 def test_db2ldif_cli_with_non_accessible_ldif_file_path(topo):
     """Export with ns-slapd db2ldif, giving a ldif file path which can't be accessed by the user (dirsrv by default)
@@ -109,7 +105,6 @@ def test_db2ldif_cli_with_non_accessible_ldif_file_path(topo):
     topo.standalone.start()
 
 
-@pytest.mark.bz1860291
 @pytest.mark.xfail(reason="bug 1860291")
 @pytest.mark.skipif(ds_is_older("1.3.10", "1.4.2"), reason="Not implemented")
 def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path_output(topo):

--- a/dirsrvtests/tests/suites/filter/filter_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_test.py
@@ -22,8 +22,6 @@ log = logging.getLogger(__name__)
 ENTRY_NAME = 'test_entry'
 
 
-@pytest.mark.bz918686
-@pytest.mark.ds497
 def test_filter_escaped(topology_st):
     """Test we can search for an '*' in a attribute value.
 
@@ -107,7 +105,6 @@ def test_filter_search_original_attrs(topology_st):
 
     log.info('test_filter_search_original_attrs: PASSED')
 
-@pytest.mark.bz1511462
 def test_filter_scope_one(topology_st):
     """Test ldapsearch with scope one gives only single entry
 
@@ -129,7 +126,6 @@ def test_filter_scope_one(topology_st):
     log.info('Search should only have one entry')
     assert len(results) == 1
 
-@pytest.mark.ds47313
 def test_filter_with_attribute_subtype(topology_st):
     """Adds 2 test entries and Search with
     filters including subtype and !
@@ -222,7 +218,6 @@ def test_filter_with_attribute_subtype(topology_st):
 
     log.info('Testcase PASSED')
 
-@pytest.mark.bz1615155
 def test_extended_search(topology_st):
     """Test we can search with equality extended matching rule
 

--- a/dirsrvtests/tests/suites/filter/large_filter_test.py
+++ b/dirsrvtests/tests/suites/filter/large_filter_test.py
@@ -138,7 +138,6 @@ FILTERS = ['(&(objectClass=person)(|(manager=uid=fmcdonnagh,dc=anuj,dc=com)'
            '(manager=uid=cnewport,*)))']
 
 
-@pytest.mark.bz772777
 @pytest.mark.parametrize("real_value", FILTERS, ids=["test_large_filter1", "test_large_filter2"])
 def test_large_filter(topo, _create_entries, real_value):
     """Exercise large eq filter with dn syntax attributes

--- a/dirsrvtests/tests/suites/filter/schema_validation_test.py
+++ b/dirsrvtests/tests/suites/filter/schema_validation_test.py
@@ -37,7 +37,6 @@ def topology_st(topology_st_pre):
     return topology_st_pre
 
 
-@pytest.mark.ds50349
 def test_filter_validation_config(topology_st):
     """Test that the new on/warn/off setting can be set and read
     correctly
@@ -89,7 +88,6 @@ def test_filter_validation_config(topology_st):
     assert(initial_value == final_value)
 
 
-@pytest.mark.ds50349
 def test_filter_validation_enabled(topology_st):
     """Test that queries which are invalid, are correctly rejected by the server.
 
@@ -127,7 +125,6 @@ def test_filter_validation_enabled(topology_st):
     inst.restart()
 
 
-@pytest.mark.ds50349
 def test_filter_validation_warn_safe(topology_st):
     """Test that queries which are invalid, are correctly marked as "notes=F" in
     the access log, and return no entries or partial sets.
@@ -195,7 +192,6 @@ def test_filter_validation_warn_safe(topology_st):
     assert(len(r_init) + 3 == len(r_s4))
 
 
-@pytest.mark.ds50349
 def test_filter_validation_warn_unsafe(topology_st):
     """Test that queries which are invalid, are correctly marked as "notes=F" in
     the access log, and uses the legacy query behaviour to return unsafe sets.

--- a/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
+++ b/dirsrvtests/tests/suites/fourwaymmr/fourwaymmr_test.py
@@ -187,7 +187,6 @@ def test_replicated_multivalued_entries(topo_m4):
         ['mail'])
 
 
-@pytest.mark.bz157377
 def test_bad_replication_agreement(topo_m4):
     """Create the bad replication agreement and try to add it
 
@@ -254,7 +253,6 @@ def test_bad_replication_agreement(topo_m4):
     for inst in topo_m4: inst.start()
 
 
-@pytest.mark.bz834074
 def test_nsds5replicaenabled_verify(topo_m4):
     """Add the attribute nsds5ReplicaEnabled to cn=config
 
@@ -366,7 +364,6 @@ def test_nsds5replicaenabled_verify(topo_m4):
         topo_m4.all_insts.get(i).start()
 
 
-@pytest.mark.bz830344
 def test_create_an_entry_on_the_supplier(topo_m4):
     """Shut down one instance and create an entry on the supplier
 
@@ -389,7 +386,6 @@ def test_create_an_entry_on_the_supplier(topo_m4):
     topo_m4.ms["supplier1"].start()
 
 
-@pytest.mark.bz923502
 def test_bob_acceptance_tests(topo_m4):
     """Run multiple modrdn_s operation on supplier1
 
@@ -439,7 +435,6 @@ def list_agmt_towards(topo_m4, serverid):
     return res
 
 
-@pytest.mark.bz830335
 def test_replica_backup_and_restore(topo_m4):
     """Test Backup and restore
 

--- a/dirsrvtests/tests/suites/fractional/fractional_test.py
+++ b/dirsrvtests/tests/suites/fractional/fractional_test.py
@@ -230,7 +230,6 @@ def test_filtered_attributes(_create_entries):
                                f'ou=People,{DEFAULT_SUFFIX}').get_attr_val_utf8('roomnumber')
 
 
-@pytest.mark.bz154948
 def test_fewer_changes_in_single_operation(_create_entries):
     """For bug 154948, which cause the server to crash if there were
     fewer changes (but more than one) in a single operation to fractionally
@@ -292,7 +291,6 @@ def _add_user_clean(request):
     request.addfinalizer(final_call)
 
 
-@pytest.mark.bz739172
 def test_newly_added_attribute_nsds5replicatedattributelisttotal(_create_entries, _add_user_clean):
     """This test case is to test the newly added attribute nsds5replicatedattributelistTotal.
 
@@ -321,7 +319,6 @@ def test_newly_added_attribute_nsds5replicatedattributelisttotal(_create_entries
             assert not UserAccount(instance, user).get_attr_val_utf8(value)
 
 
-@pytest.mark.bz739172
 def test_attribute_nsds5replicatedattributelisttotal(_create_entries, _add_user_clean):
     """This test case is to test the newly added attribute nsds5replicatedattributelistTotal.
 
@@ -353,7 +350,6 @@ def test_attribute_nsds5replicatedattributelisttotal(_create_entries, _add_user_
             assert UserAccount(instance, user).get_attr_val_utf8(value)
 
 
-@pytest.mark.bz800173
 def test_implicit_replication_of_password_policy(_create_entries):
     """For bug 800173, we want to cause the implicit replication of password policy
     attributes due to failed bind operations

--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -80,8 +80,6 @@ def setup_ldif(topology_st, request):
     request.addfinalizer(fin)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_logging_format_should_be_revised(topology_st):
     """Check if HealthCheck returns DSCLE0001 code
@@ -124,8 +122,6 @@ def test_healthcheck_logging_format_should_be_revised(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_RI_plugin_is_misconfigured(topology_st):
     """Check if HealthCheck returns DSRILE0001 code
@@ -173,8 +169,6 @@ def test_healthcheck_RI_plugin_is_misconfigured(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_RI_plugin_missing_indexes(topology_st):
     """Check if HealthCheck returns DSRILE0002 code
@@ -274,8 +268,6 @@ def test_healthcheck_MO_plugin_missing_indexes(topology_st):
     standalone.restart()
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_virtual_attr_incorrectly_indexed(topology_st):
     """Check if HealthCheck returns DSVIRTLE0001 code
@@ -334,8 +326,6 @@ def test_healthcheck_virtual_attr_incorrectly_indexed(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 @pytest.mark.xfail(ds_is_older("1.4.2.4"), reason="May fail because of bug 1796050")
 def test_healthcheck_low_disk_space(topology_st):
@@ -381,8 +371,6 @@ def test_healthcheck_low_disk_space(topology_st):
 
 
 @pytest.mark.flaky(max_runs=2, min_passes=1)
-@pytest.mark.ds50791
-@pytest.mark.bz1843567
 @pytest.mark.xfail(ds_is_older("1.4.3.8"), reason="Not implemented")
 def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
     """Check if HealthCheck returns DSLOGNOTES0001 code
@@ -435,8 +423,6 @@ def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
 
-@pytest.mark.ds50791
-@pytest.mark.bz1843567
 @pytest.mark.xfail(ds_is_older("1.4.3.8"), reason="Not implemented")
 def test_healthcheck_notes_unknown_attribute(topology_st, setup_ldif):
     """Check if HealthCheck returns DSLOGNOTES0002 code

--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -69,8 +69,6 @@ def set_changelog_trimming(instance):
     inst_changelog.set_max_age('30d')
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_replication_replica_not_reachable(topology_m2):
     """Check if HealthCheck returns DSREPLLE0005 code
@@ -125,8 +123,6 @@ def test_healthcheck_replication_replica_not_reachable(topology_m2):
     run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_changelog_trimming_not_configured(topology_m2):
     """Check if HealthCheck returns DSCLLE0001 code
@@ -173,8 +169,6 @@ def test_healthcheck_changelog_trimming_not_configured(topology_m2):
     run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_replication_presence_of_conflict_entries(topology_m2):
     """Check if HealthCheck returns DSREPLLE0002 code
@@ -251,8 +245,6 @@ def test_healthcheck_non_replicated_suffixes(topology_m2):
     health_check_run(inst, topology_m2.logcap.log, args)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_replication_out_of_sync_broken(topology_m3):
     """Check if HealthCheck returns DSREPLLE0001 code

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -65,8 +65,6 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     topology.logcap.flush()
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_insecure_pwd_hash_configured(topology_st):
     """Check if HealthCheck returns DSCLE0002 code
@@ -114,8 +112,6 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_min_allowed_tls_version_too_low(topology_st):
     """Check if HealthCheck returns DSELE0001 code
@@ -173,8 +169,6 @@ def test_healthcheck_min_allowed_tls_version_too_low(topology_st):
         assert subprocess.check_call(['update-crypto-policies', '--set', 'DEFAULT']) == 0
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_resolvconf_bad_file_perm(topology_st):
     """Check if HealthCheck returns DSPERMLE0001 code
@@ -216,8 +210,6 @@ def test_healthcheck_resolvconf_bad_file_perm(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_pwdfile_bad_file_perm(topology_st):
     """Check if HealthCheck returns DSPERMLE0002 code
@@ -260,8 +252,6 @@ def test_healthcheck_pwdfile_bad_file_perm(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_certif_expiring_within_30d(topology_st):
     """Check if HealthCheck returns DSCERTLE0001 code
@@ -299,8 +289,6 @@ def test_healthcheck_certif_expiring_within_30d(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_certif_expired(topology_st):
     """Check if HealthCheck returns DSCERTLE0002 code

--- a/dirsrvtests/tests/suites/healthcheck/health_sync_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_sync_test.py
@@ -58,8 +58,6 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
 
 
 # This test is in separate file because it is timeout specific
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 #unstable or unstatus tests, skipped for now
 @pytest.mark.flaky(max_runs=2, min_passes=1)

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -96,8 +96,6 @@ def test_healthcheck_disabled_suffix(topology_st):
     mt.replace("nsslapd-state", "backend")
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_standalone(topology_st):
     """Check functionality of HealthCheck Tool on standalone instance with no errors
@@ -120,8 +118,6 @@ def test_healthcheck_standalone(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50746
-@pytest.mark.bz1816851
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
 def test_healthcheck_list_checks(topology_st):
     """Check functionality of HealthCheck Tool with --list-checks option
@@ -162,8 +158,6 @@ def test_healthcheck_list_checks(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_checks=True, searched_list=output_list)
 
 
-@pytest.mark.ds50746
-@pytest.mark.bz1816851
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
 def test_healthcheck_list_errors(topology_st):
     """Check functionality of HealthCheck Tool with --list-errors option
@@ -215,8 +209,6 @@ def test_healthcheck_list_errors(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_errors=True, searched_list=output_list)
 
 
-@pytest.mark.ds50746
-@pytest.mark.bz1816851
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
 def test_healthcheck_check_option(topology_st):
     """Check functionality of HealthCheck Tool with --check option
@@ -265,8 +257,6 @@ def test_healthcheck_check_option(topology_st):
         run_healthcheck_and_flush_log(topology_st, standalone, searched_code=JSON_OUTPUT, json=True, check=[item])
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_standalone_tls(topology_st):
     """Check functionality of HealthCheck Tool on TLS enabled standalone instance with no errors
@@ -292,8 +282,6 @@ def test_healthcheck_standalone_tls(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_replication(topology_m2):
     """Check functionality of HealthCheck Tool on replication instance with no errors
@@ -330,8 +318,6 @@ def test_healthcheck_replication(topology_m2):
     run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_replication_tls(topology_m2):
     """Check functionality of HealthCheck Tool on replication instance with no errors
@@ -369,8 +355,6 @@ def test_healthcheck_replication_tls(topology_m2):
     run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1685160
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 @pytest.mark.xfail(ds_is_older("1.4.3"),reason="Might fail because of bz1835619")
 def test_healthcheck_backend_missing_mapping_tree(topology_st):
@@ -420,8 +404,6 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1796343
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 @pytest.mark.xfail(reason="Will fail because of bz1837315. Set proper version after bug is fixed")
 def test_healthcheck_unable_to_query_backend(topology_st):
@@ -470,8 +452,6 @@ def test_healthcheck_unable_to_query_backend(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
 
-@pytest.mark.ds50873
-@pytest.mark.bz1796343
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_database_not_initialized(topology_no_sample):
     """Check if HealthCheck returns DSBLE0003 code

--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -323,7 +323,6 @@ def test_crash_on_ldif2db(topo, _import_clean):
     _import_offline(topo, 5)
 
 
-@pytest.mark.bz185477
 def test_ldif2db_allows_entries_without_a_parent_to_be_imported(topo, _import_clean):
     """Should reject import of entries that's missing parent suffix
 
@@ -483,7 +482,6 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     assert total_time1 < total_time2
 
 
-@pytest.mark.bz175063
 def test_entry_with_escaped_characters_fails_to_import_and_index(topo, _import_clean):
     """If missing entry_id is found, skip it and continue reading the primary db to be re indexed.
 

--- a/dirsrvtests/tests/suites/import/import_warning_test.py
+++ b/dirsrvtests/tests/suites/import/import_warning_test.py
@@ -75,8 +75,6 @@ sn: demo
 
 
 @pytest.mark.skipif(ds_is_older('1.4.3.26'), reason="Fail because of bug 1951537")
-@pytest.mark.bz1951537
-@pytest.mark.ds4734
 def test_import_warning(topology_st):
     """Import ldif file with skipped entries to generate a warning message
 

--- a/dirsrvtests/tests/suites/import/regression_test.py
+++ b/dirsrvtests/tests/suites/import/regression_test.py
@@ -261,8 +261,6 @@ def test_del_suffix_backend(topo):
     assert not topo.standalone.detectDisorderlyShutdown()
 
 
-@pytest.mark.bz1406101
-@pytest.mark.ds49071
 def test_import_duplicate_dn(topo):
     """Import ldif with duplicate DNs, should not log error "unable to flush"
 
@@ -321,7 +319,6 @@ ou: myDups00001
     log.info('Error log should have "Duplicated DN detected" message')
     assert standalone.ds_error_log.match('.*Duplicated DN detected.*')
 
-@pytest.mark.bz1749595
 @pytest.mark.tier2
 @pytest.mark.xfail(not _check_disk_space(), reason="not enough disk space for lmdb map")
 @pytest.mark.xfail(ds_is_older("1.3.10.1"), reason="bz1749595 not fixed on versions older than 1.3.10.1")

--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -226,7 +226,6 @@ def test_reindex_task_creates_abandoned_index_file(topo):
     assert os.path.exists(f"{inst.ds_paths.db_dir}/{DEFAULT_BENAME}/{attr_name}.db")
 
 
-@pytest.mark.bz1905450
 def test_unindexed_internal_search_crashes_server(topo, add_a_group_with_users, set_small_idlistscanlimit):
     """
     An internal unindexed search was able to crash the server due to missing logging function.

--- a/dirsrvtests/tests/suites/mapping_tree/regression_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/regression_test.py
@@ -88,7 +88,6 @@ EXPECTED_ENTRIES = (("dc=parent", 39), ("dc=child1,dc=parent", 13), ("dc=child2,
 )
 
 
-@pytest.mark.bz2083589
 @pytest.mark.skipif(not has_orphan_attribute, reason = "compatibility attribute not yet implemented in this version")
 def test_sub_suffixes(topo, orphan_param):
     """ check the entries found on suffix/sub-suffix

--- a/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
@@ -98,7 +98,6 @@ def _find_memberof(server, member_dn, group_dn):
     assert group._dn.lower() in user.get_attr_vals_utf8_l('memberOf')
 
 
-@pytest.mark.bz1352121
 def test_memberof_with_repl(topo):
     """Test that we allowed to enable MemberOf plugin in dedicated consumer
 
@@ -327,7 +326,6 @@ def test_scheme_violation_errors_logged(topo_m2):
     assert inst.ds_error_log.match(pattern)
 
 
-@pytest.mark.bz1192099
 def test_memberof_with_changelog_reset(topo_m2):
     """Test that replication does not break, after DS stop-start, due to changelog reset
 
@@ -449,7 +447,6 @@ def _find_memberof_ext(server, user_dn=None, group_dn=None, find_result=True):
         assert (not found)
 
 
-@pytest.mark.ds49161
 def test_memberof_group(topology_st):
     """Test memberof does not fail if group is moved into scope
 
@@ -527,7 +524,6 @@ def _disable_auto_oc_memberof(server):
         [(ldap.MOD_REPLACE, 'memberOfAutoAddOC', b'nsContainer')])
 
 
-@pytest.mark.ds49967
 def test_entrycache_on_modrdn_failure(topology_st):
     """This test checks that when a modrdn fails, the destination entry is not returned by a search
     This could happen in case the destination entry remains in the entry cache

--- a/dirsrvtests/tests/suites/memory_leaks/MMR_double_free_test.py
+++ b/dirsrvtests/tests/suites/memory_leaks/MMR_double_free_test.py
@@ -65,9 +65,6 @@ def topology_setup(topology_m2):
 
 
 @pytest.mark.skipif(not ds_paths.asan_enabled, reason="Don't run if ASAN is not enabled")
-@pytest.mark.ds48226
-@pytest.mark.bz1243970
-@pytest.mark.bz1262363
 def test_MMR_double_free(topology_m2, topology_setup, timeout=5):
     """Reproduce conditions where a double free occurs and check it does not make
     the server crash

--- a/dirsrvtests/tests/suites/monitor/db_locks_monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/db_locks_monitor_test.py
@@ -255,8 +255,6 @@ def test_exhaust_db_locks_big_pause(topology_st_fn, setup_attruniq_index_be_impo
     inst.restart()
 
 
-@pytest.mark.ds4623
-@pytest.mark.bz1812286
 @pytest.mark.skipif(ds_is_older("1.4.3.23"), reason="Not implemented")
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 @pytest.mark.parametrize("invalid_value", [("0"), ("1"), ("42"), ("68"), ("69"), ("96"), ("120")])
@@ -285,8 +283,6 @@ def test_invalid_threshold_range(topology_st_fn, invalid_value):
         assert msg in str(e)
 
 
-@pytest.mark.ds4623
-@pytest.mark.bz1812286
 @pytest.mark.skipif(ds_is_older("1.4.3.23"), reason="Not implemented")
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 @pytest.mark.parametrize("locks_invalid", [("0"), ("1"), ("9999"), ("10000")])

--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -154,10 +154,6 @@ def test_monitor_backend(topo):
         assert False
 
 
-@pytest.mark.bz1843550
-@pytest.mark.ds4153
-@pytest.mark.bz1903539
-@pytest.mark.ds4528
 def test_num_subordinates_with_monitor_suffix(topo):
     """This test is to compare the numSubordinates value on the root entry with the actual number of direct subordinate(s).
 

--- a/dirsrvtests/tests/suites/password/password_test.py
+++ b/dirsrvtests/tests/suites/password/password_test.py
@@ -21,8 +21,6 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.bz918684
-@pytest.mark.ds394
 def test_password_delete_specific_password(topology_st):
     """Delete a specific userPassword, and make sure
     it is actually deleted from the entry

--- a/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
@@ -71,7 +71,6 @@ def password_policy(topology_st, add_test_user):
     log.info('Create password policy for user {}'.format(TEST_USER_DN))
     pwp.create_user_policy(TEST_USER_DN, policy_props)
 
-@pytest.mark.bz1845094
 @pytest.mark.skipif(ds_is_older('1.4.3.3'), reason="Not implemented")
 def test_pwdReset_by_user_DM(topology_st, add_test_user):
     """Test new password policy attribute "pwdReset"

--- a/dirsrvtests/tests/suites/password/pwdPolicy_controls_sequence_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_controls_sequence_test.py
@@ -81,8 +81,6 @@ def change_passwd(topo):
     topo.standalone.simple_bind(DN_DM, PASSWORD)
 
 
-@pytest.mark.bz1724914
-@pytest.mark.ds3585
 def test_controltype_expired_grace_limit(topo, init_user):
     """Test for expiration control when password is expired with available and exhausted grace login
 

--- a/dirsrvtests/tests/suites/password/pwdPolicy_syntax_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_syntax_test.py
@@ -293,8 +293,6 @@ def test_basic(topology_st, create_user, password_policy):
                     '13_#Kad472h', 'Password found in user entry')
 
 
-@pytest.mark.bz1816857
-@pytest.mark.ds50875
 @pytest.mark.skipif(ds_is_older("1.4.1.18"), reason="Not implemented")
 def test_config_set_few_user_attributes(topology_st, create_user, password_policy):
     """Test that we can successfully set multiple values to passwordUserAttributes
@@ -333,8 +331,6 @@ def test_config_set_few_user_attributes(topology_st, create_user, password_polic
                         '13_#Kad472h', 'Password found in user entry')
 
 
-@pytest.mark.bz1816857
-@pytest.mark.ds50875
 @pytest.mark.skipif(ds_is_older("1.4.1.18"), reason="Not implemented")
 def test_config_set_few_bad_words(topology_st, create_user, password_policy):
     """Test that we can successfully set multiple values to passwordBadWords

--- a/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
@@ -499,8 +499,6 @@ def test_with_local_policy(topology_st, global_policy, local_policy):
     topology_st.standalone.simple_bind_s(DN_DM, PASSWORD)
 
 
-@pytest.mark.bz1589144
-@pytest.mark.ds50091
 def test_search_shadowWarning_when_passwordWarning_is_lower(topology_st, global_policy):
     """Test if value shadowWarning is present with global password policy
        when passwordWarning is set with lower value.
@@ -546,7 +544,6 @@ def test_search_shadowWarning_when_passwordWarning_is_lower(topology_st, global_
     assert testuser.present('shadowWarning')
 
 
-@pytest.mark.bug624080
 def test_password_expire_works(topology_st):
     """Regression test for bug624080. If passwordMaxAge is set to a
     value and a new user is added, if the passwordMaxAge is changed

--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -151,7 +151,6 @@ def test_pwd_algo_test(topology_st, algo):
     log.info('Test %s PASSED' % algo)
 
 
-@pytest.mark.ds397
 def test_pbkdf2_algo(topology_st):
     """Changing password storage scheme to PBKDF2_SHA256
     and trying to bind with different password combination

--- a/dirsrvtests/tests/suites/password/pwd_log_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_log_test.py
@@ -20,7 +20,6 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds365
 def test_hide_unhashed_pwd(topology_st):
     """Change userPassword, enable hiding of un-hashed
     password and check the audit logs.

--- a/dirsrvtests/tests/suites/password/regression_of_bugs_test.py
+++ b/dirsrvtests/tests/suites/password/regression_of_bugs_test.py
@@ -106,7 +106,6 @@ def _add_user(request, topo):
     request.addfinalizer(fin)
 
 
-@pytest.mark.bz1044164
 def test_local_password_policy(topo, _add_user):
     """Regression test for bz1044164 part 1.
 
@@ -157,7 +156,6 @@ def test_local_password_policy(topo, _add_user):
                          f'passwords";allow (write)(userdn = "ldap:///{user.dn}");)')
 
 
-@pytest.mark.bz1118006
 def test_passwordexpirationtime_attribute(topo, _add_user):
     """Regression test for bz1118006.
 
@@ -180,8 +178,6 @@ def test_passwordexpirationtime_attribute(topo, _add_user):
     time.sleep(1)
 
 
-@pytest.mark.bz1118007
-@pytest.mark.bz1044164
 def test_admin_group_to_modify_password(topo, _add_user):
     """Regression test for bz1044164 part 2.
 
@@ -417,7 +413,6 @@ def test_admin_group_to_modify_password(topo, _add_user):
                                 f'uid=pwadm_admin_1,{DEFAULT_SUFFIX}')
 
 
-@pytest.mark.bz834060
 def test_password_max_failure_should_lockout_password(topo):
     """Regression test for bz834060.
 
@@ -452,7 +447,6 @@ def test_password_max_failure_should_lockout_password(topo):
     config.replace('nsslapd-pwpolicy-local', 'on')
 
 
-@pytest.mark.bz834063
 def test_pwd_update_time_attribute(topo):
     """Regression test for bz834063
 
@@ -597,7 +591,6 @@ def test_password_track_update_time(topo):
     assert last_login_time_user2 != last_login_time_user2_last
 
 
-@pytest.mark.bz834063
 def test_signal_11(topo):
     """ns-slapd instance crashed with signal 11 SIGSEGV
 

--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -157,7 +157,6 @@ def test_pwp_local_unlock(topo, passw_policy, create_user):
     create_user.bind(PASSWORD)
 
 
-@pytest.mark.bz1465600
 @pytest.mark.parametrize("user_pasw", TEST_PASSWORDS)
 def test_trivial_passw_check(topo, passw_policy, create_user, user_pasw):
     """PasswordCheckSyntax attribute fails to validate cn, sn, uid, givenname, ou and mail attributes
@@ -217,7 +216,6 @@ def test_global_vs_local(topo, passw_policy, create_user, user_pasw):
     # reset password
     create_user.set('userPassword', PASSWORD)
 
-@pytest.mark.ds49789
 def test_unhashed_pw_switch(topo_supplier):
     """Check that nsslapd-unhashed-pw-switch works corrently
 

--- a/dirsrvtests/tests/suites/plugins/attr_nsslapd-pluginarg_test.py
+++ b/dirsrvtests/tests/suites/plugins/attr_nsslapd-pluginarg_test.py
@@ -32,7 +32,6 @@ def enable_plugin(topology_st):
     topology_st.standalone.plugins.enable(name=PLUGIN_7_BIT_CHECK)
 
 
-@pytest.mark.ds47431
 def test_duplicate_values(topology_st, enable_plugin):
     """Check 26 duplicate values are treated as one
 
@@ -86,7 +85,6 @@ def test_duplicate_values(topology_st, enable_plugin):
     log.info("Ticket 47431 - 1: done")
 
 
-@pytest.mark.ds47431
 def test_multiple_value(topology_st, enable_plugin):
     """Check two values belonging to one arg is fixed
 
@@ -142,7 +140,6 @@ def test_multiple_value(topology_st, enable_plugin):
     log.info("Ticket 47431 - 2: done")
 
 
-@pytest.mark.ds47431
 def test_missing_args(topology_st, enable_plugin):
     """Check missing args are fixed
 

--- a/dirsrvtests/tests/suites/plugins/cos_test.py
+++ b/dirsrvtests/tests/suites/plugins/cos_test.py
@@ -34,7 +34,6 @@ def add_user(server, uid, testbase, locality=None, tel=None, title=None):
                              'telephoneNumber': tel,
                              'description': 'description real'})))
 
-@pytest.mark.ds50053
 def test_cos_operational_default(topo):
     """operational-default cosAttribute should not overwrite an existing value
 

--- a/dirsrvtests/tests/suites/plugins/dna_test.py
+++ b/dirsrvtests/tests/suites/plugins/dna_test.py
@@ -22,7 +22,6 @@ pytestmark = pytest.mark.tier1
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds47937
 def test_dnatype_only_valid(topology_st):
     """Test that DNA plugin only accepts valid attributes for "dnaType"
 

--- a/dirsrvtests/tests/suites/plugins/managed_entry_test.py
+++ b/dirsrvtests/tests/suites/plugins/managed_entry_test.py
@@ -65,7 +65,6 @@ def _create_user(inst, name):
     })
 
 
-@pytest.mark.ds1870
 @pytest.mark.xfail(reason='https://github.com/389ds/389-ds-base/issues/1870')
 def test_overlapping_scope(topo):
     """Test overlapping scopes in Managed Entries

--- a/dirsrvtests/tests/suites/plugins/pluginpath_validation_test.py
+++ b/dirsrvtests/tests/suites/plugins/pluginpath_validation_test.py
@@ -18,8 +18,6 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds47384
-@pytest.mark.ds47601
 def test_pluginpath_validation(topology_st):
     """Test pluginpath validation: relative and absolute paths
     With the inclusion of ticket 47601 - we do allow plugin paths

--- a/dirsrvtests/tests/suites/plugins/rootdn_plugin_test.py
+++ b/dirsrvtests/tests/suites/plugins/rootdn_plugin_test.py
@@ -643,8 +643,6 @@ def test_rootdn_config_validate(topology_st, rootdn_setup, rootdn_cleanup):
         plugin.apply_mods([(ldap.MOD_REPLACE, 'rootdn-deny-host', 'host.####.com')])
 
 
-@pytest.mark.ds50800
-@pytest.mark.bz1807537
 @pytest.mark.xfail(ds_is_older('1.3.11', '1.4.3.5'), reason="May fail because of bz1807537")
 def test_rootdn_access_denied_ip_wildcard(topology_st, rootdn_setup, rootdn_cleanup, timeout=5):
     """Test denied IP feature with a wildcard
@@ -689,8 +687,6 @@ def test_rootdn_access_denied_ip_wildcard(topology_st, rootdn_setup, rootdn_clea
             time.sleep(.5)
 
 
-@pytest.mark.ds50800
-@pytest.mark.bz1807537
 @pytest.mark.xfail(ds_is_older('1.3.11', '1.4.3.5'), reason="May fail because of bz1807537")
 def test_rootdn_access_allowed_ip_wildcard(topology_st, rootdn_setup, rootdn_cleanup, timeout=5):
     """Test allowed ip feature

--- a/dirsrvtests/tests/suites/replication/acceptance_test.py
+++ b/dirsrvtests/tests/suites/replication/acceptance_test.py
@@ -299,7 +299,6 @@ def test_modrdn_after_pause(topo_m4):
         topo_m4.ms["supplier1"].delete_s(newrdn_dn)
 
 
-@pytest.mark.bz842441
 def test_modify_stripattrs(topo_m4):
     """Check that we can modify nsds5replicastripattrs
 
@@ -551,7 +550,6 @@ def test_warining_for_invalid_replica(topo_m4):
     log.info('Check the error log for the error')
     assert topo_m4.ms["supplier1"].ds_error_log.match('.*nsds5ReplicaBackoffMax.*10.*invalid.*')
 
-@pytest.mark.ds51082
 def test_csnpurge_large_valueset(topo_m2):
     """Test csn generator test
 
@@ -607,7 +605,6 @@ def test_csnpurge_large_valueset(topo_m2):
     for i in range(21,25):
         test_user.add('description', 'value {}'.format(str(i)))
 
-@pytest.mark.ds51244
 def test_urp_trigger_substring_search(topo_m2):
     """Test that a ADD of a entry with a '*' in its DN, triggers
     an internal search with a escaped DN

--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -248,9 +248,6 @@ def remove_ldif_files_from_changelogdir(topo, extension):
 
 @pytest.mark.xfail(ds_is_older('1.3.10.1', '1.4.3'), reason="bug bz1685059")
 @pytest.mark.skip(reason="does not work for prefix builds")
-@pytest.mark.bz1685059
-@pytest.mark.ds50498
-@pytest.mark.bz1769296
 def test_cldump_files_removed(topo):
     """Verify bz1685059 : cl-dump generated ldif files are removed at the end, -l option is the way to keep them
 
@@ -562,7 +559,6 @@ def test_verify_changelog_offline_backup(topo):
     _check_changelog_ldif(topo, changelog_ldif)
 
 
-@pytest.mark.ds47669
 def test_changelog_maxage(topo, changelog_init):
     """Check nsslapd-changelog max age values
 
@@ -594,7 +590,6 @@ def test_changelog_maxage(topo, changelog_init):
     add_and_check(topo, CHANGELOG, MAXAGE, 'xyz', False)
 
 
-@pytest.mark.ds47669
 def test_ticket47669_changelog_triminterval(topo, changelog_init):
     """Check nsslapd-changelog triminterval values
 
@@ -627,7 +622,6 @@ def test_ticket47669_changelog_triminterval(topo, changelog_init):
     add_and_check(topo, CHANGELOG, TRIMINTERVAL, 'xyz', False)
 
 
-@pytest.mark.ds47669
 @pytest.mark.skipif(ds_supports_new_changelog(), reason="changelog compaction is done by the backend itself, with id2entry as well, nsslapd-changelogcompactdb-interval is no longer supported")
 def test_changelog_compactdbinterval(topo, changelog_init):
     """Check nsslapd-changelog compactdbinterval values
@@ -662,7 +656,6 @@ def test_changelog_compactdbinterval(topo, changelog_init):
     add_and_check(topo, CHANGELOG, COMPACTDBINTERVAL, 'xyz', False)
 
 
-@pytest.mark.ds47669
 def test_retrochangelog_maxage(topo, changelog_init):
     """Check nsslapd-retrochangelog max age values
 
@@ -697,7 +690,6 @@ def test_retrochangelog_maxage(topo, changelog_init):
 
     topo.ms["supplier1"].log.info("ticket47669 was successfully verified.")
 
-@pytest.mark.ds50736
 def test_retrochangelog_trimming_crash(topo, changelog_init):
     """Check that when retroCL nsslapd-retrocthangelog contains invalid
     value, then the instance does not crash at shutdown
@@ -743,7 +735,6 @@ def test_retrochangelog_trimming_crash(topo, changelog_init):
     topo.ms["supplier1"].log.info("ticket 50736 was successfully verified.")
 
 
-@pytest.mark.bz2034407
 @pytest.mark.skipif(not os.path.isfile("/usr/bin/db_stat"), reason="libdb-utils package is not installed")
 def test_changelog_pagesize(topo):
     """Test that changelog page size is set properly

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -355,7 +355,6 @@ def test_double_delete(topo_m2, create_entry):
     repl.test_replication(m2, m1)
 
 
-@pytest.mark.bz1506831
 def test_repl_modrdn(topo_m2):
     """Test that replicated MODRDN does not break replication
 
@@ -742,8 +741,6 @@ def test_plugin_bind_dn_tracking_and_replication(topo_m2):
     agmt.set(REPL_PROTOCOL_TIMEOUT, "20")
 
 
-@pytest.mark.bz1314956
-@pytest.mark.ds48755
 def test_moving_entry_make_online_init_fail(topo_m2):
     """
     Moving an entry could make the online init fail
@@ -941,7 +938,6 @@ def test_keepalive_entries(topo_m2):
         pytest.param( "replMgr", id="using-bind-dn"),
     ],
 )
-@pytest.mark.bz1956987
 def test_change_repl_passwd(topo_m2, request, bind_cn):
     """Replication may break after changing password.
        Testing when agmt bind group are used.
@@ -1025,8 +1021,6 @@ def test_repl_after_reindex(topo_m2):
     repl.wait_for_replication(m2, m1)
 
 
-@pytest.mark.ds49915
-@pytest.mark.bz1626375
 def test_online_reinit_may_hang(topo_with_sigkill):
     """Online reinitialization may hang when the first
        entry of the DB is RUV entry instead of the suffix

--- a/dirsrvtests/tests/suites/replication/replica_config_test.py
+++ b/dirsrvtests/tests/suites/replication/replica_config_test.py
@@ -272,7 +272,6 @@ def test_agmt_num_modify(topo, attr, too_small, too_big, overflow, notnum, valid
 
 
 @pytest.mark.skipif(ds_is_older('1.4.1.4'), reason="Not implemented")
-@pytest.mark.bz1546739
 def test_same_attr_yields_same_return_code(topo):
     """Test that various operations with same incorrect attribute value yield same return code
 

--- a/dirsrvtests/tests/suites/replication/ruvstore_test.py
+++ b/dirsrvtests/tests/suites/replication/ruvstore_test.py
@@ -204,7 +204,6 @@ def test_ruv_after_reindex(topo):
     assert not inst.searchErrorsLog("entryrdn_insert_key")
 
 
-@pytest.mark.ds1317
 @pytest.mark.xfail(reason='https://github.com/389ds/389-ds-base/issues/1317')
 def test_ruv_after_import(topo):
     """Test the RUV behavior after an LDIF import operation.

--- a/dirsrvtests/tests/suites/replication/series_of_repl_bugs_test.py
+++ b/dirsrvtests/tests/suites/replication/series_of_repl_bugs_test.py
@@ -34,7 +34,6 @@ def _delete_after(request, topo_m2):
     request.addfinalizer(last)
 
 
-@pytest.mark.bz830337
 def test_deletions_are_not_replicated(topo_m2):
     """usn + mmr = deletions are not replicated
 
@@ -87,7 +86,6 @@ def test_deletions_are_not_replicated(topo_m2):
         user.status()
 
 
-@pytest.mark.bz891866
 def test_error_20(topo_m2, _delete_after):
     """DS returns error 20 when replacing values of a multi-valued attribute (only when replication is enabled)
 
@@ -110,7 +108,6 @@ def test_error_20(topo_m2, _delete_after):
     assert user.replace_many(('cn', 'BUG 891866'), ('cn', 'Test'))
 
 
-@pytest.mark.bz1955658
 def test_enable_repl_w_master(topo):
     """Check that enabling replication with the role "master" succeeds.
 
@@ -147,7 +144,6 @@ def test_enable_repl_w_master(topo):
     assert os.system(cmd) == 0
 
 
-@pytest.mark.bz914305
 def test_segfaults(topo_m2, _delete_after):
     """ns-slapd segfaults while trying to delete a tombstone entry
 

--- a/dirsrvtests/tests/suites/sasl/allowed_mechs_test.py
+++ b/dirsrvtests/tests/suites/sasl/allowed_mechs_test.py
@@ -177,8 +177,6 @@ def test_basic_feature(topology_st):
     assert(set(final_mechs) == set(orig_mechs))
 
 
-@pytest.mark.bz1816854
-@pytest.mark.ds50869
 @pytest.mark.xfail(ds_is_older('1.3.11', '1.4.3.6'), reason="May fail because of bz1816854")
 def test_config_set_few_mechs(topology_st):
     """Test that we can successfully set multiple values to nsslapd-allowed-sasl-mechanisms

--- a/dirsrvtests/tests/suites/sasl/regression_test.py
+++ b/dirsrvtests/tests/suites/sasl/regression_test.py
@@ -101,7 +101,6 @@ def relocate_pem_files(topology_m2):
     topology_m2.ms["supplier1"].restart()
     check_pems(certdir_prefix, mycacert, myservercert, myserverkey, "")
 
-@pytest.mark.ds47536
 def test_openldap_no_nss_crypto(topology_m2):
     """Check that we allow usage of OpenLDAP libraries
     that don't use NSS for crypto

--- a/dirsrvtests/tests/suites/schema/schema_replication_test.py
+++ b/dirsrvtests/tests/suites/schema/schema_replication_test.py
@@ -192,7 +192,6 @@ def schema_replication_init(topology_m1c1):
         'cn': 'test_entry'})))
 
 
-@pytest.mark.ds47490
 def test_schema_replication_one(topology_m1c1, schema_replication_init):
     """Check supplier schema is a superset (one extra OC) of consumer schema, then
     schema is pushed and there is no message in the error log
@@ -241,7 +240,6 @@ def test_schema_replication_one(topology_m1c1, schema_replication_init):
         assert False
 
 
-@pytest.mark.ds47490
 def test_schema_replication_two(topology_m1c1, schema_replication_init):
     """Check consumer schema is a superset (one extra OC) of supplier schema, then
         schema is pushed and there is a message in the error log
@@ -311,7 +309,6 @@ def test_schema_replication_two(topology_m1c1, schema_replication_init):
     assert new_oc['x_origin'][0].lower() == "user defined"
 
 
-@pytest.mark.ds47490
 def test_schema_replication_three(topology_m1c1, schema_replication_init):
     """Check supplier schema is again a superset (one extra OC), then
     schema is pushed and there is no message in the error log
@@ -360,7 +357,6 @@ def test_schema_replication_three(topology_m1c1, schema_replication_init):
         assert False
 
 
-@pytest.mark.ds47490
 def test_schema_replication_four(topology_m1c1, schema_replication_init):
     """Check supplier schema is again a superset (OC with more MUST), then
     schema is pushed and there is no message in the error log
@@ -409,7 +405,6 @@ def test_schema_replication_four(topology_m1c1, schema_replication_init):
         assert False
 
 
-@pytest.mark.ds47490
 def test_schema_replication_five(topology_m1c1, schema_replication_init):
     """Check consumer schema is  a superset (OC with more MUST), then
     schema is  pushed (fix for 47721) and there is a message in the error log
@@ -474,7 +469,6 @@ def test_schema_replication_five(topology_m1c1, schema_replication_init):
     res = pattern_errorlog(topology_m1c1.ms["supplier1"].errorlog_file, regex)
 
 
-@pytest.mark.ds47490
 def test_schema_replication_six(topology_m1c1, schema_replication_init):
     """Check supplier schema is  again a superset (OC with more MUST), then
     schema is pushed and there is no message in the error log
@@ -529,7 +523,6 @@ def test_schema_replication_six(topology_m1c1, schema_replication_init):
         assert False
 
 
-@pytest.mark.ds47490
 def test_schema_replication_seven(topology_m1c1, schema_replication_init):
     """Check supplier schema is again a superset (OC with more MAY), then
     schema is pushed and there is no message in the error log
@@ -582,7 +575,6 @@ def test_schema_replication_seven(topology_m1c1, schema_replication_init):
         assert False
 
 
-@pytest.mark.ds47490
 def test_schema_replication_eight(topology_m1c1, schema_replication_init):
     """Check consumer schema is a superset (OC with more MAY), then
     schema is  pushed (fix for 47721) and there is  message in the error log
@@ -647,7 +639,6 @@ def test_schema_replication_eight(topology_m1c1, schema_replication_init):
     res = pattern_errorlog(topology_m1c1.ms["supplier1"].errorlog_file, regex)
 
 
-@pytest.mark.ds47490
 def test_schema_replication_nine(topology_m1c1, schema_replication_init):
     """Check consumer schema is a superset (OC with more MAY), then
     schema is  not pushed and there is message in the error log

--- a/dirsrvtests/tests/suites/setup_ds/db_home_test.py
+++ b/dirsrvtests/tests/suites/setup_ds/db_home_test.py
@@ -36,8 +36,6 @@ else:
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds2790
-@pytest.mark.bz1780842
 def test_check_db_home_dir_in_config(topo):
     """Test to check nsslapd-db-home-directory is set to /dev/shm/slapd-instance in cn=config
 
@@ -64,8 +62,6 @@ def test_check_db_home_dir_in_config(topo):
     assert bdb_ldbmconfig.get_attr_val_utf8('nsslapd-db-home-directory') == dbhome_value
 
 
-@pytest.mark.ds2790
-@pytest.mark.bz1780842
 def test_check_db_home_dir_contents(topo):
     """Test to check contents of /dev/shm/slapd-instance
 
@@ -106,8 +102,6 @@ def test_check_db_home_dir_contents(topo):
         assert item not in old_location_files
 
 
-@pytest.mark.ds2790
-@pytest.mark.bz1780842
 def test_check_db_home_dir_in_dse(topo):
     """Test to check nsslapd-db-home-directory is set to /dev/shm/slapd-instance in dse.ldif
 
@@ -135,8 +129,6 @@ def test_check_db_home_dir_in_dse(topo):
     assert dse_value == dbhome_value
 
 
-@pytest.mark.ds2790
-@pytest.mark.bz1780842
 def test_check_db_home_dir_in_defaults(topo):
     """Test to check nsslapd-db-home-directory is set to /dev/shm/slapd-instance in defaults.inf file
 
@@ -165,8 +157,6 @@ def test_check_db_home_dir_in_defaults(topo):
         assert dbhome_value in f.read()
 
 
-@pytest.mark.ds2790
-@pytest.mark.bz1780842
 def test_delete_db_home_dir(topo):
     """Test to check behaviour when deleting contents of /dev/shm/slapd-instance/ and restarting the instance
 

--- a/dirsrvtests/tests/suites/tls/tls_cert_namespace_test.py
+++ b/dirsrvtests/tests/suites/tls/tls_cert_namespace_test.py
@@ -23,8 +23,6 @@ log = logging.getLogger(__name__)
 p = Paths()
 
 
-@pytest.mark.ds50889
-@pytest.mark.bz1638875
 @pytest.mark.skipif(p.with_systemd == False, reason='Will not run without systemd')
 @pytest.mark.skipif(ds_is_older("1.4.3"), reason="Not implemented")
 def test_pem_cert_in_private_namespace(topology_st):
@@ -77,8 +75,6 @@ def test_pem_cert_in_private_namespace(topology_st):
         assert not os.path.exists(cert_path + item)
 
 
-@pytest.mark.ds50952
-@pytest.mark.bz1809279
 @pytest.mark.xfail(ds_is_older("1.4.3"), reason="Might fail because of bz1809279")
 @pytest.mark.skipif(ds_is_older("1.4.0"), reason="Not implemented")
 def test_cert_category_authority(topology_st):

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -149,7 +149,6 @@ def create_vlv_search_and_index(inst):
     return vlv_searches, vlv_index
 
 
-@pytest.mark.DS47966
 def test_bulk_import_when_the_backend_with_vlv_was_recreated(topology_m2):
     """
     Testing bulk import when the backend with VLV was recreated.

--- a/dirsrvtests/tests/tickets/ticket49623_2_test.py
+++ b/dirsrvtests/tests/tickets/ticket49623_2_test.py
@@ -23,8 +23,6 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ds49623
-@pytest.mark.bz1790986
 def test_modrdn_loop(topology_m1):
     """Test that renaming the same entry multiple times reusing the same
        RDN multiple times does not result in cenotaph error messages

--- a/src/lib389/doc/source/guidelines.rst
+++ b/src/lib389/doc/source/guidelines.rst
@@ -278,13 +278,20 @@ Parametrizing
 Marking test functions and selecting them for a run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+ You can “mark” a test function with custom meta data like this:
++ First you need to register a marker in ``pytest.ini``:
+  ::
+    # content of pytest.ini
+    [pytest]
+    markers =
+    tls: mark a test as a TLS related test
+
++ Then you can "mark" a test function with custom metadata like this:
 
   ::
 
-    @pytest.mark.ssl
+    @pytest.mark.tls
     def test_search_sec_port():
-        pass # perform some search through sec port
+        pass # perform some search through secure port
 
 
 + You can also set a module level marker in which case it will be
@@ -293,20 +300,20 @@ Marking test functions and selecting them for a run
   ::
 
     import pytest
-    pytestmark = pytest.mark.ssl
+    pytestmark = pytest.mark.tls
 
 
-+ You can then restrict a test run to only run tests marked with ssl:
++ You can then restrict a test run to only run tests marked with ``tls``:
 
   ::
 
-    py.test -v -m ssl
+    py.test -v -m tls
 
 + Or the inverse, running all tests except the ssl ones:
 
   ::
 
-    py.test -v -m "not ssl"
+    py.test -v -m "not tls"
 
 + Select tests based on their node ID
 


### PR DESCRIPTION
Bug Description:
We have pytest markers such as `bz12345` or `ds1234`, but they are not registered in `pytest.ini` and generate warnings. We no longer use them to executed tests, and `git log` and `git blame` can be used for repo archeology.

Fix Description:
Delete unused pytest markers.

Fixes: https://github.com/389ds/389-ds-base/issues/6051

Reviewed by: