### PR TITLE
Issue 6619 - test_dblib_migration fails on RHEL10

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -13,7 +13,11 @@ import os
 import time
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.backend import DatabaseConfig
-from lib389.cli_ctl.dblib import (FakeArgs, dblib_bdb2mdb, dblib_mdb2bdb, dblib_cleanup)
+from lib389.cli_ctl.dblib import (
+    FakeArgs,
+    dblib_bdb2mdb,
+    dblib_cleanup,
+    is_bdb_supported)
 from lib389.idm.user import UserAccounts
 from lib389.replica import ReplicationManager
 from lib389.topologies import topology_m2 as topo_m2, topology_st as topo_st
@@ -87,6 +91,7 @@ def _check_db(inst, log, impl):
         assert db_files == mdb_list
 
 
+@pytest.mark.skipif(is_bdb_supported() is False, reason='This test requires bdb support')
 def test_dblib_migration(init_user):
     """
     Verify dsctl dblib xxxxxxx sub commands (migration between bdb and lmdb)

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -51,7 +51,7 @@ class FakeArgs(dict):
 
 def get_bdb_impl_status():
     backldbm = 'libback-ldbm'
-    bundledbdb_plugin = 'libback-ldbm'
+    bundledbdb_plugin = 'libback-bdb'
     robdb_symbol = 'bdbro_getcb_vector'
     libdb = 'libdb-'
     plgstrs = check_plugin_strings(backldbm, [bundledbdb_plugin, robdb_symbol, libdb])
@@ -68,6 +68,14 @@ def get_bdb_impl_status():
         return BDB_IMPL_STATUS.STANDARD
     # Unable to find libback-ldbm plugin
     return BDB_IMPL_STATUS.UNKNOWN
+
+
+def is_bdb_supported(read_write=True):
+    bdbok = [BDB_IMPL_STATUS.BUNDLED, BDB_IMPL_STATUS.STANDARD]
+    if noread_write:
+        # READ_MODE is ok too
+        bdbok.append(BDB_IMPL_STATUS.READ_ONLY)
+    return get_bdb_impl_status() in bdbok
 
 
 def get_ldif_dir(instance):

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -72,7 +72,7 @@ def get_bdb_impl_status():
 
 def is_bdb_supported(read_write=True):
     bdbok = [BDB_IMPL_STATUS.BUNDLED, BDB_IMPL_STATUS.STANDARD]
-    if noread_write:
+    if not read_write:
         # READ_MODE is ok too
         bdbok.append(BDB_IMPL_STATUS.READ_ONLY)
     return get_bdb_impl_status() in bdbok


### PR DESCRIPTION
Test test_dblib_migration fails on RHEL10 because bdb is not supported. 
Test should be skipped in that case and libdb should provide a function to check if server can starts on bdb

Issue: #6619 

Reviewed by: @jchapma (Thanks!)

