### PR TITLE
Issue 6189 - CI tests fail with `[Errno 2] No such file or directory:…

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -90,6 +90,10 @@ jobs:
       run: |
         set -x
         CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        until sudo docker exec $CID sh -c "systemctl is-system-running"
+        do
+          echo "Waiting for container to be ready..."
+        done
         sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
         export PASSWD=$(openssl rand -base64 32)
         sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -90,6 +90,10 @@ jobs:
       run: |
         set -x
         CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        until sudo docker exec $CID sh -c "systemctl is-system-running"
+        do
+          echo "Waiting for container to be ready..."
+        done
         sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
         export PASSWD=$(openssl rand -base64 32)
         sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"


### PR DESCRIPTION
… '/var/cache/dnf/metadata_lock.pid'`

Bug Description:
There is an intermittent issue during container startup in our CI:
```
[Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
Error: Process completed with exit code 1.
```

`systemd` is not fully initialized when a second command runs and expects a pid file to be available.
The script should wait until `systemctl is-system-running` is successful.

Fix Description:
Add a check for `systemctl is-system-running`.

Fixes: https://github.com/389ds/389-ds-base/issues/6189

Reviewed by: ???