### PR TITLE
Issue 6141 - freeipa test_topology_TestCASpecificRUVs is failing

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2338,17 +2338,17 @@ int dbmdb_cursor_get_recno(dbi_cursor_t *cursor, MDB_val *dbmdb_key, MDB_val *db
         rc = MDB_CURSOR_OPEN(mdb_cursor_txn(cursor->cur), mdb_cursor_dbi(cursor->cur), &newcur);
     }
     if (rc == 0) {
-        rc = MDB_CURSOR_GET(newcur, &rce->key, &rce-> data, MDB_SET);
+        rc = MDB_CURSOR_GET(newcur, &rce->key, &rce->data, MDB_SET);
     }
     while (rc == 0) {
         cmpres = dbmdb_cmp_dbi_record(mdb_cursor_dbi(cursor->cur), &curpos_key, &curpos_data, &rce->key, &rce->data);
-        if (cmpres >= 0) {
+        if (cmpres <= 0) {
             break;
         }
         rce->recno++;
         rc = MDB_CURSOR_GET(newcur, &rce->key, &rce->data, MDB_NEXT);
     }
-    if (cmpres > 0) {
+    if (cmpres < 0) {
         rc = MDB_NOTFOUND;
     }
     if (rc == 0) {

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -384,7 +384,9 @@ vlv_rebuild_scope_filter(backend *be)
                                  (void *)plugin_get_default_component_id(), 0);
     slapi_pblock_set(pb, SLAPI_BACKEND, be);
     slapi_pblock_set(pb, SLAPI_PLUGIN, be->be_database);
-    slapi_pblock_set(pb, SLAPI_TXN, txn->back_txn_txn);
+    if (txn) {
+        slapi_pblock_set(pb, SLAPI_TXN, txn->back_txn_txn);
+    }
 
     slapi_rwlock_wrlock(be->vlvSearchList_lock);
     for (p = be->vlvSearchList; p != NULL; p = p->vlv_next) {


### PR DESCRIPTION
On lmdb, vlv search using a value instead of range may fail (set target on first record instead of smallest record whose key is greater of equal to the wanted value).
The reason is that a test is inverted when walking the cursor to find the record position so the loop end after first iteration. 
Also fix a coverity scan warning

Issue: #6141 

Reviewed by: @tbordaz 