### PR TITLE
Issue 6082 - Remove explicit dependencies toward libdb

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -184,7 +184,11 @@ endif
 ldaplib = @ldaplib@
 ldaplib_defs = @ldaplib_defs@
 
+if BUNDLE_LIBDB
+DB_LINK = -llmdb
+else
 DB_LINK = @db_lib@ -ldb-@db_libver@ -llmdb
+endif
 DB_INC = @db_inc@
 DB_IMPL = libback-ldbm.la
 SASL_LINK = $(SASL_LIBS)
@@ -349,7 +353,7 @@ endif
 serverplugin_LTLIBRARIES = libacl-plugin.la \
 	libaddn-plugin.la \
 	libattr-unique-plugin.la \
-	libautomember-plugin.la libback-ldbm.la libchainingdb-plugin.la \
+	libautomember-plugin.la $(DB_IMPL) libchainingdb-plugin.la \
 	libcollation-plugin.la libcos-plugin.la libderef-plugin.la \
 	libpbe-plugin.la libdistrib-plugin.la \
 	liblinkedattrs-plugin.la libmanagedentries-plugin.la \
@@ -1187,6 +1191,37 @@ libslapd_la_LDFLAGS = $(AM_LDFLAGS) $(SLAPD_LDFLAGS)
 #
 #////////////////////////////////////////////////////////////////
 #------------------------
+# libback-bdb
+#------------------------
+DB_BDB_SRCS = \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_instance_config.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_upgrade.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c \
+	ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+
+if BUNDLE_LIBDB
+  # db-bdb sources are compiled within libback-bdb.so
+  DB_BDB_WITHIN_BACKLDBM =
+  serverplugin_LTLIBRARIES += libback-bdb.la
+  libback_bdb_la_SOURCES = $(DB_BDB_SRCS)
+  libback_bdb_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(DB_INC)
+  libback_bdb_la_DEPENDENCIES = libslapd.la libback-ldbm.la
+  libback_bdb_la_LIBADD = libslapd.la  @db_lib@ -ldb-@db_libver@ $(LDAPSDK_LINK) $(NSPR_LINK)
+  libback_bdb_la_LDFLAGS = -avoid-version @db_lib@ -ldb-@db_libver@ -lback-ldbm
+else
+  # db-bdb sources are compiled within libback-ldbm.so
+  DB_BDB_WITHIN_BACKLDBM = $(DB_BDB_SRCS)
+endif
+
+#------------------------
 # libback-ldbm
 #------------------------
 libback_ldbm_la_SOURCES = ldap/servers/slapd/back-ldbm/ancestorid.c \
@@ -1244,18 +1279,6 @@ libback_ldbm_la_SOURCES = ldap/servers/slapd/back-ldbm/ancestorid.c \
 	ldap/servers/slapd/back-ldbm/vlv.c \
 	ldap/servers/slapd/back-ldbm/vlv_key.c \
 	ldap/servers/slapd/back-ldbm/vlv_srch.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_instance_config.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_perfctrs.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_upgrade.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c \
-	ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c \
@@ -1269,8 +1292,8 @@ libback_ldbm_la_SOURCES = ldap/servers/slapd/back-ldbm/ancestorid.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c \
 	ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c \
-	ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
-
+	ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c \
+	$(DB_BDB_WITHIN_BACKLDBM)
 
 
 libback_ldbm_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(DB_INC)

--- a/configure.ac
+++ b/configure.ac
@@ -541,6 +541,28 @@ else
   with_pythonexec=/usr/bin/python3
 fi
 
+dblib=".libs/libdb-5.3-389ds.so"
+AC_MSG_CHECKING(for --with-bundle-libdb)
+AC_ARG_WITH([bundle-libdb],
+   AS_HELP_STRING([--with-bundle-libdb=PATH],
+                  [Directory containing $dblib and db.h (if not using system libdb package)])
+)
+if test -n "$with_bundle_libdb"; then
+  if test  "$with_bundle_libdb" = no ; then
+    with_bundle_libdb=no
+  elif ! test -f "$with_bundle_libdb/db.h" ; then
+      AC_MSG_ERROR([Directory specified with --with-bundle-libdb=fullpath should contains db.h])
+  elif ! test -f "$with_bundle_libdb/$dblib" ; then
+      AC_MSG_ERROR([Directory specified with --with-bundle-libdb=fullpath should contains $dblib])
+  else
+    AC_MSG_RESULT([$with_bundle_libdb])
+  fi
+else
+  with_bundle_libdb=no
+fi
+AM_CONDITIONAL([BUNDLE_LIBDB],[test "$with_bundle_libdb" != no])
+
+
 AC_SUBST(prefixdir)
 AC_SUBST(configdir)
 AC_SUBST(sampledatadir)
@@ -819,7 +841,11 @@ AC_SUBST(nss_libdir)
 PKG_CHECK_MODULES([OPENSSL], [openssl])
 
 m4_include(m4/openldap.m4)
-m4_include(m4/db.m4)
+if test $with_bundle_libdb = no; then
+    m4_include(m4/db.m4)
+else
+    m4_include(m4/bundle_libdb.m4)
+fi
 
 PKG_CHECK_MODULES([SASL], [libsasl2])
 

--- a/ldap/admin/src/logconv.pl
+++ b/ldap/admin/src/logconv.pl
@@ -19,7 +19,7 @@ use warnings 'untie';
 use Time::Local;
 use IO::File;
 use Getopt::Long;
-use DB_File;
+# use DB_File;
 use sigtrap qw(die normal-signals);
 use Archive::Tar;
 use IO::Uncompress::AnyUncompress qw($AnyUncompressError);
@@ -2987,9 +2987,9 @@ openHashFiles
 	my %hashes = ();
 	for my $hn (@_) {
 		my %h = (); # using my in inner loop will create brand new hash every time through for tie
-		my $fn = "$dir/$hn.logconv.db";
-		push @removefiles, $fn;
-		tie %h, "DB_File", $fn, O_CREAT|O_RDWR, 0600, $DB_HASH or do { openFailed($!, $fn) };
+		# my $fn = "$dir/$hn.logconv.db";
+		# push @removefiles, $fn;
+		# tie %h, "DB_File", $fn, O_CREAT|O_RDWR, 0600, $DB_HASH or do { openFailed($!, $fn) };
 		$hashes{$hn} = \%h;
 	}
 	return \%hashes;
