### PR TITLE
Issue 6321 - lib389 get_db_lib function may returns the wrong db type

### DIFF
--- a/dirsrvtests/tests/suites/lib389/config_compare_test.py
+++ b/dirsrvtests/tests/suites/lib389/config_compare_test.py
@@ -9,8 +9,10 @@
 import os
 import pytest
 
+from contextlib import suppress
 from lib389.topologies import topology_i2
 from lib389.config import Config
+from lib389.dseldif import DSEldif
 
 pytestmark = pytest.mark.tier1
 
@@ -40,6 +42,81 @@ def test_config_compare(topology_i2):
     st2_config._compare_exclude.append('nsslapd-ldapssotoken-secret')
 
     assert Config.compare(st1_config, st2_config)
+
+
+@pytest.fixture(scope="function")
+def save_dse(topology_i2, request):
+    """
+    Stop standalone1 instance and save its dse.ldif then restore things at teardown.
+    """
+    inst = topology_i2.ins.get('standalone1')
+    inst.stop()
+    dse_ldif = DSEldif(inst)
+
+    def fin():
+        dse_ldif._update()
+        inst.start()
+
+    request.addfinalizer(fin)
+
+
+def get_db_lib(inst):
+    """
+    Clear cache and returns inst.get_db_lib()
+    """
+    with suppress(AttributeError):
+        del inst._db_lib
+    return inst.get_db_lib()
+
+
+def test_get_db_lib(topology_i2, save_dse):
+    """
+    Check that get_db_lib() returns the configured database type.
+
+    :id: 04205590-6c70-11ef-bfae-083a88554478
+
+    :setup: two isolated directory servers. standalone1 is stopped.
+
+    :steps: 1. Configure standalone1 with bdb
+            2. Check that test_get_db_lib() returns bdb 
+            3. Start standalone1 instance
+            4. Check that test_get_db_lib() returns bdb 
+            5. Stop standalone1 instance
+            6. Configure standalone1 with mdb
+            7. Check that test_get_db_lib() returns mdb 
+            8. Start standalone1 instance
+            9. Check that test_get_db_lib() returns mdb 
+
+    :expectedresults: 1. Success
+                      2. Success
+                      3. Success
+                      4. Success
+                      5. Success
+                      6. Success
+                      7. Success
+                      8. Success
+                      9. Success
+    """
+
+    inst = topology_i2.ins.get('standalone1')
+    dse_ldif = DSEldif(inst)
+    becfgdn = 'cn=config,cn=ldbm database,cn=plugins,cn=config'
+    becfgattr = 'nsslapd-backend-implement'
+
+    # Set db type to: bdb
+    becfgval = 'bdb'
+    dse_ldif.replace(becfgdn, becfgattr, becfgval)
+    assert get_db_lib(inst) == becfgval
+    inst.start()
+    assert get_db_lib(inst) == becfgval
+    inst.stop()
+
+    # Set db type to: mdb
+    becfgval = 'mdb'
+    dse_ldif.replace(becfgdn, becfgattr, becfgval)
+    assert get_db_lib(inst) == becfgval
+    inst.start()
+    assert get_db_lib(inst) == becfgval
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -878,11 +878,11 @@ class DirSrv(SimpleLDAPObject, object):
         with suppress(AttributeError):
             return self._db_lib
         with suppress(Exception):
-            from backend import DatabaseConfig
+            from lib389.backend import DatabaseConfig
             self._db_lib = DatabaseConfig(self).get_db_lib()
             return self._db_lib
         with suppress(Exception):
-            dse_ldif = DSEldif(None, self)
+            dse_ldif = DSEldif(self)
             self._db_lib = dse_ldif.get(DN_CONFIG_LDBM, "nsslapd-backend-implement", single=True)
             return self._db_lib
         return get_default_db_lib()


### PR DESCRIPTION
get_db_lib returns the default db type instead of the configured one because of  caught exceptions
Fix the import issue if instance is online
Fix the DSEldif parameter for the offline case

Issue: #6321 

Reviewed by: @tbordaz  (Thanks!)