### PR TITLE
Issue 6057 - vlv search may result wrong result with lmdb - Fix 2

### DIFF
--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -1752,7 +1752,7 @@ cache_is_reverted_entry(struct cache *cache, struct backentry *e)
     cache_lock(cache);
     if (find_hash(cache->c_idtable, &e->ep_id, sizeof(ID), (void **)&dummy_e)) {
         if (dummy_e->ep_state & ENTRY_STATE_INVALID) {
-            slapi_log_err(SLAPI_LOG_WARNING, "cache_is_reverted_entry", "Entry reverted = %d (0x%lX)  [entry: 0x%lX] refcnt=%d\n", 
+            slapi_log_err(SLAPI_LOG_WARNING, "cache_is_reverted_entry", "Entry reverted = %d (0x%lX)  [entry: %p] refcnt=%d\n",
                           dummy_e->ep_state,
                           pthread_self(),
                           dummy_e, dummy_e->ep_refcnt);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -117,7 +117,7 @@ char *mdb_stat_summarize(mdb_stat_info_t *sinfo, char *buf, size_t bufsize);
 #define INFO_NRDN(info)         ((char*)(&((ID*)(info))[INFO_IDX_ANCESTORS+((ID*)(info))[INFO_IDX_NB_ANCESTORS]]))
 #define INFO_RDN(info)          (INFO_NRDN(info)+((ID*)(info))[INFO_IDX_NRDN_LEN])
 #define INFO_DN(info)           (INFO_RDN(info)+((ID*)(info))[INFO_IDX_RDN_LEN])
-#define INFO_RECORD_LEN(info)   ((INFO_DN(info)-(char*)(info))+(info)[INFO_IDX_DN_LEN])  /* Total lenght of a record */
+#define INFO_RECORD_LEN(info)   ((INFO_DN(info)-(char*)(info))+(info)[INFO_IDX_DN_LEN])  /* Total length of a record */
 
 typedef struct {
     back_txn txn;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -378,7 +378,7 @@ dbmdb_open_all_files(dbmdb_ctx_t *ctx, backend *be)
         ctx = MDB_CONFIG(li);
     }
     ctxflags = ctx->readonly ? MDB_RDONLY: MDB_CREATE;
-    if (be && be->vlvSearchList_lock == NULL) {
+    if (does_vlv_need_init(inst)) {
         /* Vlv initialization is quite tricky as it require that
          *  [1] dbis_lock is not held
          *  [2] inst->inst_id2entry is set
@@ -493,7 +493,7 @@ error:
         charray_free(vlv_list);
         vlv_list = NULL;
     }
-    if (rc == 0 && be && be->vlvSearchList_lock == NULL) {
+    if (rc == 0 && does_vlv_need_init(inst)) {
         vlv_init(inst);
     }
     return dbmdb_map_error(__FUNCTION__, rc);

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -478,6 +478,7 @@ struct vlv_response
 };
 
 char ** vlv_list_filenames(ldbm_instance *inst);
+int does_vlv_need_init(ldbm_instance *inst);
 int vlv_init(ldbm_instance *inst);
 void vlv_close(ldbm_instance *inst);
 int vlv_remove_callbacks(ldbm_instance *inst);

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -477,6 +477,7 @@ struct vlv_response
     ber_int_t result;
 };
 
+char ** vlv_list_filenames(ldbm_instance *inst);
 int vlv_init(ldbm_instance *inst);
 void vlv_close(ldbm_instance *inst);
 int vlv_remove_callbacks(ldbm_instance *inst);

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -400,7 +400,7 @@ vlv_list_filenames(ldbm_instance *inst)
     }
 
     basedn = slapi_create_dn_string("cn=%s,cn=%s,cn=plugins,cn=config",
-                                        inst->inst_name, inst->inst_li->li_plugin->plg_name);
+                                    inst->inst_name, inst->inst_li->li_plugin->plg_name);
     if (NULL == basedn) {
         return names;
     }
@@ -408,7 +408,7 @@ vlv_list_filenames(ldbm_instance *inst)
     tmp_pb = slapi_search_internal(basedn, LDAP_SCOPE_SUBTREE, indexfilter, NULL, attrs, 0);
     slapi_pblock_get(tmp_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
     for (size_t i = 0; entries && entries[i] != NULL; i++) {
-        const char *name = slapi_entry_attr_get_ref(entries[0], type_vlvName);
+        const char *name = slapi_entry_attr_get_ref(entries[i], type_vlvName);
         char *filename = vlvIndex_build_filename(name);
         if (filename) {
             charray_add(&names, filename);
@@ -418,6 +418,12 @@ vlv_list_filenames(ldbm_instance *inst)
     slapi_pblock_destroy(tmp_pb);
     slapi_ch_free_string(&basedn);
     return names;
+}
+
+int
+does_vlv_need_init(ldbm_instance *inst)
+{
+    return (inst && inst->inst_be->vlvSearchList_lock == NULL);
 }
 
 /*

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -378,6 +378,49 @@ vlv_close(ldbm_instance *inst)
 }
 
 /*
+ * List vlv filenames without acceding to the vlv target
+ *  backend (unlike vlv_init).
+ * Note that vlv configuration is not fully checked so it is
+ * possible to get names that are not assiciated to working index.
+ * (Useless empty mdb db files are created in such case)
+ */
+char **
+vlv_list_filenames(ldbm_instance *inst)
+{
+    /* The FE DSE *must* be initialised before we get here */
+    const char *indexfilter = "(objectclass=vlvindex)";
+    char * attrs[] = { (char*)type_vlvName, NULL };
+    Slapi_Entry **entries = NULL;
+    Slapi_PBlock *tmp_pb;
+    char *basedn = NULL;
+    char **names = NULL;
+
+    if (!inst) {
+        return names;
+    }
+
+    basedn = slapi_create_dn_string("cn=%s,cn=%s,cn=plugins,cn=config",
+                                        inst->inst_name, inst->inst_li->li_plugin->plg_name);
+    if (NULL == basedn) {
+        return names;
+    }
+
+    tmp_pb = slapi_search_internal(basedn, LDAP_SCOPE_SUBTREE, indexfilter, NULL, attrs, 0);
+    slapi_pblock_get(tmp_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+    for (size_t i = 0; entries && entries[i] != NULL; i++) {
+        const char *name = slapi_entry_attr_get_ref(entries[0], type_vlvName);
+        char *filename = vlvIndex_build_filename(name);
+        if (filename) {
+            charray_add(&names, filename);
+        }
+    }
+    slapi_free_search_results_internal(tmp_pb);
+    slapi_pblock_destroy(tmp_pb);
+    slapi_ch_free_string(&basedn);
+    return names;
+}
+
+/*
  * Search for the VLV entries which describe the pre-computed indexes we
  * support.  Register administartion DSE callback functions.
  * This is exported to the backend initialisation routine.

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -551,7 +551,10 @@ vlvIndex_init(struct vlvIndex *p, backend *be, struct vlvSearch *pSearch, const 
         }
         slapi_timespec_expire_at(60, &(p->vlv_nextcheck));
     } else {
-        slapi_log_err(SLAPI_LOG_ERR, "vlvIndex_init - Couldn't generate valid filename from Virtual List View Index Name (%s).  Need some alphabetical characters.\n", p->vlv_name, 0, 0);
+        slapi_log_err(SLAPI_LOG_ERR, "vlvIndex_init",
+                      "Couldn't generate valid filename from Virtual List View Index Name (%s)"
+                      " on backend %s. Need some alphabetical characters.\n",
+                      p->vlv_name, be->be_name);
     }
 }
 
@@ -810,7 +813,7 @@ vlvIndex_build_filename(const char *vlvname)
         }
     }
     *pt = '\0';
-    if (strcmp(pt, file_prefix) ==0) {
+    if (strcmp(pt, file_prefix) == 0) {
         slapi_ch_free_string(&filename);
     }
     return filename;

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.c
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.c
@@ -31,8 +31,6 @@ char *const type_vlvUses = "vlvUses";
 
 static const char *file_prefix = "vlv#"; /* '#' used to avoid collision with real attributes */
 
-static int vlvIndex_createfilename(struct vlvIndex *pIndex, char **ppc);
-
 static int vlvIndex_equal(const struct vlvIndex *p1, const sort_spec *sort_control);
 static void vlvIndex_checkforindex(struct vlvIndex *p, backend *be);
 
@@ -539,11 +537,12 @@ vlvIndex_init(struct vlvIndex *p, backend *be, struct vlvSearch *pSearch, const 
     }
 
     /* Create an index filename for the search */
-    if (vlvIndex_createfilename(p, &filename)) {
-        p->vlv_filename = slapi_ch_smprintf("%s%s%s", file_prefix, filename, file_suffix);
+    filename = vlvIndex_build_filename(p->vlv_name);
+    if (filename) {
+        p->vlv_filename = slapi_ch_smprintf("%s%s", filename, file_suffix);
 
         /* Create an attrinfo structure */
-        p->vlv_attrinfo->ai_type = slapi_ch_smprintf("%s%s", file_prefix, filename);
+        p->vlv_attrinfo->ai_type = filename;
         p->vlv_attrinfo->ai_indexmask = INDEX_VLV;
 
         /* Check if the index file actually exists */
@@ -551,8 +550,9 @@ vlvIndex_init(struct vlvIndex *p, backend *be, struct vlvSearch *pSearch, const 
             vlvIndex_checkforindex(p, be);
         }
         slapi_timespec_expire_at(60, &(p->vlv_nextcheck));
+    } else {
+        slapi_log_err(SLAPI_LOG_ERR, "vlvIndex_init - Couldn't generate valid filename from Virtual List View Index Name (%s).  Need some alphabetical characters.\n", p->vlv_name, 0, 0);
     }
-    slapi_ch_free((void **)&filename);
 }
 
 /*
@@ -792,32 +792,28 @@ vlvIndex_isVlvIndexEntry(Slapi_Entry *e)
 }
 
 /*
- * Create the filename for the index.
- * Extract all the alphanumeric characters from the descriptive name.
- * Convert to all lower case.
+ * Generate the vlv db file name from the vlv name.
+ * Return NULL if vlv name cannot be converted to db name
  */
-static int
-vlvIndex_createfilename(struct vlvIndex *pIndex, char **ppc)
+char *
+vlvIndex_build_filename(const char *vlvname)
 {
-    int filenameValid = 1;
-    unsigned int i;
-    char *p, *filename;
-    filename = slapi_ch_malloc(strlen(pIndex->vlv_name) + 1);
-    p = filename;
-    for (i = 0; i < strlen(pIndex->vlv_name); i++) {
-        if (isalnum(pIndex->vlv_name[i])) {
-            *p = TOLOWER(pIndex->vlv_name[i]);
-            p++;
+    size_t len = strlen(vlvname);
+    size_t len_prefix = strlen(file_prefix);
+    char *filename = slapi_ch_malloc(len_prefix + len + 1);
+    char *pt = filename;
+    strcpy(pt, file_prefix);
+    pt += len_prefix;
+    for (;*vlvname; vlvname++) {
+        if (isalnum(*vlvname)) {
+            *pt++ = TOLOWER(*vlvname);
         }
     }
-    *p = '\0';
-    if (strlen(filename) == 0) {
-        slapi_log_err(SLAPI_LOG_ERR, "vlvIndex_createfilename - Couldn't generate valid filename from Virtual List View Index Name (%s).  Need some alphabetical characters.\n", pIndex->vlv_name, 0, 0);
-        filenameValid = 0;
+    *pt = '\0';
+    if (strcmp(pt, file_prefix) ==0) {
+        slapi_ch_free_string(&filename);
     }
-    /* JCM: Check if this file clashes with another VLV Index filename */
-    *ppc = filename;
-    return filenameValid;
+    return filename;
 }
 
 int

--- a/ldap/servers/slapd/back-ldbm/vlv_srch.h
+++ b/ldap/servers/slapd/back-ldbm/vlv_srch.h
@@ -129,6 +129,7 @@ PRUint32 vlvIndex_get_indexlength(backend *be, struct vlvIndex *p, dbi_db_t *db,
 void vlvIndex_increment_indexlength(backend *be, struct vlvIndex *p, dbi_db_t *db, back_txn *txn);
 void vlvIndex_decrement_indexlength(backend *be, struct vlvIndex *p, dbi_db_t *db, back_txn *txn);
 void vlvIndex_incrementUsage(struct vlvIndex *p);
+char *vlvIndex_build_filename(const char *vlvname);
 const char *vlvIndex_filename(const struct vlvIndex *p);
 int vlvIndex_enabled(const struct vlvIndex *p);
 int vlvIndex_online(const struct vlvIndex *p);


### PR DESCRIPTION
Previous fix is failing after a restart because of a chicken and egg issue related to vlv_init and backend initialization.
vlv_init requires that the backend get initialized to be able to generate the vlvSearch struct.
Because of deadlocks, and to be able to roll back the database instance open transaction I found it easier to avoid using vlv_getindices if vlv is not initialized but rather perform a search on cn=config to build a list of all possible vlv indexes filenames (ignoring the configuration errors) and use that list to open the database files for vlv indices and their cache.

Also fixed some minor issues:
   @droideck minor remarks done about #6091 after the merge
   a typo while logging info about the database environment parameters 

Issue: #6057 

Reviewed by: @tbordaz, @droideck , @mreynolds389  (Thanks!)