### PR TITLE
Issue 5327 - Fix test metadata

### DIFF
--- a/dirsrvtests/tests/suites/filter/large_filter_test.py
+++ b/dirsrvtests/tests/suites/filter/large_filter_test.py
@@ -176,7 +176,7 @@ def test_long_filter_value(topo):
         :setup: Standalone
         :steps:
             1. Create a specially crafted LDAP filter and
-               pass the filter to a search query with the special repeating string "a\x1Edmin"
+               pass the filter to a search query with the special repeating string "a\\x1Edmin"
             2. Pass the filter to a search query with repeating string "aAdmin"
             3. Pass the filter to a search query with string "*"
         :expectedresults:


### PR DESCRIPTION
Description:
Metadata validation job fails on unescaped sequence used in the docstring.

Fix Description:
Escape unicode value in the docstring.

Relates: https://github.com/389ds/389-ds-base/issues/5327

Reviewed by: ???