### PR TITLE
Issue 5105 - lmdb - Cannot create entries with long rdn - fix covscan

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -1733,16 +1733,15 @@ _entryrdn_put_data(entryrdn_db_ctx_t *ctx, dbi_val_t *key, dbi_val_t *data, char
     int db_retry = 0;
     int rc = -1;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_put_data",
-                  "--> _entryrdn_put_data\n");
     if (NULL == ctx || NULL == key || NULL == data) {
         slapi_log_err(SLAPI_LOG_ERR, "_entryrdn_put_data",
                       "Param error: Empty %s\n",
                       NULL == ctx ? "database context" : NULL == key
                       ? "key" : NULL == data ? "data" : "unknown");
-        _ENTRYRDN_DEBUG_GOTO_BAIL();
-        goto bail;
+        return -1;
     }
+    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_put_data",
+                  "--> _entryrdn_put_data\n");
 
     dblayer_entryrdn_init_records(ctx->be, key, data, &rec);
     if (rec.suffix_too_long) {
@@ -1819,15 +1818,14 @@ _entryrdn_del_data(entryrdn_db_ctx_t *ctx, dbi_val_t *key, dbi_val_t *data)
     int db_retry = 0;
     int rc = -1;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_del_data",
-                  "--> _entryrdn_del_data\n");
     if (NULL == ctx || NULL == key || NULL == data) {
         slapi_log_err(SLAPI_LOG_ERR, "_entryrdn_del_data",
                       "Param error: Empty %s\n",
                       NULL == ctx ? "database context" : NULL == key ? "key" : NULL == data ? "data" : "unknown");
-        _ENTRYRDN_DEBUG_GOTO_BAIL();
-        goto bail;
+        return -1;
     }
+    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_del_data",
+                  "--> _entryrdn_del_data\n");
     dblayer_entryrdn_init_records(ctx->be, key, data, &rec);
     if (rec.suffix_too_long) {
         errmsg = "Backend suffix is too long";
@@ -1928,17 +1926,16 @@ _entryrdn_insert_key_elems(entryrdn_db_ctx_t *ctx,
     int rc = 0;
     ID myid = 0;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_insert_key_elems",
-                  "--> _entryrdn_insert_key_elems\n");
-
     if (NULL == ctx || NULL == srdn ||
         NULL == key || NULL == parentelem || NULL == elem) {
         slapi_log_err(SLAPI_LOG_ERR, "_entryrdn_insert_key_elems",
                       "Param error: Empty %s\n",
                       NULL == ctx ? "database context" : NULL == srdn ? "RDN" : NULL == key ? "key" : NULL == parentelem ? "parent element" : NULL == elem ? "target element" : "unknown");
-        _ENTRYRDN_DEBUG_GOTO_BAIL();
-        goto bail;
+        return -1;
     }
+    slapi_log_err(SLAPI_LOG_TRACE, "_entryrdn_insert_key_elems",
+                  "--> _entryrdn_insert_key_elems\n");
+
     _ENTRYRDN_DUMP_RDN_ELEM(elem);
     dblayer_value_set_buffer(ctx->be, &adddata, elem, elemlen);
 
@@ -2182,7 +2179,7 @@ _entryrdn_replace_suffix_id(entryrdn_db_ctx_t *ctx, dbi_val_t *key, dbi_val_t *a
             rc = _entryrdn_resolve_redirect(ctx, &pelem, 1);
             if (rc) {
                 _ENTRYRDN_DEBUG_GOTO_BAIL();
-                goto bail;
+                goto bail0;
             }
             moddata.data = pelem;
         }
@@ -2250,16 +2247,14 @@ entryrdn_insert_key(entryrdn_db_ctx_t *ctx, Slapi_RDN *srdn, ID id)
     Slapi_RDN *tmpsrdn = NULL;
     int db_retry = 0;
 
-    slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_insert_key",
-                  "--> _entryrdn_insert_key\n");
-
     if (NULL == ctx || NULL == srdn || 0 == id) {
         slapi_log_err(SLAPI_LOG_ERR, "entryrdn_insert_key",
                       "Param error: Empty %s\n",
                       NULL == ctx ? "database context" : NULL == srdn ? "RDN" : 0 == id ? "id" : "unknown");
-        _ENTRYRDN_DEBUG_GOTO_BAIL();
-        goto bail;
+        return -1;
     }
+    slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_insert_key",
+                  "--> _entryrdn_insert_key\n");
 
     if (ctx->txn && ctx->txn->back_special_handling_fn) {
         /* back_special_handling_fn means that the calling thread is doing an import or reindex
@@ -2644,16 +2639,14 @@ entryrdn_delete_key(entryrdn_db_ctx_t *ctx, Slapi_RDN *srdn, ID id)
     int done = 0;
     char buffer[RDN_BULK_FETCH_BUFFER_SIZE];
 
-    slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_delete_key",
-                  "--> entryrdn_delete_key\n");
-
     if (NULL == ctx || NULL == srdn || 0 == id) {
         slapi_log_err(SLAPI_LOG_ERR, "entryrdn_delete_key",
                       "Param error: Empty %s\n",
                       NULL == ctx ? "database context" : NULL == srdn ? "RDN" : 0 == id ? "ID" : "unknown");
-        _ENTRYRDN_DEBUG_GOTO_BAIL();
-        goto bail;
+        return -1;
     }
+    slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_delete_key",
+                  "--> entryrdn_delete_key\n");
 
     if (ctx->txn && ctx->txn->back_special_handling_fn) {
         /* back_special_handling_fn means that the calling thread is doing an import or reindex


### PR DESCRIPTION
A minor code cleanup issue fixing: CID 1540880 CID 1540879 CID 1540878 CID 1540876 CID 1540875
  All these report have the same pattern but on different function. 
  The issue is that ctx == NULL is tested as part of the parameter validity tests (even if it is never NULL)
  then goto bail but the bail code dereference ctx to potentially free some resources.
  So I changed the code from:
     Log Entering in Function
     If (One of parameter is NULL) {
          Log Error message
          goto bail
      } 
   To:
    If (One of parameter is NULL) {
          Log Error message
          return -1;
     }
     Log Entering in Function
CID 1540877 is a real issue about a potential memory leak in case of error (shoud goto bail0 instead of bail to make sure childelem is free)

Issue: #6105      
      
Reviewed by: @droideck  Thanks!
