### PR TITLE
Issue 6099 - `systemd = False` has no effect

### DIFF
--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -947,8 +947,8 @@ class SetupDs(object):
         # Should I move this import? I think this prevents some recursion
         from lib389 import DirSrv
         ds_instance = DirSrv(self.verbose, containerised=self.containerised)
-        if self.containerised:
-            ds_instance.systemd_override = general['systemd']
+
+        ds_instance.systemd_override = general['systemd']
 
         # By default SUSE does something extremely silly - it creates a hostname
         # that CANT be resolved by DNS. As a result this causes all installs to


### PR DESCRIPTION
Bug Description:
`systemd = False` doesn't override `with_systemd = 1` from `defaults.inf` when used with `dscreate`. It is only effective when setup is running in a containerized environment (via `dscontainer`). But for some special use cases it's important that DS installation runs without systemd.

Fix Description:
Remove the condition for overriding systemd flag.
`systemd` option is not exposed in the default template, it's listed there only when `--advanced` flag is used, so it should not affect regular installations.

Fixes: https://github.com/389ds/389-ds-base/issues/6099