### PR TITLE
Issue 6224 - Fix merge issue in 389-ds-base-2.1 for ds_log_test.py

### DIFF
--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -1285,7 +1285,6 @@ def test_referral_check(topology_st, request):
 
     request.addfinalizer(fin)
 
-<<<<<<< HEAD
 def test_referral_subsuffix(topology_st, request):
     """Test the results of an inverted parent suffix definition in the configuration.
 


### PR DESCRIPTION
Fix a merge issue during cherry-pick over 389-ds-base-2.1 and  389-ds-base-1.4.3 branches 

Issue: #6224 

Reviewed by: @mreynolds389 