### PR TITLE
Issue 6222 - CI test acl/test_timeofday_keyword sometime fails

### DIFF
--- a/dirsrvtests/tests/suites/acl/keywords_part2_test.py
+++ b/dirsrvtests/tests/suites/acl/keywords_part2_test.py
@@ -40,6 +40,7 @@ NIGHTWORKER_KEY = "uid=NIGHTWORKER_KEY,{}".format(TIMEOFDAY_OU_KEY)
 NOWORKER_KEY = "uid=NOWORKER_KEY,{}".format(TIMEOFDAY_OU_KEY)
 
 
+@pytest.mark.skipif(os.getuid()!=0, reason="pytest non run by root user")
 def test_access_from_certain_network_only_ip(topo, add_user, aci_of_user, request):
     """
     User can access the data when connecting from certain network only as per the ACI.
@@ -103,6 +104,7 @@ def test_access_from_certain_network_only_ip(topo, add_user, aci_of_user, reques
     request.addfinalizer(fin)
 
 
+@pytest.mark.skipif(os.getuid()!=0, reason="pytest non run by root user")
 def test_connection_from_an_unauthorized_network(topo, add_user, aci_of_user, request):
     """
     User cannot access the data when connectin from an unauthorized network as per the ACI.
@@ -294,34 +296,58 @@ def test_timeofday_keyword(topo, add_user, aci_of_user):
 
     :id: 681dd58e-7ac5-11e8-bed1-8c16451d917b
     :customerscenario: True
-    :setup: Standalone Server
+    :setup: Standalone Server + an user entry
     :steps:
-        1. Add test entry
-        2. Add ACI
-        3. User should follow ACI role
-    :expectedresults:
-        1. Entry should be added
-        2. Operation should  succeed
-        3. Operation should  succeed
-    """
-    now = time.strftime("%c")
-    now_1 = "".join(now.split()[3].split(":"))[:4]
-    # Add ACI
-    domain = Domain(topo.standalone, DEFAULT_SUFFIX)
-    domain.add("aci", f'(target = "ldap:///{TIMEOFDAY_OU_KEY}")'
-                      f'(targetattr="*")(version 3.0; aci "Timeofday aci"; '
-                      f'allow(all) userdn = "ldap:///{NOWORKER_KEY}" '
-                      f'and timeofday = \'{now_1}\' ;)')
+        1. Compute current time (in minute)
+        2. Redo the 4 next steps until current time (in minute) has not changed
+        3. In 2. loop: Set previous time to current time
+        4. In 2. loop: Set the ACI
+        5. In 2. loop: Perform operation and record if access is allowed or not
+        6. In 2. loop: Compute again the current time
+        7. Check that access was allowed on last operation
+        8. Remove the ACI
+        9. Check that access is denied
 
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. last operation should have been allowed
+        8. Success
+        9. Operation should fail with ldap.INSUFFICIENT_ACCESS
+    """
+    domain = Domain(topo.standalone, DEFAULT_SUFFIX)
+    aci = domain.get_attr_vals_utf8('aci')
     # Create a new connection for this test.
     conn = UserAccount(topo.standalone, NOWORKER_KEY).bind(PW_DM)
-    # Perform Operation
     org = OrganizationalUnit(conn, TIMEOFDAY_OU_KEY)
-    org.replace("seeAlso", "cn=1")
+    now_1 = None
+    now_2 = "".join(time.strftime("%c").split()[3].split(":"))[:4]
+    # Perform the test in loop to avoid timing issues
+    while now_1 != now_2:
+        now_1 = now_2
+        # Set ACI
+        new_aci = f'(target = "ldap:///{TIMEOFDAY_OU_KEY}")' \
+                  '(targetattr="*")(version 3.0; aci "Timeofday aci"; ' \
+                  f'allow(all) userdn = "ldap:///{NOWORKER_KEY}" ' \
+                  f'and timeofday = \'{now_1}\' ;)'
+        domain.replace("aci", [*aci, new_aci])
+        # Perform Operation
+        try:
+            org.replace("seeAlso", "cn=1")
+            access_allowed = True
+        except ldap.INSUFFICIENT_ACCESS:
+            access_allowed = False
+        # Check that time has not changed
+        now_2 = "".join(time.strftime("%c").split()[3].split(":"))[:4]
+    # Check that previous operation was successfull
+    assert access_allowed
     # Remove ACI
-    aci = domain.get_attr_vals_utf8('aci')[-1]
-    domain.ensure_removed('aci', aci)
-    assert aci not in domain.get_attr_vals_utf8('aci')
+    domain.replace('aci', aci)
+    assert new_aci not in domain.get_attr_vals_utf8('aci')
     # after removing the ACI user cannot access the data
     time.sleep(1)
     with pytest.raises(ldap.INSUFFICIENT_ACCESS):
@@ -364,29 +390,48 @@ def test_dayofweek_keyword_today_can_access(topo, add_user, aci_of_user):
 
     :id: 7131dc88-7ac5-11e8-acc2-8c16451d917b
     :customerscenario: True
-    :setup: Standalone Server
+    :setup: Standalone Server + an user entry
     :steps:
-        1. Add test entry
-        2. Add ACI
-        3. User should follow ACI role
+        1. Compute current date
+        2. Redo the 4 next steps until current date has not changed
+        3. In 2. loop: Set previous time to current date
+        4. In 2. loop: Set the ACI
+        5. In 2. loop: Perform operation and record if access is allowed or not
+        6. In 2. loop: Compute again the current date
+        7. Check that access was allowed on last operation
     :expectedresults:
-        1. Entry should be added
-        2. Operation should  succeed
-        3. Operation should  succeed
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. last operation should have been allowed
     """
-    today_1 = time.strftime("%c").split()[0]
-    # Add ACI
-    Domain(topo.standalone,
-           DEFAULT_SUFFIX).add("aci", f'(target = "ldap:///{DAYOFWEEK_OU_KEY}")'
-                                      f'(targetattr="*")(version 3.0; aci "Dayofweek aci";  '
-                                      f'allow(all) userdn = "ldap:///{TODAY_KEY}" '
-                                      f'and dayofweek = \'{today_1}\' ;)')
-
+    domain = Domain(topo.standalone, DEFAULT_SUFFIX)
+    aci = domain.get_attr_vals_utf8('aci')
     # Create a new connection for this test.
     conn = UserAccount(topo.standalone, TODAY_KEY).bind(PW_DM)
     # Perform Operation
     org = OrganizationalUnit(conn, DAYOFWEEK_OU_KEY)
-    org.replace("seeAlso", "cn=1")
+    today_1 = None
+    today_2 = time.strftime("%c").split()[0]
+    while today_1 != today_2:
+        # Set ACI
+        today_1 = today_2
+        new_aci = f'(target = "ldap:///{DAYOFWEEK_OU_KEY}")' \
+                  '(targetattr="*")(version 3.0; aci "Dayofweek aci";  ' \
+                  f'allow(all) userdn = "ldap:///{TODAY_KEY}" ' \
+                  f'and dayofweek = \'{today_1}\' ;)'
+        domain.replace("aci", [*aci, new_aci])
+        try:
+            org.replace("seeAlso", "cn=1")
+            access_allowed = True
+        except ldap.INSUFFICIENT_ACCESS:
+            access_allowed = False
+        # Check that time has not changed
+        today_2 = time.strftime("%c").split()[0]
+    assert access_allowed
 
 
 def test_user_cannot_access_the_data_at_all(topo, add_user, aci_of_user):


### PR DESCRIPTION
CI test acl/test_timeofday_keyword sometime fails because current time (in minutes) changes during the test
Solution is to run the test in loop and retry if the time has changed.
Also fix:
Similar issue with test_dayofweek_keyword_today_can_access (with time in days)
Skip the tests that sets the hostname if run as non root

Issue: #6222 

Reviewed by: @droideck  (Thanks!)