### PR TITLE
Issue 6446 - on replica consumer, account policy plugin fails to mana…

### DIFF
--- a/ldap/servers/plugins/acctpolicy/acct_plugin.c
+++ b/ldap/servers/plugins/acctpolicy/acct_plugin.c
@@ -290,7 +290,8 @@ acct_update_login_history(const char *dn, char *timestr)
         list_of_mods[1] = NULL;
 
         mod_pb = slapi_pblock_new();
-        slapi_modify_internal_set_pb(mod_pb, dn, list_of_mods, NULL, NULL, plugin_id, 0);
+        slapi_modify_internal_set_pb(mod_pb, dn, list_of_mods, NULL, NULL, plugin_id,
+                                     SLAPI_OP_FLAG_NO_ACCESS_CHECK |SLAPI_OP_FLAG_BYPASS_REFERRALS);
         slapi_modify_internal_pb(mod_pb);
         slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
         if (rc != LDAP_SUCCESS) {


### PR DESCRIPTION
…ge the last login history

Bug description:
	An internal update needs the flag SLAPI_OP_FLAG_BYPASS_REFERRALS
	on a RO consumer. Else the server does not select the backend
	and returns LDAP_REFERRAL to the internal operation.
	In acct_update_login_history the flag is missing.

Fix description:
	Use the same flags in acct_update_login_history as it is
	used in acct_record_login

fixes: #6446

Reviewed by: