### PR TITLE
Issue 5842 - Add log buffering to audit log

### DIFF
--- a/dirsrvtests/tests/suites/ds_logs/audit_log_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/audit_log_test.py
@@ -6,6 +6,7 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import ldap
 import logging
 import pytest
 import os
@@ -113,7 +114,7 @@ def test_auditlog_bof(topo):
 
     inst.config.replace('nsslapd-auditlog-display-attrs', 'cn')
     users = UserAccounts(inst, DEFAULT_SUFFIX)
-    user = users.ensure_state(properties={
+    users.ensure_state(properties={
         'uid': 'test_auditlog_bof',
         'cn': 'A'*256,
         'sn': 'user',
@@ -124,10 +125,61 @@ def test_auditlog_bof(topo):
     time.sleep(1)
     assert inst.status() == True
 
+def test_auditlog_buffering(topo, request):
+    """Test log buffering works as expected when on or off
+
+    :id: 08f1ccf0-c1fb-4427-9300-24585e336ae7
+    :setup: Standalone Instance
+    :steps:
+        1. Set buffering on
+        2. Make update and immediately check log (update should not be present)
+        3. Make invalid update, failed update should not be in log
+        4. Disable buffering
+        5. Make update and immediately check log (update should be present)
+        6. Make invalid update, both failed updates should be in log
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+
+    # Configure instance
+    inst = topo.standalone
+    inst.config.replace('nsslapd-auditlog-logging-enabled', 'on')
+    inst.config.replace('nsslapd-auditfaillog-logging-enabled', 'on')
+    inst.config.replace('nsslapd-auditlog-logbuffering', 'on')
+    inst.deleteAuditLogs()  # Start with fresh set of logs
+    original_value = inst.config.get_attr_val_utf8('nsslapd-timelimit')
+
+    # Make a good and bad update and check neither are logged
+    inst.config.replace('nsslapd-timelimit', '999')
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        inst.config.replace('no_such_attr', 'blah')
+    time.sleep(1)
+    assert not inst.ds_audit_log.match("nsslapd-timelimit: 999")
+    assert not inst.ds_audit_log.match("result: 53")
+
+    # Make a good and bad update and check both are logged
+    inst.config.replace('nsslapd-auditlog-logbuffering', 'off')
+    inst.config.replace('nsslapd-timelimit', '888')
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        inst.config.replace('no_such_attr', 'nope')
+    time.sleep(1)
+    assert inst.ds_audit_log.match("nsslapd-timelimit: 888")
+    # Both failed updates should be present (easiest way to check log)
+    assert len(inst.ds_audit_log.match("result: 53")) == 2
+
+    # Reset timelimit just to be safe
+    def fin():
+        inst.config.replace('nsslapd-timelimit', original_value)
+    request.addfinalizer(fin)
+
 
 if __name__ == '__main__':
     # Run isolated
     # -s for DEBUG mode
     CURRENT_FILE = os.path.realpath(__file__)
     pytest.main(["-s", CURRENT_FILE])
-

--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -505,7 +505,7 @@ def test_healthcheck_unauth_binds(topology_st):
     inst.config.set("nsslapd-allow-unauthenticated-binds", "off")
 
 def test_healthcheck_accesslog_buffering(topology_st):
-    """Check if HealthCheck returns DSCLE0004 code when acccess log biffering
+    """Check if HealthCheck returns DSCLE0004 code when acccess log buffering
     is disabled
 
     :id: 5a6512fd-1c7b-4557-9278-45150423148b
@@ -537,7 +537,7 @@ def test_healthcheck_accesslog_buffering(topology_st):
     inst.config.set("nsslapd-accesslog-logbuffering", "on")
 
 def test_healthcheck_securitylog_buffering(topology_st):
-    """Check if HealthCheck returns DSCLE0005 code when security log biffering
+    """Check if HealthCheck returns DSCLE0005 code when security log buffering
     is disabled
 
     :id: 9b84287a-e022-4bdc-8c65-2276b37371b5
@@ -567,6 +567,41 @@ def test_healthcheck_securitylog_buffering(topology_st):
     # reset setting
     log.info('Reset nnsslapd-securitylog-logbuffering to on')
     inst.config.set("nsslapd-securitylog-logbuffering", "on")
+
+def test_healthcheck_auditlog_buffering(topology_st):
+    """Check if HealthCheck returns DSCLE0006 code when audit log buffering
+    is disabled
+
+    :id: f030c9f3-0ce7-4156-ba70-81ef3ac82867
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Set nsslapd-auditlog-logbuffering to off
+        3. Use HealthCheck without --json option
+        4. Use HealthCheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Healthcheck reports DSCLE0006
+        4. Healthcheck reports DSCLE0006
+    """
+
+    RET_CODE = 'DSCLE0006'
+
+    inst = topology_st.standalone
+    enabled = inst.config.get_attr_val_utf8('nsslapd-auditlog-logging-enabled')
+
+    log.info('nsslapd-auditlog-logbuffering to off')
+    inst.config.set('nsslapd-auditlog-logging-enabled', 'on')
+    inst.config.set('nsslapd-auditlog-logbuffering', 'off')
+
+    run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
+
+    # reset setting
+    log.info('Reset nnsslapd-auditlog-logbuffering to on')
+    inst.config.set('nsslapd-auditlog-logbuffering', 'on')
+    inst.config.set('nsslapd-auditlog-logging-enabled', enabled)
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -193,6 +193,7 @@ slapi_onoff_t init_securitylogbuffering;
 slapi_onoff_t init_external_libs_debug_enabled;
 slapi_onoff_t init_errorlog_logging_enabled;
 slapi_onoff_t init_auditlog_logging_enabled;
+slapi_onoff_t init_auditlogbuffering;
 slapi_onoff_t init_auditlog_logging_hide_unhashed_pw;
 slapi_onoff_t init_auditfaillog_logging_enabled;
 slapi_onoff_t init_auditfaillog_logging_hide_unhashed_pw;
@@ -832,6 +833,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.accesslogbuffering,
      CONFIG_ON_OFF, NULL, &init_accesslogbuffering, NULL},
+    {CONFIG_AUDITLOG_BUFFERING_ATTRIBUTE, config_set_auditlogbuffering,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.auditlogbuffering,
+     CONFIG_ON_OFF, NULL, &init_auditlogbuffering, NULL},
     {CONFIG_SECURITYLOG_BUFFERING_ATTRIBUTE, config_set_securitylogbuffering,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.securitylogbuffering,
@@ -1922,6 +1927,7 @@ FrontendConfig_init(void)
     cfg->auditlog_exptimeunit = slapi_ch_strdup(SLAPD_INIT_LOG_EXPTIMEUNIT);
     init_auditlog_logging_hide_unhashed_pw =
         cfg->auditlog_logging_hide_unhashed_pw = LDAP_ON;
+    init_auditlogbuffering = cfg->auditlogbuffering = LDAP_ON;
     init_auditlog_compress_enabled = cfg->auditlog_compress = LDAP_OFF;
 
     init_auditfaillog_logging_enabled = cfg->auditfaillog_logging_enabled = LDAP_OFF;
@@ -7780,6 +7786,21 @@ config_set_accesslogbuffering(const char *attrname, char *value, char *errorbuf,
     retVal = config_set_onoff(attrname,
                               value,
                               &(slapdFrontendConfig->accesslogbuffering),
+                              errorbuf,
+                              apply);
+
+    return retVal;
+}
+
+int32_t
+config_set_auditlogbuffering(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int32_t retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    retVal = config_set_onoff(attrname,
+                              value,
+                              &(slapdFrontendConfig->auditlogbuffering),
                               errorbuf,
                               apply);
 

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2024 Red Hat, Inc.
  * Copyright (C) 2010 Hewlett-Packard Development Company, L.P.
  * All rights reserved.
  *
@@ -117,12 +117,15 @@ static PRInt64 log__getfilesize_with_filename(char *filename);
 static int log__enough_freespace(char *path);
 static int vslapd_log_error(LOGFD fp, int sev_level, const char *subsystem, const char *fmt, va_list ap, int locked);
 static int vslapd_log_access(const char *fmt, va_list ap);
+static int vslapd_log_audit(const char *log_data);
 static int vslapd_log_security(const char *log_data);
 static void log_convert_time(time_t ctime, char *tbuf, int type);
 static time_t log_reverse_convert_time(char *tbuf);
 static LogBufferInfo *log_create_buffer(size_t sz);
 static void log_append_buffer2(time_t tnl, LogBufferInfo *lbi, char *msg1, size_t size1, char *msg2, size_t size2);
 static void log_append_security_buffer(time_t tnl, LogBufferInfo *lbi, char *msg, size_t size);
+static void log_append_audit_buffer(time_t tnl, LogBufferInfo *lbi, char *msg, size_t size);
+static void log_append_auditfail_buffer(time_t tnl, LogBufferInfo *lbi, char *msg, size_t size);
 static void log_flush_buffer(LogBufferInfo *lbi, int type, int sync_now);
 static void log_write_title(LOGFD fp);
 static void log__error_emergency(const char *errstr, int reopen, int locked);
@@ -440,8 +443,15 @@ g_log_init()
     loginfo.log_numof_audit_logs = 1;
     loginfo.log_audit_fdes = NULL;
     loginfo.log_audit_logchain = NULL;
+    loginfo.log_audit_buffer = log_create_buffer(LOG_BUFFER_MAXSIZE);
     loginfo.log_audit_compress = cfg->auditlog_compress;
     if ((loginfo.log_audit_rwlock = slapi_new_rwlock()) == NULL) {
+        exit(-1);
+    }
+    if (loginfo.log_audit_buffer == NULL) {
+        exit(-1);
+    }
+    if ((loginfo.log_audit_buffer->lock = PR_NewLock()) == NULL) {
         exit(-1);
     }
 
@@ -468,9 +478,16 @@ g_log_init()
     loginfo.log_numof_auditfail_logs = 1;
     loginfo.log_auditfail_fdes = NULL;
     loginfo.log_auditfail_logchain = NULL;
+    loginfo.log_auditfail_buffer = log_create_buffer(LOG_BUFFER_MAXSIZE);
     loginfo.log_backend = LOGGING_BACKEND_INTERNAL;
     loginfo.log_auditfail_compress = cfg->auditfaillog_compress;
     if ((loginfo.log_auditfail_rwlock = slapi_new_rwlock()) == NULL) {
+        exit(-1);
+    }
+    if (loginfo.log_auditfail_buffer == NULL) {
+        exit(-1);
+    }
+    if ((loginfo.log_auditfail_buffer->lock = PR_NewLock()) == NULL) {
         exit(-1);
     }
     CFG_UNLOCK_READ(cfg);
@@ -2397,6 +2414,36 @@ auditfail_log_openf(char *pathname, int locked)
 /******************************************************************************
 * write in the audit log
 ******************************************************************************/
+static int
+vslapd_log_audit(const char *log_data)
+{
+    char buffer[SLAPI_LOG_BUFSIZ];
+    time_t tnl;
+    int32_t blen = TBUFSIZE;
+    int32_t rc = LDAP_SUCCESS;
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_audit__entry);
+#endif
+
+    /* We do this sooner, because that we can use the message in other calls */
+    if ((blen = PR_snprintf(buffer, SLAPI_LOG_BUFSIZ, "%s\n", log_data)) == -1) {
+        log__error_emergency("vslapd_log_audit, Unable to format message", 1, 0);
+        return -1;
+    }
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_audit__prepared);
+#endif
+    tnl = slapi_current_utc_time();
+    log_append_audit_buffer(tnl, loginfo.log_audit_buffer, buffer, blen);
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_audit__buffer);
+#endif
+
+    return (rc);
+}
 
 int
 slapd_log_audit(
@@ -2408,18 +2455,8 @@ slapd_log_audit(
     int retval = LDAP_SUCCESS;
     int lbackend = loginfo.log_backend; /* We copy this to make these next checks atomic */
 
-    int *state;
-    if (sourcelog == SLAPD_AUDIT_LOG) {
-        state = &loginfo.log_audit_state;
-    } else if (sourcelog == SLAPD_AUDITFAIL_LOG) {
-        state = &loginfo.log_auditfail_state;
-    } else {
-        /* How did we even get here! */
-        return 1;
-    }
-
     if (lbackend & LOGGING_BACKEND_INTERNAL) {
-        retval = slapd_log_audit_internal(buffer, buf_len, state);
+        retval = vslapd_log_audit(buffer);
     }
 
     if (retval != LDAP_SUCCESS) {
@@ -2437,39 +2474,76 @@ slapd_log_audit(
     return retval;
 }
 
-int
-slapd_log_audit_internal(
-    char *buffer,
-    int buf_len,
-    int *state)
+static void
+log_append_audit_buffer(time_t tnl, LogBufferInfo *lbi, char *msg, size_t size)
 {
-    if ((*state & LOGGING_ENABLED) && (loginfo.log_audit_file != NULL)) {
-        LOG_AUDIT_LOCK_WRITE();
-        if (log__needrotation(loginfo.log_audit_fdes,
-                              SLAPD_AUDIT_LOG) == LOG_ROTATE) {
-            if (log__open_auditlogfile(LOGFILE_NEW, 1) != LOG_SUCCESS) {
-                slapi_log_err(SLAPI_LOG_ERR, "slapd_log_audit_internal",
-                              "Unable to open audit file:%s\n", loginfo.log_audit_file);
-                LOG_AUDIT_UNLOCK_WRITE();
-                return 0;
-            }
-            while (loginfo.log_audit_rotationsyncclock <= loginfo.log_audit_ctime) {
-                loginfo.log_audit_rotationsyncclock += PR_ABS(loginfo.log_audit_rotationtime_secs);
-            }
-        }
-        if (*state & LOGGING_NEED_TITLE) {
-            log_write_title(loginfo.log_audit_fdes);
-            *state &= ~LOGGING_NEED_TITLE;
-        }
-        LOG_WRITE_NOW_NO_ERR(loginfo.log_audit_fdes, buffer, buf_len, 0);
-        LOG_AUDIT_UNLOCK_WRITE();
-        return 0;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char *insert_point = NULL;
+
+    /* While holding the lock, we determine if there is space in the buffer for our payload,
+       and if we need to flush.
+     */
+    PR_Lock(lbi->lock);
+    if (((lbi->current - lbi->top) + size > lbi->maxsize) ||
+        (tnl >= loginfo.log_audit_rotationsyncclock &&
+         loginfo.log_audit_rotationsync_enabled))
+    {
+        log_flush_buffer(lbi, SLAPD_AUDIT_LOG, 0 /* do not sync to disk */);
     }
-    return 0;
+    insert_point = lbi->current;
+    lbi->current += size;
+    /* Increment the copy refcount */
+    slapi_atomic_incr_64(&(lbi->refcount), __ATOMIC_RELEASE);
+    PR_Unlock(lbi->lock);
+
+    /* Now we can copy without holding the lock */
+    memcpy(insert_point, msg, size);
+
+    /* Decrement the copy refcount */
+    slapi_atomic_decr_64(&(lbi->refcount), __ATOMIC_RELEASE);
+
+    /* If we are asked to sync to disk immediately, do so */
+    if (!slapdFrontendConfig->auditlogbuffering) {
+        PR_Lock(lbi->lock);
+        log_flush_buffer(lbi, SLAPD_AUDIT_LOG, 1 /* sync to disk now */);
+        PR_Unlock(lbi->lock);
+    }
 }
+
 /******************************************************************************
 * write in the audit fail log
 ******************************************************************************/
+static int
+vslapd_log_auditfail(const char *log_data)
+{
+    char buffer[SLAPI_LOG_BUFSIZ];
+    time_t tnl;
+    int32_t blen = TBUFSIZE;
+    int32_t rc = LDAP_SUCCESS;
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_auditfail__entry);
+#endif
+
+    /* We do this sooner, because that we can use the message in other calls */
+    if ((blen = PR_snprintf(buffer, SLAPI_LOG_BUFSIZ, "%s\n", log_data)) == -1) {
+        log__error_emergency("vslapd_log_auditfail, Unable to format message", 1, 0);
+        return -1;
+    }
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_auditfail__prepared);
+#endif
+    tnl = slapi_current_utc_time();
+    log_append_auditfail_buffer(tnl, loginfo.log_auditfail_buffer, buffer, blen);
+
+#ifdef SYSTEMTAP
+    STAP_PROBE(ns-slapd, vslapd_log_auditfail__buffer);
+#endif
+
+    return (rc);
+}
+
 int
 slapd_log_auditfail(
     char *buffer,
@@ -2479,7 +2553,7 @@ slapd_log_auditfail(
     int retval = LDAP_SUCCESS;
     int lbackend = loginfo.log_backend; /* We copy this to make these next checks atomic */
     if (lbackend & LOGGING_BACKEND_INTERNAL) {
-        retval = slapd_log_auditfail_internal(buffer, buf_len);
+        retval = vslapd_log_auditfail(buffer);
     }
     if (retval != LDAP_SUCCESS) {
         return retval;
@@ -2496,35 +2570,42 @@ slapd_log_auditfail(
     return retval;
 }
 
-int
-slapd_log_auditfail_internal(
-    char *buffer,
-    int buf_len)
+static void
+log_append_auditfail_buffer(time_t tnl, LogBufferInfo *lbi, char *msg, size_t size)
 {
-    if ((loginfo.log_auditfail_state & LOGGING_ENABLED) && (loginfo.log_auditfail_file != NULL)) {
-        LOG_AUDITFAIL_LOCK_WRITE();
-        if (log__needrotation(loginfo.log_auditfail_fdes,
-                              SLAPD_AUDITFAIL_LOG) == LOG_ROTATE) {
-            if (log__open_auditfaillogfile(LOGFILE_NEW, 1) != LOG_SUCCESS) {
-                slapi_log_err(SLAPI_LOG_ERR, "slapd_log_auditfail_internal",
-                              "Unable to open auditfail file:%s\n", loginfo.log_auditfail_file);
-                LOG_AUDITFAIL_UNLOCK_WRITE();
-                return 0;
-            }
-            while (loginfo.log_auditfail_rotationsyncclock <= loginfo.log_auditfail_ctime) {
-                loginfo.log_auditfail_rotationsyncclock += PR_ABS(loginfo.log_auditfail_rotationtime_secs);
-            }
-        }
-        if (loginfo.log_auditfail_state & LOGGING_NEED_TITLE) {
-            log_write_title(loginfo.log_auditfail_fdes);
-            loginfo.log_auditfail_state &= ~LOGGING_NEED_TITLE;
-        }
-        LOG_WRITE_NOW_NO_ERR(loginfo.log_auditfail_fdes, buffer, buf_len, 0);
-        LOG_AUDITFAIL_UNLOCK_WRITE();
-        return 0;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char *insert_point = NULL;
+
+    /* While holding the lock, we determine if there is space in the buffer for our payload,
+       and if we need to flush.
+     */
+    PR_Lock(lbi->lock);
+    if (((lbi->current - lbi->top) + size > lbi->maxsize) ||
+        (tnl >= loginfo.log_auditfail_rotationsyncclock &&
+         loginfo.log_auditfail_rotationsync_enabled))
+    {
+        log_flush_buffer(lbi, SLAPD_AUDITFAIL_LOG, 0 /* do not sync to disk */);
     }
-    return 0;
+    insert_point = lbi->current;
+    lbi->current += size;
+    /* Increment the copy refcount */
+    slapi_atomic_incr_64(&(lbi->refcount), __ATOMIC_RELEASE);
+    PR_Unlock(lbi->lock);
+
+    /* Now we can copy without holding the lock */
+    memcpy(insert_point, msg, size);
+
+    /* Decrement the copy refcount */
+    slapi_atomic_decr_64(&(lbi->refcount), __ATOMIC_RELEASE);
+
+    /* If we are asked to sync to disk immediately, do so */
+    if (!slapdFrontendConfig->auditlogbuffering) {
+        PR_Lock(lbi->lock);
+        log_flush_buffer(lbi, SLAPD_AUDITFAIL_LOG, 1 /* sync to disk now */);
+        PR_Unlock(lbi->lock);
+    }
 }
+
 /******************************************************************************
 * write in the error log
 ******************************************************************************/
@@ -6605,6 +6686,78 @@ log_flush_buffer(LogBufferInfo *lbi, int type, int sync_now)
                                  lbi->current - lbi->top, 0);
         }
         lbi->current = lbi->top;
+    } else if (type == SLAPD_AUDIT_LOG) {
+        /* It is only safe to flush once any other threads which are copying are finished */
+        while (slapi_atomic_load_64(&(lbi->refcount), __ATOMIC_ACQUIRE) > 0) {
+            /* It's ok to sleep for a while because we only flush every second or so */
+            DS_Sleep(PR_MillisecondsToInterval(1));
+        }
+
+        if ((lbi->current - lbi->top) == 0) {
+            return;
+        }
+
+        if (log__needrotation(loginfo.log_audit_fdes, SLAPD_AUDIT_LOG) == LOG_ROTATE) {
+            if (log__open_auditlogfile(LOGFILE_NEW, 1) != LOG_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_ERR,
+                              "log_flush_buffer", "Unable to open audit file:%s\n",
+                              loginfo.log_audit_file);
+                lbi->current = lbi->top; /* reset counter to prevent overwriting rest of lbi struct */
+                return;
+            }
+            while (loginfo.log_audit_rotationsyncclock <= loginfo.log_audit_ctime) {
+                loginfo.log_audit_rotationsyncclock += PR_ABS(loginfo.log_audit_rotationtime_secs);
+            }
+        }
+
+        if (loginfo.log_audit_state & LOGGING_NEED_TITLE) {
+            log_write_title(loginfo.log_audit_fdes);
+            loginfo.log_audit_state &= ~LOGGING_NEED_TITLE;
+        }
+
+        if (!sync_now && slapdFrontendConfig->auditlogbuffering) {
+            LOG_WRITE(loginfo.log_audit_fdes, lbi->top, lbi->current - lbi->top, 0);
+        } else {
+            LOG_WRITE_NOW_NO_ERR(loginfo.log_audit_fdes, lbi->top,
+                                 lbi->current - lbi->top, 0);
+        }
+        lbi->current = lbi->top;
+    } else if (type == SLAPD_AUDITFAIL_LOG) {
+        /* It is only safe to flush once any other threads which are copying are finished */
+        while (slapi_atomic_load_64(&(lbi->refcount), __ATOMIC_ACQUIRE) > 0) {
+            /* It's ok to sleep for a while because we only flush every second or so */
+            DS_Sleep(PR_MillisecondsToInterval(1));
+        }
+
+        if ((lbi->current - lbi->top) == 0) {
+            return;
+        }
+
+        if (log__needrotation(loginfo.log_auditfail_fdes, SLAPD_AUDITFAIL_LOG) == LOG_ROTATE) {
+            if (log__open_auditfaillogfile(LOGFILE_NEW, 1) != LOG_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_ERR,
+                              "log_flush_buffer", "Unable to open auditfail file:%s\n",
+                              loginfo.log_audit_file);
+                lbi->current = lbi->top; /* reset counter to prevent overwriting rest of lbi struct */
+                return;
+            }
+            while (loginfo.log_auditfail_rotationsyncclock <= loginfo.log_auditfail_ctime) {
+                loginfo.log_auditfail_rotationsyncclock += PR_ABS(loginfo.log_auditfail_rotationtime_secs);
+            }
+        }
+
+        if (loginfo.log_auditfail_state & LOGGING_NEED_TITLE) {
+            log_write_title(loginfo.log_auditfail_fdes);
+            loginfo.log_auditfail_state &= ~LOGGING_NEED_TITLE;
+        }
+
+        if (!sync_now && slapdFrontendConfig->auditlogbuffering) {
+            LOG_WRITE(loginfo.log_auditfail_fdes, lbi->top, lbi->current - lbi->top, 0);
+        } else {
+            LOG_WRITE_NOW_NO_ERR(loginfo.log_auditfail_fdes, lbi->top,
+                                 lbi->current - lbi->top, 0);
+        }
+        lbi->current = lbi->top;
     }
 }
 
@@ -6619,6 +6772,14 @@ logs_flush()
     log_flush_buffer(loginfo.log_security_buffer, SLAPD_SECURITY_LOG,
                      1 /* sync to disk now */);
     LOG_SECURITY_UNLOCK_WRITE();
+    LOG_AUDIT_LOCK_WRITE();
+    log_flush_buffer(loginfo.log_audit_buffer, SLAPD_AUDIT_LOG,
+                     1 /* sync to disk now */);
+    LOG_AUDIT_UNLOCK_WRITE();
+    LOG_AUDITFAIL_LOCK_WRITE();
+    log_flush_buffer(loginfo.log_auditfail_buffer, SLAPD_AUDITFAIL_LOG,
+                     1 /* sync to disk now */);
+    LOG_AUDITFAIL_UNLOCK_WRITE();
 }
 
 /*

--- a/ldap/servers/slapd/log.h
+++ b/ldap/servers/slapd/log.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -210,6 +210,7 @@ struct logging_opts
     char *log_auditinfo_file;           /* audit log rotation info file */
     Slapi_RWLock *log_audit_rwlock;     /* lock on audit*/
     int log_audit_compress;             /* Compress rotated logs */
+    LogBufferInfo *log_audit_buffer;    /* buffer for access log */
 
     /* These are auditfail log specific */
     int log_auditfail_state;
@@ -236,6 +237,7 @@ struct logging_opts
     char *log_auditfailinfo_file;           /* auditfail log rotation info file */
     Slapi_RWLock *log_auditfail_rwlock;     /* lock on auditfail */
     int log_auditfail_compress;             /* Compress rotated logs */
+    LogBufferInfo *log_auditfail_buffer;    /* buffer for access log */
 
     int log_backend;
 };

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -384,6 +384,7 @@ int config_set_minssf(const char *attrname, char *value, char *errorbuf, int app
 int config_set_minssf_exclude_rootdse(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_validate_cert_switch(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_accesslogbuffering(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_auditlogbuffering(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_securitylogbuffering(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_csnlogging(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_force_sasl_external(const char *attrname, char *value, char *errorbuf, int apply);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2301,6 +2301,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_PW_SEND_EXPIRING "passwordSendExpiringTime"
 #define CONFIG_ACCESSLOG_BUFFERING_ATTRIBUTE "nsslapd-accesslog-logbuffering"
 #define CONFIG_SECURITYLOG_BUFFERING_ATTRIBUTE "nsslapd-securitylog-logbuffering"
+#define CONFIG_AUDITLOG_BUFFERING_ATTRIBUTE "nsslapd-auditlog-logbuffering"
 #define CONFIG_CSNLOGGING_ATTRIBUTE "nsslapd-csnlogging"
 #define CONFIG_RETURN_EXACT_CASE_ATTRIBUTE "nsslapd-return-exact-case"
 #define CONFIG_RESULT_TWEAK_ATTRIBUTE "nsslapd-result-tweak"
@@ -2584,6 +2585,7 @@ typedef struct _slapdFrontendConfig
     int auditlog_exptime;
     char *auditlog_exptimeunit;
     slapi_onoff_t auditlog_logging_hide_unhashed_pw;
+    slapi_onoff_t auditlogbuffering;
     slapi_onoff_t auditlog_compress;
 
     /* AUDIT FAIL LOG */

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -30,8 +30,6 @@ import PropTypes from "prop-types";
 
 const settings_attrs = [
     'nsslapd-auditfaillog',
-    'nsslapd-auditfaillog-level',
-    'nsslapd-auditfaillog-logbuffering',
     'nsslapd-auditfaillog-logging-enabled',
 ];
 

--- a/src/cockpit/389-console/src/server.jsx
+++ b/src/cockpit/389-console/src/server.jsx
@@ -43,6 +43,7 @@ export class Server extends React.Component {
             node_name: "settings-config",
             node_text: "",
             attrs: [],
+            displayAttrs: [],
             loaded: false,
             disableTree: false,
             activeItems: [
@@ -55,6 +56,7 @@ export class Server extends React.Component {
         };
 
         this.loadTree = this.loadTree.bind(this);
+        this.getAttributes = this.getAttributes.bind(this);
         this.reloadConfig = this.reloadConfig.bind(this);
         this.enableTree = this.enableTree.bind(this);
         this.handleTreeClick = this.handleTreeClick.bind(this);
@@ -72,6 +74,30 @@ export class Server extends React.Component {
         this.setState({
             disableTree: false
         });
+    }
+
+    getAttributes() {
+        const attr_cmd = [
+            "dsconf",
+            "-j",
+            "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "schema",
+            "attributetypes",
+            "list"
+        ];
+        log_cmd("getAttributes", "Get attributes for audit log display attributes", attr_cmd);
+        cockpit
+                .spawn(attr_cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const attrContent = JSON.parse(content);
+                    const attrs = [];
+                    for (const content of attrContent.items) {
+                        attrs.push(content.name[0]);
+                    }
+                    this.setState({
+                        displayAttrs: attrs,
+                    });
+                });
     }
 
     loadConfig() {
@@ -198,7 +224,7 @@ export class Server extends React.Component {
         this.setState({
             nodes: basicData,
             node_name: this.state.node_name
-        });
+        }, this.getAttributes());
     }
 
     handleTreeClick(evt, treeViewItem, parentItem) {
@@ -290,6 +316,7 @@ export class Server extends React.Component {
                     <ServerAuditLog
                         serverId={this.props.serverId}
                         attrs={this.state.attrs}
+                        displayAttrs={this.state.displayAttrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
                     />

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -23,7 +23,7 @@ from lib389 import Entry
 from lib389._mapped_object import DSLdapObject
 from lib389.utils import ensure_bytes, selinux_label_port,  selinux_present
 from lib389.lint import (
-    DSCLE0001, DSCLE0002, DSCLE0003, DSCLE0004, DSCLE0005, DSELE0001
+    DSCLE0001, DSCLE0002, DSCLE0003, DSCLE0004, DSCLE0005, DSCLE0006, DSELE0001
 )
 
 class Config(DSLdapObject):
@@ -250,11 +250,21 @@ class Config(DSLdapObject):
             report['check'] = "config:accesslogbuffering"
             yield report
 
+    def _lint_auditlog_buffering(self):
+        # audit log buffering
+        enabled = self.get_attr_val_utf8_l('nsslapd-auditlog-logging-enabled')
+        buffering = self.get_attr_val_utf8_l('nsslapd-auditlog-logbuffering')
+        if enabled == "on" and buffering == "off":
+            report = copy.deepcopy(DSCLE0006)
+            report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['check'] = "config:auditlogbuffering"
+            yield report
 
     def _lint_securitylog_buffering(self):
         # security log buffering
+        enabled = self.get_attr_val_utf8_l('nsslapd-securitylog-logging-enabled')
         buffering = self.get_attr_val_utf8_l('nsslapd-securitylog-logbuffering')
-        if buffering == "off":
+        if enabled == "on" and buffering == "off":
             report = copy.deepcopy(DSCLE0005)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
             report['check'] = "config:securitylogbuffering"

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -155,6 +155,22 @@ You can use 'dsconf' to set this attribute.  Here is an example:
 """
 }
 
+DSCLE0006 = {
+    'dsle': 'DSCLE0006',
+    'severity': 'LOW',
+    'description': 'Audit Log buffering disabled',
+    'items': ['cn=config', ],
+    'detail': """nsslapd-auditlog-logbuffering is set to 'off' this will cause high
+disk IO and it will impact server performance.  This should only be used
+for debug purposes
+""",
+    'fix': """Set nsslapd-auditlog-logbuffering to 'on'.
+You can use 'dsconf' to set this attribute.  Here is an example:
+
+    # dsconf slapd-YOUR_INSTANCE config replace nsslapd-auditlog-logbuffering=on
+"""
+}
+
 # Security checks
 DSELE0001 = {
     'dsle': 'DSELE0001',

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -124,6 +124,7 @@ def _create_instances(topo_dict, suffix):
             instance.use_ldap_uri()
             instance.open()
             instance.config.set('nsslapd-accesslog-logbuffering','off')
+            instance.config.set('nsslapd-auditlog-logbuffering','off')
             if role == ReplicaRole.STANDALONE:
                 ins[instance.serverid] = instance
                 instances.update(ins)
@@ -528,7 +529,7 @@ def topology_m1h1c1(request):
     topo_roles = {ReplicaRole.SUPPLIER: 1, ReplicaRole.HUB: 1, ReplicaRole.CONSUMER: 1}
     topology = create_topology(topo_roles, request=request)
 
-    # Since topology implements timeout, create_topology supports hub 
+    # Since topology implements timeout, create_topology supports hub
     # but hub and suppliers are fully meshed while historically this topology
     # did not have hub->master agreement.
     # ==> we must remove hub->master agmt that breaks some test (like promote_demote)


### PR DESCRIPTION
Description:

Add log buffering to audit/auditfail logs.  Since these logs are intertwined there is only one config setting for both logs:

    nsslapd-auditlog-logbuffering: on/off

relates: https://github.com/389ds/389-ds-base/issues/5842
