### PR TITLE
Issue 6468 - CLI - Remove security log settings that don't exist

### DIFF
--- a/src/lib389/lib389/cli_conf/logging.py
+++ b/src/lib389/lib389/cli_conf/logging.py
@@ -676,7 +676,7 @@ def create_parser(subparsers):
             + "the server to delete rotated log files.",
         )
 
-        if log_type in ['access', 'audit', 'security']:
+        if log_type in ['access', 'audit']:
             # JSON logging
             set_log_format_parser = set_parsers.add_parser(
                 "log-format",


### PR DESCRIPTION
Description:

JSON log settings were incorrectly added for security log

relates: https://github.com/389ds/389-ds-base/issues/6468