### PR TITLE
Issue 6071 - Instance creation/removal is slow

### DIFF
--- a/src/lib389/lib389/instance/remove.py
+++ b/src/lib389/lib389/instance/remove.py
@@ -139,9 +139,11 @@ def remove_ds_instance(dirsrv, force=False):
         ssca = NssSsl(dbpath=dirsrv.get_ssca_dir())
         ssca.remove_db()
         selinux_clean_ports_label()
-        selinux_clean_files_label(all=True)
+        if dirsrv.ds_paths.prefix != '/usr':
+            selinux_clean_files_label(all=True)
     else:
-        selinux_clean_files_label()
+        if dirsrv.ds_paths.prefix != '/usr':
+            selinux_clean_files_label()
 
     ### ANY NEW REMOVAL ACTIONS MUST BE ABOVE THIS LINE!!!
 

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -1008,22 +1008,23 @@ class SetupDs(object):
         # Do selinux fixups
         if general['selinux'] and selinux_present():
             self.log.info("Perform SELinux labeling ...")
-            # Since there may be some custom path, we must explicitly set the labels
-            selinux_labels = {
-                                'backup_dir': 'dirsrv_var_lib_t',
-                                'cert_dir': 'dirsrv_config_t',
-                                'config_dir': 'dirsrv_config_t',
-                                'db_dir': 'dirsrv_var_lib_t',
-                                'ldif_dir': 'dirsrv_var_lib_t',
-                                'lock_dir': 'dirsrv_var_lock_t',
-                                'log_dir': 'dirsrv_var_log_t',
-                                'db_home_dir': 'dirsrv_tmpfs_t',
-                                'run_dir': 'dirsrv_var_run_t',
-                                'schema_dir': 'dirsrv_config_t',
-                                'tmp_dir': 'tmp_t',
-            }
-            for k, label in selinux_labels.items():
-                selinux_label_file(resolve_selinux_path(slapd[k]), label)
+            # We must explicitly set the labels for non-default prefix installs
+            if ds_instance.ds_paths.prefix != '/usr':
+                selinux_labels = {
+                                    'backup_dir': 'dirsrv_var_lib_t',
+                                    'cert_dir': 'dirsrv_config_t',
+                                    'config_dir': 'dirsrv_config_t',
+                                    'db_dir': 'dirsrv_var_lib_t',
+                                    'ldif_dir': 'dirsrv_var_lib_t',
+                                    'lock_dir': 'dirsrv_var_lock_t',
+                                    'log_dir': 'dirsrv_var_log_t',
+                                    'db_home_dir': 'dirsrv_tmpfs_t',
+                                    'run_dir': 'dirsrv_var_run_t',
+                                    'schema_dir': 'dirsrv_config_t',
+                                    'tmp_dir': 'tmp_t',
+                }
+                for k, label in selinux_labels.items():
+                    selinux_label_file(resolve_selinux_path(slapd[k]), label)
 
             selinux_label_port(slapd['port'])
 


### PR DESCRIPTION
Bug Description:
Sometimes instance creation and removal is slow (~2m). We spend a lot of time running `semanage` to define labels. But the default SELinux policy already contains the required contexts:

```
/dev/shm/slapd-.*                                  all files          system_u:object_r:dirsrv_tmpfs_t:s0
/etc/dirsrv(/.*)?                                  all files          system_u:object_r:dirsrv_config_t:s0
/usr/lib/systemd/system/dirsrv.*                   all files          system_u:object_r:dirsrv_unit_file_t:s0
/usr/sbin/ldap-agent                               regular file       system_u:object_r:dirsrv_snmp_exec_t:s0
/usr/sbin/ldap-agent-bin                           regular file       system_u:object_r:dirsrv_snmp_exec_t:s0
/usr/sbin/ns-slapd                                 regular file       system_u:object_r:dirsrv_exec_t:s0
/usr/share/dirsrv(/.*)?                            all files          system_u:object_r:dirsrv_share_t:s0
/var/lib/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_lib_t:s0
/var/lock/dirsrv(/.*)?                             all files          system_u:object_r:dirsrv_var_lock_t:s0
/var/log/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_log_t:s0
/var/log/dirsrv/ldap-agent.log.*                   all files          system_u:object_r:dirsrv_snmp_var_log_t:s0
/var/run/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_run_t:s0
/var/run/ldap-agent\.pid                           all files          system_u:object_r:dirsrv_snmp_var_run_t:s0
/var/run/slapd.*                                   socket             system_u:object_r:dirsrv_var_run_t:s0
```

Here's what's added to the system policy after creating a new instance:
```diff
--- labels_before       2024-02-05 13:56:08.667301292 -0500
+++ labels_after        2024-02-05 13:57:39.067301292 -0500
@@ -1,14 +1,23 @@
 /dev/shm/slapd-.*                                  all files          system_u:object_r:dirsrv_tmpfs_t:s0
+/dev/shm/slapd-localhost                           all files          system_u:object_r:dirsrv_tmpfs_t:s0
 /etc/dirsrv(/.*)?                                  all files          system_u:object_r:dirsrv_config_t:s0
+/etc/dirsrv/slapd-localhost                        all files          system_u:object_r:dirsrv_config_t:s0
+/etc/dirsrv/slapd-localhost/schema                 all files          system_u:object_r:dirsrv_config_t:s0
 /usr/lib/systemd/system/dirsrv.*                   all files          system_u:object_r:dirsrv_unit_file_t:s0
 /usr/sbin/ldap-agent                               regular file       system_u:object_r:dirsrv_snmp_exec_t:s0
 /usr/sbin/ldap-agent-bin                           regular file       system_u:object_r:dirsrv_snmp_exec_t:s0
 /usr/sbin/ns-slapd                                 regular file       system_u:object_r:dirsrv_exec_t:s0
 /usr/share/dirsrv(/.*)?                            all files          system_u:object_r:dirsrv_share_t:s0
 /var/lib/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_lib_t:s0
+/var/lib/dirsrv/slapd-localhost/bak                all files          system_u:object_r:dirsrv_var_lib_t:s0
+/var/lib/dirsrv/slapd-localhost/db                 all files          system_u:object_r:dirsrv_var_lib_t:s0
+/var/lib/dirsrv/slapd-localhost/ldif               all files          system_u:object_r:dirsrv_var_lib_t:s0
 /var/lock/dirsrv(/.*)?                             all files          system_u:object_r:dirsrv_var_lock_t:s0
 /var/log/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_log_t:s0
 /var/log/dirsrv/ldap-agent.log.*                   all files          system_u:object_r:dirsrv_snmp_var_log_t:s0
+/var/log/dirsrv/slapd-localhost                    all files          system_u:object_r:dirsrv_var_log_t:s0
+/var/run/dirsrv                                    all files          system_u:object_r:dirsrv_var_run_t:s0
 /var/run/dirsrv(/.*)?                              all files          system_u:object_r:dirsrv_var_run_t:s0
 /var/run/ldap-agent\.pid                           all files          system_u:object_r:dirsrv_snmp_var_run_t:s0
+/var/run/lock/dirsrv/slapd-localhost               all files          system_u:object_r:dirsrv_var_lock_t:s0
 /var/run/slapd.*                                   socket             system_u:object_r:dirsrv_var_run_t:s0
```

Fix Description:
We should not add/remove labels for paths that are already covered by the system SELinux policy. This is the case for the default `/usr` prefix.

Fixes: https://github.com/389ds/389-ds-base/issues/6071