### PR TITLE
Issue 6329 - lmdb typo in error log notice message

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -372,8 +372,8 @@ dbmdb_ctx_t_db_max_readers_set(void *arg, void *value, char *errorbuf __attribut
     if (apply) {
         conf->dsecfg.max_readers = val;
         if (CONFIG_PHASE_RUNNING == phase) {
-            slapi_log_err(SLAPI_LOG_NOTICE, "dbmdb_ctx_t_db_max_dbs_set",
-                "New nsslapd-mdb-max-dbs will not take affect until the server is restarted\n");
+            slapi_log_err(SLAPI_LOG_NOTICE, "dbmdb_ctx_t_db_max_readers_set",
+                "New nsslapd-mdb-max-readers will not take affect until the server is restarted\n");
         }
     }
 


### PR DESCRIPTION
Description: Typo in the NOTICE message generated when a user sets the number of --mdb-max-readers

Fixes: https://github.com/389ds/389-ds-base/issues/6329

Reviewed by: