### PR TITLE
Issue 4815 - RFE - Add Replication Log Analysis Tool with CLI Support

### DIFF
--- a/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
+++ b/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
@@ -1,0 +1,519 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import time
+import shutil
+import json
+import pytest
+import logging
+import tempfile
+from datetime import datetime, timezone
+
+from lib389.tasks import *
+from lib389.utils import *
+from lib389.backend import Backends
+from lib389.topologies import topology_m4 as topo_m4
+from lib389.idm.user import UserAccount
+from lib389.replica import ReplicationManager
+from lib389.repltools import ReplicationLogAnalyzer
+from lib389._constants import *
+
+pytestmark = pytest.mark.tier0
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def _generate_test_data(supplier, suffix, count, user_prefix="test_user"):
+    """Generate test users and modifications"""
+    test_users = []
+    for i in range(count):
+        user_dn = f'uid={user_prefix}_{i},{suffix}'
+        test_user = UserAccount(supplier, user_dn)
+        test_user.create(properties={
+            'uid': f'{user_prefix}_{i}',
+            'cn': f'Test User {i}',
+            'sn': f'User{i}',
+            'userPassword': 'password',
+            'uidNumber': str(1000 + i),
+            'gidNumber': '2000',
+            'homeDirectory': f'/home/{user_prefix}_{i}'
+        })
+
+        # Generate modifications
+        for j in range(3):
+            test_user.add('description', f'Description {j}')
+        test_user.replace('cn', f'Modified User {test_user.get_attr_val("uid")}')
+        for j in range(3):
+            try:
+                test_user.remove('description', f'Description {j}')
+            except Exception:
+                pass
+
+        test_users.append(test_user)
+
+    return test_users
+
+
+def _cleanup_test_data(test_users, tmp_dir):
+    """Clean up test users and temporary directory"""
+    for user in test_users:
+        try:
+            if user.exists():
+                user.delete()
+        except Exception as e:
+            log.warning(f"Error cleaning up test user: {e}")
+
+    try:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    except Exception as e:
+        log.error(f"Error cleaning up temporary directory: {e}")
+
+
+def _cleanup_multi_suffix_test(test_users_by_suffix, tmp_dir, suppliers, extra_suffixes):
+    """Clean up multi-suffix test data"""
+    for users in test_users_by_suffix.values():
+        for user in users:
+            try:
+                if user.exists():
+                    user.delete()
+            except Exception as e:
+                log.warning(f"Error cleaning up test user: {e}")
+
+    # Remove extra backends
+    for suffix in extra_suffixes:
+        for supplier in suppliers:
+            try:
+                backends = Backends(supplier)
+                backends.get(suffix).delete()
+            except Exception as e:
+                log.warning(f"Error removing backend for {suffix}: {e}")
+
+    try:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    except Exception as e:
+        log.error(f"Error cleaning up temporary directory: {e}")
+
+
+def test_replication_log_monitoring_basic(topo_m4):
+    """Test basic replication log monitoring functionality
+
+    :id: e62ed58b-1acd-4e7d-9cfd-948ded4cede8
+    :setup: Four suppliers replication setup
+    :steps:
+        1. Create test data with known replication patterns
+        2. Configure log monitoring with basic options
+        3. Generate and verify reports
+        4. Validate report contents
+    :expectedresults:
+        1. Test data should be properly replicated
+        2. Reports should be generated successfully
+        3. Report contents should match expected patterns
+        4. Reports should contain expected data and statistics
+    """
+    tmp_dir = tempfile.mkdtemp(prefix='repl_analysis_')
+    test_users = []
+    suppliers = [topo_m4.ms[f"supplier{i}"] for i in range(1, 5)]
+
+    try:
+        # Clear logs and restart servers
+        for supplier in suppliers:
+            supplier.deleteAccessLogs(restart=True)
+
+        # Generate test data with known patterns
+        log.info('Creating test data...')
+        test_users = _generate_test_data(suppliers[0], DEFAULT_SUFFIX, 10)
+
+        # Wait for replication
+        repl = ReplicationManager(DEFAULT_SUFFIX)
+        for s1 in suppliers:
+            for s2 in suppliers:
+                if s1 != s2:
+                    repl.wait_for_replication(s1, s2)
+
+        # Restart to flush logs
+        for supplier in suppliers:
+            supplier.restart()
+
+        # Configure monitoring
+        log_dirs = [s.ds_paths.log_dir for s in suppliers]
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=[DEFAULT_SUFFIX],
+            anonymous=False,
+            only_fully_replicated=True
+        )
+
+        # Parse logs and generate reports
+        repl_monitor.parse_logs()
+        generated_files = repl_monitor.generate_report(
+            output_dir=tmp_dir,
+            formats=['csv', 'html', 'json'],
+            report_name='basic_test'
+        )
+
+        # Verify report files exist and have content
+        for fmt in ['csv', 'html', 'summary']:
+            assert os.path.exists(generated_files[fmt])
+            assert os.path.getsize(generated_files[fmt]) > 0
+
+        # Verify CSV content
+        with open(generated_files['csv'], 'r') as f:
+            csv_content = f.read()
+            # Verify headers
+            assert 'Timestamp,Server,CSN,Suffix' in csv_content
+            # Verify all servers present
+            for supplier in suppliers:
+                assert supplier.serverid in csv_content
+            # Verify suffix
+            assert DEFAULT_SUFFIX in csv_content
+
+        # Verify JSON summary
+        with open(generated_files['summary'], 'r') as f:
+            summary = json.load(f)
+            assert 'analysis_summary' in summary
+            stats = summary['analysis_summary']
+
+            # Verify basic stats
+            assert stats['total_servers'] == len(suppliers)
+            assert stats['total_updates'] > 0
+            assert stats['updates_by_suffix'][DEFAULT_SUFFIX] > 0
+            assert 'average_lag' in stats
+            assert 'maximum_lag' in stats
+
+    finally:
+        _cleanup_test_data(test_users, tmp_dir)
+
+
+def test_replication_log_monitoring_advanced(topo_m4):
+    """Test advanced replication monitoring features
+
+    :id: 5bb8fd9f-c3ed-4118-a2f9-fd5d733230c7
+    :setup: Four suppliers replication setup
+    :steps:
+        1. Test filtering options
+        2. Test time range filtering
+        3. Test anonymization
+        4. Verify lag calculations
+    :expectedresults:
+        1. Filtering should work as expected
+        2. Time range filtering should limit results
+        3. Anonymization should hide server names
+        4. Lag calculations should be accurate
+    """
+    tmp_dir = tempfile.mkdtemp(prefix='repl_analysis_')
+    test_users = []
+    suppliers = [topo_m4.ms[f"supplier{i}"] for i in range(1, 5)]
+
+    try:
+        # Clear logs and restart servers
+        for supplier in suppliers:
+            supplier.deleteAccessLogs(restart=True)
+
+        # Generate test data
+        start_time = datetime.now(timezone.utc)
+        test_users = _generate_test_data(suppliers[0], DEFAULT_SUFFIX, 20)
+
+        # Force some lag by delaying operations
+        time.sleep(2)
+        for user in test_users[10:]:
+            user.replace('description', 'Modified after delay')
+
+        # Wait for replication
+        repl = ReplicationManager(DEFAULT_SUFFIX)
+        for s1 in suppliers:
+            for s2 in suppliers:
+                if s1 != s2:
+                    repl.wait_for_replication(s1, s2)
+
+        end_time = datetime.now(timezone.utc)
+
+        # Restart to flush logs
+        for supplier in suppliers:
+            supplier.restart()
+
+        log_dirs = [s.ds_paths.log_dir for s in suppliers]
+
+        # Test 1: Lag time filtering
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=[DEFAULT_SUFFIX],
+            lag_time_lowest=1.0
+        )
+        repl_monitor.parse_logs()
+        results1 = repl_monitor.build_result()
+
+        # Verify lag filtering:
+        # Only consider dict values, skip the special "__hop_lags__" (if present)
+        for csn, server_map in results1['lag'].items():
+            t_list = [
+                record['logtime']
+                for key, record in server_map.items()
+                if isinstance(record, dict) and key != '__hop_lags__'
+            ]
+            if not t_list:
+                # If no normal records exist, just skip
+                continue
+
+            lag_time = max(t_list) - min(t_list)
+            # Must be strictly > 1.0
+            assert lag_time > 1.0, f"Expected lag_time > 1.0, got {lag_time}"
+
+        # Test 2: Time range filtering
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=[DEFAULT_SUFFIX],
+            time_range={'start': start_time, 'end': end_time}
+        )
+        repl_monitor.parse_logs()
+        results2 = repl_monitor.build_result()
+
+        # Verify the 'start-time' in results is within or after our start_time
+        utc_start_time = datetime.fromtimestamp(results2['utc-start-time'], timezone.utc)
+        assert utc_start_time >= start_time, (
+            f"Expected start time >= {start_time}, got {utc_start_time}"
+        )
+
+        # Test 3: Anonymization
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=[DEFAULT_SUFFIX],
+            anonymous=True
+        )
+        repl_monitor.parse_logs()
+        generated_files = repl_monitor.generate_report(
+            output_dir=tmp_dir,
+            formats=['csv'],
+            report_name='anon_test'
+        )
+
+        # Verify anonymization
+        with open(generated_files['csv'], 'r') as f:
+            content = f.read()
+            for supplier in suppliers:
+                # Original supplier.serverid should NOT appear
+                assert supplier.serverid not in content, (
+                    f"Found real server name {supplier.serverid} in CSV"
+                )
+            # Instead, placeholders like 'server_0' should exist
+            assert 'server_0' in content, "Expected 'server_0' placeholder not found in CSV"
+
+    finally:
+        _cleanup_test_data(test_users, tmp_dir)
+
+
+def test_replication_log_monitoring_multi_suffix(topo_m4):
+    """Test multi-suffix replication monitoring
+
+    :id: 6ef38c42-4961-476f-9e72-488d99211b8b
+    :setup: Four suppliers replication setup
+    :steps:
+        1. Create multiple suffixes with different replication patterns
+        2. Generate reports for all suffixes
+        3. Verify suffix-specific statistics
+    :expectedresults:
+        1. All suffixes should be monitored
+        2. Reports should show correct per-suffix data
+        3. Statistics should be accurate for each suffix
+    """
+    tmp_dir = tempfile.mkdtemp(prefix='multi_suffix_repl_')
+    SUFFIX_2 = "dc=test2"
+    SUFFIX_3 = "dc=test3"
+    all_suffixes = [DEFAULT_SUFFIX, SUFFIX_2, SUFFIX_3]
+    test_users_by_suffix = {suffix: [] for suffix in all_suffixes}
+    suppliers = [topo_m4.ms[f"supplier{i}"] for i in range(1, 5)]
+
+    try:
+        # Clear logs and restart servers
+        for supplier in suppliers:
+            supplier.deleteAccessLogs(restart=True)
+
+        # Setup additional suffixes
+        for suffix in [SUFFIX_2, SUFFIX_3]:
+            repl = ReplicationManager(suffix)
+            for supplier in suppliers:
+                props = {
+                    'cn': f'userRoot_{suffix.split(",")[0][3:]}',
+                    'nsslapd-suffix': suffix
+                }
+                backends = Backends(supplier)
+                be = backends.create(properties=props)
+                be.create_sample_entries('001004002')
+
+                if supplier == suppliers[0]:
+                    repl.create_first_supplier(supplier)
+                else:
+                    repl.join_supplier(suppliers[0], supplier)
+
+        # Create full mesh
+        for suffix in all_suffixes:
+            repl = ReplicationManager(suffix)
+            for i, s1 in enumerate(suppliers):
+                for s2 in suppliers[i+1:]:
+                    repl.ensure_agreement(s1, s2)
+                    repl.ensure_agreement(s2, s1)
+
+        # Generate different amounts of test data per suffix
+        test_users_by_suffix[DEFAULT_SUFFIX] = _generate_test_data(
+            suppliers[0], DEFAULT_SUFFIX, 10
+        )
+        test_users_by_suffix[SUFFIX_2] = _generate_test_data(
+            suppliers[0], SUFFIX_2, 5, user_prefix="test2_user"
+        )
+        test_users_by_suffix[SUFFIX_3] = _generate_test_data(
+            suppliers[0], SUFFIX_3, 15, user_prefix="test3_user"
+        )
+
+        # Wait for replication
+        for suffix in all_suffixes:
+            repl = ReplicationManager(suffix)
+            for s1 in suppliers:
+                for s2 in suppliers:
+                    if s1 != s2:
+                        repl.wait_for_replication(s1, s2)
+
+        # Restart to flush logs
+        for supplier in suppliers:
+            supplier.restart()
+
+        # Monitor all suffixes
+        log_dirs = [s.ds_paths.log_dir for s in suppliers]
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=all_suffixes
+        )
+
+        repl_monitor.parse_logs()
+        generated_files = repl_monitor.generate_report(
+            output_dir=tmp_dir,
+            formats=['csv', 'html'],
+            report_name='multi_suffix_test'
+        )
+
+        # Verify summary statistics
+        with open(generated_files['summary'], 'r') as f:
+            summary = json.load(f)
+            stats = summary['analysis_summary']
+
+            # Verify updates by suffix
+            updates = stats['updates_by_suffix']
+            assert len(updates) == len(all_suffixes)
+            for suffix in all_suffixes:
+                assert suffix in updates
+                assert updates[suffix] > 0
+
+            # Verify relative amounts
+            assert updates[SUFFIX_3] > updates[DEFAULT_SUFFIX]
+            assert updates[DEFAULT_SUFFIX] > updates[SUFFIX_2]
+
+    finally:
+        _cleanup_multi_suffix_test(
+            test_users_by_suffix,
+            tmp_dir,
+            suppliers,
+            [SUFFIX_2, SUFFIX_3]
+        )
+
+
+def test_replication_log_monitoring_filter_combinations(topo_m4):
+    """Test complex combinations of filtering options and interactions
+
+    :id: 103fc0ac-f0b8-48f1-8cdf-1f6ff57f9672
+    :setup: Four suppliers replication setup
+    :steps:
+        1. Test multiple concurrent filters
+        2. Test filter interactions
+        3. Verify filter precedence
+    :expectedresults:
+        1. Multiple filters should work together correctly
+        2. Filter interactions should be predictable
+        3. Results should respect all applied filters
+    """
+    tmp_dir = tempfile.mkdtemp(prefix='repl_filter_test_')
+    test_users = []
+    suppliers = [topo_m4.ms[f"supplier{i}"] for i in range(1, 5)]
+
+    try:
+        # Clear logs and restart servers
+        for supplier in suppliers:
+            supplier.deleteAccessLogs(restart=True)
+
+        # Generate varied test data
+        start_time = datetime.now(timezone.utc)
+        test_users = _generate_test_data(suppliers[0], DEFAULT_SUFFIX, 30)
+
+        # Create different lag patterns
+        for i, user in enumerate(test_users):
+            if i % 3 == 0:
+                time.sleep(0.5)  # Short lag
+            elif i % 3 == 1:
+                time.sleep(1.5)  # Medium lag
+            user.replace('description', f'Modified with lag pattern {i}')
+
+        # Wait for replication
+        repl = ReplicationManager(DEFAULT_SUFFIX)
+        for s1 in suppliers:
+            for s2 in suppliers:
+                if s1 != s2:
+                    repl.wait_for_replication(s1, s2)
+
+        end_time = datetime.now(timezone.utc)
+
+        # Restart to flush logs
+        for supplier in suppliers:
+            supplier.restart()
+
+        log_dirs = [s.ds_paths.log_dir for s in suppliers]
+
+        # Test combined filters
+        repl_monitor = ReplicationLogAnalyzer(
+            log_dirs=log_dirs,
+            suffixes=[DEFAULT_SUFFIX],
+            lag_time_lowest=1.0,
+            etime_lowest=0.1,
+            only_fully_replicated=True,
+            time_range={'start': start_time, 'end': end_time}
+        )
+
+        repl_monitor.parse_logs()
+        results = repl_monitor.build_result()
+
+        # Verify filter combinations
+        for csn, server_map in results['lag'].items():
+            t_list = [
+                record['logtime']
+                for key, record in server_map.items()
+                if isinstance(record, dict) and key != '__hop_lags__'
+            ]
+            if not t_list:
+                continue
+
+            lag_time = max(t_list) - min(t_list)
+
+            # Verify all filters were applied
+            assert lag_time > 1.0, "Lag time filter not applied"
+            assert len(t_list) == len(suppliers), "Not fully replicated"
+
+            # Verify time range
+            for t in t_list:
+                dt = datetime.fromtimestamp(t, timezone.utc)
+                assert start_time <= dt <= end_time, "Time range filter violated"
+    finally:
+        _cleanup_test_data(test_users, tmp_dir)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -146,6 +146,9 @@ BuildRequires:    python%{python3_pkgversion}-argparse-manpage
 BuildRequires:    python%{python3_pkgversion}-policycoreutils
 BuildRequires:    python%{python3_pkgversion}-libselinux
 BuildRequires:    python%{python3_pkgversion}-cryptography
+BuildRequires:    python%{python3_pkgversion}-numpy
+BuildRequires:    python%{python3_pkgversion}-plotly
+BuildRequires:    python%{python3_pkgversion}-matplotlib
 
 # For cockpit
 %if %{with cockpit}
@@ -318,6 +321,9 @@ Requires: python%{python3_pkgversion}-argcomplete
 Requires: python%{python3_pkgversion}-libselinux
 Requires: python%{python3_pkgversion}-setuptools
 Requires: python%{python3_pkgversion}-cryptography
+Recommends: python%{python3_pkgversion}-numpy
+Recommends: python%{python3_pkgversion}-plotly
+Recommends: python%{python3_pkgversion}-matplotlib
 Recommends: bash-completion
 %{?python_provide:%python_provide python%{python3_pkgversion}-lib389}
 

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -385,8 +385,17 @@ class CustomHelpFormatter(argparse.HelpFormatter):
     description to the full help output
     """
     def add_arguments(self, actions):
-        if len(actions) > 0 and actions[0].option_strings:
-            actions = parent_arguments + actions
+        if len(actions) > 0:
+            # Check if this is the main options section by looking for the help action
+            is_main_section = any(
+                isinstance(action, argparse._HelpAction) 
+                for action in actions
+            )
+            
+            # Only add parent arguments to the main options section
+            if is_main_section:
+                actions = parent_arguments + actions
+        
         super(CustomHelpFormatter, self).add_arguments(actions)
 
     def _format_usage(self, usage, actions, groups, prefix):

--- a/src/lib389/lib389/repltools.py
+++ b/src/lib389/lib389/repltools.py
@@ -1,19 +1,40 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+from collections import defaultdict
+from datetime import datetime, timezone, tzinfo, timedelta
+import numpy as np
+from typing import Dict, List, Optional, Tuple, Generator, Any, NamedTuple, Union
 import os
-import os.path
 import re
-import subprocess
-import ldap
+import json
+import csv
 import logging
+import ldap
+import subprocess
 from lib389._constants import *
 from lib389.properties import *
+from lib389.utils import normalizeDN
+
+try:
+    import plotly.graph_objs as go
+    import plotly.io as pio
+    from plotly.subplots import make_subplots
+    PLOTLY_AVAILABLE = True
+except ImportError:
+    PLOTLY_AVAILABLE = False
+
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
 
 logging.getLogger(__name__).setLevel(logging.INFO)
 log = logging.getLogger(__name__)
@@ -304,3 +325,1137 @@ class ReplTools(object):
                  'passwordExpirationTime': '20381010000000Z'}
         server.setupBindDN(repl_manager_dn, repl_manager_pw, attrs)
 
+
+class DSLogParser:
+    """Base parser for Directory Server logs, focusing on replication events."""
+
+    REGEX_TIMESTAMP = re.compile(
+        r'\[(?P<day>\d*)\/(?P<month>\w*)\/(?P<year>\d*):(?P<hour>\d*):(?P<minute>\d*):(?P<second>\d*)(\.(?P<nanosecond>\d*))+\s(?P<tz>[\+\-]\d{2})(?P<tz_minute>\d{2})'
+    )
+    REGEX_LINE = re.compile(
+        r'\s(?P<quoted>[^= ]+="[^"]*")|(?P<var>[^= ]+=[^\s]+)|(?P<keyword>[^\s]+)'
+    )
+    MONTH_LOOKUP = {
+        'Jan': "01", 'Feb': "02", 'Mar': "03", 'Apr': "04",
+        'May': "05", 'Jun': "06", 'Jul': "07", 'Aug': "08",
+        'Sep': "09", 'Oct': "10", 'Nov': "11", 'Dec': "12"
+    }
+
+    class ParserResult:
+        """Container for parsed log line results."""
+        def __init__(self):
+            self.keywords: List[str] = []
+            self.vars: Dict[str, str] = {}
+            self.raw: Any = None
+            self.timestamp: Optional[str] = None
+            self.line: Optional[str] = None
+
+    def __init__(self, logname: str, suffixes: List[str],
+                tz: tzinfo = timezone.utc,
+                start_time: Optional[datetime] = None,
+                end_time: Optional[datetime] = None,
+                batch_size: int = 1000):
+        """Initialize the parser with time range filtering.
+
+        :param logname: Path to the log file
+        :param suffixes: Suffixes that should be tracked
+        :param tz: Timezone to interpret log timestamps
+        :param start_time: Optional start time filter
+        :param end_time: Optional end time filter
+        :param batch_size: Batch size for memory-efficient processing
+        """
+        self.logname = logname
+        self.lineno = 0
+        self.line: Optional[str] = None
+        self.tz = tz
+        self._suffixes = self._normalize_suffixes(suffixes)
+
+        # Ensure start_time and end_time are timezone-aware
+        self.start_time = self._ensure_timezone_aware(start_time) if start_time else None
+        self.end_time = self._ensure_timezone_aware(end_time) if end_time else None
+
+        self.batch_size = batch_size
+        self.pending_ops: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._logger = logging.getLogger(__name__)
+        self._current_batch: List[Dict[str, Any]] = []
+
+    def _ensure_timezone_aware(self, dt: datetime) -> datetime:
+        """Ensure datetime is timezone-aware using configured timezone."""
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=self.tz)
+        return dt.astimezone(self.tz)
+
+    @staticmethod
+    def parse_timestamp(ts: Union[str, datetime]) -> datetime:
+        """Parse a timestamp into a datetime object."""
+        if isinstance(ts, datetime):
+            return ts
+
+        match = DSLogParser.REGEX_TIMESTAMP.match(ts)
+        if not match:
+            raise ValueError(f"Invalid timestamp format: {ts}")
+
+        parsed = match.groupdict()
+        iso_ts = '{YEAR}-{MONTH}-{DAY}T{HOUR}:{MINUTE}:{SECOND}{TZH}:{TZM}'.format(
+            YEAR=parsed['year'],
+            MONTH=DSLogParser.MONTH_LOOKUP[parsed['month']],
+            DAY=parsed['day'],
+            HOUR=parsed['hour'],
+            MINUTE=parsed['minute'],
+            SECOND=parsed['second'],
+            TZH=parsed['tz'],
+            TZM=parsed['tz_minute']
+        )
+
+        # Create timezone-aware datetime
+        dt = datetime.fromisoformat(iso_ts)
+
+        # Handle nanoseconds if present
+        if parsed['nanosecond']:
+            dt = dt.replace(microsecond=int(parsed['nanosecond']) // 1000)
+
+        return dt
+
+    def _is_in_time_range(self, timestamp: datetime) -> bool:
+        """Check if timestamp is within configured time range."""
+        # Ensure timestamp is timezone-aware and in the same timezone
+        aware_timestamp = self._ensure_timezone_aware(timestamp)
+
+        if self.start_time and aware_timestamp < self.start_time:
+            return False
+        if self.end_time and aware_timestamp > self.end_time:
+            return False
+        return True
+
+    def _cleanup_resources(self):
+        """Clean up any remaining resources."""
+        self.pending_ops.clear()
+        self._current_batch.clear()
+
+    def _process_operation(self, result: 'DSLogParser.ParserResult') -> Optional[Dict[str, Any]]:
+        """Process operation with memory optimization."""
+        conn = result.vars.get('conn')
+        op = result.vars.get('op')
+
+        if not conn or not op:
+            return None
+
+        conn_op = (conn, op)
+
+        # Handle completion keywords
+        if any(kw in result.keywords for kw in ['RESULT', 'ABANDON', 'DISCONNECT']):
+            if conn_op in self.pending_ops:
+                op_data = self.pending_ops.pop(conn_op)
+                return self._create_record(result, op_data)
+            return None
+
+        # Manage pending operations
+        if conn_op not in self.pending_ops:
+            self.pending_ops[conn_op] = {
+                'start_time': result.timestamp,
+                'last_time': result.timestamp,
+                'conn': conn,
+                'op': op,
+                'suffix': None,
+                'target_dn': None
+            }
+        else:
+            # Update last seen time
+            self.pending_ops[conn_op]['last_time'] = result.timestamp
+
+        # Check for DN and suffix
+        if 'dn' in result.vars:
+            matched_suffix = self._match_suffix(result.vars['dn'])
+            if matched_suffix:
+                self.pending_ops[conn_op]['suffix'] = matched_suffix
+                self.pending_ops[conn_op]['target_dn'] = result.vars['dn']
+
+        # Check for CSN
+        if 'csn' in result.vars:
+            self.pending_ops[conn_op]['csn'] = result.vars['csn']
+
+        return None
+
+    def parse_file(self) -> Generator[Dict[str, Any], None, None]:
+        """Parse log file with memory-efficient batch processing."""
+        try:
+            with open(self.logname, 'r', encoding='utf-8') as f:
+                for self.line in f:
+                    self.lineno += 1
+                    try:
+                        result = self.parse_line()
+                        if result:
+                            # Record is returned if operation is complete
+                            record = self._process_operation(result)
+                            if record:
+                                self._current_batch.append(record)
+
+                                # Yield batch if full
+                                if len(self._current_batch) >= self.batch_size:
+                                    yield from self._process_batch()
+
+                    except Exception as e:
+                        self._logger.warning(
+                            f"Error parsing line {self.lineno} in {self.logname}: {e}"
+                        )
+                        continue
+
+                # Process any remaining operations in the final batch
+                if self._current_batch:
+                    yield from self._process_batch()
+
+                # Handle any remaining pending operations
+                yield from self._process_remaining_ops()
+
+        except (OSError, IOError) as e:
+            raise IOError(f"Failed to open or read log file {self.logname}: {e}")
+        finally:
+            self._cleanup_resources()
+
+    def parse_line(self) -> Optional['DSLogParser.ParserResult']:
+        """Parse a single line, returning a ParserResult object if recognized."""
+        line = self.line
+        if not line:
+            return None
+
+        # Extract timestamp
+        timestamp_match = self.REGEX_TIMESTAMP.match(line)
+        if not timestamp_match:
+            return None
+
+        result = DSLogParser.ParserResult()
+        result.raw = line
+        result.timestamp = timestamp_match.group(0)
+
+        # Remove the timestamp portion from the line for parsing
+        after_ts = line[timestamp_match.end():].strip()
+        # Use REGEX_LINE to parse remaining content
+        for match in self.REGEX_LINE.finditer(after_ts):
+            if match.group('keyword'):
+                # Something that is not in key=value format
+                result.keywords.append(match.group('keyword'))
+            elif match.group('var'):
+                # key=value
+                var = match.group('var')
+                k, v = var.split('=', 1)
+                result.vars[k] = v.strip()
+            elif match.group('quoted'):
+                # key="value"
+                kv = match.group('quoted')
+                k, v = kv.split('=', 1)
+                result.vars[k] = v.strip('"')
+
+        return result
+
+    def _normalize_suffixes(self, suffixes: List[str]) -> List[str]:
+        """Normalize suffixes for matching (lowercase, remove spaces)."""
+        normalized = [normalizeDN(s) for s in suffixes if s]
+        # Sort by length descending so we match the longest suffix first
+        return sorted(normalized, key=len, reverse=True)
+
+    def _match_suffix(self, dn: str) -> Optional[str]:
+        """Return a matched suffix if dn ends with one of our suffixes."""
+        if not dn:
+            return None
+        dn_clean = normalizeDN(dn)
+        for sfx in self._suffixes:
+            if dn_clean.endswith(sfx):
+                return sfx
+        return None
+
+    def _process_batch(self) -> Generator[Dict[str, Any], None, None]:
+        """Process and yield a batch of operations."""
+        for record in self._current_batch:
+            try:
+                # Handle timestamp regardless of type
+                if isinstance(record['timestamp'], str):
+                    timestamp = self.parse_timestamp(record['timestamp'])
+                else:
+                    timestamp = record['timestamp']
+
+                if not self._is_in_time_range(timestamp):
+                    continue
+
+                record['timestamp'] = timestamp
+                yield record
+
+            except ValueError as e:
+                self._logger.warning(
+                    f"Error processing timestamp in batch: {e}"
+                )
+        self._current_batch.clear()
+
+    def _create_record(self, result: Optional['DSLogParser.ParserResult'] = None,
+                    op_data: Dict[str, Any] = None) -> Optional[Dict[str, Any]]:
+        """Create a standardized record from either a parser result or operation data."""
+        try:
+            # Determine source of data
+            if result and op_data:
+                # Active operation
+                timestamp = self.parse_timestamp(result.timestamp)
+                conn = result.vars.get('conn')
+                op = result.vars.get('op')
+                csn = result.vars.get('csn')
+                etime = result.vars.get('etime')
+                duration = self._calculate_duration(op_data['start_time'], result.timestamp)
+            elif op_data:
+                # Remaining operation
+                timestamp = op_data.get('last_time', op_data['start_time'])
+                if isinstance(timestamp, str):
+                    timestamp = self.parse_timestamp(timestamp)
+                conn = op_data.get('conn')
+                op = op_data.get('op')
+                csn = op_data.get('csn')
+                etime = None
+                duration = self._calculate_duration(
+                    op_data['start_time'],
+                    timestamp
+                )
+            else:
+                self._logger.warning("Invalid record creation attempt: no data provided")
+                return None
+
+            # Validate required fields
+            if not all([timestamp, conn, op]):
+                self._logger.debug(
+                    f"Missing required fields: timestamp={timestamp}, conn={conn}, op={op}"
+                )
+                return None
+
+            # Create standardized record
+            record = {
+                'timestamp': timestamp,
+                'conn': conn,
+                'op': op,
+                'csn': csn,
+                'suffix': op_data.get('suffix'),
+                'target_dn': op_data.get('target_dn'),
+                'duration': duration,
+                'etime': etime
+            }
+
+            # Verify time range
+            if not self._is_in_time_range(timestamp):
+                return None
+
+            return record
+
+        except Exception as e:
+            self._logger.warning(f"Error creating record: {e}")
+            return None
+
+    def _process_remaining_ops(self) -> Generator[Dict[str, Any], None, None]:
+        """Process any remaining pending operations."""
+        for (conn, op), op_data in list(self.pending_ops.items()):
+            try:
+                if 'csn' in op_data and 'suffix' in op_data:
+                    record = self._create_record(op_data=op_data)
+                    if record:
+                        yield record
+            except Exception as e:
+                self._logger.warning(
+                    f"Error processing remaining operation {conn}-{op}: {e}"
+                )
+            finally:
+                self.pending_ops.pop((conn, op), None)
+
+    def _calculate_duration(self, start: Union[str, datetime],
+                        end: Union[str, datetime]) -> float:
+        """Compute duration between two timestamps. """
+        try:
+            if isinstance(start, str):
+                st = self.parse_timestamp(start)
+            else:
+                st = start
+
+            if isinstance(end, str):
+                et = self.parse_timestamp(end)
+            else:
+                et = end
+
+            return (et - st).total_seconds()
+        except (ValueError, TypeError):
+            return 0.0
+
+
+class ChartData(NamedTuple):
+    """Container for chart data series."""
+    times: List[datetime]
+    lags: List[float]
+    durations: List[float]
+    hover: List[str]
+
+class VisualizationHelper:
+    """Helper class for visualization-related functionality."""
+
+    @staticmethod
+    def generate_color_palette(num_colors: int) -> List[str]:
+        """Generate a visually pleasing color palette.
+
+        :param num_colors: Number of colors needed
+        :returns: List of rgba color strings
+        """
+        colors = []
+        for i in range(num_colors):
+            hue = i / num_colors
+            saturation = 0.7
+            value = 0.9
+
+            # Convert HSV to RGB
+            c = value * saturation
+            x = c * (1 - abs((hue * 6) % 2 - 1))
+            m = value - c
+
+            h_sector = int(hue * 6)
+            if h_sector == 0:
+                r, g, b = c, x, 0
+            elif h_sector == 1:
+                r, g, b = x, c, 0
+            elif h_sector == 2:
+                r, g, b = 0, c, x
+            elif h_sector == 3:
+                r, g, b = 0, x, c
+            elif h_sector == 4:
+                r, g, b = x, 0, c
+            else:
+                r, g, b = c, 0, x
+
+            # Convert to RGB values
+            rgb = [int((val + m) * 255) for val in (r, g, b)]
+            colors.append(f'rgba({rgb[0]},{rgb[1]},{rgb[2]},0.8)')
+
+        return colors
+
+    @staticmethod
+    def prepare_chart_data(csns: Dict[str, Dict[Union[int, str], Dict[str, Any]]]) -> Dict[Tuple[str, str], ChartData]:
+        """Prepare data for visualization."""
+        chart_data = defaultdict(lambda: {
+            'times': [], 'lags': [], 'durations': [], 'hover': []
+        })
+
+        for csn, server_map in csns.items():
+            # Gather only valid records (dict, not '__hop_lags__', must have 'logtime')
+            valid_records = [
+                rec for key, rec in server_map.items()
+                if isinstance(rec, dict)
+                   and key != '__hop_lags__'
+                   and 'logtime' in rec
+            ]
+            if not valid_records:
+                continue
+
+            # Compute global lag for this CSN (earliest vs. latest among valid records)
+            t_list = [rec['logtime'] for rec in valid_records]
+            earliest = min(t_list)
+            latest = max(t_list)
+            lag_val = latest - earliest
+
+            # Populate chart data for each server record
+            for rec in valid_records:
+                suffix_val = rec.get('suffix', 'unknown')
+                server_val = rec.get('server_name', 'unknown')
+
+                # Convert numeric UTC to a datetime
+                ts_dt = datetime.fromtimestamp(rec['logtime'])
+
+                # Operation duration, defaulting to 0.0 if missing
+                duration_val = float(rec.get('duration', 0.0))
+
+                # Build the ChartData slot
+                data_slot = chart_data[(suffix_val, server_val)]
+                data_slot['times'].append(ts_dt)
+                data_slot['lags'].append(lag_val)  # The same global-lag for all servers
+                data_slot['durations'].append(duration_val)
+                data_slot['hover'].append(
+                    f"CSN: {csn}<br>"
+                    f"Server: {server_val}<br>"
+                    f"Suffix: {suffix_val}<br>"
+                    f"Target DN: {rec.get('target_dn', '')}<br>"
+                    f"Lag Time: {lag_val:.3f}s<br>"
+                    f"Duration: {duration_val:.3f}s"
+                )
+
+        # Convert the dict-of-lists into your namedtuple-based ChartData
+        return {
+            key: ChartData(
+                times=value['times'],
+                lags=value['lags'],
+                durations=value['durations'],
+                hover=value['hover']
+            )
+            for key, value in chart_data.items()
+        }
+
+
+class ReplicationLogAnalyzer:
+    """This class handles:
+    - Collecting log files from multiple directories.
+    - Parsing them for replication events (CSN).
+    - Filtering by suffix.
+    - Storing earliest and latest timestamps for each CSN to compute lag.
+    - Generating final dictionaries to be used for CSV, HTML, or JSON reporting.
+    """
+
+    def __init__(self, log_dirs: List[str], suffixes: Optional[List[str]] = None,
+                anonymous: bool = False, only_fully_replicated: bool = False,
+                only_not_replicated: bool = False, lag_time_lowest: Optional[float] = None,
+                etime_lowest: Optional[float] = None, repl_lag_threshold: Optional[float] = None,
+                utc_offset: Optional[int] = None, time_range: Optional[Dict[str, datetime]] = None):
+        if not log_dirs:
+            raise ValueError("No log directories provided for analysis.")
+
+        self.log_dirs = log_dirs
+        self.suffixes = suffixes or []
+        self.anonymous = anonymous
+        self.only_fully_replicated = only_fully_replicated
+        self.only_not_replicated = only_not_replicated
+        self.lag_time_lowest = lag_time_lowest
+        self.etime_lowest = etime_lowest
+        self.repl_lag_threshold = repl_lag_threshold
+
+        # Set timezone
+        if utc_offset is not None:
+            try:
+                self.tz = self._parse_timezone_offset(utc_offset)
+            except ValueError as e:
+                raise ValueError(f"Invalid UTC offset: {e}")
+        else:
+            self.tz = timezone.utc
+
+        self.time_range = time_range or {}
+        self.csns: Dict[str, Dict[Union[int, str], Dict[str, Any]]] = {}
+
+        # Track earliest global timestamp
+        self.start_dt: Optional[datetime] = None
+        self.start_udt: Optional[float] = None
+        self._logger = logging.getLogger(__name__)
+
+    def _should_include_record(self, csn: str, server_map: Dict[Union[int, str], Dict[str, Any]]) -> bool:
+        """Determine if a record should be included based on filtering criteria."""
+        if self.only_fully_replicated and len(server_map) != len(self.log_dirs):
+            return False
+        if self.only_not_replicated and len(server_map) == len(self.log_dirs):
+            return False
+
+        # Check lag time threshold
+        if self.lag_time_lowest is not None:
+            # Only consider dict items, skipping the '__hop_lags__' entry
+            t_list = [
+                d['logtime']
+                for key, d in server_map.items()
+                if isinstance(d, dict) and key != '__hop_lags__'
+            ]
+            if not t_list:
+                return False
+            lag_time = max(t_list) - min(t_list)
+            if lag_time <= self.lag_time_lowest:
+                return False
+
+        # Check etime threshold
+        if self.etime_lowest is not None:
+            for key, record in server_map.items():
+                if not isinstance(record, dict) or key == '__hop_lags__':
+                    continue
+                if float(record.get('etime', 0)) <= self.etime_lowest:
+                    return False
+
+        return True
+
+    def _collect_logs(self) -> List[Tuple[str, List[str]]]:
+        """For each directory in self.log_dirs, return a tuple (server_name, [logfiles])."""
+        data = []
+        for dpath in self.log_dirs:
+            if not os.path.isdir(dpath):
+                self._logger.warning(f"{dpath} is not a directory or not accessible.")
+                continue
+
+            server_name = os.path.basename(dpath.rstrip('/'))
+            logfiles = []
+            for fname in os.listdir(dpath):
+                if fname.startswith('access'):  # Only parse access logs
+                    full_path = os.path.join(dpath, fname)
+                    if os.path.isfile(full_path) and os.access(full_path, os.R_OK):
+                        logfiles.append(full_path)
+                    else:
+                        self._logger.warning(f"Cannot read file: {full_path}")
+
+            logfiles.sort()
+            if logfiles:
+                data.append((server_name, logfiles))
+            else:
+                self._logger.warning(f"No accessible 'access' logs found in {dpath}")
+        return data
+
+    @staticmethod
+    def _parse_timezone_offset(offset_str: str) -> timezone:
+        """Parse timezone offset string in ±HHMM format."""
+        if not isinstance(offset_str, str):
+            raise ValueError("Timezone offset must be a string in ±HHMM format")
+
+        match = re.match(r'^([+-])(\d{2})(\d{2})$', offset_str)
+        if not match:
+            raise ValueError("Invalid timezone offset format. Use ±HHMM (e.g., -0400, +0530)")
+
+        sign, hours, minutes = match.groups()
+        hours = int(hours)
+        minutes = int(minutes)
+
+        if hours > 12 or minutes >= 60:
+            raise ValueError("Invalid timezone offset. Hours must be ≤12, minutes <60")
+
+        total_minutes = hours * 60 + minutes
+        if sign == '-':
+            total_minutes = -total_minutes
+
+        return timezone(timedelta(minutes=total_minutes))
+
+    def _compute_hop_lags(self, server_map: Dict[Union[int, str], Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Compute per-hop replication lags for one CSN across multiple servers."""
+        arrivals = []
+        for key, data in server_map.items():
+            # Skip the special '__hop_lags__' and any non-dict
+            if not isinstance(data, dict) or key == '__hop_lags__':
+                continue
+            arrivals.append({
+                'server_name': data.get('server_name', 'unknown'),
+                'logtime': data.get('logtime', 0.0),  # numeric UTC timestamp
+                'suffix': data.get('suffix'),
+                'target_dn': data.get('target_dn'),
+            })
+
+        # Sort by ascending logtime
+        arrivals.sort(key=lambda x: x['logtime'])
+
+        # Iterate pairs (supplier -> consumer)
+        hops = []
+        for i in range(1, len(arrivals)):
+            supplier = arrivals[i - 1]
+            consumer = arrivals[i]
+            hop_lag = consumer['logtime'] - supplier['logtime']  # in seconds
+            hops.append({
+                'supplier': supplier['server_name'],
+                'consumer': consumer['server_name'],
+                'hop_lag': hop_lag,
+                'arrival_consumer': consumer['logtime'],
+                'suffix': consumer.get('suffix'),
+                'target_dn': consumer.get('target_dn'),
+            })
+
+        return hops
+
+    def parse_logs(self) -> None:
+        """Parse logs from all directories. Each directory is treated as one server
+        unless anonymized, in which case we use 'server_{index}'.
+        """
+        server_data = self._collect_logs()
+        if not server_data:
+            raise ValueError("No valid log directories with accessible logs found.")
+
+        for idx, (server_name, logfiles) in enumerate(server_data):
+            displayed_name = f"server_{idx}" if self.anonymous else server_name
+
+            # For each log file, parse line by line
+            for logfile in logfiles:
+                parser = DSLogParser(
+                    logname=logfile,
+                    suffixes=self.suffixes,
+                    tz=self.tz,
+                    start_time=self.time_range.get('start'),
+                    end_time=self.time_range.get('end')
+                )
+
+                for record in parser.parse_file():
+                    # If there's no CSN or no suffix, skip
+                    if not record.get('csn') or not record.get('suffix'):
+                        continue
+
+                    csn = record['csn']
+                    ts = record['timestamp']
+                    # Convert timestamp to numeric UTC
+                    udt = ts.astimezone(timezone.utc).timestamp()
+
+                    # Track earliest global timestamp
+                    if self.start_udt is None or udt < self.start_udt:
+                        self.start_udt = udt
+                        self.start_dt = ts
+
+                    if csn not in self.csns:
+                        self.csns[csn] = {}
+
+                    # Build record for this server
+                    self.csns[csn][idx] = {
+                        'logtime': udt,
+                        'etime': record.get('etime'),
+                        'server_name': displayed_name,
+                        'suffix': record.get('suffix'),
+                        'target_dn': record.get('target_dn'),
+                        'duration': record.get('duration', 0.0),
+                    }
+
+        # Apply filters after collecting all data
+        filtered_csns = {}
+        for csn, server_map in self.csns.items():
+            if self._should_include_record(csn, server_map):
+                filtered_csns[csn] = server_map
+                # Compute hop-lags and store
+                hop_list = self._compute_hop_lags(server_map)
+                filtered_csns[csn]['__hop_lags__'] = hop_list
+
+        self.csns = filtered_csns
+
+    def build_result(self) -> Dict[str, Any]:
+        """Build the final dictionary object with earliest timestamp, UTC offset, and replication data."""
+        if not self.start_dt:
+            raise ValueError("No valid replication data collected.")
+
+        obj = {
+            "start-time": str(self.start_dt),
+            "utc-start-time": self.start_udt,
+            "utc-offset": self.start_dt.utcoffset().total_seconds() if self.start_dt.utcoffset() else 0,
+            "lag": self.csns
+        }
+        # Also record the log-files (anonymous or not)
+        if self.anonymous:
+            obj['log-files'] = list(range(len(self.log_dirs)))
+        else:
+            obj['log-files'] = self.log_dirs
+        return obj
+
+    def generate_report(self, output_dir: str,
+                       formats: List[str],
+                       report_name: str = "replication_analysis") -> Dict[str, str]:
+        """Generate reports in specified formats."""
+        if not os.path.exists(output_dir):
+            try:
+                os.makedirs(output_dir)
+            except OSError as e:
+                raise OSError(f"Could not create directory {output_dir}: {e}")
+
+        if not self.csns:
+            raise ValueError("No CSN data available for reporting. Did you call parse_logs()?")
+
+        results = self.build_result()
+        generated_files = {}
+
+        # Always produce JSON summary
+        summary_path = os.path.join(output_dir, f"{report_name}_summary.json")
+        self._generate_summary_json(results, summary_path)
+        generated_files["summary"] = summary_path
+
+        # Generate requested formats
+        for fmt in formats:
+            fmt = fmt.lower()
+            outfile = os.path.join(output_dir, f"{report_name}.{fmt}")
+
+            if fmt == 'csv':
+                self._generate_csv(results, outfile)
+                generated_files["csv"] = outfile
+
+            elif fmt == 'html':
+                if not PLOTLY_AVAILABLE:
+                    self._logger.warning("Plotly not installed. Skipping HTML report.")
+                    continue
+                fig = self._create_plotly_figure(results)
+                self._generate_html(fig, outfile)
+                generated_files["html"] = outfile
+
+            elif fmt == 'png':
+                if not MATPLOTLIB_AVAILABLE:
+                    self._logger.warning("Matplotlib not installed. Skipping PNG report.")
+                    continue
+                fig = self._create_plotly_figure(results)
+                self._generate_png(fig, outfile)
+                generated_files["png"] = outfile
+
+            else:
+                self._logger.warning(f"Unknown report format requested: {fmt}")
+
+        return generated_files
+
+    def _create_plotly_figure(self, results: Dict[str, Any]) -> go.Figure:
+        """Create a plotly figure for visualization."""
+        if not PLOTLY_AVAILABLE:
+            raise ImportError("Plotly is required for figure creation")
+
+        # Create figure with 3 subplots: we still generate all 3 for HTML usage
+        fig = make_subplots(
+            rows=3, cols=1,
+            subplot_titles=(
+                "Global Replication Lag Over Time",
+                "Operation Duration Over Time",
+                "Per-Hop Replication Lags"
+            ),
+            vertical_spacing=0.10,   # spacing between subplots
+            shared_xaxes=True
+        )
+
+        # Collect all (suffix, server_name) pairs to color consistently
+        server_suffix_pairs = set()
+        for csn, server_map in self.csns.items():
+            for key, rec in server_map.items():
+                if not isinstance(rec, dict) or key == '__hop_lags__':
+                    continue
+
+                suffix_val = rec.get('suffix', 'unknown')
+                srv_val = rec.get('server_name', 'unknown')
+                server_suffix_pairs.add((suffix_val, srv_val))
+
+        # Generate colors
+        colors = VisualizationHelper.generate_color_palette(len(server_suffix_pairs))
+
+        # Prepare chart data for the first two subplots
+        chart_data = VisualizationHelper.prepare_chart_data(self.csns)
+
+        # Plot Per-Hop Lags in row=3 (for HTML usage)
+        for csn, server_map in self.csns.items():
+            hop_list = server_map.get('__hop_lags__', [])
+            for hop in hop_list:
+                consumer_ts = hop.get("arrival_consumer", 0.0)
+                consumer_dt = datetime.fromtimestamp(consumer_ts)
+                hop_lag = hop.get("hop_lag", 0.0)
+
+                hover_text = (
+                    f"Supplier: {hop.get('supplier','unknown')}<br>"
+                    f"Consumer: {hop.get('consumer','unknown')}<br>"
+                    f"Hop Lag: {hop_lag:.3f}s<br>"
+                    f"Arrival Time: {consumer_dt}"
+                )
+
+                # showlegend=False means these hop-lag traces won't crowd the legend
+                fig.add_trace(
+                    go.Scatter(
+                        x=[consumer_dt],
+                        y=[hop_lag],
+                        mode='markers',
+                        marker=dict(size=7, symbol='circle'),
+                        name=f"{hop.get('supplier','?')}→{hop.get('consumer','?')}",
+                        text=[hover_text],
+                        hoverinfo='text+x+y',
+                        showlegend=False
+                    ),
+                    row=3, col=1
+                )
+
+        # Plot Global Lag (row=1) and Durations (row=2)
+        for idx, ((sfx, srv), data) in enumerate(sorted(chart_data.items())):
+            color = colors[idx % len(colors)]
+
+            # Row=1: Global Replication Lag
+            fig.add_trace(
+                go.Scatter(
+                    x=data.times,
+                    y=data.lags,
+                    mode='lines+markers',
+                    name=f"{sfx} - {srv}",
+                    text=data.hover,
+                    hoverinfo='text+x+y',
+                    line=dict(color=color, width=2),
+                    marker=dict(size=6),
+                    showlegend=True
+                ),
+                row=1, col=1
+            )
+
+            # Row=2: Operation Durations
+            fig.add_trace(
+                go.Scatter(
+                    x=data.times,
+                    y=data.durations,
+                    mode='lines+markers',
+                    name=f"{sfx} - {srv}",
+                    text=data.hover,
+                    hoverinfo='text+x+y',
+                    line=dict(color=color, width=2, dash='solid'),
+                    marker=dict(size=6),
+                    showlegend=False
+                ),
+                row=2, col=1
+            )
+
+        # Add a horizontal threshold line to the Replication Lag subplot
+        if self.repl_lag_threshold is not None:
+            fig.add_hline(
+                y=self.repl_lag_threshold,
+                line=dict(color='red', width=2, dash='dash'),
+                annotation=dict(
+                    text=f"Lag Threshold = {self.repl_lag_threshold}s",
+                    font=dict(color='red'),
+                    showarrow=False,
+                    x=1,
+                    xanchor='left',
+                    y=self.repl_lag_threshold
+                ),
+                row=1, col=1
+            )
+
+        # Figure layout settings
+        fig.update_layout(
+            title={
+                'text': 'Replication Analysis Report',
+                'y': 0.96,
+                'x': 0.5,
+                'xanchor': 'center',
+                'yanchor': 'top'
+            },
+            template='plotly_white',
+            hovermode='closest',
+            showlegend=True,
+            legend=dict(
+                title="Suffix / Server",
+                yanchor="top",
+                y=0.99,
+                xanchor="right",
+                x=1.15,
+                bgcolor='rgba(255, 255, 255, 0.8)'
+            ),
+            height=900,
+            margin=dict(t=100, r=200, l=80)
+        )
+
+        # X-axis styling
+        fig.update_xaxes(title_text="Time", gridcolor='lightgray', row=1, col=1)
+        fig.update_xaxes(
+            title_text="Time",
+            gridcolor='lightgray',
+            rangeslider_visible=True,
+            rangeselector=dict(
+                buttons=list([
+                    dict(count=1, label="1h", step="hour", stepmode="backward"),
+                    dict(count=6, label="6h", step="hour", stepmode="backward"),
+                    dict(count=1, label="1d", step="day", stepmode="backward"),
+                    dict(count=7, label="1w", step="day", stepmode="backward"),
+                    dict(step="all")
+                ]),
+                bgcolor='rgba(255, 255, 255, 0.8)'
+            ),
+            row=2, col=1
+        )
+        fig.update_xaxes(title_text="Time", gridcolor='lightgray', row=3, col=1)
+
+        # Y-axis styling
+        fig.update_yaxes(title_text="Lag Time (seconds)", gridcolor='lightgray', row=1, col=1)
+        fig.update_yaxes(title_text="Duration (seconds)", gridcolor='lightgray', row=2, col=1)
+        fig.update_yaxes(title_text="Hop Lag (seconds)", gridcolor='lightgray', row=3, col=1)
+
+        return fig
+
+    def _generate_png(self, fig: go.Figure, outfile: str) -> None:
+        """Generate PNG snapshot of the plotly figure using matplotlib.
+        For PNG, we deliberately omit the hop-lag (3rd subplot) data.
+        """
+        try:
+            # Create a matplotlib figure with 2 subplots
+            plt.figure(figsize=(12, 8))
+
+            # Extract data from the Plotly figure.
+            # We'll plot only the first two subplots (y-axis = 'y' or 'y2').
+            for trace in fig.data:
+                # Check which y-axis the trace belongs to.
+                # 'y'  => subplot row=1
+                # 'y2' => subplot row=2
+                # 'y3' => subplot row=3 (hop-lags) - skip those
+                if trace.yaxis == 'y':  # Global Lag subplot
+                    plt.subplot(2, 1, 1)
+                    plt.plot(trace.x, trace.y, label=trace.name)
+                elif trace.yaxis == 'y2':  # Duration subplot
+                    plt.subplot(2, 1, 2)
+                    plt.plot(trace.x, trace.y, label=trace.name)
+                else:
+                    # This is likely the hop-lag data on subplot row=3, so skip it
+                    continue
+
+            # Format each subplot
+            for idx, title in enumerate(['Replication Lag Times', 'Operation Durations']):
+                plt.subplot(2, 1, idx + 1)
+                plt.title(title)
+                plt.xlabel('Time')
+                plt.ylabel('Seconds')
+                plt.grid(True)
+                plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+                # Format x-axis as date/time
+                plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
+                plt.gcf().autofmt_xdate()
+
+            plt.tight_layout()
+            plt.savefig(outfile, dpi=300, bbox_inches='tight')
+            plt.close()
+
+        except Exception as e:
+            raise IOError(f"Failed to generate PNG report: {e}")
+
+    def _generate_html(self, fig: go.Figure, outfile: str) -> None:
+        """Generate HTML report from the plotly figure."""
+        try:
+            pio.write_html(
+                fig,
+                outfile,
+                include_plotlyjs='cdn',
+                full_html=True,
+                include_mathjax='cdn',
+                config={
+                    'responsive': True,
+                    'scrollZoom': True,
+                    'modeBarButtonsToAdd': ['drawline', 'drawopenpath', 'eraseshape'],
+                    'toImageButtonOptions': {
+                        'format': 'png',
+                        'filename': 'replication_analysis',
+                        'height': 1000,
+                        'width': 1500,
+                        'scale': 2
+                    }
+                }
+            )
+        except Exception as e:
+            raise IOError(f"Failed to write HTML report: {e}")
+
+    def _generate_csv(self, results: Dict[str, Any], outfile: str) -> None:
+        """Generate a CSV report listing each replication event and its hop-lags."""
+        try:
+            with open(outfile, 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.writer(csvfile)
+
+                # Global-lag rows
+                writer.writerow([
+                    'Timestamp', 'Server', 'CSN', 'Suffix', 'Target DN',
+                    'Global Lag (s)', 'Duration (s)', 'Operation Etime'
+                ])
+                for csn, server_map in self.csns.items():
+                    # Compute global-lag for normal dict entries
+                    t_list = [
+                        d['logtime']
+                        for key, d in server_map.items()
+                        if isinstance(d, dict) and key != '__hop_lags__'
+                    ]
+                    if not t_list:
+                        continue
+                    earliest = min(t_list)
+                    latest = max(t_list)
+                    global_lag = latest - earliest
+
+                    # Write lines for each normal server record
+                    for key, data_map in server_map.items():
+                        if not isinstance(data_map, dict) or key == '__hop_lags__':
+                            continue
+                        ts_str = datetime.fromtimestamp(data_map['logtime']).strftime('%Y-%m-%d %H:%M:%S')
+                        writer.writerow([
+                            ts_str,
+                            data_map['server_name'],
+                            csn,
+                            data_map.get('suffix', 'unknown'),
+                            data_map.get('target_dn', ''),
+                            f"{global_lag:.3f}",
+                            f"{float(data_map.get('duration', 0.0)):.3f}",
+                            data_map.get('etime', 'N/A')
+                        ])
+
+                # Hop-lag rows
+                writer.writerow([])  # blank line
+                writer.writerow(["-- Hop-Lag Data --"])
+                writer.writerow([
+                    'CSN', 'Supplier', 'Consumer', 'Hop Lag (s)', 'Arrival (Consumer)', 'Suffix', 'Target DN'
+                ])
+                for csn, server_map in self.csns.items():
+                    hop_list = server_map.get('__hop_lags__', [])
+                    for hop_info in hop_list:
+                        hop_lag_str = f"{hop_info['hop_lag']:.3f}"
+                        arrival_ts = datetime.fromtimestamp(hop_info['arrival_consumer']).strftime('%Y-%m-%d %H:%M:%S')
+                        writer.writerow([
+                            csn,
+                            hop_info['supplier'],
+                            hop_info['consumer'],
+                            hop_lag_str,
+                            arrival_ts,
+                            hop_info.get('suffix', 'unknown'),
+                            hop_info.get('target_dn', '')
+                        ])
+
+        except Exception as e:
+            raise IOError(f"Failed to write CSV report {outfile}: {e}")
+
+    def _generate_summary_json(self, results: Dict[str, Any], outfile: str) -> None:
+        """Create a JSON summary from the final dictionary."""
+        global_lag_times = []
+        hop_lag_times = []
+        suffix_updates = {}
+
+        for csn, server_map in self.csns.items():
+            t_list = [
+                rec['logtime']
+                for key, rec in server_map.items()
+                if isinstance(rec, dict) and key != '__hop_lags__' and 'logtime' in rec
+            ]
+            if not t_list:
+                continue
+
+            # Global earliest vs. latest (for "global lag")
+            earliest = min(t_list)
+            latest = max(t_list)
+            global_lag = latest - earliest
+            global_lag_times.append(global_lag)
+
+            # Suffix counts
+            for key, record in server_map.items():
+                # Only process normal server records, skip the special '__hop_lags__'
+                if not isinstance(record, dict) or key == '__hop_lags__':
+                    continue
+
+                sfx = record.get('suffix', 'unknown')
+                suffix_updates[sfx] = suffix_updates.get(sfx, 0) + 1
+
+            # Hop-lag data
+            hop_list = server_map.get('__hop_lags__', [])
+            for hop_info in hop_list:
+                hop_lag_times.append(hop_info['hop_lag'])
+
+        # Compute global-lag stats
+        if global_lag_times:
+            min_lag = min(global_lag_times)
+            max_lag = max(global_lag_times)
+            avg_lag = sum(global_lag_times) / len(global_lag_times)
+        else:
+            min_lag = 0.0
+            max_lag = 0.0
+            avg_lag = 0.0
+
+        # Compute hop-lag stats
+        if hop_lag_times:
+            min_hop_lag = min(hop_lag_times)
+            max_hop_lag = max(hop_lag_times)
+            avg_hop_lag = sum(hop_lag_times) / len(hop_lag_times)
+            total_hops = len(hop_lag_times)
+        else:
+            min_hop_lag = 0.0
+            max_hop_lag = 0.0
+            avg_hop_lag = 0.0
+            total_hops = 0
+
+        # Build analysis summary
+        analysis_summary = {
+            'total_servers': len(self.log_dirs),
+            'analyzed_logs': len(self.csns),
+            'total_updates': sum(suffix_updates.values()),
+            'minimum_lag': min_lag,
+            'maximum_lag': max_lag,
+            'average_lag': avg_lag,
+            'minimum_hop_lag': min_hop_lag,
+            'maximum_hop_lag': max_hop_lag,
+            'average_hop_lag': avg_hop_lag,
+            'total_hops': total_hops,
+            'updates_by_suffix': suffix_updates,
+            'time_range': {
+                'start': results['start-time'],
+                'end': 'current'
+            }
+        }
+
+        # Wrap it up for writing
+        summary = {
+            'analysis_summary': analysis_summary
+        }
+
+        # Write to JSON
+        try:
+            with open(outfile, 'w', encoding='utf-8') as f:
+                json.dump(summary, f, indent=2)
+        except Exception as e:
+            raise IOError(f"Failed to write summary JSON: {e}")

--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -7,3 +7,6 @@ python-ldap
 setuptools
 distro
 cryptography
+plotly
+matplotlib
+numpy

--- a/src/lib389/setup.py.in
+++ b/src/lib389/setup.py.in
@@ -98,7 +98,10 @@ setup(
         'python-ldap',
         'setuptools',
         'distro',
-        'cryptography'
+        'cryptography',
+        'plotly',
+        'matplotlib',
+        'numpy'
         ],
 
     cmdclass={


### PR DESCRIPTION
Description: Add a new ReplicationLogAnalyzer class and supporting infrastructure
to analyze replication performance across multiple servers. The tool parses
replication logs, tracks CSNs, calculates lag times, and generates comprehensive
reports in interactive HTML and CSV formats.

Based on: https://github.com/droideck/ansible-ds389-repl-monitoring

Fixes: https://github.com/389ds/389-ds-base/issues/6465

Reviewed by: ?