### PR TITLE
Issue 6254 - Enabling replication for a sub suffix crashes browser

### DIFF
--- a/src/cockpit/389-console/src/lib/replication/replConfig.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replConfig.jsx
@@ -40,8 +40,8 @@ export class ReplConfig extends React.Component {
             saveBtnDisabled: true,
             isExpanded: false,
             // Config Settings
-            nsds5replicabinddn: this.props.data.nsds5replicabinddn,
-            nsds5replicabinddngroup: this.props.data.nsds5replicabinddngroup,
+            nsds5replicabinddn: this.props.data?.nsds5replicabinddn || [],
+            nsds5replicabinddngroup: this.props.data?.nsds5replicabinddngroup || "",
             nsds5replicabinddngroupcheckinterval: Number(this.props.data.nsds5replicabinddngroupcheckinterval) === 0 ? -1 : Number(this.props.data.nsds5replicabinddngroupcheckinterval),
             nsds5replicareleasetimeout: Number(this.props.data.nsds5replicareleasetimeout),
             nsds5replicapurgedelay: Number(this.props.data.nsds5replicapurgedelay) === 0 ? 604800 : Number(this.props.data.nsds5replicapurgedelay),
@@ -52,8 +52,8 @@ export class ReplConfig extends React.Component {
             nsds5replicabackoffmax: Number(this.props.data.nsds5replicabackoffmax) === 0 ? 300 : Number(this.props.data.nsds5replicabackoffmax),
             nsds5replicakeepaliveupdateinterval: Number(this.props.data.nsds5replicakeepaliveupdateinterval) === 0 ? 3600 : Number(this.props.data.nsds5replicakeepaliveupdateinterval),
             // Original settings
-            _nsds5replicabinddn: this.props.data.nsds5replicabinddn,
-            _nsds5replicabinddngroup: this.props.data.nsds5replicabinddngroup,
+            _nsds5replicabinddn: this.props.data?.nsds5replicabinddn || [],
+            _nsds5replicabinddngroup: this.props.data?.nsds5replicabinddngroup || "",
             _nsds5replicabinddngroupcheckinterval: Number(this.props.data.nsds5replicabinddngroupcheckinterval) === 0 ? -1 : Number(this.props.data.nsds5replicabinddngroupcheckinterval),
             _nsds5replicareleasetimeout: this.props.data.nsds5replicareleasetimeout,
             _nsds5replicapurgedelay: Number(this.props.data.nsds5replicapurgedelay) === 0 ? 604800 : Number(this.props.data.nsds5replicapurgedelay),

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -162,8 +162,11 @@ export class Replication extends React.Component {
             }
             if (treeBranch[sub].children.length === 0) {
                 delete treeBranch[sub].children;
+            } else {
+                this.processBranch(treeBranch[sub].children);
             }
-            this.processBranch(treeBranch[sub].children);
+            // Load replication data for this suffix
+            this.loadReplSuffix(treeBranch[sub].id);
         }
     }
 
@@ -528,7 +531,7 @@ export class Replication extends React.Component {
                             nsds5flags: config.attrs.nsds5flags[0],
                             nsds5replicatype: config.attrs.nsds5replicatype[0],
                             nsds5replicaid: 'nsds5replicaid' in config.attrs ? config.attrs.nsds5replicaid[0] : "",
-                            nsds5replicabinddn: 'nsds5replicabinddn' in config.attrs ? config.attrs.nsds5replicabinddn : "",
+                            nsds5replicabinddn: 'nsds5replicabinddn' in config.attrs ? config.attrs.nsds5replicabinddn : [],
                             nsds5replicabinddngroup: 'nsds5replicabinddngroup' in config.attrs ? config.attrs.nsds5replicabinddngroup[0] : "",
                             nsds5replicabinddngroupcheckinterval: 'nsds5replicabinddngroupcheckinterval' in config.attrs ? config.attrs.nsds5replicabinddngroupcheckinterval[0] : "",
                             nsds5replicareleasetimeout: 'nsds5replicareleasetimeout' in config.attrs ? config.attrs.nsds5replicareleasetimeout[0] : "",
@@ -671,7 +674,7 @@ export class Replication extends React.Component {
                             nsds5flags: config.attrs.nsds5flags[0],
                             nsds5replicatype: config.attrs.nsds5replicatype[0],
                             nsds5replicaid: 'nsds5replicaid' in config.attrs ? config.attrs.nsds5replicaid[0] : "",
-                            nsds5replicabinddn: 'nsds5replicabinddn' in config.attrs ? config.attrs.nsds5replicabinddn : "",
+                            nsds5replicabinddn: 'nsds5replicabinddn' in config.attrs ? config.attrs.nsds5replicabinddn : [],
                             nsds5replicabinddngroup: 'nsds5replicabinddngroup' in config.attrs ? config.attrs.nsds5replicabinddngroup[0] : "",
                             nsds5replicabinddngroupcheckinterval: 'nsds5replicabinddngroupcheckinterval' in config.attrs ? config.attrs.nsds5replicabinddngroupcheckinterval[0] : "",
                             nsds5replicareleasetimeout: 'nsds5replicareleasetimeout' in config.attrs ? config.attrs.nsds5replicareleasetimeout[0] : "",


### PR DESCRIPTION
Bug Description: Web Console: Enabling replication for a sub-suffix causes
TypeError: this.props.data.nsds5replicabinddn is not iterable.

Fix Description: Make sure that loadSuffixTree is run for subsuffixes, too. Set defaults if data is absent.

Fixes: https://github.com/389ds/389-ds-base/issues/6254

Reviewed by: ?