### PR TITLE
Issue 6349 - RFE - Use previously extracted key path

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -1161,6 +1161,7 @@ cleanup:
     compute_terminate();
     SSL_ShutdownServerSessionIDCache();
     SSL_ClearSessionCache();
+    slapd_ssl_destroy();
     ndn_cache_destroy();
     NSS_Shutdown();
     dse_destroy_backup_lock();

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1164,6 +1164,7 @@ void do_search(Slapi_PBlock *pb);
 char *check_private_certdir(void);
 int slapd_nss_init(int init_ssl, int config_available);
 int slapd_ssl_init(void);
+void slapd_ssl_destroy(void);
 int slapd_ssl_init2(PRFileDesc **fd, int startTLS);
 int slapd_security_library_is_initialized(void);
 int slapd_ssl_listener_is_initialized(void);


### PR DESCRIPTION
Bug Description: slapd_SSL_client_auth uses the values of KeyExtractFile and CertExtractFile from the configuration entry, and each time it's called attempts to determine if this is an absolute or relative path. If the path is relative, it prepends a /tmp location based on if the running system /tmp is a private namespace or not. This causes a replication client that uses TLS certificate authentication to repeatedly emit warnings that the key extraction occurred to non-private tmp in a
container.

Fix Description: During key extraction, we extract keys and files using the "last token" from nss as the item that we extract. Because of this, we know that there can only be a single extracted key and cert, allowing us to extract these and store the full abs path of the extracted files rather than deriving them during each client iteration.

fixes: https://github.com/389ds/389-ds-base/issues/6340

Author: William Brown <william@blackhats.net.au>

Review by: ???