### PR TITLE
Issue 6359 - Fix incorrect License tag

### DIFF
--- a/rpm/bundle-rust-npm.py
+++ b/rpm/bundle-rust-npm.py
@@ -146,11 +146,11 @@ def replace_license(spec_file: str, license_string: str):
         for line in contents:
             if line.startswith("License: "):
                 if args.fix_it:
-                    result.append(f"License:          GPL-3.0-or-later AND WITH GPL-3.0-389-ds-base-exception {license_string}\n")
+                    result.append(f"License:          GPL-3.0-or-later WITH GPL-3.0-389-ds-base-exception AND {license_string}\n")
                 else:
                     result.append("# IMPORTANT - Check if it looks right. Additionally, "
                                   "compare with the original line. Then, remove this comment and # FIXME - part.\n")
-                    result.append(f"# FIXME - License:          GPL-3.0-or-later AND WITH GPL-3.0-389-ds-base-exception {license_string}\n")
+                    result.append(f"# FIXME - License:          GPL-3.0-or-later WITH GPL-3.0-389-ds-base-exception AND {license_string}\n")
             else:
                 result.append(line)
     with open(spec_file, "w") as file:


### PR DESCRIPTION
Description:
License tag generated by bundle-rust-npm.py had misplaced 'AND' for the default license.

Relates: https://github.com/389ds/389-ds-base/issues/6359