### PR TITLE
Issue 6238 - Fix test_audit_json_logging CI test regression

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -133,7 +133,7 @@ def pytest_runtest_makereport(item, call):
                         instance_name = os.path.basename(os.path.dirname(f)).split("slapd-",1)[1]
                         extra.append(pytest_html.extras.text(text, name=f"{instance_name}-{log_name}"))
                 elif 'rotationinfo' not in f:
-                    with open(f) as dirsrv_log:
+                    with open(f, errors='ignore') as dirsrv_log:
                         text = dirsrv_log.read()
                         log_name = os.path.basename(f)
                         instance_name = os.path.basename(os.path.dirname(f)).split("slapd-",1)[1]


### PR DESCRIPTION
CI test test_audit_json_logging report generation fails because some log file contains non UTF-8 characters.
The fix is to ignore invalid characters when generating the report.
(So that the logs get properly copied in the assets)

Issue #6238

Reviewed by: @mreynolds389 (Thanks!)
