### PR TITLE
Issue 6258 - Add sleep for ramdom failure in two tests

### DIFF
--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -237,6 +237,7 @@ def paged_search(conn, suffix, controls, search_flt, searchreq_attrlist, abandon
     msgid = conn.search_ext(suffix, ldap.SCOPE_SUBTREE, search_flt, searchreq_attrlist, serverctrls=controls)
     log.info('Getting page %d' % (pages,))
     while True:
+        time.sleep(0.001)
         try:
             rtype, rdata, rmsgid, rctrls = conn.result3(msgid, timeout=0.001)
         except ldap.TIMEOUT:


### PR DESCRIPTION
Bug Description: The following test fails frequently. In the first one, the access log is checked before it's written. In the second one, multiple threads with the same file descriptor for access log file writes the logs with out of order.

dirsrvtests/tests/suites/healthcheck/health_config_test.py::test_healthcheck_notes_unindexed_search dirsrvtests/tests/suites/paged_results/paged_results_test.py::test_multi_suffix_search

Fix Description: Adding sleep mitigates the failure.

Fixes: https://github.com/389ds/389-ds-base/issues/6258

(cherry-picked from the commit 1bd2e6e2a95e3f373fbdb7f5f79764687cae46e9)