### PR TITLE
Issue 6490 - Add a new macro function and print rounds on startup

### DIFF
--- a/dirsrvtests/tests/suites/pwp_storage/storage_test.py
+++ b/dirsrvtests/tests/suites/pwp_storage/storage_test.py
@@ -147,7 +147,7 @@ def test_pbkdf2_default_rounds(topo, new_user, scheme_name, plugin_class, defaul
         topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
         
         assert topo.standalone.searchErrorsLog(
-            f'Number of iterations for {scheme_name} password scheme set to {default_rounds} from default'
+            f'{scheme_name} - Number of iterations set to {default_rounds} from default'
         )
     finally:
         topo.standalone.simple_bind_s(DN_DM, PASSWORD)
@@ -205,7 +205,7 @@ def test_pbkdf2_rounds_reset(topo, new_user, scheme_name, plugin_class, default_
         topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
         
         assert topo.standalone.searchErrorsLog(
-            f'Number of iterations for {scheme_name} password scheme set to {default_rounds} from default'
+            f'{scheme_name} - Number of iterations set to {default_rounds} from default'
         )
     finally:
         topo.standalone.simple_bind_s(DN_DM, PASSWORD)
@@ -256,7 +256,7 @@ def test_pbkdf2_custom_rounds(topo, new_user, scheme_name, plugin_class, _, roun
         topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
         
         assert topo.standalone.searchErrorsLog(
-            f'Number of iterations for {scheme_name}'
+            f'{scheme_name} - Number of iterations set'
         )
     finally:
         topo.standalone.simple_bind_s(DN_DM, PASSWORD)

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -317,19 +317,19 @@ impl PwdChanCrypto {
         Self::set_pbkdf2_rounds(digest, rounds)?;
 
         let digest_name = if digest == MessageDigest::sha1() {
-            "SHA1"
+            "PBKDF2-SHA1"
         } else if digest == MessageDigest::sha256() {
-            "SHA256"
+            "PBKDF2-SHA256"
         } else if digest == MessageDigest::sha512() {
-            "SHA512"
+            "PBKDF2-SHA512"
         } else {
             "Unknown"
         };
 
-        log_error!(
-            ErrorLevel::Plugin,
-            "handle_pbkdf2_rounds_config -> Number of iterations for PBKDF2-{} password scheme set to {} from {}",
+        log_error_ext!(
+            ErrorLevel::Info,
             digest_name,
+            "Number of iterations set to {} from {}",
             rounds,
             source
         );

--- a/src/slapi_r_plugin/src/macros.rs
+++ b/src/slapi_r_plugin/src/macros.rs
@@ -1,16 +1,16 @@
 #[macro_export]
 #[cfg(not(feature = "test_log_direct"))]
-macro_rules! log_error {
-    ($level:expr, $($arg:tt)*) => ({
+macro_rules! log_error_ext {
+    ($level:expr, $source:expr, $($arg:tt)*) => ({
         use std::fmt;
         match log_error(
             $level,
-            format!("{}:{}", file!(), line!()),
+            $source.to_string(),
             format!("{}\n", fmt::format(format_args!($($arg)*)))
         ) {
             Ok(_) => {},
             Err(e) => {
-                eprintln!("A logging error occured {}, {} -> {:?}", file!(), line!(), e);
+                eprintln!("A logging error occurred {}, {} -> {:?}", file!(), line!(), e);
             }
         };
     })
@@ -18,10 +18,24 @@ macro_rules! log_error {
 
 #[macro_export]
 #[cfg(feature = "test_log_direct")]
+macro_rules! log_error_ext {
+    ($level:expr, $source:expr, $($arg:tt)*) => ({
+        use std::fmt;
+        eprintln!("{} -> {}", $source, fmt::format(format_args!($($arg)*)));
+    })
+}
+
+#[macro_export]
 macro_rules! log_error {
     ($level:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        eprintln!("{}:{} -> {}", file!(), line!(), fmt::format(format_args!($($arg)*)));
+        log_error_ext!($level, format!("{}:{}", file!(), line!()), $($arg)*)
+    })
+}
+
+#[macro_export]
+macro_rules! log_error_fn {
+    ($level:expr, $funcname:expr, $($arg:tt)*) => ({
+        log_error_ext!($level, $funcname, $($arg)*)
     })
 }
 


### PR DESCRIPTION
Description: This commit introduces a new macro function (log_error_ext!) to improve logging by providing a way to write a custom subsystem instead of file:line. It also modifies the handle_pbkdf2_rounds_config method to print the PBKDF2 rounds (number of iterations) on startup.

Fixes: https://github.com/389ds/389-ds-base/issues/6490

Reviewed by: ?