### PR TITLE
Avoid to use f-strings in 1.3.11

### DIFF
--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -55,7 +55,7 @@ def _check_unhashed_userpw(inst, user_dn, is_present=False):
         dbscanOut = inst.dbscan(DEFAULT_BENAME, 'replication_changelog')
     else:
         changelog_dbdir = os.path.join(os.path.dirname(inst.dbdir), DEFAULT_CHANGELOG_DB)
-        for changelog_dbfile in glob.glob(f'{changelog_dbdir}*/*.db*'):
+        for changelog_dbfile in glob.glob('{}*/*.db*'.format(changelog_dbdir)):
             log.info('Changelog dbfile file exist: {}'.format(changelog_dbfile))
             dbscanOut = inst.dbscan(DEFAULT_CHANGELOG_DB, changelog_dbfile)
 


### PR DESCRIPTION
1.3.11 is used by RHEL7 with python2.7, which doesn't suppport f-strings. f-strings is not used at any other place in 1.3.11. This caused a build problem for RHEL7.

Relates: d9c98691c2e7ff6c495a00dded988e688202d789