### PR TITLE
Issue 6459 - crash on 3.0/3.1 branch

### DIFF
--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -412,7 +412,7 @@ vlv_rebuild_scope_filter(backend *be)
     }
     slapi_rwlock_unlock(be->vlvSearchList_lock);
     if (txn == &new_txn) {
-        dblayer_txn_abort(be, txn);
+        dblayer_read_txn_abort(be, txn);
     }
     slapi_pblock_destroy(pb);
 }


### PR DESCRIPTION
vlv_rebuild_scope_filter code looks fishy:
it aborts the dblayer_read_txn_begin txn with dblayer_txn_abort instead of dblayer_read_txn_abort
(Meaning that it tries to release the backend serial lock without having locked it.)
This generates assertion failure on some distributions.

Issue: [6459](https://github.com/389ds/389-ds-base/issues/6459)

Reviewed by: @tbordaz (Thanks!)