### PR TITLE
Issue 6345 - Ensure all slapi_log_err calls end format strings with newline character \n

### DIFF
--- a/ldap/servers/plugins/acl/aclutil.c
+++ b/ldap/servers/plugins/acl/aclutil.c
@@ -257,7 +257,7 @@ aclutil_print_err(int rv, const Slapi_DN *sdn, const struct berval *val, char **
         aclutil_str_append(errbuf, lineptr);
     }
 
-    slapi_log_err(SLAPI_LOG_ERR, plugin_name, "aclutil_print_err - %s", lineptr);
+    slapi_log_err(SLAPI_LOG_ERR, plugin_name, "aclutil_print_err - %s\n", lineptr);
     slapi_ch_free_string(&newline);
 }
 

--- a/ldap/servers/plugins/acl/aclutil.c
+++ b/ldap/servers/plugins/acl/aclutil.c
@@ -257,7 +257,7 @@ aclutil_print_err(int rv, const Slapi_DN *sdn, const struct berval *val, char **
         aclutil_str_append(errbuf, lineptr);
     }
 
-    slapi_log_err(SLAPI_LOG_ERR, plugin_name, "aclutil_print_err - %s\n", lineptr);
+    slapi_log_err(SLAPI_LOG_ERR, plugin_name, "aclutil_print_err - %s", lineptr);
     slapi_ch_free_string(&newline);
 }
 

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -2036,7 +2036,7 @@ memberof_postop_modify(Slapi_PBlock *pb)
         slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &entry);
         if (entry) {
             if (SLAPI_DSE_CALLBACK_ERROR == memberof_apply_config(pb, NULL, entry, &result, returntext, NULL)) {
-                slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "%s", returntext);
+                slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "%s\n", returntext);
                 ret = SLAPI_PLUGIN_FAILURE;
                 goto done;
             }

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -1019,7 +1019,7 @@ bail:
     if (ret) {
         slapi_pblock_set(pb, SLAPI_RESULT_CODE, &ret);
         slapi_pblock_set(pb, SLAPI_PB_RESULT_TEXT, returntext);
-        slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "memberof_shared_config_validate - %s/n",
+        slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "memberof_shared_config_validate - %s\n",
                       returntext);
     }
     slapi_sdn_free(&config_sdn);

--- a/ldap/servers/plugins/replication/profile.c
+++ b/ldap/servers/plugins/replication/profile.c
@@ -25,7 +25,7 @@ void
 profile_log(char *file, int line)
 {
     if (profile_fd == NULL)
-        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "profile_log: profile file not open.");
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "profile_log: profile file not open.\n");
     else {
         /* JCMREPL - Probably need a lock around here */
         fprintf(profile_fd, "%s %d\n", file, line);
@@ -44,7 +44,7 @@ void
 profile_close()
 {
     if (profile_fd == NULL)
-        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "profile_close: profile file not open.");
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "profile_close: profile file not open.\n");
     else
         textfile_close(profile_fd);
 }

--- a/ldap/servers/plugins/replication/repl5_ruv.c
+++ b/ldap/servers/plugins/replication/repl5_ruv.c
@@ -1470,7 +1470,7 @@ ruv_dump(const RUV *ruv, char *ruv_name, PRFileDesc *prFile)
     if (prFile) {
         slapi_write_buffer(prFile, buff, strlen(buff));
     } else {
-        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s\n", buff);
+        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s", buff);
     }
     for (replica = dl_get_first(ruv->elements, &cookie); replica;
          replica = dl_get_next(ruv->elements, &cookie)) {
@@ -1491,7 +1491,7 @@ ruv_dump(const RUV *ruv, char *ruv_name, PRFileDesc *prFile)
         if (prFile) {
             slapi_write_buffer(prFile, buff, strlen(buff));
         } else {
-            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s\n", buff);
+            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s", buff);
         }
     }
 

--- a/ldap/servers/plugins/replication/repl5_ruv.c
+++ b/ldap/servers/plugins/replication/repl5_ruv.c
@@ -1470,7 +1470,7 @@ ruv_dump(const RUV *ruv, char *ruv_name, PRFileDesc *prFile)
     if (prFile) {
         slapi_write_buffer(prFile, buff, strlen(buff));
     } else {
-        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s", buff);
+        slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s\n", buff);
     }
     for (replica = dl_get_first(ruv->elements, &cookie); replica;
          replica = dl_get_next(ruv->elements, &cookie)) {
@@ -1491,7 +1491,7 @@ ruv_dump(const RUV *ruv, char *ruv_name, PRFileDesc *prFile)
         if (prFile) {
             slapi_write_buffer(prFile, buff, strlen(buff));
         } else {
-            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s", buff);
+            slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "%s\n", buff);
         }
     }
 

--- a/ldap/servers/plugins/schema_reload/schema_reload.c
+++ b/ldap/servers/plugins/schema_reload/schema_reload.c
@@ -88,7 +88,7 @@ schemareload_start(Slapi_PBlock *pb)
     int rc = 0;
 
     if ((schemareload_lock = PR_NewLock()) == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "schemareload", "schemareload_start - Failed to create global schema reload lock.");
+        slapi_log_err(SLAPI_LOG_ERR, "schemareload", "schemareload_start - Failed to create global schema reload lock.\n");
         return -1;
     }
     rc = slapi_plugin_task_register_handler("schema reload task", schemareload_add, pb);
@@ -154,7 +154,7 @@ schemareload_thread(void *arg)
     if (slapi_is_shutting_down()) {
         slapi_task_log_notice(task, "Server is shuttoing down; Schema validation aborted.");
         slapi_task_log_status(task, "Server is shuttoing down; Schema validation aborted.");
-        slapi_log_err(SLAPI_LOG_ERR, "schemareload", "schemareload_thread - Server is shutting down; Schema validation aborted.");
+        slapi_log_err(SLAPI_LOG_ERR, "schemareload", "schemareload_thread - Server is shutting down; Schema validation aborted.\n");
     } else if (LDAP_SUCCESS == rv) {
         slapi_task_log_notice(task, "Schema validation passed.");
         slapi_task_log_status(task, "Schema validation passed.");

--- a/ldap/servers/plugins/whoami/whoami.c
+++ b/ldap/servers/plugins/whoami/whoami.c
@@ -58,7 +58,7 @@ whoami_exop(Slapi_PBlock *pb)
     /* Fetch the client dn */
 
     if (slapi_pblock_get(pb, SLAPI_CONN_DN, &client_dn) != 0) {
-        slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not get client_dn");
+        slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not get client_dn\n");
         slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get client_dn\n", 0, NULL);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
     }
@@ -75,8 +75,8 @@ whoami_exop(Slapi_PBlock *pb)
     /* Set the return value in pblock */
 
     if (slapi_pblock_set(pb, SLAPI_EXT_OP_RET_OID, NULL) != 0 || slapi_pblock_set(pb, SLAPI_EXT_OP_RET_VALUE, &retbval) != 0) {
-        slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not set return values");
-        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not set return values", 0, NULL);
+        slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not set return values\n");
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not set return values\n", 0, NULL);
         slapi_ch_free_string(&client_dn);
         slapi_ch_free_string(&fdn);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);

--- a/ldap/servers/plugins/whoami/whoami.c
+++ b/ldap/servers/plugins/whoami/whoami.c
@@ -45,13 +45,13 @@ whoami_exop(Slapi_PBlock *pb)
 
     if (slapi_pblock_get(pb, SLAPI_EXT_OP_REQ_OID, &oid) != 0) {
         slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not get OID from request\n");
-        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get OID from request\n", 0, NULL);
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get OID from request", 0, NULL);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
     }
 
     if (slapi_pblock_get(pb, SLAPI_EXT_OP_REQ_VALUE, &bval) != 0 || bval->bv_val != NULL) {
         slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not get correct request value from request\n");
-        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get correct request value from request\n", 0, NULL);
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get correct request value from request", 0, NULL);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
     }
 
@@ -59,7 +59,7 @@ whoami_exop(Slapi_PBlock *pb)
 
     if (slapi_pblock_get(pb, SLAPI_CONN_DN, &client_dn) != 0) {
         slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not get client_dn\n");
-        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get client_dn\n", 0, NULL);
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not get client_dn", 0, NULL);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);
     }
 
@@ -76,7 +76,7 @@ whoami_exop(Slapi_PBlock *pb)
 
     if (slapi_pblock_set(pb, SLAPI_EXT_OP_RET_OID, NULL) != 0 || slapi_pblock_set(pb, SLAPI_EXT_OP_RET_VALUE, &retbval) != 0) {
         slapi_log_err(SLAPI_LOG_ERR, PLUGIN_NAME, "whoami_exop - Could not set return values\n");
-        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not set return values\n", 0, NULL);
+        slapi_send_ldap_result(pb, LDAP_OPERATIONS_ERROR, NULL, "Could not set return values", 0, NULL);
         slapi_ch_free_string(&client_dn);
         slapi_ch_free_string(&fdn);
         return (SLAPI_PLUGIN_EXTENDED_SENT_RESULT);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -1047,7 +1047,7 @@ bdb_start(struct ldbminfo *li, int dbmode)
     slapi_pal_meminfo *mi = spal_meminfo_get();
     util_cachesize_result result = util_is_cachesize_sane(mi, &(conf->bdb_cachesize));
     if (result == UTIL_CACHESIZE_ERROR) {
-        slapi_log_err(SLAPI_LOG_CRIT, "bdb_start", "Unable to determine if cachesize was valid!!!");
+        slapi_log_err(SLAPI_LOG_CRIT, "bdb_start", "Unable to determine if cachesize was valid!!!\n");
     } else if (result == UTIL_CACHESIZE_REDUCED) {
         /* In some cases we saw this go to 0, prevent this. */
         if (conf->bdb_cachesize < MINCACHESIZE) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c
@@ -240,7 +240,7 @@ bdb_start_autotune(struct ldbminfo *li)
     issane = util_is_cachesize_sane(mi, &zone_size);
     if (issane == UTIL_CACHESIZE_REDUCED) {
         slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "Your autosized cache values have been reduced. Likely your nsslapd-cache-autosize percentage is too high.\n");
-        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s", msg);
+        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s\n", msg);
     }
     /* It's valid, lets divide it up and set according to user prefs */
     db_size = (autosize_db_percentage_split * zone_size) / 100;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_misc.c
@@ -240,7 +240,7 @@ bdb_start_autotune(struct ldbminfo *li)
     issane = util_is_cachesize_sane(mi, &zone_size);
     if (issane == UTIL_CACHESIZE_REDUCED) {
         slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "Your autosized cache values have been reduced. Likely your nsslapd-cache-autosize percentage is too high.\n");
-        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s\n", msg);
+        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s", msg);
     }
     /* It's valid, lets divide it up and set according to user prefs */
     db_size = (autosize_db_percentage_split * zone_size) / 100;
@@ -382,7 +382,7 @@ bdb_start_autotune(struct ldbminfo *li)
         slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "In a future release this WILL prevent server start up. You MUST alter your configuration.\n");
         slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "Total entry cache size: %" PRIu64 " B; dbcache size: %" PRIu64 " B; available memory size: %" PRIu64 " B; \n",
                       total_cache_size, (uint64_t)li->li_dbcachesize, mi->system_available_bytes);
-        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s\n", msg);
+        slapi_log_err(SLAPI_LOG_WARNING, "bdb_start_autotune", "%s", msg);
         /* WB 2016 - This should be UNCOMMENTED in a future release */
         /* return SLAPI_FAIL_GENERAL; */
     }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -1299,7 +1299,7 @@ dbmdb_import_producer(void *param)
                 continue;
             case DNRC_ERROR:
                 import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_import_producer",
-                                  "Import is arborted because a LMDB database error was detected. Please check the error log for more details.");
+                                  "Import is aborted because a LMDB database error was detected. Please check the error log for more details.");
                 slapi_ch_free_string(&wqelmt.dn);
                 slapi_ch_free(&wqelmt.data);
                 thread_abort(info);
