### PR TITLE
Issue 6295 - test_password_modify_non_utf8 should set default passwor…

### DIFF
--- a/dirsrvtests/tests/suites/password/password_test.py
+++ b/dirsrvtests/tests/suites/password/password_test.py
@@ -62,8 +62,21 @@ def test_password_delete_specific_password(topology_st):
 
     log.info('test_password_delete_specific_password: PASSED')
 
+@pytest.fixture(scope="function")
+def pbkdf2_sha512_scheme(request, topology_st):
+    """Set default password storage scheme to PBKDF2-SHA512"""
 
-def test_password_modify_non_utf8(topology_st):
+    inst = topology_st.standalone
+    default_scheme = inst.config.get_attr_val_utf8('passwordStorageScheme')
+    inst.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+
+    def fin():
+        inst.config.set('passwordStorageScheme', default_scheme)
+
+    request.addfinalizer(fin)
+
+
+def test_password_modify_non_utf8(topology_st, pbkdf2_sha512_scheme):
     """Attempt a modify of the userPassword attribute with
     an invalid non utf8 value
 


### PR DESCRIPTION
…d storage scheme

Bug Description:
Test dirsrvtests/tests/suites/password/password_test.py::test_password_modify_non_utf8 assumes the default password storage scheme is PBKDF2-SHA512, but it's not true on old versions.

Fix Description:
The test should set PBKDF2-SHA512 explicitly, since it tests a crash in pwdchan plugin that provides this storage scheme.

Fixes: https://github.com/389ds/389-ds-base/issues/6295

Reviewed by: @tbordaz 