### PR TITLE
Issue 6555 - Potential crash when deleting a replicated backend

### DIFF
--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -29,6 +29,7 @@
 #include "repl5_ruv.h"
 #include "plstr.h"
 #include <pthread.h>
+#include <stdbool.h>
 
 #define START_UPDATE_DELAY                   2 /* 2 second */
 #define REPLICA_TYPE_WINDOWS                 1
@@ -710,6 +711,8 @@ PRBool replica_is_updatedn(Replica *r, const Slapi_DN *sdn);
 void replica_set_updatedn(Replica *r, const Slapi_ValueSet *vs, int mod_op);
 void replica_set_groupdn(Replica *r, const Slapi_ValueSet *vs, int mod_op);
 char *replica_get_generation(const Replica *r);
+bool replica_check_validity(Replica *replica);
+
 
 /* currently supported flags */
 #define REPLICA_LOG_CHANGES 0x1 /* enable change logging */

--- a/ldap/servers/plugins/replication/repl_connext.c
+++ b/ldap/servers/plugins/replication/repl_connext.c
@@ -61,7 +61,7 @@ consumer_connection_extension_destructor(void *ext, void *object __attribute__((
          * a replica. If so, release it here.
          */
         consumer_connection_extension *connext = (consumer_connection_extension *)ext;
-        if (NULL != connext->replica_acquired) {
+        if (replica_check_validity(connext->replica_acquired)) {
             Replica *r = connext->replica_acquired;
             /* If a total update was in progress, abort it */
             if (REPL_PROTOCOL_50_TOTALUPDATE == connext->repl_protocol_version) {


### PR DESCRIPTION
Problem: connection cleanup may try to access a freed replica
Solution: Ensure that the replica is still existing before using its pointer

Issue: #6555 

Reviewed by: @tbordaz, @droideck  (Thanks!)