### PR TITLE
Fix duplicate detection logic in slapi_str2charray_ext by ensuring exact match on string length

### DIFF
--- a/ldap/servers/slapd/charray.c
+++ b/ldap/servers/slapd/charray.c
@@ -354,8 +354,9 @@ slapi_str2charray_ext(char *str, char *brkstr, int allow_dups)
         /* Always copy the first value into the array */
         if ((!allow_dups) && (i != 0)) {
             /* Check for duplicates */
+            size_t len_s = strlen(s);
             for (j = 0; j < i; j++) {
-                if (strncmp(res[j], s, strlen(s)) == 0) {
+                if (len_s == strlen(res[j]) && strncmp(res[j], s, len_s) == 0) {
                     dup_found = 1;
                     break;
                 }


### PR DESCRIPTION
Updated the condition for checking duplicates to ensure that the lengths of the candidate and original strings are equal. This prevents false positives by confirming that the strings are identical at the start and match in length, enforcing an exact duplicate check.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Pavel Nekrasov ([p.nekrasov@fobos-nt.ru](mailto:p.nekrasov@fobos-nt.ru)).

issue: #6338 

Reviewed by: @progier