### PR TITLE
Issue 6200 - Disable WebUI CI tests

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -24,6 +24,9 @@ else:
     # Filter out snmp as it is an empty directory:
     suites.remove('snmp')
 
+    # Filter out webui because of broken tests
+    suites.remove('webui')
+
     # Run each replication test module separately to speed things up
     suites.remove('replication')
     repl_tests = glob.glob('dirsrvtests/tests/suites/replication/*_test.py')


### PR DESCRIPTION
Description:
Currently WebUI tests fail. There are known issues both in tests and the code. We should re-enable the tests back when we get to fix those issues.

Fixes: https://github.com/389ds/389-ds-base/issues/6200