### PR TITLE
Issue 5772 - ONE LEVEL search fails to return sub-suffixes

### DIFF
--- a/dirsrvtests/tests/suites/mapping_tree/regression_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/regression_test.py
@@ -91,7 +91,6 @@ EXPECTED_ENTRIES = (("dc=parent", 39), ("dc=child1,dc=parent", 13), ("dc=child2,
 @pytest.mark.skipif(not has_orphan_attribute, reason = "compatibility attribute not yet implemented in this version")
 def test_sub_suffixes(topo, orphan_param):
     """ check the entries found on suffix/sub-suffix
-    used int
 
     :id: 5b4421c2-d851-11ec-a760-482ae39447e5
     :feature: mapping-tree
@@ -121,8 +120,41 @@ def test_sub_suffixes(topo, orphan_param):
         log.info(f'Verifying domain component entries count for search under {suffix} ...')
         entries = topo.standalone.search_s(suffix, ldap.SCOPE_SUBTREE, "(dc=*)")
         assert len(entries) == expected
-        log.info('Found {expected} domain component entries as expected while searching {suffix}')
+        log.info(f'Found {expected} domain component entries as expected while searching {suffix}')
 
     log.info('Test PASSED')
 
+
+def test_one_level_search_on_sub_suffixes(topo):
+    """ Perform one level scoped search accross suffix and sub-suffix
+
+    :id: 92f3139e-280e-11ef-a989-482ae39447e5
+    :feature: mapping-tree
+    :setup: Standalone instance with 3 additional backends:
+            dc=parent, dc=child1,dc=parent, dc=childr21,dc=parent
+    :steps:
+        1. Perform a ONE LEVEL search on dc=parent
+        2. Check that all expected entries have been returned
+        3. Check that only the expected entries have been returned
+    :expectedresults:
+        1. Success
+        2. each expected dn should be in the result set
+        3. Number of returned entries should be the same as the number of expected entries
+    """
+    expected_dns = ( 'dc=child1,dc=parent',
+                         'dc=child2,dc=parent',
+                         'ou=accounting,dc=parent',
+                         'ou=product development,dc=parent',
+                         'ou=product testing,dc=parent',
+                         'ou=human resources,dc=parent',
+                         'ou=payroll,dc=parent',
+                         'ou=people,dc=parent',
+                         'ou=groups,dc=parent', )
+    entries = topo.standalone.search_s("dc=parent", ldap.SCOPE_ONELEVEL, "(objectClass=*)",
+                                       attrlist=("dc","ou"), escapehatch='i am sure')
+    log.info(f'one level search on dc=parent returned the following entries: {entries}')
+    dns = [ entry.dn for entry in entries ]
+    for dn in expected_dns:
+        assert dn in dns
+    assert len(entries) == len(expected_dns)
 

--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -240,6 +240,36 @@ slapi_filter_test_ext(
 }
 
 
+static const char *
+filter_type_as_string(int filter_type)
+{
+    switch (filter_type) {
+    case LDAP_FILTER_AND:
+        return "&";
+    case LDAP_FILTER_OR:
+        return "|";
+    case LDAP_FILTER_NOT:
+        return "!";
+    case LDAP_FILTER_EQUALITY:
+        return "=";
+    case LDAP_FILTER_SUBSTRINGS:
+        return "*";
+    case LDAP_FILTER_GE:
+        return ">=";
+    case LDAP_FILTER_LE:
+        return "<=";
+    case LDAP_FILTER_PRESENT:
+        return "=*";
+    case LDAP_FILTER_APPROX:
+        return "~";
+    case LDAP_FILTER_EXT:
+        return "EXT";
+    default:
+        return "?";
+    }
+}
+
+
 int
 test_ava_filter(
     Slapi_PBlock *pb,
@@ -253,7 +283,13 @@ test_ava_filter(
 {
     int rc;
 
-    slapi_log_err(SLAPI_LOG_FILTER, "test_ava_filter", "=>\n");
+    if (slapi_is_loglevel_set(SLAPI_LOG_FILTER)) {
+        char *val = slapi_berval_get_string_copy(&ava->ava_value);
+        char buf[BUFSIZ];
+        slapi_log_err(SLAPI_LOG_FILTER, "test_ava_filter", "=> AVA: %s%s%s\n",
+                      ava->ava_type, filter_type_as_string(ftype), escape_string(val, buf));
+        slapi_ch_free_string(&val);
+    }
 
     *access_check_done = 0;
 


### PR DESCRIPTION
Problem: ONE LEVEL scoped search fails to return sub-suffixes entries
Reason: When such search is done, a one level search is done on the main suffix and base search are done on any matching sub-suffix. But main suffix is processed search (to ensure that parent entries are returned before children ones when searching subtree) and ldbm_back_search change the filter to (&(parentid=xxx)old_filter) so the filter test reject the entry on the sub-suffixes.
Solution: Revert the backend list when doing one level search so that the sub-suffixes are processed first
  and restore the base dn for the main suffix.
Alternative rejected: reset the filter when discivering a sub-suffix. Not so easy because filter is altered by the rewriteres.
And systematic duplication is an useless overhead if there is no matching sub-suffixes (which is the usual case)

Issue: #5772  

Reviewed by: @tbordaz, @droideck (Thanks!)
