### PR TITLE
Issue 6288 - dsidm crash with account policy plugin when alt-state-attr is disabled

### DIFF
--- a/src/lib389/lib389/idm/account.py
+++ b/src/lib389/lib389/idm/account.py
@@ -140,7 +140,8 @@ class Account(DSLdapObject):
                                                  "nsAccountLock", state_attr])
 
         last_login_time = self._dict_get_with_ignore_indexerror(account_data, state_attr)
-        if not last_login_time:
+        # if last_login_time not exist then check alt_state_attr only if its not disabled and exist 
+        if not last_login_time and alt_state_attr in account_data:
             last_login_time = self._dict_get_with_ignore_indexerror(account_data, alt_state_attr)
 
         create_time = self._dict_get_with_ignore_indexerror(account_data, "createTimestamp")


### PR DESCRIPTION
Issue 6288 - dsidm crash with account policy plugin when alt-state-attr is disabled

Bug Description:
If disable alt-state-attr for account policy plugin by using value 1.1 then dsidm command will crash if state-attr doesn't exit at that time.

Fix Description:
Check if alt-state-attri key exist under account data dict before getting its value.

relates: https://github.com/389ds/389-ds-base/issues/6288

Author: Navid Yaghoobi

Reviewed by: @progier389 