### PR TITLE
Issue 6191 - Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -58,7 +58,7 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and configure
         run: autoreconf -fvi && ./configure
         env:
@@ -72,7 +72,7 @@ jobs:
       - name: Build using ${{ matrix.compiler }}
         run: bash -c "(make V=0 2> >(tee /dev/stderr)) > log.txt"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: log.txt

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -31,7 +31,7 @@ jobs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -47,7 +47,7 @@ jobs:
         run: tar -cvf dist.tar dist/
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpms
           path: dist.tar
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -79,7 +79,7 @@ jobs:
         sudo systemctl start docker
 
     - name: Download RPMs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: rpms
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: Upload pytest test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
         path: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,7 +19,7 @@ jobs:
       image: quay.io/389ds/ci-images:test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run NPM Audit CI
         run: cd $GITHUB_WORKSPACE/src/cockpit/389-console && npx --yes audit-ci --config audit-ci.json

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -47,7 +47,7 @@ jobs:
         run: tar -cvf dist.tar dist/
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpms
           path: dist.tar
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -79,7 +79,7 @@ jobs:
         sudo systemctl start docker
 
     - name: Download RPMs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: rpms
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: Upload pytest test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version || github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.get_version.outputs.version }}
@@ -60,7 +60,7 @@ jobs:
           TAG=${{ steps.get_version.outputs.version }} make -f rpm.mk dist-bz2
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get_version.outputs.version }}.tar.bz2
           path: ${{ steps.get_version.outputs.version }}.tar.bz2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
       image: quay.io/389ds/ci-images:test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run testimony
         if: always()


### PR DESCRIPTION
Description:
Node.js 16 actions are deprecated.
Update
* actions/checkout to v4
* actions/download-artifact to v4
* actions/upload-artifact to v4

Fixes: https://github.com/389ds/389-ds-base/issues/6191