### PR TITLE
Issue 6082 - Remove explicit dependencies toward libdb - revert default

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -20,7 +20,7 @@ GIT_TAG = ${TAG}
 #  then uploaded in https://fedorapeople.org
 LIBDB_URL ?= $(shell rpmspec -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source4:/ {print $$2}')
 LIBDB_TARBALL ?= $(shell basename "$(LIBDB_URL)")
-BUNDLE_LIBDB = 1
+BUNDLE_LIBDB ?= 0
 
 # Some sanitizers are supported only by clang
 CLANG_ON = 0


### PR DESCRIPTION
Change BUNDLE_LIBDB default value so that Fedora packages are still using /lib64/libdb-5.3.so by default. The version with bundled lib may still be generated by using: BUNDLE_LIBDB=1 SKIP_AUDIT_CI=1 make -f rpm.mk update-cargo-dependencies download-cargo-dependencies srpms BUNDLE_LIBDB=1 SKIP_AUDIT_CI=1 make -f rpm.mk rpms

Issue: #6082 

reviewed by: @jchapma 
