### PR TITLE
Issue 6119 - Synchronise accept_thread with slapd_daemon

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -868,6 +868,8 @@ accept_thread(void *vports)
     slapi_ch_free((void **)&listener_idxs);
     slapd_sockets_ports_free(ports);
     slapi_ch_free((void **)&fds);
+    g_decr_active_threadcnt();
+    slapi_log_err(SLAPI_LOG_INFO, "slapd_daemon", "slapd shutting down - accept_thread\n");
 }
 
 void
@@ -1158,6 +1160,8 @@ slapd_daemon(daemon_ports_t *ports)
         slapi_log_err(SLAPI_LOG_EMERG, "slapd_daemon", "Unable to fd accept thread - Shutting Down (" SLAPI_COMPONENT_NAME_NSPR " error %d - %s)\n",
                       errorCode, slapd_pr_strerror(errorCode));
         g_set_shutdown(SLAPI_SHUTDOWN_EXIT);
+    } else{
+            g_incr_active_threadcnt();
     }
 
 #ifdef WITH_SYSTEMD

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1161,7 +1161,7 @@ slapd_daemon(daemon_ports_t *ports)
                       errorCode, slapd_pr_strerror(errorCode));
         g_set_shutdown(SLAPI_SHUTDOWN_EXIT);
     } else{
-            g_incr_active_threadcnt();
+        g_incr_active_threadcnt();
     }
 
 #ifdef WITH_SYSTEMD


### PR DESCRIPTION
Bug Description: A corner cases exists, where the slapd_daemon has begun its shutdown process but the accept_thread is still running and capable of handling new connections. When this scenario occurs, the connection subsystem has been partially deallocated and is in an unstable state. A segfault is generated when attempting to get a new connection from the connection table.

Fix Description: The connection table is only deallocated when the number of active threads is 0. Modify the accept_thread to adjust the the active thread count during creation/destruction, meaning the connection table can only be freed when the accept_thread has completed

Relates: https://github.com/389ds/389-ds-base/issues/6119

Reviewed by: