### PR TITLE
Issue 6227 - dsconf schema does not show inChain matching rule

### DIFF
--- a/dirsrvtests/tests/suites/filter/inchain_test.py
+++ b/dirsrvtests/tests/suites/filter/inchain_test.py
@@ -15,6 +15,7 @@ from lib389._constants import DEFAULT_SUFFIX, PW_DM, PLUGIN_MEMBER_OF
 from lib389.topologies import topology_st as topo
 from lib389.plugins import MemberOfPlugin
 
+from lib389.schema import Schema
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.idm.account import Accounts
 from lib389.idm.account import Anonymous
@@ -811,6 +812,24 @@ def test_invalid_assertion(topo):
     user = "uid=not_existing_entry,ou=People,%s" % (DEFAULT_SUFFIX)
     memberof = topo.standalone.search_s(DEFAULT_SUFFIX, SCOPE_SUBTREE, "(member:%s:=%s)" % (INCHAIN_OID, user))
     assert len(memberof) == 0
+
+def test_check_dsconf_matchingrule(topo):
+    """Test that the matching rule 'inchain' is listed by dsconf
+
+    :id: b8dd4049-ccec-4316-bc9c-5aa5c5afcfbd
+    :setup: Standalone Instance
+    :steps:
+        1. fetch matching rules from the schema
+        2. Checks that matching rules contains inchaineMatch matching rule
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    schema = Schema(topo.standalone)
+    mrs = [ f"{mr.oid} {mr.names[0]}" for mr in schema.get_matchingrules() if len(mr.names) > 0 ]
+    for mr in mrs:
+        log.info("retrieved matching rules are: %s", mr)
+    assert '1.2.840.113556.1.4.1941 inchainMatch' in mrs
 
 if __name__ == "__main__":
     CURRENT_FILE = os.path.realpath(__file__)

--- a/ldap/servers/plugins/syntaxes/inchain.c
+++ b/ldap/servers/plugins/syntaxes/inchain.c
@@ -38,7 +38,7 @@ static char *names[] = {"inchain", "inchain", LDAP_MATCHING_RULE_IN_CHAIN_OID, 0
 static Slapi_PluginDesc pdesc = {"inchain-matching-rule", VENDOR, DS_PACKAGE_VERSION,
                                  "inchain matching rule plugin"};
 
-static const char *inchainMatch_names[] = {"inchainMatch", "1.2.840.113556.1.4.1941", NULL};
+static const char *inchainMatch_names[] = {"inchainMatch", LDAP_MATCHING_RULE_IN_CHAIN_OID, NULL};
 
 static struct mr_plugin_def mr_plugin_table[] = {
     {
@@ -64,7 +64,7 @@ static struct mr_plugin_def mr_plugin_table[] = {
             "the AVA comparisons evaluate to Undefined and the remaining AVA "
             "comparisons return TRUE then the distinguishedNameMatch rule "
             "evaluates to Undefined.",
-            NULL,
+            DN_SYNTAX_OID,
             0,
             NULL /* dn only for now */
         },       /* matching rule desc */


### PR DESCRIPTION
Bug description:
	The registered inChain MR does defined any matching rule
	syntax (mr_syntax).
	When dsconf reads the matching rules (read_schema_dse)
	it only reports those which have OID and SYNTAX.
	As a consequence InChain was not reported.

Fix description:
	The syntax defines that assersion syntax that is
	distinguished name. Add this syntax to the register
	struct

relates: #6227

Reviewed by: