### PR TITLE
Issue 6057 - Fix3 - Fix covscan issues

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -374,8 +374,17 @@ dbmdb_open_all_files(dbmdb_ctx_t *ctx, backend *be)
     int i;
 
     if (!ctx) {
-        struct ldbminfo *li = (struct ldbminfo *)(be->be_database->plg_private);
-        ctx = MDB_CONFIG(li);
+        if (!be) {
+            /* Testing for "be" to avoid a covscan warning although 
+              * dbmdb_open_all_files is never called with both parameters NULL
+              */
+            slapi_log_err(SLAPI_LOG_ERR, "dbmdb_open_all_files",
+                          "Unable to open the database environment witout either the database context or a backend.\n");
+            return DBI_RC_INVALID;
+        } else {
+            struct ldbminfo *li = (struct ldbminfo *)(be->be_database->plg_private);
+            ctx = MDB_CONFIG(li);
+        }
     }
     ctxflags = ctx->readonly ? MDB_RDONLY: MDB_CREATE;
     if (does_vlv_need_init(inst)) {

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -409,7 +409,7 @@ vlv_list_filenames(ldbm_instance *inst)
     slapi_pblock_get(tmp_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
     for (size_t i = 0; entries && entries[i] != NULL; i++) {
         const char *name = slapi_entry_attr_get_ref(entries[i], type_vlvName);
-        char *filename = vlvIndex_build_filename(name);
+        char *filename = name ? vlvIndex_build_filename(name) : NULL;
         if (filename) {
             charray_add(&names, filename);
         }


### PR DESCRIPTION
Fix two minor issues reported by covscan after the previews fix: 
- CID 1540758:  Null pointer dereferences  - NULL_RETURNS
   /ldap/servers/slapd/back-ldbm/vlv.c: 412 in vlv_list_filenames
   Generate Null pointer exception if vlv config entry is not compliant to the schema
   Added a ternary test to harden the code. 
- CID 1540757:  Null pointer dereferences  - FORWARD_NULL
/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c: 377 in dbmdb_open_all_files
    covscan complain that be may be null (which is true but not in the case database context is also NULL)
    Added a test to avoid the warning

Issue #6057 

Reviewed by: @tbordaz, @droideck  Thanks!