### PR TITLE
Issue 6432 - Crash during bind when acct policy plugin does not have "alwaysrecordlogin" set

### DIFF
--- a/dirsrvtests/tests/suites/plugins/accpol_check_all_state_attrs_test.py
+++ b/dirsrvtests/tests/suites/plugins/accpol_check_all_state_attrs_test.py
@@ -21,10 +21,11 @@ from lib389._constants import (
     PASSWORD,
     PLUGIN_ACCT_POLICY,
 )
-from lib389.idm.user import (UserAccount, UserAccounts)
+from lib389.idm.user import (UserAccount)
 from lib389.plugins import (AccountPolicyPlugin, AccountPolicyConfig)
+from lib389.cos import (CosTemplate, CosPointerDefinition)
 from lib389.idm.domain import Domain
-from datetime import datetime, timedelta
+
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ TEST_ENTRY_DN = 'uid={},{}'.format(TEST_ENTRY_NAME, DEFAULT_SUFFIX)
 NEW_PASSWORD = 'password123'
 USER_SELF_MOD_ACI = '(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)'
 ANON_ACI = "(targetattr=\"*\")(version 3.0; acl \"Anonymous Read access\"; allow (read,search,compare) userdn = \"ldap:///anyone\";)"
+
 
 def test_inactivty_and_expiration(topo):
     """Test account expiration works when we are checking all state attributes
@@ -122,9 +124,79 @@ def test_inactivty_and_expiration(topo):
         test_user.bind(NEW_PASSWORD)
 
 
+def test_alwaysrecordlogin_off(topo):
+    """Test the server does not crash when alwaysrecordlogin is "off"
+
+    :id: 49eb0993-ee59-48a9-8324-fb965b202ba9
+    :setup: Standalone Instance
+    :steps:
+        1. Create test user
+        2. Configure account policy, COS, and restart
+        3. Bind as test user
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    LOCAL_POLICY = 'cn=Account Inactivation Policy,dc=example,dc=com'
+    TEMPL_COS = 'cn=TempltCoS,ou=people,dc=example,dc=com'
+    DEFIN_COS = 'cn=DefnCoS,ou=people,dc=example,dc=com'
+    TEST_USER_NAME = 'crash'
+    TEST_USER_DN = f'uid={TEST_USER_NAME},ou=people,{DEFAULT_SUFFIX}'
+
+    inst = topo.standalone
+
+    # Create the test user
+    test_user = UserAccount(inst, TEST_USER_DN)
+    test_user.create(properties={
+        'uid': TEST_USER_NAME,
+        'cn': TEST_USER_NAME,
+        'sn': TEST_USER_NAME,
+        'userPassword': PASSWORD,
+        'uidNumber': '1000',
+        'gidNumber': '2000',
+        'homeDirectory': '/home/crash',
+    })
+
+    # Configure account policy plugin
+    plugin = AccountPolicyPlugin(inst)
+    plugin.enable()
+    plugin.set('nsslapd-pluginarg0', ACCP_CONF)
+    accp = AccountPolicyConfig(inst, dn=ACCP_CONF)
+    accp.set('alwaysrecordlogin', 'no')
+    accp.set('stateattrname', 'lastLoginTime')
+    accp.set('altstateattrname', 'passwordexpirationtime')
+    accp.set('specattrname', 'acctPolicySubentry')
+    accp.set('limitattrname', 'accountInactivityLimit')
+    accp.set('accountInactivityLimit', '123456')
+    accp.set('checkAllStateAttrs', 'on')
+    inst.restart()
+    # Local policy
+    laccp = AccountPolicyConfig(inst, dn=LOCAL_POLICY)
+    laccp.create(properties={
+        'cn': 'Account Inactivation Policy',
+        'accountInactivityLimit': '12312321'
+    })
+    # COS
+    cos_template = CosTemplate(inst, dn=TEMPL_COS)
+    cos_template.create(properties={'cn': 'TempltCoS',
+                                    'acctPolicySubentry': LOCAL_POLICY})
+    cos_def = CosPointerDefinition(inst, dn=DEFIN_COS)
+    cos_def.create(properties={
+        'cn': 'DefnCoS',
+        'cosTemplateDn': TEMPL_COS,
+        'cosAttribute': 'acctPolicySubentry default operational-default'})
+    inst.restart()
+
+    # Bind as test user to make sure the server does not crash
+    conn = test_user.bind(PASSWORD)
+    test_user = UserAccount(conn, TEST_USER_DN)
+    test_user.bind(PASSWORD)
+
+
 if __name__ == '__main__':
     # Run isolated
     # -s for DEBUG mode
     CURRENT_FILE = os.path.realpath(__file__)
     pytest.main(["-s", CURRENT_FILE])
-

--- a/ldap/servers/plugins/acctpolicy/acct_plugin.c
+++ b/ldap/servers/plugins/acctpolicy/acct_plugin.c
@@ -372,7 +372,9 @@ acct_record_login(const char *dn)
                       "acct_record_login - Recorded %s=%s on \"%s\"\n", cfg->always_record_login_attr, timestr, dn);
 
         /* update login history */
-        acct_update_login_history(dn, timestr);
+        if (cfg->login_history_attr) {
+            acct_update_login_history(dn, timestr);
+        }
     }
 
 done:


### PR DESCRIPTION
Description:

If alwaysrecordlogin is off then we dereference NULL ptr cfg->login_history_attr when trying to write the history/time value. Instead we should skip over this code if it is not set.

Relates: https://github.com/389ds/389-ds-base/issues/6432
