### PR TITLE
Issue 6481 - UI - When ports that are in use are used to update a DS instance the error message is not helpful

### DIFF
--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -309,6 +309,9 @@ async validateSaveBtn(nav_tab, attr, value) {
                         const portInUse = await is_port_in_use(portValue);
                         if (portInUse) {
                             disableSaveBtn = true;
+                            if (portValue !== Number(this.state['_' + attr])) {
+                                valueErr = true;
+                            }
                         }
                     } catch (error) {
                         console.error("Error checking port:", error);

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -1026,8 +1026,6 @@ async validateSaveBtn(nav_tab, attr, value) {
                 });
     }
 
-
-
     render() {
         let body = "";
         let diskMonitor = "";

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -212,6 +212,32 @@ export function valid_port(val) {
     return result;
 }
 
+export function is_port_in_use(port) {
+    // Check if a port number is being used
+    return new Promise((resolve, reject) => {
+        // First check port number is within range
+        if (!valid_port(port)) {
+            reject('Invalid port number');
+            return;
+        }
+
+        let cmd = ['bash', '-c', `sudo lsof -i :${port} || echo "free"`];
+        log_cmd("is_port_in_use", cmd);
+
+        cockpit
+            .spawn(cmd, { superuser: true, err: "message" })
+            .done((result) => {
+                const isPortInUse = result.trim() !== "free";
+                // Resolve the promise with a result
+                resolve(isPortInUse);
+            })
+            .fail((error) => {
+                // Reject the promise on error
+                reject('Error checking port');
+            });
+    });
+}
+
 export function valid_dn(dn) {
     // Validate value is a valid DN (sanity validation)
     if (dn === "" || dn.endsWith(",")) {


### PR DESCRIPTION
Bug description:
When updating port values on a DS instance, if the port value is already in use the error message displayed by the UI is not helpful.

Fix description:
Add a UI method that checks if the updated port value is already in use. If it is, disable the save button.

Fixes: https://github.com/389ds/389-ds-base/issues/6481

Reviewed by: