### PR TITLE
Issue 6343 - Improve onlne import robustness when the server is under load

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -586,7 +586,7 @@ def test_import_wrong_file_path(topo):
 
 @pytest.mark.skipif(get_default_db_lib() != "mdb", reason="lmdb specific test")
 def test_crash_on_ldif2db_with_lmdb(topo, _import_clean):
-    """Make an import fail by specifying a too small db size then check that 
+    """Make an import fail by specifying a too small db size then check that
     there is no crash.
 
     :id: d42585b6-31d0-11ee-8724-482ae39447e5
@@ -601,9 +601,9 @@ def test_crash_on_ldif2db_with_lmdb(topo, _import_clean):
         1. Success
         2. Success
         3. Success (ns-slapd should not have aborted)
-        4. Import should fail 
+        4. Import should fail
         5. Success (ns-slapd should not have aborted)
-     
+
     """
     TINY_MAP_SIZE =  16 * 1024 * 1024
     inst = topo.standalone
@@ -625,6 +625,69 @@ def test_crash_on_ldif2db_with_lmdb(topo, _import_clean):
     with pytest.raises(AssertionError):
         _import_offline(topo, 500_000)
     __check_for_core(now)
+
+def test_online_import_under_load(topo):
+    """Perform an online import while the server is under load
+
+    :id: 56f7ac6f-4285-4bc4-8822-5ae9b502eee3
+    :setup: Standalone Instance
+    :steps:
+        1. Create and import LDIF for ldclt load
+        2. Start ldclt
+        3. Start online import
+        4. Wait a bit and kill the ldclt load
+        5. Check import task successfully completed
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+    inst = topo.standalone
+
+    # Create and import ldif to use with ldclt
+    ldif_dir = inst.get_ldif_dir()
+    import_ldif = ldif_dir + '/stress_import.ldif'
+    dbgen_users(inst, 1000, import_ldif, generic=True, suffix=DEFAULT_SUFFIX)
+    import_task = ImportTask(topo.standalone)
+    import_task.import_suffix_from_ldif(ldiffile=import_ldif,
+                                        suffix=DEFAULT_SUFFIX)
+    import_task.wait()
+    assert import_task.get_exit_code() == 0
+
+    # Start ldclt load
+    ldclt_cmd = [
+        '%s/ldclt' % inst.get_bin_dir(),
+        '-h', inst.host, '-p', str(inst.port),
+        '-f', '(uid=userXXXX)', '-e', 'esearch,random',
+        '-r1', '-R999', '-Q'
+    ]
+    p = subprocess.Popen(ldclt_cmd, start_new_session=True,
+                         stdout=subprocess.PIPE)
+    time.sleep(1)
+
+    # Start online import
+    import_task = ImportTask(topo.standalone)
+    import_task.import_suffix_from_ldif(ldiffile=import_ldif,
+                                        suffix=DEFAULT_SUFFIX)
+
+    # Wait a bit till the task is created and available for searching
+    for x in range(10):
+        if import_task.present('nstaskcreated'):
+            break
+        time.sleep(0.5)
+    assert import_task.present('nstaskcreated')
+
+    # Stop the load
+    time.sleep(3)
+    cmd = ['kill', '-9', str(p.pid)]
+    subprocess.Popen(cmd, stdout=subprocess.PIPE)
+
+    # import should finish
+    import_task.wait()
+    assert import_task.get_exit_code() == 0
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -274,25 +274,11 @@ bdb_ldif2db(Slapi_PBlock *pb)
         slapi_task_log_notice(task,
                 "Backend instance '%s' already in the middle of  another task",
                 inst->inst_name);
-        slapi_log_err(SLAPI_LOG_ERR, "bdb_ldif2db", "ldbm: '%s' is already in the middle of "
-                                                            "another task and cannot be disturbed.\n",
-                      inst->inst_name);
+        slapi_log_err(SLAPI_LOG_ERR, "bdb_ldif2db",
+                "ldbm: '%s' is already in the middle of another task "
+                "and cannot be disturbed.\n",
+                inst->inst_name);
         return -1;
