### PR TITLE
Issue 6155 - ldap-agent fails to start because of permission error

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -21,9 +21,6 @@ else:
     # Use tests from the source
     suites = next(os.walk('dirsrvtests/tests/suites/'))[1]
 
-    # Filter out snmp as it is an empty directory:
-    suites.remove('snmp')
-
     # Filter out webui because of broken tests
     suites.remove('webui')
 

--- a/dirsrvtests/tests/suites/snmp/snmp.py
+++ b/dirsrvtests/tests/suites/snmp/snmp.py
@@ -1,0 +1,214 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2024 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import pytest
+import logging
+import subprocess
+import ldap
+from datetime import datetime
+from shutil import copyfile
+from lib389.topologies import topology_m2 as topo_m2
+from lib389.utils import selinux_present
+
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+SNMP_USER = 'user_name'
+SNMP_PASSWORD = 'authentication_password'
+SNMP_PRIVATE = 'private_password'
+
+# LDAP OID in MIB
+LDAP_OID = '.1.3.6.1.4.1.2312.6.1.1'
+LDAPCONNECTIONS_OID = f'{LDAP_OID}.21'
+
+
+def run_cmd(cmd, check_returncode=True):
+    """Run a command"""
+
+    log.info(f'Run: {cmd}')
+    result = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+    log.info(f'STDOUT of {cmd} is:\n{result.stdout}')
+    log.info(f'STDERR of {cmd} is:\n{result.stderr}')
+    if check_returncode:
+        result.check_returncode()
+    return result
+
+
+def add_lines(lines, filename):
+    """Add lines that are not already present at the end of a file"""
+
+    log.info(f'add_lines({lines}, {filename})')
+    try:
+        with open(filename, 'r') as fd:
+            for line in fd:
+                try:
+                    lines.remove(line.strip())
+                except ValueError:
+                    pass
+    except FileNotFoundError:
+        pass
+    if lines:
+        with open(filename, 'a') as fd:
+            for line in lines:
+                fd.write(f'{line}\n')
+
+
+def remove_lines(lines, filename):
+    """Remove lines in a file"""
+
+    log.info(f'remove_lines({lines}, {filename})')
+    file_lines = []
+    with open(filename, 'r') as fd:
+        for line in fd:
+            if not line.strip() in lines:
+                file_lines.append(line)
+    with open(filename, 'w') as fd:
+        for line in file_lines:
+            fd.write(line)
+
+
+@pytest.fixture(scope="module")
+def setup_snmp(topo_m2, request):
+    """Install snmp and configure it
+
+    Returns the time just before dirsrv-snmp get restarted
+    """
+
+    inst1 = topo_m2.ms["supplier1"]
+    inst2 = topo_m2.ms["supplier2"]
+
+    # Check for the test prerequisites
+    if os.getuid() != 0:
+        pytest.skip('This test should be run by root superuser')
+        return None
+    if not inst1.with_systemd_running():
+        pytest.skip('This test requires systemd')
+        return None
+    required_packages = {
+        '389-ds-base-snmp': os.path.join(inst1.get_sbin_dir(), 'ldap-agent'),
+        'net-snmp': '/etc/snmp/snmpd.conf', }
+    skip_msg = ""
+    for package,file in required_packages.items():
+        if not os.path.exists(file):
+            skip_msg += f"Package {package} is not installed ({file} is missing).\n"
+    if skip_msg != "":
+        pytest.skip(f'This test requires the following package(s): {skip_msg}')
+        return None
+
+    # Install snmp
+    # run_cmd(['/usr/bin/dnf', 'install', '-y', 'net-snmp', 'net-snmp-utils', '389-ds-base-snmp'])
+
+    # Prepare the lines to add/remove in files:
+    #  master agentx
+    #  snmp user (user_name - authentication_password - private_password)
+    #  ldap_agent ds instances
+    #
+    # Adding rwuser and createUser lines is the same as running:
+    #  net-snmp-create-v3-user -A authentication_password -a SHA -X private_password -x AES user_name
+    # but has the advantage of removing the user at cleanup phase
+    #
+    agent_cfg = '/etc/dirsrv/config/ldap-agent.conf'
+    lines_dict = { '/etc/snmp/snmpd.conf' : ['master agentx', f'rwuser {SNMP_USER}'],
+                   '/var/lib/net-snmp/snmpd.conf' : [
+                        f'createUser {SNMP_USER} SHA "{SNMP_PASSWORD}" AES "{SNMP_PRIVATE}"',],
+                   agent_cfg : [] }
+    for inst in topo_m2:
+        lines_dict[agent_cfg].append(f'server slapd-{inst.serverid}')
+
+    # Prepare the cleanup
+    def fin():
+        run_cmd(['systemctl', 'stop', 'dirsrv-snmp'])
+        if not DEBUGGING:
+            run_cmd(['systemctl', 'stop', 'snmpd'])
+            try:
+                os.remove('/usr/share/snmp/mibs/redhat-directory.mib')
+            except FileNotFoundError:
+                pass
+            for filename,lines in lines_dict.items():
+                remove_lines(lines, filename)
+            run_cmd(['systemctl', 'start', 'snmpd'])
+
+    request.addfinalizer(fin)
+
+    # Copy RHDS MIB in default MIB search path (Ugly because I have not found how to change the search path)
+    copyfile('/usr/share/dirsrv/mibs/redhat-directory.mib', '/usr/share/snmp/mibs/redhat-directory.mib')
+
+    run_cmd(['systemctl', 'stop', 'snmpd'])
+    for filename,lines in lines_dict.items():
+        add_lines(lines, filename)
+
+    run_cmd(['systemctl', 'start', 'snmpd'])
+
+    curtime = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    run_cmd(['systemctl', 'start', 'dirsrv-snmp'])
+    return curtime
+
+
+@pytest.mark.skipif(not os.path.exists('/usr/bin/snmpwalk'), reason="net-snmp-utils package is not installed")
+def test_snmpwalk(topo_m2, setup_snmp):
+    """snmp smoke tests.
+
+    :id: e5d29998-1c21-11ef-a654-482ae39447e5
+    :setup: Two suppliers replication setup, snmp
+    :steps:
+        1. use snmpwalk to display LDAP statistics
+        2.  use snmpwalk to get the number of open connections
+    :expectedresults:
+        1. Success and no messages in stderr
+        2. The number of open connections should be positive
+    """
+
+    inst1 = topo_m2.ms["supplier1"]
+    inst2 = topo_m2.ms["supplier2"]
+
+
+    cmd = [ '/usr/bin/snmpwalk', '-v3', '-u', SNMP_USER, '-l', 'AuthPriv',
+            '-m', '+RHDS-MIB', '-A', SNMP_PASSWORD, '-a', 'SHA',
+            '-X', SNMP_PRIVATE, '-x', 'AES', 'localhost',
+            LDAP_OID ]
+    result = run_cmd(cmd)
+    assert not result.stderr
+
+    cmd = [ '/usr/bin/snmpwalk', '-v3', '-u', SNMP_USER, '-l', 'AuthPriv',
+            '-m', '+RHDS-MIB', '-A', SNMP_PASSWORD, '-a', 'SHA',
+            '-X', SNMP_PRIVATE, '-x', 'AES', 'localhost',
+            f'{LDAPCONNECTIONS_OID}.{inst1.port}', '-Ov' ]
+    result = run_cmd(cmd)
+    nbconns = int(result.stdout.split()[1])
+    log.info(f'There are {nbconns} open connections on {inst1.serverid}')
+    assert nbconns > 0
+
+
+@pytest.mark.skipif(not selinux_present(), reason="SELinux is not enabled")
+def test_snmp_avc(topo_m2, setup_snmp):
+    """snmp smoke tests.
+
+    :id: fb79728e-1d0d-11ef-9213-482ae39447e5
+    :setup: Two suppliers replication setup, snmp
+    :steps:
+        1. Get the system journal about ldap-agent
+    :expectedresults:
+        1. No AVC should be present
+    """
+    result = run_cmd(['journalctl', '-S', setup_snmp, '-g', 'ldap-agent'])
+    assert not 'AVC' in result.stdout
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/ldap/servers/slapd/agtmmap.h
+++ b/ldap/servers/slapd/agtmmap.h
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <semaphore.h>
 #include <errno.h>
 #include "nspr.h"
 
