### PR TITLE
Issue 6617 - test_vlv_as_freeipa_backup_restore fails

### DIFF
--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -10,6 +10,7 @@ import pytest, time
 import os
 import glob
 import ldap
+import pwd
 from shutil import copyfile, rmtree
 from datetime import datetime
 from contextlib import contextmanager, suppress
@@ -366,7 +367,14 @@ def freeipa(topology_st):
         with open(target, 'a') as fout:
             fout.write(fin.read())
     # import ipaca
-    file = f'{datadir}/ipaca.ldif'
+    # Make the ldif filke readable by ns-slapd process
+    file_ref = f'{datadir}/ipaca.ldif'
+    file = f'{inst.ds_paths.ldif_dir}/ipaca.ldif'
+    log.info(f'Copying ldif {file_ref} to {file}')
+    copyfile(file_ref, file)
+    dirsrv = pwd.getpwnam('dirsrv')
+    os.chown(file, dirsrv.pw_uid, dirsrv.pw_gid)
+    # Then import it
     log.info(f'Importing ldif {file} to ipaca')
     assert inst.ldif2db('ipaca', None, None, None, file)
     # restart instance


### PR DESCRIPTION
Problem:
dirsrvtests/tests/suites/vlv/regression_test.py::test_vlv_as_freeipa_backup_restore CI test fails on image mode
because import fails
because /var/roothome/389-ds-base/dirsrvtests/tests/suites/vlv/../../data/freeipa/issue6136/ipaca.ldif cannot be open in read mode
because /var/roothome permissions are 0700 (so ns-slapd process does not have the permission to read subdirectories)

Solution:
 copy the ldif file on a place that ns-slapd can read

Issue: #6617 

Reviewed by: @jchapma (Thanks!)