### PR TITLE
Issue 6583 - Fix CI on older branches - 2.6

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,13 +23,13 @@ jobs:
 
         include:
           - name: GCC
-            image: quay.io/389ds/ci-images:fedora
+            image: quay.io/389ds/ci-images:el9test
             compiler: gcc
             cpp-compiler: g++
             cflags:  "-O2 -g"
 
           - name: GCC strict
-            image: quay.io/389ds/ci-images:fedora
+            image: quay.io/389ds/ci-images:el9test
             compiler: gcc
             cpp-compiler: g++
             cflags:  "-O2 -g -Wall -Wextra -Wundef -Wpointer-arith -Wfloat-equal \
@@ -37,19 +37,19 @@ jobs:
             -Wuninitialized -Wno-sign-compare -Wshadow -Wformat-security"
 
           - name: GCC Static Analyzer
-            image: quay.io/389ds/ci-images:fedora
+            image: quay.io/389ds/ci-images:el9test
             compiler: gcc
             cpp-compiler: g++
             cflags:  "-O2 -g -fanalyzer"
 
           - name: Clang
-            image: quay.io/389ds/ci-images:fedora
+            image: quay.io/389ds/ci-images:el9test
             compiler: clang
             cpp-compiler: clang++
             cflags: "-O2 -g -Qunused-arguments"
 
           - name: Clang -Weverything
-            image: quay.io/389ds/ci-images:fedora
+            image: quay.io/389ds/ci-images:el9test
             compiler: clang
             cpp-compiler: clang++
             cflags: "-O2 -g -Weverything -Qunused-arguments"

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     container:
-      image: quay.io/389ds/ci-images:test
+      image: quay.io/389ds/ci-images:el9test
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -89,7 +89,7 @@ jobs:
     - name: Run pytest in a container
       run: |
         set -x
-        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:el9test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do
           echo "Waiting for container to be ready..."

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,7 +16,7 @@ jobs:
     name: npm-audit-ci
     runs-on: ubuntu-latest
     container:
-      image: quay.io/389ds/ci-images:test
+      image: quay.io/389ds/ci-images:el9test
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     container:
-      image: quay.io/389ds/ci-images:test
+      image: quay.io/389ds/ci-images:el9test
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -89,7 +89,7 @@ jobs:
     - name: Run pytest in a container
       run: |
         set -x
-        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:el9test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do
           echo "Waiting for container to be ready..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/389ds/ci-images:test
+      image: quay.io/389ds/ci-images:el9test
     steps:
       - name: Get the version
         id: get_version

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/389ds/ci-images:test
+      image: quay.io/389ds/ci-images:el9test
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Bug Description:
Test execution on older branches (1.4.x, some 2.x) fails. We use the same Fedora base image across all branches, but it contains newer toolchain and doesn't have some build dependencies.

Fix Description:
Use appropriate images: EL8 for 1.4.x, EL9 for 2.x, EL10/Fedora for 3.x.

Fixes: https://github.com/389ds/389-ds-base/issues/6583