### PR TITLE
Issue 5305 - OpenLDAP version autodetection doesn't work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -908,7 +908,7 @@ AC_ARG_WITH(libldap-r, AS_HELP_STRING([--with-libldap-r],[Use lldap_r shared lib
     AC_SUBST(with_libldap_r)
   fi
 ],
-OPENLDAP_VERSION=`ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([[[0-9]]]\+\.[[[0-9]]]\+\.[[[0-9]]]\+\) .*/\1/p')`
+OPENLDAP_VERSION=`ldapsearch -VV 2>&1 | sed -n '/ldapsearch/ s/.*ldapsearch \([[[0-9]]]\+\.[[[0-9]]]\+\.[[[0-9]]]\+\) .*/\1/p'`
 AX_COMPARE_VERSION([$OPENLDAP_VERSION], [lt], [2.5], [ with_libldap_r=yes ], [ with_libldap_r=no ])
 AC_MSG_RESULT($with_libldap_r))
 

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -176,6 +176,7 @@ Provides:  bundled(crate(zeroize_derive)) = 1.3.3
 # Attach the buildrequires to the top level package:
 BuildRequires:    nspr-devel
 BuildRequires:    nss-devel >= 3.34
+BuildRequires:    openldap-clients
 BuildRequires:    openldap-devel
 BuildRequires:    lmdb-devel
 BuildRequires:    cyrus-sasl-devel


### PR DESCRIPTION
Bug Description:
An error is logged during a build in `mock` with Bash 4.4:

```
checking for --with-libldap-r... ./configure: command substitution: line 22848: syntax error near unexpected token `>'
./configure: command substitution: line 22848: `ldapsearch -VV 2> >(sed -n '/ldapsearch/ s/.*ldapsearch \([0-9]\+\.[0-9]\+\.[0-9]\+\) .*/\1/p')'
no
```

`mock` runs Bash as `sh` (POSIX mode). Support for process substitution in POSIX mode was added in version 5.1:
https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00002.html

> Process substitution is now available in posix mode.

Fix Description:
* Add missing `BuildRequires` for openldap-clients
* Replace process substitution with a pipe

Fixes: https://github.com/389ds/389-ds-base/issues/5305