### PR TITLE
Issue 6142 - [RFE] Add LMDB configuration related checks into Healthcheck tool

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -9,15 +9,18 @@
 
 import pytest
 import os
-from lib389.backend import Backends
+from lib389 import DirSrv
+from lib389.backend import Backends, DatabaseConfig
 from lib389.mappingTree import MappingTrees
 from lib389.replica import Changelog5,  Changelog
 from lib389.utils import *
 from lib389._constants import *
-from lib389.cli_base import FakeArgs
+from lib389.cli_base import FakeArgs, LogCapture
 from lib389.topologies import topology_st, topology_no_sample, topology_m2
 from lib389.cli_ctl.health import health_check_run
+from lib389.cli_conf.backend import db_config_set
 from lib389.paths import Paths
+from lib389.instance.setup import SetupDs
 
 CMD_OUTPUT = 'No issues found.'
 JSON_OUTPUT = '[]'
@@ -27,7 +30,7 @@ ds_paths = Paths()
 log = logging.getLogger(__name__)
 
 
-def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=False, searched_code2=None,
+def run_healthcheck_and_flush_log(logcap, instance, searched_code=None, json=False, searched_code2=None,
                                   list_checks=False, list_errors=False, check=None, searched_list=None):
     args = FakeArgs()
     args.instance = instance.serverid
@@ -39,22 +42,22 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=F
     args.json = json
 
     log.info('Use healthcheck with --json == {} option'.format(json))
-    health_check_run(instance, topology.logcap.log, args)
+    health_check_run(instance, logcap.log, args)
 
     if searched_list is not None:
         for item in searched_list:
-            assert topology.logcap.contains(item)
+            assert logcap.contains(item)
             log.info('Healthcheck returned searched item: %s' % item)
     else:
-        assert topology.logcap.contains(searched_code)
+        assert logcap.contains(searched_code)
         log.info('Healthcheck returned searched code: %s' % searched_code)
 
     if searched_code2 is not None:
-        assert topology.logcap.contains(searched_code2)
+        assert logcap.contains(searched_code2)
         log.info('Healthcheck returned searched code: %s' % searched_code2)
 
     log.info('Clear the log')
-    topology.logcap.flush()
+    logcap.flush()
 
 
 def set_changelog_trimming(instance):
@@ -89,8 +92,8 @@ def test_healthcheck_disabled_suffix(topology_st):
     mt.replace("nsslapd-state", "disabled")
     topology_st.standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
-    run_healthcheck_and_flush_log(topology_st, topology_st.standalone, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_st, topology_st.standalone, RET_CODE, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, topology_st.standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, topology_st.standalone, RET_CODE, json=True)
 
     # reset the suffix state
     mt.replace("nsslapd-state", "backend")
@@ -114,8 +117,8 @@ def test_healthcheck_standalone(topology_st):
 
     standalone = topology_st.standalone
 
-    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT,json=False)
-    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT,json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
 
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
@@ -155,7 +158,7 @@ def test_healthcheck_list_checks(topology_st):
 
     standalone = topology_st.standalone
 
-    run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_checks=True, searched_list=output_list)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_checks=True, searched_list=output_list)
 
 
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
@@ -177,6 +180,9 @@ def test_healthcheck_list_errors(topology_st):
     output_list = ['DSBLE0001 :: Possibly incorrect mapping tree',
                    'DSBLE0002 :: Unable to query backend',
                    'DSBLE0003 :: Uninitialized backend database',
+                   'DSBLE0004 :: Both MDB and BDB database files are present',
+                   'DSBLE0005 :: Backend configuration attributes mismatch',
+                   'DSBLE0006 :: BDB is still used as a backend',
                    'DSCERTLE0001 :: Certificate about to expire',
                    'DSCERTLE0002 :: Certificate expired',
                    'DSCLE0001 :: Different log timestamp format',
@@ -206,7 +212,7 @@ def test_healthcheck_list_errors(topology_st):
 
     standalone = topology_st.standalone
 
-    run_healthcheck_and_flush_log(topology_st, standalone, json=False, list_errors=True, searched_list=output_list)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_errors=True, searched_list=output_list)
 
 
 @pytest.mark.xfail(ds_is_older("1.4.2"), reason="Not implemented")
@@ -252,9 +258,9 @@ def test_healthcheck_check_option(topology_st):
     for item in output_list:
         pattern = 'Checking ' + item
         log.info('Check {}'.format(item))
-        run_healthcheck_and_flush_log(topology_st, standalone, searched_code=pattern, json=False, check=[item],
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, searched_code=pattern, json=False, check=[item],
                                       searched_code2=CMD_OUTPUT)
-        run_healthcheck_and_flush_log(topology_st, standalone, searched_code=JSON_OUTPUT, json=True, check=[item])
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, searched_code=JSON_OUTPUT, json=True, check=[item])
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -278,8 +284,8 @@ def test_healthcheck_standalone_tls(topology_st):
     standalone = topology_st.standalone
     standalone.enable_tls()
 
-    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT,json=False)
-    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT,json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -310,12 +316,12 @@ def test_healthcheck_replication(topology_m2):
     M2.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('Run healthcheck for supplier1')
-    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
-    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
 
     log.info('Run healthcheck for supplier2')
-    run_healthcheck_and_flush_log(topology_m2, M2, CMD_OUTPUT, json=False)
-    run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -347,12 +353,12 @@ def test_healthcheck_replication_tls(topology_m2):
     log.info('Run healthcheck for supplier1')
     M1.config.set("nsslapd-accesslog-logbuffering", "on")
     M2.config.set("nsslapd-accesslog-logbuffering", "on")
