### PR TITLE
Issue 6427 - fix various memory leaks

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -1327,8 +1327,11 @@ slapd_daemon(daemon_ports_t *ports)
             slapi_log_err(SLAPI_LOG_ERR, "slapd_daemon", "Failed to remove pid file %s\n", get_pid_file());
         }
     }
-}
 
+    /* final cleanup for ASAN and other analyzers */
+    PR_JoinThread(accept_thread_p);
+    free_worker_thread_indexes();
+}
 
 void
 ct_thread_cleanup(void)
@@ -1647,7 +1650,7 @@ handle_pr_read_ready(Connection_Table *ct, int list_num, PRIntn num_poll __attri
                 continue;
             }
 
-            /* Try to get connection mutex, if not available just skip the connection and 
+            /* Try to get connection mutex, if not available just skip the connection and
              * process other connections events. May generates cpu load for listening thread
              * if connection mutex is held for a long time
              */

--- a/ldap/servers/slapd/plugin_internal_op.c
+++ b/ldap/servers/slapd/plugin_internal_op.c
@@ -249,6 +249,12 @@ slapi_search_internal_set_pb(Slapi_PBlock *pb, const char *base, int scope, cons
         return;
     }
 
+    /* Free op just in case this pb is being reused */
+    slapi_pblock_get(pb, SLAPI_OPERATION, &op);
+    operation_free(&op, NULL);
+    slapi_pblock_get(pb, SLAPI_SEARCH_ATTRS, &tmp_attrs);
+    slapi_ch_array_free(tmp_attrs);
+
     op = internal_operation_new(SLAPI_OPERATION_SEARCH, operation_flags);
     slapi_pblock_set(pb, SLAPI_OPERATION, op);
     slapi_pblock_set(pb, SLAPI_ORIGINAL_TARGET_DN, (void *)base);
@@ -275,6 +281,12 @@ slapi_search_internal_set_pb_ext(Slapi_PBlock *pb, Slapi_DN *sdn, int scope, con
                       "NULL parameter\n");
         return;
     }
+
+    /* Free op/attrs just in case this pb is being reused */
+    slapi_pblock_get(pb, SLAPI_OPERATION, &op);
+    operation_free(&op, NULL);
+    slapi_pblock_get(pb, SLAPI_SEARCH_ATTRS, &tmp_attrs);
+    slapi_ch_array_free(tmp_attrs);
 
     op = internal_operation_new(SLAPI_OPERATION_SEARCH, operation_flags);
     slapi_pblock_set(pb, SLAPI_OPERATION, op);
@@ -304,6 +316,12 @@ slapi_seq_internal_set_pb(Slapi_PBlock *pb, char *base, int type, char *attrname
                       "NULL parameter\n");
         return;
     }
+
+    /* Free op/attrs just in case this pb is being reused */
+    slapi_pblock_get(pb, SLAPI_OPERATION, &op);
+    operation_free(&op, NULL);
+    slapi_pblock_get(pb, SLAPI_SEARCH_ATTRS, &tmp_attrs);
+    slapi_ch_array_free(tmp_attrs);
 
     op = internal_operation_new(SLAPI_OPERATION_SEARCH, operation_flags);
     slapi_pblock_set(pb, SLAPI_OPERATION, op);

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1541,6 +1541,7 @@ int connection_is_free(Connection *conn, int user_lock);
 int connection_is_active_nolock(Connection *conn);
 ber_slen_t openldap_read_function(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len);
 int32_t connection_has_psearch(Connection *c);
+void free_worker_thread_indexes(void);
 
 /*
  * saslbind.c

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1392,9 +1392,8 @@ exit:
     if (NULL != typelist) {
         slapi_vattr_attrs_free(&typelist, typelist_flags);
     }
-    if (NULL != default_attrs) {
-        slapi_ch_free((void **)&default_attrs);
-    }
+    slapi_ch_array_free(default_attrs);
+
     return rc;
 }
 


### PR DESCRIPTION
Description:

This was all on main branch

- Display attributes were leaked on searches
- Work thread indexes were leaked at shutdown
- Accept thread was leaked at shutdown
- When we reused a search pblock, we did not free the "operation" and "search attributes" before overwriting them with freshly allocated structures.

Fixes: https://github.com/389ds/389-ds-base/issues/6427
