### PR TITLE
Issue 6057 - vlv search may result wrong result with lmdb

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -1396,11 +1396,7 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     dbmdb_delete_instance_dir(be);
     /* it's okay to fail -- it might already be gone */
 
-    /* vlv_init should be called before dbmdb_instance_start
-     * so the vlv dbi get created
-     */
-    vlv_init(job->inst);
-    /* dbmdb_instance_start will init the id2entry index. */
+    /* dbmdb_instance_start will init the id2entry index and the vlv search list. */
     /* it also (finally) fills in inst_dir_name */
     ret = dbmdb_instance_start(be, DBLAYER_IMPORT_MODE);
     if (ret != 0)

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
@@ -144,6 +144,7 @@ struct importctx {
     ImportWorkerInfo writer;
     ImportWorkerGlobalContext_t wgc;
     char **indexAttrs;  /* reindex index to rebuild */
+    char **indexVlvs;  /* reindex vlv index to rebuild */
     ID idsuffix;
     ID idruv;
     int dupdn;
@@ -177,3 +178,5 @@ void dbmdb_free_worker_slot(struct importqueue *q, void *slot);
 int dbmdb_import_init_writer(ImportJob *job, ImportRole_t role);
 void dbmdb_free_import_ctx(ImportJob *job);
 void dbmdb_build_import_index_list(ImportCtx_t *ctx);
+
+int is_reindexed_attr(const char *attrname, const ImportCtx_t *ctx, char **list);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -914,7 +914,7 @@ dbmdb_import_entry_info_by_param(EntryInfoParam_t *param, WorkerQueueData_t *wqe
         size_t dnlen = 0;
         if (param->flags & EIP_RDN) {
             /* In reindex case, dn must be rebuilt to be able to scope properly the vlv index */
-            dnlen = rdnlen + 1 + pinfo[4];  /* dn len (including final \0) */
+            dnlen = rdnlen + 1 + pinfo[INFO_IDX_DN_LEN];  /* dn len (including final \0) */
         }
 
         len = rdnlen + strlen(nrdn) + 2 + dnlen + (INFO_IDX_ANCESTORS + 1 + pinfo[INFO_IDX_NB_ANCESTORS]) * sizeof(ID);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2110,7 +2110,7 @@ void *dbmdb_recno_cache_build(void *arg)
         }
     }
     while (rc == 0) {
-        slapi_log_err(SLAPI_LOG_INFO, "dbmdb_recno_cache_build", "recno=%d\n", recno);
+        slapi_log_err(SLAPI_LOG_DEBUG, "dbmdb_recno_cache_build", "recno=%d\n", recno);
         if (recno % RECNO_CACHE_INTERVAL != 1) {
             recno++;
             rc = MDB_CURSOR_GET(txn_ctx.cursor, &key, &data, MDB_NEXT);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
@@ -242,11 +242,7 @@ dbmdb_ldif2db(Slapi_PBlock *pb)
     dbmdb_delete_instance_dir(inst->inst_be);
     /* it's okay to fail -- the directory might have already been deleted */
 
-    /* vlv_init should be called before dbmdb_instance_start
-     * so the vlv dbi get created
-     */
-    vlv_init(inst);
-    /* dbmdb_instance_start will init the id2entry index. */
+    /* dbmdb_instance_start will init the id2entry index and the vlv search list. */
     /* it also (finally) fills in inst_dir_name */
     ret = dbmdb_instance_start(inst->inst_be, DBLAYER_IMPORT_MODE);
     if (ret != 0) {
@@ -1259,11 +1255,7 @@ dbmdb_db2index(Slapi_PBlock *pb)
             return -1;
         }
 
-        /* vlv_init should be called before dbmdb_instance_start
-         * so the vlv dbi get created by dbmdb_instance_start
-         */
-        vlv_init(inst);
-        /* dblayer_instance_start will init the id2entry index. */
+        /* dblayer_instance_start will init the id2entry index and the vlv search list. */
         if (0 != dblayer_instance_start(be, DBLAYER_INDEX_MODE)) {
             slapi_task_log_notice(task, "Failed to start instance: %s", instance_name);
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_db2index", "db2ldif: Failed to start instance\n");
@@ -1834,14 +1826,7 @@ dbmdb_upgradednformat(Slapi_PBlock *pb)
         }
     }
 
-    if (run_from_cmdline) {
-        /* vlv_init should be called before dbmdb_instance_start
-         * so the vlv dbi get created
-         */
-        vlv_init(inst);
-    }
-
-    /* dbmdb_instance_start will init the id2entry index. */
+    /* dbmdb_instance_start will init the id2entry index and the vlv search list. */
     be = inst->inst_be;
     if (0 != dbmdb_instance_start(be, DBLAYER_IMPORT_MODE)) {
         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_upgradednformat",


### PR DESCRIPTION
Different issue related to vlv index and import/bulk import:

1.   vlv sub database was not open when the backend was started 
2.   vlv index was not cleaned by import/bulk import
3.   vlv index was not rebuilt by import/bulk import
4.   vlv index not rebuilt by explicit vlv reindex.
5.   vlv index not rebuilt by explicit vlv reindex if vlv name contains hyphen.
6. vlv index not rebuilt if basedn is not the suffix. 

 In fact all theses issues had the same cause: the backend vlv search list is empty after the server get restarted.

 Solution:
    [For 1,2 and 3] Fix the test_vlv_cache_subdb_names to ensure that vlv index are properly cleaned 
      and recreated by a bulk import
    Initialize the vlv search list if it is not yet initialized when starting an instance (just before opening 
      all the sub databases associated with the backend) rather than doing it before restarting the instance after the import.
    [For 4] Add a new member for vlv in the import context and handle it properly.
    [For 5] Convert the vlv name as a dbname and store it is a separate list - compare the dbname when checking if vlv is reindexed.
    [for 6] Rebuild the proper entry dn (in case of reindex) to be able to evaluate the vlv scope
             to rebuild the dn I used the entry_info data (stored in a temporary database) that contains the rdn/nrdn/ 
               and ancestors IDs (used to to rebuild the entryrdn index) and now also store the dn which is simply 
                propagated by adding the entry rdn to the parent entry dn.  

Issue: #6057 

Reviewed by: @tbordaz , @droideck  (Thanks!)