### PR TITLE
Issue 4778 - Add COMPACT_CL5 task to dsconf replication

### DIFF
--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -1199,6 +1199,11 @@ def restore_cl_dir(inst, basedn, log, args):
     replicas.restore_changelog(replica_roots=args.REPLICA_ROOTS, log=log)
 
 
+def compact_cl5(inst, basedn, log, args):
+    replicas = Replicas(inst)
+    replicas.compact_changelog(replica_roots=args.REPLICA_ROOTS, log=log)
+
+
 def create_parser(subparsers):
 
     ############################################
@@ -1325,6 +1330,11 @@ def create_parser(subparsers):
     restore_ldif.add_argument('-r', '--replica-root', nargs=1, required=True,
                               help="Specify one replica root whose changelog you want to restore. "
                                    "The replica root will be consumed from the LDIF file name if the option is omitted.")
+
+    compact_cl = repl_subcommands.add_parser('compact-changelog', help='Compact the changelog database')
+    compact_cl.set_defaults(func=compact_cl5)
+    compact_cl.add_argument('REPLICA_ROOTS', nargs="+",
+                            help="Specify replica roots whose changelog you want to compact.")
 
     restore_changelogdir = restore_subcommands.add_parser('from-changelogdir', help='Restore LDIF files from changelogdir.')
     restore_changelogdir.set_defaults(func=restore_cl_dir)


### PR DESCRIPTION
Description: In 1.4.3, the changelog is not part of a backend. It can be compacted with nsTask: CAMPACT_CL5 as part of the replication entry.
Add the task as a compact-changelog command under the dsconf replication tool. Add tests for the feature and fix old tests.

Related: https://github.com/389ds/389-ds-base/issues/4778

Reviewed by: ?