### PR TITLE
Issue 6181 - RFE - Allow system to manage uid/gid at startup

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -817,11 +817,17 @@ main(int argc, char **argv)
     }
 
     /* Now, sockets are open, so we can safely change identity now */
-    return_value = main_setuid(slapdFrontendConfig->localuser);
-    if (0 != return_value) {
-        slapi_log_err(SLAPI_LOG_ERR, "main", "Failed to change user and group identity to that of %s\n",
-                      slapdFrontendConfig->localuser);
-        exit(1);
+    /*
+     * We can only change uid if we are already root - otherwise it's likely
+     * that our external service manager has setup the uid/gid for us.
+     */
+    if (getuid() == 0) {
+        return_value = main_setuid(slapdFrontendConfig->localuser);
+        if (0 != return_value) {
+            slapi_log_err(SLAPI_LOG_ERR, "main", "Failed to change user and group identity to that of %s\n",
+                          slapdFrontendConfig->localuser);
+            exit(1);
+        }
     }
 
     /*

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1734,7 +1734,7 @@ class DirSrv(SimpleLDAPObject, object):
         if not self.with_systemd():
             return False
         cp = subprocess.run(["systemctl", "is-system-running"],
-                            universal_newlines=True, capture_output=True)
+                            universal_newlines=True, stdout=subprocess.PIPE)
         # is-system-running can detect the 7 modes (initializing, starting,
         # running, degraded, maintenance, stopping, offline) or "unknown".
         # To keep things simple, we assume that anything other than "offline"

--- a/src/lib389/lib389/instance/remove.py
+++ b/src/lib389/lib389/instance/remove.py
@@ -81,8 +81,9 @@ def remove_ds_instance(dirsrv, force=False):
 
     # Stop the instance (if running) and now we know it really does exist
     # and hopefully have permission to access it ...
-    _log.debug("Stopping instance %s" % dirsrv.serverid)
-    dirsrv.stop()
+    if dirsrv.status():
+        _log.debug("Stopping instance %s" % dirsrv.serverid)
+        dirsrv.stop()
 
     _log.debug("Found instance marker at %s! Proceeding to remove ..." % dse_ldif_path)
 

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -861,6 +861,7 @@ class SetupDs(object):
                 ldapi_autobind="on",
             )
             file_dse.write(dse_fmt)
+        os.chown(os.path.join(slapd['config_dir'], 'dse.ldif'), slapd['user_uid'], slapd['group_gid'])
 
         self.log.info("Create file system structures ...")
         # Create all the needed paths
@@ -977,7 +978,7 @@ class SetupDs(object):
         # Create a certificate database.
         tlsdb = NssSsl(dirsrv=ds_instance, dbpath=slapd['cert_dir'])
         if not tlsdb._db_exists():
-            tlsdb.reinit()
+            tlsdb.reinit(uid=slapd['user_uid'], gid=slapd['group_gid'])
 
         if slapd['self_sign_cert']:
             self.log.info("Create self-signed certificate database ...")

--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -15,9 +15,18 @@ NotifyAccess=all
 EnvironmentFile=-@initconfigdir@/@package_name@
 EnvironmentFile=-@initconfigdir@/@package_name@-%i
 PIDFile=/run/@package_name@/slapd-%i.pid
-ExecStartPre=@libexecdir@/ds_systemd_ask_password_acl @instconfigdir@/slapd-%i/dse.ldif
-ExecStartPre=@libexecdir@/ds_selinux_restorecon.sh @instconfigdir@/slapd-%i/dse.ldif
+
+# The =+ denotes that ExecStartPre tasks will be run with privileges in the case the instance
+# is configured with a non root User/Group via an override.
+# See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines
+ExecStartPre=+@libexecdir@/ds_systemd_ask_password_acl @instconfigdir@/slapd-%i/dse.ldif
+ExecStartPre=+@libexecdir@/ds_selinux_restorecon.sh @instconfigdir@/slapd-%i/dse.ldif
 ExecStart=@sbindir@/ns-slapd -D @instconfigdir@/slapd-%i -i /run/@package_name@/slapd-%i.pid
+
+# Allow non-root instances to bind to low ports.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
 PrivateTmp=on
 # https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
 ProtectSystem=full


### PR DESCRIPTION
Bug Description: We have a user who wishes to implement a non-standard configuration in which the running gid is not the primary gid of the uid that the server runs as. Currently this trips up most of our setup tools.

Rather than support dropping to an alternate gid in the server, it is simpler to allow systemd to pre-configure our user and group at start up. This needs a small number of changes.

Fix Description:
- dscreate needs to correctly setup file ownships for dse.ldif and friends rather than relying on the server having root access and changing the perms itself
- Our unit file needs to enable the CAP_NET_BIND privilege so that the service can bind to ports lower than 1024 without being root
- The server needs to not attempt to change it's uid/gid if we are already running as that user/gid.

fixes: https://github.com/389ds/389-ds-base/issues/6181

Author: William Brown <william@blackhats.net.au>

Review by: ???