### PR TITLE
Issue 6294 - Nightly copr builds are failing

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,6 +6,7 @@ srpm:
 	# Install build dependencies
 	dnf install -y dnf-plugins-core
 	dnf builddep -y --skip-broken --spec rpmbuild/SPECS/389-ds-base.spec --best --allowerasing --setopt=install_weak_deps=False
+	cargo install cargo-license --root /usr
 	# chown files in current working directory to root:root
 	# because when npm is run as root, scripts are always run
 	# with the effective uid and gid of the working directory owner.
@@ -14,8 +15,8 @@ srpm:
 	# So npm fails if current working directory is not owned by root.
 	chown -R root:root .
 	# Generate srpm
-	SKIP_AUDIT_CI=1 make -f rpm.mk srpms
-	
+	SKIP_AUDIT_CI=1 make BUNDLE_LIBDB=1 -f rpm.mk srpm
+
 	if [[ "${outdir}" != "" ]]; then \
 	        mv dist/srpms/* ${outdir}; \
 	fi

--- a/rpm.mk
+++ b/rpm.mk
@@ -8,21 +8,23 @@ PACKAGE = 389-ds-base
 RPM_NAME_VERSION = $(PACKAGE)-$(RPM_VERSION)$(RPM_VERSION_PREREL)
 NAME_VERSION = $(PACKAGE)-$(RPM_VERSION)$(VERSION_PREREL)
 TARBALL = $(NAME_VERSION).tar.bz2
-JEMALLOC_URL ?= $(shell rpmspec -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source3:/ {print $$2}')
-JEMALLOC_TARBALL ?= $(shell basename "$(JEMALLOC_URL)")
-BUNDLE_JEMALLOC = 1
-RPMBUILD_OPTIONS += $(if $(filter 1, $(BUNDLE_JEMALLOC)),--with bundle_jemalloc,--without bundle_jemalloc)
 NODE_MODULES_TEST = src/cockpit/389-console/package-lock.json
 NODE_MODULES_PATH = src/cockpit/389-console/
 CARGO_PATH = src/
 GIT_TAG = ${TAG}
+
+BUNDLE_JEMALLOC = 1
+RPMBUILD_OPTIONS += $(if $(filter 1, $(BUNDLE_JEMALLOC)),--with bundle_jemalloc,--without bundle_jemalloc)
+JEMALLOC_URL ?= $(shell rpmspec $(RPMBUILD_OPTIONS) -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source3:/ {print $$2}')
+JEMALLOC_TARBALL ?= $(shell basename "$(JEMALLOC_URL)")
+
+BUNDLE_LIBDB ?= 0
+RPMBUILD_OPTIONS += $(if $(filter 1, $(BUNDLE_LIBDB)),--with bundle_libdb,--without bundle_libdb)
 # LIBDB tarball was generated from
 #  https://kojipkgs.fedoraproject.org//packages/libdb/5.3.28/59.fc40/src/libdb-5.3.28-59.fc40.src.rpm
 #  then uploaded in https://fedorapeople.org
-LIBDB_URL ?= $(shell rpmspec -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source4:/ {print $$2}')
+LIBDB_URL ?= $(shell rpmspec $(RPMBUILD_OPTIONS) -P $(RPMBUILD)/SPECS/389-ds-base.spec | awk '/^Source4:/ {print $$2}')
 LIBDB_TARBALL ?= $(shell basename "$(LIBDB_URL)")
-BUNDLE_LIBDB ?= 0
-RPMBUILD_OPTIONS += $(if $(filter 1, $(BUNDLE_LIBDB)),--with bundle_libdb,--without bundle_libdb)
 
 # Some sanitizers are supported only by clang
 CLANG_ON = 0

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -4,9 +4,10 @@
 %if %{with bundle_jemalloc}
 %global jemalloc_name jemalloc
 %global jemalloc_ver 5.3.0
+%global __provides_exclude ^libjemalloc\\.so.*$
 %endif
 
-%bcond bundle_libdb 1
+%bcond bundle_libdb %{defined rhel}
 %if %{with bundle_libdb}
 %global libdb_version 5.3
 %global libdb_base_version db-%{libdb_version}.28


### PR DESCRIPTION
Bug Description:
Nightly copr builds fail to generate SRPM due to missing cargo-license.

Fix Description:
Update Makefile for copr to install cargo-license before SRPM is generated.

Fixes: https://github.com/389ds/389-ds-base/issues/6294

Review by: