### PR TITLE
Issue 6170 - audit log buffering doesn't handle large updates

### DIFF
--- a/ldap/servers/slapd/log.h
+++ b/ldap/servers/slapd/log.h
@@ -208,7 +208,6 @@ struct logging_opts
     time_t log_audit_ctime;             /* log creation time */
     LogFileInfo *log_audit_logchain;    /* all the logs info */
     char *log_auditinfo_file;           /* audit log rotation info file */
-    Slapi_RWLock *log_audit_rwlock;     /* lock on audit*/
     int log_audit_compress;             /* Compress rotated logs */
     LogBufferInfo *log_audit_buffer;    /* buffer for access log */
 
@@ -235,7 +234,6 @@ struct logging_opts
     time_t log_auditfail_ctime;             /* log creation time */
     LogFileInfo *log_auditfail_logchain;    /* all the logs info */
     char *log_auditfailinfo_file;           /* auditfail log rotation info file */
-    Slapi_RWLock *log_auditfail_rwlock;     /* lock on auditfail */
     int log_auditfail_compress;             /* Compress rotated logs */
     LogBufferInfo *log_auditfail_buffer;    /* buffer for access log */
 
@@ -262,15 +260,15 @@ struct logging_opts
 #define LOG_ERROR_LOCK_WRITE()   slapi_rwlock_wrlock(loginfo.log_error_rwlock)
 #define LOG_ERROR_UNLOCK_WRITE() slapi_rwlock_unlock(loginfo.log_error_rwlock)
 
-#define LOG_AUDIT_LOCK_READ()    slapi_rwlock_rdlock(loginfo.log_audit_rwlock)
-#define LOG_AUDIT_UNLOCK_READ()  slapi_rwlock_unlock(loginfo.log_audit_rwlock)
-#define LOG_AUDIT_LOCK_WRITE()   slapi_rwlock_wrlock(loginfo.log_audit_rwlock)
-#define LOG_AUDIT_UNLOCK_WRITE() slapi_rwlock_unlock(loginfo.log_audit_rwlock)
+#define LOG_AUDIT_LOCK_READ()    PR_Lock(loginfo.log_audit_buffer->lock)
+#define LOG_AUDIT_UNLOCK_READ()  PR_Unlock(loginfo.log_audit_buffer->lock)
+#define LOG_AUDIT_LOCK_WRITE()   PR_Lock(loginfo.log_audit_buffer->lock)
+#define LOG_AUDIT_UNLOCK_WRITE() PR_Unlock(loginfo.log_audit_buffer->lock)
 
-#define LOG_AUDITFAIL_LOCK_READ()    slapi_rwlock_rdlock(loginfo.log_auditfail_rwlock)
-#define LOG_AUDITFAIL_UNLOCK_READ()  slapi_rwlock_unlock(loginfo.log_auditfail_rwlock)
-#define LOG_AUDITFAIL_LOCK_WRITE()   slapi_rwlock_wrlock(loginfo.log_auditfail_rwlock)
-#define LOG_AUDITFAIL_UNLOCK_WRITE() slapi_rwlock_unlock(loginfo.log_auditfail_rwlock)
+#define LOG_AUDITFAIL_LOCK_READ()    PR_Lock(loginfo.log_auditfail_buffer->lock)
+#define LOG_AUDITFAIL_UNLOCK_READ()  PR_Unlock(loginfo.log_auditfail_buffer->lock)
+#define LOG_AUDITFAIL_LOCK_WRITE()   PR_Lock(loginfo.log_auditfail_buffer->lock)
+#define LOG_AUDITFAIL_UNLOCK_WRITE() PR_Unlock(loginfo.log_auditfail_buffer->lock)
 
 /* For using with slapi_log_access */
 #define TBUFSIZE 75                         /* size for time buffers */


### PR DESCRIPTION
Description:

A large update, like adding 10K memebrs to a group, gets truncated. When the update is larger than the buffer then flush the current buffer, and then directly write the large update to the log file (skipping the buffering)

Relates: https://github.com/389ds/389-ds-base/issues/6170
