### PR TITLE
Issue 5841 - dsconf incorrectly setting up Pass-Through Authentication

### DIFF
--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -1544,7 +1544,7 @@ class PAMPassThroughAuthConfigs(DSLdapObjects):
 
     def __init__(self, instance, basedn="cn=PAM Pass Through Auth,cn=plugins,cn=config"):
         super(PAMPassThroughAuthConfigs, self).__init__(instance)
-        self._objectclasses = ['top', 'extensibleObject', 'nsslapdplugin', 'pamConfig']
+        self._objectclasses = ['top', 'extensibleObject', 'pamConfig']
         self._filterattrs = ['cn']
         self._scope = ldap.SCOPE_ONELEVEL
         self._childobject = PAMPassThroughAuthConfig


### PR DESCRIPTION
Bug description:
During init, PAMPassThroughAuthConfigs defines an "objectclass=nsslapdplugin" plugin object. During filter creation, dsconf fails as objectclass=nsslapdplugin is not present in the PAM PT config entry. This objectclass has been removed in all other branches, branch 1.4.3 was skipped as there are cherry pick conflicts.

Fix description:
Remove nsslapdplugin from the plugin object, objectclass list.

Fixes: https://github.com/389ds/389-ds-base/issues/5841

Reviewed by: