### PR TITLE
Issue 6472 - CLI - Improve error message format

### DIFF
--- a/src/lib389/cli/dsconf
+++ b/src/lib389/cli/dsconf
@@ -34,6 +34,7 @@ from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389.cli_base import setup_script_logger
 from lib389.cli_base import format_error_to_dict
 from lib389.cli_base import parent_argparser
+from lib389.cli_base import format_pretty_error
 from lib389.utils import instance_choices
 
 parser = argparse.ArgumentParser(allow_abbrev=True, parents=[parent_argparser])
@@ -133,14 +134,16 @@ if __name__ == '__main__':
         if args.verbose:
             log.info("Command successful.")
     except Exception as e:
+        result = False
         log.debug(e, exc_info=True)
         msg = format_error_to_dict(e)
 
         if args and args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
+            if not args.verbose:
+                msg = format_pretty_error(msg)
             log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
-        result = False
 
     disconnect_instance(inst)
 

--- a/src/lib389/cli/dscreate
+++ b/src/lib389/cli/dscreate
@@ -18,7 +18,7 @@ from textwrap import dedent
 from lib389 import DirSrv
 from lib389.cli_ctl import instance as cli_instance
 from lib389.cli_base import setup_script_logger
-from lib389.cli_base import format_error_to_dict
+from lib389.cli_base import format_error_to_dict, format_pretty_error
 
 
 epilog = """
@@ -103,6 +103,8 @@ if __name__ == '__main__':
         if args and args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
+            if not args.verbose:
+                msg = format_pretty_error(msg)
             log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
         result = False
 

--- a/src/lib389/cli/dsctl
+++ b/src/lib389/cli/dsctl
@@ -31,6 +31,7 @@ from lib389.cli_base import (
     disconnect_instance,
     setup_script_logger,
     format_error_to_dict,
+    format_pretty_error,
     parent_argparser
     )
 from lib389._constants import DSRC_CONTAINER
@@ -131,6 +132,8 @@ if __name__ == '__main__':
             if args.json:
                 sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
             else:
+                if not args.verbose:
+                    msg = format_pretty_error(msg)
                 log.error("Error: %s" % " - ".join(msg.values()))
             sys.exit(1)
         except Exception as e:
@@ -138,6 +141,8 @@ if __name__ == '__main__':
             if args.json:
                 sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
             else:
+                if not args.verbose:
+                    msg = format_pretty_error(msg)
                 log.error("Error: %s" % " - ".join(msg.values()))
             sys.exit(1)
     if len(insts) != 1:
@@ -160,6 +165,8 @@ if __name__ == '__main__':
         if args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
+            if not args.verbose:
+                msg = format_pretty_error(msg)
             log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
         result = False
     disconnect_instance(inst)

--- a/src/lib389/cli/dsidm
+++ b/src/lib389/cli/dsidm
@@ -32,7 +32,7 @@ from lib389.cli_idm import role as cli_role
 from lib389.cli_idm import service as cli_service
 from lib389.cli_base import connect_instance, disconnect_instance, setup_script_logger
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
-from lib389.cli_base import format_error_to_dict
+from lib389.cli_base import format_error_to_dict, format_pretty_error
 from lib389.cli_base import parent_argparser
 
 parser = argparse.ArgumentParser(allow_abbrev=True, parents=[parent_argparser])
@@ -145,10 +145,9 @@ if __name__ == '__main__':
         if args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
-            if 'desc' in msg:
-                log.error(f"Error: {msg['desc']}")
-            else:
-                log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
+            if not args.verbose:
+                msg = format_pretty_error(msg)
+            log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
         result = False
 
     disconnect_instance(inst)

--- a/src/lib389/cli/openldap_to_ds
+++ b/src/lib389/cli/openldap_to_ds
@@ -12,6 +12,7 @@
 
 import argparse
 import argcomplete
+import json
 import signal
 import sys
 from lib389 import DirSrv
@@ -19,7 +20,8 @@ from lib389.cli_base import (
     connect_instance,
     disconnect_instance,
     setup_script_logger,
-    format_error_to_dict)
+    format_error_to_dict,
+    format_pretty_error)
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389._constants import DSRC_HOME
 
@@ -254,6 +256,8 @@ if __name__ == '__main__':
         if args.json:
             sys.stderr.write(f"{json.dumps(msg, indent=4)}\n")
         else:
+            if not args.verbose:
+                msg = format_pretty_error(msg)
             log.error("Error: %s" % " - ".join(str(val) for val in msg.values()))
         result = False
     disconnect_instance(inst)

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -73,7 +73,7 @@ def _ldap_op_s(inst, f, fname, *args, **kwargs):
     try:
         return f(*args, **kwargs)
     except ldap.LDAPError as e:
-        new_desc = f"{fname}({args},{kwargs}) on instance {inst.serverid}";
+        new_desc = f"{fname}({args},{kwargs}) on instance {inst.serverid}"
         if len(e.args) >= 1:
             e.args[0]['ldap_request'] = new_desc
             logging.getLogger().debug(f"args={e.args}")
@@ -527,9 +527,10 @@ class DSLdapObject(DSLogging, DSLint):
         elif value is not None:
             value = [ensure_bytes(value)]
 
-        return _modify_ext_s(self._instance,self._dn, [(action, key, value)],
-                                           serverctrls=self._server_controls, clientctrls=self._client_controls,
-                                           escapehatch='i am sure')
+        return _modify_ext_s(self._instance, self._dn, [(action, key, value)],
+                             serverctrls=self._server_controls,
+                             clientctrls=self._client_controls,
+                             escapehatch='i am sure')
 
     def apply_mods(self, mods):
         """Perform modification operation using several mods at once

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -388,7 +388,7 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         if len(actions) > 0 and actions[0].option_strings:
             actions = parent_arguments + actions
         super(CustomHelpFormatter, self).add_arguments(actions)
-    
+
     def _format_usage(self, usage, actions, groups, prefix):
         usage = super(CustomHelpFormatter, self)._format_usage(usage, actions, groups, prefix)
         formatted_options = self._format_actions_usage(parent_arguments, [])
@@ -504,9 +504,24 @@ def format_error_to_dict(exception):
     # We should fix the code here after the issue is fixed
     errmsg = str(exception)
     try:
-        # The function literal_eval parses the string and returns only if it's a literal.
-        # Also, the code is never executed. So there is no reason for a security risk.
+        # The function literal_eval parses the string and returns only if it's
+        # a literal. Also, the code is never executed. So there is no reason
+        # for a security risk.
         msg = ast.literal_eval(errmsg)
     except Exception:
         msg = {'desc': errmsg}
+
     return msg
+
+
+def format_pretty_error(msg_dict):
+    """
+    Take a raw exception dict and make a pretty message for the user
+    """
+    msg = f"{msg_dict['desc']}"
+    if 'result' in msg_dict:
+        msg += f"({msg_dict['result']})"
+    if 'info' in msg_dict:
+        msg += f" - {msg_dict['info']}"
+
+    return {'desc': msg}


### PR DESCRIPTION
Description:

For non-json/non-verbose generic exceptions format the message into something more readable and friendly (desc, result, and info)

Relates: https://github.com/389ds/389-ds-base/issues/6472
