### PR TITLE
Issue 6397 - Remove deprecated setting for HR time stamps in logs

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -146,8 +146,7 @@ def test_healthcheck_list_checks(topology_st):
         3. Success
     """
 
-    output_list = ['config:hr_timestamp',
-                   'config:passwordscheme',
+    output_list = ['config:passwordscheme',
                    'backends:userroot:cl_trimming',
                    'backends:userroot:mappingtree',
                    'backends:userroot:search',
@@ -194,7 +193,6 @@ def test_healthcheck_list_errors(topology_st):
                    'DSBLE0006 :: BDB is still used as a backend',
                    'DSCERTLE0001 :: Certificate about to expire',
                    'DSCERTLE0002 :: Certificate expired',
-                   'DSCLE0001 :: Different log timestamp format',
                    'DSCLE0002 :: Weak passwordStorageScheme',
                    'DSCLE0003 :: Unauthorized Binds Allowed',
                    'DSCLE0004 :: Access Log buffering disabled',
@@ -240,8 +238,7 @@ def test_healthcheck_check_option(topology_st):
         3. Success
     """
 
-    output_list = ['config:hr_timestamp',
-                   'config:passwordscheme',
+    output_list = ['config:passwordscheme',
                    # 'config:accesslog_buffering',  Skip test access log buffering is disabled
                    'config:securitylog_buffering',
                    'config:unauth_binds',

--- a/dirsrvtests/tests/suites/replication/wait_for_async_feature_test.py
+++ b/dirsrvtests/tests/suites/replication/wait_for_async_feature_test.py
@@ -157,15 +157,13 @@ def test_behavior_with_value(topology_m2, waitfor_async_attr, entries):
         None, '2000', '0', '-5'
     :steps:
         1. Set Replication Debugging loglevel for the errorlog
-        2. Set nsslapd-logging-hr-timestamps-enabled to 'off' on both suppliers
-        3. Gather all sync attempts,  group by timestamp
-        4. Take the most common timestamp and assert it has appeared
+        2. Gather all sync attempts,  group by timestamp
+        3. Take the most common timestamp and assert it has appeared
            in the set range
     :expectedresults:
         1. Replication Debugging loglevel should be set
-        2. nsslapd-logging-hr-timestamps-enabled  should be set
-        3. Operation should be successful
-        4. Errors log should have all timestamp appear
+        2. Operation should be successful
+        3. Errors log should have all timestamp appear
     """
 
     supplier1 = topology_m2.ms["supplier1"]

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -868,8 +868,8 @@ bail:
 }
 
 /* Perform fixup (similar as fixup task) on all backends */
-int
-perform_needed_fixup()
+static int
+perform_needed_fixup(void)
 {
     task_data td = {0};
     MemberOfConfig config = {0};
@@ -1354,13 +1354,11 @@ memberof_postop_del(Slapi_PBlock *pb)
         struct slapi_entry *e = NULL;
         Slapi_DN *copied_sdn;
         PRBool deferred_update;
-        MemberofDeferredList* deferred_list;
 
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
         deferred_update = mainConfig->deferred_update;
-        deferred_list = mainConfig->deferred_list;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -1740,13 +1738,11 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
         Slapi_DN *origin_sdn;
         Slapi_DN *copied_sdn;
         PRBool deferred_update;
-        MemberofDeferredList* deferred_list;
 
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
         deferred_update = mainConfig->deferred_update;
-        deferred_list = mainConfig->deferred_list;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2060,13 +2056,11 @@ memberof_postop_modify(Slapi_PBlock *pb)
         MemberOfConfig *mainConfig = 0;
         MemberOfConfig configCopy = {0};
         PRBool deferred_update;
-        MemberofDeferredList* deferred_list;
 
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
         deferred_update = mainConfig->deferred_update;
-        deferred_list = mainConfig->deferred_list;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2322,13 +2316,11 @@ memberof_postop_add(Slapi_PBlock *pb)
         MemberOfConfig *mainConfig;
         Slapi_DN *copied_sdn;
         PRBool deferred_update;
-        MemberofDeferredList* deferred_list;
 
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
         deferred_update = mainConfig->deferred_update;
-        deferred_list = mainConfig->deferred_list;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2972,7 +2964,7 @@ memberof_mod_attr_list_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod, Slap
 
     op_this_val = slapi_value_new_string(slapi_sdn_get_ndn(op_this_sdn));
     slapi_value_set_flags(op_this_val, SLAPI_ATTR_FLAG_NORMALIZED_CIS);
-    /* For gcc -analyser: ignore false positive about dn_str 
+    /* For gcc -analyser: ignore false positive about dn_str
      * (last_str cannot be NULL if last_size > bv->bv_len)
      */
 #pragma GCC diagnostic push
@@ -4176,14 +4168,14 @@ static memberof_cached_value *
 ancestors_cache_lookup(MemberOfConfig *config, const char *ndn)
 {
     memberof_cached_value *e;
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     long int start;
     struct timespec tsnow;
 #endif
 
     cache_stat.total_lookup++;
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
         start = 0;
     } else {
@@ -4193,7 +4185,7 @@ ancestors_cache_lookup(MemberOfConfig *config, const char *ndn)
 
     e = (memberof_cached_value *) PL_HashTableLookupConst(config->ancestors_cache, (const void *) ndn);
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (start) {
         if (clock_gettime(CLOCK_REALTIME, &tsnow) == 0) {
             cache_stat.cumul_duration_lookup += (tsnow.tv_nsec - start);
@@ -4209,14 +4201,14 @@ static PRBool
 ancestors_cache_remove(MemberOfConfig *config, const char *ndn)
 {
     PRBool rc;
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     long int start;
     struct timespec tsnow;
 #endif
 
     cache_stat.total_remove++;
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
         start = 0;
     } else {
@@ -4227,7 +4219,7 @@ ancestors_cache_remove(MemberOfConfig *config, const char *ndn)
 
     rc = PL_HashTableRemove(config->ancestors_cache, (const void *)ndn);
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (start) {
         if (clock_gettime(CLOCK_REALTIME, &tsnow) == 0) {
             cache_stat.cumul_duration_remove += (tsnow.tv_nsec - start);
@@ -4241,13 +4233,13 @@ static PLHashEntry *
 ancestors_cache_add(MemberOfConfig *config, const void *key, void *value)
 {
     PLHashEntry *e;
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     long int start;
     struct timespec tsnow;
 #endif
     cache_stat.total_add++;
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
         start = 0;
     } else {
@@ -4257,7 +4249,7 @@ ancestors_cache_add(MemberOfConfig *config, const void *key, void *value)
 
     e = PL_HashTableAdd(config->ancestors_cache, key, value);
 
-#if defined(DEBUG) && defined(HAVE_CLOCK_GETTIME)
+#if defined(DEBUG)
     if (start) {
         if (clock_gettime(CLOCK_REALTIME, &tsnow) == 0) {
             cache_stat.cumul_duration_add += (tsnow.tv_nsec - start);

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -1477,20 +1477,14 @@ vlv_filter_candidates(backend *be, Slapi_PBlock *pb, const IDList *candidates, c
 
             /* Check to see if our journey is really necessary */
             if (counter++ % 10 == 0) {
-/* check time limit */
-#ifdef HAVE_CLOCK_GETTIME
+                /* check time limit */
                 if (slapi_timespec_expire_check(expire_time) == TIMER_EXPIRED) {
-                    slapi_log_err(SLAPI_LOG_TRACE, "vlv_filter_candidates", "LDAP_TIMELIMIT_EXCEEDED\n");
+                    slapi_log_err(SLAPI_LOG_TRACE, "vlv_filter_candidates",
+                                  "LDAP_TIMELIMIT_EXCEEDED\n");
                     return_value = LDAP_TIMELIMIT_EXCEEDED;
                     done = 1;
                 }
-#else
-                time_t curtime = current_time();
-                if (time_up != -1 && curtime > time_up) {
-                    return_value = LDAP_TIMELIMIT_EXCEEDED;
-                    done = 1;
-                }
-#endif
+
                 /* check lookthrough limit */
                 if (lookthrough_limit != -1 && lookedat > lookthrough_limit) {
                     return_value = LDAP_ADMINLIMIT_EXCEEDED;
@@ -1875,7 +1869,7 @@ vlv_print_access_log(Slapi_PBlock *pb, struct vlv_request *vlvi, struct vlv_resp
     } else {
         char fmt[18+NUMLEN];
         char *msg = NULL;
-        PR_snprintf(fmt, (sizeof fmt), "VLV %%d:%%d:%%.%ds %%s", vlvi->value.bv_len);
+        PR_snprintf(fmt, (sizeof fmt), "VLV %%d:%%d:%%.%lds %%s", vlvi->value.bv_len);
         msg = slapi_ch_smprintf(fmt,
                                 vlvi->beforeCount,
                                 vlvi->afterCount,

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -197,7 +197,6 @@ slapi_onoff_t init_auditlogbuffering;
 slapi_onoff_t init_auditlog_logging_hide_unhashed_pw;
 slapi_onoff_t init_auditfaillog_logging_enabled;
 slapi_onoff_t init_auditfaillog_logging_hide_unhashed_pw;
-slapi_onoff_t init_logging_hr_timestamps;
 slapi_onoff_t init_csnlogging;
 slapi_onoff_t init_pw_unlock;
 slapi_onoff_t init_pw_must_change;
@@ -1389,13 +1388,6 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.securitylog,
      CONFIG_STRING_OR_EMPTY, NULL, "", NULL /* prevents deletion when null */},
-/* warning: initialization makes pointer from integer without a cast [enabled by default]. Why do we get this? */
-#ifdef HAVE_CLOCK_GETTIME
-    {CONFIG_LOGGING_HR_TIMESTAMPS, config_set_logging_hr_timestamps,
-     NULL, 0,
-     (void **)&global_slapdFrontendConfig.logging_hr_timestamps,
-     CONFIG_ON_OFF, NULL, &init_logging_hr_timestamps, NULL},
-#endif
     {CONFIG_EXTRACT_PEM, config_set_extract_pem,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.extract_pem,
@@ -1957,11 +1949,6 @@ FrontendConfig_init(void)
     init_auditfaillog_logging_hide_unhashed_pw =
         cfg->auditfaillog_logging_hide_unhashed_pw = LDAP_ON;
     init_auditfaillog_compress_enabled = cfg->auditfaillog_compress = LDAP_OFF;
-
-#ifdef HAVE_CLOCK_GETTIME
-    init_logging_hr_timestamps =
-        cfg->logging_hr_timestamps = LDAP_ON;
-#endif
     init_entryusn_global = cfg->entryusn_global = LDAP_OFF;
     cfg->entryusn_import_init = slapi_ch_strdup(SLAPD_ENTRYUSN_IMPORT_INIT);
     cfg->default_naming_context = NULL; /* store normalized dn */
@@ -2247,26 +2234,6 @@ config_set_auditfaillog_unhashed_pw(const char *attrname, char *value, char *err
     }
     return retVal;
 }
-
-#ifdef HAVE_CLOCK_GETTIME
-int32_t
-config_set_logging_hr_timestamps(const char *attrname, char *value, char *errorbuf, int apply)
-{
-    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
-    int32_t retVal = LDAP_SUCCESS;
-
-    retVal = config_set_onoff(attrname, value, &(slapdFrontendConfig->logging_hr_timestamps),
-                              errorbuf, apply);
-    if (apply && retVal == LDAP_SUCCESS) {
-        if (strcasecmp(value, "on") == 0) {
-            log_enable_hr_timestamps();
-        } else {
-            log_disable_hr_timestamps();
-        }
-    }
-    return retVal;
-}
-#endif
 
 /*
  * Utility function called by many of the config_set_XXX() functions.

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -47,7 +47,6 @@ PRUintn logbuf_tsdindex;
 struct logbufinfo *logbuf_accum;
 static struct logging_opts loginfo;
 static int detached = 0;
-static int logging_hr_timestamps_enabled = 1;
 
 //extern int slapd_ldap_debug;
 
@@ -2236,24 +2235,6 @@ log_set_expirationtimeunit(const char *attrname, char *expunit, int logtype, cha
     return rv;
 }
 
-/*
- * Enables HR timestamps in logs.
- */
-void
-log_enable_hr_timestamps()
-{
-    logging_hr_timestamps_enabled = 1;
-}
-
-/*
- * Disables HR timestamps in logs.
- */
-void
-log_disable_hr_timestamps()
-{
-    logging_hr_timestamps_enabled = 0;
-}
-
 /******************************************************************************
  * Write title line in log file
  *****************************************************************************/
@@ -2766,29 +2747,20 @@ vslapd_log_emergency_error(LOGFD fp, const char *msg, int locked)
     char tbuf[TBUFSIZE];
     char buffer[SLAPI_LOG_BUFSIZ];
     int size = TBUFSIZE;
+    struct timespec tsnow;
 
-#ifdef HAVE_CLOCK_GETTIME
-    if (logging_hr_timestamps_enabled == 1) {
-        struct timespec tsnow;
-        if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
-            syslog(LOG_EMERG, "vslapd_log_emergency_error, Unable to determine system time for message :: %s\n", msg);
-            return;
-        }
-        if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(tbuf), tbuf, &size) != 0) {
-            syslog(LOG_EMERG, "vslapd_log_emergency_error, Unable to format system time for message :: %s\n", msg);
-            return;
-        }
-    } else {
-#endif
-        time_t tnl;
-        tnl = slapi_current_utc_time();
-        if (format_localTime_log(tnl, sizeof(tbuf), tbuf, &size) != 0) {
-            syslog(LOG_EMERG, "vslapd_log_emergency_error, Unable to format system time for message :: %s\n", msg);
-            return;
-        }
-#ifdef HAVE_CLOCK_GETTIME
+    if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
+        syslog(LOG_EMERG,
+               "vslapd_log_emergency_error, Unable to determine system time for message :: %s\n",
+               msg);
+        return;
     }
-#endif
+    if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(tbuf), tbuf, &size) != 0) {
+        syslog(LOG_EMERG,
+               "vslapd_log_emergency_error, Unable to format system time for message :: %s\n",
+               msg);
+        return;
+    }
 
     PR_snprintf(buffer, sizeof(buffer), "%s- EMERG - %s\n", tbuf, msg);
     size = strlen(buffer);
@@ -2841,6 +2813,7 @@ vslapd_log_error(
     int locked)
 {
     char buffer[SLAPI_LOG_BUFSIZ];
+    struct timespec tsnow;
     char sev_name[10];
     int blen = TBUFSIZE;
     char *vbuf = NULL;
@@ -2852,32 +2825,21 @@ vslapd_log_error(
         return -1;
     }
 
-#ifdef HAVE_CLOCK_GETTIME
-    if (logging_hr_timestamps_enabled == 1) {
-        struct timespec tsnow;
-        if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_error, Unable to determine system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, locked);
-            return -1;
-        }
-        if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(buffer), buffer, &blen) != 0) {
-            /* MSG may be truncated */
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_error, Unable to format system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, locked);
-            return -1;
-        }
-    } else {
-#endif
-        time_t tnl;
-        tnl = slapi_current_utc_time();
-        if (format_localTime_log(tnl, sizeof(buffer), buffer, &blen) != 0) {
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_error, Unable to format system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, locked);
-            return -1;
-        }
-#ifdef HAVE_CLOCK_GETTIME
+    if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
+        PR_snprintf(buffer, sizeof(buffer),
+                    "vslapd_log_error, Unable to determine system time for message :: %s",
+                    vbuf);
+        log__error_emergency(buffer, 1, locked);
+        return -1;
     }
-#endif
+    if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(buffer), buffer, &blen) != 0) {
+        /* MSG may be truncated */
+        PR_snprintf(buffer, sizeof(buffer),
+                    "vslapd_log_error, Unable to format system time for message :: %s",
+                    vbuf);
+        log__error_emergency(buffer, 1, locked);
+        return -1;
+    }
 
     /* Bug 561525: to be able to remove timestamp to not over pollute syslog, we may need
         to skip the timestamp part of the message.
@@ -3060,6 +3022,7 @@ vslapd_log_access(const char *fmt, va_list ap)
     int32_t blen = TBUFSIZE;
     int32_t vlen;
     int32_t rc = LDAP_SUCCESS;
+    struct timespec tsnow;
     time_t tnl;
 
 #ifdef SYSTEMTAP
@@ -3072,34 +3035,23 @@ vslapd_log_access(const char *fmt, va_list ap)
         return -1;
     }
 
-#ifdef HAVE_CLOCK_GETTIME
-    if (logging_hr_timestamps_enabled == 1) {
-        struct timespec tsnow;
-        if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
-            /* Make an error */
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_access, Unable to determine system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, 0);
-            return -1;
-        }
-        tnl = tsnow.tv_sec;
-        if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(buffer), buffer, &blen) != 0) {
-            /* MSG may be truncated */
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_access, Unable to format system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, 0);
-            return -1;
-        }
-    } else {
-#endif
-        tnl = slapi_current_utc_time();
-        if (format_localTime_log(tnl, sizeof(buffer), buffer, &blen) != 0) {
-            /* MSG may be truncated */
-            PR_snprintf(buffer, sizeof(buffer), "vslapd_log_access, Unable to format system time for message :: %s", vbuf);
-            log__error_emergency(buffer, 1, 0);
-            return -1;
-        }
-#ifdef HAVE_CLOCK_GETTIME
+    if (clock_gettime(CLOCK_REALTIME, &tsnow) != 0) {
+        /* Make an error */
+        PR_snprintf(buffer, sizeof(buffer),
+                    "vslapd_log_access, Unable to determine system time for message :: %s",
+                    vbuf);
+        log__error_emergency(buffer, 1, 0);
+        return -1;
     }
-#endif
+    tnl = tsnow.tv_sec;
+    if (format_localTime_hr_log(tsnow.tv_sec, tsnow.tv_nsec, sizeof(buffer), buffer, &blen) != 0) {
+        /* MSG may be truncated */
+        PR_snprintf(buffer, sizeof(buffer),
+                    "vslapd_log_access, Unable to format system time for message :: %s",
+                    vbuf);
+        log__error_emergency(buffer, 1, 0);
+        return -1;
+    }
 
     if (SLAPI_LOG_BUFSIZ - blen < vlen) {
         /* We won't be able to fit the message in! Uh-oh! */

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -423,12 +423,6 @@ int config_set_maxsimplepaged_per_conn(const char *attrname, char *value, char *
 int log_external_libs_debug_set_log_fn(void);
 int log_set_backend(const char *attrname, char *value, int logtype, char *errorbuf, int apply);
 
-#ifdef HAVE_CLOCK_GETTIME
-int config_set_logging_hr_timestamps(const char *attrname, char *value, char *errorbuf, int apply);
-void log_enable_hr_timestamps(void);
-void log_disable_hr_timestamps(void);
-#endif
-
 int config_get_SSLclientAuth(void);
 int config_get_ssl_check_hostname(void);
 tls_check_crl_t config_get_tls_check_crl(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2389,10 +2389,6 @@ typedef struct _slapdEntryPoints
 
 #define CONFIG_EXTRACT_PEM "nsslapd-extract-pemfiles"
 
-#ifdef HAVE_CLOCK_GETTIME
-#define CONFIG_LOGGING_HR_TIMESTAMPS "nsslapd-logging-hr-timestamps-enabled"
-#endif
-
 /* getenv alternative */
 #define CONFIG_MALLOC_MXFAST         "nsslapd-malloc-mxfast"
 #define CONFIG_MALLOC_TRIM_THRESHOLD "nsslapd-malloc-trim-threshold"
@@ -2625,9 +2621,6 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t auditfaillog_compress;
 
     char *logging_backend;
-#ifdef HAVE_CLOCK_GETTIME
-    slapi_onoff_t logging_hr_timestamps;
-#endif
     slapi_onoff_t return_exact_case; /* Return attribute names with the same case
                                        as they appear in at.conf */
 

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6778,7 +6778,7 @@ time_t slapi_current_time(void) __attribute__((deprecated));
  * and should NOT be used for timer information.
  */
 int32_t slapi_clock_gettime(struct timespec *tp);
-/* 
+/*
  * slapi_clock_gettime should have better been called
  * slapi_clock_utc_gettime but sice the function pre-existed
  * we are just adding an alias (to avoid risking to break
@@ -8321,8 +8321,6 @@ int slapi_is_special_rdn(const char *rdn, int flag);
  */
 void DS_Sleep(PRIntervalTime ticks);
 
-
-#ifdef HAVE_CLOCK_GETTIME
 /**
  * Diffs two timespects a - b into *diff. This is useful with
  * clock_monotonic to find time taken to perform operations.
@@ -8373,7 +8371,6 @@ void slapi_operation_workq_time_elapsed(Slapi_Operation *o, struct timespec *ela
  * \param Slapi_Operation o - the operation which is inprogress
  */
 void slapi_operation_set_time_started(Slapi_Operation *o);
-#endif
 
 /**
  * Store a 32bit integral value atomicly

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -23,7 +23,7 @@ from lib389 import Entry
 from lib389._mapped_object import DSLdapObject
 from lib389.utils import ensure_bytes, selinux_label_port,  selinux_present
 from lib389.lint import (
-    DSCLE0001, DSCLE0002, DSCLE0003, DSCLE0004, DSCLE0005, DSCLE0006, DSELE0001
+    DSCLE0002, DSCLE0003, DSCLE0004, DSCLE0005, DSCLE0006, DSELE0001
 )
 
 class Config(DSLdapObject):
@@ -202,14 +202,6 @@ class Config(DSLdapObject):
     @classmethod
     def lint_uid(cls):
         return 'config'
-
-    def _lint_hr_timestamp(self):
-        hr_timestamp = self.get_attr_val('nsslapd-logging-hr-timestamps-enabled')
-        if ensure_bytes('on') != hr_timestamp:
-            report = copy.deepcopy(DSCLE0001)
-            report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
-            report['check'] = "config:hr_timestamp"
-            yield report
 
     def _lint_passwordscheme(self):
         allowed_schemes = ['PBKDF2-SHA512', 'PBKDF2_SHA256', 'PBKDF2_SHA512', 'GOST_YESCRYPT']

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -87,28 +87,6 @@ DSBLE0006 = {
 }
 
 # Config checks
-DSCLE0001 = {
-    'dsle': 'DSCLE0001',
-    'severity': 'LOW',
-    'description': 'Different log timestamp format.',
-    'items': ['cn=config', ],
-    'detail': """nsslapd-logging-hr-timestamps-enabled changes the log format in directory server from
-
-[07/Jun/2017:17:15:58 +1000]
-
-to
-
-[07/Jun/2017:17:15:58.716117312 +1000]
-
-This actually provides a performance improvement. Additionally, this setting will be
-removed in a future release.
-""",
-    'fix': """Set nsslapd-logging-hr-timestamps-enabled to on.
-You can use 'dsconf' to set this attribute.  Here is an example:
-
-    # dsconf slapd-YOUR_INSTANCE config replace nsslapd-logging-hr-timestamps-enabled=on"""
-}
-
 DSCLE0002 = {
     'dsle': 'DSCLE0002',
     'severity': 'HIGH',

--- a/src/lib389/lib389/tests/healthcheck_test.py
+++ b/src/lib389/lib389/tests/healthcheck_test.py
@@ -31,11 +31,6 @@ def test_hc_encryption(topology_st):
     assert result == DSELE0001
 
 def test_hc_config(topology_st):
-    # Check the HR timestamp
-    topology_st.standalone.config.set('nsslapd-logging-hr-timestamps-enabled', 'off')
-    result = topology_st.standalone.config._lint_hr_timestamp()
-    assert result == DSCLE0001
-
     # Check the password scheme check.
     topology_st.standalone.config.set('passwordStorageScheme', 'SSHA')
     result = topology_st.standalone.config._lint_passwordscheme()


### PR DESCRIPTION
Remove the code for checking is CLOCK exists and the logging_hr_timestamps config settings

Also fixed some compiler warnings

relates: https://github.com/389ds/389-ds-base/issues/6397
