### PR TITLE
Issue 6347 - VLV search sometime fails with operation error

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2387,6 +2387,10 @@ int dbmdb_cursor_set_recno(dbi_cursor_t *cursor, MDB_val *dbmdb_key, MDB_val *db
         rce->recno++;
         rc = MDB_CURSOR_GET(cursor->cur, &rce->key, &rce->data, MDB_NEXT);
     }
+    if (rc == MDB_NOTFOUND) {
+        /* Stay on last record if there are no more records */
+        rc = 0;
+    }
     if (rc == 0 && dbmdb_data->mv_size == rce->data.mv_size) {
         /* Should always be the case */
         memcpy(dbmdb_data->mv_data , rce->data.mv_data, dbmdb_data->mv_size);


### PR DESCRIPTION
if  enabling certificate pruning freeipa tests sometime fails because VLV search sometime fails with err=1 and
error logs show - ERR - vlv_build_idl - Can't follow db cursor (err -12797)
Cause: The end of records is reached when trying to get a record in vlv index using its position
Solution: avoid to return MDB_NOT_FOUND in such case but return the last record instead

Issue: #6347 

Reviewed by: tbordaz (Thanks!) 