### PR TITLE
Issue 6544 - logconv.py: python3-magic conflicts with python3-file-magic

### DIFF
--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -1798,8 +1798,7 @@ class logAnalyser:
             return None
 
         try:
-            mime = magic.Magic(mime=True)
-            filetype = mime.from_file(filepath)
+            filetype = magic.detect_from_filename(filepath).mime_type
 
             # List of supported compression types
             compressed_mime_types = [

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -200,7 +200,7 @@ Requires:         json-c
 # Log compression
 Requires:         zlib-devel
 # logconv.py, MIME type
-Requires:         python-magic
+Requires:         python3-file-magic
 # Picks up our systemd deps.
 %{?systemd_requires}
 


### PR DESCRIPTION
Bug Description:
python3-magic and python3-file-magic can't be installed simultaneously, python3-magic is not packaged for EL10.

Fix Description:
Use python3-file-magic instead.

Issue identified and fix suggested by Adam Williamson.

Fixes: https://github.com/389ds/389-ds-base/issues/6544

Reviewed by: