### PR TITLE
Issue 6429 - UI - clicking on a database suffix under the Monitor tab crashes UI

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1253,20 +1253,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         // Check if a setting was changed, if so enable the save button
         for (const config_attr of check_attrs) {
             if (this.state[config_attr] !== this.state['_' + config_attr]) {
-                // jc console.log(config_attr);
                 saveBtnDisabled = false;
                 break;
             }
         }
-
-        // Check if have any errors on our attributes
-        for (const config_attr of check_attrs) {
-            if (config_attr in this.state.error && this.state.error[config_attr]) {
-                saveBtnDisabled = true;
-                break;
-            }
-        }
-
         this.setState({
             saveBtnDisabled
         });

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1257,6 +1257,15 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                 break;
             }
         }
+
+        // Check if have any errors on our attributes
+        for (const config_attr of check_attrs) {
+            if (config_attr in this.state.error && this.state.error[config_attr]) {
+                saveBtnDisabled = true;
+                break;
+            }
+        }
+
         this.setState({
             saveBtnDisabled
         });

--- a/src/cockpit/389-console/src/lib/monitor/dbMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/dbMonitor.jsx
@@ -326,7 +326,6 @@ export class DatabaseMonitor extends React.Component {
                             </GridItem>
                         </Grid>
                     </Tab>
-
                     <Tab eventKey={1} title={<TabTitleText>{_("Normalized DN Cache")}</TabTitleText>}>
                         <div className="ds-margin-top-lg">
                             <Grid hasGutter>
@@ -511,12 +510,394 @@ export class DatabaseMonitor extends React.Component {
 // Prop types and defaults
 
 DatabaseMonitor.propTypes = {
+    data: PropTypes.object,
     serverId: PropTypes.string,
     enableTree: PropTypes.func,
 };
 
 DatabaseMonitor.defaultProps = {
+    data: {},
     serverId: "",
 };
 
-export default DatabaseMonitor;
+export class DatabaseMonitorMDB extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            activeTabKey: 0,
+            data: {},
+            loading: true,
+            // refresh chart
+            cache_refresh: "",
+            count: 10,
+            ndnCount: 5,
+            dbCacheList: [],
+            ndnCacheList: [],
+            ndnCacheUtilList: []
+        };
+
+        // Toggle currently active tab
+        this.handleNavSelect = (event, tabIndex) => {
+            this.setState({
+                activeTabKey: tabIndex
+            });
+        };
+
+        this.startCacheRefresh = this.startCacheRefresh.bind(this);
+        this.refreshCache = this.refreshCache.bind(this);
+    }
+
+    componentDidMount() {
+        this.resetChartData();
+        this.refreshCache();
+        this.startCacheRefresh();
+        this.props.enableTree();
+    }
+
+    componentWillUnmount() {
+        this.stopCacheRefresh();
+    }
+
+    resetChartData() {
+        this.setState({
+            data: {
+                normalizeddncachehitratio: [0],
+                maxnormalizeddncachesize: [0],
+                currentnormalizeddncachesize: [0],
+                normalizeddncachetries: [0],
+                normalizeddncachehits: [0],
+                normalizeddncacheevictions: [0],
+                currentnormalizeddncachecount: [0],
+                normalizeddncachethreadsize: [0],
+                normalizeddncachethreadslots: [0],
+            },
+            ndnCacheList: [
+                { name: "", x: "1", y: 0 },
+                { name: "", x: "2", y: 0 },
+                { name: "", x: "3", y: 0 },
+                { name: "", x: "4", y: 0 },
+                { name: "", x: "5", y: 0 },
+            ],
+            ndnCacheUtilList: [
+                { name: "", x: "1", y: 0 },
+                { name: "", x: "2", y: 0 },
+                { name: "", x: "3", y: 0 },
+                { name: "", x: "4", y: 0 },
+                { name: "", x: "5", y: 0 },
+            ],
+        });
+    }
+
+    refreshCache() {
+        // Search for db cache stat and update state
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "monitor", "ldbm"
+        ];
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const config = JSON.parse(content);
+                    let count = this.state.count + 1;
+                    const ndnCount = this.state.ndnCount + 1;
+                    if (count > 100) {
+                        // Keep progress count in check
+                        count = 1;
+                    }
+
+                    // Build up the DB Cache chart data
+                    const dbratio = config.attrs.dbcachehitratio[0];
+                    const chart_data = this.state.dbCacheList;
+                    chart_data.shift();
+                    chart_data.push({ name: _("Cache Hit Ratio"), x: count.toString(), y: parseInt(dbratio) });
+
+                    // Build up the NDN Cache chart data
+                    const ndnratio = config.attrs.normalizeddncachehitratio[0];
+                    const ndn_chart_data = this.state.ndnCacheList;
+                    ndn_chart_data.shift();
+                    ndn_chart_data.push({ name: _("Cache Hit Ratio"), x: count.toString(), y: parseInt(ndnratio) });
+
+                    // Build up the DB Cache Util chart data
+                    const ndn_util_chart_data = this.state.ndnCacheUtilList;
+                    const currNDNSize = parseInt(config.attrs.currentnormalizeddncachesize[0]);
+                    const maxNDNSize = parseInt(config.attrs.maxnormalizeddncachesize[0]);
+                    const ndn_utilization = (currNDNSize / maxNDNSize) * 100;
+                    ndn_util_chart_data.shift();
+                    ndn_util_chart_data.push({ name: _("Cache Utilization"), x: ndnCount.toString(), y: parseInt(ndn_utilization) });
+
+                    this.setState({
+                        data: config.attrs,
+                        loading: false,
+                        dbCacheList: chart_data,
+                        ndnCacheList: ndn_chart_data,
+                        ndnCacheUtilList: ndn_util_chart_data,
+                        count,
+                        ndnCount
+                    });
+                })
+                .fail(() => {
+                    this.resetChartData();
+                });
+    }
+
+    startCacheRefresh() {
+        this.setState({
+            cache_refresh: setInterval(this.refreshCache, 2000),
+        });
+    }
+
+    stopCacheRefresh() {
+        clearInterval(this.state.cache_refresh);
+    }
+
+    render() {
+        let chartColor = ChartThemeColor.green;
+        let ndnChartColor = ChartThemeColor.green;
+        let ndnUtilColor = ChartThemeColor.green;
+        let dbcachehit = 0;
+        let ndncachehit = 0;
+        let ndncachemax = 0;
+        let ndncachecurr = 0;
+        let utilratio = 0;
+        let content = (
+            <div className="ds-margin-top-xlg ds-center">
+                <TextContent>
+                    <Text component={TextVariants.h3}>
+                        {_("Loading database monitor information ...")}
+                    </Text>
+                </TextContent>
+                <Spinner className="ds-margin-top-lg" size="xl" />
+            </div>
+        );
+
+        if (!this.state.loading) {
+            dbcachehit = parseInt(this.state.data.dbcachehitratio[0]);
+            ndncachehit = parseInt(this.state.data.normalizeddncachehitratio[0]);
+            ndncachemax = parseInt(this.state.data.maxnormalizeddncachesize[0]);
+            ndncachecurr = parseInt(this.state.data.currentnormalizeddncachesize[0]);
+            utilratio = Math.round((ndncachecurr / ndncachemax) * 100);
+            if (utilratio === 0) {
+                // Just round up to 1
+                utilratio = 1;
+            }
+
+            // Database cache
+            if (dbcachehit > 89) {
+                chartColor = ChartThemeColor.green;
+            } else if (dbcachehit > 74) {
+                chartColor = ChartThemeColor.orange;
+            } else {
+                chartColor = ChartThemeColor.purple;
+            }
+            // NDN cache ratio
+            if (ndncachehit > 89) {
+                ndnChartColor = ChartThemeColor.green;
+            } else if (ndncachehit > 74) {
+                ndnChartColor = ChartThemeColor.orange;
+            } else {
+                ndnChartColor = ChartThemeColor.purple;
+            }
+            // NDN cache utilization
+            if (utilratio > 95) {
+                ndnUtilColor = ChartThemeColor.purple;
+            } else if (utilratio > 90) {
+                ndnUtilColor = ChartThemeColor.orange;
+            } else {
+                ndnUtilColor = ChartThemeColor.green;
+            }
+
+            content = (
+                <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
+                    <Tab eventKey={0} title={<TabTitleText>{_("Normalized DN Cache")}</TabTitleText>}>
+                        <div className="ds-margin-top-lg">
+                            <Grid hasGutter>
+                                <GridItem span={6}>
+                                    <Card isSelectable>
+                                        <CardBody>
+                                            <div className="ds-container">
+                                                <div className="ds-center">
+                                                    <TextContent className="ds-margin-top-xlg" title={_("The normalized DN cache hit ratio (normalizeddncachehitratio).")}>
+                                                        <Text component={TextVariants.h3}>
+                                                            {_("Cache Hit Ratio")}
+                                                        </Text>
+                                                    </TextContent>
+                                                    <TextContent>
+                                                        <Text component={TextVariants.h2}>
+                                                            <b>{ndncachehit}%</b>
+                                                        </Text>
+                                                    </TextContent>
+                                                </div>
+                                                <div className="ds-margin-left" style={{ height: '200px', width: '350px' }}>
+                                                    <Chart
+                                                        ariaDesc="NDN Cache"
+                                                        ariaTitle={_("Live Normalized DN Cache Statistics")}
+                                                        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+                                                        height={200}
+                                                        maxDomain={{ y: 100 }}
+                                                        minDomain={{ y: 0 }}
+                                                        padding={{
+                                                            bottom: 40,
+                                                            left: 60,
+                                                            top: 10,
+                                                            right: 15,
+                                                        }}
+                                                        width={350}
+                                                        themeColor={ndnChartColor}
+                                                    >
+                                                        <ChartAxis />
+                                                        <ChartAxis dependentAxis showGrid tickValues={[25, 50, 75, 100]} />
+                                                        <ChartGroup>
+                                                            <ChartArea
+                                                                data={this.state.ndnCacheList}
+                                                            />
+                                                        </ChartGroup>
+                                                    </Chart>
+                                                </div>
+                                            </div>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                                <GridItem span={6}>
+                                    <Card isSelectable>
+                                        <CardBody>
+                                            <div className="ds-container">
+                                                <div className="ds-center">
+                                                    <TextContent className="ds-margin-top-lg" title={_("The amount of the cache that is being used: max size (maxnormalizeddncachesize) vs current size (currentnormalizeddncachesize)")}>
+                                                        <Text component={TextVariants.h2}>
+                                                            {_("Cache Utilization")}
+                                                        </Text>
+                                                    </TextContent>
+                                                    <TextContent>
+                                                        <Text component={TextVariants.h3}>
+                                                            <b>{utilratio}%</b>
+                                                        </Text>
+                                                    </TextContent>
+                                                    <TextContent className="ds-margin-top-xlg">
+                                                        <Text component={TextVariants.h5}>
+                                                            {_("Cached DN's")}
+                                                        </Text>
+                                                    </TextContent>
+                                                    <b>{numToCommas(this.state.data.currentnormalizeddncachecount[0])}</b>
+                                                </div>
+                                                <div className="ds-margin-left" style={{ height: '200px', width: '350px' }}>
+                                                    <Chart
+                                                        ariaDesc="NDN Cache Utilization"
+                                                        ariaTitle={_("Live Normalized DN Cache Utilization Statistics")}
+                                                        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+                                                        height={200}
+                                                        maxDomain={{ y: 100 }}
+                                                        minDomain={{ y: 0 }}
+                                                        padding={{
+                                                            bottom: 40,
+                                                            left: 60,
+                                                            top: 10,
+                                                            right: 15,
+                                                        }}
+                                                        width={350}
+                                                        themeColor={ndnUtilColor}
+                                                    >
+                                                        <ChartAxis />
+                                                        <ChartAxis dependentAxis showGrid tickValues={[25, 50, 75, 100]} />
+                                                        <ChartGroup>
+                                                            <ChartArea
+                                                                data={this.state.ndnCacheUtilList}
+                                                            />
+                                                        </ChartGroup>
+                                                    </Chart>
+                                                </div>
+                                            </div>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                            </Grid>
+
+                            <Grid hasGutter className="ds-margin-top-xlg">
+                                <GridItem span={3}>
+                                    {_("NDN Cache Hit Ratio:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{this.state.data.normalizeddncachehitratio}%</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Max Size:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{displayBytes(this.state.data.maxnormalizeddncachesize)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Tries:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.normalizeddncachetries)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Current Cache Size:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{displayBytes(this.state.data.currentnormalizeddncachesize)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Hits:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.normalizeddncachehits)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache DN Count:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.currentnormalizeddncachecount)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Evictions:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.normalizeddncacheevictions)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Thread Size:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.normalizeddncachethreadsize)}</b>
+                                </GridItem>
+                                <GridItem span={3}>
+                                    {_("NDN Cache Thread Slots:")}
+                                </GridItem>
+                                <GridItem span={2}>
+                                    <b>{numToCommas(this.state.data.normalizeddncachethreadslots)}</b>
+                                </GridItem>
+                            </Grid>
+                        </div>
+                    </Tab>
+                </Tabs>
+            );
+        }
+
+        return (
+            <div id="db-content">
+                <TextContent>
+                    <Text className="ds-sub-header" component={TextVariants.h2}>
+                        {_("Database Performance Statistics")}
+                    </Text>
+                </TextContent>
+                <div className="ds-margin-top-lg">
+                    {content}
+                </div>
+
+            </div>
+        );
+    }
+}
+
+// Prop types and defaults
+
+DatabaseMonitorMDB.propTypes = {
+    data: PropTypes.object,
+    serverId: PropTypes.string,
+    enableTree: PropTypes.func,
+};
+
+DatabaseMonitorMDB.defaultProps = {
+    data: {},
+    serverId: "",
+};

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -605,6 +605,13 @@ export class Monitor extends React.Component {
                             dbEngine: attrs['nsslapd-backend-implement'][0],
                         });
                     }
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format("Error detecting DB implementation type - $0", errMsg.desc)
+                    );
                 });
     }
 

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -3,8 +3,8 @@ import React from "react";
 import { log_cmd } from "./lib/tools.jsx";
 import PropTypes from "prop-types";
 import ServerMonitor from "./lib/monitor/serverMonitor.jsx";