@@ -1772,7 +1772,7 @@ dbmdb_index_producer(void *param)
                 continue;
             case DNRC_ERROR:
                 import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_index_producer",
-                                  "Reindex is arborted because a LMDB database error was detected. Please check the error log for more details.");
+                                  "Reindex is aborted because a LMDB database error was detected. Please check the error log for more details.");
                 thread_abort(info);
                 continue;
             case DNRC_WAIT:
@@ -2263,7 +2263,7 @@ dbmdb_upgrade_prepare_worker_entry(WorkerQueueData_t *wqelmnt)
                                                   inst->inst_name, dn_id);
                         }
                         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_upgradedn_producer",
-                                      "%s: Error: failed to write a line \"%s\"",
+                                      "%s: Error: failed to write a line \"%s\"\n",
                                       inst->inst_name, dn_id);
                         slapi_ch_free_string(&dn_id);
                         goto error;
@@ -3689,7 +3689,7 @@ dbmdb_read_ldif_entries(struct ldbminfo *li, char *src_dir, char *file_name)
         slapi_ch_free_string(&estr);
         if (!e) {
             slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_read_ldif_entries",
-                          "Skipping bad LDIF entry ending line %d of file \"%s\"",
+                          "Skipping bad LDIF entry ending line %d of file \"%s\"\n",
                           curr_lineno, filename);
             continue;
         }
@@ -3701,7 +3701,7 @@ dbmdb_read_ldif_entries(struct ldbminfo *li, char *src_dir, char *file_name)
     }
     if (!backup_entries) {
         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_read_ldif_entries",
-                      "No entry found in backup config file \"%s\"",
+                      "No entry found in backup config file \"%s\"\n",
                       filename);
         goto out;
     }
@@ -4114,7 +4114,7 @@ dbmdb_bulk_producer(void *param)
                 continue;
             case DNRC_ERROR:
                 import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
-                                  "Reindex is arborted because a LMDB database error was detected. Please check the error log for more details.");
+                                  "Reindex is aborted because a LMDB database error was detected. Please check the error log for more details.");
                 thread_abort(info);
                 continue;
             case DNRC_WAIT:

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -1569,7 +1569,7 @@ dbmdb_privdb_handle_cursor(mdb_privdb_t *db, int dbi_index)
         db->wcount = 0;
         if (rc) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to commit dndb transaction. Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to commit dndb transaction. Error is %d: %s.\n", rc, mdb_strerror(rc));
             TXN_ABORT(db->txn);
             return -1;
         }
@@ -1578,13 +1578,13 @@ dbmdb_privdb_handle_cursor(mdb_privdb_t *db, int dbi_index)
         rc = TXN_BEGIN(db->env, NULL, 0, &db->txn);
         if (rc) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to begin dndb transaction. Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to begin dndb transaction. Error is %d: %s.\n", rc, mdb_strerror(rc));
             return -1;
         }
         rc = MDB_CURSOR_OPEN(db->txn, db->dbis[dbi_index].dbi, &db->cursor);
         if (rc) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to open dndb cursor. Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to open dndb cursor. Error is %d: %s.\n", rc, mdb_strerror(rc));
             dbmdb_privdb_discard_cursor(db);
             return -1;
         }
@@ -1687,7 +1687,7 @@ dbmdb_privdb_get(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
         }
         if (rc && rc != MDB_NOTFOUND) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to get key from dndb cursor Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to get key from dndb cursor Error is %d: %s.\n", rc, mdb_strerror(rc));
         }
     }
     return rc;
@@ -1713,7 +1713,7 @@ dbmdb_privdb_put(mdb_privdb_t *db, int dbi_idx, MDB_val *key, MDB_val *data)
         }
         if (rc && rc != MDB_KEYEXIST) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_privdb_handle_cursor",
