### PR TITLE
Change default salt sizes generated in crypt_pwd

### DIFF
--- a/ldap/servers/plugins/pwdstorage/crypt_pwd.c
+++ b/ldap/servers/plugins/pwdstorage/crypt_pwd.c
@@ -39,11 +39,6 @@
 static unsigned char itoa64[] = /* 0 ... 63 => ascii - 64 */
     "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-#define CRYPT_UNIX 0
-#define CRYPT_MD5 1
-#define CRYPT_SHA256 2
-#define CRYPT_SHA512 3
-
 /* Use the same salt lengths as passwd */
 #define CRYPT_UNIX_SALT_LENGTH 2
 #define CRYPT_MD5_SALT_LENGTH 8
@@ -78,7 +73,7 @@ crypt_pw_cmp(const char *userpwd, const char *dbpwd)
 }
 
 static char *
-crypt_pw_enc_by_hash(const char *pwd, int hash_algo, int salt_len, const char *algo_id)
+crypt_pw_enc_by_hash(const char *pwd, int salt_len, const char *algo_id)
 {
     char salt[CRYPT_SALT_STRING_MAXLEN];
     char *algo_salt = NULL;
@@ -114,21 +109,20 @@ crypt_pw_enc_by_hash(const char *pwd, int hash_algo, int salt_len, const char *a
 char *
 crypt_pw_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_UNIX, CRYPT_UNIX_SALT_LENGTH, NULL);
+    return crypt_pw_enc_by_hash(pwd, CRYPT_UNIX_SALT_LENGTH, NULL);
 }
-
 char *
 crypt_pw_md5_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_MD5, CRYPT_MD5_SALT_LENGTH, "$1$");
+    return crypt_pw_enc_by_hash(pwd, CRYPT_MD5_SALT_LENGTH, "$1$");
 }
 char *
 crypt_pw_sha256_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA256, CRYPT_SHA_SALT_LENGTH, "$5$");
+    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA_SALT_LENGTH, "$5$");
 }
 char *
 crypt_pw_sha512_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA512, CRYPT_SHA_SALT_LENGTH, "$6$");
+    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA_SALT_LENGTH, "$6$");
 }

--- a/ldap/servers/plugins/pwdstorage/crypt_pwd.c
+++ b/ldap/servers/plugins/pwdstorage/crypt_pwd.c
@@ -44,6 +44,12 @@ static unsigned char itoa64[] = /* 0 ... 63 => ascii - 64 */
 #define CRYPT_SHA256 2
 #define CRYPT_SHA512 3
 
+/* Use the same salt lengths as passwd */
+#define CRYPT_UNIX_SALT_LENGTH 2
+#define CRYPT_MD5_SALT_LENGTH 8
+#define CRYPT_SHA_SALT_LENGTH 16
+
+#define CRYPT_SALT_STRING_MAXLEN CRYPT_SHA_SALT_LENGTH + 1
 
 int
 crypt_pw_cmp(const char *userpwd, const char *dbpwd)
@@ -72,40 +78,29 @@ crypt_pw_cmp(const char *userpwd, const char *dbpwd)
 }
 
 static char *
-crypt_pw_enc_by_hash(const char *pwd, int hash_algo)
+crypt_pw_enc_by_hash(const char *pwd, int hash_algo, int salt_len, const char *algo_id)
 {
-    char salt[3];
+    char salt[CRYPT_SALT_STRING_MAXLEN];
     char *algo_salt = NULL;
     char *cry;
     char *enc = NULL;
-    long v;
-    static unsigned int seed = 0;
+    int i;
     struct crypt_data data;
     data.initialized = 0;
 
-    if (seed == 0) {
-        seed = (unsigned int)slapi_rand();
-    }
-    v = slapi_rand_r(&seed);
+    /* Fill salt with salt_len random chars */
+    slapi_rand_array(salt, salt_len);
 
-    salt[0] = itoa64[v & 0x3f];
-    v >>= 6;
-    salt[1] = itoa64[v & 0x3f];
-    salt[2] = '\0';
-
-    /* Prepare our salt based on the hashing algorithm */
-    if (hash_algo == CRYPT_UNIX) {
-        algo_salt = strdup(salt);
-    } else if (hash_algo == CRYPT_MD5) {
-        algo_salt = slapi_ch_smprintf("$1$%s", salt);
-    } else if (hash_algo == CRYPT_SHA256) {
-        algo_salt = slapi_ch_smprintf("$5$%s", salt);
-    } else if (hash_algo == CRYPT_SHA512) {
-        algo_salt = slapi_ch_smprintf("$6$%s", salt);
-    } else {
-        /* default to CRYPT_UNIX */
-        algo_salt = strdup(salt);
+    /* Convert each 8bit random char to a 6bit base64 char */
+    for (i=0; i < salt_len; i++) {
+        salt[i] = itoa64[salt[i] & 0x3f];
     }
+    salt[i] = 0;
+
+    if (NULL == algo_id)
+        algo_salt = strdup(salt);
+    else
+        algo_salt = slapi_ch_smprintf("%s%s", algo_id, salt);
 
     cry = crypt_r(pwd, algo_salt, &data);
     if (cry != NULL) {
@@ -119,21 +114,21 @@ crypt_pw_enc_by_hash(const char *pwd, int hash_algo)
 char *
 crypt_pw_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_UNIX);
+    return crypt_pw_enc_by_hash(pwd, CRYPT_UNIX, CRYPT_UNIX_SALT_LENGTH, NULL);
 }
 
 char *
 crypt_pw_md5_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_MD5);
+    return crypt_pw_enc_by_hash(pwd, CRYPT_MD5, CRYPT_MD5_SALT_LENGTH, "$1$");
 }
 char *
 crypt_pw_sha256_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA256);
+    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA256, CRYPT_SHA_SALT_LENGTH, "$5$");
 }
 char *
 crypt_pw_sha512_enc(const char *pwd)
 {
-    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA512);
+    return crypt_pw_enc_by_hash(pwd, CRYPT_SHA512, CRYPT_SHA_SALT_LENGTH, "$6$");
 }


### PR DESCRIPTION
I have a use case where I need to use CRYPT-SHA512 as my password storage scheme in order to synchronize external authentication. My issue is that the passwords generated only use 12 bits of salt making them a lot weaker than they should be.

This commit changes the salt length generated in crypt_pwd from 12 bits to instead match the salt length used by linux shadow:

12bits (2 b64 chars) for CRYPT
48bits (8 b64 chars) for CRYPT-MD5
96bits (16 b64 chars) for CRYPT-SHA256 and CRYPT-SHA512