-import DatabaseMonitor from "./lib/monitor/dbMonitor.jsx";
-import SuffixMonitor from "./lib/monitor/suffixMonitor.jsx";
+import { DatabaseMonitor, DatabaseMonitorMDB } from "./lib/monitor/dbMonitor.jsx";
+import { SuffixMonitor, SuffixMonitorMDB } from "./lib/monitor/suffixMonitor.jsx";
 import ChainingMonitor from "./lib/monitor/chainingMonitor.jsx";
 import AccessLogMonitor from "./lib/monitor/accesslog.jsx";
 import AuditLogMonitor from "./lib/monitor/auditlog.jsx";
@@ -34,6 +34,8 @@ import {
 } from '@patternfly/react-icons';
 
 const _ = cockpit.gettext;
+
+const BE_IMPL_MDB = "mdb";
 
 export class Monitor extends React.Component {
     constructor(props) {
@@ -82,6 +84,8 @@ export class Monitor extends React.Component {
             auditlogLocation: "",
             auditfaillogLocation: "",
             securitylogLocation: "",
+            // DB engine, bdb or mdb (default)
+            dbEngine: BE_IMPL_MDB,
         };
 
         // Bindings
@@ -98,6 +102,7 @@ export class Monitor extends React.Component {
         this.loadMonitorChaining = this.loadMonitorChaining.bind(this);
         this.loadDiskSpace = this.loadDiskSpace.bind(this);
         this.reloadDisks = this.reloadDisks.bind(this);
+        this.getDBEngine = this.getDBEngine.bind(this);
         // Replication
         this.onHandleLoadMonitorReplication = this.onHandleLoadMonitorReplication.bind(this);
         this.loadCleanTasks = this.loadCleanTasks.bind(this);
@@ -112,6 +117,10 @@ export class Monitor extends React.Component {
         this.getAgmts = this.getAgmts.bind(this);
         // Logging
         this.loadMonitor = this.loadMonitor.bind(this);
+    }
+
+    componentDidMount() {
+        this.getDBEngine();
     }
 
     componentDidUpdate(prevProps) {
@@ -580,6 +589,25 @@ export class Monitor extends React.Component {
                 });
     }
 
+    getDBEngine () {
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "backend", "config", "get"
+        ];
+        log_cmd("getDBEngine", "Get DB Implementation", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const config = JSON.parse(content);
+                    const attrs = config.attrs;
+                    if ('nsslapd-backend-implement' in attrs) {
+                        this.setState({
+                            dbEngine: attrs['nsslapd-backend-implement'][0],
+                        });
+                    }
+                });
+    }
+
     reloadSNMP() {
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
@@ -955,13 +983,24 @@ export class Monitor extends React.Component {
                         </div>
                     );
                 } else {
-                    monitor_element = (
-                        <DatabaseMonitor
-                            data={this.state.ldbmData}
-                            enableTree={this.enableTree}
-                            serverId={this.props.serverId}
-                        />
-                    );
+                    if (this.state.dbEngine === BE_IMPL_MDB) {
+                        monitor_element = (
+                            <DatabaseMonitorMDB
+                                data={this.state.ldbmData}
+                                enableTree={this.enableTree}
+                                serverId={this.props.serverId}
+                            />
+                        );
+                    } else {
+                        monitor_element = (
+                            <DatabaseMonitor
+                                data={this.state.ldbmData}
+                                enableTree={this.enableTree}
+                                serverId={this.props.serverId}
+                            />
+                        );
+                    }
+
                 }
             } else if (this.state.node_name === "server-monitor") {
                 if (this.state.serverLoading) {
@@ -1142,16 +1181,29 @@ export class Monitor extends React.Component {
                         );
                     } else {
                         // Suffix
-                        monitor_element = (
-                            <SuffixMonitor
-                                serverId={this.props.serverId}
-                                suffix={this.state.node_text}
-                                bename={this.state.bename}
-                                enableTree={this.enableTree}
-                                key={this.state.node_text}
-                                addNotification={this.props.addNotification}
-                            />
-                        );
+                        if (this.state.dbEngine === BE_IMPL_MDB) {
+                            monitor_element = (
+                                <SuffixMonitorMDB
+                                    serverId={this.props.serverId}
+                                    suffix={this.state.node_text}
+                                    bename={this.state.bename}
+                                    enableTree={this.enableTree}
+                                    key={this.state.node_text}
+                                    addNotification={this.props.addNotification}
+                                />
+                            );
+                        } else {
+                            monitor_element = (
+                                <SuffixMonitor
+                                    serverId={this.props.serverId}
+                                    suffix={this.state.node_text}
+                                    bename={this.state.bename}
+                                    enableTree={this.enableTree}
+                                    key={this.state.node_text}
+                                    addNotification={this.props.addNotification}
+                                />
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Bug description:
Clicking on a db suffix under the Monitor tab causes the UI to crash when the instance is configured with the mdb db engine.

Fix description:
Introduced separate database and suffix monitor classes tailored for mdb. Parent class detects the configured db engine and calls the appropriate monitor class.

Fixes: https://github.com/389ds/389-ds-base/issues/6429

Reviewed by: