### PR TITLE
Issue 6319 - bdb subpackage has `%description` in the wrong place

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -284,19 +284,20 @@ SNMP Agent for the 389 Directory Server base package.
 %if %{with bundle_libdb}
 %package          bdb
 Summary:          Berkeley Database backend for 389 Directory Server
-%description      bdb
-Berkeley Database backend for 389 Directory Server
-Warning! This backend is deprecated in favor of lmdb and its support
-may be removed in future versions.
 
 Requires:         %{name} = %{version}-%{release}
+Requires:         %{name}-libs = %{version}-%{release}
 # Berkeley DB database libdb was marked as deprecated since F40:
 # https://fedoraproject.org/wiki/Changes/389_Directory_Server_3.0.0
 # because libdb was marked as deprecated since F33
 # https://fedoraproject.org/wiki/Changes/Libdb_deprecated
 Provides:         deprecated()
-%endif
 
+%description      bdb
+Berkeley Database backend for 389 Directory Server
+Warning! This backend is deprecated in favor of lmdb and its support
+may be removed in future versions.
+%endif
 
 %package -n python%{python3_pkgversion}-lib389
 Summary:  A library for accessing, testing, and configuring the 389 Directory Server


### PR DESCRIPTION
Bug Description:
Currently, `%description` section comes before `Requires` and `Provides`. This is a problem for rpmbuild because it is still reading lines for the description when it encounters the `Requires` and `Provides` lines. So those never end up in the subpackage RPM header which causes the rpminspect error.

Fix Description:
The %description section needs to come after the Requires and Provides lines.

Fixes: https://github.com/389ds/389-ds-base/issues/6319
Relates: https://github.com/rpminspect/rpminspect/issues/1427

Reviewed by: