### PR TITLE
Issue 6542 - RPM build errors on Fedora 42

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -447,6 +447,9 @@ autoreconf -fiv
 %endif
 
 # lib389
+%if 0%{?fedora} >= 42 || 0%{?rhel} >= 11
+  sed -i "/prefix/s@sbin@bin@g" src/lib389/setup.py.in
+%endif
 make src/lib389/setup.py
 pushd ./src/lib389
 %py3_build


### PR DESCRIPTION
Bug Description:
Fedora 42 has unified `/bin` and `/sbin`: https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin https://docs.fedoraproject.org/en-US/packaging-guidelines/#_merged_file_system_layout

This change causes RPM build to fail with:
```
RPM build errors:
    File not found: /builddir/build/BUILD/389-ds-base-3.1.2-build/BUILDROOT/usr/bin/openldap_to_ds
```

Fix Description:
Patch `setup.py.in` based on Fedora or RHEL version that support unified `/bin` and `/sbin`.

Fixes: https://github.com/389ds/389-ds-base/issues/6542

Reviewed by: