### PR TITLE
Fix spelling error in cockpit-389-ds certificateManagement.jsx

### DIFF
--- a/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
+++ b/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
@@ -1282,7 +1282,7 @@ export class CertificateManagement extends React.Component {
                             </Button>
                         </div>
                     </Tab>
-                    <Tab eventKey={2} title={<TabTitleText>{_("Certificate Sigining Requests")} <font size="2">({this.state.ServerCSRs.length})</font></TabTitleText>}>
+                    <Tab eventKey={2} title={<TabTitleText>{_("Certificate Signing Requests")} <font size="2">({this.state.ServerCSRs.length})</font></TabTitleText>}>
                         <div className="ds-margin-top-lg ds-left-indent">
                             <CSRTable
                                 ServerCSRs={this.state.ServerCSRs}


### PR DESCRIPTION
spelling fix (Certificate Sigining Requests --> Certificate Signing Requests)

I saw this spelling error in Fedora 41's cockpit-389-ds-3.1.1-3.fc41.noarch, which is the latest version available.