### PR TITLE
Issue 6216 - CI test_fast_slow_import sometime fail

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -416,7 +416,7 @@ def _toggle_private_import_mem(request, topo):
 
 
 #unstable or unstatus tests, skipped for now
-#@pytest.mark.flaky(max_runs=2, min_passes=1)
+@pytest.mark.flaky(max_runs=2, min_passes=1)
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="nsslapd-db-private-import-mem and nsslapd-import-cache-autosize parameters are ignored when usign lmdb")
 def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     """With nsslapd-db-private-import-mem: on is faster import.
@@ -460,7 +460,8 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("total_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert total_time1 < total_time2
+    # Comparing small time values is instable ==> Lets ignore it
+    # assert total_time1 < total_time2
 
     # Set nsslapd-db-private-import-mem:on, nsslapd-import-cache-autosize: -1
     config.replace_many(
@@ -479,7 +480,8 @@ def test_fast_slow_import(topo, _toggle_private_import_mem, _import_clean):
     # total_time1 < total_time2
     log.info("total_time1 = %f" % total_time1)
     log.info("total_time2 = %f" % total_time2)
-    assert total_time1 < total_time2
+    # Comparing small time values is instable ==> Lets ignore it
+    # assert total_time1 < total_time2
 
 
 def test_entry_with_escaped_characters_fails_to_import_and_index(topo, _import_clean):


### PR DESCRIPTION
The test comparing times around 2 seconds is pretty instable.
With this fix, the test is still running, checking that import with private memory works
but does not check any more that it is faster than standard import

Issue: #6216 

Reviewed by: @droideck (Thanks!)