### PR TITLE
Issue 6340 - RFE - extract keys once (#6394)

### DIFF
--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1325,7 +1325,8 @@ slapd_ssl_init()
                 slapi_ch_free((void **)&token);
                 return -1;
             }
-            if (config_get_extract_pem()) {
+            /* Only extract the keys/cert *once* */
+            if (config_get_extract_pem() && _security_library_initialized == 0) {
                 /* Get Server{Key,Cert}ExtractFile from cn=Cipher,cn=encryption entry if any. */
                 slapd_extract_cert(entry, PR_FALSE);
                 slapd_extract_key(entry, isinternal ? internalTokenName : token, slot);
@@ -2195,7 +2196,7 @@ slapd_SSL_client_auth(LDAP *ld)
                            "(no password). (" SLAPI_COMPONENT_NAME_NSPR " error %d - %s)",
                            errorCode, slapd_pr_strerror(errorCode));
         } else {
-            if (slapi_client_uses_non_nss(ld)  && key_extract_file && cert_extract_file) {
+            if (slapi_client_uses_non_nss(ld)  && key_extract_file != NULL && cert_extract_file != NULL) {
                 char *keyfile = slapi_ch_strdup(key_extract_file);
                 char *certfile = slapi_ch_strdup(cert_extract_file);
                 /* If a private tmp namespace exists


### PR DESCRIPTION
Bug Description: Keys/Certs are extracted to PEM
repeatedly causing many warnings during outbound TLS authenticated replication

Fix Description: slapd_ssl_init() is called every time an outbound TLS connection is made, and will trigger a key extraction. If key extraction is already complete then the extraction is skipped.

fixes: https://github.com/389ds/389-ds-base/issues/6340

Author: William Brown <william@blackhats.net.au>

Review by: ???