### PR TITLE
Issue 6258 - Resolve race condition for two tests in health_config.py

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -24,6 +24,8 @@ from lib389.topologies import topology_st
 from lib389.cli_ctl.health import health_check_run
 from lib389.paths import Paths
 
+from time import sleep
+
 pytestmark = pytest.mark.tier1
 
 CMD_OUTPUT = 'No issues found.'
@@ -378,6 +380,7 @@ def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
     log.info('Use filters to reproduce "notes=A" in access log')
     accounts = Accounts(standalone, DEFAULT_SUFFIX)
     accounts.filter('(uid=test*)')
+    sleep(1)
 
     log.info('Check that access log contains "notes=A"')
     assert standalone.ds_access_log.match(r'.*notes=A.*')
@@ -429,6 +432,7 @@ def test_healthcheck_notes_unknown_attribute(topology_st, setup_ldif):
     log.info('Use filters to reproduce "notes=F" in access log')
     accounts = Accounts(standalone, DEFAULT_SUFFIX)
     accounts.filter('(unknown=test)')
+    sleep(1)
 
     log.info('Check that access log contains "notes=F"')
     assert standalone.ds_access_log.match(r'.*notes=F.*')


### PR DESCRIPTION
The following two tests in health_config.py have race conditions preventing them from working consistently: 
dirsrvtests/tests/suites/healthcheck/health_config_test.py::test_healthcheck_notes_unindexed_search 
dirsrvtests/tests/suites/healthcheck/health_config_test.py::test_healthcheck_notes_unknown_attribute

These failures are mitigated by adding a sleep command shortly after the filter command to ensure it has time to complete.

Helps fix: https://github.com/389ds/389-ds-base/issues/6258