### PR TITLE
Issue 6336 - Fix failing CI tests (roles) due to slow import

### DIFF
--- a/dirsrvtests/tests/suites/roles/basic_test.py
+++ b/dirsrvtests/tests/suites/roles/basic_test.py
@@ -584,8 +584,8 @@ def test_managed_and_filtered_role_rewrite(topo, request):
     # online import
     import_task = ImportTask(topo.standalone)
     import_task.import_suffix_from_ldif(ldiffile=import_ldif, suffix=DEFAULT_SUFFIX)
-    # Check for up to 120sec that the completion
-    for i in range(1, 12):
+    # Check for up to 200sec that the completion
+    for i in range(1, 20):
         if len(topo.standalone.ds_error_log.match('.*import userRoot: Import complete.  Processed 9000.*')) > 0:
             break
         time.sleep(10)
@@ -719,8 +719,8 @@ def test_not_such_entry_role_rewrite(topo, request):
     # online import
     import_task = ImportTask(topo.standalone)
     import_task.import_suffix_from_ldif(ldiffile=import_ldif, suffix=DEFAULT_SUFFIX)
-    # Check for up to 120sec that the completion
-    for i in range(1, 12):
+    # Check for up to 200sec that the completion
+    for i in range(1, 20):
         if len(topo.standalone.ds_error_log.match('.*import userRoot: Import complete.  Processed 9100.*')) > 0:
             break
         time.sleep(10)


### PR DESCRIPTION
Bug description:
	Tests test_managed_and_filtered_role_rewrite and test_not_such_entry_role_rewrite
	import a significant number of entries (>90K).
	If import rate drop below 800/sec the tests fail

Fix description:
	increase the maximum time to wait.

fixes: 6336

Reviewed by: