### PR TITLE
Issue 4596 - Build with clang/lld fails when LTO enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,6 @@ NQBUILDNUM := $(subst \,,$(subst $(QUOTE),,$(BUILDNUM)))
 DEBUG_DEFINES = @debug_defs@
 DEBUG_CFLAGS = @debug_cflags@
 DEBUG_CXXFLAGS = @debug_cxxflags@
-GCCSEC_CFLAGS = @gccsec_cflags@
 if CLANG_ENABLE
 ASAN_CFLAGS = @asan_cflags@
 else
@@ -32,6 +31,7 @@ ASAN_CFLAGS = @asan_cflags@ -lasan
 else
 ASAN_CFLAGS = @asan_cflags@
 endif
+GCCSEC_CFLAGS = @gccsec_cflags@
 endif
 MSAN_CFLAGS = @msan_cflags@
 TSAN_CFLAGS = @tsan_cflags@
@@ -77,7 +77,7 @@ endif
 
 if CLANG_ENABLE
 CLANG_ON = 1
-CLANG_LDFLAGS = -latomic -fuse-ld=lld
+CLANG_LDFLAGS = -latomic -fuse-ld=lld -Wl,--build-id=sha1
 EXPORT_LDFLAGS =
 else
 CLANG_ON = 0

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,11 +60,11 @@ CARGO_FLAGS = @cargo_defs@
 
 if CLANG_ENABLE
 RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@
-RUSTC_LINK_FLAGS = -C link-arg=-fuse-ld=lld
+RUSTC_LINK_FLAGS = -Clink-arg=-fuse-ld=lld
 RUST_LDFLAGS = -ldl -lpthread -lc -lm -lrt -lutil
 else
 RUSTC_FLAGS = @asan_rust_defs@ @msan_rust_defs@ @tsan_rust_defs@ @debug_rust_defs@
-RUSTC_LINK_FLAGS =
+RUSTC_LINK_FLAGS = -Clink-arg=-fuse-ld=ld
 # This avoids issues with stderr being double provided with clang + asan.
 RUST_LDFLAGS = -ldl -lpthread -lgcc_s -lc -lm -lrt -lutil
 endif
@@ -81,7 +81,7 @@ CLANG_LDFLAGS = -latomic -fuse-ld=lld
 EXPORT_LDFLAGS =
 else
 CLANG_ON = 0
-CLANG_LDFLAGS =
+CLANG_LDFLAGS = -flto
 if DEBUG
 EXPORT_LDFLAGS = -rdynamic
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -124,8 +124,8 @@ AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug], [Enable debug features (de
 AC_MSG_RESULT($enable_debug)
 if test "$enable_debug" = yes ; then
   debug_defs="-DDEBUG -DMCC_DEBUG"
-  debug_cflags="-g3 -ggdb -gdwarf-5  -O0"
-  debug_cxxflags="-g3 -ggdb -gdwarf-5  -O0"
+  debug_cflags="-g3 -ggdb -gdwarf-4 -O0"
+  debug_cxxflags="-g3 -ggdb -gdwarf-4 -O0"
   debug_rust_defs="-C debuginfo=2 -Z macro-backtrace"
   cargo_defs=""
   rust_target_dir="debug"
@@ -252,7 +252,7 @@ AC_ARG_ENABLE(profiling, AS_HELP_STRING([--enable-profiling], [Enable gcov profi
               [], [ enable_profiling=no ])
 AC_MSG_RESULT($enable_profiling)
 if test "$enable_profiling" = yes ; then
-  profiling_defs="-fprofile-arcs -ftest-coverage -g3 -ggdb -gdwarf-5  -O0"
+  profiling_defs="-fprofile-arcs -ftest-coverage -g3 -ggdb -gdwarf-4  -O0"
   profiling_links="-lgcov --coverage"
 else
   profiling_defs=""

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -43,7 +43,7 @@
 
 %if %{with clang}
 %global toolchain clang
-%global _missing_build_ids_terminate_build 0
+%global _lto_cflags %nil
 %endif
 
 # Build cockpit plugin


### PR DESCRIPTION
Issue 4596 - Build with clang/lld fails when LTO enabled

Bug Description:
Build with clang/lld fails with undefined reference error.
```
ld.lld: error: ./.libs/libslapd.so: undefined reference to __rust_probestack [--no-allow-shlib-undefined]
ld.lld: error: ./.libs/libslapd.so: undefined reference to __muloti4 [--no-allow-shlib-undefined]
```
 
Fix Description:
* Disabled GCC security flags when building with clang.
* lld by default uses xxhash for build ids, which is too small for rpm
(it requires it between 16 and 64 bytes in size), use sha1 instead.
* Switch debug CFLAGS and LDFLAGS to use DWARF4 instead of DWARF5.
* Disable LTO for clang rpm build.
 
Fixes: https://github.com/389ds/389-ds-base/issues/4596
 
Reviewed by: ???