-                          "Failed to put data into dndb cursor Error is %d: %s.", rc, mdb_strerror(rc));
+                          "Failed to put data into dndb cursor Error is %d: %s.\n", rc, mdb_strerror(rc));
         }
     }
     if (!rc) {

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -387,7 +387,7 @@ presence_candidates(
     int unindexed = 0;
     back_txn txn = {NULL};
 
-    slapi_log_err(SLAPI_LOG_TRACE, "presence_candidates", "=> n");
+    slapi_log_err(SLAPI_LOG_TRACE, "presence_candidates", "=> \n");
 
     if (slapi_filter_get_type(f, &type) != 0) {
         slapi_log_err(SLAPI_LOG_ERR, "presence_candidates", "slapi_filter_get_type failed\n");

--- a/ldap/servers/slapd/bind.c
+++ b/ldap/servers/slapd/bind.c
@@ -185,7 +185,7 @@ do_bind(Slapi_PBlock *pb)
             static char *kmsg =
                 "LDAPv2-style kerberos authentication received "
                 "on LDAPv3 connection.";
-            slapi_log_err(SLAPI_LOG_ERR, "do_bind", "%s", kmsg);
+            slapi_log_err(SLAPI_LOG_ERR, "do_bind", "%s\n", kmsg);
             log_bind_access(pb, dn ? dn : "empty", method, version, saslmech, kmsg);
             send_ldap_result(pb, LDAP_PROTOCOL_ERROR, NULL,
                              kmsg, 0, NULL);

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -443,7 +443,7 @@ csngen_test()
     int rc;
     CSNGen *gen = csngen_new(255, NULL);
 
-    slapi_log_err(SLAPI_LOG_DEBUG, "csngen_test", "staring csn generator test ...");
+    slapi_log_err(SLAPI_LOG_DEBUG, "csngen_test", "staring csn generator test ...\n");
     csngen_dump_state(gen, SLAPI_LOG_INFO);
 
     rc = _csngen_start_test_threads(gen);
@@ -455,7 +455,7 @@ csngen_test()
 
     _csngen_stop_test_threads();
     csngen_dump_state(gen, SLAPI_LOG_INFO);
-    slapi_log_err(SLAPI_LOG_DEBUG, "csngen_test", "csn generator test is complete...");
+    slapi_log_err(SLAPI_LOG_DEBUG, "csngen_test", "csn generator test is complete...\n");
 }
 
 /*

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -2334,7 +2334,7 @@ createprlistensockets(PRUint16 port, PRNetAddr **listenaddr, int secure __attrib
     if (local) { /* ldapi */
         if (chmod((*listenaddr)->local.path,
                   S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) {
-            slapi_log_err(SLAPI_LOG_ERR, logname, "err: %d", errno);
+            slapi_log_err(SLAPI_LOG_ERR, logname, "err: %d\n", errno);
         }
     }
 #endif /* ENABLE_LDAPI */

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -9853,7 +9853,7 @@ validate_num_config_reservedescriptors(void)
     for (be = slapi_get_first_backend(&cookie); be != NULL; be = slapi_get_next_backend(cookie)) {
         entry_str = slapi_create_dn_string("cn=%s,cn=ldbm database,cn=plugins,cn=config", be->be_name);
         if (NULL == entry_str) {
-            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create backend dn string");
+            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create backend dn string\n");
             return -1;
         }
         slapi_sdn_init_dn_byref(&sdn, entry_str);
@@ -9876,7 +9876,7 @@ validate_num_config_reservedescriptors(void)
     for (be = slapi_get_first_backend(&cookie); be; be = slapi_get_next_backend(cookie)) {
         entry_str = slapi_create_dn_string("cn=index,cn=%s,cn=ldbm database,cn=plugins,cn=config", be->be_name);
         if (NULL == entry_str) {
-            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create index dn string");
+            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create index dn string\n");
             return -1;
         }
         slapi_sdn_init_dn_byref(&sdn, entry_str);
@@ -9902,7 +9902,7 @@ validate_num_config_reservedescriptors(void)
     /* If replication is enabled add replication descriptor constant, plus the number of enabled repl agmts */
     mt_str = slapi_get_mapping_tree_config_root();
     if (NULL == mt_str) {
-        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to get mapping tree config string");
+        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to get mapping tree config string\n");
         return -1;
     }
     search_pb = slapi_pblock_new();
@@ -9925,7 +9925,7 @@ validate_num_config_reservedescriptors(void)
     /* Get the operation connection limit from the default instance config */
     entry_str = slapi_create_dn_string("cn=default instance config,cn=chaining database,cn=plugins,cn=config");
     if (NULL == entry_str) {
-        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create default chaining config dn string");
+        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create default chaining config dn string\n");
         return -1;
     }
     slapi_sdn_init_dn_byref(&sdn, entry_str);
@@ -9941,7 +9941,7 @@ validate_num_config_reservedescriptors(void)
     for (be = slapi_get_first_backend(&cookie); be; be = slapi_get_next_backend(cookie)) {
         entry_str = slapi_create_dn_string("cn=%s,cn=chaining database,cn=plugins,cn=config", be->be_name);
         if (NULL == entry_str) {
-            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create chaining be dn string");
+            slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create chaining be dn string\n");
             return -1;
         }
         slapi_sdn_init_dn_byref(&sdn, entry_str);
@@ -9963,7 +9963,7 @@ validate_num_config_reservedescriptors(void)
     /* If PTA is enabled add the pass through auth descriptor constant */
     entry_str = slapi_create_dn_string("cn=Pass Through Authentication,cn=plugins,cn=config");
     if (NULL == entry_str) {
-        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create PTA dn string");
+        slapi_log_err(SLAPI_LOG_ERR, "validate_num_config_reservedescriptors", "Failed to create PTA dn string\n");
         return -1;
     }
     slapi_sdn_init_dn_byref(&sdn, entry_str);

--- a/ldap/servers/slapd/modutil.c
+++ b/ldap/servers/slapd/modutil.c
@@ -807,7 +807,7 @@ slapi_mod_dump(LDAPMod *mod, int n)
                 bufp = buf;
                 slapi_ldif_put_type_and_value_with_options(&bufp, mod->mod_type, mod->mod_bvalues[i]->bv_val, mod->mod_bvalues[i]->bv_len, 0);
                 *bufp = '\0';
-                slapi_log_err(SLAPI_LOG_DEBUG, "slapi_mod_dump", "smod %d - value: %s", n, buf);
+                slapi_log_err(SLAPI_LOG_DEBUG, "slapi_mod_dump", "smod %d - value: %s\n", n, buf);
                 slapi_ch_free((void **)&buf);
             }
         }

--- a/ldap/servers/slapd/passwd_extop.c
+++ b/ldap/servers/slapd/passwd_extop.c
@@ -493,7 +493,7 @@ passwd_modify_extop(Slapi_PBlock *pb)
      * connections using SASL privacy layers */
     slapi_pblock_get(pb, SLAPI_CONNECTION, &conn);
     if (conn == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "passwd_modify_extop", "conn is NULL");
+        slapi_log_err(SLAPI_LOG_ERR, "passwd_modify_extop", "conn is NULL\n");
         goto free_and_return;
     }
     if (slapi_pblock_get(pb, SLAPI_CONN_SASL_SSF, &sasl_ssf) != 0) {
@@ -734,7 +734,7 @@ parse_req_done:
     Operation *pb_op = NULL;
     slapi_pblock_get(pb, SLAPI_OPERATION, &pb_op);
     if (pb_op == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "passwd_modify_extop", "pb_op is NULL");
+        slapi_log_err(SLAPI_LOG_ERR, "passwd_modify_extop", "pb_op is NULL\n");
         goto free_and_return;
     }
 

--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -3639,7 +3639,7 @@ plugin_invoke_plugin_pb(struct slapdplugin *plugin, int operation, Slapi_PBlock 
 
     slapi_pblock_get(pb, SLAPI_OPERATION, &pb_op);
     if (pb_op == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "plugin_invoke_plugin_pb", "pb_op is NULL");
+        slapi_log_err(SLAPI_LOG_ERR, "plugin_invoke_plugin_pb", "pb_op is NULL\n");
         PR_ASSERT(0);
         return PR_FALSE;
     }

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -2568,7 +2568,7 @@ slapi_pwpolicy_make_response_control(Slapi_PBlock *pb, int seconds, int logins, 
         ber_bvfree(bvp);
     }
 
-    slapi_log_err(SLAPI_LOG_TRACE, "slapi_pwpolicy_make_response_control", "<= (%d)", rc);
+    slapi_log_err(SLAPI_LOG_TRACE, "slapi_pwpolicy_make_response_control", "<= (%d)\n", rc);
 
     return (rc == -1 ? LDAP_OPERATIONS_ERROR : LDAP_SUCCESS);
 }

--- a/ldap/servers/slapd/saslbind.c
+++ b/ldap/servers/slapd/saslbind.c
@@ -554,7 +554,7 @@ ids_sasl_userdb_checkpass(sasl_conn_t *conn,
         goto out;
     }
 
-    slapi_log_err(SLAPI_LOG_CONNS, "ids_sasl_userdb_checkpass", "Using mech %s", mech);
+    slapi_log_err(SLAPI_LOG_CONNS, "ids_sasl_userdb_checkpass", "Using mech %s\n", mech);
     if (passlen == 0) {
         goto out;
     }

--- a/ldap/servers/slapd/slapi-memberof.c
+++ b/ldap/servers/slapd/slapi-memberof.c
@@ -1254,7 +1254,7 @@ slapi_memberof(Slapi_MemberOfConfig *config, Slapi_DN *member_sdn, Slapi_MemberO
              */
             rc = sm_entry_get_groups(config, member_sdn, groupvals, nsuniqueidvals);
         } else {
-            slapi_log_err(SLAPI_LOG_ERR, "slapi_memberof", "memberof plugin is not enabled, with MEMBEROF_REUSE_ONLY return empty result");
+            slapi_log_err(SLAPI_LOG_ERR, "slapi_memberof", "memberof plugin is not enabled, with MEMBEROF_REUSE_ONLY return empty result\n");
         }
     } else if ((config->flag == MEMBEROF_REUSE_IF_POSSIBLE) &&
                sm_compare_memberof_config(config->memberof_attr,

--- a/ldap/servers/slapd/slapi_pal.c
+++ b/ldap/servers/slapd/slapi_pal.c
@@ -290,7 +290,7 @@ spal_meminfo_get()
         } else if (cg_mem_hard > cg_mem_usage) {
             cg_mem_soft_avail = cg_mem_hard - cg_mem_usage;
         } else {
-            slapi_log_err(SLAPI_LOG_CRIT, "spal_meminfo_get", "Your cgroup memory usage exceeds your hard limit?");
+            slapi_log_err(SLAPI_LOG_CRIT, "spal_meminfo_get", "Your cgroup memory usage exceeds your hard limit?\n");
         }
     }
 

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -1120,7 +1120,7 @@ task_export_thread(void *arg)
 
     if (!ldif_file) {
         slapi_task_log_notice(task, "export failed (NULL ldif_file).");
-        slapi_log_err(SLAPI_LOG_ERR, "task_export_thread", "Export failed (NULL ldif_file).");
+        slapi_log_err(SLAPI_LOG_ERR, "task_export_thread", "Export failed (NULL ldif_file).\n");
         return;
     }
 

--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -1532,7 +1532,7 @@ util_is_cachesize_sane(slapi_pal_meminfo *mi, uint64_t *cachesize)
 {
     /* Check we have a valid meminfo struct */
     if (mi->system_available_bytes == 0) {
-        slapi_log_err(SLAPI_LOG_CRIT, "util_is_cachesize_sane", "Invalid system memory info, can not proceed.");
+        slapi_log_err(SLAPI_LOG_CRIT, "util_is_cachesize_sane", "Invalid system memory info, can not proceed.\n");
         return UTIL_CACHESIZE_ERROR;
     }
 


### PR DESCRIPTION
Description: In the codebase, there are instances where calls to slapi_log_err are missing a newline character \n at the end of the format string. This omission can lead to log messages being concatenated in the logs, affecting readability and potentially hindering log parsing and analysis tools. Fix the typos.

Fixes: https://github.com/389ds/389-ds-base/issues/6345

Reviewed by: ?