### PR TITLE
Issue 6417 - (3rd) If an entry RDN is identical to the suffix, then E…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -1033,21 +1033,25 @@ entryrdn_lookup_dn(backend *be,
     dblayer_value_free(be, &data);
     dblayer_value_init(be, &data);
 
-    /* Just in case the suffix ID is not '1' retrieve it from the database */
-    keybuf = slapi_ch_strdup(slapi_sdn_get_ndn(be->be_suffix));
-    dblayer_value_set(be, &key, keybuf, strlen(keybuf) + 1);
-    rc = dblayer_cursor_op(&ctx.cursor, DBI_OP_MOVE_TO_KEY, &key, &data);
-    if (rc) {
-        slapi_log_err(SLAPI_LOG_WARNING, "entryrdn_lookup_dn",
-                      "Fails to retrieve the ID of suffix %s - keep the default value '%d'\n",
-                      slapi_sdn_get_ndn(be->be_suffix),
-                      suffix_id);
-    } else {
-        elem = (rdn_elem *)data.data;
-        suffix_id = id_stored_to_internal(elem->rdn_elem_id);
+    /* Just in case the suffix ID is not '1' retrieve it from the database
+     * if the suffix is not defined suffix_id remains '1'
+     */
+    if (be->be_suffix) {
+        keybuf = slapi_ch_strdup(slapi_sdn_get_ndn(be->be_suffix));
+        dblayer_value_set(be, &key, keybuf, strlen(keybuf) + 1);
+        rc = dblayer_cursor_op(&ctx.cursor, DBI_OP_MOVE_TO_KEY, &key, &data);
+        if (rc) {
+            slapi_log_err(SLAPI_LOG_WARNING, "entryrdn_lookup_dn",
+                          "Fails to retrieve the ID of suffix %s - keep the default value '%d'\n",
+                          slapi_sdn_get_ndn(be->be_suffix),
+                          suffix_id);
+        } else {
+            elem = (rdn_elem *)data.data;
+            suffix_id = id_stored_to_internal(elem->rdn_elem_id);
+        }
+        dblayer_value_free(be, &data);
+        dblayer_value_free(be, &key);
     }
-    dblayer_value_free(be, &data);
-    dblayer_value_free(be, &key);
 
     do {
         /* Setting up a key for the node to get its parent */


### PR DESCRIPTION
…ntryrdn gets broken during a reindex

Bug description:
	The previous fix had a flaw.
	In case entryrdn_lookup_dn is called with an undefined suffix
	the lookup of the suffix trigger a crash.
	For example it can occur during internal search of an
	unexisting map (view plugin).
	The issue exists in all releases but is hidden since 2.3.

Fix description:
	testing the suffix is defined

fixes: #6417

Reviewed by: