### PR TITLE
Issue 6133 - Move slapi_pblock_set_flag_operation_notes() to slapi-pl…

### DIFF
--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -7326,6 +7326,16 @@ typedef enum _slapi_op_note_t {
     SLAPI_OP_NOTE_MFA_AUTH = 0x10,
 } slapi_op_note_t;
 
+/**
+ * Set an operation note on an operation.  This will append a notes keyword
+ * in the access log result line for this operation
+ *
+ * \param pb - The slapi_pblock structure
+ * \param opnotes
+ * \return void
+ */
+void slapi_pblock_set_operation_notes(Slapi_PBlock *pb, uint32_t opnotes);
+
 
 /* Allows controls to be passed before operation object is created */
 #define SLAPI_CONTROLS_ARG 58

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1510,7 +1510,6 @@ struct slapi_entry *slapi_pblock_get_pw_entry(Slapi_PBlock *pb);
 void slapi_pblock_set_pw_entry(Slapi_PBlock *pb, struct slapi_entry *entry);
 
 uint32_t slapi_pblock_get_operation_notes(Slapi_PBlock *pb);
-void slapi_pblock_set_operation_notes(Slapi_PBlock *pb, uint32_t opnotes);
 void slapi_pblock_set_flag_operation_notes(Slapi_PBlock *pb, uint32_t opflag);
 void slapi_pblock_set_result_text_if_empty(Slapi_PBlock *pb, char *text);
 


### PR DESCRIPTION
…ugin.h

Description:

slapi_pblock_set_flag_operation_notes() is currently only available in slapi-private.h, but with the latest changes to add "notes=M" it needs to be available to plugins.

relates: https://github.com/389ds/389-ds-base/issues/6133

Reviewed by: ?