### PR TITLE
Issue 6525 - Fix srpm generation in COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,12 +1,8 @@
 srpm:
-	# Install git in the buildroot to correctly generate commit hash
-	dnf install -y git
-	# Generate spec file
-	make -f rpm.mk rpmroot
-	# Install build dependencies
-	dnf install -y dnf-plugins-core
-	dnf builddep -y --skip-broken --spec rpmbuild/SPECS/389-ds-base.spec --best --allowerasing --setopt=install_weak_deps=False
+	# Install dependencies to generate srpm
+	dnf install -y git rsync bzip2 rpm-build cargo rust npm make python3-argcomplete
 	cargo install cargo-license --root /usr
+
 	# chown files in current working directory to root:root
 	# because when npm is run as root, scripts are always run
 	# with the effective uid and gid of the working directory owner.


### PR DESCRIPTION
Bug Description:
After update of COPR to F41 and DNF5, srpm generation no longer works due to missing `builddep` command.

Fix Description:
Instead of installing all build dependencies, we should install the ones required for srpm generation.

Reviewed by:

Fixes: https://github.com/389ds/389-ds-base/issues/6525