### PR TITLE
Issue 6075 - Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,7 @@ vendor.tar.gz
 .history
 .vscode/launch.json
 .cargo/config
+/rs/
+/rust-nsslapd-private.h
+/rust-slapi-private.h
+/src/lib389/setup.py


### PR DESCRIPTION
Bug Description:
When running the build I noticed some generated files are not included in .gitignore, thereby cluttering and distracting git use during local development.

Fix Description:
Update .gitignore.

Fixes https://github.com/389ds/389-ds-base/issues/6075

Reviewed by @progier389 