### PR TITLE
Issue 6073 - Improve error log when running out of memory

### DIFF
--- a/ldap/servers/slapd/ch_malloc.c
+++ b/ldap/servers/slapd/ch_malloc.c
@@ -22,6 +22,7 @@
 #include "slap.h"
 
 #define OOM_PREALLOC_SIZE 65536
+#define BACKTRACE_THRESHOLD (1LU<<20)
 static void *oom_emergency_area = NULL;
 static PRLock *oom_emergency_lock = NULL;
 
@@ -33,8 +34,10 @@ static const char *const oom_advice =
     "one or more of the following server configuration settings:\n"
     "  nsslapd-cachesize        (Database Settings - Maximum entries in cache)\n"
     "  nsslapd-cachememsize     (Database Settings - Memory available for cache)\n"
-    "  nsslapd-dbcachesize      (LDBM Plug-in Settings - Maximum cache size)\n"
-    "  nsslapd-import-cachesize (LDBM Plug-in Settings - Import cache size).\n"
+    "  nsslapd-cachememsize     (Database Settings - Memory available for cache)\n"
+    "  nsslapd-dbcachesize      (LDBM Plug-in Settings (if bdb) - Maximum cache size)\n"
+    "  nsslapd-import-cachesize (LDBM Plug-in Settings (if bdb) - Import cache size)\n"
+    "  nsslapd-mdb-max-size     (LDBM Plug-in Settings (if mdb) - Maximum database sizee).\n"
     "Can't recover; calling exit(1).\n";
 
 static void
@@ -79,6 +82,15 @@ log_negative_alloc_msg(const char *op, const char *units, unsigned long size)
                   "trying to allocate 0 or a negative number of %s is not portable and\n"
                   "gives different results on different platforms.\n",
                   op, size, units, units);
+    slapi_log_backtrace(SLAPI_LOG_ERR);
+}
+
+static void
+oom_log_backtrace(unsigned long size)
+{
+    if (size > BACKTRACE_THRESHOLD) {
+        slapi_log_backtrace(SLAPI_LOG_ERR);
+    }
 }
 
 char *
@@ -99,6 +111,7 @@ slapi_ch_malloc(
         slapi_log_err(SLAPI_LOG_ERR, SLAPD_MODULE,
                       "malloc of %lu bytes failed; OS error %d (%s)%s\n",
                       size, oserr, slapd_system_strerror(oserr), oom_advice);
+        oom_log_backtrace(size);
         exit(1);
     }
     /* So long as this happens once, we are happy, put it in ch_malloc. */
@@ -120,6 +133,7 @@ slapi_ch_memalign(uint32_t size, uint32_t alignment)
         slapi_log_err(SLAPI_LOG_ERR, SLAPD_MODULE,
                       "malloc of %" PRIu32 " bytes failed; OS error %d (%s)%s\n",
                       size, oserr, slapd_system_strerror(oserr), oom_advice);
+        oom_log_backtrace(size);
         exit(1);
     }
 
@@ -149,6 +163,7 @@ slapi_ch_realloc(
         slapi_log_err(SLAPI_LOG_ERR, SLAPD_MODULE,
                       "realloc of %lu bytes failed; OS error %d (%s)%s\n",
                       size, oserr, slapd_system_strerror(oserr), oom_advice);
+        oom_log_backtrace(size);
         exit(1);
     }
 
@@ -179,6 +194,7 @@ slapi_ch_calloc(
         slapi_log_err(SLAPI_LOG_ERR, SLAPD_MODULE,
                       "calloc of %lu elems of %lu bytes failed; OS error %d (%s)%s\n",
                       nelem, size, oserr, slapd_system_strerror(oserr), oom_advice);
+        oom_log_backtrace(nelem*size);
         exit(1);
     }
 
@@ -219,6 +235,7 @@ slapi_ch_bvdup(const struct berval *v)
                       "ber_bvdup of %lu bytes failed; OS error %d (%s)%s\n",
                       (unsigned long)v->bv_len, oserr, slapd_system_strerror(oserr),
                       oom_advice);
+        oom_log_backtrace((unsigned long)v->bv_len);
         exit(1);
     }
     return newberval;

--- a/ldap/servers/slapd/ch_malloc.c
+++ b/ldap/servers/slapd/ch_malloc.c
@@ -34,10 +34,9 @@ static const char *const oom_advice =
     "one or more of the following server configuration settings:\n"
     "  nsslapd-cachesize        (Database Settings - Maximum entries in cache)\n"
     "  nsslapd-cachememsize     (Database Settings - Memory available for cache)\n"
-    "  nsslapd-cachememsize     (Database Settings - Memory available for cache)\n"
     "  nsslapd-dbcachesize      (LDBM Plug-in Settings (if bdb) - Maximum cache size)\n"
     "  nsslapd-import-cachesize (LDBM Plug-in Settings (if bdb) - Import cache size)\n"
-    "  nsslapd-mdb-max-size     (LDBM Plug-in Settings (if mdb) - Maximum database sizee).\n"
+    "  nsslapd-mdb-max-size     (LDBM Plug-in Settings (if mdb) - Maximum database size).\n"
     "Can't recover; calling exit(1).\n";
 
 static void


### PR DESCRIPTION
Log the stack backtrace when a calloc/malloc/realloc fails and requested memory size is larger than 1Mb
Also adapt the advices to lmdb (some of the tuning mentioned in the error message are now irrelevant)

Issue #6073 

Reviewed by: @tbordaz, @droideck (Thanks!)