### PR TITLE
Issue 6105 - lmdb - Cannot create entries with long rdn

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -834,6 +834,7 @@ typedef struct _back_search_result_set
 
 #define LDBM_ANCESTORID_STR                "ancestorid"
 #define LDBM_ENTRYDN_STR                   SLAPI_ATTR_ENTRYDN
+#define LDBM_LONG_ENTRYRDN_STR             "@long-entryrdn"
 #define LDBM_ENTRYRDN_STR                  "entryrdn"
 #define LDBM_NUMSUBORDINATES_STR           "numsubordinates"
 #define LDBM_TOMBSTONE_NUMSUBORDINATES_STR "tombstonenumsubordinates"

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
@@ -370,6 +370,7 @@ int
 dbg_mdb_put(const char *file, int lineno, const char *funcname, MDB_txn *txn, MDB_dbi dbi, MDB_val *key, MDB_val *data, unsigned int flags)
 {
     int rc = mdb_put(txn, dbi, key, data, flags);
+if (data->mv_size <= 511) return 0;
     if (dbg_should_log(DBGMDB_LEVEL_MDBAPI, dbi, NULL)) {
         char keystr[DBGVAL2STRMAXSIZE];
         char datastr[DBGVAL2STRMAXSIZE];
@@ -380,7 +381,9 @@ dbg_mdb_put(const char *file, int lineno, const char *funcname, MDB_txn *txn, MD
         dbgval2str(keystr, sizeof keystr, key);
         dbgval2str(datastr, sizeof datastr, data);
         append_flags(flagsstr, sizeof flagsstr, 0, "flags", flags, mdb_op_flags_desc);
-        dbg_log(file, lineno, funcname, DBGMDB_LEVEL_MDBAPI+DBGMDB_LEVEL_FORCE, "mdb_put(txn: 0x%p, %s, key: %s, data: %s, %s)=%d %s", txn, dbistr, keystr, datastr, flagsstr, rc, dbistr);
+        dbg_log(file, lineno, funcname, DBGMDB_LEVEL_MDBAPI+DBGMDB_LEVEL_FORCE,
+                "mdb_put(txn: 0x%p, %s, key: [%ld]%s, data: [%ld]%s, %s)=%d %s",
+                txn, dbistr, key->mv_size, keystr, data->mv_size, datastr, flagsstr, rc, dbistr);
     }
     return rc;
 }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.h
@@ -129,6 +129,7 @@ struct importctx {
     ImportJob *job;
     dbmdb_ctx_t *ctx;
     MdbIndexInfo_t *entryrdn;
+    MdbIndexInfo_t *redirect;
     MdbIndexInfo_t *parentid;
     MdbIndexInfo_t *ancestorid;
     MdbIndexInfo_t *numsubordinates;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -1610,7 +1610,7 @@ dbmdb_privdb_init_small_key(mdb_privdb_t *db, const MDB_val *longkey, int addnew
     key.mv_data = smallkey;
     key.mv_size = sizeof (*smallkey);
     rc = MDB_CURSOR_GET(db->cursor, &key, &data, MDB_SET_RANGE);
-    /* Let walk all the keys cwthjat have the right hash */
+    /* Let walk all the keys that have the right hash */
     while (rc == 0 && key.mv_size == sizeof(privdb_small_key_t) &&
            memcmp(key.mv_data, smallkey, offsetof(privdb_small_key_t, id)) == 0) {
         if (longkey->mv_size == data.mv_size &&

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -80,6 +80,13 @@ typedef struct {
     int line;
 } errinfo_t;
 
+/* Helper used to generate smaller key if privdn nrdn is too long. */
+typedef struct {
+    char header[sizeof (long)];
+    unsigned long h;
+    unsigned long id;
+} privdb_small_key_t;
+
 /*
  * Global reference to dbi slot table (used for debug purpose and for
  * dbmdb_dbicmp function. dbi are not closed (until either
@@ -167,6 +174,8 @@ dbmdb_get_file_params(const char *dbname, int *flags, MDB_cmp_func **dupsort_fn)
     if (is_dbfile(fname, LDBM_ENTRYRDN_STR)) {
         *flags |= MDB_DUPSORT;
         *dupsort_fn = dbmdb_entryrdn_compare_dups;
+    } else if (is_dbfile(fname, LDBM_LONG_ENTRYRDN_STR)) {
+        *flags |= 0;
     } else if (is_dbfile(fname, ID2ENTRY)) {
         *flags |= 0;
     } else if (strstr(fname,  CHANGELOG_PATTERN)) {
@@ -1581,6 +1590,58 @@ dbmdb_privdb_destroy(mdb_privdb_t **db)
     }
 }
 
+
+/* Compute a smaller key for long rdn */
+int
+dbmdb_privdb_init_small_key(mdb_privdb_t *db, const MDB_val *longkey, int addnewkey, privdb_small_key_t *smallkey)
+{
+    MDB_val key = {0};
+    MDB_val data = {0};
+    unsigned long nextid = 0;
+    char *pt = longkey->mv_data;
+    int rc = 0;
+
+    memset(smallkey, 0, sizeof *smallkey);
+    /* Prepare the samllkey used to store the long key with id=0 */
+    strcpy(smallkey->header, "==>");
+    for (pt += longkey->mv_size - 1; pt >= (char*)longkey->mv_data; pt--) {
+        smallkey->h += ((smallkey->h << 3) | (smallkey->h >> ((8 * sizeof(long)) - 3))) ^ (*pt & 0x1f);
+    }
+    key.mv_data = smallkey;
+    key.mv_size = sizeof (*smallkey);
+    rc = MDB_CURSOR_GET(db->cursor, &key, &data, MDB_SET_RANGE);
+    /* Let walk all the keys cwthjat have the right hash */
+    while (rc == 0 && key.mv_size == sizeof(privdb_small_key_t) &&
+           memcmp(key.mv_data, smallkey, offsetof(privdb_small_key_t, id)) == 0) {
+        if (longkey->mv_size == data.mv_size &&
+            memcmp(longkey->mv_data, data.mv_data, data.mv_size) == 0) {
+            /* Key to the wanted data exists, lets return the small key used for getting/storing data ! */
+            memcpy(smallkey, key.mv_data, key.mv_size);
+            smallkey->header[0] = '@';
+            return 0;
+        }
+        /* Wrong key, lets get next one */
+        memcpy(&nextid, &((privdb_small_key_t*)data.mv_data)->id, sizeof nextid);
+        nextid++;
+        rc = MDB_CURSOR_GET(db->cursor, &key, &data, MDB_NEXT);
+    }
+    if (rc ==0 || rc == MDB_NOTFOUND) {
+        /* Key does not exists */
+        if (addnewkey) {
+            /* Lets add it! */
+            smallkey->id = nextid;
+            key.mv_data = smallkey;
+            key.mv_size = sizeof (*smallkey);
+            rc = MDB_CURSOR_PUT(db->cursor, &key, (MDB_val*)longkey, 0);
+            smallkey->header[0] = '@';
+        } else {
+            rc = MDB_NOTFOUND;
+        }
+    }
+    return rc;
+}
+
+
 int
 dbmdb_privdb_get(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
 {
@@ -1588,7 +1649,18 @@ dbmdb_privdb_get(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
     data->mv_data = NULL;
     data->mv_size = 0;
     if (!rc) {
-        rc = MDB_CURSOR_GET(db->cursor, key, data, MDB_SET_KEY);
+        if (key->mv_size > db->maxkeysize) {
+            privdb_small_key_t small_key = {0};
+            MDB_val key2 = {0};
+            key2.mv_data = &small_key;
+            key2.mv_size = sizeof small_key;
+            rc = dbmdb_privdb_init_small_key(db, key, 0, &small_key);
+            if (!rc) {
+                rc = MDB_CURSOR_GET(db->cursor, &key2, data, MDB_SET_KEY);
+            }
+        } else {
+            rc = MDB_CURSOR_GET(db->cursor, key, data, MDB_SET_KEY);
+        }
         if (rc && rc != MDB_NOTFOUND) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
                           "Failed to get key from dndb cursor Error is %d: %s.", rc, mdb_strerror(rc));
@@ -1597,15 +1669,27 @@ dbmdb_privdb_get(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
     return rc;
 }
 
+
 int
 dbmdb_privdb_put(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
 {
     int rc = dbmdb_privdb_handle_cursor(db, 0);
     if (!rc) {
-        rc = MDB_CURSOR_PUT(db->cursor, key, data, MDB_NOOVERWRITE);
+        if (key->mv_size > db->maxkeysize) {
+            privdb_small_key_t small_key = {0};
+            MDB_val key2 = {0};
+            key2.mv_data = &small_key;
+            key2.mv_size = sizeof small_key;
+            rc = dbmdb_privdb_init_small_key(db, key, 1, &small_key);
+            if (!rc) {
+                rc = MDB_CURSOR_PUT(db->cursor, &key2, data, MDB_NOOVERWRITE);
+            }
+        } else {
+            rc = MDB_CURSOR_PUT(db->cursor, key, data, MDB_NOOVERWRITE);
+        }
         if (rc && rc != MDB_KEYEXIST) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to get key from dndb cursor Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to put data into dndb cursor Error is %d: %s.", rc, mdb_strerror(rc));
         }
     }
     if (!rc) {
@@ -1643,6 +1727,7 @@ dbmdb_privdb_create(dbmdb_ctx_t *ctx, size_t dbsize, ...)
         goto bail;
     }
 
+    db->maxkeysize = mdb_env_get_maxkeysize(db->env);
     mdb_env_set_maxdbs(db->env, nbdbis);
     mdb_env_set_mapsize(db->env, db->db_size);
 
@@ -1663,7 +1748,7 @@ dbmdb_privdb_create(dbmdb_ctx_t *ctx, size_t dbsize, ...)
         goto bail;
     }
 
-    rc = mdb_txn_begin(db->env, NULL, 0, &txn);
+    rc = TXN_BEGIN(db->env, NULL, 0, &txn);
     if (rc) {
         slapi_log_error(SLAPI_LOG_ERR, "dbmdb_privdb_create", "Failed to begin a txn for lmdb environment with path %s. Error %d :%s.\n", db->path, rc, mdb_strerror(rc));
         goto bail;
@@ -1675,18 +1760,18 @@ dbmdb_privdb_create(dbmdb_ctx_t *ctx, size_t dbsize, ...)
         db->dbis[i].state.flags = MDB_CREATE;
         db->dbis[i].dbname = va_arg(va, char*);
         if (rc == 0) {
-            rc = mdb_dbi_open(txn, db->dbis[i].dbname, db->dbis[i].state.flags, &db->dbis[i].dbi);
+            rc = MDB_DBI_OPEN(txn, db->dbis[i].dbname, db->dbis[i].state.flags, &db->dbis[i].dbi);
         }
     }
     va_end(va);
     if (rc) {
-        mdb_txn_abort(txn);
+        TXN_ABORT(txn);
         slapi_log_error(SLAPI_LOG_ERR, "dbmdb_privdb_create", "Failed to open a database instance for lmdb environment with path %s. Error %d :%s.\n", db->path, rc, mdb_strerror(rc));
         goto bail;
     }
-    rc = mdb_txn_commit(txn);
+    rc = TXN_COMMIT(txn);
     if (rc) {
-        mdb_txn_abort(txn);
+        TXN_ABORT(txn);
         slapi_log_error(SLAPI_LOG_ERR, "dbmdb_privdb_create", "Failed to commit database instance creation transaction for lmdb environment with path %s. Error %d :%s.\n", db->path, rc, mdb_strerror(rc));
         goto bail;
     }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -274,6 +274,7 @@ typedef struct {
     MDB_txn     *txn;
     MDB_cursor  *cursor;
     int         wcount;
+    int         maxkeysize;
 } mdb_privdb_t;
 
 #include "mdb_debug.h"

--- a/ldap/servers/slapd/back-ldbm/dbimpl.h
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.h
@@ -115,6 +115,16 @@ typedef struct {
     char info[PATH_MAX];
 } dbi_dbslist_t;
 
+/* For dblayer_entryrdn_records() */
+typedef struct {
+    int redirect;              /* 0 means: no redirect record */
+    int suffix_too_long;       /* !0 means: that suffix is too long */
+    dbi_val_t key;             /* entryrdn db key */
+    dbi_val_t data;            /* entryrdn db data */
+    dbi_val_t redirect_key;    /* redirect db key */
+    dbi_val_t redirect_data;   /* redirect db data */
+} dbi_entryrdn_records_t;
+
 struct attrinfo;
 typedef int dbi_iterate_cb_t(dbi_val_t *key, dbi_val_t *data, void *ctx);
 
@@ -165,9 +175,11 @@ dbi_dbslist_t *dblayer_list_dbs(const char *dbimpl_name, const char *dbhome);
 int dblayer_db_remove(Slapi_Backend *be, dbi_db_t *db);
 int dblayer_show_statistics(const char *dbimpl_name, const char *dbhome, FILE *fout, FILE *ferr);
 int dblayer_is_lmdb(Slapi_Backend *be);
-int dblayer_cursor_iterate(dbi_cursor_t *cursor, 
+int dblayer_cursor_iterate(dbi_cursor_t *cursor,
                            int (*action_cb)(dbi_val_t *key, dbi_val_t *data, void *ctx),
                            const dbi_val_t *startingkey, void *ctx);
-
+void dblayer_entryrdn_init_records(Slapi_Backend *be, const dbi_val_t *key, const dbi_val_t *data,
+                                  dbi_entryrdn_records_t *record);
+void dblayer_entryrdn_discard_records(Slapi_Backend *be, dbi_entryrdn_records_t *record);
 
 #endif /* DBIMPL_H_ */

--- a/ldap/servers/slapd/back-ldbm/nextid.c
+++ b/ldap/servers/slapd/back-ldbm/nextid.c
@@ -193,7 +193,7 @@ id_internal_to_stored(ID i, char *b)
 }
 
 ID
-id_stored_to_internal(char *b)
+id_stored_to_internal(const char *b)
 {
     ID i;
     i = (ID)b[3] & 0x000000ff;
@@ -212,7 +212,7 @@ sizeushort_internal_to_stored(size_t i, char *b)
 }
 
 size_t
-sizeushort_stored_to_internal(char *b)
+sizeushort_stored_to_internal(const char *b)
 {
     size_t i;
     i = (PRUint16)b[1] & 0x000000ff;

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -633,8 +633,6 @@ void entryrdn_set_switch(int val);
 int entryrdn_get_switch(void);
 void entryrdn_set_noancestorid(int val);
 int entryrdn_get_noancestorid(void);
-int entryrdn_insert_key(backend *be, dbi_cursor_t *cursor, Slapi_RDN *srdn, ID id, back_txn *txn);
-int entryrdn_delete_key(backend *be, dbi_cursor_t *cursor, Slapi_RDN *srdn, ID id, back_txn *txn);
 int entryrdn_index_entry(backend *be, struct backentry *e, int flags, back_txn *txn);
 int entryrdn_index_read(backend *be, const Slapi_DN *sdn, ID *id, back_txn *txn);
 int

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -351,9 +351,9 @@ ID next_id(backend *be);
 void next_id_return(backend *be, ID id);
 ID next_id_get(backend *be);
 void id_internal_to_stored(ID, char *);
-ID id_stored_to_internal(char *);
+ID id_stored_to_internal(const char *);
 void sizeushort_internal_to_stored(size_t i, char *b);
-size_t sizeushort_stored_to_internal(char *b);
+size_t sizeushort_stored_to_internal(const char *b);
 void get_ids_from_disk(backend *be);
 void get_both_ids(struct ldbminfo *li, ID *nextid, ID *nextid2index);
 


### PR DESCRIPTION
The issue is that entryrdn.db does not support data longer than 511 bytes and same issue about the internal db keys used for the import/reindex pipeline. 
Solution for entryrdn. I created a dbi that does not support duplicate keys (but it supports long data)
  and replaced the long rdn_elem  by a "redirect" rdn_elem that contains the key to the long data in @long-entryrdn.db
 As entryrdn code is tricky, I have first done some cleanup by using a context as parameter rather than several parameters
   (because the parameter list was getting quite large for some functions)  and added new functions to factorize the open/close for the context (and the cursor open/close) retry loop)
  I also improved the debug features because I need it ! 
  About the import internal db/ I create redirect key that refer to records whose data contains the real key
  
  Issue #6105 
  
  Reviewed by: @droideck 