-    run_healthcheck_and_flush_log(topology_m2, M1, CMD_OUTPUT, json=False)
-    run_healthcheck_and_flush_log(topology_m2, M1, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
 
     log.info('Run healthcheck for supplier2')
-    run_healthcheck_and_flush_log(topology_m2, M2, CMD_OUTPUT, json=False)
-    run_healthcheck_and_flush_log(topology_m2, M2, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -390,8 +396,8 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
     mt = mts.get(DEFAULT_SUFFIX)
     mt.delete()
 
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE1, json=False, searched_code2=RET_CODE2)
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE1, json=True, searched_code2=RET_CODE2)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=False, searched_code2=RET_CODE2)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=True, searched_code2=RET_CODE2)
 
     log.info('Create the dc=example,dc=com backend suffix entry')
     mts.create(properties={
@@ -400,8 +406,8 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
         'nsslapd-backend': 'USERROOT',
     })
 
-    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
-    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -443,13 +449,13 @@ def test_healthcheck_unable_to_query_backend(topology_st):
     mt_new = mts.get(NEW_SUFFIX)
     mt_new.replace('nsslapd-state', 'disabled')
 
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
 
     log.info('Enable the suffix again and check if nothing is broken')
     mt_new.replace('nsslapd-state', 'backend')
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")
@@ -471,8 +477,78 @@ def test_healthcheck_database_not_initialized(topology_no_sample):
     RET_CODE = 'DSBLE0003'
     standalone = topology_no_sample.standalone
 
-    run_healthcheck_and_flush_log(topology_no_sample, standalone, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_no_sample, standalone, RET_CODE, json=True)
+    run_healthcheck_and_flush_log(topology_no_sample.logcap, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_no_sample.logcap, standalone, RET_CODE, json=True)
+
+
+def create_dummy_db_files(inst, backend_type):
+    # Define the sets of dummy files for each backend type
+    mdb_files = ['data.mdb', 'lock.mdb', 'INFO.mdb']
+    bdb_files = ['__db.001', 'DBVERSION', '__db.003', 'userRoot', 'log.0000000001', '__db.002']
+    
+    # Determine the target file list based on the backend type
+    if backend_type == 'mdb':
+        target_files = mdb_files
+    else:
+        target_files = bdb_files
+
+    # Get the database directory paths from the instance
+    db_dir = inst.ds_paths.db_dir
+    
+    # Create dummy files in the primary database directory
+    for filename in target_files:
+        filepath = os.path.join(db_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write('')  # Create an empty file for simplicity
+
+
+def test_lint_backend_implementation_wrong_files(topology_st):
+    """Test the lint for backend implementation wrong files
+
+    :id: 22cd14f2-c5ba-45e0-96fc-0678adc5c5db
+    :setup: Custom instance with db_lib set to either mdb or bdb.
+    :steps:
+        1. Manually create dummy backend files for the test instance.
+        2. Run the linting function to check for errors.
+    :expectedresults:
+        1. The dummy backend files are created successfully.
+        2. The linting function identifies the issue and reports correctly.
+    """
+
+    RET_CODE = 'DSBLE0004'
+
+    inst = topology_st.standalone
+
+    if inst.get_db_lib() == 'mdb':
+        create_dummy_db_files(inst, 'bdb')
+    else:
+        create_dummy_db_files(inst, 'mdb')
+
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+
+
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")
+def test_lint_backend_implementation(create_custom_db_instance):
+    """Test the lint for backend implementation mismatch
+
+    :id: eff607de-768a-4cf4-bcde-48d4c7368934
+    :setup: Custom instance with db_lib set to either mdb or bdb.
+    :steps:
+        1. Fetch the 'nsslapd-backend-implement' attribute value.
+        2. Manually set BDB as the backend implementation if MDB
+        3. Run the linting function to check if BDB is used
+    :expectedresults:
+        1. The 'nsslapd-backend-implement' attribute is fetched correctly.
+        2. The implementation is set to BDB.
+        3. The linting function identifies that BDB is still used as a backend and reports the correct severity issue.
+    """
+
+    RET_CODE = 'DSBLE0006'
+    inst = topology_st.standalone
+
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -57,6 +57,35 @@ DSBLE0003 = {
     'fix': """You need to import an LDIF file, or create the suffix entry, in order to initialize the database."""
 }
 
+# BDB and MDB checks
+DSBLE0004 = {
+    'dsle': 'DSBLE0004',
+    'severity': 'LOW',
+    'description': 'Both MDB and BDB database files are present.',
+    'items': [],
+    'detail': """Files for both MDB and BDB databases have been found. This indicates that a cleanup of the database 
+files has not been performed after a backend implementation change.""",
+    'fix': """Run 'dsctl <instance> dblib cleanup' to remove old database files that are no longer needed or remove them manually."""
+}
+
+DSBLE0005 = {
+    'dsle': 'DSBLE0005',
+    'severity': 'LOW',
+    'description': 'Backend configuration attributes mismatch.',
+    'items': [],
+    'detail': 'Found configuration attributes that are not applicable for the configured backend type.',
+    'fix': 'Review the backend configuration and remove or adjust the incorrect attributes.'
+}
+
+DSBLE0006 = {
+    'dsle': 'DSBLE0006',
+    'severity': 'MEDIUM',
+    'description': 'BDB is still used as a backend.',
+    'items': [],
+    'detail': 'BDB is deprecated and should not be used as a backend.',
+    'fix': 'Migrate the backend to MDB.'
+}
+
 # Config checks
 DSCLE0001 = {
     'dsle': 'DSCLE0001',


### PR DESCRIPTION
Description
Add a warning in healthcheck if bdb is still used. Add warnings if there's a mismatch in configuration attributes.

Fixes: https://github.com/389ds/389-ds-base/issues/6142

Reviewed by: @progier389 (Thanks!)