### PR TITLE
Issue 6157 - Cockipt crashes when getting replication status if

### DIFF
--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1262,7 +1262,7 @@ class Replica(DSLdapObject):
                             report['detail'] = report['detail'].replace('MSG', status['reason'])
                             report['check'] = f'replication:agmts_status'
                             yield report
-                except ldap.LDAPError as e:
+                except (ldap.LDAPError, TypeError, ValueError, KeyError) as e:
                     report = copy.deepcopy(DSREPLLE0004)
                     report['detail'] = report['detail'].replace('SUFFIX', suffix)
                     report['detail'] = report['detail'].replace('AGMT', agmt_name)


### PR DESCRIPTION
the topology contains an old 389ds version.

dsconf -j instance replica status --suffix ... aborts if a topology contains an old version that does not set nsds5replicaLastUpdateStatusJSON in the replica agreement.
Fix is in two parts:
   Catch TypeError, ValueError and KeyError in the _lint_agmts_status function to preserve the cockpit page and
       the other agreement status in case of unexpected error.
   While decoding the json attribute in get_agmt_status:
        Catch the jsonDecodeError and generates a red state with a message explaining that value has an invalid format
        Catch the TypeError and generates an amber state with legacy replica status message 

Issue: #6157  

Reviewed by: @droideck (Thanks!)
