### PR TITLE
Rearrange includes for 32-bit support logic

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -7,12 +7,12 @@
  * END COPYRIGHT BLOCK **/
 
 
-#include <sys/types.h>
-#include <sys/statvfs.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
 #include "bdb_layer.h"
+#include <sys/types.h>
+#include <sys/statvfs.h>
 #include <prthread.h>
 #include <prclist.h>
 #include <glob.h>
@@ -7198,7 +7198,7 @@ bdb_dblayer_cursor_iterate(dbi_cursor_t *cursor, dbi_iterate_cb_t *action_cb,
     dbi_val_t key = {0};
     dbi_val_t data = {0};
     int rc = 0;
-    
+
     if (bdb_cur == NULL) {
         return  DBI_RC_INVALID;
     }

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -74,6 +74,7 @@ static char ptokPBE[34] = "Internal (Software) Token        ";
 #include <cert.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 


### PR DESCRIPTION
The logic to support 32-bit architectures was correctly written (define _LARGEFILE64_SOURCE) but placed too "late". If a standard library header (e.g., <stdio.h>) is included before _LARGEFILE64_SOURCE is defined, then the correct symbols will not be made available during compliation. In this instance, armhf builds were failing due to off64_t not getting defined correctly.
The inclusion of <sys/statvfs.h> in slap.h is required to prevent a cryptic compliation error on "#define f_type f_un.f_un_type". The following bug is possibly related:
https://github.com/389ds/389-ds-base/issues/5962