-    } else {
-        uint64_t refcnt;
-        refcnt = slapi_counter_get_value(inst->inst_ref_count);
-        if (refcnt > 0) {
-            slapi_task_log_notice(task,
-                    "Backend instance '%s': there are %" PRIu64 " pending operation(s)."
-                    " Import can not proceed until they are completed.\n",
-                    inst->inst_name, refcnt);
-            slapi_log_err(SLAPI_LOG_ERR, "bdb_ldif2db",
-                    "ldbm: '%s' there are %" PRIu64 " pending operation(s)."
-                     " Import can not proceed until they are completed.\n",
-                    inst->inst_name, refcnt);
-            instance_set_not_busy(inst);
-            return -1;
-        }
     }
 
     if ((task_flags & SLAPI_TASK_RUNNING_FROM_COMMANDLINE)) {
@@ -310,10 +296,27 @@ bdb_ldif2db(Slapi_PBlock *pb)
     /***** prepare & init libdb and dblayer *****/
 
     if (!(task_flags & SLAPI_TASK_RUNNING_FROM_COMMANDLINE)) {
+        uint64_t refcnt;
+
         /* shutdown this instance of the db */
         slapi_log_err(SLAPI_LOG_INFO, "bdb_ldif2db", "Bringing %s offline...\n",
                       instance_name);
         slapi_mtn_be_disable(inst->inst_be);
+
+        /* Wait a little for pending operations to complete */
+        if((refcnt = wait_for_ref_count(inst->inst_ref_count)) != 0 ) {
+            slapi_task_log_notice(task,
+                    "Backend instance '%s': there are %" PRIu64 " pending "
+                    "operation(s). Import can not proceed until they are "
+                    "completed.\n",
+                    inst->inst_name, refcnt);
+            slapi_log_err(SLAPI_LOG_ERR, "bdb_ldif2db",
+                    "ldbm: '%s' there are %" PRIu64 " pending operation(s). "
+                    "Import can not proceed until they are completed.\n",
+                    inst->inst_name, refcnt);
+            instance_set_not_busy(inst);
+            return -1;
+        }
 
         cache_clear(&inst->inst_cache, CACHE_TYPE_ENTRY);
         if (entryrdn_get_switch()) {

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
@@ -136,25 +136,11 @@ dbmdb_ldif2db(Slapi_PBlock *pb)
         slapi_task_log_notice(task,
                 "Backend instance '%s' already in the middle of  another task",
                 inst->inst_name);
-        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_ldif2db", "ldbm: '%s' is already in the middle of "
-                                                            "another task and cannot be disturbed.\n",
-                      inst->inst_name);
+        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_ldif2db",
+                "ldbm: '%s' is already in the middle of another task "
+                "and cannot be disturbed.\n",
+                inst->inst_name);
         return -1;
-    } else {
-        uint64_t refcnt;
-        refcnt = slapi_counter_get_value(inst->inst_ref_count);
-        if (refcnt > 0) {
-            slapi_task_log_notice(task,
-                    "Backend instance '%s': there are %" PRIu64 " pending operation(s)."
-                    " Import can not proceed until they are completed.\n",
-                    inst->inst_name, refcnt);
-            slapi_log_err(SLAPI_LOG_ERR, "dbmdb_ldif2db",
-                    "ldbm: '%s' there are %" PRIu64 " pending operation(s)."
-                     " Import can not proceed until they are completed.\n",
-                    inst->inst_name, refcnt);
-            instance_set_not_busy(inst);
-            return -1;
-        }
     }
 
     if ((task_flags & SLAPI_TASK_RUNNING_FROM_COMMANDLINE)) {
@@ -172,10 +158,27 @@ dbmdb_ldif2db(Slapi_PBlock *pb)
     /***** prepare & init lmdb and dblayer *****/
 
     if (!(task_flags & SLAPI_TASK_RUNNING_FROM_COMMANDLINE)) {
+        uint64_t refcnt = 0;
+
         /* shutdown this instance of the db */
         slapi_log_err(SLAPI_LOG_INFO, "dbmdb_ldif2db", "Bringing %s offline...\n",
                       instance_name);
         slapi_mtn_be_disable(inst->inst_be);
+
+        /* Wait a little for pending operations to complete */
+        if((refcnt = wait_for_ref_count(inst->inst_ref_count)) != 0 ) {
+            slapi_task_log_notice(task,
+                    "Backend instance '%s': there are %" PRIu64 " pending "
+                    "operation(s). Import can not proceed until they are "
+                    "completed.\n",
+                    inst->inst_name, refcnt);
+            slapi_log_err(SLAPI_LOG_ERR, "dbmdb_ldif2db",
+                    "ldbm: '%s' there are %" PRIu64 " pending operation(s). "
+                    "Import can not proceed until they are completed.\n",
+                    inst->inst_name, refcnt);
+            instance_set_not_busy(inst);
+            return -1;
+        }
 
         cache_clear(&inst->inst_cache, CACHE_TYPE_ENTRY);
         if (entryrdn_get_switch()) {
@@ -1134,7 +1137,7 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
         rc = dbmdb_export_one_entry(li, inst, &eargs);
         backentry_free(&ep);
         if (rc && !return_value) {
-            return_value = rc; 
+            return_value = rc;
         }
     }
     /* MDB_NOTFOUND -> successful end */
@@ -1176,7 +1179,7 @@ bye:
         slapi_log_err(SLAPI_LOG_INFO, "dbmdb_export_one_entry", "export %s: Failed to write in export file. errno=%d\n", inst->inst_name, errno);
         return_value = wrc;
     }
-        
+
 
     slapi_log_err(SLAPI_LOG_TRACE, "dbmdb_db2ldif", "<=\n");
 

--- a/ldap/servers/slapd/back-ldbm/import.c
+++ b/ldap/servers/slapd/back-ldbm/import.c
@@ -198,3 +198,31 @@ factory_destructor(void *extension, void *object __attribute__((unused)), void *
     /* extension object is free'd by bdb_import_main */
     return;
 }
+
+/*
+ * Wait 10 seconds for a reference counter to get to zero, otherwise return
+ * the reference count.
+ */
+uint64_t
+wait_for_ref_count(Slapi_Counter *inst_ref_count)
+{
+    uint64_t refcnt = 0;
+    PRBool logged_msg = PR_FALSE;
+
+    for (size_t i = 0; i < 20; i++) {
+        refcnt = slapi_counter_get_value(inst_ref_count);
+        if (refcnt == 0) {
+            return 0;
+        }
+        if(!logged_msg) {
+            slapi_log_err(SLAPI_LOG_INFO, "db2ldif",
+                          "waiting for pending operations to complete ...\n");
+            logged_msg = PR_TRUE;
+        }
+
+        DS_Sleep(PR_MillisecondsToInterval(500));
+    }
+
+    /* Done waiting, return the current ref count */
+    return slapi_counter_get_value(inst_ref_count);
+}

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -606,8 +606,7 @@ int ldbm_back_wire_import(Slapi_PBlock *pb);
 void import_abort_all(struct _ImportJob *job, int wait_for_them);
 void *factory_constructor(void *object __attribute__((unused)), void *parent __attribute__((unused)));
 void factory_destructor(void *extension, void *object __attribute__((unused)), void *parent __attribute__((unused)));
-
-
+uint64_t wait_for_ref_count(Slapi_Counter *inst_ref_count);
 
 /*
  * ldbm_attrcrypt.c


### PR DESCRIPTION
Description:

When the server is under load is can sometimes cause an online import to fail with an error message about "pending operations".

Move this ref count check (pending op check) after the backend is disabled, and retry for a few seconds.  If there are still pending operations then abort the import, otherwise continue.

Fixes: https://github.com/389ds/389-ds-base/issues/6343

