### PR TITLE
Issue 6064 - bdb2mdb shows errors

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2731,7 +2731,7 @@ dbmdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_
 
 
 int
-dbmdb_public_private_close(dbi_env_t **env, dbi_db_t **db)
+dbmdb_public_private_close(struct ldbminfo *li, dbi_env_t **env, dbi_db_t **db)
 {
     if (*db)
         dbmdb_public_db_op(*db, NULL, DBI_OP_CLOSE, NULL, NULL);

--- a/ldap/servers/slapd/back-ldbm/dbimpl.c
+++ b/ldap/servers/slapd/back-ldbm/dbimpl.c
@@ -476,14 +476,12 @@ int dblayer_private_close(Slapi_Backend **be, dbi_env_t **env, dbi_db_t **db)
         dblayer_private *priv = li->li_dblayer_private;
 
         if (priv && priv->dblayer_private_close_fn) {
-            rc = priv->dblayer_private_close_fn(env, db);
+            rc = priv->dblayer_private_close_fn(li, env, db);
         }
+        slapi_ch_free_string(&li->li_directory);
         slapi_ch_free((void**)&li->li_dblayer_private);
         slapi_ch_free((void**)&li->li_dblayer_config);
-        if (dblayer_is_lmdb(*be)) {
-            /* Generate use after free and double free in bdb case */
-            ldbm_config_destroy(li);
-        }
+        ldbm_config_destroy(li);
         slapi_ch_free((void**)&(*be)->be_database);
         slapi_ch_free((void**)&(*be)->be_instance_info);
         slapi_ch_free((void**)be);

--- a/ldap/servers/slapd/back-ldbm/dblayer.h
+++ b/ldap/servers/slapd/back-ldbm/dblayer.h
@@ -113,7 +113,7 @@ typedef int dblayer_dbi_txn_abort_fn_t(dbi_txn_t *txn);
 typedef int dblayer_get_entries_count_fn_t(dbi_db_t *db, dbi_txn_t *txn, int *count);
 typedef int dblayer_cursor_get_count_fn_t(dbi_cursor_t *cursor, dbi_recno_t *count);
 typedef int dblayer_private_open_fn_t(backend *be, const char *db_filename, int rw, dbi_env_t **env, dbi_db_t **db);
-typedef int dblayer_private_close_fn_t(dbi_env_t **env, dbi_db_t **db);
+typedef int dblayer_private_close_fn_t(struct ldbminfo *li, dbi_env_t **env, dbi_db_t **db);
 typedef int ldbm_back_wire_import_fn_t(Slapi_PBlock *pb);
 typedef int dblayer_restore_file_init_fn_t(struct ldbminfo *li);
 typedef void dblayer_restore_file_update_fn_t(struct ldbminfo *li, const char *directory);


### PR DESCRIPTION
Fix several issues with dsctl dblib migration tools:
Fix some problem related to dbscan -D bdb --import:
 - random crash when closing  the database - Fixed by fully cleaning the bdb framework if open in read-write mode
 - random records were missing - Fixed by fully starting the bdb framework when it is open in read-write mode
   and by using txn
 Fixed error messages displayed when trying to reopen ldap connection on restarted instance by not reopening the connection that are not needed.
 Fixed error messages displayed when there is no replication changelog by detecting the presence of replication changelog before trying to export it.

Issue: #6064 

Reviewed by: @tbordaz (Thans!)