### PR TITLE
Issue 6328 - vlv control may not be logged

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.c
@@ -185,6 +185,7 @@ static flagsdesc_t mdb_loglvl_desc[] = {
     { "TXN", DBGMDB_LEVEL_TXN },
     { "IMPORT", DBGMDB_LEVEL_IMPORT },
     { "BULKOP", DBGMDB_LEVEL_BULKOP },
+    { "VLV", DBGMDB_LEVEL_VLV },
     { "DBGMDB", DBGMDB_LEVEL_OTHER },
     { 0 }
 };

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_debug.h
@@ -10,12 +10,13 @@
 void dbmdb_format_dbslist_info(char *info, dbmdb_dbi_t *dbi);
 
 #define DBGMDB_LEVEL_MDBAPI 1
-#define DBGMDB_LEVEL_TXN 2
+#define DBGMDB_LEVEL_TXN    2
 #define DBGMDB_LEVEL_IMPORT 4
 #define DBGMDB_LEVEL_BULKOP 8
-#define DBGMDB_LEVEL_OTHER 0x20
-#define DBGMDB_LEVEL_REPL 0x1000
-#define DBGMDB_LEVEL_FORCE 0x10000
+#define DBGMDB_LEVEL_VLV    0x10
+#define DBGMDB_LEVEL_OTHER  0x20
+#define DBGMDB_LEVEL_REPL   0x1000
+#define DBGMDB_LEVEL_FORCE  0x10000
 
 #define DBGMDB_LEVEL_PRINTABLE 0xfff
 
@@ -26,7 +27,8 @@ void dbgval2str(char *buff, size_t bufsiz, MDB_val *val);
 void dbmdb_dbg_set_dbi_slots(dbmdb_dbi_t *slots);
 
 /* #define DBMDB_DEBUG 1 */
-#define DBGMDB_LEVEL_DEFAULT DBGMDB_LEVEL_MDBAPI+DBGMDB_LEVEL_TXN+DBGMDB_LEVEL_IMPORT+DBGMDB_LEVEL_BULKOP+DBGMDB_LEVEL_OTHER
+#define DBGMDB_LEVEL_DEFAULT DBGMDB_LEVEL_MDBAPI+DBGMDB_LEVEL_TXN+DBGMDB_LEVEL_IMPORT+ \
+                             DBGMDB_LEVEL_BULKOP+DBGMDB_LEVEL_OTHER+DBGMDB_LEVEL_VLV
 
 /* Define the wrapper associated with each log level */
 #ifdef DBMDB_DEBUG
@@ -51,6 +53,8 @@ void dbmdb_dbg_set_dbi_slots(dbmdb_dbi_t *slots);
 #define TXN_RENEW(txn) dbg_txn_renew(__FILE__,__LINE__,__FUNCTION__, txn)
 #define TXN_LOG(msg,txn) dbg_log(__FILE__,__LINE__,__FUNCTION__,DBGMDB_LEVEL_TXN, msg, (ulong)(txn))
 #define pthread_gettid() syscall(__NR_gettid)
+
+#define DBG_LOG(...) dbg_log(__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__)
 
 
 int dbg_mdb_cursor_open(const char *file, int lineno, const char *funcname, MDB_txn *txn, MDB_dbi dbi, MDB_cursor **cursor);
@@ -97,5 +101,7 @@ void dbmdb_log_dbi_set_fn(const char *file, int lineno, const char *funcname, co
 #define TXN_RENEW(txn) mdb_txn_renew(txn)
 #define TXN_LOG(msg,txn)
 #define pthread_gettid() 0
+
+#define DBG_LOG(...)
 
 #endif /* DBMDB_DEBUG */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2384,6 +2384,7 @@ int dbmdb_cursor_set_recno(dbi_cursor_t *cursor, MDB_val *dbmdb_key, MDB_val *db
         rc = MDB_CURSOR_GET(cursor->cur, &rce->key, &rce->data, MDB_SET_RANGE);
     }
     while (rc == 0 && recno > rce->recno) {
+        DBG_LOG(DBGMDB_LEVEL_VLV, "Current record index is %d Target is %d\n", rce->recno, recno);
         rce->recno++;
         rc = MDB_CURSOR_GET(cursor->cur, &rce->key, &rce->data, MDB_NEXT);
     }
@@ -2393,7 +2394,10 @@ int dbmdb_cursor_set_recno(dbi_cursor_t *cursor, MDB_val *dbmdb_key, MDB_val *db
     }
     if (rc == 0 && dbmdb_data->mv_size == rce->data.mv_size) {
         /* Should always be the case */
+        DBG_LOG(DBGMDB_LEVEL_VLV, "SUCCESS\n");
         memcpy(dbmdb_data->mv_data , rce->data.mv_data, dbmdb_data->mv_size);
+    } else {
+        DBG_LOG(DBGMDB_LEVEL_VLV, "FAILURE: rc=%d dbmdb_data->mv_size=%d rce->data.mv_size=%d\n", rc, dbmdb_data->mv_size, rce->data.mv_size);
     }
 
     slapi_ch_free((void**)&rce);

--- a/src/lib389/lib389/dirsrv_log.py
+++ b/src/lib389/lib389/dirsrv_log.py
@@ -117,19 +117,31 @@ class DirsrvLog(DSLint):
                             results.append(line)
         return results
 
-    def match(self, pattern):
+    def match(self, pattern, after_pattern=None):
         """Search the current log file for the pattern
         @param pattern - a regex pattern
+        @param after_pattern - None or a regex pattern
+               if set only matches found seeing last occurance
+               of after_pattern are returned
         @return - results of the pattern matching
         """
         results = []
         prog = re.compile(pattern)
+        if after_pattern:
+            aprog = re.compile(after_pattern)
+            aprog_hit = False
+        else:
+            aprog_hit = True
         self.lpath = self._get_log_path()
         if self.lpath is not None:
             with open(self.lpath, 'r') as lf:
                 for line in lf:
+                    if after_pattern is not None:
+                        if aprog.match(line):
+                            aprog_hit = True
+                            results.clear()
                     mres = prog.match(line)
-                    if mres:
+                    if aprog_hit and mres:
                         results.append(line)
         return results
 


### PR DESCRIPTION
VLV control is logged only after succesfully sending the VLV response control 
which means that VLV is not visible if the search fail which make troubleshooting harder.
This fix, logs the VLV (with None as vlv result) everytime a VLV is used

This fix also improve lmdb debug log about VLVs

Issue: #6328 

Reviewed by: @tbordaz, @droideck  (Thanks!) 