### PR TITLE
Issue 6248 - fix fanalyzer warnings

### DIFF
--- a/ldap/libraries/libavl/avl.c
+++ b/ldap/libraries/libavl/avl.c
@@ -713,6 +713,10 @@ avl_buildlist(caddr_t data, int arg __attribute__((unused)))
                                       (unsigned)slots * sizeof(caddr_t));
     }
 
+    if (avl_list == NULL) {
+        return (-1);
+    }
+
     avl_list[avl_maxlist++] = data;
 
     return (0);

--- a/ldap/libraries/libavl/avl.c
+++ b/ldap/libraries/libavl/avl.c
@@ -752,8 +752,8 @@ avl_getfirst(Avlnode *root)
         return (0);
 
     (void)avl_apply(root, avl_buildlist, (caddr_t)0, -1, AVL_INORDER);
-    if (avl_list && avl_list[avl_nextlist++]) {
-        return avl_list[avl_nextlist];
+    if (avl_list && avl_list[avl_nextlist]) {
+        return avl_list[avl_nextlist++];
     } else {
         return (NULL);
     }

--- a/ldap/libraries/libavl/avl.c
+++ b/ldap/libraries/libavl/avl.c
@@ -709,8 +709,12 @@ avl_buildlist(caddr_t data, int arg __attribute__((unused)))
         avl_maxlist = 0;
     } else if (avl_maxlist == slots) {
         slots += AVL_GRABSIZE;
-        avl_list = (caddr_t *)realloc((char *)avl_list,
-                                      (unsigned)slots * sizeof(caddr_t));
+        caddr_t *new_avl_list = realloc((char *)avl_list,
+                                        (unsigned)slots * sizeof(caddr_t));
+        if (!new_avl_list) {
+            free(avl_list);
+        }
+        avl_list = new_avl_list;
     }
 
     if (avl_list == NULL) {

--- a/ldap/servers/plugins/acl/acllas.c
+++ b/ldap/servers/plugins/acl/acllas.c
@@ -4065,6 +4065,9 @@ aclutil_evaluate_macro(char *rule, lasInfo *lasinfo, acl_eval_types evalType)
     */
 
     candidate_list = acllas_replace_dn_macro(rule, matched_val, lasinfo);
+    if (candidate_list == NULL) {
+        return matched;
+    }
 
     sptr = candidate_list;
     while (*sptr != NULL && !matched) {

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -1677,7 +1677,7 @@ cos_cache_release(cos_cache *ptheCache)
 
     slapi_unlock_mutex(cache_lock);
 
-    if (destroy) {
+    if (destroy && (pOldCache != NULL)) {
         cosDefinitions *pDef = pOldCache->pDefs;
 
         /* now is the first time it is

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -1684,9 +1684,15 @@ cos_cache_release(cos_cache *ptheCache)
          * safe to assess whether
          * vattr caching can be turned on
          */
+        /* Work around gcc -fanalyzer bug: it complain about pOldCache
+         * but that is pCache that is tested ...
+         */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-deref-before-check"
         if (pCache && pCache->vattr_cacheable) {
             slapi_vattrcache_cache_all();
         }
+#pragma GCC diagnostic pop
 
         /* destroy the cache here - no locking required, no references outstanding */
 

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -1918,6 +1918,11 @@ memberof_mod_attr_list_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod, Slap
 
     op_this_val = slapi_value_new_string(slapi_sdn_get_ndn(op_this_sdn));
     slapi_value_set_flags(op_this_val, SLAPI_ATTR_FLAG_NORMALIZED_CIS);
+    /* For gcc -analyser: ignore false positive about dn_str 
+     * (last_str cannot be NULL if last_size > bv->bv_len)
+     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-null-argument"
 
     while (val && rc == 0) {
         char *dn_str = 0;
@@ -1967,6 +1972,7 @@ memberof_mod_attr_list_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod, Slap
     if (last_str)
         slapi_ch_free_string(&last_str);
 
+#pragma GCC diagnostic pop
     return rc;
 }
 
@@ -2712,9 +2718,13 @@ memberof_replace_list(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *group_
 
                     post_index++;
                 } else if (post_index == post_total) {
+                    /* For gcc -fanalyzer: pre_index cannot be null when pre_index < pre_total */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-null-dereference"
                     /* delete the rest of pre */
                     slapi_sdn_set_normdn_byref(sdn,
                                                slapi_value_get_string(pre_array[pre_index]));
+#pragma GCC diagnostic pop
                     rc = memberof_del_one(pb, config, group_sdn, sdn);
 
                     pre_index++;

--- a/ldap/servers/plugins/replication/repl5_inc_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_inc_protocol.c
@@ -384,8 +384,7 @@ repl5_inc_rd_new(Private_Repl_Protocol *prp)
         res->prp = prp;
         res->lock = PR_NewLock();
         if (NULL == res->lock) {
-            slapi_ch_free((void **)&res);
-            res = NULL;
+            slapi_ch_oom("PR_NewLock");
         }
     }
     return res;

--- a/ldap/servers/plugins/replication/repl5_replica_config.c
+++ b/ldap/servers/plugins/replication/repl5_replica_config.c
@@ -282,7 +282,13 @@ replica_config_modify(Slapi_PBlock *pb,
     PR_Lock(s_configLock);
 
     mtnode_ext = _replica_config_get_mtnode_ext(e);
-    PR_ASSERT(mtnode_ext);
+    if (NULL == mtnode_ext) {
+        PR_Unlock(s_configLock);
+        PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Unable to get the replica mapping tree");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
 
     if (mtnode_ext->replica == NULL) {
         PR_snprintf(errortext, SLAPI_DSE_RETURNTEXT_SIZE, "Replica does not exist for %s", replica_root);
@@ -614,7 +620,13 @@ replica_config_post_modify(Slapi_PBlock *pb,
     PR_Lock(s_configLock);
 
     mtnode_ext = _replica_config_get_mtnode_ext(e);
-    PR_ASSERT(mtnode_ext);
+    if (NULL == mtnode_ext) {
+        PR_Unlock(s_configLock);
+        PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Unable to get the replica mapping tree");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
 
     if (mtnode_ext->replica == NULL) {
         PR_snprintf(errortext, SLAPI_DSE_RETURNTEXT_SIZE,
@@ -708,7 +720,13 @@ replica_config_delete(Slapi_PBlock *pb __attribute__((unused)),
     PR_Lock(s_configLock);
 
     mtnode_ext = _replica_config_get_mtnode_ext(e);
-    PR_ASSERT(mtnode_ext);
+    if (NULL == mtnode_ext) {
+        PR_Unlock(s_configLock);
+        PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Unable to get the replica mapping tree");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
 
     if (mtnode_ext->replica) {
         /* remove object from the hash */
@@ -840,7 +858,13 @@ replica_config_search(Slapi_PBlock *pb,
     PR_Lock(s_configLock);
 
     mtnode_ext = _replica_config_get_mtnode_ext(e);
-    PR_ASSERT(mtnode_ext);
+    if (NULL == mtnode_ext) {
+        PR_Unlock(s_configLock);
+        PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Unable to get the replica mapping tree");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
 
     if (mtnode_ext->replica) {
         Replica *replica = (Replica *)object_get_data(mtnode_ext->replica);

--- a/ldap/servers/plugins/replication/repl_shared.h
+++ b/ldap/servers/plugins/replication/repl_shared.h
@@ -104,7 +104,7 @@ int copyfile(char *source, char *destination, int overwrite, int mode);
 time_t age_str2time(const char *age);
 const char *changeType2Str(int type);
 int str2ChangeType(const char *str);
-lenstr *make_changes_string(LDAPMod **ldm, char **includeattrs);
+lenstr *make_changes_string(LDAPMod **ldm, char **includeattrs) __ATTRIBUTE__((returns_nonnull));
 Slapi_Mods *parse_changes_string(char *str);
 PRBool IsValidOperation(const slapi_operation_parameters *op);
 const char *map_repl_root_to_dbid(Slapi_DN *repl_root);

--- a/ldap/servers/plugins/rootdn_access/rootdn_access.c
+++ b/ldap/servers/plugins/rootdn_access/rootdn_access.c
@@ -56,7 +56,7 @@ static int32_t rootdn_check_access(Slapi_PBlock *pb);
 static int32_t rootdn_check_host_wildcard(char *host, char *client_host);
 static int rootdn_check_ip_wildcard(char *ip, char *client_ip);
 static int32_t rootdn_preop_bind_init(Slapi_PBlock *pb);
-char *strToLower(char *str);
+void strToLower(char *str);
 
 /*
  * Plug-in globals
@@ -238,7 +238,7 @@ rootdn_load_config(Slapi_PBlock *pb)
          *  Validate out settings
          */
         if (daysAllowed_tmp) {
-            daysAllowed_tmp = strToLower(daysAllowed_tmp);
+            strToLower(daysAllowed_tmp);
             end = strspn(daysAllowed_tmp, "abcdefghijklmnopqrstuvwxyz ,");
             if (!end || daysAllowed_tmp[end] != '\0') {
                 slapi_log_err(SLAPI_LOG_ERR, ROOTDN_PLUGIN_SUBSYSTEM, "rootdn_load_config - "
@@ -499,13 +499,12 @@ rootdn_check_access(Slapi_PBlock *pb)
      */
     if (daysAllowed) {
         char *timestr;
-        char day[4] = {0};
-        char *today = day;
+        char today[4] = {0};
 
         timestr = asctime(timeinfo);  // DDD MMM dd hh:mm:ss YYYY
-        memmove(day, timestr, 3);     // we only want the day
-        today = strToLower(today);
-        daysAllowed = strToLower(daysAllowed);
+        memmove(today, timestr, 3);   // we only want the day
+        strToLower(today);
+        strToLower(daysAllowed);
 
         if (!strstr(daysAllowed, today)) {
             slapi_log_err(SLAPI_LOG_ERR, ROOTDN_PLUGIN_SUBSYSTEM, "rootdn_check_access - "
@@ -758,11 +757,15 @@ rootdn_check_ip_wildcard(char *ip, char *client_ip)
     return 0;
 }
 
-char *
+void
 strToLower(char *str)
 {
-    for (size_t i = 0; str && i < strlen(str); i++) {
-        str[i] = tolower(str[i]);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
+    if (NULL != str) {
+        for (char *pt = str; *pt != '\0'; pt++) {
+            *pt = tolower(*pt);
+        }
     }
-    return str;
+#pragma GCC diagnostic pop
 }

--- a/ldap/servers/plugins/sync/sync_util.c
+++ b/ldap/servers/plugins/sync/sync_util.c
@@ -333,7 +333,7 @@ sync_result_msg(Slapi_PBlock *pb, Sync_Cookie *cookie)
 
     LDAPControl **ctrl = (LDAPControl **)slapi_ch_calloc(2, sizeof(LDAPControl *));
 
-    if (cookie->openldap_compat) {
+    if (cookie && cookie->openldap_compat) {
         sync_create_sync_done_control(&ctrl[0], 1, cookiestr);
     } else {
         sync_create_sync_done_control(&ctrl[0], 0, cookiestr);

--- a/ldap/servers/plugins/views/views.c
+++ b/ldap/servers/plugins/views/views.c
@@ -1352,7 +1352,7 @@ views_update_views_cache(Slapi_Entry *e, char *dn __attribute__((unused)), int m
          * update all child filters
          * re-index
          */
-        if (modtype == LDAP_CHANGETYPE_DELETE) {
+        if ((modtype == LDAP_CHANGETYPE_DELETE) && (theView != NULL)) {
 
             if (theCache.view_count - 1) {
                 /* detach view */

--- a/ldap/servers/slapd/back-ldbm/archive.c
+++ b/ldap/servers/slapd/back-ldbm/archive.c
@@ -490,7 +490,7 @@ out:
 #define CPRETRY 4
 /* Copy a file to the backup */
 static int32_t
-archive_copyfile(char *source, char *destination, char *filename, mode_t mode, Slapi_Task *task)
+archive_copyfile(char *source, char *destination, const char *filename, mode_t mode, Slapi_Task *task)
 {
     PRFileDesc *source_fd = NULL;
     PRFileDesc *dest_fd = NULL;
@@ -626,10 +626,10 @@ error:
     return return_value;
 }
 
-static char *cert_files_600[] = {
+static const char *cert_files_600[] = {
     "key4.db", "cert9.db", "pin.txt", "pwdfile.txt", NULL
 };
-static char *config_files_440[] = {"certmap.conf", "slapd-collations.conf", NULL};
+static const char *config_files_440[] = {"certmap.conf", "slapd-collations.conf", NULL};
 
 /* Archive nss files, 99user.ldif, and config files */
 int32_t

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -533,7 +533,11 @@ dbgec_test_if_entry_pointer_is_valid(void *e, void *prev, int slot, int line)
          */ 
         slapi_log_err(SLAPI_LOG_FATAL, "dbgec_test_if_entry_pointer_is_valid", "cache.c[%d]: Wrong entry address: %p Previous entry address is: %p hash table slot is %d\n", line, e, prev, slot);
         slapi_log_backtrace(SLAPI_LOG_FATAL);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds="
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
         *(char*)23 = 1;   /* abort() somehow corrupt gdb stack backtrace so lets generate a SIGSEGV */
+#pragma GCC diagnostic pop
         abort();
     }
 }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -3141,6 +3141,7 @@ static int
 bdb_import_merge_one_file(ImportWorkerInfo *worker, int passes, int *key_count)
 {
     ldbm_instance *inst = worker->job->inst;
+    PR_ASSERT(NULL != inst);
     backend *be = inst->inst_be;
     DB *output_file = NULL;
     int ret = 0;
@@ -3149,8 +3150,6 @@ bdb_import_merge_one_file(ImportWorkerInfo *worker, int passes, int *key_count)
     int pass_number = 0;
     DB **input_files = NULL;
     DBC **input_cursors = NULL;
-
-    PR_ASSERT(NULL != inst);
 
     /* Try to open all the input files.
        If we can't open file a file, we assume that is

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -1474,10 +1474,6 @@ bdb_upgradedn_producer(void *param)
     PR_ASSERT(inst != NULL);
     PR_ASSERT(be != NULL);
 
-/* Disable fanalyzer false positive about job->upgradefd */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
-
     if (job->flags & FLAG_ABORT) {
         goto error;
     }
@@ -1721,6 +1717,11 @@ bdb_upgradedn_producer(void *param)
                            the temp work file */
             /* open "path" once, and set FILE* to upgradefd */
             if (NULL == job->upgradefd) {
+                /* Disable gcc -fanalyzer false positive about job->upgradefd */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
+#pragma GCC diagnostic ignored "-Wanalyzer-file-leak"
+
                 char *ldifdir = config_get_ldifdir();
                 if (ldifdir) {
                     path = slapi_ch_smprintf("%s/%s_dn_norm_sp.txt",
@@ -1757,6 +1758,7 @@ bdb_upgradedn_producer(void *param)
                         goto error;
                     }
                 }
+#pragma GCC diagnostic pop
             }
             slapi_ch_free_string(&path);
             if (is_dryrun) {
@@ -2199,7 +2201,6 @@ done:
     if (job->upgradefd) {
         fclose(job->upgradefd);
     }
-#pragma GCC diagnostic pop
 }
 
 static void

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -1474,6 +1474,10 @@ bdb_upgradedn_producer(void *param)
     PR_ASSERT(inst != NULL);
     PR_ASSERT(be != NULL);
 
+/* Disable fanalyzer false positive about job->upgradefd */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
+
     if (job->flags & FLAG_ABORT) {
         goto error;
     }
@@ -2195,6 +2199,7 @@ done:
     if (job->upgradefd) {
         fclose(job->upgradefd);
     }
+#pragma GCC diagnostic pop
 }
 
 static void

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -5713,14 +5713,14 @@ bdb_restore(struct ldbminfo *li, char *src_dir, Slapi_Task *task)
         slapi_log_err(SLAPI_LOG_ERR,
                       "bdb_restore", "%s is on, while the instance %s is in the DN format. "
                                          "Please run dn2rdn to convert the database format.\n",
-                      CONFIG_ENTRYRDN_SWITCH, inst->inst_name);
+                      CONFIG_ENTRYRDN_SWITCH, (inst != NULL) ? inst->inst_name : "<Null>");
         return_value = -1;
         goto error_out;
     } else if (action & DBVERSION_NEED_RDN2DN) {
         slapi_log_err(SLAPI_LOG_ERR,
                       "bdb_restore", "%s is off, while the instance %s is in the RDN format. "
                                          "Please change the value to on in dse.ldif.\n",
-                      CONFIG_ENTRYRDN_SWITCH, inst->inst_name);
+                      CONFIG_ENTRYRDN_SWITCH, (inst != NULL) ? inst->inst_name : "<Null>");
         return_value = -1;
         goto error_out;
     } else {

--- a/ldap/servers/slapd/bind.c
+++ b/ldap/servers/slapd/bind.c
@@ -248,7 +248,7 @@ do_bind(Slapi_PBlock *pb)
     /* You are "bound" when the SSL connection is made,
        but the client still passes a BIND SASL/EXTERNAL request.
      */
-    if ((LDAP_AUTH_SASL == method) &&
+    if ((LDAP_AUTH_SASL == method) && (saslmech != NULL) &&
         (0 == strcasecmp(saslmech, LDAP_SASL_EXTERNAL)) &&
         (0 == dn || 0 == dn[0]) && pb_conn->c_unix_local) {
         slapd_bind_local_user(pb_conn);

--- a/ldap/servers/slapd/ch_malloc.c
+++ b/ldap/servers/slapd/ch_malloc.c
@@ -370,3 +370,15 @@ slapi_ct_memcmp(const void *p1, const void *p2, size_t n)
     }
     return result;
 }
+
+/* Log out of memory error message and exit process */
+void
+slapi_ch_oom(const char *funcname)
+{
+        int oserr = errno;
+        oom_occurred();
+        slapi_log_err(SLAPI_LOG_ERR, SLAPD_MODULE,
+                      "Run out of memory while calling %s(); OS error %d (%s)%s\n",
+                      funcname, oserr, slapd_system_strerror(oserr), oom_advice);
+        exit(1);
+}

--- a/ldap/servers/slapd/ch_malloc.c
+++ b/ldap/servers/slapd/ch_malloc.c
@@ -244,6 +244,10 @@ struct berval **
 slapi_ch_bvecdup(struct berval **v)
 {
     struct berval **newberval = NULL;
+    /* Disable fanalyzer false positive */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
+
     if (v != NULL) {
         size_t i = 0;
         while (v[i] != NULL)
@@ -254,6 +258,7 @@ slapi_ch_bvecdup(struct berval **v)
             newberval[i] = slapi_ch_bvdup(v[i]);
         }
     }
+#pragma GCC diagnostic pop
     return newberval;
 }
 

--- a/ldap/servers/slapd/counters.c
+++ b/ldap/servers/slapd/counters.c
@@ -123,7 +123,7 @@ counters_as_entry(Slapi_Entry *e)
     fetch_counters();
     for (i = 0; i < num_counters; i++) {
         char value[40];
-        char *type = (char *)malloc(counter_size(&counters[i]) + 4);
+        char *type = (char *)slapi_ch_malloc(counter_size(&counters[i]) + 4);
         counter_dump(type, value, i);
         slapi_entry_attr_set_charptr(e, type, value);
         free(type);
@@ -141,7 +141,7 @@ counters_to_errors_log(const char *text)
     slapi_log_err(SLAPI_LOG_DEBUG, "counters_to_errors_log", "Counter Dump - %s\n", text);
     for (i = 0; i < num_counters; i++) {
         char value[40];
-        char *type = (char *)malloc(counter_size(&counters[i]) + 4);
+        char *type = (char *)slapi_ch_malloc(counter_size(&counters[i]) + 4);
         counter_dump(type, value, i);
         slapi_log_err(SLAPI_LOG_DEBUG, "counters_to_errors_log", "%s %s\n", type, value);
         free(type);

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -858,6 +858,10 @@ void csngen_multi_suppliers_test(void)
         if (gen[i]) {
             gen[i]->gettime = _csngen_tester_gettime;
             gen[i]->state.sampled_time = now.tv_sec;
+        } else {
+            slapi_log_err(SLAPI_LOG_ERR, "csngen_multi_suppliers_test",
+                          "Failed to initialize the CSNs\n");
+            return;
         }
     }
 

--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -3051,6 +3051,9 @@ slapi_sdn_common_ancestor(Slapi_DN *dn1, Slapi_DN *dn2)
     }
     dn1str = slapi_sdn_get_ndn(dn1);
     dn2str = slapi_sdn_get_ndn(dn2);
+    if ((NULL == dn1str) || (NULL == dn2str)) {
+        return NULL;
+    }
     if (0 == strcmp(dn1str, dn2str)) {
         /* identical */
         return slapi_sdn_dup(dn1);

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -9143,6 +9143,9 @@ config_set_value(
     int ival = 0;
     uintptr_t pval;
 
+    /* gcc -fanalyzer false postive with switch and type lenght */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
     switch (cgas->config_var_type) {
     case CONFIG_ON_OFF: /* convert 0,1 to "off","on" */
         slapi_entry_attr_set_charptr(e, cgas->attr_name,
@@ -9362,6 +9365,7 @@ config_set_value(
         PR_ASSERT(0); /* something went horribly wrong . . . */
         break;
     }
+#pragma GCC diagnostic pop
 
     return;
 }

--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -2534,6 +2534,10 @@ mtn_get_be(mapping_tree_node *target_node, Slapi_PBlock *pb, Slapi_Backend **be,
         /* shut down detected */
         return LDAP_OPERATIONS_ERROR;
     }
+    if (target_node == NULL) {
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+
     /* Get usefull stuff like the type of operation, target dn */
     slapi_pblock_get(pb, SLAPI_OPERATION, &op);
     op_type = operation_get_type(op);

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -863,13 +863,17 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
 
             case -1: /* an error occurred */
                 /* PAGED RESULTS */
-                /* Need to test ctrlp to avoid gcc -fanalyzer warning */
-                if (ctrlp && op_is_pagedresults(operation)) {
+                /* Explicit ctrlp test avoid gcc -fanalyzer warning */
+                if (op_is_pagedresults(operation)) {
+                    /* Disable gcc -fanalyzer false positive about pagedresults_mutex == NULL */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-null-argument"
                     /* cleanup the slot */
                     pthread_mutex_lock(pagedresults_mutex);
                     pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
                     rc = pagedresults_set_current_be(pb_conn, NULL, pr_idx, 1);
                     pthread_mutex_unlock(pagedresults_mutex);
+#pragma GCC diagnostic pop
                 }
                 if (1 == flag_no_such_object) {
                     break;

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -863,7 +863,8 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
 
             case -1: /* an error occurred */
                 /* PAGED RESULTS */
-                if (op_is_pagedresults(operation)) {
+                /* Need to test ctrlp to avoid gcc -fanalyzer warning */
+                if (ctrlp && op_is_pagedresults(operation)) {
                     /* cleanup the slot */
                     pthread_mutex_lock(pagedresults_mutex);
                     pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);

--- a/ldap/servers/slapd/protect_db.c
+++ b/ldap/servers/slapd/protect_db.c
@@ -99,6 +99,7 @@ grab_lockfile(void)
             size_t nb_bytes = 0;
 
             nb_bytes = read(fd, (void *)&owning_pid, sizeof(pid_t));
+            close(fd);
             if ((nb_bytes != (size_t)(sizeof(pid_t))) || (owning_pid == 0) || (kill(owning_pid, 0) != 0 && errno == ESRCH)) {
                 /* The process that owns the lock is dead. Try to remove the old lockfile. */
                 if (unlink(lockfile) != 0) {

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -1135,10 +1135,13 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
                     }
                     attr = attrlist_find(e->e_attrs, SLAPI_USERPWD_ATTR);
                     if (attr && !valueset_isempty(&attr->a_present_values)) {
-                        if (old_pw && (va = valueset_get_valuearray(&attr->a_present_values))) {
-                            *old_pw = slapi_ch_strdup(slapi_value_get_string(va[0]));
-                        } else {
-                            *old_pw = NULL;
+                        if (old_pw) {
+                            va = valueset_get_valuearray(&attr->a_present_values);
+                            if (va != NULL) {
+                                *old_pw = slapi_ch_strdup(slapi_value_get_string(va[0]));
+                            } else {
+                                *old_pw = NULL;
+                            }
                         }
                     }
                     slapi_entry_free(e);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5836,6 +5836,7 @@ char *slapi_ch_smprintf(const char *fmt, ...) __ATTRIBUTE__((format(printf, 1, 2
  * \return 0 on match. 1 on non-match. 2 on presence of NULL pointer in p1 or p2.
  */
 int slapi_ct_memcmp(const void *p1, const void *p2, size_t n);
+void slapi_ch_oom(const char *funcname) __ATTRIBUTE__((noreturn));
 
 /*
  * syntax plugin routines

--- a/ldap/servers/slapd/tools/dbscan.c
+++ b/ldap/servers/slapd/tools/dbscan.c
@@ -1127,7 +1127,6 @@ importdb(const char *dbimpl_name, const char *filename, const char *dump_name)
 
     if (!dump) {
         printf("Failed to open dump file %s. Error %d: %s\n", dump_name, errno, strerror(errno));
-        fclose(dump);
         return 1;
     }
 

--- a/ldap/servers/slapd/tools/ldclt/data.c
+++ b/ldap/servers/slapd/tools/ldclt/data.c
@@ -41,6 +41,7 @@
 #include <sys/mman.h>                           /* mmap(), etc... */
 #include "port.h" /* Portability definitions */ /*JLS 28-11-00*/
 #include "ldclt.h"                              /* This tool's include file */
+#include "utils.h"                              /* Utilities functions */
 
 
 /* ****************************************************************************
@@ -324,7 +325,7 @@ loadDataListFile(
    */
     for (dlf->strNb = 0; fgets(line, MAX_FILTER, ifile) != NULL; dlf->strNb++)
         ;
-    dlf->str = (char **)malloc(dlf->strNb * sizeof(char *));
+    dlf->str = (char **)safe_malloc(dlf->strNb * sizeof(char *));
     if (fseek(ifile, 0, SEEK_SET) != 0) {
         perror(dlf->fname);
         fprintf(stderr, "Error: cannot rewind file \"%s\"\n", dlf->fname);

--- a/ldap/servers/slapd/tools/ldclt/data.c
+++ b/ldap/servers/slapd/tools/ldclt/data.c
@@ -193,6 +193,7 @@ loadImages(
                 fprintf(stderr, "Cannot close(%s)\n", name);
                 fflush(stderr);
                 rc = -1;
+                fd = -1;
                 goto exit;
             } else {
                 fd = -1;

--- a/ldap/servers/slapd/tools/ldclt/ldclt.c
+++ b/ldap/servers/slapd/tools/ldclt/ldclt.c
@@ -117,27 +117,6 @@ ldcltExit(
 
 
 /* ****************************************************************************
-    FUNCTION :    safe_malloc
-    PURPOSE :    alloc data from the heap and returns NULL.
-    INPUT :        datalen    = lenght of the alloced buffer in bytes.
-    OUTPUT :        None
-    RETURN :    alloced buffer
-    DESCRIPTION :
- *****************************************************************************/
-void *
-safe_malloc(size_t datalen)
-{
-    void *pt = malloc(datalen);
-    if (pt == NULL) {
-        fprintf(stderr, "ldclt: %s\n", strerror(ENOMEM));
-        fprintf(stderr, "ldclt: Error: Unable to alloc %zd bytes.\n", datalen);
-        exit(3);
-    }
-    return pt;
-}
-
-
-/* ****************************************************************************
     FUNCTION :    copyVersAttribute
     PURPOSE :    Copy a versatile object's attribute
     INPUT :        srcattr    = source attribute
@@ -267,6 +246,7 @@ tttctxInit(
     tttctx->status = FREE;
     tttctx->thrdNum = num;
     tttctx->totalReq = mctx.totalReq;
+    tttctx->bufBindDN = NULL;
     sprintf(tttctx->thrdId, "T%03d", tttctx->thrdNum);
 
     if (mctx.mod2 & M2_OBJECT) {

--- a/ldap/servers/slapd/tools/ldclt/parser.c
+++ b/ldap/servers/slapd/tools/ldclt/parser.c
@@ -154,7 +154,7 @@ parseVariant(
      * We need a variable !
      */
         if (obj->var[field->var] == NULL)
-            obj->var[field->var] = (char *)malloc(MAX_FILTER);
+            obj->var[field->var] = (char *)safe_malloc(MAX_FILTER);
     }
 
     /*
@@ -331,11 +331,11 @@ parseAttribValue(
      * Allocate a new field
      */
         if (field == NULL) {
-            field = (vers_field *)malloc(sizeof(vers_field));
+            field = (vers_field *)safe_malloc(sizeof(vers_field));
             field->next = NULL;
             attrib->field = field;
         } else {
-            field->next = (vers_field *)malloc(sizeof(vers_field));
+            field->next = (vers_field *)safe_malloc(sizeof(vers_field));
             field = field->next;
             field->next = NULL;
         }
@@ -364,7 +364,7 @@ parseAttribValue(
        * We need to allocate a buffer in this attribute !
        */
             if (attrib->buf == NULL) {
-                attrib->buf = (char *)malloc(MAX_FILTER);
+                attrib->buf = (char *)safe_malloc(MAX_FILTER);
                 if (mctx.mode & VERY_VERBOSE)
                     printf("parseAttribValue: buffer allocated\n");
             }
@@ -375,7 +375,7 @@ parseAttribValue(
             for (start = end; (line[end] != '\0') && (line[end] != '['); end++)
                 ;
             field->how = HOW_CONSTANT;
-            field->cst = (char *)malloc(1 + end - start);
+            field->cst = (char *)safe_malloc(1 + end - start);
             strncpy(field->cst, line + start, end - start);
             field->cst[end - start] = '\0';
         }
@@ -437,7 +437,7 @@ parseLine(
    */
     obj->attribs[obj->attribsNb].buf = NULL;
     obj->attribs[obj->attribsNb].src = strdup(line);
-    obj->attribs[obj->attribsNb].name = (char *)malloc(1 + end);
+    obj->attribs[obj->attribsNb].name = (char *)safe_malloc(1 + end);
     strncpy(obj->attribs[obj->attribsNb].name, line, end);
     obj->attribs[obj->attribsNb].name[end] = '\0';
     for (end++; line[end] == ' '; end++)

--- a/ldap/servers/slapd/tools/ldclt/repcheck.c
+++ b/ldap/servers/slapd/tools/ldclt/repcheck.c
@@ -71,7 +71,7 @@ send_op(char *s, int sfd)
         if (pendops[i].op == tmp.op && pendops[i].conn == tmp.conn) {
             t = strstr(s, "err=");
             sz = strlen(pendops[i].dn);
-            result = (repconfirm *)malloc(sizeof(repconfirm) + sz);
+            result = (repconfirm *)safe_malloc(sizeof(repconfirm) + sz);
             for (t += 4, result->res = 0; isdigit(*t); t++)
                 result->res = result->res * 10 + *t - '0';
             result->type = htonl(ldap_val[pendops[i].type]);
@@ -126,7 +126,7 @@ main(int argc, char **argv)
     srvsaddr.sin_port = htons(port);
     freeaddrinfo(info);
     maxop = npend = 0;
-    pendops = (Optype *)malloc(sizeof(Optype) * 20);
+    pendops = (Optype *)safe_malloc(sizeof(Optype) * 20);
     sigset(SIGPIPE, SIG_IGN);
     while (fgets(logline, sizeof(logline), stdin)) {
         if ((p = strchr(logline, '\n'))) {

--- a/ldap/servers/slapd/tools/ldclt/repworker.c
+++ b/ldap/servers/slapd/tools/ldclt/repworker.c
@@ -159,7 +159,7 @@ send_op(char *s)
      */
         if (pendops[i].op == tmp.op && pendops[i].conn == tmp.conn) {
             sz = strlen(pendops[i].dn);
-            result = (repconfirm *)malloc(sizeof(repconfirm) + sz);
+            result = (repconfirm *)safe_malloc(sizeof(repconfirm) + sz);
             t = strstr(s, "err=");
             for (t += 4, result->res = 0; isdigit(*t); t++)
                 result->res = result->res * 10 + *t - '0';
@@ -287,7 +287,7 @@ main(int argc, char **argv)
             printf("Unknown host %s\n", hn);
             exit(1);
         }
-        srvlist = (Towho *)malloc(sizeof(Towho));
+        srvlist = (Towho *)safe_malloc(sizeof(Towho));
         srvlist[nsrv].addr.sin_addr.s_addr = htonl(*((u_long *)(info->ai_addr)));
         srvlist[nsrv].addr.sin_family = AF_INET;
         srvlist[nsrv].addr.sin_port = htons(port);
@@ -298,7 +298,7 @@ main(int argc, char **argv)
         freeaddrinfo(info);
     }
     maxop = npend = 0;
-    pendops = (Optype *)malloc(sizeof(Optype) * 20);
+    pendops = (Optype *)safe_malloc(sizeof(Optype) * 20);
     /*
   * Ignore SIGPIPE during write()
   */

--- a/ldap/servers/slapd/tools/ldclt/scalab01.c
+++ b/ldap/servers/slapd/tools/ldclt/scalab01.c
@@ -380,6 +380,7 @@ scalab01_addLogin(
         if (s1ctx.list->counter >= duration) {
             new->next = s1ctx.list;
             s1ctx.list = new;
+            new = NULL;
         } else {
             cur = s1ctx.list;
 
@@ -391,10 +392,12 @@ scalab01_addLogin(
             while (cur != NULL) {
                 if (cur->next == NULL) {
                     cur->next = new;
+                    new = NULL;
                     cur = NULL; /* Exit loop */
                 } else if (cur->next->counter >= duration) {
                     new->next = cur->next;
                     cur->next = new;
+                    new = NULL;
                     cur = NULL; /* Exit loop */
                 } else {
                     cur = cur->next;
@@ -403,13 +406,10 @@ scalab01_addLogin(
         }
     }
 
-    goto done;
-
 error:
     if (new)
         free(new);
 
-done:
     /*
    * Free mutex
    */

--- a/ldap/servers/slapd/tools/ldclt/scalab01.c
+++ b/ldap/servers/slapd/tools/ldclt/scalab01.c
@@ -336,7 +336,7 @@ scalab01_addLogin(
 {
     int ret;       /* Return value */
     isp_user *new; /* New entry */
-    isp_user *cur; /* Current entry */
+    isp_user **ptcur; /* Current entry address */
     int rc = 0;
 
     /*
@@ -368,43 +368,19 @@ scalab01_addLogin(
         goto error;
     }
 
-    /*
-   * Maybe this is the first entry of the list ?
-   */
-    if (s1ctx.list == NULL)
-        s1ctx.list = new;
-    else {
-        /*
-     * Check with the list's head
+    /* 
+     * Find insertion point
      */
-        if (s1ctx.list->counter >= duration) {
-            new->next = s1ctx.list;
-            s1ctx.list = new;
-            new = NULL;
-        } else {
-            cur = s1ctx.list;
-
-            /* If cur is NULL, we should just bail and free new. */
-            if (cur == NULL) {
-                goto error;
-            }
-
-            while (cur != NULL) {
-                if (cur->next == NULL) {
-                    cur->next = new;
-                    new = NULL;
-                    cur = NULL; /* Exit loop */
-                } else if (cur->next->counter >= duration) {
-                    new->next = cur->next;
-                    cur->next = new;
-                    new = NULL;
-                    cur = NULL; /* Exit loop */
-                } else {
-                    cur = cur->next;
-                }
-            }
-        }
+    ptcur = &s1ctx.list;
+    while ((*ptcur != NULL) && ((*ptcur)->counter < duration)) {
+        ptcur = &(*ptcur)->next;
     }
+    /*
+     * Insert new element
+     */
+    new->next = *ptcur;
+    *ptcur = new;
+    new = NULL;
 
 error:
     if (new)

--- a/ldap/servers/slapd/tools/ldclt/threadMain.c
+++ b/ldap/servers/slapd/tools/ldclt/threadMain.c
@@ -817,7 +817,7 @@ threadMain(
     if ((mctx.mode & NEED_FILTER) || (mctx.mod2 & (M2_GENLDIF | M2_NEED_FILTER))) /*JLS 19-03-01*/
     {
         if (mctx.mod2 & M2_RDN_VALUE)                       /*JLS 23-03-01*/
-            tttctx->bufFilter = (char *)malloc(MAX_FILTER); /*JLS 23-03-01*/
+            tttctx->bufFilter = (char *)safe_malloc(MAX_FILTER); /*JLS 23-03-01*/
         else                                                /*JLS 23-03-01*/
         {                                                   /*JLS 23-03-01*/
             /*
@@ -921,6 +921,9 @@ threadMain(
    */
     if (mctx.mod2 & M2_RNDBINDFILE)                        /*JLS 03-05-01*/
     {                                                      /*JLS 03-05-01*/
+        if (tttctx->bufBindDN != NULL) {
+            free(tttctx->bufBindDN);
+        }
         tttctx->bufBindDN = (char *)malloc(MAX_DN_LENGTH); /*JLS 03-05-01*/
         tttctx->bufPasswd = (char *)malloc(MAX_DN_LENGTH); /*JLS 03-05-01*/
         mctx.passwd = "foo bar"; /* trick... */            /*JLS 03-05-01*/

--- a/ldap/servers/slapd/tools/ldclt/utils.c
+++ b/ldap/servers/slapd/tools/ldclt/utils.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>                             /* lrand48(), etc... */
 #include <ctype.h>    /* isascii(), etc... */   /*JLS 16-11-00*/
 #include <string.h>    /* strerror(), etc... */ /*JLS 14-11-00*/
+#include <errno.h>    /* ENOMEM */
 
 
 /*
@@ -201,4 +202,24 @@ incr_and_wrap(int val, int min, int max, int incr)
 {
     int range = max - min + 1;
     return (((val + incr) - min) % range) + min;
+}
+
+/* ****************************************************************************
+    FUNCTION :    safe_malloc
+    PURPOSE :    a malloc that never returns NULL
+    INPUT :        datalen    = lenght of the alloced buffer in bytes.
+    OUTPUT :        None
+    RETURN :    alloced buffer
+    DESCRIPTION :
+ *****************************************************************************/
+void *
+safe_malloc(size_t datalen)
+{
+    void *pt = malloc(datalen);
+    if (pt == NULL) {
+        fprintf(stderr, "ldclt: %s\n", strerror(ENOMEM));
+        fprintf(stderr, "ldclt: Error: Unable to alloc %zd bytes.\n", datalen);
+        exit(3);
+    }
+    return pt;
 }

--- a/ldap/servers/slapd/tools/ldclt/utils.h
+++ b/ldap/servers/slapd/tools/ldclt/utils.h
@@ -12,6 +12,7 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <sys/types.h>
 
 
 /*
@@ -46,6 +47,7 @@ extern int rndlim(int low, int high);
 extern void rndstr(char *buf, int ndigits);
 extern int utilsInit(void);
 extern int incr_and_wrap(int val, int min, int max, int incr);
+void *safe_malloc(size_t datalen);
 
 
 /* End of file */

--- a/ldap/servers/snmp/ldap-agent.c
+++ b/ldap/servers/snmp/ldap-agent.c
@@ -57,6 +57,8 @@ init_ldap_agent(void)
         /* Check if this row already exists. */
         if (stats_table_find_row(serv_p->port) == NULL) {
             /* Create a new row */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
             if ((new_row = stats_table_create_row(serv_p->port)) != NULL) {
                 /* Set pointer for entity table */
                 new_row->entity_tbl = serv_p;
@@ -67,6 +69,8 @@ init_ldap_agent(void)
                 /* Insert new row into the table */
                 snmp_log(LOG_DEBUG, "Inserting row for server: %d\n", serv_p->port);
                 CONTAINER_INSERT(ops_cb.container, new_row);
+                new_row = NULL;
+#pragma GCC diagnostic pop
             } else {
                 /* error during malloc of row */
                 snmp_log(LOG_ERR, "Error creating row for server: %d\n",

--- a/lib/ldaputil/encode.c
+++ b/lib/ldaputil/encode.c
@@ -71,9 +71,12 @@ Snip-n-shift, snip-n-shift, etc....
 
     /* Always do 4-for-3, but if not round threesome, have to go
           clean up the last extra bytes */
-
+    
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
     for (; i != srclen; i--)
         *--p = '=';
+#pragma GCC diagnostic pop
 
     return r;
 }
@@ -107,6 +110,9 @@ _uudecode(const char *bufcoded)
     nbytesdecoded = ((nprbytes + 3) / 4) * 3;
 
     bufout = (unsigned char *)malloc(nbytesdecoded + 1);
+    if (bufout == NULL) {
+        return NULL;
+    }            
     bufplain = bufout;
 
     bufin = bufcoded;

--- a/lib/ldaputil/ldapauth.c
+++ b/lib/ldaputil/ldapauth.c
@@ -161,10 +161,10 @@ ldapu_find_entire_tree(LDAP *ld, int scope, const char *filter, const char **att
             retval = LDAPU_FAILED;
             return retval;
         }
-        for (i = num_namingcontexts; i < (num_namingcontexts + num_private_suffix); ++i) {
-            suffix_list[i] = strdup(private_suffix_list[i - num_namingcontexts]);
+        for (i = 0; i < num_private_suffix; ++i) {
+            suffix_list[num_namingcontexts + i] = strdup(private_suffix_list[i]);
         }
-        suffix_list[i] = NULL;
+        suffix_list[num_namingcontexts + i] = NULL;
         num_namingcontexts += num_private_suffix;
         suffix = suffix_list;
     }

--- a/lib/libsi18n/txtfile.c
+++ b/lib/libsi18n/txtfile.c
@@ -47,6 +47,7 @@ OpenTextFile(char *filename, int access)
 
     txtfile = (TEXTFILE *)malloc(sizeof(TEXTFILE));
     if (txtfile == NULL) {
+        (void) fclose(file);
         return NULL;
     }
     memset(txtfile, 0, sizeof(TEXTFILE));

--- a/lib/libsi18n/txtfile.c
+++ b/lib/libsi18n/txtfile.c
@@ -46,6 +46,9 @@ OpenTextFile(char *filename, int access)
         return NULL;
 
     txtfile = (TEXTFILE *)malloc(sizeof(TEXTFILE));
+    if (txtfile == NULL) {
+        return NULL;
+    }
     memset(txtfile, 0, sizeof(TEXTFILE));
 
     txtfile->file = file;


### PR DESCRIPTION
This change remove all gcc -fanalyzer warnings.
Number of them are not that interesting (False/positive due to some limts of the analyzer and some possible crashes when running out of memory.
But some of these warnings where real concerns.

Issue #6248 

Reviewed by: @droideck (Thanks!)