### PR TITLE
Issue 6439 - Dsidm get_dn option fails for organizational unit, service and posixgroup

### DIFF
--- a/src/lib389/lib389/cli_idm/organizationalunit.py
+++ b/src/lib389/lib389/cli_idm/organizationalunit.py
@@ -34,7 +34,7 @@ def get(inst, basedn, log, args):
     _generic_get(inst, basedn, log.getChild('_generic_get'), MANY, rdn, args)
 
 def get_dn(inst, basedn, log, args):
-    dn = lambda args: _get_arg( args.dn, msg="Enter dn to retrieve")
+    dn = _get_arg( args.dn, msg="Enter dn to retrieve")
     _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY, dn, args)
 
 def create(inst, basedn, log, args):

--- a/src/lib389/lib389/cli_idm/posixgroup.py
+++ b/src/lib389/lib389/cli_idm/posixgroup.py
@@ -38,7 +38,7 @@ def get(inst, basedn, log, args):
 
 
 def get_dn(inst, basedn, log, args):
-    dn = lambda args: _get_arg( args.dn, msg="Enter dn to retrieve")
+    dn = _get_arg( args.dn, msg="Enter dn to retrieve")
     _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY, dn, args)
 
 

--- a/src/lib389/lib389/cli_idm/service.py
+++ b/src/lib389/lib389/cli_idm/service.py
@@ -35,7 +35,7 @@ def get(inst, basedn, log, args):
     _generic_get(inst, basedn, log.getChild('_generic_get'), MANY, rdn, args)
 
 def get_dn(inst, basedn, log, args):
-    dn = lambda args: _get_arg( args.dn, msg="Enter dn to retrieve")
+    dn = _get_arg( args.dn, msg="Enter dn to retrieve")
     _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY, dn, args)
 
 def create(inst, basedn, log, args):


### PR DESCRIPTION
Fixing "dsidm organizationalunit/service/posixgroup get_dn" command as it was failing with an error.

Relates: https://github.com/389ds/389-ds-base/issues/6439

Author: Lenka Doudova

Reviewed by: ???