### PR TITLE
Issue 6339 - Address Coverity scan issues in memberof and bdb_layer

### DIFF
--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -884,6 +884,11 @@ perform_needed_fixup()
     memberof_rlock_config();
     memberof_copy_config(&config, memberof_get_config());
     memberof_unlock_config();
+    if (config.memberof_attr == NULL) {
+        slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
+                      "Failed to perform memberof fixup task: The memberof attribute is not configured.\n");
+        return -1;
+    }
     slapi_log_err(SLAPI_LOG_INFO, MEMBEROF_PLUGIN_SUBSYSTEM,
                   "Memberof plugin started the global fixup task for attribute %s\n", config.memberof_attr);
     /* Compute the filter for entries that may contains the attribute */
@@ -922,6 +927,7 @@ perform_needed_fixup()
         }
         be = slapi_get_next_backend(cookie);
     }
+    slapi_ch_free_string(&cookie);
     slapi_ch_free_string(&td.bind_dn);
     slapi_ch_free_string(&td.filter_str);
     slapi_log_err(SLAPI_LOG_INFO, MEMBEROF_PLUGIN_SUBSYSTEM,

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6899,6 +6899,7 @@ bdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_t 
     bdb_config *conf = (bdb_config *)li->li_dblayer_config;
     bdb_db_env **ppEnv = (bdb_db_env**)&priv->dblayer_env;
     char dbhome[MAXPATHLEN];
+    bdb_db_env *pEnv = NULL;
     DB_ENV *bdb_env = NULL;
     DB *bdb_db = NULL;
     struct stat st = {0};
@@ -6948,7 +6949,13 @@ bdb_public_private_open(backend *be, const char *db_filename, int rw, dbi_env_t 
         conf->bdb_tx_max = 50;
         rc = bdb_start(li, DBLAYER_NORMAL_MODE);
         if (rc == 0) {
-            bdb_env = ((struct bdb_db_env*)(priv->dblayer_env))->bdb_DB_ENV;
+            pEnv = (bdb_db_env *)priv->dblayer_env;
+            if (pEnv == NULL) {
+                fprintf(stderr, "bdb_public_private_open: dbenv is not available (0x%p) for database %s\n",
+                        (void *)pEnv, db_filename ? db_filename : "unknown");
+                return EINVAL;
+            }
+            bdb_env = pEnv->bdb_DB_ENV;
         }
     } else {
         /* Setup minimal environment */
@@ -6992,9 +6999,11 @@ bdb_public_private_close(struct ldbminfo *li, dbi_env_t **env, dbi_db_t **db)
     if (priv) {
         /* Detect if db is fully set up in read write mode */
         bdb_db_env *pEnv = (bdb_db_env *)priv->dblayer_env;
+        pthread_mutex_lock(&pEnv->bdb_thread_count_lock);
         if (pEnv && pEnv->bdb_thread_count>0) {
             rw = 1;
         }
+        pthread_mutex_unlock(&pEnv->bdb_thread_count_lock);
     }
     if (rw == 0) {
         if (bdb_db) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -6999,11 +6999,13 @@ bdb_public_private_close(struct ldbminfo *li, dbi_env_t **env, dbi_db_t **db)
     if (priv) {
         /* Detect if db is fully set up in read write mode */
         bdb_db_env *pEnv = (bdb_db_env *)priv->dblayer_env;
-        pthread_mutex_lock(&pEnv->bdb_thread_count_lock);
-        if (pEnv && pEnv->bdb_thread_count>0) {
-            rw = 1;
+        if (pEnv) {
+            pthread_mutex_lock(&pEnv->bdb_thread_count_lock);
+            if (pEnv->bdb_thread_count > 0) {
+                rw = 1;
+            }
+            pthread_mutex_unlock(&pEnv->bdb_thread_count_lock);
         }
-        pthread_mutex_unlock(&pEnv->bdb_thread_count_lock);
     }
     if (rw == 0) {
         if (bdb_db) {


### PR DESCRIPTION
Description: Add null check for memberof attribute in memberof.c
Fix memory leak by freeing 'cookie' in memberof.c
Add null check for database environment in bdb_layer.c
Fix race condition by adding mutex lock/unlock in bdb_layer.c

Fixes: https://github.com/389ds/389-ds-base/issues/6339

Reviewed by: ?