### PR TITLE
Revert "Issue #6562 - Prevent undefined behaviour in in filter_stuff_func (#6563)"

### DIFF
--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -338,10 +338,6 @@ filter_stuff_func(void *arg, const char *val, PRUint32 slen)
             } else {
                 filter_len = escaped_filter.bv_len;
                 buf = escaped_filter.bv_val;
-                if (buf == NULL) {
-                    slapi_log_err(SLAPI_LOG_TRACE, "filter_stuff_func", "Attempt to copy from NULL pointer\n");
-                    return -1;
-                }
             }
         }
 


### PR DESCRIPTION
This reverts commit c27fe457431b78c4a7d9e8681a9462def67a76ba.

Reverting c27fe457431b78c4a7d9e8681a9462def67a76ba that is causing
 an heap corruption: buffer overflow

Issue: #6562

Reviewed by: @tbordaz , @droideck (Thanks!)