@@ -187,6 +188,18 @@ int agt_mopen_stats(char *statsfile, int mode, int *hdl);
 int agt_mclose_stats(int hdl);
 
 int agt_mread_stats(int hdl, struct hdr_stats_t *, struct ops_stats_t *, struct entries_stats_t *);
+
+/****************************************************************************
+ *
+ *  agt_sem_open () - Like sem_open but ignores umask
+ *
+ *
+ * Inputs:            see sem_open man page.
+ * Outputs:           see sem_open man page.
+ * Return Values:     see sem_open man page.
+ *
+ ****************************************************************************/
+sem_t *agt_sem_open(const char *name, int oflag, mode_t mode, unsigned int value);
 
 #ifdef __cplusplus
 }

--- a/ldap/servers/slapd/dse.c
+++ b/ldap/servers/slapd/dse.c
@@ -687,7 +687,7 @@ dse_read_one_file(struct dse *pdse, const char *filename, Slapi_PBlock *pb, int 
                           "The configuration file %s could not be accessed, error %d\n",
                           filename, rc);
             rc = 0; /* Fail */
-        } else if ((prfd = PR_Open(filename, PR_RDONLY, SLAPD_DEFAULT_FILE_MODE)) == NULL) {
+        } else if ((prfd = PR_Open(filename, PR_RDONLY, SLAPD_DEFAULT_DSE_FILE_MODE)) == NULL) {
             slapi_log_err(SLAPI_LOG_ERR, "dse_read_one_file",
                           "The configuration file %s could not be read. " SLAPI_COMPONENT_NAME_NSPR " %d (%s)\n",
                           filename,
@@ -875,7 +875,7 @@ dse_rw_permission_to_one_file(const char *name, int loglevel)
         PRFileDesc *prfd;
 
         prfd = PR_Open(name, PR_RDWR | PR_CREATE_FILE | PR_TRUNCATE,
-                       SLAPD_DEFAULT_FILE_MODE);
+                       SLAPD_DEFAULT_DSE_FILE_MODE);
         if (NULL == prfd) {
             prerr = PR_GetError();
             accesstype = "create";
@@ -976,7 +976,7 @@ dse_write_file_nolock(struct dse *pdse)
     dse_backup_lock();
 
     if (NULL != pdse->dse_filename) {
-        if ((fpw.fpw_prfd = PR_Open(pdse->dse_tmpfile, PR_RDWR | PR_CREATE_FILE | PR_TRUNCATE, SLAPD_DEFAULT_FILE_MODE)) == NULL) {
+        if ((fpw.fpw_prfd = PR_Open(pdse->dse_tmpfile, PR_RDWR | PR_CREATE_FILE | PR_TRUNCATE, SLAPD_DEFAULT_DSE_FILE_MODE)) == NULL) {
             rc = PR_GetOSError();
             slapi_log_err(SLAPI_LOG_ERR, "dse_write_file_nolock", "Cannot open "
                                                                   "temporary DSE file \"%s\" for update: OS error %d (%s)\n",

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -246,6 +246,12 @@ typedef void (*VFPV)(); /* takes undefined arguments */
  */
 
 #define SLAPD_DEFAULT_FILE_MODE S_IRUSR | S_IWUSR
+/* ldap_agent run as uid=root gid=dirsrv and requires S_IRGRP | S_IWGRP
+ * on semaphore and mmap file if SELinux is enforced.
+ */
+#define SLAPD_DEFAULT_SNMP_FILE_MODE S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP
+/* ldap_agent run as uid=root gid=dirsrv and requires S_IRGRP on dse.ldif if SELinux is enforced. */
+#define SLAPD_DEFAULT_DSE_FILE_MODE S_IRUSR | S_IWUSR | S_IRGRP
 #define SLAPD_DEFAULT_DIR_MODE S_IRWXU
 #define SLAPD_DEFAULT_IDLE_TIMEOUT 3600 /* seconds - 0 == never */
 #define SLAPD_DEFAULT_IDLE_TIMEOUT_STR "3600"

--- a/ldap/servers/slapd/snmp_collator.c
+++ b/ldap/servers/slapd/snmp_collator.c
@@ -474,7 +474,7 @@ static void
 snmp_collator_create_semaphore(void)
 {
     /* First just try to create the semaphore.  This should usually just work. */
-    if ((stats_sem = sem_open(stats_sem_name, O_CREAT | O_EXCL, SLAPD_DEFAULT_FILE_MODE, 1)) == SEM_FAILED) {
+    if ((stats_sem = agt_sem_open(stats_sem_name, O_CREAT | O_EXCL, SLAPD_DEFAULT_SNMP_FILE_MODE, 1)) == SEM_FAILED) {
         if (errno == EEXIST) {
             /* It appears that we didn't exit cleanly last time and left the semaphore
              * around.  Recreate it since we don't know what state it is in. */
@@ -486,7 +486,7 @@ snmp_collator_create_semaphore(void)
                 exit(1);
             }
 
-            if ((stats_sem = sem_open(stats_sem_name, O_CREAT | O_EXCL, SLAPD_DEFAULT_FILE_MODE, 1)) == SEM_FAILED) {
+            if ((stats_sem = agt_sem_open(stats_sem_name, O_CREAT | O_EXCL, SLAPD_DEFAULT_SNMP_FILE_MODE, 1)) == SEM_FAILED) {
                 /* No dice */
                 slapi_log_err(SLAPI_LOG_EMERG, "snmp_collator_create_semaphore",
                               "Failed to create semaphore for stats file (/dev/shm/sem.%s). Error %d (%s).\n",

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -10,6 +10,7 @@
 import os
 import sys
 import shutil
+import stat
 import pwd
 import grp
 import re
@@ -861,6 +862,9 @@ class SetupDs(object):
                 ldapi_autobind="on",
             )
             file_dse.write(dse_fmt)
+            # Set minimum permission required by snmp ldap-agent
+            status = os.fstat(file_dse.fileno())
+            os.fchmod(file_dse.fileno(), status.st_mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
         os.chown(os.path.join(slapd['config_dir'], 'dse.ldif'), slapd['user_uid'], slapd['group_gid'])
 
         self.log.info("Create file system structures ...")

--- a/wrappers/systemd-snmp.service.in
+++ b/wrappers/systemd-snmp.service.in
@@ -9,6 +9,7 @@ After=network.target
 
 [Service]
 Type=forking
+Group=@defaultgroup@
 PIDFile=/run/dirsrv/ldap-agent.pid
 ExecStart=@sbindir@/ldap-agent @configdir@/ldap-agent.conf
 PrivateTmp=on


### PR DESCRIPTION
Issue: dirsrv-snmp service fails to starts when SELinux is enforced because of AVC preventing to open some files
One workaround is to use the dac_override capability but it is a bad practice.
Fix:  Setting proper permissions:
  - Running ldap-agent with uid=root and gid=dirsrv to be able to access both snmp and dirsrv resources.
  - Setting read permission on the group for the dse.ldif file
  - Setting r/w permissions on the group for the snmp semaphore and mmap file
     For that one special care is needed because ns-slapd umask overrides the file creation permission
     as is better to avoid changing the umask (changing umask within the code is not thread safe, 
     and the current 0022 umask value is correct for most of the files) so the safest way is to chmod the snmp file 
     if the needed permission are not set.
     
Issue: #6155

Reviewed by: @droideck , @vashirov (Thanks ! )