### PR TITLE
Issue 6415 - BUG - Incorrect icu linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -849,7 +849,7 @@ fi
 
 PKG_CHECK_MODULES([SASL], [libsasl2])
 
-PKG_CHECK_MODULES([ICU], [icu-i18n >= 60.2])
+PKG_CHECK_MODULES([ICU], [icu-i18n >= 60.2 icu-uc >= 60.2])
 
 m4_include(m4/netsnmp.m4)
 


### PR DESCRIPTION
Bug Description: ICU has been updated to version 76.x - the .pc file of icu-18n for example no longer includes -licuuc, which was so far the most common reason for buildfailures (as icu-uc is not linked automatically, resulting in underlining)

Fix Description: Correct configure.ac to request linking to icu-uc

fixes: https://github.com/389ds/389-ds-base/issues/6415

Author: William Brown <william@blackhats.net.au>

Review by: ???