### PR TITLE
Issue 6258 - Resolve race condition in paged_results_test.py

### DIFF
--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -1123,7 +1123,7 @@ def test_multi_suffix_search(topology_st, create_user, new_suffixes):
     try:
         req_ctrl = SimplePagedResultsControl(True, size=page_size, cookie='')
 
-        all_results = paged_search(topology_st.standalone, NEW_SUFFIX_1, [req_ctrl], search_flt, searchreq_attrlist, 0, True)
+        all_results = paged_search(topology_st.standalone, NEW_SUFFIX_1, [req_ctrl], search_flt, searchreq_attrlist, avoid_race_con=True)
 
         log.info('{} results'.format(len(all_results)))
         assert len(all_results) == users_num


### PR DESCRIPTION
The regression test dirsrvtests/tests/suites/paged_results/paged_results_test.py::test_multi_suffix_search has a race condition causing it to fail due to multiple queries potentially writing their logs out of chronological order.

This failure is mitigated by adding a boolean parameter to the paged_search() function so that, when the parameter is true, the function will sleep for a second after each query to avoid this race condition. The parameter is necessary because paged_search() is also used in a stress test, and sleeping after each query would result in that test being slowed down quite a bit. This new parameter defaults to False, so by default paged_search() will not sleep.

Helps fix: https://github.com/389ds/389-ds-base/pull/6261