### PR TITLE
Issue 6465 - Create optional meta-package for replication reporting dependencies

### DIFF
--- a/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
+++ b/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
@@ -24,6 +24,13 @@ from lib389.replica import ReplicationManager
 from lib389.repltools import ReplicationLogAnalyzer
 from lib389._constants import *
 
+try:
+    import plotly
+    import matplotlib
+    HTML_PNG_REPORTS_AVAILABLE = True
+except ImportError:
+    HTML_PNG_REPORTS_AVAILABLE = False
+
 pytestmark = pytest.mark.tier0
 
 DEBUGGING = os.getenv("DEBUGGING", default=False)
@@ -105,6 +112,7 @@ def _cleanup_multi_suffix_test(test_users_by_suffix, tmp_dir, suppliers, extra_s
         log.error(f"Error cleaning up temporary directory: {e}")
 
 
+@pytest.mark.skipif(not HTML_PNG_REPORTS_AVAILABLE, reason="HTML/PNG report libraries not available")
 def test_replication_log_monitoring_basic(topo_m4):
     """Test basic replication log monitoring functionality
 
@@ -195,6 +203,7 @@ def test_replication_log_monitoring_basic(topo_m4):
         _cleanup_test_data(test_users, tmp_dir)
 
 
+@pytest.mark.skipif(not HTML_PNG_REPORTS_AVAILABLE, reason="HTML/PNG report libraries not available")
 def test_replication_log_monitoring_advanced(topo_m4):
     """Test advanced replication monitoring features
 
@@ -312,6 +321,7 @@ def test_replication_log_monitoring_advanced(topo_m4):
         _cleanup_test_data(test_users, tmp_dir)
 
 
+@pytest.mark.skipif(not HTML_PNG_REPORTS_AVAILABLE, reason="HTML/PNG report libraries not available")
 def test_replication_log_monitoring_multi_suffix(topo_m4):
     """Test multi-suffix replication monitoring
 
@@ -425,6 +435,7 @@ def test_replication_log_monitoring_multi_suffix(topo_m4):
         )
 
 
+@pytest.mark.skipif(not HTML_PNG_REPORTS_AVAILABLE, reason="HTML/PNG report libraries not available")
 def test_replication_log_monitoring_filter_combinations(topo_m4):
     """Test complex combinations of filtering options and interactions
 

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -146,9 +146,6 @@ BuildRequires:    python%{python3_pkgversion}-argparse-manpage
 BuildRequires:    python%{python3_pkgversion}-policycoreutils
 BuildRequires:    python%{python3_pkgversion}-libselinux
 BuildRequires:    python%{python3_pkgversion}-cryptography
-BuildRequires:    python%{python3_pkgversion}-numpy
-BuildRequires:    python%{python3_pkgversion}-plotly
-BuildRequires:    python%{python3_pkgversion}-matplotlib
 
 # For cockpit
 %if %{with cockpit}
@@ -324,15 +321,26 @@ Requires: python%{python3_pkgversion}-argcomplete
 Requires: python%{python3_pkgversion}-libselinux
 Requires: python%{python3_pkgversion}-setuptools
 Requires: python%{python3_pkgversion}-cryptography
-Recommends: python%{python3_pkgversion}-numpy
-Recommends: python%{python3_pkgversion}-plotly
-Recommends: python%{python3_pkgversion}-matplotlib
 Recommends: bash-completion
 %{?python_provide:%python_provide python%{python3_pkgversion}-lib389}
 
 %description -n python%{python3_pkgversion}-lib389
 This module contains tools and libraries for accessing, testing,
  and configuring the 389 Directory Server.
+
+%package -n python%{python3_pkgversion}-lib389-repl-reports
+Summary: HTML and PNG report generation for 389 Directory Server replication monitoring tools
+BuildArch: noarch
+Requires: python%{python3_pkgversion}-lib389 = %{version}-%{release}
+Requires: python%{python3_pkgversion}-plotly
+Requires: python%{python3_pkgversion}-matplotlib
+
+%description -n python%{python3_pkgversion}-lib389-repl-reports
+Extended reporting capabilities for 389 Directory Server replication analysis.
+This package provides additional report formats (HTML and PNG) with interactive
+visualizations and graphs for replication lag analysis. These formats require
+additional dependencies and are optional - the base package supports CSV
+reports without this extension.
 
 %if %{with cockpit}
 %package -n cockpit-389-ds
@@ -761,6 +769,9 @@ fi
 %{bash_completions_dir}/dsconf
 %{bash_completions_dir}/dscreate
 %{bash_completions_dir}/dsidm
+
+%files -n python%{python3_pkgversion}-lib389-repl-reports
+# No files needed as this is just a meta-package for dependencies
 
 %if %{with cockpit}
 %files -n cockpit-389-ds -f cockpit.list

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -21,6 +21,11 @@
 %endif
 %endif
 
+%bcond repl_reports 0
+%if 0%{?fedora} >= 40
+%bcond repl_reports 1
+%endif
+
 # This is used in certain builds to help us know if it has extra features.
 %global variant base
 %global prerel __VERSION_PREREL__%{nil}
@@ -328,6 +333,7 @@ Recommends: bash-completion
 This module contains tools and libraries for accessing, testing,
  and configuring the 389 Directory Server.
 
+%if %{with repl_reports}
 %package -n python%{python3_pkgversion}-lib389-repl-reports
 Summary: HTML and PNG report generation for 389 Directory Server replication monitoring tools
 BuildArch: noarch
@@ -341,6 +347,7 @@ This package provides additional report formats (HTML and PNG) with interactive
 visualizations and graphs for replication lag analysis. These formats require
 additional dependencies and are optional - the base package supports CSV
 reports without this extension.
+%endif
 
 %if %{with cockpit}
 %package -n cockpit-389-ds
@@ -770,8 +777,10 @@ fi
 %{bash_completions_dir}/dscreate
 %{bash_completions_dir}/dsidm
 
+%if %{with repl_reports}
 %files -n python%{python3_pkgversion}-lib389-repl-reports
 # No files needed as this is just a meta-package for dependencies
+%endif
 
 %if %{with cockpit}
 %files -n cockpit-389-ds -f cockpit.list

--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -23,6 +23,18 @@ from lib389.replica import Replicas, ReplicationMonitor, BootstrapReplicationMan
 from lib389.tasks import CleanAllRUVTask, AbortCleanAllRUVTask
 from lib389._mapped_object import DSLdapObjects
 
+try:
+    import plotly
+    PLOTLY_AVAILABLE = True
+except ImportError:
+    PLOTLY_AVAILABLE = False
+
+try:
+    import matplotlib
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
 arg_to_attr = {
         # replica config
         'replica_id': 'nsds5replicaid',

--- a/src/lib389/lib389/repltools.py
+++ b/src/lib389/lib389/repltools.py
@@ -8,7 +8,6 @@
 
 from collections import defaultdict
 from datetime import datetime, timezone, tzinfo, timedelta
-import numpy as np
 from typing import Dict, List, Optional, Tuple, Generator, Any, NamedTuple, Union
 import os
 import re
@@ -1053,7 +1052,7 @@ class ReplicationLogAnalyzer:
 
             elif fmt == 'html':
                 if not PLOTLY_AVAILABLE:
-                    self._logger.warning("Plotly not installed. Skipping HTML report.")
+                    self._logger.warning("Plotly not installed. Skipping HTML report. Please install python3-lib389-repl-reports package to get required dependencies.")
                     continue
                 fig = self._create_plotly_figure(results)
                 self._generate_html(fig, outfile)
@@ -1061,7 +1060,7 @@ class ReplicationLogAnalyzer:
 
             elif fmt == 'png':
                 if not MATPLOTLIB_AVAILABLE:
-                    self._logger.warning("Matplotlib not installed. Skipping PNG report.")
+                    self._logger.warning("Matplotlib not installed. Skipping PNG report. Please install python3-lib389-repl-reports package to get required dependencies.")
                     continue
                 fig = self._create_plotly_figure(results)
                 self._generate_png(fig, outfile)
@@ -1072,7 +1071,7 @@ class ReplicationLogAnalyzer:
 
         return generated_files
 
-    def _create_plotly_figure(self, results: Dict[str, Any]) -> go.Figure:
+    def _create_plotly_figure(self, results: Dict[str, Any]):
         """Create a plotly figure for visualization."""
         if not PLOTLY_AVAILABLE:
             raise ImportError("Plotly is required for figure creation")
@@ -1239,7 +1238,7 @@ class ReplicationLogAnalyzer:
 
         return fig
 
-    def _generate_png(self, fig: go.Figure, outfile: str) -> None:
+    def _generate_png(self, fig, outfile: str) -> None:
         """Generate PNG snapshot of the plotly figure using matplotlib.
         For PNG, we deliberately omit the hop-lag (3rd subplot) data.
         """
@@ -1283,7 +1282,7 @@ class ReplicationLogAnalyzer:
         except Exception as e:
             raise IOError(f"Failed to generate PNG report: {e}")
 
-    def _generate_html(self, fig: go.Figure, outfile: str) -> None:
+    def _generate_html(self, fig, outfile: str) -> None:
         """Generate HTML report from the plotly figure."""
         try:
             pio.write_html(

--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -7,6 +7,3 @@ python-ldap
 setuptools
 distro
 cryptography
-plotly
-matplotlib
-numpy

--- a/src/lib389/setup.py.in
+++ b/src/lib389/setup.py.in
@@ -98,10 +98,7 @@ setup(
         'python-ldap',
         'setuptools',
         'distro',
-        'cryptography',
-        'plotly',
-        'matplotlib',
-        'numpy'
+        'cryptography'
         ],
 
     cmdclass={


### PR DESCRIPTION
Description: Introduce a new `python3-lib389-repl-reports` meta-package that bundles optional dependencies like Plotly and Matplotlib. This enables advanced replication reporting (HTML/PNG) without forcing these libraries on all installations. Update replication tests.
Remove direct references to Plotly, Matplotlib, and Numpy from the base package.

Fixes: https://github.com/389ds/389-ds-base/issues/6465

Reviewed by: ?