### PR TITLE
Issue 6236  - rpm: fix compatibility with RPM 4.20

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -12,6 +12,12 @@
 %global libdb_base_version db-%{libdb_version}.28
 %global libdb_full_version lib%{libdb_base_version}-59
 %global libdb_bundle_name libdb-%{libdb_version}-389ds.so
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 11
+# RPM 4.20
+%global libdb_base_dir lib%{libdb_base_version}-build/%{libdb_base_version}
+%else
+%global libdb_base_dir %{libdb_base_version}
+%endif
 %endif
 
 # This is used in certain builds to help us know if it has extra features.
@@ -405,7 +411,7 @@ popd
 %if %{with bundle_libdb}
 mkdir -p ../%{libdb_base_version}
 pushd ../%{libdb_base_version}
-tar -xjf  ../../SOURCES/%{libdb_full_version}.tar.bz2
+tar -xjf  %{_topdir}/SOURCES/%{libdb_full_version}.tar.bz2
 mv %{libdb_full_version} SOURCES
 rpmbuild  --define "_topdir $PWD" -bc %{_builddir}/%{name}-%{version}/rpm/bundle-libdb.spec
 popd
@@ -416,7 +422,7 @@ autoreconf -fiv
 
 %configure \
 %if %{with bundle_libdb}
-           --with-bundle-libdb=%{_builddir}/%{libdb_base_version}/BUILD/%{libdb_base_version}/dist/dist-tls \
+           --with-bundle-libdb=%{_builddir}/%{libdb_base_version}/BUILD/%{libdb_base_dir}/dist/dist-tls \
 %endif
            --with-selinux $TMPFILES_FLAG \
            --with-systemd \
@@ -511,7 +517,7 @@ popd
 
 %if %{with bundle_libdb}
 pushd ../%{libdb_base_version}
-libdbbuilddir=$PWD/BUILD/%{libdb_base_version}
+libdbbuilddir=$PWD/BUILD/%{libdb_base_dir}
 libdbdestdir=$PWD/../%{name}-%{version}
 cp -pa $libdbbuilddir/LICENSE $libdbdestdir/LICENSE.libdb
 cp -pa $libdbbuilddir/README $libdbdestdir/README.libdb

--- a/rpm/add_patches.sh
+++ b/rpm/add_patches.sh
@@ -48,8 +48,8 @@ fi
 for p in $patches; do
     p=`basename $p`
     echo "Adding patch to spec file - $p"
-    sed -i -e "/${prefix}/a Patch${i}: ${p}" -e "/$prepprefix/a %patch${i} -p1" $specfile
+    sed -i -e "/${prefix}/a Patch${i}: ${p}" -e "/$prepprefix/a %patch -P${i} -p1" $specfile
     prefix="Patch${i}:"
-    prepprefix="%patch${i}"
+    prepprefix="%patch -P${i}"
     i=`expr $i + 1`
 done

--- a/rpm/bundle-libdb.spec
+++ b/rpm/bundle-libdb.spec
@@ -154,39 +154,39 @@ cp %{SOURCE2} .
 tar -xf %{SOURCE3}
 
 
-%patch0 -p1
+%patch -P0 -p1
 pushd db.1.85/PORT/linux
-%patch10 -p0
+%patch -P10 -p0
 popd
 pushd db.1.85
-%patch11 -p0
-%patch12 -p0
-%patch13 -p0
-%patch20 -p1
+%patch -P11 -p0
+%patch -P12 -p0
+%patch -P13 -p0
+%patch -P20 -p1
 popd
 
-%patch22 -p1
-%patch24 -p1
-%patch25 -p1
-%patch27 -p1
-%patch28 -p1
-%patch29 -p1
-%patch30 -p1
-%patch31 -p1
-%patch32 -p1
-%patch33 -p1
-%patch34 -p1
-%patch35 -p1
-%patch36 -p1
-%patch37 -p1
-%patch38 -p1
-%patch39 -p1
-%patch40 -p1 -b .cve-2019-2708
-%patch41 -p1
-%patch42 -p1
-%patch43 -p1
-%patch44 -p1
-%patch45 -p1
+%patch -P22 -p1
+%patch -P24 -p1
+%patch -P25 -p1
+%patch -P27 -p1
+%patch -P28 -p1
+%patch -P29 -p1
+%patch -P30 -p1
+%patch -P31 -p1
+%patch -P32 -p1
+%patch -P33 -p1
+%patch -P34 -p1
+%patch -P35 -p1
+%patch -P36 -p1
+%patch -P37 -p1
+%patch -P38 -p1
+%patch -P39 -p1
+%patch -P40 -p1 -b .cve-2019-2708
+%patch -P41 -p1
+%patch -P42 -p1
+%patch -P43 -p1
+%patch -P44 -p1
+%patch -P45 -p1
 
 cd dist
 ./s_config


### PR DESCRIPTION
RPM 4.20 drops support for the deprecated %patchN syntax, and adds a build-specific path to %_builddir.