### PR TITLE
Issue 6516 - Allow to configure the password scheme not updated on bind

### DIFF
--- a/dirsrvtests/tests/suites/password/password_test.py
+++ b/dirsrvtests/tests/suites/password/password_test.py
@@ -75,6 +75,19 @@ def pbkdf2_sha512_scheme(request, topology_st):
 
     request.addfinalizer(fin)
 
+@pytest.fixture(scope="function")
+def crypt_scheme(request, topology_st):
+    """Set default password storage scheme to CRYPT"""
+
+    inst = topology_st.standalone
+    default_scheme = inst.config.get_attr_val_utf8('passwordStorageScheme')
+    inst.config.set('passwordStorageScheme', 'CRYPT')
+
+    def fin():
+        inst.config.set('passwordStorageScheme', default_scheme)
+
+    request.addfinalizer(fin)
+
 
 def test_password_modify_non_utf8(topology_st, pbkdf2_sha512_scheme):
     """Attempt a modify of the userPassword attribute with
@@ -131,6 +144,73 @@ def test_password_modify_non_utf8(topology_st, pbkdf2_sha512_scheme):
         assert False
 
     log.info('test_password_modify_non_utf8: PASSED')
+
+
+@pytest.mark.parametrize('no_upgrade_hash, expected_hash',
+                         [('CRYPT,CLEAR', '{crypt}'),
+                          ('CrYpT,CLEAR', '{crypt}'),
+                          ('PBKDF2-SHA512', '{PBKDF2-SHA512}'),
+                          ('clear', '{PBKDF2-SHA512}')])
+def test_pwd_scheme_no_upgrade_on_bind(topology_st, crypt_scheme, request, no_upgrade_hash, expected_hash):
+    """Check that password is/is_not updated on bind weither
+    the current hash is in nsslapd-scheme-list-no-upgrade-hash
+
+    :id: b4d2c525-a239-4ca6-a168-5126da7abedd
+    :setup: Standalone instance
+    :steps:
+        1. Create a user with userpassword stored as CRYPT
+        2. Make sure configured stored hash is set to PBKDF2-SHA512
+        3. Make sure that the configuration skips update on bind for
+           CRYPT,CLEAR original hashes and set it to no_upgrade_hash value
+        4. Bind and check the hash password starts with expected_hash
+    :expectedresults:
+        1. The user with userPassword should be added successfully
+        2. Operation should be successful
+        3. Operation should be successful
+        4. After bind, the password has the expected hash
+     """
+
+    log.info('test_pwd_scheme_crypt_upgraded_on_bind...')
+
+    # Create user and set password with CRYPT
+    standalone = topology_st.standalone
+    users = UserAccounts(standalone, DEFAULT_SUFFIX)
+    if not users.exists(TEST_USER_PROPERTIES['uid'][0]):
+        user = users.create(properties=TEST_USER_PROPERTIES)
+    else:
+        user = users.get(TEST_USER_PROPERTIES['uid'][0])
+
+    # Check that the password is stored as CRYPT
+    user.set('userpassword', PASSWORD)
+    value_crypt = user.get_attr_val_utf8('userpassword')
+    assert value_crypt.startswith('{crypt}')
+
+    # change the default password Scheme to PBKDF2-SHA512
+    standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+
+    # Check that default no upgrade hash is CRYPT,CLEAR
+    # and set it to no_upgrade_hash parameter value
+    original_no_upgrade_hash = standalone.config.get_attr_val_utf8('nsslapd-scheme-list-no-upgrade-hash')
+    assert original_no_upgrade_hash.lower() == "CRYPT,CLEAR".lower()
+    standalone.config.set('nsslapd-scheme-list-no-upgrade-hash', no_upgrade_hash)
+    new_no_upgrade_hash = standalone.config.get_attr_val_utf8('nsslapd-scheme-list-no-upgrade-hash')
+    assert new_no_upgrade_hash.lower() == no_upgrade_hash.lower()
+
+    # Authenticate user and check its password
+    # hash starts with expected_hash
+    user.bind(PASSWORD)
+    standalone.simple_bind_s(DN_DM, PASSWORD)
+    pwd_hashed_value = user.get_attr_val_utf8('userpassword')
+    assert pwd_hashed_value.startswith(expected_hash)
+
+    log.info('test_pwd_scheme_upgrade_on_bind PASSED')
+
+    def fin():
+        user.delete()
+        standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+        standalone.config.set('nsslapd-scheme-list-no-upgrade-hash', 'CRYPT,CLEAR')
+
+    request.addfinalizer(fin)
 
 if __name__ == '__main__':
     # Run isolated

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -630,6 +630,7 @@ int config_get_extract_pem(void);
 
 int32_t config_get_enable_upgrade_hash(void);
 int32_t config_set_enable_upgrade_hash(const char *attrname, char *value, char *errorbuf, int apply);
+int32_t config_set_scheme_list_no_upgrade_hash(const char *attrname, char *value, char *errorbuf, int apply);
 
 
 int32_t config_get_enable_ldapssotoken(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -316,6 +316,8 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_DEFAULT_LDAPI_AUTO_DN     "cn=peercred,cn=external,cn=auth"
 #define SLAPD_DEFAULT_LDAPI_MAPPING_DN  "cn=auto_bind,cn=config"
 
+#define SLAPD_DEFAULT_PWD_SCHEME_LIST_NO_UPGRADE_HASH "CRYPT,CLEAR"
+
 #define SLAPD_SCHEMA_DN  "cn=schema"
 #define SLAPD_CONFIG_DN  "cn=config"
 
@@ -2346,6 +2348,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_GLOBAL_BACKEND_LOCK "nsslapd-global-backend-lock"
 #define CONFIG_ENABLE_NUNC_STANS "nsslapd-enable-nunc-stans"
 #define CONFIG_ENABLE_UPGRADE_HASH "nsslapd-enable-upgrade-hash"
+#define CONFIG_SCHEME_LIST_NO_UPGRADE_HASH "nsslapd-scheme-list-no-upgrade-hash"
 #define CONFIG_CONFIG_ATTRIBUTE "nsslapd-config"
 #define CONFIG_INSTDIR_ATTRIBUTE "nsslapd-instancedir"
 #define CONFIG_SCHEMADIR_ATTRIBUTE "nsslapd-schemadir"
@@ -2723,6 +2726,9 @@ typedef struct _slapdFrontendConfig
 #endif
     slapi_onoff_t extract_pem; /* If "on", export key/cert as pem files */
     slapi_onoff_t enable_upgrade_hash; /* If on, upgrade hashes for PW at bind */
+    char *scheme_list_no_upgrade_hash; /* It contains the list of password storage scheme
+                                        * that are not updated (at bind)
+                                        */
     /*
      * Do we verify the filters we recieve by schema?
      * reject-invalid - reject filter if there is anything invalid


### PR DESCRIPTION
Bug description:
	The configuration option 'nsslapd-enable-upgrade-hash: on' allows
	to update, during a user bind, the password storage hash of the
	user password.
	The update sets the password storage hash to the one defined in the
	password policy (passwordStorageScheme)

	If the current user password hash is 'CRYPT' or 'CLEAR' then the
	password storage hash is not updated. This is hardcoded.

Fix description:
	Introduce a new configuration parameter that list the hashes
	that are *not* upgraded during a bind.
	'nsslapd-scheme-list-no-upgrade-hash'

fixes: #6516

Reviewed by: