### PR TITLE
Issue 6181 - RFE - Allow system to manage uid/gid at startup

### DIFF
--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -25,7 +25,7 @@ ExecStart=@sbindir@/ns-slapd -D @instconfigdir@/slapd-%i -i /run/@package_name@/
 
 # Allow non-root instances to bind to low ports.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_CHOWN
 
 PrivateTmp=on
 # https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort


### PR DESCRIPTION
Description:
Expand CapabilityBoundingSet to include addittional capabilites.

Fixes: https://github.com/389ds/389-ds-base/issues/6181