### PR TITLE
Issue 6110 - Typo in Account Policy plugin message

### DIFF
--- a/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
@@ -490,7 +490,7 @@ class AccountPolicy extends React.Component {
                     console.info("accountPolicyOperation", "Result", content);
                     this.props.addNotification(
                         "success",
-                        cockpit.format(_("Config entry $0 was successfully $1ed"), configDN, action)
+                        cockpit.format(_("Config entry $0 was successfully $1"), configDN, action === "add" ? "added" : "set")
                     );
                     this.props.pluginListHandler();
                     this.handleCloseModal();


### PR DESCRIPTION
Description:
Remove the additional letters after success message

Fixes: https://github.com/389ds/389-ds-base/issues/6110

Reviewed by: ???