### PR TITLE
Issue 6243 - dsctl bdb2mdb should cleanly fail if bundled libdb is not available

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -17,7 +17,7 @@ from lib389.cli_ctl.dblib import (FakeArgs, dblib_bdb2mdb, dblib_mdb2bdb, dblib_
 from lib389.idm.user import UserAccounts
 from lib389.replica import ReplicationManager
 from lib389.topologies import topology_m2 as topo_m2, topology_st as topo_st
-from lib389.utils import check_installed_packages, check_plugin_symbols
+from lib389.utils import check_plugin_strings
 
 
 log = logging.getLogger(__name__)
@@ -137,14 +137,14 @@ def test_dblib_migration(init_user):
             repl.test_replication_topology([s1, s2])
 
 
-def test_check_installed_packages():
+def test_check_plugin_strings():
     """
-    Check that lib389.utils check_installed_packages is working properly
+    Check that lib389.utils check_plugin_strings is working properly
 
     :id: 5194e88a-80c6-11ef-a2ee-482ae39447e5
     :setup: None
     :steps:
-        1. Call check_installed_packages
+        1. Call check_plugin_strings
         2. Check that an installed rpm is detected
         3. Check that a non installed rpm is not detected
     :expectedresults:
@@ -152,29 +152,7 @@ def test_check_installed_packages():
         2. Success
         3. Success
     """
-    res = check_installed_packages(('389-ds-base', 'Dummyrpm'))
-    log.info(f'check_installed_packages returned {res}')
-    assert res['389-ds-base'] is True
-    assert res['Dummyrpm'] is False
-
-
-def test_check_plugin_symbols():
-    """
-    Check that lib389.utils check_installed_packages is working properly
-
-    :id: 1cb19ebe-80c7-11ef-9516-482ae39447e5
-    :setup: None
-    :steps:
-        1. Call check_plugin_symbols
-        2. Check that an existing symbol is found
-        3. Check that a not existing symbol is not found
-    :expectedresults:
-        1. Success
-        2. Success
-        3. Success
-    """
-    res = check_plugin_symbols('libback-ldbm', ('ldbm_back_search', 'DummySymbol'))
-    log.info(f'check_plugin_symbols returned {res}')
+    res = check_plugin_strings('libback-ldbm', ('ldbm_back_search', 'DummyString'))
+    log.info(f'check_plugin_strings returned {res}')
     assert res['ldbm_back_search'] is True
-    assert res['DummySymbol'] is False
-
+    assert res['DummyString'] is False

--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -17,6 +17,7 @@ from lib389.cli_ctl.dblib import (FakeArgs, dblib_bdb2mdb, dblib_mdb2bdb, dblib_
 from lib389.idm.user import UserAccounts
 from lib389.replica import ReplicationManager
 from lib389.topologies import topology_m2 as topo_m2, topology_st as topo_st
+from lib389.utils import check_installed_packages, check_plugin_symbols
 
 
 log = logging.getLogger(__name__)
@@ -134,3 +135,46 @@ def test_dblib_migration(init_user):
         _check_db(s1, log, 'mdb')
         if s2 is not None:
             repl.test_replication_topology([s1, s2])
+
+
+def test_check_installed_packages():
+    """
+    Check that lib389.utils check_installed_packages is working properly
+
+    :id: 5194e88a-80c6-11ef-a2ee-482ae39447e5
+    :setup: None
+    :steps:
+        1. Call check_installed_packages
+        2. Check that an installed rpm is detected
+        3. Check that a non installed rpm is not detected
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    res = check_installed_packages(('389-ds-base', 'Dummyrpm'))
+    log.info(f'check_installed_packages returned {res}')
+    assert res['389-ds-base'] is True
+    assert res['Dummyrpm'] is False
+
+
+def test_check_plugin_symbols():
+    """
+    Check that lib389.utils check_installed_packages is working properly
+
+    :id: 1cb19ebe-80c7-11ef-9516-482ae39447e5
+    :setup: None
+    :steps:
+        1. Call check_plugin_symbols
+        2. Check that an existing symbol is found
+        3. Check that a not existing symbol is not found
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    res = check_plugin_symbols('libback-ldbm', ('ldbm_back_search', 'DummySymbol'))
+    log.info(f'check_plugin_symbols returned {res}')
+    assert res['ldbm_back_search'] is True
+    assert res['DummySymbol'] is False
+

--- a/dirsrvtests/tests/suites/tls/tls_cert_namespace_test.py
+++ b/dirsrvtests/tests/suites/tls/tls_cert_namespace_test.py
@@ -10,7 +10,7 @@ import time
 import subprocess
 import pytest
 
-from glob import glob
+import glob
 from lib389.utils import *
 from lib389.topologies import topology_st
 from lib389.paths import Paths
@@ -60,7 +60,7 @@ def test_pem_cert_in_private_namespace(topology_st):
     assert PRIVATE_TMP in ensure_str(result)
 
     log.info('Check files in private /tmp')
-    cert_path = glob('/tmp/systemd-private-*-dirsrv@{}.service-*/tmp/slapd-{}/'.format(standalone.serverid,
+    cert_path = glob.glob('/tmp/systemd-private-*-dirsrv@{}.service-*/tmp/slapd-{}/'.format(standalone.serverid,
                                                                                        standalone.serverid))
     assert os.path.exists(cert_path[0])
     for item in PEM_CHECK:
@@ -105,9 +105,9 @@ def test_cert_category_authority(topology_st):
 
     log.info('Get certificate path')
     if ds_is_older('1.4.3'):
-        cert_path = glob('/etc/dirsrv/slapd-{}/'.format(standalone.serverid))
+        cert_path = glob.glob('/etc/dirsrv/slapd-{}/'.format(standalone.serverid))
     else:
-        cert_path = glob('/tmp/systemd-private-*-dirsrv@{}.service-*/tmp/slapd-{}/'.format(standalone.serverid,
+        cert_path = glob.glob('/tmp/systemd-private-*-dirsrv@{}.service-*/tmp/slapd-{}/'.format(standalone.serverid,
                                                                                            standalone.serverid))
     log.info('Check that {} is present'.format(PEM_FILE))
     signed_cert = cert_path[0] + PEM_FILE

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -379,7 +379,7 @@ CONTAINER_TLS_PWDFILE = '/data/config/pwdfile.txt'
 # Describe what kind of Berkeley Database library is available
 BDB_IMPL_STATUS = Enum('BDB_IMPL_STATUS', [
                        'UNKNOWN',   # Unable to discover
-                       'RPM',       # os libdb rpm is installed
+                       'STANDARD',  # os libdb rpm is installed
                        'BUNDLED',   # lib389 bundled rpm is installed
                        'READ_ONLY', # Read-only version is available
                        'NONE' ])    # bdb is not usasable

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -375,3 +375,11 @@ CONTAINER_TLS_SERVER_KEY = '/data/tls/server.key'
 CONTAINER_TLS_SERVER_CERT = '/data/tls/server.crt'
 CONTAINER_TLS_SERVER_CADIR = '/data/tls/ca'
 CONTAINER_TLS_PWDFILE = '/data/config/pwdfile.txt'
+
+# Describe what kind of Berkeley Database library is available
+BDB_IMPL_STATUS = Enum('BDB_IMPL_STATUS', [
+                       'UNKNOWN',   # Unable to discover
+                       'RPM',       # os libdb rpm is installed
+                       'BUNDLED',   # lib389 bundled rpm is installed
+                       'READ_ONLY', # Read-only version is available
+                       'NONE' ])    # bdb is not usasable

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -51,7 +51,7 @@ class FakeArgs(dict):
 
 def get_bdb_impl_status():
     backldbm = 'libback-ldbm'
-    bundledbdb_plugin = 'libback-bdb'
+    bundledbdb_plugin = 'libback-ldbm'
     robdb_symbol = 'bdbro_getcb_vector'
     libdb = 'libdb-'
     plgstrs = check_plugin_strings(backldbm, [bundledbdb_plugin, robdb_symbol, libdb])

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -65,7 +65,7 @@ def get_bdb_impl_status():
         return BDB_IMPL_STATUS.READ_ONLY
     if plgstrs[libdb] is True:
         # standard bdb package build
-        return BDB_IMPL_STATUS.STABDARD
+        return BDB_IMPL_STATUS.STANDARD
     # Unable to find libback-ldbm plugin
     return BDB_IMPL_STATUS.UNKNOWN
 

--- a/src/lib389/lib389/dirsrv_log.py
+++ b/src/lib389/lib389/dirsrv_log.py
@@ -11,10 +11,10 @@
 
 import copy
 import json
+import glob
 import re
 import gzip
 from dateutil.parser import parse as dt_parse
-from glob import glob
 from lib389.utils import ensure_bytes
 from lib389._mapped_object_lint import DSLint
 from lib389.lint import (
@@ -60,7 +60,7 @@ class DirsrvLog(DSLint):
 
     def _get_all_log_paths(self):
         """Return all the log paths"""
-        return glob("%s.*-*" % self._get_log_path()) + [self._get_log_path()]
+        return glob.glob("%s.*-*" % self._get_log_path()) + [self._get_log_path()]
 
     def readlines_archive(self):
         """

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -31,6 +31,7 @@ import glob
 import logging
 import shutil
 import ldap
+import mmap
 import socket
 import time
 import stat
@@ -189,6 +190,7 @@ SIZE_UNITS = { 't': 2**40, 'g': 2**30, 'm': 2**20, 'k': 2**10, '': 1, }
 SIZE_PATTERN = r'\s*(\d*\.?\d*)\s*([tgmk]?)b?\s*'
 
 RPM_TOOL = '/usr/bin/rpm'
+LDD_TOOL = '/usr/bin/ldd'
 OBJDUMP_TOOL = '/usr/bin/objdump'
 
 #
@@ -1763,7 +1765,7 @@ def get_default_mdb_max_size(paths):
     # otherwise decrease the value
     dbdir = paths.db_dir
     # dbdir may not exists because:
-    #  - paths instance name has not been expanded 
+    #  - paths instance name has not been expanded
     #  - dscreate has not yet created it.
     # so let use the first existing parent in that case.
     while not os.path.exists(dbdir):
@@ -1990,38 +1992,24 @@ def get_passwd_from_file(passwd_file):
     raise ValueError(f"The password file '{passwd_file}' does not exist, or can not be read.")
 
 
-def check_installed_packages(tested_packages):
-    """
-    Returns a dict mapping each tested rpm package to True, False or None
-    """
-    try:
-        from rpm import TransactionSet
-        ts = TransactionSet()
-        pkgs = { pkgname:(len ([ pkg for pkg in ts.dbMatch( 'name', \
-                 pkgname ) ]) > 0) for pkgname in tested_packages}
-        ts.closeDB()
-        return pkgs
-    except ImportError:
-        if os.path.isfile(RPM_TOOL):
-            pkgs = { pkgname:( subprocess.run([RPM_TOOL, '-q', pkgname], \
-                     stdin=subprocess.DEVNULL,stderr=subprocess.DEVNULL \
-                     ).returncode  == 0 ) for pkgname in tested_packages }
-        else:
-            pkgs = { pkg:None for pkg in tested_packages}
-    return pkgs
-
-
-def check_plugin_symbols(plugin_name, tested_symbols):
-    """
-    Returns a dict mapping each tested symbol to True, False or None
-    """
+def find_plugin_path(plugin_name):
     p = Paths()
     plugin = None
     for ppath in glob.glob(f'{p.plugin_dir}/{plugin_name}.*'):
-        plugin = ppath
-    if plugin and os.path.isfile(OBJDUMP_TOOL):
-        rc = subprocess.run(['objdump', '-R', plugin], text=True, capture_output=True)
-        return { symb: symb in rc.stdout for symb in tested_symbols }
-    else:
-        return { symb: None for symb in tested_symbols }
+        if not ppath.endswith('.la'):
+            plugin = ppath
+    return plugin
+
+
+def check_plugin_strings(plugin_name, tested_strings):
+    """
+    Returns a dict mapping each tested symbol to True, False or None
+    """
+    plugin = find_plugin_path(plugin_name)
+    if plugin:
+        # Otherwise looks directly for the string in the plugin
+        with open(plugin, "rb") as f:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                return { astring:(mm.find(astring.encode()) >=0) for astring in tested_strings }
+    return { astring:None for astring in tested_strings }
 


### PR DESCRIPTION
Determine what kind of Berkeley Database library is available
 and display a clear error message if it is not available or not usable 

Issue: #6243 

Reviewed by: @tbordaz , @vashirov , @droideck (Thanks!)