### PR TITLE
Issue 6521 - Typo in dsidm (unique)group add_member prompt

### DIFF
--- a/src/lib389/lib389/cli_idm/group.py
+++ b/src/lib389/lib389/cli_idm/group.py
@@ -78,7 +78,7 @@ def members(inst, basedn, log, args):
 
 
 def add_member(inst, basedn, log, args):
-    cn = _get_arg( args.cn, msg="Enter %s of group to add member too" % RDN)
+    cn = _get_arg( args.cn, msg="Enter %s of group to add member to" % RDN)
     dn = _get_arg( args.dn, msg="Enter dn to add as member")
     groups = MANY(inst, basedn)
     group = groups.get(cn)

--- a/src/lib389/lib389/cli_idm/uniquegroup.py
+++ b/src/lib389/lib389/cli_idm/uniquegroup.py
@@ -77,7 +77,7 @@ def members(inst, basedn, log, args):
 
 
 def add_member(inst, basedn, log, args):
-    cn = _get_arg( args.cn, msg="Enter %s of group to add member too" % RDN)
+    cn = _get_arg( args.cn, msg="Enter %s of group to add member to" % RDN)
     dn = _get_arg( args.dn, msg="Enter dn to add as member")
     groups = MANY(inst, basedn)
     group = groups.get(cn)


### PR DESCRIPTION
Fixing a typo in dsidm group/uniquegroup add_member prompt

Relates to: https://github.com/389ds/389-ds-base/issues/6521

Author: Lenka Doudova

Reviewed by: ???