### PR TITLE
Issue 6233 - CI test wait_for_async_feature_test sometime fails

### DIFF
--- a/dirsrvtests/tests/suites/replication/wait_for_async_feature_test.py
+++ b/dirsrvtests/tests/suites/replication/wait_for_async_feature_test.py
@@ -25,10 +25,14 @@ log = logging.getLogger(__name__)
 
 installation1_prefix = None
 
-@pytest.fixture(params=[(None, (4, 11)),
+# Expected minimum and maximum number of async result in usual cases
+USUAL_MIN_AP = 3
+USUAL_MAX_AP = 11
+
+@pytest.fixture(params=[(None, (USUAL_MIN_AP, USUAL_MAX_AP)),
                         ('2000', (0, 2)),
-                        ('0', (4, 11)),
-                        ('-5', (4, 11))])
+                        ('0', (USUAL_MIN_AP, USUAL_MAX_AP)),
+                        ('-5', (USUAL_MIN_AP, USUAL_MAX_AP))])
 def waitfor_async_attr(topology_m2, request):
     """Sets attribute on all replicas"""
 


### PR DESCRIPTION
CI test random failure related to timing. 
Fixed by decreasing the minimum number of expected asynchronous results

Issue: #6233 

Reviewed by: @droideck, @tbordaz 