### PR TITLE
Issue 6331 - UI - Instance fails to load when DB backup directory doesn't exist

### DIFF
--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -178,6 +178,7 @@ export class ServerSettings extends React.Component {
         ];
 
         this.validatePaths = this.validatePaths.bind(this);
+        this.validateAllTabs = this.validateAllTabs.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.loadConfig = this.loadConfig.bind(this);
         this.handleSaveConfig = this.handleSaveConfig.bind(this);
@@ -217,6 +218,7 @@ export class ServerSettings extends React.Component {
         if (!this.state.loaded) {
             this.loadConfig();
         } else {
+            this.validateAllTabs();
             this.props.enableTree();
         }
     }
@@ -376,6 +378,30 @@ export class ServerSettings extends React.Component {
         }, () => { this.validateSaveBtn(nav_tab, attr, value) });
     }
 
+    validateAllTabs() {
+        const tabs = ['config', 'rootdn', 'diskmon', 'adv'];
+        tabs.forEach(tab => {
+            let attrs;
+            switch (tab) {
+            case 'config':
+                attrs = general_attrs;
+                break;
+            case 'rootdn':
+                attrs = rootdn_attrs;
+                break;
+            case 'diskmon':
+                attrs = disk_attrs;
+                break;
+            case 'adv':
+                attrs = adv_attrs;
+                break;
+            }
+            attrs.forEach(attr => {
+                this.validateSaveBtn(tab, attr, this.state[attr]);
+            });
+        });
+    }
+
     loadConfig() {
         const attrs = this.state.attrs;
         // Handle the checkbox values
@@ -502,7 +528,10 @@ export class ServerSettings extends React.Component {
             '_nsslapd-entryusn-global': usnGlobal,
             '_nsslapd-ignore-time-skew': ignoreSkew,
             '_nsslapd-readonly': readOnly,
-        }, this.props.enableTree);
+        }, () => {
+            this.validateAllTabs();
+            this.props.enableTree();
+        });
     }
 
     handleSaveRootDN() {


### PR DESCRIPTION
Description: RHDS Console will fail to load an instance if the DB backup directory ( nsslapd-bakdir ) is set to a non-existing directory. The Console will show a spinner and won't allow to select any other RHDS instances.

Correctly process 'failed' case, update the progress bar and send a notification. Also, validate all settings tabs after the load, so the error is visible right away.

Fixes: https://github.com/389ds/389-ds-base/issues/6331

Reviewed by: ?