### PR TITLE
Issue 6368 - fix basic test suite

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -124,7 +124,7 @@ exec {nsslapd} -D {cfgdir} -i {pidfile}
                 if self.status():
                     return
                 time.sleep(1)
-            raise TimeoutException('Failed to start ns-slpad')
+            raise TimeoutError('Failed to start ns-slpad')
 
         def stop(self, timeout=120):
             self._reset_systemd()
@@ -173,7 +173,7 @@ exec {nsslapd} -D {cfgdir} -i {pidfile}
             if not backend_list:
                 continue
             for backend in backend_list:
-                target_be = CustomSetup._search_be(backend_options, backend)
+                target_be = CustomSetup._search_be(self, backend_options, backend)
                 if not target_be:
                     target_be = {}
                     backend_options.append(target_be)


### PR DESCRIPTION
Bug Description:
Basic test suite started to error out:
```
>               target_be = CustomSetup._search_be(backend_options, backend)
E               TypeError: CustomSetup._search_be() missing 1 required positional argument: 'beinfo'
```

Fix Description:
Add missing argument.

Relates: https://github.com/389ds/389-ds-base/issues/6368