### PR TITLE
Issue 6417 - (2nd) If an entry RDN is identical to the suffix, then E…

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -1165,6 +1165,15 @@ def test_online_reinit_may_hang(topo_with_sigkill):
     """
     M1 = topo_with_sigkill.ms["supplier1"]
     M2 = topo_with_sigkill.ms["supplier2"]
+
+    # The RFE 5367 (when enabled) retrieves the DN
+    # from the dncache. This hides an issue
+    # with primary fix for 6417.
+    # We need to disable the RFE to verify that the primary
+    # fix is properly fixed.
+    if ds_is_newer('2.3.1'):
+        M1.config.replace('nsslapd-return-original-entrydn', 'off')
+
     M1.stop()
     ldif_file = '%s/supplier1.ldif' % M1.get_ldif_dir()
     M1.db2ldif(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX],

--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -992,6 +992,7 @@ entryrdn_lookup_dn(backend *be,
     ID workid = id; /* starting from the given id */
     rdn_elem *elem = NULL;
     int maybesuffix = 0;
+    ID suffix_id = 1;
 
     slapi_log_err(SLAPI_LOG_TRACE, "entryrdn_lookup_dn",
                   "--> entryrdn_lookup_dn\n");
@@ -1031,6 +1032,22 @@ entryrdn_lookup_dn(backend *be,
     /* Setting the bulk fetch buffer */
     dblayer_value_free(be, &data);
     dblayer_value_init(be, &data);
+
+    /* Just in case the suffix ID is not '1' retrieve it from the database */
+    keybuf = slapi_ch_strdup(slapi_sdn_get_ndn(be->be_suffix));
+    dblayer_value_set(be, &key, keybuf, strlen(keybuf) + 1);
+    rc = dblayer_cursor_op(&ctx.cursor, DBI_OP_MOVE_TO_KEY, &key, &data);
+    if (rc) {
+        slapi_log_err(SLAPI_LOG_WARNING, "entryrdn_lookup_dn",
+                      "Fails to retrieve the ID of suffix %s - keep the default value '%d'\n",
+                      slapi_sdn_get_ndn(be->be_suffix),
+                      suffix_id);
+    } else {
+        elem = (rdn_elem *)data.data;
+        suffix_id = id_stored_to_internal(elem->rdn_elem_id);
+    }
+    dblayer_value_free(be, &data);
+    dblayer_value_free(be, &key);
 
     do {
         /* Setting up a key for the node to get its parent */
@@ -1077,7 +1094,7 @@ entryrdn_lookup_dn(backend *be,
                     _ENTRYRDN_DEBUG_GOTO_BAIL();
                     goto bail;
                 }
-                if (workid == 1) {
+                if (workid == suffix_id) {
                     /* The loop (workid) iterates from the starting 'id'
                      * up to the suffix ID (i.e. '1').
                      * A corner case (#6417) is if an entry, on the path


### PR DESCRIPTION
…ntryrdn gets broken during a reindex

Bug description:
	The primary fix has a flaw as it assumes that the
	suffix ID is '1'.
	If the RUV entry is the first entry of the database
	the server loops indefinitely

Fix description:
	Read the suffix ID from the entryrdn index

fixes: #6417

Reviewed by: Pierre Rogier (reviewed the first fix)