### PR TITLE
Issue 6470 - Some replication status data are reset upon a restart

### DIFF
--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -169,6 +169,9 @@ extern const char *type_nsds5ReplicaBootstrapCredentials;
 extern const char *type_nsds5ReplicaBootstrapBindMethod;
 extern const char *type_nsds5ReplicaBootstrapTransportInfo;
 extern const char *type_replicaKeepAliveUpdateInterval;
+extern const char *type_nsds5ReplicaLastInitStart;
+extern const char *type_nsds5ReplicaLastInitEnd;
+extern const char *type_nsds5ReplicaLastInitStatus;
 
 /* Attribute names for windows replication agreements */
 extern const char *type_nsds7WindowsReplicaArea;
@@ -435,6 +438,7 @@ void agmt_notify_change(Repl_Agmt *ra, Slapi_PBlock *pb);
 Object *agmt_get_consumer_ruv(Repl_Agmt *ra);
 ReplicaId agmt_get_consumer_rid(Repl_Agmt *ra, void *conn);
 int agmt_set_consumer_ruv(Repl_Agmt *ra, RUV *ruv);
+void agmt_update_init_status(Repl_Agmt *ra);
 void agmt_update_consumer_ruv(Repl_Agmt *ra);
 CSN *agmt_get_consumer_schema_csn(Repl_Agmt *ra);
 void agmt_set_consumer_schema_csn(Repl_Agmt *ra, CSN *csn);

--- a/ldap/servers/plugins/replication/repl5_agmtlist.c
+++ b/ldap/servers/plugins/replication/repl5_agmtlist.c
@@ -786,6 +786,7 @@ agmtlist_shutdown()
         ra = (Repl_Agmt *)object_get_data(ro);
         agmt_stop(ra);
         agmt_update_consumer_ruv(ra);
+        agmt_update_init_status(ra);
         next_ro = objset_next_obj(agmt_set, ro);
         /* Object ro was released in objset_next_obj,
          * but the address ro can be still used to remove ro from objset. */

--- a/ldap/servers/plugins/replication/repl_cleanallruv.c
+++ b/ldap/servers/plugins/replication/repl_cleanallruv.c
@@ -2441,6 +2441,7 @@ clean_agmts(cleanruv_data *data)
                      "Cleaning agmt (%s) ...", agmt_get_long_name(agmt));
         agmt_stop(agmt);
         agmt_update_consumer_ruv(agmt);
+        agmt_update_init_status(agmt);
         agmt_start(agmt);
         agmt_obj = agmtlist_get_next_agreement_for_replica(data->replica, agmt_obj);
     }

--- a/ldap/servers/plugins/replication/repl_globals.c
+++ b/ldap/servers/plugins/replication/repl_globals.c
@@ -118,6 +118,9 @@ const char *type_nsds5ReplicaBootstrapBindDN = "nsds5ReplicaBootstrapBindDN";
 const char *type_nsds5ReplicaBootstrapCredentials = "nsds5ReplicaBootstrapCredentials";
 const char *type_nsds5ReplicaBootstrapBindMethod = "nsds5ReplicaBootstrapBindMethod";
 const char *type_nsds5ReplicaBootstrapTransportInfo = "nsds5ReplicaBootstrapTransportInfo";
+const char *type_nsds5ReplicaLastInitStart = "nsds5replicaLastInitStart";
+const char *type_nsds5ReplicaLastInitEnd = "nsds5replicaLastInitEnd";
+const char *type_nsds5ReplicaLastInitStatus = "nsds5replicaLastInitStatus";
 
 /* windows sync specific attributes */
 const char *type_nsds7WindowsReplicaArea = "nsds7WindowsReplicaSubtree";


### PR DESCRIPTION
Bug description:
	The replication agreement contains operational attributes
	related to the total init: nsds5replicaLastInitStart,
	nsds5replicaLastInitEnd, nsds5replicaLastInitStatus.
	Those attributes are reset at restart

Fix description:
	When reading the replication agreement from config
	(agmt_new_from_entry) restore the attributes into
	the in-memory RA.
	Updates the RA config entry from the in-memory RA
	during shutdown/cleanallruv/enable_ra

fixes: #6470

Reviewed by: