### PR TITLE
Issue 6553 - Update concread to 0.5.4 and refactor statistics tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ vendor.tar.gz
 /rust-nsslapd-private.h
 /rust-slapi-private.h
 /src/lib389/setup.py
+/src/target

--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -58,7 +58,7 @@ struct ndn_cache {
 
 /*
  * This means we need 1 MB minimum per thread
- * 
+ *
  */
 #define NDN_CACHE_MINIMUM_CAPACITY 1048576
 /*
@@ -3008,7 +3008,7 @@ ndn_cache_get_stats(uint64_t *hits, uint64_t *tries, uint64_t *size, uint64_t *m
     uint64_t freq_evicts;
     uint64_t recent_evicts;
     uint64_t p_weight;
-    cache_char_stats(cache, 
+    cache_char_stats(cache,
         &reader_hits,
         &reader_includes,
         &write_hits,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,29 +4,43 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "getrandom",
+ "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "atty"
@@ -41,23 +55,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -74,9 +88,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "byteorder"
@@ -105,12 +119,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -145,51 +160,20 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.2.21"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc9816f5ac93ebd51c37f7f9a6bf2b40dfcd42978ad2aea5d542016e9244cf6"
+checksum = "cba00cef522c2597dfbb0a8d1b0ac8ac2b99714f50cc354cda71da63164da0be"
 dependencies = [
  "ahash",
- "crossbeam",
- "crossbeam-epoch",
- "crossbeam-utils",
- "lru",
- "parking_lot",
- "rand",
- "smallvec",
- "tokio",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
+ "arc-swap",
  "crossbeam-epoch",
  "crossbeam-queue",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "lru",
+ "smallvec",
+ "sptr",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -203,18 +187,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "entryuuid"
@@ -239,10 +223,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.9"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
@@ -250,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fernet"
@@ -262,10 +252,16 @@ checksum = "93804560e638370a8be6d59ce71ed803e55e230abdbf42598e666b41adda9b1f"
 dependencies = [
  "base64",
  "byteorder",
- "getrandom",
+ "getrandom 0.2.15",
  "openssl",
  "zeroize",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -290,22 +286,42 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "ahash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -330,38 +346,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "librnsslapd"
@@ -384,33 +391,23 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -421,27 +418,27 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -449,7 +446,7 @@ version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -466,7 +463,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -486,31 +483,6 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
 
 [[package]]
 name = "paste"
@@ -533,21 +505,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro-hack"
@@ -557,9 +523,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -579,50 +545,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -633,11 +560,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -646,46 +573,47 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slapd"
@@ -710,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,12 +673,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
  "rustix",
  "windows-sys",
 ]
@@ -766,24 +702,12 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
 ]
 
 [[package]]
@@ -796,10 +720,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.12"
+name = "tracing"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "uuid"
@@ -807,7 +762,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -818,15 +773,24 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -846,9 +810,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
@@ -861,9 +825,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -933,6 +897,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,5 +942,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.98",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba00cef522c2597dfbb0a8d1b0ac8ac2b99714f50cc354cda71da63164da0be"
+checksum = "0a06c26e76cd1d7a88a44324d0cf18b11589be552e97af09bee345f7e7334c6d"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -403,9 +403,9 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "sptr"

--- a/src/librslapd/Cargo.toml
+++ b/src/librslapd/Cargo.toml
@@ -16,8 +16,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 slapd = { path = "../slapd" }
 libc = "0.2"
-concread =  "^0.2.20"
+concread =  "0.5.3"
 
 [build-dependencies]
 cbindgen = "0.26"
-

--- a/src/librslapd/Cargo.toml
+++ b/src/librslapd/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 slapd = { path = "../slapd" }
 libc = "0.2"
-concread =  "0.5.3"
+concread = "0.5.4"
 
 [build-dependencies]
 cbindgen = "0.26"

--- a/src/librslapd/src/cache.rs
+++ b/src/librslapd/src/cache.rs
@@ -1,38 +1,160 @@
 // This exposes C-FFI capable bindings for the concread concurrently readable cache.
+use concread::arcache::stats::{ARCacheWriteStat, ReadCountStat};
 use concread::arcache::{ARCache, ARCacheBuilder, ARCacheReadTxn, ARCacheWriteTxn};
-use std::convert::TryInto;
+use concread::cowcell::CowCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
+#[derive(Clone, Debug, Default)]
+struct CacheStats {
+    reader_hits: u64,      // Hits from read transactions (main + local)
+    reader_includes: u64,  // Number of includes from read transactions
+    write_hits: u64,       // Hits from write transactions
+    write_inc_or_mod: u64, // Number of includes/modifications from write transactions
+    freq_evicts: u64,      // Number of evictions from frequent set
+    recent_evicts: u64,    // Number of evictions from recent set
+}
+
+impl CacheStats {
+    fn new() -> Self {
+        CacheStats::default()
+    }
+
+    fn update_from_read_stat(&mut self, stat: ReadCountStat) {
+        self.reader_hits += stat.main_hit + stat.local_hit;
+        self.reader_includes += stat.include + stat.local_include;
+    }
+
+    fn update_from_write_stat(&mut self, stat: &FFIWriteStat) {
+        self.write_hits += stat.read_hits;
+        self.write_inc_or_mod += stat.includes + stat.modifications;
+        self.freq_evicts += stat.freq_evictions;
+        self.recent_evicts += stat.recent_evictions;
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FFIWriteStat {
+    pub read_ops: u64,
+    pub read_hits: u64,
+    pub p_weight: u64,
+    pub shared_max: u64,
+    pub freq: u64,
+    pub recent: u64,
+    pub all_seen_keys: u64,
+    pub includes: u64,
+    pub modifications: u64,
+    pub freq_evictions: u64,
+    pub recent_evictions: u64,
+    pub ghost_freq_revives: u64,
+    pub ghost_rec_revives: u64,
+    pub haunted_includes: u64,
+}
+
+impl<K> ARCacheWriteStat<K> for FFIWriteStat {
+    fn cache_clear(&mut self) {
+        self.read_ops = 0;
+        self.read_hits = 0;
+    }
+
+    fn cache_read(&mut self) {
+        self.read_ops += 1;
+    }
+
+    fn cache_hit(&mut self) {
+        self.read_hits += 1;
+    }
+
+    fn p_weight(&mut self, p: u64) {
+        self.p_weight = p;
+    }
+
+    fn shared_max(&mut self, i: u64) {
+        self.shared_max = i;
+    }
+
+    fn freq(&mut self, i: u64) {
+        self.freq = i;
+    }
+
+    fn recent(&mut self, i: u64) {
+        self.recent = i;
+    }
+
+    fn all_seen_keys(&mut self, i: u64) {
+        self.all_seen_keys = i;
+    }
+
+    fn include(&mut self, _k: &K) {
+        self.includes += 1;
+    }
+
+    fn include_haunted(&mut self, _k: &K) {
+        self.haunted_includes += 1;
+    }
+
+    fn modify(&mut self, _k: &K) {
+        self.modifications += 1;
+    }
+
+    fn ghost_frequent_revive(&mut self, _k: &K) {
+        self.ghost_freq_revives += 1;
+    }
+
+    fn ghost_recent_revive(&mut self, _k: &K) {
+        self.ghost_rec_revives += 1;
+    }
+
+    fn evict_from_recent(&mut self, _k: &K) {
+        self.recent_evictions += 1;
+    }
+
+    fn evict_from_frequent(&mut self, _k: &K) {
+        self.freq_evictions += 1;
+    }
+}
+
 pub struct ARCacheChar {
     inner: ARCache<CString, CString>,
+    stats: CowCell<CacheStats>,
 }
 
 pub struct ARCacheCharRead<'a> {
-    inner: ARCacheReadTxn<'a, CString, CString>,
+    inner: ARCacheReadTxn<'a, CString, CString, ReadCountStat>,
+    cache: &'a ARCacheChar,
 }
 
 pub struct ARCacheCharWrite<'a> {
-    inner: ARCacheWriteTxn<'a, CString, CString>,
+    inner: ARCacheWriteTxn<'a, CString, CString, FFIWriteStat>,
+}
+
+impl ARCacheChar {
+    fn new(max: usize, read_max: usize) -> Option<Self> {
+        ARCacheBuilder::new()
+            .set_size(max, read_max)
+            .set_reader_quiesce(false)
+            .build()
+            .map(|inner| Self {
+                inner,
+                stats: CowCell::new(CacheStats::new()),
+            })
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn cache_char_create(max: usize, read_max: usize) -> *mut ARCacheChar {
-    let inner = if let Some(cache) = ARCacheBuilder::new().set_size(max, read_max).build() {
-        cache
+    if let Some(cache) = ARCacheChar::new(max, read_max) {
+        Box::into_raw(Box::new(cache))
     } else {
-        return std::ptr::null_mut();
-    };
-    let cache: Box<ARCacheChar> = Box::new(ARCacheChar { inner });
-    Box::into_raw(cache)
+        std::ptr::null_mut()
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn cache_char_free(cache: *mut ARCacheChar) {
-    // Should we be responsible to drain and free everything?
     debug_assert!(!cache.is_null());
     unsafe {
-        let _drop = Box::from_raw(cache);
+        drop(Box::from_raw(cache));
     }
 }
 
@@ -53,22 +175,26 @@ pub extern "C" fn cache_char_stats(
 ) {
     let cache_ref = unsafe {
         debug_assert!(!cache.is_null());
-        &(*cache) as &ARCacheChar
+        &(*cache)
     };
-    let stats = cache_ref.inner.view_stats();
-    *reader_hits = stats.reader_hits.try_into().unwrap();
-    *reader_includes = stats.reader_includes.try_into().unwrap();
-    *write_hits = stats.write_hits.try_into().unwrap();
-    *write_inc_or_mod = (stats.write_includes + stats.write_modifies)
-        .try_into()
-        .unwrap();
-    *shared_max = stats.shared_max.try_into().unwrap();
-    *freq = stats.freq.try_into().unwrap();
-    *recent = stats.recent.try_into().unwrap();
-    *freq_evicts = stats.freq_evicts.try_into().unwrap();
-    *recent_evicts = stats.recent_evicts.try_into().unwrap();
-    *p_weight = stats.p_weight.try_into().unwrap();
-    *all_seen_keys = stats.all_seen_keys.try_into().unwrap();
+
+    // Get accumulated stats
+    let stats_read = cache_ref.stats.read();
+    *reader_hits = stats_read.reader_hits;
+    *reader_includes = stats_read.reader_includes;
+    *freq_evicts = stats_read.freq_evicts;
+    *recent_evicts = stats_read.recent_evicts;
+    *write_inc_or_mod = stats_read.write_inc_or_mod;
+    *write_hits = stats_read.write_hits;
+
+    // Get the cache stats that are valid through the whole cache's lifetime
+    let write_txn = cache_ref.inner.write_stats(FFIWriteStat::default());
+    let write_stats = write_txn.commit();
+    *shared_max = write_stats.shared_max;
+    *freq = write_stats.freq;
+    *recent = write_stats.recent;
+    *p_weight = write_stats.p_weight;
+    *all_seen_keys = write_stats.all_seen_keys;
 }
 
 // start read
@@ -79,7 +205,8 @@ pub extern "C" fn cache_char_read_begin(cache: *mut ARCacheChar) -> *mut ARCache
         &(*cache) as &ARCacheChar
     };
     let read_txn = Box::new(ARCacheCharRead {
-        inner: cache_ref.inner.read(),
+        inner: cache_ref.inner.read_stats(ReadCountStat::default()),
+        cache: cache_ref,
     });
     Box::into_raw(read_txn)
 }
@@ -87,8 +214,20 @@ pub extern "C" fn cache_char_read_begin(cache: *mut ARCacheChar) -> *mut ARCache
 #[no_mangle]
 pub extern "C" fn cache_char_read_complete(read_txn: *mut ARCacheCharRead) {
     debug_assert!(!read_txn.is_null());
+
     unsafe {
-        let _drop = Box::from_raw(read_txn);
+        let read_txn_box = Box::from_raw(read_txn);
+        let read_stats = read_txn_box.inner.finish();
+        let write_stats = read_txn_box
+            .cache
+            .inner
+            .try_quiesce_stats(FFIWriteStat::default());
+
+        // Update stats
+        let mut stats_write = read_txn_box.cache.stats.write();
+        stats_write.update_from_read_stat(read_stats);
+        stats_write.update_from_write_stat(&write_stats);
+        stats_write.commit();
     }
 }
 
@@ -141,7 +280,7 @@ pub extern "C" fn cache_char_write_begin(
         &(*cache) as &ARCacheChar
     };
     let write_txn = Box::new(ARCacheCharWrite {
-        inner: cache_ref.inner.write(),
+        inner: cache_ref.inner.write_stats(FFIWriteStat::default()),
     });
     Box::into_raw(write_txn)
 }
@@ -149,15 +288,17 @@ pub extern "C" fn cache_char_write_begin(
 #[no_mangle]
 pub extern "C" fn cache_char_write_commit(write_txn: *mut ARCacheCharWrite) {
     debug_assert!(!write_txn.is_null());
-    let wr = unsafe { Box::from_raw(write_txn) };
-    (*wr).inner.commit();
+    unsafe {
+        let write_txn_box = Box::from_raw(write_txn);
+        let _stats = write_txn_box.inner.commit();
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn cache_char_write_rollback(write_txn: *mut ARCacheCharWrite) {
     debug_assert!(!write_txn.is_null());
     unsafe {
-        let _drop = Box::from_raw(write_txn);
+        drop(Box::from_raw(write_txn));
     }
 }
 
@@ -182,7 +323,7 @@ pub extern "C" fn cache_char_write_include(
 
 #[cfg(test)]
 mod tests {
-    use crate::cache::*;
+    use super::*;
 
     #[test]
     fn test_cache_basic() {
@@ -198,5 +339,117 @@ mod tests {
 
         cache_char_read_complete(read_txn);
         cache_char_free(cache_ptr);
+    }
+
+    #[test]
+    fn test_cache_stats() {
+        let cache = cache_char_create(100, 8);
+
+        // Variables to store stats
+        let mut reader_hits = 0;
+        let mut reader_includes = 0;
+        let mut write_hits = 0;
+        let mut write_inc_or_mod = 0;
+        let mut shared_max = 0;
+        let mut freq = 0;
+        let mut recent = 0;
+        let mut freq_evicts = 0;
+        let mut recent_evicts = 0;
+        let mut p_weight = 0;
+        let mut all_seen_keys = 0;
+
+        // Do some operations
+        let key = CString::new("stats_test").unwrap();
+        let value = CString::new("value").unwrap();
+
+        let write_txn = cache_char_write_begin(cache);
+        cache_char_write_include(write_txn, key.as_ptr(), value.as_ptr());
+        cache_char_write_commit(write_txn);
+
+        let read_txn = cache_char_read_begin(cache);
+        let _ = cache_char_read_get(read_txn, key.as_ptr());
+        cache_char_read_complete(read_txn);
+
+        // Get stats
+        cache_char_stats(
+            cache,
+            &mut reader_hits,
+            &mut reader_includes,
+            &mut write_hits,
+            &mut write_inc_or_mod,
+            &mut shared_max,
+            &mut freq,
+            &mut recent,
+            &mut freq_evicts,
+            &mut recent_evicts,
+            &mut p_weight,
+            &mut all_seen_keys,
+        );
+
+        // Verify that stats were updated
+        assert!(write_inc_or_mod > 0);
+        assert!(all_seen_keys > 0);
+
+        cache_char_free(cache);
+    }
+
+    #[test]
+    fn test_cache_read_write_operations() {
+        let cache = cache_char_create(100, 8);
+
+        // Create test data
+        let key = CString::new("test_key").unwrap();
+        let value = CString::new("test_value").unwrap();
+
+        // Test write operation
+        let write_txn = cache_char_write_begin(cache);
+        cache_char_write_include(write_txn, key.as_ptr(), value.as_ptr());
+        cache_char_write_commit(write_txn);
+
+        // Test read operation
+        let read_txn = cache_char_read_begin(cache);
+        let result = cache_char_read_get(read_txn, key.as_ptr());
+        assert!(!result.is_null());
+
+        // Verify the value
+        let retrieved_value = unsafe { CStr::from_ptr(result) };
+        assert_eq!(retrieved_value.to_bytes(), value.as_bytes());
+
+        cache_char_read_complete(read_txn);
+        cache_char_free(cache);
+    }
+
+    #[test]
+    fn test_cache_miss() {
+        let cache = cache_char_create(100, 8);
+        let read_txn = cache_char_read_begin(cache);
+
+        let missing_key = CString::new("nonexistent").unwrap();
+        let result = cache_char_read_get(read_txn, missing_key.as_ptr());
+        assert!(result.is_null());
+
+        cache_char_read_complete(read_txn);
+        cache_char_free(cache);
+    }
+
+    #[test]
+    fn test_write_rollback() {
+        let cache = cache_char_create(100, 8);
+
+        let key = CString::new("rollback_test").unwrap();
+        let value = CString::new("value").unwrap();
+
+        // Start write transaction and rollback
+        let write_txn = cache_char_write_begin(cache);
+        cache_char_write_include(write_txn, key.as_ptr(), value.as_ptr());
+        cache_char_write_rollback(write_txn);
+
+        // Verify key doesn't exist
+        let read_txn = cache_char_read_begin(cache);
+        let result = cache_char_read_get(read_txn, key.as_ptr());
+        assert!(result.is_null());
+
+        cache_char_read_complete(read_txn);
+        cache_char_free(cache);
     }
 }


### PR DESCRIPTION
Description: Implement new cache statistics tracking with atomic counters
and dedicated stats structs.
Update concread dependency to 0.5.4 for improved cache performance.
Add tests for cache statistics functionality.

Fixes: https://github.com/389ds/389-ds-base/issues/6553

Reviewed by: ?