### PR TITLE
fix issue6165

### DIFF
--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -1627,7 +1627,6 @@ writeintegritylog(Slapi_PBlock *pb, char *logfilename, Slapi_DN *sdn, char *newr
                       "writeintegritylog - Could not write integrity log \"%s\" " SLAPI_COMPONENT_NAME_NSPR " %d (%s)\n",
                       logfilename, PR_GetError(), slapd_pr_strerror(PR_GetError()));
 
-        PR_Unlock(referint_mutex);
         referint_unlock();
         return;
     }


### PR DESCRIPTION
Problem: Server crash when using the referential integrity plugin when transactions are used and an error occurs when opening a file for writing.
Cause: The crash is caused by using an uninitialized mutex PR_Unlock(referint_mutex)) after the error message and before calling referint_unlock();
Fix: The line using the uninitialized mutex **PR_Unlock(referint_mutex)** has been _removed_. It opens with an initialization check in the function below - **referint_unlock().**

Issue: #6166 

Reviewed by: @progier389 