### PR TITLE
Issue 6368 - Fix crash when testing access json logging

### DIFF
--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -293,7 +293,7 @@ int32_t
 slapd_log_access_result(slapd_log_pblock *logpb)
 {
     int32_t rc = 0;
-    char *bind_dn;
+    char *bind_dn = NULL;
 
     /* get the bind dn */
     slapi_pblock_get(logpb->pb, SLAPI_CONN_DN, &bind_dn);

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -7059,7 +7059,7 @@ void
 slapd_log_pblock_init(slapd_log_pblock *logpb, int32_t log_format, Slapi_PBlock *pb)
 {
     Slapi_Operation *op = NULL;
-    Connection *conn = NULL;;
+    Connection *conn = NULL;
 
     if (pb) {
         slapi_pblock_get(pb, SLAPI_OPERATION, &op);


### PR DESCRIPTION
Description:

An uninitialized pointer led to a crash when getting the bind dn from the pblock and then freeing it.

Fixes: https://github.com/389ds/389-ds-base/issues/6368
