### PR TITLE
Issue #6562 - Prevent undefined behaviour in in filter_stuff_func

### DIFF
--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -338,6 +338,10 @@ filter_stuff_func(void *arg, const char *val, PRUint32 slen)
             } else {
                 filter_len = escaped_filter.bv_len;
                 buf = escaped_filter.bv_val;
+                if (buf == NULL) {
+                    slapi_log_err(SLAPI_LOG_TRACE, "filter_stuff_func", "Attempt to copy from NULL pointer\n");
+                    return -1;
+                }
             }
         }
 


### PR DESCRIPTION
Bug Description:

Undefined behaviour caused by escaping null character.

Fix Description:

Add simple check when ldap_bv2escaped_filter_value return null terminator which return error.

relates: https://github.com/389ds/389-ds-base/issues/6562

Reviewed by: @progier389 (Thanks!)