### PR TITLE
Issue 6531 - Fix CI Tests - Decrease mdb map size for large topologies

### DIFF
--- a/src/lib389/lib389/properties.py
+++ b/src/lib389/lib389/properties.py
@@ -42,13 +42,14 @@ SER_PROPNAME_TO_ATTRNAME = {SER_HOST: 'nsslapd-localhost',
                             SER_DB_LIB: 'nsslapd-backend-implement',
                             }
 #
-# Those WITHOUT related attribute name
+# Properties that are not associated with an attribute in cn=config entry
 #
 SER_SERVERID_PROP = 'server-id'
 SER_GROUP_ID = 'group-id'
 SER_DEPLOYED_DIR = 'deployed-dir'
 SER_BACKUP_INST_DIR = 'inst-backupdir'
 SER_STRICT_HOSTNAME_CHECKING = 'strict_hostname_checking'
+SER_MDB_MAX_SIZE = 'mdb_max_size'
 
 ####################################
 #

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -15,7 +15,7 @@ from signal import SIGALRM, alarm, signal
 from datetime import timedelta
 import pytest
 from lib389 import DirSrv
-from lib389.utils import generate_ds_params, is_fips
+from lib389.utils import generate_ds_params, is_fips, get_default_db_lib
 from lib389.mit_krb5 import MitKrb5
 from lib389.saslmap import SaslMappings
 from lib389.replica import Agreements, ReplicationManager, Replicas
@@ -80,6 +80,7 @@ def _create_instances(topo_dict, suffix):
     :return - TopologyMain object
     """
 
+    nbinsts = sum(topo_dict.values())
     instances = {}
     ms = {}
     cs = {}
@@ -103,6 +104,8 @@ def _create_instances(topo_dict, suffix):
             args_instance[SER_PORT] = instance_data[SER_PORT]
             args_instance[SER_SECURE_PORT] = instance_data[SER_SECURE_PORT]
             args_instance[SER_SERVERID_PROP] = instance_data[SER_SERVERID_PROP]
+            if nbinsts > 3 and get_default_db_lib() == "mdb":
+                args_instance[SER_MDB_MAX_SIZE] = '10g'
             # It's required to be able to make a suffix-less install for
             # some cli tests. It's invalid to require replication with
             # no suffix however ....


### PR DESCRIPTION
Decrease mdb map size to 10 gb when using topologies whose number of instances is > 3

Issue: #6531

Reviewed by: @tbordaz (Thanks!)