### PR TITLE
Issue 6265 - lmdb - missing entries in range searches

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -276,10 +276,9 @@ def preserve_topo_m2(topo_m2, request):
     if not DEBUGGING:
         request.addfinalizer(fin)
 
-    bindcn = "replication managerg"
+    bindcn = "replication manager"
     binddn = f"cn={bindcn},cn=config"
     bindpw = ''.join(random.choices(string.ascii_letters + string.digits, k=15))
-    bindpw = "secret12"
     for inst in topo_m2:
         backup_dir = f'{inst.ds_paths.backup_dir}/topo_bak'
         try:

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -15,6 +15,10 @@ import ldap
 import pytest
 import subprocess
 import time
+import random
+import string
+from shutil import rmtree
+from lib389.dbgen import dbgen_users
 from lib389.idm.user import TEST_USER_PROPERTIES, UserAccount, UserAccounts
 from lib389.pwpolicy import PwPolicyManager
 from lib389.utils import *
@@ -25,7 +29,7 @@ from lib389.idm.group import Groups, Group
 from lib389.idm.domain import Domain
 from lib389.idm.directorymanager import DirectoryManager
 from lib389.idm.services import ServiceAccounts, ServiceAccount
-from lib389.replica import Replicas, ReplicationManager, ReplicaRole
+from lib389.replica import Replicas, ReplicationManager, ReplicaRole, BootstrapReplicationManager
 from lib389.agreement import Agreements
 from lib389 import pid_from_file
 from lib389.dseldif import *
@@ -256,6 +260,47 @@ def topo_with_sigkill(request):
     request.addfinalizer(fin)
 
     return topology
+
+
+@pytest.fixture(scope="function")
+def preserve_topo_m2(topo_m2, request):
+    """Backup the topology and restore it at the end."""
+
+    saves = []
+
+    def fin():
+        for inst,backup_dir in saves:
+            inst.tasks.bak2db(backup_dir=backup_dir, args={TASK_WAIT: True})
+            rmtree(backup_dir)
+
+    if not DEBUGGING:
+        request.addfinalizer(fin)
+
+    bindcn = "replication managerg"
+    binddn = f"cn={bindcn},cn=config"
+    bindpw = ''.join(random.choices(string.ascii_letters + string.digits, k=15))
+    bindpw = "secret12"
+    for inst in topo_m2:
+        backup_dir = f'{inst.ds_paths.backup_dir}/topo_bak'
+        try:
+            rmtree(backup_dir)
+        except FileNotFoundError:
+            pass
+        inst.tasks.db2bak(backup_dir=backup_dir, args={TASK_WAIT: True})
+        # Ensure that we are not using group bind dn
+        # because the test may delete credentials
+        replmgr = BootstrapReplicationManager(inst, dn=binddn)
+        if replmgr.exists():
+            replmgr.replace('userPassword', bindpw)
+        else:
+            replmgr.create(properties={'cn':bindcn, 'userPassword':bindpw})
+        replica = Replicas(inst).get(DEFAULT_SUFFIX)
+        replica.replace(REPL_BINDDN, binddn);
+        replica.remove_all(REPL_BIND_GROUP);
+        for agmt in replica.get_agreements().list():
+            agmt.replace_many((AGMT_CRED, bindpw), (REPL_BINDDN, binddn))
+        saves.append((inst, backup_dir))
+    return topo_m2
 
 
 @pytest.fixture()
@@ -1019,6 +1064,85 @@ def test_repl_after_reindex(topo_m2):
     # Check that replication is still working
     repl.wait_for_replication(m1, m2)
     repl.wait_for_replication(m2, m1)
+
+
+def test_suffix_entryid(preserve_topo_m2):
+    """Test that entryid attribute is present in suffix entry
+
+    :id: 9201f2c8-3eb8-11ef-80cc-482ae39447e5
+    :setup: Two suppliers replicated instances
+    :steps:
+        1. Generate LDIF file
+        2. Import the ldif file
+        3. Check that identry is still present in suffix entry
+        4. Check that parentid>=1 search returns all entries but one
+    :expectedresults:
+        1. Operation successful
+        2. Operation successful
+        3. Suffix id2entry should be 1
+        4. parentid>=1 search returns all entries but one
+    """
+    s1 = preserve_topo_m2.ms["supplier1"]
+    ldif_file = f'{s1.get_ldif_dir()}/db10.ldif'
+    dbgen_users(s1, 10, ldif_file, DEFAULT_SUFFIX)
+    s1.tasks.importLDIF(benamebase=DEFAULT_BENAME,
+                        input_file=ldif_file,
+                        args={TASK_WAIT: True})
+    dc = Domain(s1, dn=DEFAULT_SUFFIX)
+    assert dc.get_attr_val_utf8('entryid') == '1'
+    all_entries =  s1.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(objectclass=*)", attrlist=('dn',), escapehatch='i am sure')
+    childrens =  s1.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(parentid>=1)", attrlist=('dn',), escapehatch='i am sure')
+    assert len(all_entries) == (len(childrens) + 1)
+
+
+def test_bulk_import(preserve_topo_m2):
+    """Test that bulk import is working properly
+
+    :id: 4e73254a-3ed6-11ef-aa44-482ae39447e5
+    :setup: Two suppliers replicated instances
+    :steps:
+        1. Generate LDIF file
+        2. Import the ldif file
+        3. Add replication_managers group
+        4. Perform bulk import
+        5. Check that replication is still working
+        6. Check that the replicas have the same number of users
+    :expectedresults:
+        1. Operation successful
+        2. Operation successful
+        3. Operation successful
+        4. Operation successful
+        5. Replication should be in sync
+        6. Replicas should have same number of user entries
+    """
+    s1 = preserve_topo_m2.ms["supplier1"]
+    s2 = preserve_topo_m2.ms["supplier2"]
+    ldif_file = f'{s1.get_ldif_dir()}/db2K.ldif'
+    dbgen_users(s1, 2000, ldif_file, DEFAULT_SUFFIX)
+    s1.tasks.importLDIF(benamebase=DEFAULT_BENAME,
+                        input_file=ldif_file,
+                        args={TASK_WAIT: True})
+
+    # Create replication_managers group so that we can use
+    #  repl.test_replication_topology
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl._create_service_group(s1)
+    repl._create_service_account(s1, s2)
+
+    agmt = Agreements(s1).list()[0]
+    agmt.begin_reinit()
+    (done, error) = agmt.wait_reinit()
+    assert done is True
+    assert error is False
+
+    repl.test_replication_topology(preserve_topo_m2)
+
+    # Cannot use UserAccounts().list() because 'account' objectclass is missing
+    users_s1 =  s1.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(uid=*)", escapehatch='i am sure')
+    log.info(f"{len(users_s1)} user entries found on supplier1")
+    users_s2 =  s2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(uid=*)", escapehatch='i am sure')
+    log.info(f"{len(users_s2)} user entries found on supplier2")
+    assert len(users_s1) == len(users_s2)
 
 
 def test_online_reinit_may_hang(topo_with_sigkill):

--- a/ldap/servers/plugins/replication/repl5_agmt.c
+++ b/ldap/servers/plugins/replication/repl5_agmt.c
@@ -381,7 +381,6 @@ agmt_new_from_entry(Slapi_Entry *e)
                       slapi_entry_get_dn(e), tmpstr ? tmpstr : "<NULL>");
         goto loser;
     }
-    use_lmdb = dblayer_is_lmdb(be);
     if (!replica) {
         slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name,
                       "agmt_new_from_entry - Failed to get replica for agreement %s on replicated suffix %s).\n",
@@ -390,6 +389,7 @@ agmt_new_from_entry(Slapi_Entry *e)
     }
 
     /* flow control update window. */
+    use_lmdb = dblayer_is_lmdb(be);
     ra->flowControlWindow = use_lmdb ? LMDB_DEFAULT_FLOWCONTROL_WINDOW : DEFAULT_FLOWCONTROL_WINDOW;
     if ((val = slapi_entry_attr_get_ref(e, type_nsds5ReplicaFlowControlWindow))){
         int64_t flow;

--- a/ldap/servers/plugins/replication/repl5_connection.c
+++ b/ldap/servers/plugins/replication/repl5_connection.c
@@ -636,7 +636,7 @@ check_flow_control_tot_init(Repl_Connection *conn, int optype, const char *extop
                      * Log it at least once to inform administrator there is
                      * a potential configuration issue here
                      */
-                    slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name,
+                    slapi_log_err(SLAPI_LOG_WARNING, repl_plugin_name,
                                   "check_flow_control_tot_init - %s -  Total update flow control gives time (%d msec) to the consumer before sending more entries [ msgid sent: %d, rcv: %d])\n"
                                   "If total update fails you can try to increase %s and/or decrease %s in the replica agreement configuration\n",
                                   agmt_get_long_name(conn->agmt),

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -3061,6 +3061,9 @@ process_entryrdn(backentry *ep, WorkerQueueData_t *wqelmnt)
         prepare_ids(&wqd, pid, &id);
         dbmdb_import_writeq_push(ctx, &wqd);
         dbmdb_add_op_attrs(job, ep, pid);  /* Before loosing the pid */
+    } else {
+        /* Update entryid */
+        add_update_entry_operational_attributes(ep, 0);
     }
 
     if (ctx->ancestorid && wqelmnt->entry_info) {

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -231,6 +231,7 @@ int idl_get_tune(void);
 size_t idl_get_allidslimit(struct attrinfo *a, int allidslimit);
 int idl_get_idl_new(void);
 IDList *idl_new_range_fetch(backend *be, dbi_db_t *db, dbi_val_t *lowerkey, dbi_val_t *upperkey, dbi_txn_t *txn, struct attrinfo *a, int *flag_err, int allidslimit, int sizelimit, struct timespec *expire_time, int lookthrough_limit, int operator);
+IDList *idl_lmdb_range_fetch(backend *be, dbi_db_t *db, dbi_val_t *lowerkey, dbi_val_t *upperkey, dbi_txn_t *txn, struct attrinfo *a, int *flag_err, int allidslimit, int sizelimit, struct timespec *expire_time, int lookthrough_limit, int operator);
 char *get_index_name(backend *be, dbi_db_t *db, struct attrinfo *a);
 
 int64_t idl_compare(IDList *a, IDList *b);


### PR DESCRIPTION
Several issue seen after generating ldif with 2000 users and importing it in a replica:

1. The entryid attribute in missing in the suffix entry.
2. Access log shows that the internal search looking for "(parentid>=1)" is not returning all entries but one.
3. When initializing a replica through a replication agreement some entries are missing (because of 2)
4. Once 2. get fixed, the bulk import still fails because the default values for nsds5ReplicaFlowControlWindow and nsds5ReplicaFlowControlPause are not adapted to lmdb (supplier sent the entry faster than bdb and the target replica import them slower.

The fix is about 
1. Ensuring that the operational attribute are properly set when importing the suffix entry.
2. Avoid using database bulk operation when computing range unless we are sure that bdb is used. 
3. Fixed by 2
4. Change the default values for nsds5ReplicaFlowControlWindow and nsds5ReplicaFlowControlPause if agreement is on a lmdb backend.

Issue: #6265 

Reviewed by: @vashirov, @droideck  (Thanks!)


