### PR TITLE
Issue 6476 - Fix build failure with GCC 15

### DIFF
--- a/ldap/include/avl.h
+++ b/ldap/include/avl.h
@@ -66,12 +66,12 @@ typedef int (*IFP)(); /* takes undefined arguments */
 #define avl_onenode(x) (x == 0 || ((x)->avl_left == 0 && (x)->avl_right == 0))
 extern int avl_insert(Avlnode **root, void *data, IFP fcmp, IFP fdup);
 extern caddr_t avl_delete(Avlnode **root, void *data, IFP fcmp);
-extern caddr_t avl_find(Avlnode *root, void *data, IFP fcmp);
+extern caddr_t avl_find(Avlnode *root, void *data, int32_t (*fcmp)(caddr_t, caddr_t));
 extern caddr_t avl_getfirst(Avlnode *root);
 extern caddr_t avl_getnext(void);
 extern int avl_dup_error(void);
 extern int avl_apply(Avlnode *root, IFP fn, void *arg, int stopflag, int type);
-extern int avl_free(Avlnode *root, IFP dfree);
+extern int avl_free(Avlnode *root, int32_t (*dfree)(caddr_t));
 
 /* apply traversal types */
 #define AVL_PREORDER 1
@@ -80,6 +80,6 @@ extern int avl_free(Avlnode *root, IFP dfree);
 /* what apply returns if it ran out of nodes */
 #define AVL_NOMORE -6
 
-caddr_t avl_find_lin(Avlnode *root, caddr_t data, IFP fcmp);
+caddr_t avl_find_lin(Avlnode *root, caddr_t data, int32_t (*fcmp)(caddr_t, caddr_t));
 
 #endif /* _AVL */

--- a/ldap/libraries/libavl/avl.c
+++ b/ldap/libraries/libavl/avl.c
@@ -69,8 +69,8 @@ ravl_insert(
     Avlnode **iroot,
     caddr_t data,
     int *taller,
-    IFP fcmp, /* comparison function */
-    IFP fdup, /* function to call for duplicates */
+    int32_t (*fcmp)(caddr_t, caddr_t), /* comparison function */
+    int32_t (*fdup)(caddr_t, caddr_t), /* function to call for duplicates */
     int depth)
 {
     int rc, cmp, tallersub;
@@ -374,7 +374,7 @@ static caddr_t
 ravl_delete(
     Avlnode **root,
     caddr_t data,
-    IFP fcmp,
+    int32_t (*fcmp)(caddr_t, caddr_t),
     int *shorter)
 {
     int shortersubtree = 0;
@@ -472,7 +472,7 @@ avl_delete(Avlnode **root, void *data, IFP fcmp)
 }
 
 static int
-avl_inapply(Avlnode *root, IFP fn, caddr_t arg, int stopflag)
+avl_inapply(Avlnode *root, int32_t(*fn)(caddr_t, caddr_t), caddr_t arg, int stopflag)
 {
     if (root == 0)
         return (AVL_NOMORE);
@@ -491,7 +491,7 @@ avl_inapply(Avlnode *root, IFP fn, caddr_t arg, int stopflag)
 }
 
 static int
-avl_postapply(Avlnode *root, IFP fn, caddr_t arg, int stopflag)
+avl_postapply(Avlnode *root, int32_t(*fn)(caddr_t, caddr_t), caddr_t arg, int stopflag)
 {
     if (root == 0)
         return (AVL_NOMORE);
@@ -508,7 +508,7 @@ avl_postapply(Avlnode *root, IFP fn, caddr_t arg, int stopflag)
 }
 
 static int
-avl_preapply(Avlnode *root, IFP fn, caddr_t arg, int stopflag)
+avl_preapply(Avlnode *root, int32_t(*fn)(caddr_t, caddr_t), caddr_t arg, int stopflag)
 {
     if (root == 0)
         return (AVL_NOMORE);
@@ -572,9 +572,9 @@ int
 avl_prefixapply(
     Avlnode *root,
     caddr_t data,
-    IFP fmatch,
+    int32_t (*fmatch)(caddr_t, caddr_t),
     caddr_t marg,
-    IFP fcmp,
+    int32_t (*fcmp)(caddr_t, caddr_t, caddr_t),
     caddr_t carg,
     int stopflag)
 {
@@ -619,7 +619,7 @@ avl_prefixapply(
  */
 
 int
-avl_free(Avlnode *root, IFP dfree)
+avl_free(Avlnode *root, int32_t (*dfree)(caddr_t))
 {
     int nleft, nright;
 
@@ -649,7 +649,7 @@ avl_free(Avlnode *root, IFP dfree)
  */
 
 caddr_t
-avl_find(Avlnode *root, void *data, IFP fcmp)
+avl_find(Avlnode *root, void *data, int32_t (*fcmp)(caddr_t, caddr_t))
 {
     int cmp;
 
@@ -671,7 +671,7 @@ avl_find(Avlnode *root, void *data, IFP fcmp)
  */
 
 caddr_t
-avl_find_lin(Avlnode *root, caddr_t data, IFP fcmp)
+avl_find_lin(Avlnode *root, caddr_t data, int32_t (*fcmp)(caddr_t, caddr_t))
 {
     caddr_t res;
 

--- a/ldap/servers/plugins/pwdstorage/md5c.c
+++ b/ldap/servers/plugins/pwdstorage/md5c.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -69,20 +69,17 @@ static unsigned char PADDING[64] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-/* F, G, H and I are basic MD5 functions.
- */
+/* F, G, H and I are basic MD5 functions. */
 #define F(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
 #define G(x, y, z) (((x) & (z)) | ((y) & (~(z))))
 #define H(x, y, z) ((x) ^ (y) ^ (z))
 #define I(x, y, z) ((y) ^ ((x) | (~(z))))
 
-/* ROTATE_LEFT rotates x left n bits.
- */
+/* ROTATE_LEFT rotates x left n bits. */
 #define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
 
 /* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
-Rotation is separate from addition to prevent recomputation.
- */
+ * Rotation is separate from addition to prevent recomputation. */
 #define FF(a, b, c, d, x, s, ac)                     \
     {                                                \
         (a) += F((b), (c), (d)) + (x) + (UINT4)(ac); \
@@ -108,14 +105,11 @@ Rotation is separate from addition to prevent recomputation.
         (a) += (b);                                  \
     }
 
-/* MD5 initialization. Begins an MD5 operation, writing a new context.
- */
-void mta_MD5Init(context)
-    mta_MD5_CTX *context; /* context */
+/* MD5 initialization. Begins an MD5 operation, writing a new context. */
+void mta_MD5Init(mta_MD5_CTX *context)
 {
     context->count[0] = context->count[1] = 0;
-    /* Load magic initialization constants.
-*/
+    /* Load magic initialization constants */
     context->state[0] = 0x67452301;
     context->state[1] = 0xefcdab89;
     context->state[2] = 0x98badcfe;
@@ -123,13 +117,9 @@ void mta_MD5Init(context)
 }
 
 /* MD5 block update operation. Continues an MD5 message-digest
-  operation, processing another message block, and updating the
-  context.
- */
-void mta_MD5Update(context, input, inputLen)
-    mta_MD5_CTX *context;   /* context */
-const unsigned char *input; /* input block */
-unsigned int inputLen;      /* length of input block */
+ * operation, processing another message block, and updating the
+ * context. */
+void mta_MD5Update(mta_MD5_CTX *context, const unsigned char *input, unsigned int inputLen)
 {
     unsigned int i, index, partLen;
 
@@ -143,8 +133,7 @@ unsigned int inputLen;      /* length of input block */
 
     partLen = 64 - index;
 
-    /* Transform as many times as possible.
-*/
+    /* Transform as many times as possible. */
     if (inputLen >= partLen) {
         MD5_memcpy((POINTER)&context->buffer[index], (POINTER)input, partLen);
         MD5Transform(context->state, context->buffer);
@@ -162,10 +151,8 @@ unsigned int inputLen;      /* length of input block */
 }
 
 /* MD5 finalization. Ends an MD5 message-digest operation, writing the
-  the message digest and zeroizing the context.
- */
-void mta_MD5Final(digest, context) unsigned char digest[16]; /* message digest */
-mta_MD5_CTX *context;                                        /* context */
+ * the message digest and zeroizing the context. */
+void mta_MD5Final(unsigned char digest[16], mta_MD5_CTX *context)
 {
     unsigned char bits[8];
     unsigned int index, padLen;
@@ -173,8 +160,7 @@ mta_MD5_CTX *context;                                        /* context */
     /* Save number of bits */
     Encode(bits, context->count, 8);
 
-    /* Pad out to 56 mod 64.
-*/
+    /* Pad out to 56 mod 64.*/
     index = (unsigned int)((context->count[0] >> 3) & 0x3f);
     padLen = (index < 56) ? (56 - index) : (120 - index);
     mta_MD5Update(context, PADDING, padLen);
@@ -185,16 +171,12 @@ mta_MD5_CTX *context;                                        /* context */
     /* Store state in digest */
     Encode(digest, context->state, 16);
 
-    /* Zeroize sensitive information.
-*/
+    /* Zeroize sensitive information.*/
     MD5_memset((POINTER)context, 0, sizeof(*context));
 }
 
-/* MD5 basic transformation. Transforms state based on block.
- */
-static void MD5Transform(state, block)
-    UINT4 state[4];
-const unsigned char block[64];
+/* MD5 basic transformation. Transforms state based on block. */
+static void MD5Transform(UINT4 state[4], const unsigned char block[64])
 {
     UINT4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
@@ -277,17 +259,13 @@ const unsigned char block[64];
     state[2] += c;
     state[3] += d;
 
-    /* Zeroize sensitive information.
-*/
+    /* Zeroize sensitive information. */
     MD5_memset((POINTER)x, 0, sizeof(x));
 }
 
 /* Encodes input (UINT4) into output (unsigned char). Assumes len is
-  a multiple of 4.
- */
-static void Encode(output, input, len) unsigned char *output;
-const UINT4 *input;
-unsigned int len;
+ * a multiple of 4. */
+static void Encode(unsigned char *output, const UINT4 *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -300,12 +278,8 @@ unsigned int len;
 }
 
 /* Decodes input (unsigned char) into output (UINT4). Assumes len is
-  a multiple of 4.
- */
-static void Decode(output, input, len)
-    UINT4 *output;
-const unsigned char *input;
-unsigned int len;
+ * a multiple of 4. */
+static void Decode(UINT4 *output, const unsigned char *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -314,13 +288,8 @@ unsigned int len;
                     (((UINT4)input[j + 2]) << 16) | (((UINT4)input[j + 3]) << 24);
 }
 
-/* Note: Replace "for loop" with standard memcpy if possible.
- */
-
-static void MD5_memcpy(output, input, len)
-    POINTER output;
-const POINTER input;
-unsigned int len;
+/* Note: Replace "for loop" with standard memcpy if possible. */
+static void MD5_memcpy(POINTER output, const POINTER input, unsigned int len)
 {
     unsigned int i;
 
@@ -328,12 +297,8 @@ unsigned int len;
         output[i] = input[i];
 }
 
-/* Note: Replace "for loop" with standard memset if possible.
- */
-static void MD5_memset(output, value, len)
-    POINTER output;
-int value;
-unsigned int len;
+/* Note: Replace "for loop" with standard memset if possible. */
+static void MD5_memset(POINTER output, int value, unsigned int len)
 {
     unsigned int i;
 

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -462,7 +462,7 @@ extensible_candidates(
         case SLAPI_OP_EQUAL:
         case SLAPI_OP_GREATER_OR_EQUAL:
         case SLAPI_OP_GREATER: {
-            IFP mrINDEX = NULL;
+            int32_t (*mrINDEX)(Slapi_PBlock *) = NULL;
             void *mrOBJECT = NULL;
             struct berval **mrVALUES = NULL;
             char *mrOID = NULL;

--- a/ldap/servers/slapd/back-ldbm/ldbm_attr.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attr.c
@@ -68,7 +68,7 @@ attrinfo_delete(struct attrinfo **pp)
 }
 
 static int
-attrinfo_internal_delete(caddr_t data, caddr_t arg __attribute__((unused)))
+attrinfo_internal_delete(caddr_t data)
 {
     struct attrinfo *n = (struct attrinfo *)data;
     attrinfo_delete(&n);
@@ -85,8 +85,9 @@ attrinfo_deletetree(ldbm_instance *inst)
 static int
 ainfo_type_cmp(
     char *type,
-    struct attrinfo *a)
+    caddr_t val)
 {
+    struct attrinfo *a = (struct attrinfo *)val;
     return (strcasecmp(type, a->ai_type));
 }
 
@@ -203,7 +204,7 @@ attr_index_parse_idlistsize_values(Slapi_Attr *attr, struct index_idlistsizeinfo
     char *lasts = NULL;
     char *val;
     int syntaxcheck = config_get_syntaxcheck();
-    IFP syntax_validate_fn = syntaxcheck ? attr->a_plugin->plg_syntax_validate : NULL;
+    int32_t (*syntax_validate_fn)(struct berval *) = syntaxcheck ? attr->a_plugin->plg_syntax_validate : NULL;
     char staticfiltstrbuf[1024];                     /* for small filter strings */
     char *filtstrbuf = staticfiltstrbuf;             /* default if not malloc'd */
     size_t filtstrbuflen = sizeof(staticfiltstrbuf); /* default if not malloc'd */
@@ -880,7 +881,7 @@ attr_index_config(
                 *  It would improve speed to save the indexer, for future use.
                 * But, for simplicity, we destroy it now:
                 */
-                IFP mrDESTROY = NULL;
+                int32_t (*mrDESTROY)(Slapi_PBlock *) = NULL;
                 if (!slapi_pblock_get(pb, SLAPI_PLUGIN_DESTROY_FN, &mrDESTROY) &&
                     mrDESTROY != NULL) {
                     mrDESTROY(pb);

--- a/ldap/servers/slapd/back-ldbm/matchrule.c
+++ b/ldap/servers/slapd/back-ldbm/matchrule.c
@@ -79,7 +79,7 @@ int
 destroy_matchrule_indexer(Slapi_PBlock *pb)
 {
     Slapi_Value **keys = NULL;
-    IFP mrDESTROY = NULL;
+    int32_t (*mrDESTROY)(Slapi_PBlock *) = NULL;
     if (!slapi_pblock_get(pb, SLAPI_PLUGIN_DESTROY_FN, &mrDESTROY)) {
         if (mrDESTROY != NULL) {
             mrDESTROY(pb);
@@ -109,7 +109,7 @@ destroy_matchrule_indexer(Slapi_PBlock *pb)
 int
 matchrule_values_to_keys(Slapi_PBlock *pb, Slapi_Value **input_values, struct berval ***output_values)
 {
-    IFP mrINDEX = NULL;
+    int32_t (*mrINDEX)(Slapi_PBlock *) = NULL;
 
     slapi_pblock_get(pb, SLAPI_PLUGIN_MR_INDEX_FN, &mrINDEX);
     slapi_pblock_set(pb, SLAPI_PLUGIN_MR_VALUES, input_values);
@@ -130,7 +130,7 @@ matchrule_values_to_keys(Slapi_PBlock *pb, Slapi_Value **input_values, struct be
 int
 matchrule_values_to_keys_sv(Slapi_PBlock *pb, Slapi_Value **input_values, Slapi_Value ***output_values)
 {
-    IFP mrINDEX = NULL;
+    int32_t (*mrINDEX)(Slapi_PBlock *) = NULL;
 
     slapi_pblock_get(pb, SLAPI_PLUGIN_MR_INDEX_SV_FN, &mrINDEX);
     if (NULL == mrINDEX) { /* old school - does not have SV function */

--- a/ldap/servers/slapd/back-ldbm/misc.c
+++ b/ldap/servers/slapd/back-ldbm/misc.c
@@ -329,7 +329,7 @@ ldbm_txn_ruv_modify_context(Slapi_PBlock *pb, modify_context *mc)
     Slapi_Mods *smods = NULL;
     struct backentry *bentry;
     entry_address bentry_addr;
-    IFP fn = NULL;
+    int32_t (*fn)(Slapi_PBlock *, char *, Slapi_Mods *) = NULL;
     int rc = 0;
     back_txn txn = {NULL};
 
@@ -340,7 +340,7 @@ ldbm_txn_ruv_modify_context(Slapi_PBlock *pb, modify_context *mc)
         return (0);
     }
 
-    rc = (*fn)(pb, &uniqueid, &smods);
+    rc = (*fn)(pb, uniqueid, smods);
 
     /* Either something went wrong when the RUV callback tried to assemble
      * the updates for us, or there were no updates because the op doesn't

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -496,7 +496,7 @@ int vlv_trim_candidates_txn(backend *be, const IDList *candidates, const sort_sp
 int vlv_trim_candidates(backend *be, const IDList *candidates, const sort_spec *sort_control, const struct vlv_request *vlv_request_control, IDList **filteredCandidates, struct vlv_response *pResponse);
 int vlv_parse_request_control(backend *be, struct berval *vlv_spec_ber, struct vlv_request *vlvp);
 int vlv_make_response_control(Slapi_PBlock *pb, const struct vlv_response *vlvp);
-void vlv_getindices(IFP callback_fn, void *param, backend *be);
+void vlv_getindices(int32_t (*callback_fn)(struct attrinfo * ,void *),  void *param, backend *be);
 void vlv_print_access_log(Slapi_PBlock *pb, struct vlv_request *vlvi, struct vlv_response *vlvo, sort_spec_thing *sort_control);
 void vlv_grok_new_import_entry(const struct backentry *e, backend *be, int *seen_them_all);
 IDList *vlv_find_index_by_filter(struct backend *be, const char *base, Slapi_Filter *f);

--- a/ldap/servers/slapd/back-ldbm/vlv.c
+++ b/ldap/servers/slapd/back-ldbm/vlv.c
@@ -673,11 +673,11 @@ vlv_getindexnames(backend *be)
 /* Return the list of VLV indices to the import code. Added read lock */
 
 void
-vlv_getindices(IFP callback_fn, void *param, backend *be)
+vlv_getindices(int32_t (*callback_fn)(struct attrinfo * ,void *), void *param, backend *be)
 {
     /* Traverse the list, calling the import code's callback function */
     struct vlvSearch *ps = NULL;
-
+// MARK (*callback_fn)(struct attrinfo * ,void *)
     slapi_rwlock_rdlock(be->vlvSearchList_lock);
     ps = (struct vlvSearch *)be->vlvSearchList;
     for (; ps != NULL; ps = ps->vlv_next) {

--- a/ldap/servers/slapd/backend.c
+++ b/ldap/servers/slapd/backend.c
@@ -682,7 +682,7 @@ slapi_back_ctrl_info(Slapi_Backend *be, int cmd, void *info)
 int
 slapi_back_transaction_begin(Slapi_PBlock *pb)
 {
-    IFP txn_begin;
+    int32_t (*txn_begin)(Slapi_PBlock *);
     if (slapi_pblock_get(pb, SLAPI_PLUGIN_DB_BEGIN_FN, (void *)&txn_begin) ||
         !txn_begin) {
         return SLAPI_BACK_TRANSACTION_NOT_SUPPORTED;
@@ -695,7 +695,7 @@ slapi_back_transaction_begin(Slapi_PBlock *pb)
 int
 slapi_back_transaction_commit(Slapi_PBlock *pb)
 {
-    IFP txn_commit;
+    int32_t (*txn_commit)(Slapi_PBlock *);
     if (slapi_pblock_get(pb, SLAPI_PLUGIN_DB_COMMIT_FN, (void *)&txn_commit) ||
         !txn_commit) {
         return SLAPI_BACK_TRANSACTION_NOT_SUPPORTED;
@@ -708,7 +708,7 @@ slapi_back_transaction_commit(Slapi_PBlock *pb)
 int
 slapi_back_transaction_abort(Slapi_PBlock *pb)
 {
-    IFP txn_abort;
+    int32_t (*txn_abort)(Slapi_PBlock *);
     if (slapi_pblock_get(pb, SLAPI_PLUGIN_DB_ABORT_FN, (void *)&txn_abort) ||
         !txn_abort) {
         return SLAPI_BACK_TRANSACTION_NOT_SUPPORTED;

--- a/ldap/servers/slapd/filtercmp.c
+++ b/ldap/servers/slapd/filtercmp.c
@@ -86,7 +86,7 @@ get_mr_normval(char *oid, char *type, struct berval **inval, struct berval ***ou
 {
     Slapi_PBlock *pb = slapi_pblock_new();
     unsigned int sort_indicator = SLAPI_PLUGIN_MR_USAGE_SORT;
-    IFP mrIndex = NULL;
+    int32_t (*mrIndex)(Slapi_PBlock *) = NULL;
 
     if (!pb) {
         return NULL;
@@ -118,7 +118,7 @@ get_mr_normval(char *oid, char *type, struct berval **inval, struct berval ***ou
 static void
 done_mr_normval(Slapi_PBlock *pb)
 {
-    IFP mrDestroy = NULL;
+    int32_t (*mrDestroy)(Slapi_PBlock *) = NULL;
 
     if (slapi_pblock_get(pb, SLAPI_PLUGIN_DESTROY_FN, &mrDestroy) == 0) {
         if (mrDestroy)

--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -663,7 +663,7 @@ slapi_send_ldap_intermediate(Slapi_PBlock *pb, LDAPControl **ectrls, char *respo
 int
 slapi_send_ldap_search_entry(Slapi_PBlock *pb, Slapi_Entry *e, LDAPControl **ectrls, char **attrs, int attrsonly)
 {
-    IFP fn = NULL;
+    int32_t (*fn)(Slapi_PBlock *, Slapi_Entry *, LDAPControl **, char **, int32_t) = NULL;
     slapi_pblock_get(pb, SLAPI_PLUGIN_DB_ENTRY_FN, (void *)&fn);
     if (NULL == fn) {
         return -1;
@@ -698,7 +698,7 @@ slapi_send_ldap_result_from_pb(Slapi_PBlock *pb)
     int err;
     char *matched;
     char *text;
-    IFP fn = NULL;
+    int32_t (*fn)(Slapi_PBlock*, int32_t, char*, char*, int32_t, struct berval **) = NULL;
 
     slapi_pblock_get(pb, SLAPI_RESULT_CODE, &err);
     slapi_pblock_get(pb, SLAPI_RESULT_TEXT, &text);
@@ -718,7 +718,7 @@ slapi_send_ldap_result_from_pb(Slapi_PBlock *pb)
 void
 slapi_send_ldap_result(Slapi_PBlock *pb, int err, char *matched, char *text, int nentries, struct berval **urls)
 {
-    IFP fn = NULL;
+    int32_t (*fn)(Slapi_PBlock*, int32_t, char*, char*, int32_t, struct berval *) = NULL;
     Slapi_Operation *operation;
     long op_type;
 
@@ -756,7 +756,7 @@ slapi_send_ldap_result(Slapi_PBlock *pb, int err, char *matched, char *text, int
 int
 slapi_send_ldap_referral(Slapi_PBlock *pb, Slapi_Entry *e, struct berval **refs, struct berval ***urls)
 {
-    IFP fn = NULL;
+    int32_t (*fn)(Slapi_PBlock*, Slapi_Entry*, struct berval **, struct berval **) = NULL;
     slapi_pblock_get(pb, SLAPI_PLUGIN_DB_REFERRAL_FN, (void *)&fn);
     if (NULL == fn) {
         return -1;
@@ -1969,7 +1969,7 @@ plugin_call_func(struct slapdplugin *list, int operation, Slapi_PBlock *pb, int 
     int count = 0;
 
     for (; list != NULL; list = list->plg_next) {
-        IFP func = NULL;
+        int32_t (*func)(Slapi_PBlock *) = NULL;
 
         slapi_pblock_set(pb, SLAPI_PLUGIN, list);
         set_db_default_result_handlers(pb); /* JCM: What's this do? Is it needed here? */

--- a/ldap/servers/slapd/plugin_mmr.c
+++ b/ldap/servers/slapd/plugin_mmr.c
@@ -1,10 +1,10 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
- * See LICENSE for details. 
+ * See LICENSE for details.
  * END COPYRIGHT BLOCK **/
 
 #ifdef HAVE_CONFIG_H
@@ -19,11 +19,11 @@
 #include "slap.h"
 
 int
-plugin_call_mmr_plugin_preop ( Slapi_PBlock *pb, Slapi_Entry *e, int flags)
+plugin_call_mmr_plugin_preop(Slapi_PBlock *pb, Slapi_Entry *e, int flags)
 {
-	struct slapdplugin	*p;
-	int			rc = LDAP_INSUFFICIENT_ACCESS;
-	Operation	*operation;
+	struct slapdplugin *p;
+	int rc = LDAP_INSUFFICIENT_ACCESS;
+	Operation *operation;
 
 	slapi_pblock_get (pb, SLAPI_OPERATION, &operation);
 
@@ -45,11 +45,11 @@ plugin_call_mmr_plugin_preop ( Slapi_PBlock *pb, Slapi_Entry *e, int flags)
 }
 
 int
-plugin_call_mmr_plugin_postop ( Slapi_PBlock *pb, Slapi_Entry *e, int flags)
+plugin_call_mmr_plugin_postop(Slapi_PBlock *pb, Slapi_Entry *e, int flags)
 {
-	struct slapdplugin	*p;
-	int			rc = LDAP_INSUFFICIENT_ACCESS;
-	Operation	*operation;
+	struct slapdplugin *p;
+	int rc = LDAP_INSUFFICIENT_ACCESS;
+	Operation *operation;
 
 	slapi_pblock_get (pb, SLAPI_OPERATION, &operation);
 

--- a/ldap/servers/slapd/plugin_mr.c
+++ b/ldap/servers/slapd/plugin_mr.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -35,7 +35,7 @@ struct mr_private
     const struct berval *value;   /* orig value from filter */
     int ftype;                    /* filter type */
     int op;                       /* query op type */
-    IFP match_fn;                 /* match func to use */
+    int32_t (*match_fn)(Slapi_PBlock *, char*, char*, int32_t, Slapi_Value **); /* match func to use */
     /* note - substring matching rules not currently supported */
     char *initial;                  /* these are for substring matches */
     char *any[2];                   /* at most one value for extensible filter */
@@ -225,7 +225,7 @@ int /* an LDAP error code, hopefully LDAP_SUCCESS */
     int rc;
     char *oid;
     if (!(rc = slapi_pblock_get(opb, SLAPI_PLUGIN_MR_OID, &oid))) {
-        IFP createFn = NULL;
+        int32_t (*createFn)(Slapi_PBlock *) = NULL;
         struct slapdplugin *mrp = plugin_mr_find_registered(oid);
         if (mrp != NULL) {
             /* Great the matching OID -> MR plugin was already found, just reuse it */
@@ -251,7 +251,6 @@ int /* an LDAP error code, hopefully LDAP_SUCCESS */
             rc = LDAP_UNAVAILABLE_CRITICAL_EXTENSION;
 
             for (mrp = get_plugin_list(PLUGIN_LIST_MATCHINGRULE); mrp != NULL; mrp = mrp->plg_next) {
-
                 Slapi_PBlock *pb = slapi_pblock_new();
                 mr_indexer_init_pb(opb, pb);
                 slapi_pblock_set(pb, SLAPI_PLUGIN, mrp);
@@ -263,8 +262,8 @@ int /* an LDAP error code, hopefully LDAP_SUCCESS */
                 }
 
                 if (createFn && !createFn(pb)) {
-                    IFP indexFn = NULL;
-                    IFP indexSvFn = NULL;
+                    int32_t (*indexFn)(void) = NULL;
+                    int32_t (*indexSvFn)(void) = NULL;
                     /* These however, are in the pblock direct, so we need to copy them. */
                     slapi_pblock_get(pb, SLAPI_PLUGIN_MR_INDEX_FN, &indexFn);
                     slapi_pblock_get(pb, SLAPI_PLUGIN_MR_INDEX_SV_FN, &indexSvFn);
@@ -624,7 +623,7 @@ static int
 attempt_mr_filter_create(mr_filter_t *f, struct slapdplugin *mrp, Slapi_PBlock *pb)
 {
     int rc;
-    IFP mrf_create = NULL;
+    int32_t  (*mrf_create)(Slapi_PBlock *) = NULL;
     f->mrf_match = NULL;
     pblock_init(pb);
     if (!(rc = slapi_pblock_set(pb, SLAPI_PLUGIN, mrp)) &&

--- a/ldap/servers/slapd/plugin_syntax.c
+++ b/ldap/servers/slapd/plugin_syntax.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2005 Red Hat, Inc.
+ * Copyright (C) 2005-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -95,7 +95,7 @@ plugin_call_syntax_filter_ava_sv(
     int useDeletedValues)
 {
     int rc;
-    IFP ava_fn = NULL;
+    int32_t (*ava_fn)(Slapi_PBlock *, struct berval *, Slapi_Value **, int32_t, Slapi_Value **) = NULL;
 
     slapi_log_err(SLAPI_LOG_FILTER,
                   "plugin_call_syntax_filter_ava_sv", "=> %s=%s\n", ava->ava_type,
@@ -207,7 +207,7 @@ plugin_call_syntax_filter_sub_sv(
     struct subfilt *fsub)
 {
     int rc;
-    IFP sub_fn = NULL;
+    int32_t (*sub_fn)(Slapi_PBlock *, char *, char **, char*, Slapi_Value **) = NULL;
     int filter_normalized = 0;
 
     slapi_log_err(SLAPI_LOG_FILTER,
@@ -396,7 +396,7 @@ slapi_entry_syntax_check(
                 /* iterate through each value to check if it's valid */
                 while (val != NULL) {
                     bval = slapi_value_get_berval(val);
-                    if ((a->a_plugin->plg_syntax_validate(bval)) != 0) {
+                    if ((a->a_plugin->plg_syntax_validate((struct berval *)bval)) != 0) {
                         if (syntaxlogging) {
                             slapi_log_err(SLAPI_LOG_ERR, "slapi_entry_syntax_check",
                                           "\"%s\": (%s) value #%d invalid per syntax\n",
@@ -586,7 +586,7 @@ slapi_attr_values2keys_sv_pb(
 {
     int rc;
     struct slapdplugin *pi = NULL;
-    IFP v2k_fn = NULL;
+    int32_t (*v2k_fn)(Slapi_PBlock*, Slapi_Value**, Slapi_Value***, int32_t) = NULL;
 
     if ((sattr->a_plugin == NULL)) {
         /* could be lazy plugin initialization, get it now */
@@ -748,7 +748,7 @@ slapi_attr_assertion2keys_ava_sv(
 {
     int rc;
     struct slapdplugin *pi = NULL;
-    IFP a2k_fn = NULL;
+    int32_t (*a2k_fn)(Slapi_PBlock *, Slapi_Value *, Slapi_Value ***, int32_t) = NULL;
 
     slapi_log_err(SLAPI_LOG_FILTER,
                   "slapi_attr_assertion2keys_ava_sv", "=>\n");
@@ -880,7 +880,7 @@ slapi_attr_assertion2keys_sub_sv_pb(
     Slapi_PBlock *work_pb = NULL;
     struct slapdplugin *pi = NULL;
     struct slapdplugin *origpi = NULL;
-    IFP a2k_fn = NULL;
+    int32_t (*a2k_fn)(Slapi_PBlock *, char *, char **, char *, Slapi_Value ***) = NULL;
 
     slapi_log_err(SLAPI_LOG_FILTER,
                   "slapi_attr_assertion2keys_sub_sv_pb", "=>\n");
@@ -951,7 +951,7 @@ slapi_attr_value_normalize_ext(
     unsigned long filter_type)
 {
     Slapi_Attr myattr = {0};
-    VFPV norm_fn = NULL;
+    void (*norm_fn)(Slapi_PBlock *, char *, int32_t, char **) = NULL;
 
     if (!sattr) {
         sattr = slapi_attr_init(&myattr, type);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1,7 +1,7 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2009 Red Hat, Inc.
  * Copyright (C) 2009 Hewlett-Packard Development Company, L.P.
+ * Copyright (C) 2009-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * Contributors:
@@ -864,10 +864,10 @@ struct slapi_entry
 struct attrs_in_extension
 {
     char *ext_type;
-    IFP ext_get;
-    IFP ext_set;
-    IFP ext_copy;
-    IFP ext_get_size;
+    int32_t (*ext_get)(Slapi_Entry *, Slapi_Value **);
+    int32_t (*ext_set)(Slapi_Entry *, Slapi_Value **, int32_t);
+    int32_t (*ext_copy)(const Slapi_Entry *, Slapi_Entry *);
+    int32_t (*ext_get_size)(Slapi_Entry *, size_t *);
 };
 
 extern struct attrs_in_extension attrs_in_extension[];
@@ -1039,7 +1039,7 @@ struct slapdplugin
     int plg_precedence;                     /* for plugin execution ordering */
     struct slapdplugin *plg_group;          /* pointer to the group to which this plugin belongs */
     struct pluginconfig plg_conf;           /* plugin configuration parameters */
-    IFP plg_cleanup;                        /* cleanup function */
+    int32_t (*plg_cleanup)(Slapi_PBlock *); /* cleanup function */
     IFP plg_start;                          /* start function */
     IFP plg_poststart;                      /* poststart function */
     int plg_closed;                         /* mark plugin as closed */
@@ -1049,47 +1049,25 @@ struct slapdplugin
     Slapi_Counter *plg_op_counter;          /* operation counter, used for shutdown */
 
     /* NOTE: These LDIF2DB and DB2LDIF fn pointers are internal only for now.
-   I don't believe you can get these functions from a plug-in and
-   then call them without knowing what IFP or VFP0 are.  (These aren't
-   declared in slapi-plugin.h.)  More importantly, it's a pretty ugly
-   way to get to these functions. (Do we want people to get locked into
-   this?)
-
-   The correct way to do this would be to expose these functions as
-   front-end API functions. We can fix this for the next release.
-   (No one has the time right now.)
- */
+     * I don't believe you can get these functions from a plug-in and
+     * then call them without knowing what IFP or VFP0 are.  (These aren't
+     * declared in slapi-plugin.h.)  More importantly, it's a pretty ugly
+     * way to get to these functions. (Do we want people to get locked into
+     * this?)
+     *
+     * The correct way to do this would be to expose these functions as
+     * front-end API functions. We can fix this for the next release.
+     * (No one has the time right now.)
+     */
     union
     { /* backend database plugin structure */
         struct plg_un_database_backend
         {
-            IFP plg_un_db_bind;              /* bind */
-            IFP plg_un_db_unbind;            /* unbind */
-            IFP plg_un_db_search;            /* search */
-            IFP plg_un_db_next_search_entry; /* iterate */
             IFP plg_un_db_next_search_entry_ext;
-            VFPP plg_un_db_search_results_release; /* PAGED RESULTS */
-            VFP plg_un_db_prev_search_results;     /* PAGED RESULTS */
-            IFP plg_un_db_entry_release;
-            IFP plg_un_db_compare;              /* compare */
-            IFP plg_un_db_modify;               /* modify */
-            IFP plg_un_db_modrdn;               /* modrdn */
-            IFP plg_un_db_add;                  /* add */
-            IFP plg_un_db_delete;               /* delete */
-            IFP plg_un_db_abandon;              /* abandon */
             IFP plg_un_db_config;               /* config */
-            IFP plg_un_db_seq;                  /* sequence */
             IFP plg_un_db_entry;                /* entry send */
             IFP plg_un_db_referral;             /* referral send */
             IFP plg_un_db_result;               /* result send */
-            IFP plg_un_db_ldif2db;              /* ldif 2 database */
-            IFP plg_un_db_db2ldif;              /* database 2 ldif */
-            IFP plg_un_db_db2index;             /* database 2 index */
-            IFP plg_un_db_dbcompact;            /* compact database */
-            IFP plg_un_db_archive2db;           /* ldif 2 database */
-            IFP plg_un_db_db2archive;           /* database 2 ldif */
-            IFP plg_un_db_upgradedb;            /* convert old idl to new */
-            IFP plg_un_db_upgradednformat;      /* convert old dn format to new */
             IFP plg_un_db_begin;                /* dbase txn begin */
             IFP plg_un_db_commit;               /* dbase txn commit */
             IFP plg_un_db_abort;                /* dbase txn abort */
@@ -1099,12 +1077,35 @@ struct slapdplugin
             IFP plg_un_db_register_dn_callback; /* Register a function to call when a operation is applied to a given DN */
             IFP plg_un_db_register_oc_callback; /* Register a function to call when a operation is applied to a given ObjectClass */
             IFP plg_un_db_init_instance;        /* initializes new db instance */
-            IFP plg_un_db_wire_import;          /* fast replica update */
-            IFP plg_un_db_verify;               /* verify db files */
             IFP plg_un_db_add_schema;           /* add schema */
-            IFP plg_un_db_get_info;             /* get info */
-            IFP plg_un_db_set_info;             /* set info */
-            IFP plg_un_db_ctrl_info;            /* ctrl info */
+            VFP plg_un_db_prev_search_results;  /* PAGED RESULTS */
+            VFPP plg_un_db_search_results_release; /* PAGED RESULTS */
+
+            int32_t (*plg_un_db_bind)(Slapi_PBlock *);             /* bind */
+            int32_t (*plg_un_db_unbind)(Slapi_PBlock *);           /* unbind */
+            int32_t (*plg_un_db_search)(Slapi_PBlock *);           /* search */
+            int32_t (*plg_un_db_entry_release)(Slapi_PBlock *, Slapi_Entry *);
+            int32_t (*plg_un_db_compare)(Slapi_PBlock *);          /* compare */
+            int32_t (*plg_un_db_modify)(Slapi_PBlock *);           /* modify */
+            int32_t (*plg_un_db_modrdn)(Slapi_PBlock *);           /* modrdn */
+            int32_t (*plg_un_db_add)(Slapi_PBlock *);              /* add */
+            int32_t (*plg_un_db_delete)(Slapi_PBlock *);           /* delete */
+            int32_t (*plg_un_db_abandon)(Slapi_PBlock *);          /* abandon */
+            int32_t (*plg_un_db_seq)(Slapi_PBlock *);              /* sequence */
+            int32_t (*plg_un_db_ldif2db)(Slapi_PBlock *);          /* ldif 2 database */
+            int32_t (*plg_un_db_db2ldif)(Slapi_PBlock *);          /* database 2 ldif */
+            int32_t (*plg_un_db_db2index)(Slapi_PBlock *);         /* database 2 index */
+            int32_t (*plg_un_db_dbcompact)(Slapi_Backend *, bool); /* compact database */
+            int32_t (*plg_un_db_archive2db)(Slapi_PBlock *);       /* ldif 2 database */
+            int32_t (*plg_un_db_db2archive)(Slapi_PBlock *);       /* database 2 ldif */
+            int32_t (*plg_un_db_upgradedb)(Slapi_PBlock *);        /* convert old idl to new */
+            int32_t (*plg_un_db_upgradednformat)(Slapi_PBlock *);  /* convert old dn format to new */
+            int32_t (*plg_un_db_wire_import)(Slapi_PBlock *);      /* fast replica update */
+            int32_t (*plg_un_db_next_search_entry)(Slapi_PBlock *);            /* iterate */
+            int32_t (*plg_un_db_verify)(Slapi_PBlock *);                       /* verify db files */
+            int32_t (*plg_un_db_get_info)(Slapi_Backend *, int32_t, void **);  /* get info */
+            int32_t (*plg_un_db_set_info)(Slapi_Backend *, int32_t, void **);  /* set info */
+            int32_t (*plg_un_db_ctrl_info)(Slapi_Backend *, int32_t, void **); /* ctrl info */
         } plg_un_db;
 #define plg_bind plg_un.plg_un_db.plg_un_db_bind
 #define plg_unbind plg_un.plg_un_db.plg_un_db_unbind
@@ -1149,10 +1150,10 @@ struct slapdplugin
         {
             char **plg_un_pe_exoids;      /* exop oids */
             char **plg_un_pe_exnames;     /* exop names (may be NULL) */
-            IFP plg_un_pe_exhandler;      /* handler */
+            int32_t (*plg_un_pe_exhandler)(Slapi_PBlock *); /* handler */
             IFP plg_un_pe_pre_exhandler;  /* pre extop */
             IFP plg_un_pe_post_exhandler; /* post extop */
-            IFP plg_un_pe_be_exhandler;   /* handler to retrieve the be name for the operation */
+            int32_t (*plg_un_pe_be_exhandler)(Slapi_PBlock *, Slapi_Backend *); /* handler to retrieve the be name for the operation */
         } plg_un_pe;
 #define plg_exoids plg_un.plg_un_pe.plg_un_pe_exoids
 #define plg_exnames plg_un.plg_un_pe.plg_un_pe_exnames
@@ -1295,7 +1296,7 @@ struct slapdplugin
             /* e.g. a SUBSTR rule will not have a filter_ava func */
             IFP plg_un_mr_filter_ava;
             IFP plg_un_mr_filter_sub;
-            IFP plg_un_mr_values2keys;
+            int32_t (*plg_un_mr_values2keys)(Slapi_PBlock *, Slapi_Value **, Slapi_Value ***, int32_t);
             IFP plg_un_mr_assertion2keys_ava;
             IFP plg_un_mr_assertion2keys_sub;
             int plg_un_mr_flags;
@@ -1322,20 +1323,20 @@ struct slapdplugin
             IFP plg_un_syntax_filter_ava_sv;
             IFP plg_un_syntax_filter_sub;
             IFP plg_un_syntax_filter_sub_sv;
-            IFP plg_un_syntax_values2keys;
+            int32_t (*plg_un_syntax_values2keys)(Slapi_PBlock*, Slapi_Value**, Slapi_Value**, int32_t);
             IFP plg_un_syntax_values2keys_sv;
-            IFP plg_un_syntax_assertion2keys_ava;
-            IFP plg_un_syntax_assertion2keys_sub;
+            int32_t (*plg_un_syntax_assertion2keys_ava)(Slapi_PBlock*, Slapi_Value**, Slapi_Value***, int32_t);
+            int32_t (*plg_un_syntax_assertion2keys_sub)(Slapi_PBlock*, char*, char**, char*, Slapi_Value***);
             int plg_un_syntax_flags;
             /*
-   from slapi-plugin.h
-#define SLAPI_PLUGIN_SYNTAX_FLAG_ORKEYS        1
-#define SLAPI_PLUGIN_SYNTAX_FLAG_ORDERING    2
-*/
+             * from slapi-plugin.h
+#define SLAPI_PLUGIN_SYNTAX_FLAG_ORKEYS    1
+#define SLAPI_PLUGIN_SYNTAX_FLAG_ORDERING  2
+             */
             char **plg_un_syntax_names;
             char *plg_un_syntax_oid;
             IFP plg_un_syntax_compare;
-            IFP plg_un_syntax_validate;
+            int32_t (*plg_un_syntax_validate)(struct berval *);
             VFPV plg_un_syntax_normalize;
         } plg_un_syntax;
 #define plg_syntax_filter_ava plg_un.plg_un_syntax.plg_un_syntax_filter_ava
@@ -1353,10 +1354,11 @@ struct slapdplugin
         struct plg_un_acl_struct
         {
             IFP plg_un_acl_init;
-            IFP plg_un_acl_syntax_check;
-            IFP plg_un_acl_access_allowed;
-            IFP plg_un_acl_mods_allowed;
-            IFP plg_un_acl_mods_update;
+            int32_t (*plg_un_acl_syntax_check)(Slapi_PBlock *, Slapi_Entry *, char **);
+            int32_t (*plg_un_acl_access_allowed)(Slapi_PBlock *, Slapi_Entry*, char **, struct berval *, int32_t, int32_t, char **);
+            int32_t (*plg_un_acl_mods_allowed)(Slapi_PBlock *, Slapi_Entry *, LDAPMod **, void *);
+            int32_t (*plg_un_acl_mods_update)(Slapi_PBlock *, int32_t, Slapi_DN *, void *);
+
         } plg_un_acl;
 #define plg_acl_init plg_un.plg_un_acl.plg_un_acl_init
 #define plg_acl_syntax_check plg_un.plg_un_acl.plg_un_acl_syntax_check
@@ -1366,8 +1368,8 @@ struct slapdplugin
 
         struct plg_un_mmr_struct
         {
-            IFP plg_un_mmr_betxn_preop;
-            IFP plg_un_mmr_betxn_postop;
+            int32_t (*plg_un_mmr_betxn_preop)(Slapi_PBlock *, int32_t);
+            int32_t (*plg_un_mmr_betxn_postop)(Slapi_PBlock *, int32_t);
         } plg_un_mmr;
 #define plg_mmr_betxn_preop 		plg_un.plg_un_mmr.plg_un_mmr_betxn_preop
 #define plg_mmr_betxn_postop 		plg_un.plg_un_mmr.plg_un_mmr_betxn_postop
@@ -1388,8 +1390,8 @@ struct slapdplugin
         /* entry fetch/store */
         struct plg_un_entry_fetch_store_struct
         {
-            IFP plg_un_entry_fetch_func;
-            IFP plg_un_entry_store_func;
+            int32_t (*plg_un_entry_fetch_func)(char **, uint32_t *);
+            int32_t (*plg_un_entry_store_func)(char **, uint32_t *);
         } plg_un_entry_fetch_store;
 #define plg_entryfetchfunc plg_un.plg_un_entry_fetch_store.plg_un_entry_fetch_func
 #define plg_entrystorefunc plg_un.plg_un_entry_fetch_store.plg_un_entry_store_func


### PR DESCRIPTION
Description:

Most of the failures are our use of function pointer with a generic typedef with unknown parameters (e.g. IFP)

There are other IFP we use, but they are not triggering build failures yet.

Relates: https://github.com/389ds/389-ds-base/issues/6476
