### PR TITLE
Issue 5843 - Fix size formatting in dscreate output and enhance tests

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1769,7 +1769,7 @@ def get_default_mdb_max_size(paths):
         avail = statvfs.f_frsize * statvfs.f_bavail
         avail *= 0.8 # Reserve 20% as margin
         if size > avail:
-            mdb_max_size = str(avail)
+            mdb_max_size = format_size(avail)
     except (TimeoutError, InterruptedError) as e:
         raise e
     except OSError as e:


### PR DESCRIPTION
Description:
Fix the size formatting in `get_default_mdb_max_size` within `utils.py` to ensure `dscreate` displays the correct value in both interactive and create-template installs. Additionally, improve and fix related LMDB configuration tests to validate the correctness of size handling. Fix typos in the test descriptions.

Relates: https://github.com/389ds/389-ds-base/issues/5843

Reviewed by: ?