### PR TITLE
Issue 6372 - Deadlock while doing online backup

### DIFF
--- a/ldap/servers/slapd/dse.c
+++ b/ldap/servers/slapd/dse.c
@@ -41,6 +41,7 @@
 #include <pwd.h>
 /* Needed to access read_config_dse */
 #include "proto-slap.h"
+#include <stdbool.h>
 
 #include <unistd.h> /* provides fsync/close */
 
@@ -102,7 +103,7 @@ struct dse
     int dse_is_updateable;           /* if non-zero, this DSE can be written to */
     int dse_readonly_error_reported; /* used to ensure that read-only errors are logged only once */
     pthread_mutex_t dse_backup_lock; /* used to block write when online backup is in progress */
-    int dse_backup_in_progress;      /* tell that online backup is in progress (protected by dse_rwlock) */
+    bool dse_backup_in_progress;     /* tell that online backup is in progress (protected by dse_rwlock) */
 };
 
 struct dse_node
@@ -211,7 +212,7 @@ dse_backup_lock_cb(struct dse *pdse)
 {
     pthread_mutex_lock(&pdse->dse_backup_lock);
     slapi_rwlock_wrlock(pdse->dse_rwlock);
-    pdse->dse_backup_in_progress = 1;
+    pdse->dse_backup_in_progress = true;
     slapi_rwlock_unlock(pdse->dse_rwlock);
 }
 
@@ -220,7 +221,7 @@ static void
 dse_backup_unlock_cb(struct dse *pdse)
 {
     slapi_rwlock_wrlock(pdse->dse_rwlock);
-    pdse->dse_backup_in_progress = 0;
+    pdse->dse_backup_in_progress = false;
     slapi_rwlock_unlock(pdse->dse_rwlock);
     pthread_mutex_unlock(&pdse->dse_backup_lock);
 }

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -2033,9 +2033,6 @@ FrontendConfig_init(void)
     /* Done, unlock!  */
     CFG_UNLOCK_WRITE(cfg);
 
-    /* init the dse file backup lock */
-    dse_init_backup_lock();
-
     init_config_get_and_set();
 }
 

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -1164,7 +1164,6 @@ cleanup:
     slapd_ssl_destroy();
     ndn_cache_destroy();
     NSS_Shutdown();
-    dse_destroy_backup_lock();
 
     /*
      * Server has stopped, lets force everything to disk: logs

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1415,8 +1415,6 @@ void modify_update_last_modified_attr(Slapi_PBlock *pb, Slapi_Mods *smods);
 void add_internal_modifiersname(Slapi_PBlock *pb, Slapi_Entry *e);
 
 /* dse.c */
-void dse_init_backup_lock(void);
-void dse_destroy_backup_lock(void);
 void dse_backup_lock(void);
 void dse_backup_unlock(void);
 

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -525,7 +525,7 @@ class Tasks(object):
             entry.setValues('nsIncludeSuffix', suffix)
 
         # start the task and possibly wait for task completion
-        self.conn.add_s(entry)
+        self.conn.add_s(entry, escapehatch='i am sure')
 
         exitCode = 0
         warningCode = 0
@@ -598,7 +598,7 @@ class Tasks(object):
             entry.setValues('nsExportReplica', 'true')
 
         # start the task and possibly wait for task completion
-        self.conn.add_s(entry)
+        self.conn.add_s(entry, escapehatch='i am sure')
         exitCode = 0
         warningCode = 0
         if args and args.get(TASK_WAIT, False):
@@ -649,7 +649,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add the backup task (%s)", dn)
             return -1
@@ -706,7 +706,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add the backup task (%s)", dn)
             return -1
@@ -834,7 +834,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add the index task for %s", attrname)
             return -1
@@ -914,7 +914,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add the memberOf fixup task")
             return -1
@@ -975,7 +975,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add the fixup tombstone task")
             return -1
@@ -1031,7 +1031,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Automember Rebuild Membership task")
             return -1
@@ -1087,7 +1087,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Automember Export Updates task")
             return -1
@@ -1138,7 +1138,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Automember Map Updates task")
             return -1
@@ -1183,7 +1183,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Fixup Linked Attributes task")
             return -1
@@ -1227,7 +1227,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Schema Reload task")
             return -1
@@ -1272,7 +1272,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add fixupWinsyncMembers 'memberuid task'")
             return -1
@@ -1319,7 +1319,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Syntax Validate task")
             return -1
@@ -1370,7 +1370,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add USN tombstone cleanup task")
             return -1
@@ -1421,7 +1421,7 @@ class Tasks(object):
             entry.setValues('logchanges', logchanges)
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Sysconfig Reload task")
             return -1
@@ -1473,7 +1473,7 @@ class Tasks(object):
             entry.setValues('replica-force-cleaning', 'yes')
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add cleanAllRUV task")
             return (dn, -1)
@@ -1528,7 +1528,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add Abort cleanAllRUV task")
             return (dn, -1)
@@ -1582,7 +1582,7 @@ class Tasks(object):
 
         # start the task and possibly wait for task completion
         try:
-            self.conn.add_s(entry)
+            self.conn.add_s(entry, escapehatch='i am sure')
         except ldap.ALREADY_EXISTS:
             self.log.error("Fail to add upgradedb task")
             return -1


### PR DESCRIPTION
Sometime server hangs during online backup because of a deadlock due to lock order inversion between the dse backup_lock mutex and the dse rwlock.

Solution:
  Add functions to manage the lock/unlock to ensure consistency.
  Ensure that threads always tries to lock dse_backup_lock mutex before the dse write lock
Code cleanup:
  - Move the backup_lock into the dse struct
  - Avoid the obsolete warning during tests (I think that we will have to do a second cleanup phase later to see if we could not replace self.conn.add_s by self.create .
  
  Issue: #6372 
  
  Closing: #6372 
  
  Reviewed by: @mreynolds389 (Thanks!)
