### PR TITLE
Issue 6120 - /usr/lib64/dirsrv/plugins/libback-bdb.so has an invalid-…

### DIFF
--- a/m4/bundle_libdb.m4
+++ b/m4/bundle_libdb.m4
@@ -8,7 +8,7 @@
 
 AC_MSG_CHECKING(Handling bundle_libdb)
 
-db_lib="-L${with_bundle_libdb}/.libs -R${prefix}/lib/dirsrv"
+db_lib="-L${with_bundle_libdb}/.libs -R${prefix}/lib64/dirsrv"
 db_incdir=$with_bundle_libdb
 db_inc="-I $db_incdir"
 db_libver="5.3-389ds"


### PR DESCRIPTION
…looking DT_RPATH: /usr/lib/dirsrv

Bug Description:
rpminspect reports an invalid DT_RPATH /usr/lib/dirsrv It's evaluated in m4/bundle_libdb.m4 from

```
-R${prefix}/lib/dirsrv"
```

Fix Description:
Change it to lib64

Fixes: https://github.com/389ds/389-ds-base/issues/6210