@@ -2999,13 +2999,13 @@ sub
 removeDataFiles
 {
 	if (!$needCleanup) { return ; }
-
-	for my $h (keys %{$hashes}) {
-		untie %{$hashes->{$h}};
-	}
-	for my $file (@removefiles) {
-		unlink $file;
-	}
+#
+# 	for my $h (keys %{$hashes}) {
+# 		untie %{$hashes->{$h}};
+# 	}
+# 	for my $file (@removefiles) {
+# 		unlink $file;
+# 	}
 	$needCleanup = 0;
 }
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -1065,7 +1065,7 @@ bdb_import_update_entry_subcount(backend *be, ID parentid, size_t sub_count, int
     /* If it is a tombstone entry, add tombstonesubordinates instead of
      * numsubordinates. */
     if (slapi_entry_flag_is_set(e->ep_entry, SLAPI_ENTRY_FLAG_TOMBSTONE)) {
-        numsub_str = tombstone_numsubordinates;
+        numsub_str = LDBM_TOMBSTONE_NUMSUBORDINATES_STR;
     }
     /* attr numsubordinates/tombstonenumsubordinates could already exist in
      * the entry, let's check whether it's already there or not */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -22,6 +22,8 @@
 #include "bdb_layer.h"
 #include "../vlv_srch.h"
 
+#define indextype_EQUALITY "eq"
+
 static void bdb_import_wait_for_space_in_fifo(ImportJob *job, size_t new_esize);
 static int bdb_import_get_and_add_parent_rdns(ImportWorkerInfo *info, ldbm_instance *inst, DB *db, ID id, ID *total_id, Slapi_RDN *srdn, int *curr_entry);
 static int _get_import_entryusn(ImportJob *job, Slapi_Value **usn_value);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -20,6 +20,8 @@
 #include "bdb_layer.h"
 #include "../vlv_srch.h"
 
+#define indextype_EQUALITY "eq"
+
 #define DB2INDEX_ANCESTORID 0x1   /* index ancestorid */
 #define DB2INDEX_ENTRYRDN 0x2     /* index entryrdn */
 #define DB2LDIF_ENTRYRDN 0x4      /* export entryrdn */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -154,7 +154,7 @@ dbmdb_import_update_entry_subcount(backend *be, ID parentid, size_t sub_count, i
     /* If it is a tombstone entry, add tombstonesubordinates instead of
      * numsubordinates. */
     if (slapi_entry_flag_is_set(e->ep_entry, SLAPI_ENTRY_FLAG_TOMBSTONE)) {
-        numsub_str = tombstone_numsubordinates;
+        numsub_str = LDBM_TOMBSTONE_NUMSUBORDINATES_STR;
     }
     /* attr numsubordinates/tombstonenumsubordinates could already exist in
      * the entry, let's check whether it's already there or not */

--- a/m4/bundle_libdb.m4
+++ b/m4/bundle_libdb.m4
@@ -1,0 +1,34 @@
+# BEGIN COPYRIGHT BLOCK
+# Copyright (C) 2024 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# END COPYRIGHT BLOCK
+
+AC_MSG_CHECKING(Handling bundle_libdb)
+
+db_lib="-L${with_bundle_libdb}/.libs -R${prefix}/lib/dirsrv"
+db_incdir=$with_bundle_libdb
+db_inc="-I $db_incdir"
+db_libver="5.3-389ds"
+
+dnl figure out which version of db we're using from the header file
+db_ver_maj=`grep DB_VERSION_MAJOR $db_incdir/db.h | awk '{print $3}'`
+db_ver_min=`grep DB_VERSION_MINOR $db_incdir/db.h | awk '{print $3}'`
+db_ver_pat=`grep DB_VERSION_PATCH $db_incdir/db.h | awk '{print $3}'`
+
+dnl Ensure that we have libdb at least 4.7, older versions aren't supported
+if test ${db_ver_maj} -lt 4; then
+  AC_MSG_ERROR([Found db ${db_ver_maj}.${db_ver_min} is too old, update to version 4.7 at least])
+elif test ${db_ver_maj} -eq 4 -a ${db_ver_min} -lt 7; then
+  AC_MSG_ERROR([Found db ${db_ver_maj}.${db_ver_min} is too old, update to version 4.7 at least])
+else
+  AC_MSG_RESULT([libdb-${db_ver_maj}.${db_ver_min}-389ds.so])
+fi
+
+
+AC_SUBST(db_inc)
+AC_SUBST(db_lib)
+AC_SUBST(db_libver)
+

--- a/rpm.mk
+++ b/rpm.mk
@@ -15,7 +15,7 @@ NODE_MODULES_TEST = src/cockpit/389-console/package-lock.json
 NODE_MODULES_PATH = src/cockpit/389-console/
 CARGO_PATH = src/
 GIT_TAG = ${TAG}
-# LIBDB tar ball was gebnerated from
+# LIBDB tarball was generated from
 #  https://kojipkgs.fedoraproject.org//packages/libdb/5.3.28/59.fc40/src/libdb-5.3.28-59.fc40.src.rpm
 #  then uploaded in https://fedorapeople.org
 LIBDB_URL ?= $(shell rpmspec -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source4:/ {print $$2}')

--- a/rpm.mk
+++ b/rpm.mk
@@ -15,6 +15,12 @@ NODE_MODULES_TEST = src/cockpit/389-console/package-lock.json
 NODE_MODULES_PATH = src/cockpit/389-console/
 CARGO_PATH = src/
 GIT_TAG = ${TAG}
+LIBDB_VERSION ?= 5.3
+LIBDB_FULL_VERSION ?= $(LIBDB_VERSION).28-59
+LIBDB_NAME ?= libdb-$(LIBDB_FULL_VERSION)
+LIBDB_SRC_RPM ?= $(LIBDB_NAME).fc40.src.rpm
+LIBDB_URL ?= https://kojipkgs.fedoraproject.org//packages/libdb/5.3.28/59.fc40/src/$(LIBDB_SRC_RPM)
+BUNDLE_LIBDB = 1
 
 # Some sanitizers are supported only by clang
 CLANG_ON = 0
@@ -82,6 +88,14 @@ local-archive: build-cockpit
 	-mkdir -p dist/$(NAME_VERSION)
 	rsync -a --exclude=node_modules --exclude=dist --exclude=__pycache__ --exclude=.git --exclude=rpmbuild . dist/$(NAME_VERSION)
 
+prep_bundle_libdb:
+	/bin/rm -rf dist/sources/libdb_bundle
+	mkdir -p dist/sources/libdb_bundle/SOURCES rpmbuild/SOURCES
+	cd dist/sources/libdb_bundle && curl -LO $(LIBDB_URL)
+	rpmbuild --define "_topdir $(PWD)/dist/sources/libdb_bundle" -rp --nodeps --noprep dist/sources/libdb_bundle/$(LIBDB_SRC_RPM)
+	tar -cjf dist/sources/$(LIBDB_NAME).tar.bz2 --transform "s,dist/sources/libdb_bundle/[^/]*,$(LIBDB_NAME),;" dist/sources/libdb_bundle/SOURCES dist/sources/libdb_bundle/SPECS/libdb.spec
+	/bin/rm -rf dist/sources/libdb_bundle
+
 tarballs: local-archive
 	-mkdir -p dist/sources
 	cd dist; tar cfj sources/$(TARBALL) $(NAME_VERSION)
@@ -92,6 +106,9 @@ endif
 	cd dist/sources ; \
 	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
 		curl -LO $(JEMALLOC_URL) ; \
+	fi ;
+	if [ $(BUNDLE_LIBDB) -eq 1 ]; then \
+        $(MAKE) -f rpm.mk prep_bundle_libdb ; \
 	fi
 
 rpmroot:
@@ -110,6 +127,7 @@ rpmroot:
 	-e s/__COCKPIT_ON__/$(COCKPIT_ON)/ \
 	-e s/__CLANG_ON__/$(CLANG_ON)/ \
 	-e s/__BUNDLE_JEMALLOC__/$(BUNDLE_JEMALLOC)/ \
+	-e s/__BUNDLE_LIBDB__/$(BUNDLE_LIBDB)/ \
 	rpm/$(PACKAGE).spec.in > $(RPMBUILD)/SPECS/$(PACKAGE).spec
 
 rpmdistdir:
@@ -124,8 +142,11 @@ rpmbuildprep:
 	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
 		cp dist/sources/$(JEMALLOC_TARBALL) $(RPMBUILD)/SOURCES/ ; \
 	fi
+	if [ $(BUNDLE_LIBDB) -eq 1 ]; then \
+		cp dist/sources/$(LIBDB_NAME).tar.bz2 $(RPMBUILD)/SOURCES/ ; \
+	fi
 
-srpms: rpmroot srpmdistdir download-cargo-dependencies tarballs rpmbuildprep 
+srpms: rpmroot srpmdistdir download-cargo-dependencies tarballs rpmbuildprep
 	rpmbuild --define "_topdir $(RPMBUILD)" -bs $(RPMBUILD)/SPECS/$(PACKAGE).spec
 	cp $(RPMBUILD)/SRPMS/$(RPM_NAME_VERSION)*.src.rpm dist/srpms/
 	rm -rf $(RPMBUILD)

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -6,6 +6,11 @@
 %global jemalloc_name jemalloc
 %global jemalloc_ver 5.3.0
 %endif
+%global bundle_libdb __BUNDLE_LIBDB__
+%global libdb_version 5.3
+%global libdb_base_version db-%{libdb_version}.28
+%global libdb_full_version lib%{libdb_base_version}-59
+%global libdb_bundle_name libdb-%{libdb_version}-389ds.so
 
 # This is used in certain builds to help us know if it has extra features.
 %global variant base
@@ -172,7 +177,6 @@ Provides:  bundled(crate(zeroize_derive)) = 1.3.3
 BuildRequires:    nspr-devel
 BuildRequires:    nss-devel >= 3.34
 BuildRequires:    openldap-devel
-BuildRequires:    libdb-devel
 BuildRequires:    lmdb-devel
 BuildRequires:    cyrus-sasl-devel
 BuildRequires:    icu
@@ -198,6 +202,10 @@ BuildRequires:    libtsan
 BuildRequires:    libubsan
 %endif
 %endif
+%if !%{bundle_libdb}
+BuildRequires:    libdb-devel
+%endif
+
 # The following are needed to build the snmp ldap-agent
 BuildRequires:    net-snmp-devel
 BuildRequires:    bzip2-devel
@@ -268,12 +276,16 @@ Requires:         cyrus-sasl-md5
 # This is optionally supported by us, as we use it in our tests
 Requires:         cyrus-sasl-plain
 # this is needed for backldbm
+%if !%{bundle_libdb}
 Requires:         libdb
+%endif
 Requires:         lmdb
 # This picks up libperl.so as a Requires, so we add this versioned one
 Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 # Needed by logconv.pl
+%if !%{bundle_libdb}
 Requires:         perl-DB_File
+%endif
 Requires:         perl-Archive-Tar
 %if 0%{?fedora} >= 33 || 0%{?rhel} >= 9
 Requires:         perl-debugger
@@ -367,6 +379,23 @@ Obsoletes:        %{name} <= 1.3.5.4
 
 %description      snmp
 SNMP Agent for the 389 Directory Server base package.
+
+%if %{bundle_libdb}
+%package          bdb
+Summary:          Berkeley Database backend for 389 Directory Server
+%description      bdb
+Berkeley Database backend for 389 Directory Server
+Warning! This backend is deprecated in favor of lmdb and its support
+may be removed in future versions.
+
+Group:            System Environment/Daemons
+Requires:         %{name} = %{version}-%{release}
+# Berkerkey DB database libdb was marked as deprecated since F40:
+# https://fedoraproject.org/wiki/Changes/389_Directory_Server_3.0.0
+# because libdb was marked as deprecated since F33
+# https://fedoraproject.org/wiki/Changes/Libdb_deprecated
+Provides:         deprecated()
+%endif
 
 
 %package -n python%{python3_pkgversion}-lib389
@@ -476,10 +505,24 @@ make %{?_smp_mflags}
 popd
 %endif
 
+# Build custom libdb package
+%if %{bundle_libdb}
+mkdir -p ../%{libdb_base_version}
+pushd ../%{libdb_base_version}
+tar -xjf  ../../SOURCES/%{libdb_full_version}.tar.bz2
+mv %{libdb_full_version} SOURCES
+rpmbuild  --define "_topdir $PWD" -bc %{_builddir}/%{name}-%{version}%{?prerel}/rpm/bundle-libdb.spec
+popd
+%endif
+
 # Rebuild the autotool artifacts now.
 autoreconf -fiv
 
-%configure --with-selinux $TMPFILES_FLAG \
+%configure \
+%if %{bundle_libdb}
+           --with-bundle-libdb=%{_builddir}/%{libdb_base_version}/BUILD/%{libdb_base_version}/dist/dist-tls \
+%endif
+           --with-selinux $TMPFILES_FLAG \
            --with-systemd \
            --with-systemdsystemunitdir=%{_unitdir} \
            --with-systemdsystemconfdir=%{_sysconfdir}/systemd/system \
@@ -571,6 +614,18 @@ cp -pa COPYING ../%{name}-%{version}%{?prerel}/COPYING.jemalloc
 cp -pa README ../%{name}-%{version}%{?prerel}/README.jemalloc
 popd
 %endif
+
+%if %{bundle_libdb}
+pushd ../%{libdb_base_version}
+libdbbuilddir=$PWD/BUILD/%{libdb_base_version}
+libdbdestdir=$PWD/../%{name}-%{version}%{?prerel}
+cp -pa $libdbbuilddir/LICENSE $libdbdestdir/LICENSE.libdb
+cp -pa $libdbbuilddir/README $libdbdestdir/README.libdb
+cp -pa $libdbbuilddir/lgpl-2.1.txt $libdbdestdir/lgpl-2.1.txt.libdb
+cp -pa $libdbbuilddir/dist/dist-tls/.libs/%{libdb_bundle_name} $RPM_BUILD_ROOT%{_libdir}/%{libdb_bundle_name}
+popd
+%endif
+
 
 %check
 # This checks the code, if it fails it prints why, then re-raises the fail to shortcircuit the rpm build.
@@ -772,6 +827,13 @@ fi
 %{_sbindir}/ldap-agent*
 %{_mandir}/man1/ldap-agent.1.gz
 %{_unitdir}/%{pkgname}-snmp.service
+
+%if %{bundle_libdb}
+%files bdb
+%doc LICENSE LICENSE.GPLv3+ README.devel LICENSE.libdb README.libdb lgpl-2.1.txt.libdb
+%{_libdir}/%{libdb_bundle_name}
+%{_libdir}/%{pkgname}/plugins/libback-bdb.so
+%endif
 
 %files -n python%{python3_pkgversion}-lib389
 %doc LICENSE LICENSE.GPLv3+

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -393,7 +393,7 @@ may be removed in future versions.
 
 Group:            System Environment/Daemons
 Requires:         %{name} = %{version}-%{release}
-# Berkerkey DB database libdb was marked as deprecated since F40:
+# Berkeley DB database libdb was marked as deprecated since F40:
 # https://fedoraproject.org/wiki/Changes/389_Directory_Server_3.0.0
 # because libdb was marked as deprecated since F33
 # https://fedoraproject.org/wiki/Changes/Libdb_deprecated

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -306,6 +306,9 @@ Source2:          %{name}-devel.README
 %if %{bundle_jemalloc}
 Source3:          https://github.com/jemalloc/%{jemalloc_name}/releases/download/%{jemalloc_ver}/%{jemalloc_name}-%{jemalloc_ver}.tar.bz2
 %endif
+%if %{bundle_libdb}
+Source4:          https://fedorapeople.org/groups/389ds/libdb-5.3.28-59.tar.bz2
+%endif
 
 %description
 389 Directory Server is an LDAPv3 compliant server.  The base package includes
@@ -443,6 +446,10 @@ A cockpit UI Plugin for configuring and administering the 389 Directory Server
 
 %if %{bundle_jemalloc}
 %setup -q -n %{name}-%{version}%{?prerel} -T -D -b 3
+%endif
+
+%if %{bundle_libdb}
+%setup -q -n %{name}-%{version}%{?prerel} -T -D -b 4
 %endif
 
 cp %{SOURCE2} README.devel
@@ -622,7 +629,7 @@ libdbdestdir=$PWD/../%{name}-%{version}%{?prerel}
 cp -pa $libdbbuilddir/LICENSE $libdbdestdir/LICENSE.libdb
 cp -pa $libdbbuilddir/README $libdbdestdir/README.libdb
 cp -pa $libdbbuilddir/lgpl-2.1.txt $libdbdestdir/lgpl-2.1.txt.libdb
-cp -pa $libdbbuilddir/dist/dist-tls/.libs/%{libdb_bundle_name} $RPM_BUILD_ROOT%{_libdir}/%{libdb_bundle_name}
+cp -pa $libdbbuilddir/dist/dist-tls/.libs/%{libdb_bundle_name} $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/%{libdb_bundle_name}
 popd
 %endif
 
@@ -831,7 +838,7 @@ fi
 %if %{bundle_libdb}
 %files bdb
 %doc LICENSE LICENSE.GPLv3+ README.devel LICENSE.libdb README.libdb lgpl-2.1.txt.libdb
-%{_libdir}/%{libdb_bundle_name}
+%{_libdir}/%{pkgname}/%{libdb_bundle_name}
 %{_libdir}/%{pkgname}/plugins/libback-bdb.so
 %endif
 

--- a/rpm/bundle-libdb.spec
+++ b/rpm/bundle-libdb.spec
@@ -1,0 +1,602 @@
+# This must remain enabled even for RHEL/ELN until all libdb dependencies
+# are dropped, then this should be Fedora-only
+%bcond_without subpackages
+
+%define __soversion_major 5
+%define __soversion %{__soversion_major}.3-389ds
+
+# The SQLite configure script does not support --runstatedir and is not
+# regenerated.
+%undefine _configure_use_runstatedir
+
+Summary: The Berkeley DB database library for C
+Name: libdb
+Version: 5.3.28
+Release: 59%{?dist}
+Source0: http://download.oracle.com/berkeley-db/db-%{version}.tar.gz
+Source1: http://download.oracle.com/berkeley-db/db.1.85.tar.gz
+# For mt19937db.c
+Source2: http://www.gnu.org/licenses/lgpl-2.1.txt
+# libdb man pages generated from the 5.3.28 documentation
+Source3: libdb-5.3.28-manpages.tar.gz
+Patch0: libdb-multiarch.patch
+# db-1.85 upstream patches
+Patch10: http://www.oracle.com/technology/products/berkeley-db/db/update/1.85/patch.1.1
+Patch11: http://www.oracle.com/technology/products/berkeley-db/db/update/1.85/patch.1.2
+Patch12: http://www.oracle.com/technology/products/berkeley-db/db/update/1.85/patch.1.3
+Patch13: http://www.oracle.com/technology/products/berkeley-db/db/update/1.85/patch.1.4
+# other patches
+Patch20: db-1.85-errno.patch
+Patch22: db-4.6.21-1.85-compat.patch
+Patch24: db-4.5.20-jni-include-dir.patch
+# License clarification patch
+# http://devel.trisquel.info/gitweb/?p=package-helpers.git;a=blob;f=helpers/DATA/db4.8/007-mt19937db.c_license.patch;h=1036db4d337ce4c60984380b89afcaa63b2ef88f;hb=df48d40d3544088338759e8bea2e7f832a564d48
+Patch25: 007-mt19937db.c_license.patch
+# memp_stat fix provided by upstream (rhbz#1211871)
+Patch27: db-5.3.21-memp_stat-upstream-fix.patch
+# fix for mutexes not being released provided by upstream (rhbz#1277887)
+Patch28: db-5.3.21-mutex_leak.patch
+# fix for overflowing hash variable inside bundled lemon
+Patch29: db-5.3.28-lemon_hash.patch
+# upstream patch adding the ability to recreate libdb's environment on version mismatch
+# or when libpthread.so is modified (rhbz#1394862)
+Patch30: db-5.3.28-condition_variable.patch
+# additional changes to the upstream patch to address rhbz#1460003
+Patch31: db-5.3.28-condition-variable-ppc.patch
+# downstream patch that adds a check for rpm transaction lock in order to be able to update libdb
+# FIXME: remove when able
+Patch32: db-5.3.28-rpm-lock-check.patch
+# downstream patch to hotfix rhbz#1464033, sent upstream
+Patch33: db-5.3.28-cwd-db_config.patch
+Patch34: libdb-5.3.21-region-size-check.patch
+# Patch sent upstream
+Patch35: checkpoint-opd-deadlock.patch
+Patch36: db-5.3.28-atomic_compare_exchange.patch
+# CDB race (rhbz #1099509)
+Patch37: libdb-cbd-race.patch
+# Limit concurrency to max 1024 CPUs (rhbz#1245410)
+# A fix for the issue should be in an upstream release already
+# https://community.oracle.com/message/13274780#13274780
+Patch38: libdb-limit-cpu.patch
+# rhbz#1608749 Patch sent upstream
+# Expects libdb-5.3.21-mutex_leak.patch applied
+Patch39: libdb-5.3.21-trickle_cpu.patch
+# cve-2019-2708 fixed by mmuzila
+Patch40: db-5.3.28_cve-2019-2708.patch
+# Prevents high CPU usage
+Patch41: db-5.3.28-mmap-high-cpu-usage.patch
+
+Patch42: libdb-1.85-c99.patch
+Patch43: libdb-c99.patch
+Patch44: libdb-configure-c99.patch
+Patch45: libdb-sqlite-c99.patch
+
+URL: http://www.oracle.com/database/berkeley-db/
+License: BSD-3-Clause AND LGPL-2.1-only AND Sleepycat
+BuildRequires: gcc gcc-c++
+BuildRequires: perl-interpreter libtool
+# BuildRequires: chrpath
+BuildRequires: zlib-devel
+Conflicts: filesystem < 3
+
+# libdb was marked as deprecated in F33:
+# https://fedoraproject.org/wiki/Changes/Libdb_deprecated
+Provides:  deprecated()
+
+%description
+The Berkeley Database (Berkeley DB) is a programmatic toolkit that
+provides embedded database support for both traditional and
+client/server applications. The Berkeley DB includes B+tree, Extended
+Linear Hashing, Fixed and Variable-length record access methods,
+transactions, locking, logging, shared memory caching, and database
+recovery. The Berkeley DB supports C, C++, and Perl APIs. It is
+used by many applications, including Python and Perl, so this should
+be installed on all systems.
+
+%package utils
+Summary: Command line tools for managing Berkeley DB databases
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+Provides:  deprecated()
+
+%description utils
+The Berkeley Database (Berkeley DB) is a programmatic toolkit that
+provides embedded database support for both traditional and
+client/server applications. Berkeley DB includes B+tree, Extended
+Linear Hashing, Fixed and Variable-length record access methods,
+transactions, locking, logging, shared memory caching, and database
+recovery. DB supports C, C++ and Perl APIs.
+
+%package devel
+Summary: C development files for the Berkeley DB library
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+Provides:  deprecated()
+
+%description devel
+The Berkeley Database (Berkeley DB) is a programmatic toolkit that
+provides embedded database support for both traditional and
+client/server applications. This package contains the header files,
+libraries, and documentation for building programs which use the
+Berkeley DB.
+
+%package devel-doc
+Summary: C development documentation files for the Berkeley DB library
+Requires: %{name} = %{version}-%{release}
+Requires: %{name}-devel = %{version}-%{release}
+BuildArch: noarch
+
+Provides:  deprecated()
+
+%description devel-doc
+The Berkeley Database (Berkeley DB) is a programmatic toolkit that
+provides embedded database support for both traditional and
+client/server applications. This package contains the header files,
+libraries, and documentation for building programs which use the
+Berkeley DB.
+
+%package devel-static
+Summary: Berkeley DB static libraries
+Requires: %{name}-devel%{?_isa} = %{version}-%{release}
+
+Provides:  deprecated()
+
+%description devel-static
+The Berkeley Database (Berkeley DB) is a programmatic toolkit that
+provides embedded database support for both traditional and
+client/server applications. This package contains static libraries
+needed for applications that require static linking of
+Berkeley DB.
+
+%prep
+%setup -q -n db-%{version} -a 1
+cp %{SOURCE2} .
+tar -xf %{SOURCE3}
+
+
+%patch0 -p1
+pushd db.1.85/PORT/linux
+%patch10 -p0
+popd
+pushd db.1.85
+%patch11 -p0
+%patch12 -p0
+%patch13 -p0
+%patch20 -p1
+popd
+
+%patch22 -p1
+%patch24 -p1
+%patch25 -p1
+%patch27 -p1
+%patch28 -p1
+%patch29 -p1
+%patch30 -p1
+%patch31 -p1
+%patch32 -p1
+%patch33 -p1
+%patch34 -p1
+%patch35 -p1
+%patch36 -p1
+%patch37 -p1
+%patch38 -p1
+%patch39 -p1
+%patch40 -p1 -b .cve-2019-2708
+%patch41 -p1
+%patch42 -p1
+%patch43 -p1
+%patch44 -p1
+%patch45 -p1
+
+cd dist
+./s_config
+cd ..
+
+%build
+CFLAGS="$RPM_OPT_FLAGS -fno-strict-aliasing"
+CFLAGS="$CFLAGS -DSHAREDSTATEDIR='\"%{_sharedstatedir}\"' -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_ENABLE_FTS3=3 -DSQLITE_ENABLE_RTREE=1 -DSQLITE_SECURE_DELETE=1 -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 -I../../../lang/sql/sqlite/ext/fts3/"
+export CFLAGS
+
+# Build the old db-185 libraries.
+make -C db.1.85/PORT/%{_os} OORG="$CFLAGS"
+
+test -d dist/dist-tls || mkdir dist/dist-tls
+# Static link db_dump185 with old db-185 libraries.
+/bin/sh libtool --tag=CC --mode=compile	%{__cc} $RPM_OPT_FLAGS -Idb.1.85/PORT/%{_os}/include -D_REENTRANT -c util/db_dump185.c -o dist/dist-tls/db_dump185.lo
+/bin/sh libtool --tag=LD --mode=link %{__cc} -o dist/dist-tls/db_dump185 dist/dist-tls/db_dump185.lo db.1.85/PORT/%{_os}/libdb.a
+
+# Update config files to understand aarch64
+for dir in dist lang/sql/sqlite lang/sql/jdbc lang/sql/odbc; do
+  cp /usr/lib/rpm/redhat/config.{guess,sub} "$dir"
+done
+
+pushd dist/dist-tls
+
+# Rename the library for 389ds
+perl -pi -e 's/^LIBVERSION=.*$/LIBVERSION=5.3-389ds/' ../Makefile.in
+
+%define _configure ../configure
+%configure -C \
+	--enable-shared --enable-static \
+	--disable-rpath
+
+# Remove libtool predep_objects and postdep_objects wonkiness so that
+# building without -nostdlib doesn't include them twice.  Because we
+# already link with g++, weird stuff happens if you don't let the
+# compiler handle this.
+perl -pi -e 's/^predep_objects=".*$/predep_objects=""/' libtool
+perl -pi -e 's/^postdep_objects=".*$/postdep_objects=""/' libtool
+perl -pi -e 's/-shared -nostdlib/-shared/' libtool
+
+%make_build
+
+popd
+
+
+%install
+%if %{with subpackages}
+rm -rf ${RPM_BUILD_ROOT}
+mkdir -p ${RPM_BUILD_ROOT}%{_includedir}
+mkdir -p ${RPM_BUILD_ROOT}%{_libdir}
+mkdir -p ${RPM_BUILD_ROOT}%{_mandir}/man1
+%make_install STRIP=/bin/true -C dist/dist-tls
+
+# XXX Nuke non-versioned archives and symlinks
+rm -f ${RPM_BUILD_ROOT}%{_libdir}/{libdb.a,libdb_cxx.a,libdb_tcl.a,libdb_sql.a}
+
+chmod +x ${RPM_BUILD_ROOT}%{_libdir}/*.so*
+
+# Move the header files to a subdirectory, in case we're deploying on a
+# system with multiple versions of DB installed.
+mkdir -p ${RPM_BUILD_ROOT}%{_includedir}/%{name}
+mv ${RPM_BUILD_ROOT}%{_includedir}/*.h ${RPM_BUILD_ROOT}%{_includedir}/%{name}/
+
+# Create symlinks to includes so that "use <db.h> and link with -ldb" works.
+for i in db.h db_cxx.h db_185.h; do
+	ln -s %{name}/$i ${RPM_BUILD_ROOT}%{_includedir}
+done
+
+# Eliminate installed doco
+rm -rf ${RPM_BUILD_ROOT}%{_prefix}/docs
+
+# XXX Avoid Permission denied. strip when building as non-root.
+chmod u+w ${RPM_BUILD_ROOT}%{_bindir} ${RPM_BUILD_ROOT}%{_bindir}/*
+
+# remove unneeded .la files (#225675)
+rm -f ${RPM_BUILD_ROOT}%{_libdir}/*.la
+
+# remove RPATHs
+# chrpath -d ${RPM_BUILD_ROOT}%{_libdir}/*.so ${RPM_BUILD_ROOT}%{_bindir}/*
+
+# unify documentation and examples, remove stuff we don't need
+rm -rf docs/csharp
+rm -rf examples/csharp
+rm -rf docs/installation
+mv examples docs
+mv man/* ${RPM_BUILD_ROOT}%{_mandir}/man1
+
+%ldconfig_scriptlets
+%else
+mkdir -p %{buildroot}%{_bindir}
+%endif
+
+%files
+%license LICENSE lgpl-2.1.txt
+%doc README
+%{_libdir}/libdb-%{__soversion}.so
+
+%changelog
+* Fri Feb 02 2024 Pierre Rogier <progier@redhad.com> 5.3.28-59 389-ds
+- Customize spec file for 389-ds specific use
+
+* Fri Jan 05 2024 Florian Weimer <fweimer@redhat.com> - 5.3.28-59
+- Additional C compatibility fixes (#2152303)
+
+* Fri Sep 08 2023 Yaakov Selkowitz <yselkowi@redhat.com> - 5.3.28-58
+- Re-enable subpackages in RHEL builds
+
+* Tue Aug 29 2023 Filip Janus <fjanus@redhat.com> - 5.3.25-57
+- Add convert-util subpackage
+- It allowes to convert BerkeleyDB database format to GDBM/LMDB format
+- Disable shiping libdb for rhel except convert-tool
+
+* Thu Jul 20 2023 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-56
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_39_Mass_Rebuild
+
+* Thu Jan 19 2023 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-55
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_38_Mass_Rebuild
+
+* Sat Dec 10 2022 Florian Weimer <fweimer@redhat.com> - 5.3.28-54
+- Various changes to improve C99 compatibility (#2152303)
+
+* Thu Jul 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-53
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
+
+* Wed Mar 02 2022 Filip Janus <fjanus@redhat.com> - 5.3.28-52
+- Marked package as deprecated
+
+* Thu Jan 20 2022 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-51
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
+
+* Thu Sep 16 2021 Filip Januš <fjanus@redhat.com> - 5.3.29-50
+- Fix mistake in patch 41
+
+* Wed Sep 15 2021 Filip Januš <fjanus@redhat.com> - 5.3.28-49
+- Improve previous (patch 41) to cover more cases
+
+* Mon Sep 13 2021 Filip Januš <fjanus@redhat.com> - 5.3.28-48
+- Bad order of sys calls cause high CPU usage
+- Related: #1992402
+- Patch no. 41 was added
+
+* Thu Jul 22 2021 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-47
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
+
+* Tue Jan 26 2021 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-46
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
+
+* Wed Dec 02 2020 Matej Mužila <mmuzila@redhat.com> 5.3.28-45
+- Resolves: CVE-2019-2708 (#1853243)
+
+* Tue Jul 28 2020 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-44
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
+* Tue Jul 21 2020 Tom Stellard <tstellar@redhat.com> - 5.3.28-43
+- Use make macros
+- https://fedoraproject.org/wiki/Changes/UseMakeBuildInstallMacro
+
+* Tue Jul 14 2020 Ondrej Dubaj <odubaj@redhat.com> - 5.3.28-42
+- Remove java subpackage due to jdk-11 (#1846398)
+
+* Sat Jul 11 2020 Jiri Vanek <jvanek@redhat.com> - 5.3.28-41
+- Rebuilt for JDK-11, see https://fedoraproject.org/wiki/Changes/Java11
+
+* Wed Jan 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-40
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Aug 22 2019 Petr Kubat <pkubat@redhat.com> 5.3.28-39
+- Set correct tcl-devel version for BuildRequires (#1712532)
+
+* Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-38
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-37
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Wed Jan 30 2019 Petr Kubat <pkubat@redhat.com> 5.3.28-36
+- Optimize trickle thread CPU usage (#1608749)
+
+* Wed Jan 16 2019 Petr Kubat <pkubat@redhat.com> - 5.3.28-35
+- Add patch to workaround issues on large systems (>1024 CPU)
+  Resolves: #1245410
+
+* Wed Sep 05 2018 Petr Kubat <pkubat@redhat.com> - 5.3.28-34
+- Add patch for CDB race issue (#1099509)
+
+* Tue Jul 24 2018 Petr Kubat <pkubat@redhat.com> - 5.3.28-33
+- Add BuildRequires for gcc and gcc-c++ (#1604566)
+
+* Fri Jul 13 2018 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-32
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Wed May 23 2018 Petr Kubat <pkubat@redhat.com> - 5.3.28-31
+- Rename __atomic_compare_exchange to not clash with gcc built-in
+
+* Wed Feb 07 2018 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-30
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Tue Oct 31 2017 Petr Kubat <pkubat@redhat.com> 5.3.28-29
+- Fix deadlocks when reading/writing off-page duplicate tree (#1349779)
+
+* Tue Oct 24 2017 Petr Kubat <pkubat@redhat.com> 5.3.28-28
+- Run a number of quick subsystem checks on build
+
+* Thu Sep 07 2017 Petr Kubat <pkubat@redhat.com> 5.3.28-27
+- Fail properly when encountering removed or 0-byte regions (#1471011)
+
+* Thu Aug 03 2017 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-26
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Binutils_Mass_Rebuild
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-25
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Mon Jun 26 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-24
+- Fix some defects found by covscan
+
+* Mon Jun 26 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-23
+- Try looking at env lock via /proc/locks during env_attach (#1460003)
+- Check rpm's transaction lock via /proc/locks
+- Do not access DB_CONFIG when db_home is not set (#1464033)
+
+* Tue Jun 13 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-23
+- Reintroduce patches removed in 5.3.28-22
+- Modify upstream patch to fail on pthread version mismatch (#1460003)
+
+* Fri Jun 09 2017 Adam Williamson <awilliam@redhat.com> - 5.3.28-22
+- Drop rhbz#1394862 patches again, DB corruption still being reported
+
+* Thu Jun 01 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-21
+- Reintroduce upstream patch for rhbz#1394862
+- Do not rebuild rpm's environment during a rpm transaction
+
+* Fri May 26 2017 Adam Williamson <awilliam@redhat.com> - 5.3.28-20
+- Drop rhbz#1394862 patch for now, it has serious issues
+
+* Wed May 24 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-19
+- Fix some issues present in the upstream patch for rhbz#1394862
+
+* Tue May 23 2017 Adam Williamson <awilliam@redhat.com> - 5.3.28-18
+- Fix issue causing RPM to hang when glibc/libpthread change (#1394862)
+
+* Wed Feb 22 2017 Petr Kubat <pkubat@redhat.com> - 5.3.28-17
+- Fix overflowing integer in bundled-in lemon.c (#1423842)
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-17
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Thu Dec 08 2016 Petr Kubat <pkubat@redhat.com> 5.3.28-16
+- Add man pages for libdb-utils
+
+* Mon Nov 14 2016 Petr Kubat <pkubat@redhat.com> 5.3.28-15
+- Fix mutexes not being released properly (#1272680)
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 5.3.28-14
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.28-13
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Tue May 19 2015 Jan Stanek <jstanek@redhat.com> - 5.3.28-12
+- Add upstream patch for a memp_stat issue.
+- Resolves: rhbz#1211871
+
+* Sat May 02 2015 Kalev Lember <kalevlember@gmail.com> - 5.3.28-11
+- Rebuilt for GCC 5 C++11 ABI change
+
+* Sat Feb 21 2015 Till Maas <opensource@till.name> - 5.3.28-10
+- Rebuilt for Fedora 23 Change
+  https://fedoraproject.org/wiki/Changes/Harden_all_packages_with_position-independent_code
+
+* Sun Aug 17 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.28-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Thu Jul 17 2014 Tom Callaway <spot@fedoraproject.org> - 5.3.28-8
+- fix license handling
+
+* Mon Jul 14 2014 Jakub Čajka <jcajka@redhat.com> - 5.3.28-7
+- Fixed build with Java 8
+
+* Tue Jun 10 2014 Jan Stanek <jstanek@redhat.com> - 5.3.28-6
+- Fixed search path for new tcl, new BuildRequires for zlib
+
+* Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.28-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Sat Feb 22 2014 Peter Robinson <pbrobinson@fedoraproject.org> 5.3.28-4
+- Add some of the previous aarch64 bits back as the sub configure don't use the macro
+
+* Sun Jan 26 2014 Peter Robinson <pbrobinson@fedoraproject.org> 5.3.28-3
+- Fix configure macro usage for better aarch64 build fix
+
+* Wed Nov 06 2013 Jan Stanek <jstanek@redhat.com> - 5.3.28-2
+- Updated config files to allow build on aarch64 (#1022970)
+
+* Tue Oct 08 2013 Jan Stanek <jstanek@redhat.com> - 5.3.28-1
+- Added Sleepycat to the license list (#1013841)
+- Updated to 5.3.28 (#1013233)
+
+* Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.21-13
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Tue May 28 2013 Tom Callaway <spot@fedoraproject.org> - 5.3.21-12
+- add copy of lgpl-2.1.txt
+
+* Thu May 16 2013 Jan Stanek <jstanek@redhat.com> - 5.3.21-11
+- Fix missing debuginfo issue for utils subpackage
+
+* Thu May  9 2013 Tom Callaway <spot@fedoraproject.org> - 5.3.21-10
+- add license clarification fix
+
+* Wed Apr 03 2013 Jan Stanek <jstanek@redhat.com> 5.3.21-9
+- Added sqlite compability CFLAGS (#788496)
+
+* Wed Mar 27 2013 Jan Stanek <jstanek@redhat.com> 5.3.21-8
+- Cleaning the specfile - removed gcc-java dependecy other way
+
+* Wed Mar 27 2013 Jan Stanek <jstanek@redhat.com> 5.3.21-7
+- Removed dependency on obsolete gcc-java package (#927742)
+
+* Thu Mar  7 2013 Jindrich Novy <jnovy@redhat.com> 5.3.21-6
+- add LGPLv2+ and remove Sleepycat in license tag (#886838)
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.21-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Tue Nov 27 2012 Tom Callaway <spot@fedoraproject.org> - 5.3.21-4
+- fix license tag
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.3.21-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Sat Jul 14 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 5.3.21-2
+- Specify tag for libtool (fixes FTBFS # 838334 )
+
+* Thu Jul  5 2012 Jindrich Novy <jnovy@redhat.com> 5.3.21-1
+- update to 5.3.21
+http://download.oracle.com/otndocs/products/berkeleydb/html/changelog_5_3.html
+
+* Tue Jul  3 2012 Jindrich Novy <jnovy@redhat.com> 5.3.15-5
+- move C++ header files to cxx-devel
+
+* Tue Jul  3 2012 Jindrich Novy <jnovy@redhat.com> 5.3.15-4
+- fix -devel packages dependencies yet more (#832225)
+
+* Sun May  6 2012 Jindrich Novy <jnovy@redhat.com> 5.3.15-3
+- package -devel packages correctly
+
+* Sat Apr 21 2012 Jindrich Novy <jnovy@redhat.com> 5.3.15-2
+- fix multiarch conflict in libdb-devel (#812901)
+- remove unneeded dos2unix BR
+
+* Thu Mar 15 2012 Jindrich Novy <jnovy@redhat.com> 5.3.15-1
+- update to 5.3.15
+  http://download.oracle.com/otndocs/products/berkeleydb/html/changelog_5_3.html
+
+* Fri Feb 17 2012 Deepak Bhole <dbhole@redhat.com> 5.2.36-5
+- Resolves rhbz#794472
+- Patch from Omair Majid <omajid@redhat.com> to remove explicit Java 6 req.
+
+* Wed Jan 25 2012 Harald Hoyer <harald@redhat.com> 5.2.36-4
+- add filesystem guard
+
+* Wed Jan 25 2012 Harald Hoyer <harald@redhat.com> 5.2.36-3
+- install everything in /usr
+  https://fedoraproject.org/wiki/Features/UsrMove
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.2.36-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Wed Jun 15 2011 Jindrich Novy <jnovy@redhat.com> 5.2.36-1
+- update to 5.2.36,
+  http://download.oracle.com/otndocs/products/berkeleydb/html/changelog_5_2.html#id3647664
+
+* Wed Jun 15 2011 Jindrich Novy <jnovy@redhat.com> 5.2.28-2
+- move development documentation to devel-doc subpackage (#705386)
+
+* Tue Jun 14 2011 Jindrich Novy <jnovy@redhat.com> 5.2.28-1
+- update to 5.2.28
+
+* Mon Feb 07 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 5.1.25-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Thu Feb  3 2011 Jindrich Novy <jnovy@redhat.com> 5.1.25-1
+- update to 5.1.25
+
+* Wed Sep 29 2010 jkeating - 5.1.19-2
+- Rebuilt for gcc bug 634757
+
+* Fri Sep 10 2010 Jindrich Novy <jnovy@redhat.com> 5.1.19-1
+- update to 5.1.19
+- rename -devel-static to -static subpackage (#617800)
+- build java on all arches
+
+* Wed Jul  7 2010 Jindrich Novy <jnovy@redhat.com> 5.0.26-1
+- update to 5.0.26
+- drop BR: ed
+
+* Thu Jun 17 2010 Jindrich Novy <jnovy@redhat.com> 5.0.21-2
+- add Requires: libdb-cxx to libdb-devel
+
+* Wed Apr 21 2010 Jindrich Novy <jnovy@redhat.com> 5.0.21-1
+- initial build
+
+* Thu Apr 15 2010 Jindrich Novy <jnovy@redhat.com> 5.0.21-0.2
+- remove C# documentation
+- disable/remove rpath
+- fix description
+- tighten dependencies
+- run ldconfig for cxx and sql subpackages
+
+* Fri Apr  9 2010 Jindrich Novy <jnovy@redhat.com> 5.0.21-0.1
+- enable sql
+- package 5.0.21


### PR DESCRIPTION
libdb is deprecated and may not be available in future os, the idea is to remove any explicit dependency towards this library:

1. Add a new configure option --with-bundle-libdb=path_to_libdb_include_and_libs
2. Modify rpm.mk to upload the libdb src rpm and extract it
3. Provide a spec file to rebuild custom version of libdb without needing  external dependencies like tcl mySql gdbm
4. Modify 389-ds-spec to:
        remove prerequisite towards libdb.
        Build a new 389-ds-base-bdb package (flagged as deprecated) that includes libback-bdb.so plugin and 
        Bundle a custom version of libdb named libdb-5.3-389ds.so built from libdb source rpm  libdb-5.3-389ds.so
5. Modify Makefile to build a new libback-bdb.so plugin if --with-bundle-libdb has been used.
     (Move the db-bdb code out of libback-ldbm.so into a new libback-bdb.so plugin)
6. Remove DB_File dependency in logconv.pl
7. Load dynamically the plugin libback-bdb.so if using bdb and if bdb_init is not present (in libback-ldbm.so) ( to support builds without bundled libdb) and shout loudly if the module is not available

Issue: #6082

Reviewed by: @vashirov (Thanks!)