### PR TITLE
Issue 6566 - RI plugin failure to handle a modrdn for rename of member of multiple groups

### DIFF
--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -985,16 +985,6 @@ _update_all_per_mod(Slapi_DN *entrySDN, /* DN of the searched entry */
         /* newRDN and superior are already normalized. */
         newDN = slapi_ch_smprintf("%s,%s", newRDN, superior);
         slapi_dn_ignore_case(newDN);
-
-        /* Check if DN has been updated already (automember) */
-        bv.bv_val = newDN;
-        bv.bv_len = strlen(newDN);
-        if (VALUE_PRESENT == attr_value_find_wsi(attr, &bv, &v)) {
-            slapi_log_err(SLAPI_LOG_PLUGIN, REFERINT_PLUGIN_SUBSYSTEM,
-                          "_update_all_per_mod - Duplicate DN update detected, ignoring %s\n", newDN);
-            bv = (struct berval){0};
-            goto bail;
-        }
         /*
          * Compare the modified dn with the value of
          * the target attribute of referint to find out
@@ -1037,22 +1027,30 @@ _update_all_per_mod(Slapi_DN *entrySDN, /* DN of the searched entry */
             }
             /* else: normalize_rc < 0) Ignore the DN normalization error for now. */
 
+            bv.bv_val = newDN;
+            bv.bv_len = strlen(newDN);
             p = PL_strstr(sval, slapi_sdn_get_ndn(origDN));
             if (p == sval) {
                 /* (case 1) */
                 slapi_mods_add_string(smods, LDAP_MOD_DELETE, attrName, sval);
-                slapi_mods_add_string(smods, LDAP_MOD_ADD, attrName, newDN);
-
+                /* Add only if the attr value does not exist */
+                if (VALUE_PRESENT != attr_value_find_wsi(attr, &bv, &v)) {
+                    slapi_mods_add_string(smods, LDAP_MOD_ADD, attrName, newDN);
+                }
             } else if (p) {
                 /* (case 2) */
                 slapi_mods_add_string(smods, LDAP_MOD_DELETE, attrName, sval);
                 *p = '\0';
                 newvalue = slapi_ch_smprintf("%s%s", sval, newDN);
-                slapi_mods_add_string(smods, LDAP_MOD_ADD, attrName, newvalue);
+                /* Add only if the attr value does not exist */
+                if (VALUE_PRESENT != attr_value_find_wsi(attr, &bv, &v)) {
+                    slapi_mods_add_string(smods, LDAP_MOD_ADD, attrName, newvalue);
+                }
                 slapi_ch_free_string(&newvalue);
             }
             /* else: value does not include the modified DN.  Ignore it. */
             slapi_ch_free_string(&sval);
+            bv = (struct berval){0};
         }
         rc = _do_modify(mod_pb, entrySDN, slapi_mods_get_ldapmods_byref(smods));
         if (rc) {


### PR DESCRIPTION
Bug description:
With AM and RI plugins enabled, the rename of a user that is part of multiple groups fails with a "value exists" error.

Fix description:
For a modrdn the RI plugin creates a new DN, before a modify is attempted check if the new DN already exists in the attr being updated.

Fixes: https://github.com/389ds/389-ds-base/issues/6566

Reviewed by: