### PR TITLE
Issue 6349 - RFE - extract keys once (#6363) (#6394)

### DIFF
--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -966,9 +966,12 @@ check_private_certdir()
 
     if (!tmp_private) {
         /* tmp is not a private name space */
-        slapi_log_err(SLAPI_LOG_WARNING, "Security Initialization",
+        if (_security_library_initialized == 0) {
+            /* only alert about this the first time around */
+            slapi_log_err(SLAPI_LOG_WARNING, "Security Initialization",
                 "%s is not a private namespace. pem files not exported there\n",
                 private_mountpoint);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
Bug Description: Keys/Certs are extracted to PEM
repeatedly causing many warnings during outbound TLS authenticated replication

Fix Description: After more testing, if the connection is dropped and restarted, the certpath is retrieved but re-extraction does not occur. This still triggers the warning however. To resolve this, we only warn about the tpm namespace during library initialisation.

I really hope I got it right this time :(

fixes: https://github.com/389ds/389-ds-base/issues/6340

Author: William Brown <william@blackhats.net.au>

Review by: ???