### PR TITLE
Issue 6188 automation - Check if nsslapd-haproxy-trusted-ip attribute is returned in default schema

### DIFF
--- a/dirsrvtests/tests/suites/basic/haproxy_test.py
+++ b/dirsrvtests/tests/suites/basic/haproxy_test.py
@@ -60,6 +60,8 @@ def test_haproxy_trust_ip_attribute(topo, setup_test):
 
     log.info("Check that nsslapd-haproxy-trusted-ip attribute is present")
     assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.0.1')
+    # Check nsslapd-haproxy-trusted-ip attribute is present in schema
+    assert topo.standalone.schema.query_attributetype('nsslapd-haproxy-trusted-ip') is not None
 
     log.info("Delete nsslapd-haproxy-trusted-ip attribute")
     topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')


### PR DESCRIPTION
    Issue 6188 : Check if nsslapd-haproxy-trusted-ip
    attribute is returned in default schema
    
    Relates : https://github.com/389ds/389-ds-base/issues/6188
    
    Reviewed by: vashirov (Thanks)