### PR TITLE
fix buffer owerflow in the function `parseVariant`

### DIFF
--- a/ldap/servers/slapd/tools/ldclt/parser.c
+++ b/ldap/servers/slapd/tools/ldclt/parser.c
@@ -125,7 +125,7 @@ parseVariant(
    * Maybe a variable ?
    */
     if (variant[1] == '\0') {
-        if ((variant[0] < VAR_MIN) || (variant[0] > VAR_MAX)) {
+        if ((variant[0] <= VAR_MIN) || (variant[0] >= VAR_MAX)) {
             fprintf(stderr, "Error: bad variable in %s : \"%s\"\n", fname, line);
             fprintf(stderr, "Error: must be in [%c-%c]\n", VAR_MIN, VAR_MAX);
             return (-1);
@@ -141,7 +141,7 @@ parseVariant(
     if (variant[1] != '=')
         field->var = -1;
     else {
-        if ((variant[0] < VAR_MIN) || (variant[0] > VAR_MAX)) {
+        if ((variant[0] <= VAR_MIN) || (variant[0] >= VAR_MAX)) {
             fprintf(stderr, "Error: bad variable in %s : \"%s\"\n", fname, line);
             fprintf(stderr, "Error: must be in [%c-%c]\n", VAR_MIN, VAR_MAX);
             return (-1);


### PR DESCRIPTION
`variant[0]` can have a maximum value of 72. `field->var = variant0 - VAR_MIN;`, so  a maximum value `field->var = 7`

This is a buffer overflow in the line
 `obj->var[field->var] = (char *)malloc(MAX_FILTER)`

if it accesses the array at index 7, an overflow will occur.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Dmitriy Fedin ([d.fedin@fobos-nt.ru](mailto:d.fedin@fobos-nt.ru)).