### PR TITLE
Issue 6125 - dscreate interactive fails when chosing mdb backend

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1718,7 +1718,7 @@ def parse_size(size):
     :raise ValueError: if the string cannot be parsed.
     """
     try:
-        val,unit = re.fullmatch(SIZE_PATTERN, size, flags=re.IGNORECASE).groups()
+        val,unit = re.fullmatch(SIZE_PATTERN, str(size), flags=re.IGNORECASE).groups()
         return round(float(val) * SIZE_UNITS[unit.lower()])
     except AttributeError:
         raise ValueError(f'Unable to parse "{size}" as a size.')


### PR DESCRIPTION
Bug description: dscreate in interactive mode fails when a mdb backend is used. Cast to string missing in the parse_size method.

Fix description: Convert the value to string in parse method.

Fixes: https://github.com/389ds/389-ds-base/issues/6125

Reviewed by: