### PR TITLE
Issue 6193 - Test failure: test_tls_command_returns_error_text

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tls_test.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import ssl
 import os
+import re
 from lib389.topologies import topology_st as topo
 from lib389.nss_ssl import NssSsl
 
@@ -79,9 +80,10 @@ def test_tls_command_returns_error_text(topo):
     except ValueError as e:
         assert '255' not in str(e)
         if 'OpenSSL 3' in ssl.OPENSSL_VERSION:
-            assert 'Could not read private key from' in str(e)
+            error_message = r"Could not (read|find) private key from"
         else:
-            assert 'unable to load private key' in str(e)
+            error_message = r"unable to load private key"
+        assert re.search(error_message, str(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug Description:
openssl changed error message in
https://github.com/openssl/openssl/commit/fedab100a4b8f4c3b81de632f29c159fb46ac3f2

Fix Description:
Adjust assert to use regex for different messages.

Fixes: https://github.com/389ds/389-ds-base/issues/6193

Reviewed by: