### PR TITLE
Issue 6238 - RFE - add option to write audit log in JSON format

### DIFF
--- a/dirsrvtests/tests/suites/logging/audit_json_logging_test.py
+++ b/dirsrvtests/tests/suites/logging/audit_json_logging_test.py
@@ -1,0 +1,170 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2024 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import ldap
+import re
+import time
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.topologies import topology_st as topo
+from lib389.idm.user import UserAccount, UserAccounts
+from lib389.dirsrv_log import DirsrvAuditJSONLog
+
+log = logging.getLogger(__name__)
+
+DN = "uid=audit_json,ou=people," + DEFAULT_SUFFIX
+MAIN_KEYS = [
+    "gm_time",
+    "local_time",
+    "target_dn",
+    "bind_dn",
+    "client_ip",
+    "server_ip",
+    "conn_id",
+    "op_id",
+    "result",
+]
+
+@pytest.fixture
+def setup_test(topo, request):
+    """Configure log settings"""
+    inst = topo.standalone
+    inst.config.replace('nsslapd-auditlog-logbuffering', 'off')
+    inst.config.replace('nsslapd-auditlog-logging-enabled', 'on')
+    inst.config.replace('nsslapd-auditfaillog-logging-enabled', 'on')
+    inst.config.replace('nsslapd-auditlog-log-format', 'json')
+    inst.config.replace('nsslapd-auditlog-display-attrs', 'cn')
+    inst.deleteAuditLogs()
+
+
+def get_log_event(inst, dn, op):
+    """Get a specific audit log event by target_dn and op type
+    """
+    time.sleep(1)  # give a little time to flush to disk
+
+    audit_log = DirsrvAuditJSONLog(inst)
+    log_lines = audit_log.readlines()
+    for line in log_lines:
+        if re.match(r'[ \t\n]', line):
+            # Skip log title lines and newlines
+            continue
+
+        event = audit_log.parse_line(line)
+        if event['target_dn'].lower() == dn.lower() and op in event:
+            return event
+
+    # Not found, must assert
+    assert False
+
+
+def test_audit_json_logging(topo, setup_test):
+    """Test audit json logging is working
+
+    :id: 837a89a3-9c5a-4f8f-90fd-27c6b32f13f6
+    :setup: Standalone Instance
+    :steps:
+        1. Add entry
+        2. Check it was logged in json and default keys are present
+        3. Modify entry
+        4. Check audit log
+        5. Modrdn of entry
+        6. Check log
+        7. Delete entry
+        8. Check log
+        9. Modify time format
+        10. Delete of non-existent entry fails
+        11. Check log for expected "result == 32"
+        12. Verify new time format is applied
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Success
+        10. Success
+        11. Success
+        12. Success
+    """
+    inst = topo.standalone
+
+    # Add entry
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user_dn = "uid=test_audit_log,ou=people," + DEFAULT_SUFFIX
+    user = users.ensure_state(properties={
+        'uid': 'test_audit_log',
+        'cn': 'test',
+        'sn': 'user',
+        'uidNumber': '1000',
+        'gidNumber': '1000',
+        'homeDirectory': '/home/test',
+        'userPassword': 'pppppppp'
+    })
+
+    event = get_log_event(inst, user_dn, "add")
+    # Check all the expected keys are present
+    for key in MAIN_KEYS:
+        assert key in event and event[key] != ""
+
+    # Check specific values
+    assert event['result'] == 0
+    assert event['add']
+    assert 'id_list' in event
+    assert event['id_list'][0]['cn'] == "test"
+
+    # Modify entry
+    user.replace('sn', 'new sn')
+    event = get_log_event(inst, user_dn, "modify")
+    assert event['result'] == 0
+    assert event['modify'][0]['op'] == "replace"
+    assert event['modify'][0]['attr'] == "sn"
+    assert event['modify'][0]['values'][0] == "new sn"
+
+    # ModRDN entry
+    NEW_SUP = "ou=groups," + DEFAULT_SUFFIX
+    user.rename('uid=test_modrdn', newsuperior=NEW_SUP, deloldrdn=True)
+    event = get_log_event(inst, user_dn, "modrdn")
+    assert event['result'] == 0
+    assert event['modrdn']['newrdn'] == "uid=test_modrdn"
+    assert event['modrdn']['deleteoldrdn'] is True
+    assert event['modrdn']['newsuperior'] == NEW_SUP
+
+    # Delete entry
+    DN = "uid=test_modrdn," + NEW_SUP
+    user.delete()
+    event = get_log_event(inst, DN, "delete")
+    assert event['result'] == 0
+    assert event['delete']['dn'] == DN
+
+    # CHange time format and check it after the next test
+    inst.config.replace('nsslapd-auditlog-time-format', '%F %T')
+
+    # Perform invalid update (result != 0)
+    DN = "uid=does_not_exist," + DEFAULT_SUFFIX
+    user = UserAccount(inst, DN)
+    with pytest.raises(ldap.NO_SUCH_OBJECT):
+        user.delete()
+    event = get_log_event(inst, DN, "delete")
+    assert event['result'] == 32
+
+    # Check time format
+    assert re.match(
+        r'[0-9]{4}\-[0-9]{2}\-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
+        event['local_time'])
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2024 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -10,7 +10,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-
 
 #include "slap.h"
 
@@ -23,6 +22,7 @@
 #define ATTR_DELETEOLDRDN "deleteoldrdn"
 #define ATTR_NEWSUPERIOR "newsuperior"
 #define ATTR_MODIFIERSNAME "modifiersname"
+#define JBUFSIZE 75
 char *attr_changetype = ATTR_CHANGETYPE;
 char *attr_newrdn = ATTR_NEWRDN;
 char *attr_deleteoldrdn = ATTR_DELETEOLDRDN;
@@ -33,7 +33,9 @@ static int audit_hide_unhashed_pw = 1;
 static int auditfail_hide_unhashed_pw = 1;
 
 /* Forward Declarations */
-static void write_audit_file(Slapi_Entry *entry, int logtype, int optype, const char *dn, void *change, int flag, time_t curtime, int rc, int sourcelog);
+static void write_audit_file(Slapi_PBlock *pb, Slapi_Entry *entry, int logtype,
+                             int optype, const char *dn, void *change,
+                             int flag, time_t curtime, int rc, int sourcelog);
 
 static const char *modrdn_changes[4];
 
@@ -99,7 +101,8 @@ write_audit_log_entry(Slapi_PBlock *pb)
     curtime = slapi_current_utc_time();
     /* log the raw, unnormalized DN */
     dn = slapi_sdn_get_udn(sdn);
-    write_audit_file(entry, SLAPD_AUDIT_LOG, operation_get_type(op), dn, change, flag, curtime, LDAP_SUCCESS, SLAPD_AUDIT_LOG);
+    write_audit_file(pb, entry, SLAPD_AUDIT_LOG, operation_get_type(op), dn,
+                     change, flag, curtime, LDAP_SUCCESS, SLAPD_AUDIT_LOG);
 }
 
 void
@@ -168,10 +171,12 @@ write_auditfail_log_entry(Slapi_PBlock *pb)
     audit_config = config_get_auditlog();
     if (auditfail_config == NULL || strlen(auditfail_config) == 0 || PL_strcasecmp(auditfail_config, audit_config) == 0) {
         /* If no auditfail log or "auditfaillog" == "auditlog", write to audit log */
-        write_audit_file(NULL, SLAPD_AUDIT_LOG, operation_get_type(op), dn, change, flag, curtime, pbrc, SLAPD_AUDITFAIL_LOG);
+        write_audit_file(pb, NULL, SLAPD_AUDIT_LOG, operation_get_type(op), dn,
+                         change, flag, curtime, pbrc, SLAPD_AUDITFAIL_LOG);
     } else {
         /* If we have our own auditfail log path */
-        write_audit_file(NULL, SLAPD_AUDITFAIL_LOG, operation_get_type(op), dn, change, flag, curtime, pbrc, SLAPD_AUDITFAIL_LOG);
+        write_audit_file(pb, NULL, SLAPD_AUDITFAIL_LOG, operation_get_type(op),
+                         dn, change, flag, curtime, pbrc, SLAPD_AUDITFAIL_LOG);
     }
     slapi_ch_free_string(&auditfail_config);
     slapi_ch_free_string(&audit_config);
@@ -211,6 +216,29 @@ log_entry_attr(Slapi_Attr *entry_attr, char *attrname, lenstr *l)
     }
 }
 
+static void
+log_entry_attr_json(Slapi_Attr *entry_attr, char *attrname, json_object *attr_list)
+{
+    Slapi_Value **vals = attr_get_present_values(entry_attr);
+    for(size_t i = 0; vals && vals[i]; i++) {
+        json_object *attr_obj = json_object_new_object();
+        char log_val[256] = "";
+        const struct berval *bv = slapi_value_get_berval(vals[i]);
+
+        if (bv->bv_len >= 256) {
+            strncpy(log_val, bv->bv_val, 252);
+            strcpy(log_val+252, "...");
+        } else {
+            strncpy(log_val, bv->bv_val, bv->bv_len);
+            log_val[bv->bv_len] = 0;
+        }
+
+        json_object_object_add(attr_obj, attrname,
+                               json_object_new_string(log_val));
+        json_object_array_add(attr_list, attr_obj);
+    }
+}
+
 /*
  * Write "requested" attributes from the entry to the audit log as "comments"
  *
@@ -223,9 +251,10 @@ log_entry_attr(Slapi_Attr *entry_attr, char *attrname, lenstr *l)
  *       #ATTR: VALUE
  */
 static void
-add_entry_attrs(Slapi_Entry *entry, lenstr *l)
+add_entry_attrs_ext(Slapi_Entry *entry, lenstr *l, PRBool use_json, json_object *json_log)
 {
     Slapi_Attr *entry_attr = NULL;
+    json_object *id_list;
     char *display_attrs = NULL;
     char *req_attr = NULL;
     char *last = NULL;
@@ -240,6 +269,8 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
         return;
     }
 
+    id_list = json_object_new_array();
+
     entry_attr = entry->e_attrs;
     if (strcmp(display_attrs, "*")) {
         /* Return specific attributes */
@@ -248,7 +279,11 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
         {
             slapi_entry_attr_find(entry, req_attr, &entry_attr);
             if (entry_attr) {
-                log_entry_attr(entry_attr, req_attr, l);
+                if (use_json) {
+                    log_entry_attr_json(entry_attr, req_attr, id_list);
+                } else {
+                    log_entry_attr(entry_attr, req_attr, l);
+                }
             }
         }
     } else {
@@ -266,20 +301,288 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
                 strcasecmp(attr, CONFIG_ROOTPW_ATTRIBUTE) == 0)
             {
                 /* userpassword/rootdn password - mask the value */
-                addlenstr(l, "#");
-                addlenstr(l, attr);
-                addlenstr(l, ": ****************************\n");
+                if (use_json) {
+                    json_object *secret_obj = json_object_new_object();
+                    json_object_object_add(secret_obj, attr,
+                                           json_object_new_string("**********************"));
+                    json_object_array_add(id_list, secret_obj);
+                } else {
+                    addlenstr(l, "#");
+                    addlenstr(l, attr);
+                    addlenstr(l, ": ****************************\n");
+                }
                 continue;
             }
-            log_entry_attr(entry_attr, attr, l);
+            if (use_json) {
+                log_entry_attr_json(entry_attr, attr, id_list);
+            } else {
+                log_entry_attr(entry_attr, attr, l);
+            }
         }
     }
+    if (json_object_array_length(id_list) > 0) {
+        json_object_object_add(json_log, "id_list", id_list);
+    } else {
+        /* free empty list */
+        json_object_put(id_list);
+    }
     slapi_ch_free_string(&display_attrs);
+}
+
+static void
+add_entry_attrs(Slapi_Entry *entry, lenstr *l)
+{
+    add_entry_attrs_ext(entry, l, PR_FALSE, NULL);
+}
+
+static void
+add_entry_attrs_json(Slapi_Entry *entry,  json_object *json_log)
+{
+    add_entry_attrs_ext(entry, NULL, PR_TRUE, json_log);
+}
+
+static void
+write_audit_file_json(Slapi_PBlock *pb, Slapi_Entry *entry, int logtype,
+                      int optype, const char *dn, void *change, int flag,
+                      time_t curtime, int result, int log_format)
+{
+    Connection *pb_conn = NULL;
+    Slapi_Operation *operation = NULL;
+    Slapi_DN *target_sdn = NULL;
+    Slapi_Entry *e = NULL;
+    LDAPMod **mods = NULL;
+    json_object *log_json = NULL;
+    json_object *del_obj = NULL;
+    json_object *modrdn_obj = NULL;
+    struct tm tms;
+    struct tm gmtime;
+    const char *target_dn = NULL;
+    char binddn[JBUFSIZE] = "";
+    char local_time[JBUFSIZE] = "";
+    char gm_time[JBUFSIZE] = "";
+    char *client_ip = NULL;
+    char *server_ip = NULL;
+    char *newrdn = NULL;
+    char *mod_dn = NULL;
+    char *msg = NULL;
+    char *time_format = NULL;
+    char *tmp = NULL;
+    char *tmpsave = NULL;
+    uint64_t conn_id = 0;
+    int32_t rc = -1;
+    int32_t op_id = 0;
+
+    /* custom local time */
+    time_format = config_get_auditlog_time_format();
+    (void)localtime_r(&curtime, &tms);
+    if (strftime(local_time, JBUFSIZE, time_format, &tms) == 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "write_audit_file_json",
+                      "Unable to format time "
+                      "(%ld) using format (%s), trying default format...\n",
+                      curtime, time_format);
+        /* Got an error, use default format and try again */
+        if (strftime(local_time, JBUFSIZE, SLAPD_INIT_AUDITLOG_TIME_FORMAT, &tms) == 0) {
+            slapi_log_err(SLAPI_LOG_ERR, "write_audit_file_json",
+                      "Unable to format time (%ld)\n", curtime);
+            return;
+        }
+    }
+
+    /* gmtime */
+    gmtime_r(&curtime, &gmtime);
+    strftime(gm_time, 21, "%FT%TZ", &gmtime);
+
+    slapi_pblock_get(pb, SLAPI_CONNECTION, &pb_conn);
+    slapi_pblock_get(pb, SLAPI_OPERATION, &operation);
+    slapi_pblock_get(pb, SLAPI_ORIGINAL_TARGET_DN, &target_dn);
+
+    if (target_dn == NULL) {
+        if (optype == SLAPI_OPERATION_ADD) {
+            slapi_pblock_get(pb, SLAPI_TARGET_SDN, &target_sdn);
+            if (target_sdn) {
+                target_dn = slapi_sdn_get_ndn(target_sdn);
+            } else {
+                target_dn = "unknown";
+            }
+        } else if (optype == SLAPI_OPERATION_DELETE) {
+            slapi_pblock_get(pb, SLAPI_DELETE_TARGET_SDN, &target_dn);
+            if (target_sdn) {
+                target_dn = slapi_sdn_get_ndn(target_sdn);
+            } else {
+                target_dn = "unknown";
+            }
+        } else if (optype == SLAPI_OPERATION_MODRDN) {
+            slapi_pblock_get(pb, SLAPI_MODRDN_TARGET_SDN, &target_dn);
+            if (target_sdn) {
+                target_dn = slapi_sdn_get_ndn(target_sdn);
+            } else {
+                target_dn = "unknown";
+            }
+        } else {
+            target_dn = "unknown";
+        }
+    }
+
+    if (pb_conn) {
+        conn_id = pb_conn->c_connid,
+        op_id = operation->o_opid,
+        client_ip = pb_conn->c_ipaddr;
+        server_ip = pb_conn->c_serveripaddr;
+        slapi_pblock_get(pb, SLAPI_CONN_DN, &mod_dn);
+        PR_snprintf(binddn, sizeof(binddn), "%s", mod_dn ? mod_dn : "");
+        slapi_ch_free_string(&mod_dn);
+    } else {
+        conn_id = -1,
+        op_id = -1,
+        client_ip = "internal";
+        server_ip = "internal";
+        PR_snprintf(binddn, sizeof(binddn), "internal");
+    }
+
+    /* Start building the JSON obj */
+    log_json = json_object_new_object();
+    json_object_object_add(log_json, "gm_time",    json_object_new_string(gm_time));
+    json_object_object_add(log_json, "local_time", json_object_new_string(local_time));
+    json_object_object_add(log_json, "target_dn",  json_object_new_string(target_dn));
+    json_object_object_add(log_json, "bind_dn",    json_object_new_string(binddn));
+    json_object_object_add(log_json, "client_ip",  json_object_new_string(client_ip));
+    json_object_object_add(log_json, "server_ip",  json_object_new_string(server_ip));
+    json_object_object_add(log_json, "conn_id",    json_object_new_int64(conn_id));
+    json_object_object_add(log_json, "op_id",      json_object_new_int(op_id));
+    json_object_object_add(log_json, "result",     json_object_new_int(result));
+
+    // Add the display attributes
+    add_entry_attrs_json(entry, log_json);
+
+    switch (optype) {
+        case SLAPI_OPERATION_MODIFY:
+            json_object *mod_list = json_object_new_array();
+            mods = change;
+            for (size_t j = 0; (mods != NULL) && (mods[j] != NULL); j++) {
+                json_object *mod = NULL;
+                int operationtype = mods[j]->mod_op & ~LDAP_MOD_BVALUES;
+
+                if (strcmp(mods[j]->mod_type, PSEUDO_ATTR_UNHASHEDUSERPASSWORD) == 0) {
+                    switch (logtype) {
+                    case SLAPD_AUDIT_LOG:
+                        if (audit_hide_unhashed_pw != 0) {
+                            continue;
+                        }
+                        break;
+                    case SLAPD_AUDITFAIL_LOG:
+                        if (auditfail_hide_unhashed_pw != 0) {
+                            continue;
+                        }
+                        break;
+                    }
+                }
+
+                mod = json_object_new_object();
+                switch (operationtype) {
+                case LDAP_MOD_ADD:
+                    json_object_object_add(mod, "op", json_object_new_string("add"));
+                    break;
+
+                case LDAP_MOD_DELETE:
+                    json_object_object_add(mod, "op", json_object_new_string("delete"));
+                    break;
+
+                case LDAP_MOD_REPLACE:
+                    json_object_object_add(mod, "op", json_object_new_string("replace"));
+                    break;
+
+                default:
+                    operationtype = LDAP_MOD_IGNORE;
+                    break;
+                }
+                json_object_object_add(mod, "attr", json_object_new_string(mods[j]->mod_type));
+
+                if (operationtype != LDAP_MOD_IGNORE) {
+                    json_object *val_list = NULL;
+                    val_list = json_object_new_array();
+                    for (size_t i = 0; mods[j]->mod_bvalues != NULL && mods[j]->mod_bvalues[i] != NULL; i++) {
+                        json_object_array_add(val_list, json_object_new_string(mods[j]->mod_bvalues[i]->bv_val));
+                    }
+                    json_object_object_add(mod, "values", val_list);
+                }
+                json_object_array_add(mod_list, mod);
+            }
+            /* Add entire mod list to the main object */
+            json_object_object_add(log_json, "modify", mod_list);
+            break;
+
+        case SLAPI_OPERATION_ADD:
+            int len;
+            e = change;
+            tmp = slapi_entry2str(e, &len);
+            tmpsave = tmp;
+            while ((tmp = strchr(tmp, '\n')) != NULL) {
+                tmp++;
+                if (!ldap_utf8isspace(tmp)) {
+                    break;
+                }
+            }
+            json_object_object_add(log_json, "add", json_object_new_string(tmp));
+            slapi_ch_free_string(&tmpsave);
+            break;
+
+        case SLAPI_OPERATION_DELETE:
+            tmp = change;
+            del_obj = json_object_new_object();
+            if (tmp && tmp[0]) {
+                json_object_object_add(del_obj, "dn", json_object_new_string(target_dn));
+                json_object_object_add(log_json, "delete", del_obj);
+            } else {
+                json_object_object_add(del_obj, "dn", json_object_new_string(target_dn));
+                json_object_object_add(log_json, "delete", del_obj);
+            }
+            break;
+
+        case SLAPI_OPERATION_MODDN:
+            newrdn = ((char **)change)[0];
+            modrdn_obj = json_object_new_object();
+            json_object_object_add(modrdn_obj, attr_newrdn, json_object_new_string(newrdn));
+            json_object_object_add(modrdn_obj, attr_deleteoldrdn, json_object_new_boolean(flag));
+
+            if (((char **)change)[2]) {
+                char *newsuperior = ((char **)change)[2];
+                json_object_object_add(modrdn_obj, attr_newsuperior, json_object_new_string(newsuperior));
+            }
+            json_object_object_add(log_json, "modrdn", modrdn_obj);
+            break;
+    }
+
+    msg = (char *)json_object_to_json_string_ext(log_json, log_format);
+
+    switch (logtype) {
+    case SLAPD_AUDIT_LOG:
+        rc = slapd_log_audit(msg, PR_TRUE);
+        break;
+    case SLAPD_AUDITFAIL_LOG:
+        rc = slapd_log_auditfail(msg, PR_TRUE);
+        break;
+    default:
+        /* Unsupported log type, we should make some noise */
+        slapi_log_err(SLAPI_LOG_ERR, "write_audit_file_json",
+                      "Invalid log type specified. logtype %d\n", logtype);
+        break;
+    }
+
+    /* Done with JSON object, this will free it */
+    json_object_put(log_json);
+    slapi_ch_free_string(&time_format);
+
+    if (rc != LDAP_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_ERR, "write_audit_file_json",
+                      "Failed to update audit log, error %d\n", rc);
+    }
 }
 
 /*
  * Function: write_audit_file
  * Arguments:
+ *            pb - pblock
+ *            entry - Slapi Entry used for sdiplay attributes
  *            logtype - Destination where the message will go.
  *            optype - type of LDAP operation being logged
  *            dn     - distinguished name of entry being changed
@@ -293,6 +596,7 @@ add_entry_attrs(Slapi_Entry *entry, lenstr *l)
  */
 static void
 write_audit_file(
+    Slapi_PBlock *pb,
     Slapi_Entry *entry,
     int logtype,
     int optype,
@@ -310,6 +614,14 @@ write_audit_file(
     char *timestr;
     char *rcstr;
     lenstr *l;
+    int log_format = config_get_auditlog_log_format();
+
+    if (log_format != LOG_FORMAT_DEFAULT) {
+        /* We are using the json format instead of the LDIF format */
+        write_audit_file_json(pb, entry, logtype, optype, dn, change, flag,
+                              curtime, rc, log_format);
+        return;
+    }
 
     l = lenstr_new();
 
@@ -455,10 +767,10 @@ write_audit_file(
 
     switch (logtype) {
     case SLAPD_AUDIT_LOG:
-        slapd_log_audit(l->ls_buf, l->ls_len, sourcelog);
+        slapd_log_audit(l->ls_buf, PR_FALSE);
         break;
     case SLAPD_AUDITFAIL_LOG:
-        slapd_log_auditfail(l->ls_buf, l->ls_len);
+        slapd_log_auditfail(l->ls_buf, PR_FALSE);
         break;
     default:
         /* Unsupported log type, we should make some noise */

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -435,7 +435,7 @@ slapi_pblock_get(Slapi_PBlock *pblock, int arg, void *value)
          * a pointer that could be freed out from under them.
          */
         if (pblock->pb_conn == NULL) {
-            slapi_log_err(SLAPI_LOG_ERR,
+            slapi_log_err(SLAPI_LOG_TRACE,
                           "slapi_pblock_get", "Connection is NULL and hence cannot access SLAPI_CONN_DN \n");
             return (-1);
         }

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -397,6 +397,8 @@ int config_set_disk_threshold(const char *attrname, char *value, char *errorbuf,
 int config_set_disk_grace_period(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_disk_logging_critical(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditlog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_auditlog_log_format(const char *attrname, char *value, char *errorbuf, int apply);
+int config_set_auditlog_time_format(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_auditfaillog_unhashed_pw(const char *attrname, char *value, char *errorbuf, int apply);
 int32_t config_set_auditlog_display_attrs(const char *attrname, char *value, char *errorbuf, int apply);
 int config_set_external_libs_debug_enabled(const char *attrname, char *value, char *errorbuf, int apply);
@@ -525,6 +527,8 @@ int config_get_securitylog_level(void);
 int config_get_auditlog_logging_enabled(void);
 int config_get_auditfaillog_logging_enabled(void);
 char *config_get_auditlog_display_attrs(void);
+int config_get_auditlog_log_format(void);
+char *config_get_auditlog_time_format(void);
 char *config_get_referral_mode(void);
 int config_get_num_listeners(void);
 int config_check_referral_mode(void);
@@ -855,10 +859,8 @@ int slapi_log_access(int level, const char *fmt, ...)
 #endif
 int slapi_log_security(Slapi_PBlock *pb, const char *event_type, const char *msg);
 int slapi_log_security_tcp(Connection *pb_conn, const char *event_type, PRErrorCode error, const char *msg);
-int slapd_log_audit(char *buffer, int buf_len, int sourcelog);
-int slapd_log_audit_internal(char *buffer, int buf_len, int *state);
-int slapd_log_auditfail(char *buffer, int buf_len);
-int slapd_log_auditfail_internal(char *buffer, int buf_len);
+int slapd_log_audit(char *buffer, PRBool json);
+int slapd_log_auditfail(char *buffer, PRBool json);
 void logs_flush(void);
 
 int access_log_openf(char *pathname, int locked);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -142,6 +142,8 @@ typedef struct symbol_t
 #define GET_THREAD_ID() pthread_self()
 #endif
 
+#include <json-c/json.h>
+
 /*
  * XXXmcs: these are defined by ldap.h or ldap-extension.h,
  * but only in a newer release than we use with DS today.
@@ -318,6 +320,11 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_INIT_AUDITLOG_ROTATIONUNIT     "week"
 #define SLAPD_INIT_AUDITFAILLOG_ROTATIONUNIT "week"
 #define SLAPD_INIT_LOG_EXPTIMEUNIT           "month"
+#define SLAPD_INIT_AUDITLOG_TIME_FORMAT "%FT%TZ"
+#define SLAPD_INIT_AUDITLOG_LOG_FORMAT "default"
+#define LOG_FORMAT_DEFAULT 1
+#define LOG_FORMAT_JSON 0
+#define LOG_FORMAT_JSON_PRETTY JSON_C_TO_STRING_PRETTY
 
 #define SLAPD_DEFAULT_LOG_ROTATIONSYNCHOUR 0
 #define SLAPD_DEFAULT_LOG_ROTATIONSYNCHOUR_STR "0"
@@ -2195,6 +2202,8 @@ typedef struct _slapdEntryPoints
 #define CONFIG_AUDITLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditlog-compress"
 #define CONFIG_AUDITFAILLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-auditfaillog-compress"
 #define CONFIG_ERRORLOG_COMPRESS_ENABLED_ATTRIBUTE "nsslapd-errorlog-compress"
+#define CONFIG_AUDITLOG_LOG_FORMAT_ATTRIBUTE "nsslapd-auditlog-log-format"
+#define CONFIG_AUDITLOG_TIME_FORMAT_ATTRIBUTE "nsslapd-auditlog-time-format"
 #define CONFIG_UNHASHED_PW_SWITCH_ATTRIBUTE "nsslapd-unhashed-pw-switch"
 #define CONFIG_ROOTDN_ATTRIBUTE "nsslapd-rootdn"
 #define CONFIG_ROOTPW_ATTRIBUTE "nsslapd-rootpw"
@@ -2572,6 +2581,8 @@ typedef struct _slapdFrontendConfig
     char *auditlog; /* replication audit file */
     int auditloglevel;
     slapi_onoff_t auditlog_logging_enabled;
+    char *auditlog_log_format;
+    char *auditlog_time_format;
     char *auditlog_mode;
     int auditlog_maxnumlogs;
     int auditlog_maxlogsize;

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -36,6 +36,8 @@ const settings_attrs = [
     'nsslapd-auditlog',
     'nsslapd-auditlog-logging-enabled',
     'nsslapd-auditlog-logbuffering',
+    'nsslapd-auditlog-log-format',
+    'nsslapd-auditlog-time-format',
 ];
 
 const rotation_attrs = [
@@ -385,6 +387,8 @@ export class ServerAuditLog extends React.Component {
                         'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
                         'nsslapd-auditlog-compress': compressed,
                         'nsslapd-auditlog-logbuffering': buffering,
+                        'nsslapd-auditlog-log-format': attrs['nsslapd-auditlog-log-format'][0],
+                        'nsslapd-auditlog-time-format': attrs['nsslapd-auditlog-time-format'][0],
                         displayAttrs: display_attrs,
                         displayAllAttrs,
                         // Record original values
@@ -403,6 +407,8 @@ export class ServerAuditLog extends React.Component {
                         '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
                         '_nsslapd-auditlog-compress': compressed,
                         '_nsslapd-auditlog-logbuffering': buffering,
+                        '_nsslapd-auditlog-log-format': attrs['nsslapd-auditlog-log-format'][0],
+                        '_nsslapd-auditlog-time-format': attrs['nsslapd-auditlog-time-format'][0],
                         _displayAttrs: display_attrs,
                         _displayAllAttrs: displayAllAttrs,
                     });
@@ -467,6 +473,8 @@ export class ServerAuditLog extends React.Component {
             'nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
             'nsslapd-auditlog-compress': compressed,
             'nsslapd-auditlog-logbuffering': buffering,
+            'nsslapd-auditlog-log-format': attrs['nsslapd-auditlog-log-format'][0],
+            'nsslapd-auditlog-time-format': attrs['nsslapd-auditlog-time-format'][0],
             displayAttrs: display_attrs,
             displayAllAttrs,
             // Record original values,
@@ -485,6 +493,8 @@ export class ServerAuditLog extends React.Component {
             '_nsslapd-auditlog-maxlogsperdir': attrs['nsslapd-auditlog-maxlogsperdir'][0],
             '_nsslapd-auditlog-compress': compressed,
             '_nsslapd-auditlog-logbuffering': buffering,
+            '_nsslapd-auditlog-log-format': attrs['nsslapd-auditlog-log-format'][0],
+            '_nsslapd-auditlog-time-format': attrs['nsslapd-auditlog-time-format'][0],
             _displayAttrs: display_attrs,
             _displayAllAttrs: displayAllAttrs,
         }, this.props.enableTree);
@@ -546,17 +556,41 @@ export class ServerAuditLog extends React.Component {
                                     }}
                                 />
                             </FormGroup>
+                            <FormGroup
+                                label="Time Format"
+                                fieldId="nsslapd-auditlog-time-format"
+                                title="Time format using strftime formatting (nsslapd-auditlog-time-format)."
+                            >
+                                <TextInput
+                                    value={this.state['nsslapd-auditlog-time-format']}
+                                    type="text"
+                                    id="nsslapd-auditlog-time-format"
+                                    aria-describedby="horizontal-form-name-helper"
+                                    name="nsslapd-auditlog-time-format"
+                                    onChange={(str, e) => {
+                                        this.handleChange(e, "settings");
+                                    }}
+                                />
+                            </FormGroup>
+                            <FormGroup
+                                label="Log Format"
+                                fieldId="nsslapd-auditlog-log-format"
+                                title="Choose the log format (nsslapd-auditlog-log-format)."
+                            >
+                                <FormSelect
+                                    id="nsslapd-auditlog-log-format"
+                                    value={this.state['nsslapd-auditlog-log-format']}
+                                    onChange={(str, e) => {
+                                        this.handleChange(e, "settings");
+                                    }}
+                                    aria-label="FormSelect Input"
+                                >
+                                    <FormSelectOption key="0" value="default" label="Default" />
+                                    <FormSelectOption key="1" value="json" label="JSON" />
+                                    <FormSelectOption key="2" value="json-pretty" label="JSON (pretty)" />
+                                </FormSelect>
+                            </FormGroup>
                         </Form>
-                        <Checkbox
-                            className="ds-left-margin-md ds-margin-top-lg"
-                            id="nsslapd-auditlog-logbuffering"
-                            isChecked={this.state['nsslapd-auditlog-logbuffering']}
-                            onChange={(checked, e) => {
-                                this.handleChange(e, "settings");
-                            }}
-                            title={_("This applies to both the audit & auditfail logs.  Disable audit log buffering for faster troubleshooting, but this will impact server performance (nsslapd-auditlog-logbuffering).")}
-                            label={_("Audit Log Buffering Enabled")}
-                        />
                         <Form className="ds-margin-top-lg ds-left-margin-md" isHorizontal autoComplete="off">
                             <FormGroup
                                 label={_("Display Attributes")}
@@ -596,6 +630,16 @@ export class ServerAuditLog extends React.Component {
                                 />
                             </FormGroup>
                         </Form>
+                        <Checkbox
+                            className="ds-left-margin-md ds-margin-top-lg"
+                            id="nsslapd-auditlog-logbuffering"
+                            isChecked={this.state['nsslapd-auditlog-logbuffering']}
+                            onChange={(checked, e) => {
+                                this.handleChange(e, "settings");
+                            }}
+                            title={_("This applies to both the audit & auditfail logs.  Disable audit log buffering for faster troubleshooting, but this will impact server performance (nsslapd-auditlog-logbuffering).")}
+                            label={_("Audit Log Buffering Enabled")}
+                        />
                         <Button
                             key="save settings"
                             isDisabled={this.state.saveSettingsDisabled || this.state.loading}

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -321,7 +321,10 @@ class DirSrv(SimpleLDAPObject, object):
         from lib389.aci import Aci
         from lib389.config import RSA
         from lib389.config import Encryption
-        from lib389.dirsrv_log import DirsrvAccessLog, DirsrvErrorLog, DirsrvAuditLog, DirsrvSecurityLog
+        from lib389.dirsrv_log import (
+            DirsrvAccessLog, DirsrvErrorLog, DirsrvAuditLog,
+            DirsrvAuditJSONLog, DirsrvSecurityLog
+        )
         from lib389.ldclt import Ldclt
         from lib389.mappingTree import MappingTrees
         from lib389.mappingTree import MappingTreeLegacy as MappingTree
@@ -367,6 +370,7 @@ class DirSrv(SimpleLDAPObject, object):
         self.ds_access_log = DirsrvAccessLog(self)
         self.ds_error_log = DirsrvErrorLog(self)
         self.ds_audit_log = DirsrvAuditLog(self)
+        self.ds_audit_json_log = DirsrvAuditJSONLog(self)
         self.ds_security_log = DirsrvSecurityLog(self)
         self.ldclt = Ldclt(self)
         self.saslmaps = SaslMappings(self)
@@ -1050,7 +1054,7 @@ class DirSrv(SimpleLDAPObject, object):
 
     def dump_errorlog(self):
         '''
-            Its logs all errors messages within the error log that occured 
+            Its logs all errors messages within the error log that occured
             after the last startup.
         '''
         errlog = self.ds_paths.error_log


### PR DESCRIPTION
Description:

Add option to set the format between: default, json, or json-pretty

json-pretty just writes the JSON format in a vertical structure verses one condensed line of text.

You can also adjust the date format using strftime formatting

Relates: https://github.com/389ds/389-ds-base/issues/6238

