### PR TITLE
Issue 6625 - UI - fix next round of bugs

### DIFF
--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -195,17 +195,17 @@ uniqueness_entry_to_config(Slapi_PBlock *pb, Slapi_Entry *config_entry)
     slapi_pblock_get(pb, SLAPI_PLUGIN_ARGC, &argc);
     if (argc == 0) {
         /* This is new config style
-                 * uniqueness-attribute-name: uid
-                 * uniqueness-subtrees: dc=people,dc=example,dc=com
-                 * uniqueness-subtrees: dc=sales, dc=example,dc=com
-                 * uniqueness-across-all-subtrees: on
-                 *
-                 * or
-                 *
-                 * uniqueness-attribute-name: uid
-                 * uniqueness-top-entry-oc: organizationalUnit
-                 * uniqueness-subtree-entries-oc: person
-                 */
+         * uniqueness-attribute-name: uid
+         * uniqueness-subtrees: dc=people,dc=example,dc=com
+         * uniqueness-subtrees: dc=sales, dc=example,dc=com
+         * uniqueness-across-all-subtrees: on
+         *
+         * or
+         *
+         * uniqueness-attribute-name: uid
+         * uniqueness-top-entry-oc: organizationalUnit
+         * uniqueness-subtree-entries-oc: person
+         */
 
         /* Attribute name of the attribute we are going to check value uniqueness */
         values = slapi_entry_attr_get_charray(config_entry, ATTR_UNIQUENESS_ATTRIBUTE_NAME);
@@ -293,16 +293,15 @@ uniqueness_entry_to_config(Slapi_PBlock *pb, Slapi_Entry *config_entry)
         }
         if (UNTAGGED_PARAMETER == result) {
             /* This is
-                         * nsslapd-pluginarg0: uid
-                         * nsslapd-pluginarg1: dc=people,dc=example,dc=com
-                         * nsslapd-pluginarg2: dc=sales, dc=example,dc=com
-                         *
-                         * config attribute are in argc/argv
-                         *
-                         * attrName is set
-                         * markerObjectClass/requiredObjectClass are NOT set
-                         */
-
+             * nsslapd-pluginarg0: uid
+             * nsslapd-pluginarg1: dc=people,dc=example,dc=com
+             * nsslapd-pluginarg2: dc=sales, dc=example,dc=com
+             *
+             * config attribute are in argc/argv
+             *
+             * attrName is set
+             * markerObjectClass/requiredObjectClass are NOT set
+             */
             if (slapi_pblock_get(pb, SLAPI_PLUGIN_ARGC, &argc) || slapi_pblock_get(pb, SLAPI_PLUGIN_ARGV, &argv)) {
                 slapi_log_err(SLAPI_LOG_PLUGIN, plugin_name, "uniqueness_entry_to_config - "
                                                              "Only attribute name is valid\n");

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -62,7 +62,6 @@ td {
 
 .ds-tree {
     border: 1px solid #909090;
-    background-color: #f8f8f8;
     width: 300px;
     min-width: 300px;
     min-height: 350px;
@@ -75,7 +74,6 @@ td {
 
 .pf-theme-dark .ds-tree {
     border: 1px solid #909090;
-    background-color: rgb(54 55 58);
     width: 300px;
     min-width: 300px;
     min-height: 350px;

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn } from "./lib/tools.jsx";
+import { log_cmd, valid_dn, valid_db_name } from "./lib/tools.jsx";
 import {
     ChainingConfig,
     ChainingDatabaseConfig
@@ -12,6 +12,7 @@ import { GlobalPwPolicy } from "./lib/database/globalPwp.jsx";
 import { LocalPwPolicy } from "./lib/database/localPwp.jsx";
 import {
     Button,
+    Card,
     Form,
     FormGroup,
     FormSelect,
@@ -749,7 +750,11 @@ export class Database extends React.Component {
         } else if (e.target.id === "createSuffix" && !valid_dn(str)) {
             valueErr = true;
             createNotOK = true;
+        } else if (e.target.id === "createBeName" && !valid_db_name(str)) {
+            valueErr = true;
+            createNotOK = true;
         }
+
         // Check existing values
         if (e.target.id !== "createSuffix") {
             if (!valid_dn(this.state.createSuffix)) {
@@ -758,7 +763,7 @@ export class Database extends React.Component {
             }
         }
         if (e.target.id !== "createBeName") {
-            if (this.state.createBeName === "") {
+            if (this.state.createBeName === "" || !valid_db_name(this.state.createBeName)) {
                 errObj.createBeName = true;
                 createNotOK = true;
             }
@@ -1386,18 +1391,16 @@ export class Database extends React.Component {
             }
             body = (
                 <div className="ds-container">
-                    <div>
-                        <div className="ds-tree">
-                            <div className={disabled} id="db-tree">
-                                <TreeView
-                                    hasSelectableNodes
-                                    data={this.state.nodes}
-                                    activeItems={this.state.activeItems}
-                                    onSelect={this.handleTreeClick}
-                                />
-                            </div>
+                    <Card className="ds-tree">
+                        <div className={disabled} id="db-tree">
+                            <TreeView
+                                hasSelectableNodes
+                                data={this.state.nodes}
+                                activeItems={this.state.activeItems}
+                                onSelect={this.handleTreeClick}
+                            />
                         </div>
-                    </div>
+                    </Card>
                     <div className="ds-tree-content">
                         {db_element}
                     </div>

--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -270,7 +270,7 @@ export class DSInstance extends React.Component {
                                                         wasActiveList: [this.state.activeTabKey]
                                                     },
                                                     () => {
-                                                        this.loadBackups();
+                                                        this.loadBackups(true);
                                                     }
                                                 );
                                                 if (action === "restart") {
@@ -305,7 +305,7 @@ export class DSInstance extends React.Component {
                                                                 wasActiveList: []
                                                             },
                                                             () => {
-                                                                this.loadBackups();
+                                                                this.loadBackups(true);
                                                             }
                                                         );
                                                     }
@@ -329,7 +329,7 @@ export class DSInstance extends React.Component {
                                                     wasActiveList: []
                                                 },
                                                 () => {
-                                                    this.loadBackups();
+                                                    this.loadBackups(true);
                                                 }
                                             );
                                         }
@@ -371,7 +371,7 @@ export class DSInstance extends React.Component {
                                     wasActiveList: []
                                 },
                                 () => {
-                                    this.loadBackups();
+                                    this.loadBackups(true);
                                 }
                             );
                         }
@@ -448,7 +448,7 @@ export class DSInstance extends React.Component {
         );
     }
 
-    loadBackups() {
+    loadBackups(initializing) {
         let cmd = ["dsctl", "-j", this.state.serverId, "backups"];
         log_cmd("loadBackups", "Load Backups", cmd);
         cockpit.spawn(cmd, { superuser: true, err: "message" })
@@ -479,10 +479,13 @@ export class DSInstance extends React.Component {
                 .fail(err => {
                     this.updateProgress(25);
                     const errMsg = JSON.parse(err);
-                    this.addNotification(
-                        "error",
-                        cockpit.format(_("Load Backups operation failed - $0"), errMsg.desc)
-                    );
+                    if (!initializing) {
+                        // Don't log an error when first initializing the UI
+                        this.addNotification(
+                            "error",
+                            cockpit.format(_("Load Backups operation failed - $0"), errMsg.desc)
+                        );
+                    }
                     this.setState({
                         backupRows: [],
                     });

--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -12,6 +12,8 @@ import {
     FormHelperText,
     FormSelect,
     FormSelectOption,
+    HelperText,
+    HelperTextItem,
     Grid,
     GridItem,
     Modal,
@@ -419,12 +421,18 @@ export class CreateInstanceModal extends React.Component {
                                     }}
                                     validated={errObj.createServerId ? ValidatedOptions.error : ValidatedOptions.default}
                                 />
-                                <FormHelperText  >
-                                    {this.state.createServerIdMsg}
-                                </FormHelperText>
+                                {errObj.createServerId &&
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">
+                                                {this.state.createServerIdMsg}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                }
                             </GridItem>
                         </Grid>
-                        <Grid title={_("The server port number should be in the range of 0 to 65534.")}>
+                        <Grid title={_("The server port number should be in the range of 0 to 65534")}>
                             <GridItem className="ds-label" span={4}>
                                 {_("Port")}
                             </GridItem>
@@ -443,11 +451,15 @@ export class CreateInstanceModal extends React.Component {
                                     widthChars={8}
                                 />
                                 <FormHelperText className="ds-info-color" >
-                                    {_("Port 0 will disable non-TLS connections")}
+                                    <HelperText>
+                                        <HelperTextItem variant={"indeterminate"}>
+                                            {_("Port 0 will disable non-TLS connections")}
+                                        </HelperTextItem>
+                                    </HelperText>
                                 </FormHelperText>
                             </GridItem>
                         </Grid>
-                        <Grid title={_("The secure port number for TLS connections. It should be in the range of 1 to 65534.")}>
+                        <Grid title={_("The secure port number for TLS connections. It should be in the range of 1 to 65534")}>
                             <GridItem className="ds-label" span={4}>
                                 {_("Secure Port")}
                             </GridItem>
@@ -467,7 +479,7 @@ export class CreateInstanceModal extends React.Component {
                                 />
                             </GridItem>
                         </Grid>
-                        <Grid title={_("Create a self-signed certificate database in /etc/dirsrc/ssca directory.")}>
+                        <Grid title={_("Create a self-signed certificate database in /etc/dirsrc/ssca directory")}>
                             <GridItem className="ds-label-checkbox" span={4}>
                                 {_("Create Self-Signed TLS Certificate")}
                             </GridItem>
@@ -497,12 +509,18 @@ export class CreateInstanceModal extends React.Component {
                                     }}
                                     validated={errObj.createDM ? ValidatedOptions.error : ValidatedOptions.default}
                                 />
-                                <FormHelperText  >
-                                    {_("Enter a valid DN")}
-                                </FormHelperText>
+                                {errObj.createDM &&
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">
+                                                {_("Enter a valid DN")}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                }
                             </GridItem>
                         </Grid>
-                        <Grid title={_("Directory Manager password must be at least 8 characters in length.")}>
+                        <Grid title={_("Directory Manager password must be at least 8 characters in length")}>
                             <GridItem className="ds-label" span={4}>
                                 {_("Directory Manager Password")}
                             </GridItem>
@@ -518,12 +536,18 @@ export class CreateInstanceModal extends React.Component {
                                     }}
                                     validated={errObj.createDMPassword ? ValidatedOptions.error : ValidatedOptions.default}
                                 />
-                                <FormHelperText  >
-                                    {_("Password must be set and it must match the confirmation password.")}
-                                </FormHelperText>
+                                {errObj.createDMPassword &&
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">
+                                                Password must be set with at least 8 characters, and it must match the confirmation password
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                }
                             </GridItem>
                         </Grid>
-                        <Grid title={_("Confirm the previously entered password.")}>
+                        <Grid title={_("Confirm the previously entered password")}>
                             <GridItem className="ds-label" span={4}>
                                 {_("Confirm Password")}
                             </GridItem>
@@ -539,12 +563,18 @@ export class CreateInstanceModal extends React.Component {
                                     }}
                                     validated={errObj.createDMPasswordConfirm ? ValidatedOptions.error : ValidatedOptions.default}
                                 />
-                                <FormHelperText  >
-                                    {_("Confirmation password must be set and it must match the first password.")}
-                                </FormHelperText>
+                                {errObj.createDMPasswordConfirm &&
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">
+                                                Confirmation password must be set with at least 8 characters, and it must match the first password
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                }
                             </GridItem>
                         </Grid>
-                        <Grid className="ds-margin-top" title={_("Create a database during the installation.")}>
+                        <Grid className="ds-margin-top" title={_("Create a database during the installation")}>
                             <Checkbox
                                 id="createDBCheckbox"
                                 label={_("Create Database")}
@@ -573,12 +603,18 @@ export class CreateInstanceModal extends React.Component {
                                         }}
                                         validated={errObj.createDBSuffix ? ValidatedOptions.error : ValidatedOptions.default}
                                     />
-                                    <FormHelperText  >
-                                        {_("Value must be a valid DN")}
-                                    </FormHelperText>
+                                    {errObj.createDBSuffix &&
+                                        <FormHelperText>
+                                            <HelperText>
+                                                <HelperTextItem variant="error">
+                                                    {_("Value must be a valid DN")}
+                                                </HelperTextItem>
+                                            </HelperText>
+                                        </FormHelperText>
+                                    }
                                 </GridItem>
                             </Grid>
-                            <Grid title={_("The name for the backend database, like 'userroot'. The name can be a combination of alphanumeric characters, dashes (-), and underscores (_). No other characters are allowed, and the name must be unique across all backends.")}>
+                            <Grid className="ds-margin-top" title={_("The name for the backend database, like 'userroot'. The name can be a combination of alphanumeric characters, dashes (-), and underscores (_). No other characters are allowed, and the name must be unique across all backends")}>
                                 <GridItem className="ds-label" offset={1} span={3}>
                                     {_("Database Name")}
                                 </GridItem>
@@ -596,12 +632,18 @@ export class CreateInstanceModal extends React.Component {
                                         }}
                                         validated={errObj.createDBName ? ValidatedOptions.error : ValidatedOptions.default}
                                     />
-                                    <FormHelperText  >
-                                        {_("Name is required")}
-                                    </FormHelperText>
+                                    {errObj.createDBName &&
+                                        <FormHelperText >
+                                            <HelperText>
+                                                <HelperTextItem variant="error">
+                                                    {_("Name is required")}
+                                                </HelperTextItem>
+                                            </HelperText>
+                                        </FormHelperText>
+                                    }
                                 </GridItem>
                             </Grid>
-                            <Grid>
+                            <Grid className="ds-margin-top" >
                                 <GridItem className="ds-label" offset={1} span={3}>
                                     {_("Database Initialization")}
                                 </GridItem>

--- a/src/cockpit/389-console/src/lib/database/databaseModal.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseModal.jsx
@@ -17,6 +17,7 @@ import {
 import { LDIFTable } from "./databaseTables.jsx";
 import PropTypes from "prop-types";
 
+
 const _ = cockpit.gettext;
 
 class CreateLinkModal extends React.Component {

--- a/src/cockpit/389-console/src/lib/database/databaseTables.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseTables.jsx
@@ -88,12 +88,12 @@ class ReferralTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedRefs = [...this.props.rows];
-        
+
         sortedRefs.sort();
         if (direction !== 'asc') {
             sortedRefs.reverse();
         }
-        
+
         const rows = sortedRefs.map(refRow => [
             refRow,
             this.getDeleteButton(refRow)
@@ -130,6 +130,7 @@ class ReferralTable extends React.Component {
                                         onSort: this.handleSort,
                                         columnIndex: idx
                                     } : undefined}
+                                    textCenter={idx === 1}
                                 >
                                     {column.title}
                                 </Th>
@@ -140,7 +141,7 @@ class ReferralTable extends React.Component {
                         {displayRows.map((row, rowIndex) => (
                             <Tr key={rowIndex}>
                                 {row.map((cell, cellIndex) => (
-                                    <Td 
+                                    <Td
                                         key={cellIndex}
                                         textCenter={cellIndex === 1}
                                     >
@@ -203,10 +204,10 @@ class IndexTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -219,14 +220,15 @@ class IndexTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = [...this.props.rows];
         } else {
             for (const row of this.props.rows) {
+                const mr_row = row[2].length > 0 ? row[2] : "";
                 if (row[0].toLowerCase().includes(val) ||
                     row[1].toLowerCase().includes(val) ||
-                    row[2].toLowerCase().includes(val)) {
+                    mr_row.toLowerCase().includes(val)) {
                     rows.push([row[0], row[1], row[2]]);
                 }
             }
@@ -281,14 +283,14 @@ class IndexTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     aria-label="index table"
                     variant="compact"
                 >
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -309,7 +311,7 @@ class IndexTable extends React.Component {
                                     // Handle array-type rows
                                     row.map((cell, cellIndex) => (
                                         <Td key={cellIndex}>
-                                            {Array.isArray(cell) && cell.length === 0 ? 
+                                            {Array.isArray(cell) && cell.length === 0 ?
                                                 '' : // Handle empty arrays
                                                 String(cell) // Convert any value to string
                                             }
@@ -323,7 +325,7 @@ class IndexTable extends React.Component {
                                 )}
                                 {has_rows && this.props.editable && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={getActionsForRow(row)}
                                         />
                                     </Td>
@@ -415,7 +417,7 @@ class EncryptedAttrTable extends React.Component {
         if (direction !== 'asc') {
             sortedAttrs.reverse();
         }
-        
+
         const rows = sortedAttrs.map(attrRow => [
             attrRow,
             this.getDeleteButton(attrRow)
@@ -452,6 +454,7 @@ class EncryptedAttrTable extends React.Component {
                                         onSort: this.handleSort,
                                         columnIndex: idx
                                     } : undefined}
+                                    textCenter={idx === 1}
                                 >
                                     {column.title}
                                 </Th>
@@ -462,7 +465,7 @@ class EncryptedAttrTable extends React.Component {
                         {displayRows.map((row, rowIndex) => (
                             <Tr key={rowIndex}>
                                 {row.map((cell, cellIndex) => (
-                                    <Td 
+                                    <Td
                                         key={cellIndex}
                                         textCenter={cellIndex === 1}
                                     >
@@ -552,10 +555,10 @@ class LDIFTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -615,7 +618,7 @@ class LDIFTable extends React.Component {
                                 {/* Only render the action column if we have rows */}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -689,7 +692,7 @@ class LDIFManageTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedLDIF = [...this.state.rows];
-        
+
         sortedLDIF.sort((a, b) => {
             const aValue = Array.isArray(a) ? a[index] : a.cells[index];
             const bValue = Array.isArray(b) ? b[index] : b.cells[index];
@@ -726,7 +729,7 @@ class LDIFManageTable extends React.Component {
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
         const hasRows = this.props.rows.length > 0;
-        
+
         // Calculate pagination
         const startIdx = (perPage * page) - perPage;
         const tableRows = [...rows].splice(startIdx, perPage);
@@ -769,7 +772,7 @@ class LDIFManageTable extends React.Component {
                                 )}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -842,7 +845,7 @@ class BackupTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedBaks = [...this.state.rows];
-        
+
         sortedBaks.sort((a, b) => {
             const aValue = Array.isArray(a) ? a[index] : a[0];
             const bValue = Array.isArray(b) ? b[index] : b[0];
@@ -879,7 +882,7 @@ class BackupTable extends React.Component {
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
         const hasRows = this.props.rows.length > 0;
-        
+
         // Calculate pagination
         const startIdx = (perPage * page) - perPage;
         const tableRows = [...rows].splice(startIdx, perPage);
@@ -922,7 +925,7 @@ class BackupTable extends React.Component {
                                 )}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -995,7 +998,7 @@ class PwpTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedPwp = [...this.state.rows];
-        
+
         sortedPwp.sort((a, b) => {
             const aValue = Array.isArray(a) ? a[index] : a.cells[index];
             const bValue = Array.isArray(b) ? b[index] : b.cells[index];
@@ -1032,7 +1035,7 @@ class PwpTable extends React.Component {
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
         const hasRows = this.props.rows.length > 0;
-        
+
         // Calculate pagination
         const startIdx = (perPage * page) - perPage;
         const tableRows = [...rows].splice(startIdx, perPage);
@@ -1075,7 +1078,7 @@ class PwpTable extends React.Component {
                                 )}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -1313,7 +1316,7 @@ class VLVTable extends React.Component {
 
         return (
             <div className={(this.props.saving || this.props.updating) ? "ds-margin-top-lg ds-disabled" : "ds-margin-top-lg"}>
-                <Table 
+                <Table
                     aria-label="vlv table"
                     variant='compact'
                 >
@@ -1321,7 +1324,7 @@ class VLVTable extends React.Component {
                         <Tr>
                             {!noRows && <Th screenReaderText="Row expansion" />}
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -1340,7 +1343,7 @@ class VLVTable extends React.Component {
                             <React.Fragment key={rowIndex}>
                                 <Tr>
                                     {!noRows && (
-                                        <Td 
+                                        <Td
                                             expand={{
                                                 rowIndex,
                                                 isExpanded: row.isOpen,
@@ -1353,7 +1356,7 @@ class VLVTable extends React.Component {
                                     ))}
                                     {!noRows && (
                                         <Td isActionCell>
-                                            <ActionsColumn 
+                                            <ActionsColumn
                                                 items={this.getActions(row)}
                                             />
                                         </Td>
@@ -1362,7 +1365,7 @@ class VLVTable extends React.Component {
                                 {row.isOpen && row.originalData && (
                                     <Tr isExpanded={true}>
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
@@ -1264,7 +1264,7 @@ class AddNewAci extends React.Component {
                             className="ds-left-margin"
                             time={this.state.timeOfDayStart}
                             is24Hour
-                            onChange={(val) => this.handleTimeChange(val, "timeOfDayStart")}
+                            onChange={(_event, time, hour, min, seconds, isValid) => this.handleTimeChange(time, "timeOfDayStart")}
                         />
                     </GridItem>
                 </Grid>
@@ -1292,7 +1292,7 @@ class AddNewAci extends React.Component {
                             className="ds-left-margin"
                             time={this.state.timeOfDayEnd}
                             is24Hour
-                            onChange={(val) => this.handleTimeChange(val, "timeOfDayEnd")}
+                            onChange={(_event, time, hour, min, seconds, isValid) => this.handleTimeChange(time, "timeOfDayEnd")}
                         />
                     </GridItem>
                 </Grid>

--- a/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
@@ -324,7 +324,7 @@ export class ServerMonitor extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("Server Statistics")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh suffix monitor")}
                                     onClick={this.props.handleReload}
@@ -523,8 +523,8 @@ export class ServerMonitor extends React.Component {
                                 <b>{uptime}</b>
                             </GridItem>
                             <hr />
-                            <GridItem span={3}>
-                                {_("Worker Threads")}
+                            <GridItem span={3} title="Active threads includes worker threads, listener threads, tasks, and persistent searches">
+                                {_("Active Threads")}
                             </GridItem>
                             <GridItem span={2}>
                                 <b>{this.props.data.threads}</b>

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -225,6 +225,10 @@ class MemberOf extends React.Component {
 
         // Handle scope subtree
         this.handleSubtreeScopeSelect = (event, selection) => {
+            if (selection === "") {
+                this.setState({isSubtreeScopeOpen: false});
+                return;
+            }
             if (this.state.memberOfEntryScope.includes(selection)) {
                 this.setState(
                     (prevState) => ({
@@ -253,7 +257,7 @@ class MemberOf extends React.Component {
             }, () => { this.validateConfig() });
         };
         this.handleSubtreeScopeCreateOption = newValue => {
-            if (!this.state.memberOfEntryScopeOptions.includes(newValue)) {
+            if (newValue && !this.state.memberOfEntryScopeOptions.includes(newValue)) {
                 this.setState({
                     memberOfEntryScopeOptions: [...this.state.memberOfEntryScopeOptions, newValue],
                     isSubtreeScopeOpen: false
@@ -263,6 +267,10 @@ class MemberOf extends React.Component {
 
         // Handle Exclude Scope subtree
         this.handleExcludeScopeSelect = (event, selection) => {
+            if (selection === "") {
+                this.setState({isExcludeScopeOpen: false});
+                return;
+            }
             if (this.state.memberOfEntryScopeExcludeSubtree.includes(selection)) {
                 this.setState(
                     (prevState) => ({
@@ -291,7 +299,7 @@ class MemberOf extends React.Component {
             }, () => { this.validateConfig() });
         };
         this.handleExcludeCreateOption = newValue => {
-            if (!this.state.memberOfEntryScopeOptions.includes(newValue)) {
+            if (newValue && !this.state.memberOfEntryScopeOptions.includes(newValue)) {
                 this.setState({
                     memberOfEntryScopeExcludeOptions: [...this.state.memberOfEntryScopeExcludeOptions, newValue],
                     isExcludeScopeOpen: false
@@ -302,6 +310,10 @@ class MemberOf extends React.Component {
         // Modal scope and exclude Scope
         // Handle scope subtree
         this.handleConfigScopeSelect = (event, selection) => {
+            if (selection === "") {
+                this.setState({isConfigSubtreeScopeOpen: false});
+                return;
+            }
             if (this.state.configEntryScope.includes(selection)) {
                 this.setState(
                     (prevState) => ({
@@ -330,7 +342,7 @@ class MemberOf extends React.Component {
             }, () => { this.validateModal() });
         };
         this.handleConfigCreateOption = newValue => {
-            if (!this.state.configEntryScopeOptions.includes(newValue)) {
+            if (newValue && !this.state.configEntryScopeOptions.includes(newValue)) {
                 this.setState({
                     configEntryScopeOptions: [...this.state.configEntryScopeOptions, newValue],
                     isConfigSubtreeScopeOpen: false
@@ -340,6 +352,10 @@ class MemberOf extends React.Component {
 
         // Handle Exclude Scope subtree
         this.handleConfigExcludeScopeSelect = (event, selection) => {
+            if (selection === "") {
+                this.setState({isConfigExcludeScopeOpen: false});
+                return;
+            }
             if (this.state.configEntryScopeExcludeSubtree.includes(selection)) {
                 this.setState(
                     (prevState) => ({
@@ -368,7 +384,7 @@ class MemberOf extends React.Component {
             }, () => { this.validateModal() });
         };
         this.handleConfigExcludeCreateOption = newValue => {
-            if (!this.state.configEntryScopeExcludeOptions.includes(newValue)) {
+            if (newValue && !this.state.configEntryScopeExcludeOptions.includes(newValue)) {
                 this.setState({
                     configEntryScopeExcludeOptions: [...this.state.configEntryScopeExcludeOptions, newValue],
                     isConfigExcludeScopeOpen: false
@@ -395,7 +411,7 @@ class MemberOf extends React.Component {
         ];
 
         const reqLists = [
-            'memberOfGroupAttr', 'memberOfEntryScope',
+            'memberOfGroupAttr',
         ];
 
         const dnAttrs = [
@@ -481,7 +497,7 @@ class MemberOf extends React.Component {
         ];
 
         const reqLists = [
-            'configEntryScope', 'configGroupAttr'
+            'configGroupAttr'
         ];
 
         const dnAttrs = [

--- a/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
@@ -633,7 +633,7 @@ class RootDNAccessControl extends React.Component {
                             <GridItem span={10}>
                                 <TimePicker
                                     time={openTime}
-                                    onChange={(str) => { this.handleTimeChange("openTime", str) }}
+                                    onChange={(_event, time, hour, min, seconds, isValid) => { this.handleTimeChange("openTime", time) }}
                                     is24Hour
                                 />
                             </GridItem>
@@ -645,7 +645,7 @@ class RootDNAccessControl extends React.Component {
                             <GridItem span={10}>
                                 <TimePicker
                                     time={closeTime}
-                                    onChange={(str) => { this.handleTimeChange("closeTime", str) }}
+                                    onChange={(_event, time, hour, min, seconds, isValid) => { this.handleTimeChange("closeTime", time) }}
                                     is24Hour
                                 />
                             </GridItem>

--- a/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
@@ -1569,7 +1569,8 @@ export class ReplAgmts extends React.Component {
     onSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        for (const row of this.state.rows) {
+
+        for (const row of this.props.rows) {
             if (val !== "" &&
                 row[0].indexOf(val) === -1 &&
                 row[1].indexOf(val) === -1 &&

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -292,8 +292,8 @@ export class WinsyncAgmtModal extends React.Component {
                         <TimePicker
                             time={startTime}
                             id="agmtStartTime"
-                            onChange={(val) => {
-                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtStartTime", val);
+                            onChange={(_event, time, hour, min, seconds, isValid) => {
+                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtStartTime", time);
                             }}
                             stepMinutes={5}
                             direction="up"
@@ -312,8 +312,8 @@ export class WinsyncAgmtModal extends React.Component {
                         <TimePicker
                             time={endTime}
                             id="agmtEndTime"
-                            onChange={(val) => {
-                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtEndTime", val);
+                            onChange={(_event, time, hour, min, seconds, isValid) => {
+                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtEndTime", time);
                             }}
                             stepMinutes={5}
                             direction="up"
@@ -1066,8 +1066,8 @@ export class ReplAgmtModal extends React.Component {
                         <TimePicker
                             time={startTime}
                             id="agmtStartTime"
-                            onChange={(val) => {
-                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtStartTime", val);
+                            onChange={(_event, time, hour, min, seconds, isValid) => {
+                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtStartTime", time);
                             }}
                             stepMinutes={5}
                             is24Hour
@@ -1085,8 +1085,8 @@ export class ReplAgmtModal extends React.Component {
                         <TimePicker
                             time={endTime}
                             id="agmtEndTime"
-                            onChange={(val) => {
-                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtEndTime", val);
+                            onChange={(_event, time, hour, min, seconds, isValid) => {
+                                handleTimeChange(this.props.edit ? "edit" : "create", "agmtEndTime", time);
                             }}
                             stepMinutes={5}
                             is24Hour

--- a/src/cockpit/389-console/src/lib/replication/replTables.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replTables.jsx
@@ -126,7 +126,7 @@ class ReplAgmtTable extends React.Component {
                     onChange={this.props.handleSearch}
                     onClear={(evt) => this.props.search(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top-lg"
                     aria-label="agmt table"
                     variant="compact"
@@ -134,7 +134,7 @@ class ReplAgmtTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.props.sortBy,
@@ -162,7 +162,7 @@ class ReplAgmtTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -193,11 +193,11 @@ class ManagerTable extends React.Component {
             sortBy: {},
             rows: [],
             columns: [
-                { 
-                    title: 'Manager Name', 
-                    sortable: true 
+                {
+                    title: 'Manager Name',
+                    sortable: true
                 },
-                { 
+                {
                     title: 'Actions',
                     screenReaderText: 'Manager actions'
                 }
@@ -211,19 +211,19 @@ class ManagerTable extends React.Component {
     componentDidMount() {
         let rows = [];
         let columns = this.state.columns;
-        
+
         for (const managerRow of this.props.rows) {
             rows.push([
                 managerRow,
                 this.getDeleteButton(managerRow)
             ]);
         }
-        
+
         if (rows.length === 0) {
             rows = [[_("No Replication Managers")]];
             columns = [{ title: '' }];
         }
-        
+
         this.setState({
             rows,
             columns
@@ -231,7 +231,7 @@ class ManagerTable extends React.Component {
     }
 
     handleSort(_event, columnIndex, sortDirection) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
         );
 
@@ -275,6 +275,7 @@ class ManagerTable extends React.Component {
                                     columnIndex
                                 } : undefined}
                                 screenReaderText={column.screenReaderText}
+                                textCenter={columnIndex === 1}
                             >
                                 {column.title}
                             </Th>
@@ -285,7 +286,7 @@ class ManagerTable extends React.Component {
                     {this.state.rows.map((row, rowIndex) => (
                         <Tr key={rowIndex}>
                             {row.map((cell, cellIndex) => (
-                                <Td 
+                                <Td
                                     key={cellIndex}
                                     textCenter={cellIndex === 1}
                                 >
@@ -341,7 +342,7 @@ class RUVTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
         this.setState({
@@ -399,7 +400,7 @@ class RUVTable extends React.Component {
                         {tableRows.map((row, rowIndex) => (
                             <Tr key={rowIndex}>
                                 {row.cells.map((cell, cellIndex) => (
-                                    <Td 
+                                    <Td
                                         key={cellIndex}
                                         textCenter={cellIndex === row.cells.length - 1}
                                     >
@@ -462,7 +463,7 @@ class ReplicaLDIFTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
 
@@ -487,7 +488,7 @@ class ReplicaLDIFTable extends React.Component {
                 <Thead>
                     <Tr>
                         {columns.map((column, idx) => (
-                            <Th 
+                            <Th
                                 key={idx}
                                 sort={column.sortable ? {
                                     sortBy: sortBy,

--- a/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
@@ -1178,7 +1178,7 @@ export class WinsyncAgmts extends React.Component {
     onSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        for (const row of this.state.rows) {
+        for (const row of this.props.rows) {
             if (val !== "" &&
                 row[0].indexOf(val) === -1 &&
                 row[1].indexOf(val) === -1 &&

--- a/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
@@ -40,9 +40,9 @@ class ObjectClassesTable extends React.Component {
                     title: _("Objectclass Name"),
                     sortable: true
                 },
-                { 
-                    title: _("OID"), 
-                    sortable: true 
+                {
+                    title: _("OID"),
+                    sortable: true
                 },
             ],
         };
@@ -67,7 +67,7 @@ class ObjectClassesTable extends React.Component {
 
     handleSort(_event, columnIndex, direction) {
         const rows = [...this.state.rows];
-        
+
         rows.sort((a, b) => (a.cells[columnIndex].content > b.cells[columnIndex].content) ? 1 : -1);
         if (direction !== SortByDirection.asc) {
             rows.reverse();
@@ -96,7 +96,7 @@ class ObjectClassesTable extends React.Component {
 
         for (const row of this.props.rows) {
             // Check for matches of all the parts
-            if (val !== "" && 
+            if (val !== "" &&
                 row.name[0].toLowerCase().indexOf(val) === -1 &&
                 row.oid[0].toLowerCase().indexOf(val) === -1) {
                 continue;
@@ -218,7 +218,7 @@ class ObjectClassesTable extends React.Component {
                             />
                         </GridItem>
                     </Grid>
-                    <Table 
+                    <Table
                         aria-label="objectclasses table"
                         variant='compact'
                     >
@@ -257,7 +257,7 @@ class ObjectClassesTable extends React.Component {
                                             </Td>
                                         ))}
                                         <Td isActionCell>
-                                            <ActionsColumn 
+                                            <ActionsColumn
                                                 items={this.getActionsForRow(row)}
                                                 isDisabled={row.disableActions}
                                             />
@@ -422,6 +422,15 @@ class AttributesTable extends React.Component {
         );
     }
 
+    getOIDContent(oid) {
+        for (const syntax of this.props.syntaxes) {
+            if (oid == syntax.id) {
+                return oid + " (" + syntax.label + ")";
+            }
+        }
+        return oid + " (Unknown)";
+    }
+
     componentDidMount() {
         let rows = [];
         let columns = this.state.columns;
@@ -434,7 +443,7 @@ class AttributesTable extends React.Component {
                 cells: [
                     { content: row.name[0] },
                     { content: row.oid[0] },
-                    { content: row.syntax[0] }
+                    { content: this.getOIDContent(row.syntax[0]) }
                 ],
                 disableActions: !user_defined,
                 originalData: row
@@ -465,11 +474,11 @@ class AttributesTable extends React.Component {
 
     handleSearchChange(event, value) {
         const rows = [];
+        const val = value.toLowerCase();
         let count = 0;
 
         for (const row of this.props.rows) {
             let user_defined = false;
-            const val = value.toLowerCase();
 
             // Check for matches of all the parts
             if (val !== "" && row.name[0].toLowerCase().indexOf(val) === -1 &&
@@ -486,16 +495,15 @@ class AttributesTable extends React.Component {
             rows.push(
                 {
                     isOpen: false,
-                    cells: [row.name[0], row.oid[0], row.syntax[0]],
-                    disableActions: !user_defined
-                },
-                {
-                    parent: count,
-                    fullWidth: true,
-                    cells: [{ title: this.getExpandedRow(row) }]
+                    cells: [
+                        { content: row.name[0] },
+                        { content: row.oid[0] },
+                        { content: this.getOIDContent(row.syntax[0]) },
+                    ],
+                    disableActions: !user_defined,
+                    originalData: row
                 },
             );
-            count += 2;
         }
 
         this.setState({
@@ -545,7 +553,7 @@ class AttributesTable extends React.Component {
                             />
                         </GridItem>
                     </Grid>
-                    <Table 
+                    <Table
                         aria-label="attributes table"
                         variant='compact'
                     >
@@ -584,7 +592,7 @@ class AttributesTable extends React.Component {
                                             </Td>
                                         ))}
                                         <Td isActionCell>
-                                            <ActionsColumn 
+                                            <ActionsColumn
                                                 items={this.getActionsForRow(row)}
                                                 isDisabled={row.disableActions}
                                             />

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -81,7 +81,7 @@ export class ServerAccessLog extends React.Component {
         this.refLevel = <>{_("Entry Access and Referrals")} <font size="1" className="ds-info-color">(level 512)</font></>;
 
         this.state = {
-            loading: true,
+            loading: false,
             loaded: false,
             activeTabKey: 0,
             saveSettingsDisabled: true,
@@ -218,11 +218,9 @@ export class ServerAccessLog extends React.Component {
         });
     }
 
-    handleTimeChange(time_str) {
+    handleTimeChange = (_event, time, hour, min, seconds, isValid) => {
         let disableSaveBtn = true;
-        const time_parts = time_str.split(":");
-        let hour = time_parts[0];
-        let min = time_parts[1];
+
         if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
@@ -304,19 +302,25 @@ export class ServerAccessLog extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "success",
                         _("Successfully updated Access Log settings")
                     );
+                    this.setState({
+                        loading: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error saving Access Log settings - $0"), errMsg.desc)
                     );
+                    this.setState({
+                        loading: false
+                    });
                 });
     }
 
@@ -426,6 +430,10 @@ export class ServerAccessLog extends React.Component {
         let compress = false;
         const level_val = parseInt(attrs['nsslapd-accesslog-level'][0]);
         const rows = [...this.state.rows];
+
+        this.setState({
+            loading: true
+        });
 
         if (attrs['nsslapd-accesslog-logging-enabled'][0] === "on") {
             enabled = true;

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -71,7 +71,7 @@ export class ServerAuditLog extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            loading: true,
+            loading: false,
             loaded: false,
             activeTabKey: 0,
             saveSettingsDisabled: true,
@@ -220,11 +220,9 @@ export class ServerAuditLog extends React.Component {
         });
     }
 
-    handleTimeChange(time_str) {
+    handleTimeChange = (_event, time, hour, min, seconds, isValid) => {
         let disableSaveBtn = true;
-        const time_parts = time_str.split(":");
-        let hour = time_parts[0];
-        let min = time_parts[1];
+
         if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
@@ -309,19 +307,26 @@ export class ServerAuditLog extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "success",
                         _("Successfully updated Audit Log settings")
                     );
+                    this.setState({
+                        loading: false
+                    });
+
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error saving Audit Log settings - $0"), errMsg.desc)
                     );
+                    this.setState({
+                        loading: false,
+                    });
                 });
     }
 
@@ -330,6 +335,7 @@ export class ServerAuditLog extends React.Component {
             loading: true,
             loaded: false,
         });
+
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "config", "get"
@@ -431,6 +437,11 @@ export class ServerAuditLog extends React.Component {
         let buffering = false;
         let display_attrs = [];
         let displayAllAttrs = this.state.displayAllAttrs;
+
+        this.setState({
+            loading: true,
+            loaded: false,
+        });
 
         if (attrs['nsslapd-auditlog-logging-enabled'][0] === "on") {
             enabled = true;
@@ -908,7 +919,7 @@ export class ServerAuditLog extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("Audit Log Settings")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh log settings")}
                                     onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -62,7 +62,7 @@ export class ServerAuditFailLog extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            loading: true,
+            loading: false,
             loaded: false,
             activeTabKey: 0,
             saveSettingsDisabled: true,
@@ -172,11 +172,9 @@ export class ServerAuditFailLog extends React.Component {
         });
     }
 
-    handleTimeChange(time_str) {
+    handleTimeChange = (_event, time, hour, min, seconds, isValid) => {
         let disableSaveBtn = true;
-        const time_parts = time_str.split(":");
-        let hour = time_parts[0];
-        let min = time_parts[1];
+
         if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
@@ -245,19 +243,25 @@ export class ServerAuditFailLog extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "success",
                         _("Successfully updated Audit Fail Log settings")
                     );
+                    this.setState({
+                        loading: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error saving Audit Fail Log settings - $0"), errMsg.desc)
                     );
+                    this.setState({
+                        loading: false
+                    });
                 });
     }
 
@@ -343,6 +347,10 @@ export class ServerAuditFailLog extends React.Component {
         const attrs = this.state.attrs;
         let enabled = false;
         let compressed = false;
+
+        this.setState({
+            loading: true
+        });
 
         if (attrs['nsslapd-auditfaillog-logging-enabled'][0] === "on") {
             enabled = true;
@@ -709,7 +717,7 @@ export class ServerAuditFailLog extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("Audit Fail Log Settings")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh log settings")}
                                     onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -91,7 +91,7 @@ export class ServerErrorLog extends React.Component {
         this.pwdpolicyLevel = <>{_("Password Policy")} <font size="1" className="ds-info-color">{_("(level 1048576)")}</font></>;
 
         this.state = {
-            loading: true,
+            loading: false,
             loaded: false,
             activeTabKey: 0,
             saveSettingsDisabled: true,
@@ -241,11 +241,9 @@ export class ServerErrorLog extends React.Component {
         });
     }
 
-    handleTimeChange(time_str) {
+    handleTimeChange = (_event, time, hour, min, seconds, isValid) => {
         let disableSaveBtn = true;
-        const time_parts = time_str.split(":");
-        let hour = time_parts[0];
-        let min = time_parts[1];
+
         if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
@@ -327,19 +325,25 @@ export class ServerErrorLog extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.handleRefreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "success",
                         _("Successfully updated Error Log settings")
                     );
+                    this.setState({
+                        loading: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.handleRefreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error saving Error Log settings - $0"), errMsg.desc)
                     );
+                    this.setState({
+                        loading: false
+                    });
                 });
     }
 
@@ -442,6 +446,10 @@ export class ServerErrorLog extends React.Component {
         const level_val = parseInt(attrs['nsslapd-errorlog-level'][0]);
         const rows = [...this.state.rows];
 
+        this.setState({
+            loading: true
+        });
+
         if (attrs['nsslapd-errorlog-logging-enabled'][0] === "on") {
             enabled = true;
         }
@@ -501,7 +509,7 @@ export class ServerErrorLog extends React.Component {
     handleOnSelect = (_event, isSelected, rowIndex) => {
         let disableSaveBtn = true;
         const rows = [...this.state.rows];
-        
+
         // Update the selected row
         rows[rowIndex].selected = isSelected;
 
@@ -610,7 +618,7 @@ export class ServerErrorLog extends React.Component {
                                             <Td
                                                 select={{
                                                     rowIndex,
-                                                    onSelect: (_event, isSelecting) => 
+                                                    onSelect: (_event, isSelecting) =>
                                                         this.handleOnSelect(_event, isSelecting, rowIndex),
                                                     isSelected: row.selected
                                                 }}
@@ -888,7 +896,7 @@ export class ServerErrorLog extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("Error Log Settings")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh log settings")}
                                     onClick={() => {

--- a/src/cockpit/389-console/src/lib/server/securityLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/securityLog.jsx
@@ -64,7 +64,7 @@ export class ServerSecurityLog extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            loading: true,
+            loading: false,
             loaded: false,
             activeTabKey: 0,
             saveSettingsDisabled: true,
@@ -173,11 +173,9 @@ export class ServerSecurityLog extends React.Component {
         });
     }
 
-    handleTimeChange(time_str) {
+    handleTimeChange = (_event, time, hour, min, seconds, isValid) => {
         let disableSaveBtn = true;
-        const time_parts = time_str.split(":");
-        let hour = time_parts[0];
-        let min = time_parts[1];
+
         if (hour.length === 2 && hour[0] === "0") {
             hour = hour[1];
         }
@@ -246,19 +244,25 @@ export class ServerSecurityLog extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "success",
                         _("Successfully updated Security Log settings")
                     );
+                    this.setState({
+                        loading: false
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.refreshConfig();
+                    this.props.reload();
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error saving Security Log settings - $0"), errMsg.desc)
                     );
+                    this.setState({
+                        loading: false
+                    });
                 });
     }
 
@@ -349,6 +353,10 @@ export class ServerSecurityLog extends React.Component {
         let enabled = false;
         let buffering = false;
         let compress = false;
+
+        this.setState({
+            loading: true
+        });
 
         if (attrs['nsslapd-securitylog-logging-enabled'][0] === "on") {
             enabled = true;
@@ -732,7 +740,7 @@ export class ServerSecurityLog extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("Security Log Settings")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh log settings")}
                                     onClick={() => {

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -243,9 +243,48 @@ export function valid_dn(dn) {
     if (dn === "" || dn.endsWith(",")) {
         return false;
     }
-    const dn_regex = /^([A-Za-z])+=\S.*/;
-    const result = dn_regex.test(dn);
-    return result;
+
+    // For validation purposes we can simply replace any escaped sequences with
+    // generic characters
+    if (dn.includes("\\,")) {
+        dn = dn.replace("\\,","ZZ");
+    }
+    if (dn.includes("\\<")) {
+        dn = dn.replace("\\<","ZZ");
+    }
+    if (dn.includes("\\>")) {
+        dn = dn.replace("\\>","ZZ");
+    }
+    if (dn.includes('\\"')) {
+        dn = dn.replace('\\"',"ZZ");
+    }
+    if (dn.includes("\\;")) {
+        dn = dn.replace("\\;","ZZ");
+    }
+    if (dn.includes("\\=")) {
+        dn = dn.replace("\\=","ZZ");
+    }
+    if (dn.includes("\\+")) {
+        dn = dn.replace("\\+","ZZ");
+    }
+    const dn_regex = /^([A-Za-z])+=([A-Za-z0-9 _\-$^*!~.])+$/;
+    const parts = dn.split(",");
+    for (const part of parts) {
+        if (!dn_regex.test(part)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function valid_db_name(name) {
+    // Validate name is a valid backend name
+    if (name === "") {
+        return false;
+    }
+
+    const name_regex = /^[A-Za-z][A-Za-z_\-0-9]+$/;
+    return name_regex.test(name);
 }
 
 export function valid_filter(filter) {

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -17,6 +17,7 @@ import ReplAgmtWinsync from "./lib/monitor/replMonWinsync.jsx";
 import ReplMonTasks from "./lib/monitor/replMonTasks.jsx";
 import ReplMonConflict from "./lib/monitor/replMonConflict.jsx";
 import {
+    Card,
     Spinner,
     TreeView,
     Text,
@@ -1149,18 +1150,16 @@ export class Monitor extends React.Component {
             monitorPage = (
                 <div className="container-fluid">
                     <div className="ds-container">
-                        <div>
-                            <div className="ds-tree">
-                                <div className={disabled} id="monitor-tree">
-                                    <TreeView
-                                        hasSelectableNodes
-                                        data={nodes}
-                                        activeItems={this.state.activeItems}
-                                        onSelect={this.handleTreeClick}
-                                    />
-                                </div>
+                        <Card className="ds-tree">
+                            <div className={disabled} id="monitor-tree">
+                                <TreeView
+                                    hasSelectableNodes
+                                    data={nodes}
+                                    activeItems={this.state.activeItems}
+                                    onSelect={this.handleTreeClick}
+                                />
                             </div>
-                        </div>
+                        </Card>
                         <div className="ds-tree-content">
                             {monitor_element}
                         </div>

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -4,6 +4,7 @@ import { log_cmd } from "./lib/tools.jsx";
 import { ReplSuffix } from "./lib/replication/replSuffix.jsx";
 import PropTypes from "prop-types";
 import {
+    Card,
     Spinner,
     TreeView,
     Text,
@@ -1061,17 +1062,15 @@ export class Replication extends React.Component {
             repl_page = (
                 <div className="container-fluid">
                     <div className="ds-container">
-                        <div>
-                            <div className="ds-tree">
-                                <div className={disabled} id="repl-tree">
-                                    <TreeView
-                                        data={nodes}
-                                        activeItems={this.state.activeItems}
-                                        onSelect={this.handleTreeClick}
-                                    />
-                                </div>
+                        <Card className="ds-tree">
+                            <div className={disabled} id="repl-tree">
+                                <TreeView
+                                    data={nodes}
+                                    activeItems={this.state.activeItems}
+                                    onSelect={this.handleTreeClick}
+                                />
                             </div>
-                        </div>
+                        </Card>
                         <div className="ds-tree-content">
                             {repl_element}
                         </div>

--- a/src/cockpit/389-console/src/server.jsx
+++ b/src/cockpit/389-console/src/server.jsx
@@ -13,6 +13,7 @@ import { ServerErrorLog } from "./lib/server/errorLog.jsx";
 import { ServerSecurityLog } from "./lib/server/securityLog.jsx";
 import { Security } from "./security.jsx";
 import {
+    Card,
     Spinner,
     TreeView,
     Text,
@@ -306,6 +307,7 @@ export class Server extends React.Component {
                         attrs={this.state.attrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
+                        reload={this.reloadConfig}
                     />
                 );
             } else if (this.state.node_name === "audit-log-config") {
@@ -316,6 +318,7 @@ export class Server extends React.Component {
                         displayAttrs={this.state.displayAttrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
+                        reload={this.reloadConfig}
                     />
                 );
             } else if (this.state.node_name === "auditfail-log-config") {
@@ -325,6 +328,7 @@ export class Server extends React.Component {
                         attrs={this.state.attrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
+                        reload={this.reloadConfig}
                     />
                 );
             } else if (this.state.node_name === "error-log-config") {
@@ -334,6 +338,7 @@ export class Server extends React.Component {
                         attrs={this.state.attrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
+                        reload={this.reloadConfig}
                     />
                 );
             } else if (this.state.node_name === "security-log-config") {
@@ -343,6 +348,7 @@ export class Server extends React.Component {
                         attrs={this.state.attrs}
                         enableTree={this.enableTree}
                         addNotification={this.props.addNotification}
+                        reload={this.reloadConfig}
                     />
                 );
             }
@@ -350,7 +356,7 @@ export class Server extends React.Component {
             serverPage = (
                 <div className="container-fluid">
                     <div className="ds-container">
-                        <div className="ds-tree">
+                        <Card className="ds-tree">
                             <div
                                 className={disabled}
                                 id="server-tree"
@@ -361,7 +367,7 @@ export class Server extends React.Component {
                                     onSelect={this.handleTreeClick}
                                 />
                             </div>
-                        </div>
+                        </Card>
                         <div className="ds-tree-content">
                             {server_element}
                         </div>

--- a/src/lib389/lib389/cli_conf/plugins/attruniq.py
+++ b/src/lib389/lib389/cli_conf/plugins/attruniq.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -16,12 +16,14 @@ arg_to_attr = {
     'enabled': 'nsslapd-pluginenabled',
     'attr_name': 'uniqueness-attribute-name',
     'subtree': 'uniqueness-subtrees',
+    'exclude_subtree': 'uniqueness-exclude-subtrees',
     'across_all_subtrees': 'uniqueness-across-all-subtrees',
     'top_entry_oc': 'uniqueness-top-entry-oc',
     'subtree_entries_oc': 'uniqueness-subtree-entries-oc'
 }
 
 PLUGIN_DN = "cn=plugins,cn=config"
+
 
 def attruniq_list(inst, basedn, log, args):
     log = log.getChild('attruniq_list')
@@ -124,6 +126,9 @@ def _add_parser_args(parser):
     parser.add_argument('--subtree', nargs='+',
                         help='Sets the DN under which the plug-in checks for uniqueness of '
                              'the attributes value. This attribute is multi-valued (uniqueness-subtrees)')
+    parser.add_argument('--exclude-subtree', nargs='+',
+                        help='Sets subtrees that should not excludedfrom attribute uniqueness. '
+                             'This attribute is multi-valued (uniqueness-exclude-subtrees)')
     parser.add_argument('--across-all-subtrees', choices=['on', 'off'], type=str.lower,
                         help='If enabled (on), the plug-in checks that the attribute is unique across all subtrees '
                              'set. If you set the attribute to off, uniqueness is only enforced within the subtree '

--- a/src/lib389/lib389/cli_conf/schema.py
+++ b/src/lib389/lib389/cli_conf/schema.py
@@ -220,8 +220,8 @@ def get_syntaxes(inst, basedn, log, args):
     if args.json:
         print(dump_json(result, indent=4))
     else:
-        for id, name in result.items():
-            print("%s (%s)", name, id)
+        for oid, name in result.items():
+            print(f"{name} ({oid})")
 
 
 def import_openldap_schema_file(inst, basedn, log, args):


### PR DESCRIPTION
Description:

This fixes the following issues:

- Subtrees field must not be mandatory If you configure the Attribute Uniqueness plug-in over object classes
- MemberOf configuration window you can select empty values for Subtree Scope and Exclude Subtree fields
- Database suffix field accepts dash symbol which ends in error
- Enable logs checkboxes do not display properly after changes
- Instance fails to load when DB backup directory doesn't exist
- Improvement for Create New Instance form
- Database Name is not validated
- Database Suffix is not validated properly
- Failing to update NDN cache size
- Import cache size is not easy to set
- Import cache autosize off/on fails
- Statistic about worker threads is incorrect
- Database index table searching does not work
- Schema attribute table searching does not work
- TimePicker component needs updating for PF5
- Fix Treeview appearance for browser Dark Mode
- Add attribute syntax oid name to table

Fixes: https://github.com/389ds/389-ds-base/issues/6625
