### PR TITLE
Issue 6183 - Slow ldif2db import on a newly created BDB backend

### DIFF
--- a/dirsrvtests/tests/suites/import/regression_test.py
+++ b/dirsrvtests/tests/suites/import/regression_test.py
@@ -434,7 +434,59 @@ def test_large_ldif2db_ancestorid_index_creation(topo, _set_mdb_map_size):
         # The time for the ancestorid index creation should be less than 10s for an offline import of an ldif file with 100000 entries / 5 entries per node
         # Should be adjusted if these numbers are modified in the test
         assert etime <= 10
-    
+
+
+def create_backend_and_import(instance, ldif_file, suffix, backend):
+    log.info(f'Add suffix:{suffix} and backend: {backend}...')
+    backends = Backends(instance)
+    backends.create(properties={'nsslapd-suffix': suffix, 'name': backend})
+    props = {'numUsers': 10000, 'nodeLimit': 5, 'suffix': suffix}
+
+    log.info(f'Create a large nested ldif file using dbgen : {ldif_file}')
+    dbgen_nested_ldif(instance, ldif_file, props)
+
+    log.info('Stop the server and run offline import...')
+    instance.stop()
+    log.info('Measure the import time for the ldif file...')
+    start = time.time()
+    assert instance.ldif2db(backend, None, None, None, ldif_file)
+    end = time.time()
+    instance.start()
+    return end - start
+
+
+@pytest.mark.xfail(not _check_disk_space(), reason="not enough disk space for lmdb map")
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not cache size over mdb")
+def test_ldif2db_after_backend_create(topo):
+    """Test that ldif2db after backend creation is not slow first time
+
+    :id: c1ab1df7-c70a-46be-bbca-8d65c6ebaa14
+    :setup: Standalone Instance
+    :steps:
+        1. Create backend and suffix
+        2. Generate large LDIF file
+        3. Stop server and run offline import
+        4. Measure import time
+        5. Restart server and repeat steps 1-4 with new backend and suffix
+    :expectedresults:
+        1. Operation successful
+        2. Operation successful
+        3. Operation successful
+        4. Import times should be approximately the same
+        5. Operation successful
+    """
+
+    instance = topo.standalone
+    ldif_dir = instance.get_ldif_dir()
+    ldif_file_1 = os.path.join(ldif_dir, 'large_nested_1.ldif')
+    ldif_file_2 = os.path.join(ldif_dir, 'large_nested_2.ldif')
+
+    import_time_1 = create_backend_and_import(instance, ldif_file_1, 'o=test_1', 'test_1')
+    import_time_2 = create_backend_and_import(instance, ldif_file_2, 'o=test_2', 'test_2')
+
+    log.info('Import times should be approximately the same')
+    assert abs(import_time_1 - import_time_2) < 5
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/dirsrvtests/tests/suites/import/regression_test.py
+++ b/dirsrvtests/tests/suites/import/regression_test.py
@@ -455,7 +455,6 @@ def create_backend_and_import(instance, ldif_file, suffix, backend):
     return end - start
 
 
-@pytest.mark.xfail(not _check_disk_space(), reason="not enough disk space for lmdb map")
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not cache size over mdb")
 def test_ldif2db_after_backend_create(topo):
     """Test that ldif2db after backend creation is not slow first time

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -1031,6 +1031,24 @@ ldbm_instance_postadd_instance_entry_callback(Slapi_PBlock *pb __attribute__((un
     /* Initialize and register callbacks for VLV indexes */
     vlv_init(inst);
 
+    /* We are autotuning the caches. was:
+     * retval = ldbm_back_start_autotune(li);
+     * This involves caches specific to instances managed in the ldbm layer
+     * and to caches specific to the db implementation.
+     * The cache usage and requirements of the db is not known here, also it
+     * might have impact on the sizing of the instance caches.
+     * Therfor this functionality is moved to the db_xxx layer.
+     * The latest autotune function was implemented only with BDB in mind
+     * so it should be safe to move it to db_bdb.
+     */
+    priv = (dblayer_private *)li->li_dblayer_private;
+    rval = priv->dblayer_auto_tune_fn(li);
+    if (rval != 0) {
+        slapi_log_err(SLAPI_LOG_ERR,
+                      "ldbm_instance_postadd_instance_entry_callback",
+                      "Failed to set database tuning on backends\n");
+    }
+
     /* this is an ACTUAL ADD being done while the server is running!
      * start up the appropriate backend...
      */
@@ -1044,7 +1062,6 @@ ldbm_instance_postadd_instance_entry_callback(Slapi_PBlock *pb __attribute__((un
 
 
     /* call the backend implementation specific callbacks */
-    priv = (dblayer_private *)li->li_dblayer_private;
     priv->instance_postadd_config_fn(li, inst);
 
     slapi_ch_free((void **)&instance_name);


### PR DESCRIPTION
Bug Description: After creating a new BDB backend, we autotune the cache only when restarting. So, an administrator will try to import an LDIF before that; she will have a very slow import.

Fix Description: Do the autotuning during the backend creation. Add a CI test for the scenario.

Fixes: https://github.com/389ds/389-ds-base/issues/6183

Reviewed by: ?