### PR TITLE
Issue 6625 - UI - various fixes part 3

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -151,6 +151,7 @@ BuildRequires:    python%{python3_pkgversion}-argparse-manpage
 BuildRequires:    python%{python3_pkgversion}-policycoreutils
 BuildRequires:    python%{python3_pkgversion}-libselinux
 BuildRequires:    python%{python3_pkgversion}-cryptography
+BuildRequires:    python%{python3_pkgversion}-psutil
 
 # For cockpit
 %if %{with cockpit}
@@ -326,6 +327,7 @@ Requires: python%{python3_pkgversion}-argcomplete
 Requires: python%{python3_pkgversion}-libselinux
 Requires: python%{python3_pkgversion}-setuptools
 Requires: python%{python3_pkgversion}-cryptography
+Requires: python%{python3_pkgversion}-psutil
 Recommends: bash-completion
 %{?python_provide:%python_provide python%{python3_pkgversion}-lib389}
 

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
@@ -135,6 +135,12 @@ class AddGroup extends React.Component {
             }
         };
 
+        this.handleBack = ({ id }) => {
+            this.setState({
+                stepIdReached: id
+            });
+        };
+
         this.handleSearchClick = () => {
             this.setState({
                 isSearchRunning: true,
@@ -639,7 +645,12 @@ class AddGroup extends React.Component {
 
         const title = (
             <>
-                {_("Parent DN: ")}&nbsp;&nbsp;<strong>{this.props.wizardEntryDn}</strong>
+                {_("Parent DN: ")}&nbsp;&nbsp;&nbsp;<strong>{this.props.wizardEntryDn}</strong>
+                {stepIdReached >= 2 &&
+                    <>
+                        <br />Group type:&nbsp;&nbsp;<strong>{this.state.groupType}</strong>
+                    </>
+                }
             </>
         );
 
@@ -648,6 +659,7 @@ class AddGroup extends React.Component {
                 isOpen={this.props.isWizardOpen}
                 onClose={this.props.handleToggleWizard}
                 onNext={this.handleNext}
+                onBack={this.handleBack}
                 title={_("Add A Group")}
                 description={title}
                 steps={addGroupSteps}

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addRole.jsx
@@ -196,6 +196,9 @@ class AddRole extends React.Component {
                 // true ==> Do not check the attribute selection when navigating back.
                 this.updateValuesTableRows(true);
             }
+            this.setState({
+                stepIdReached: id
+            });
         };
 
         this.handleSearchClick = () => {
@@ -1067,6 +1070,11 @@ class AddRole extends React.Component {
         const title = (
             <>
                 {_("Parent DN: ")}&nbsp;&nbsp;<strong>{this.props.wizardEntryDn}</strong>
+                {stepIdReached >= 2 &&
+                    <>
+                        <br />Role type:&nbsp;&nbsp;&nbsp;&nbsp;<strong>{this.state.roleType}</strong>
+                    </>
+                }
             </>
         );
 

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addUser.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addUser.jsx
@@ -1,32 +1,33 @@
 import cockpit from "cockpit";
 import React from 'react';
 import {
-	Alert,
-	Card,
-	CardBody,
-	CardTitle,
-	Form,
-	Grid,
-	GridItem,
-	Label,
-	Pagination,
-	SearchInput,
-	SimpleList,
-	SimpleListItem,
-	Spinner,
-	Text,
-	TextContent,
-	TextVariants
+    Alert,
+    Card,
+    CardBody,
+    CardTitle,
+    Form,
+    Grid,
+    GridItem,
+    Label,
+    Pagination,
+    SearchInput,
+    Select,
+    SelectOption,
+    SelectList,
+    MenuToggle,
+    SimpleList,
+    SimpleListItem,
+    Spinner,
+    Text,
+    TextContent,
+    TextVariants
 } from '@patternfly/react-core';
 import {
-	BadgeToggle,
-	Dropdown,
-	DropdownItem,
-	DropdownPosition,
-	Select,
-	SelectOption,
-	SelectVariant,
-	Wizard
+    BadgeToggle,
+    Dropdown,
+    DropdownItem,
+    DropdownPosition,
+    Wizard
 } from '@patternfly/react-core/deprecated';
 import {
     InfoCircleIcon,
@@ -38,7 +39,7 @@ import {
     Th,
     Tbody,
     Td,
-	headerCol
+    headerCol
 } from '@patternfly/react-table';
 import EditableTable from '../../lib/editableTable.jsx';
 import {
@@ -63,6 +64,12 @@ class AddUser extends React.Component {
                 'objectClass: nsPerson',
                 'objectClass: nsAccount',
                 'objectClass: nsOrgPerson',
+            ],
+            'Traditional Account': [
+                'objectclass: top',
+                'objectClass: person',
+                'objectClass: organizationalPerson',
+                'objectClass: inetOrgPerson',
             ],
             'Posix Account': [
                 'objectclass: top',
@@ -89,6 +96,21 @@ class AddUser extends React.Component {
                 'uid', 'userCertificate', 'userPassword', 'userSMIMECertificate',
                 'userPKCS12', 'x500UniqueIdentifier'
             ],
+            'Traditional Account': [
+                'userPassword', 'telephoneNumber', 'seeAlso', 'description',
+                'title', 'registeredAddress', 'destinationIndicator',
+                'preferredDeliveryMethod', 'telexNumber', 'teletexTerminalIdentifier',
+                'internationalISDNNumber', 'facsimileTelephoneNumber', 'street',
+                'postOfficeBox', 'postalCode', 'postalAddress',
+                'physicalDeliveryOfficeName', 'ou', 'st', 'l', 'audio',
+                'businessCategory', 'carLicense', 'departmentNumber', 'displayName',
+                'employeeNumber', 'employeeType', 'givenName', 'homePhone',
+                'homePostalAddress', 'initials', 'jpegPhoto', 'labeledURI',
+                'mail', 'manager', 'mobile', 'o', 'pager', 'photo', 'roomNumber',
+                'secretary', 'uid', 'userCertificate', 'preferredLanguage',
+                'userSMIMECertificate', 'userPKCS12', 'x500uniqueIdentifier',
+                'x121Address'
+            ],
             'Posix Account': [
                 'businessCategory', 'carLicense', 'departmentNumber',
                 'description', 'employeeNumber', 'employeeType', 'homePhone',
@@ -109,6 +131,9 @@ class AddUser extends React.Component {
             'Basic Account': [
                 'cn', 'displayName',
             ],
+            'Traditional Account': [
+                'cn', 'sn',
+            ],
             'Posix Account': [
                 'cn', 'uid', 'uidNumber', 'gidNumber', 'homeDirectory',
                 'displayName'
@@ -122,6 +147,10 @@ class AddUser extends React.Component {
             'Basic Account': [
                 'preferredDeliveryMethod', 'displayName', 'employeeNumber',
                 'preferredLanguage', 'userPassword',
+            ],
+            'Traditional Account': [
+                'displayName', 'employeeNumber', 'preferredLanguage',
+                'userPassword', 'preferredDeliveryMethod',
             ],
             'Posix Account': [
                 'preferredDeliveryMethod', 'displayName', 'employeeNumber',
@@ -229,11 +258,15 @@ class AddUser extends React.Component {
                 // true ==> Do not check the attribute selection when navigating back.
                 this.updateValuesTableRows(true);
             }
+            this.setState({
+                stepIdReached: id
+            });
         };
 
-        this.handleToggleType = (_event, isOpenType) => {
+        this.handleToggleType = () => {
+            const open = !this.state.isOpenType;
             this.setState({
-                isOpenType
+                isOpenType: open
             });
         };
         this.handleSelectType = (event, selection) => {
@@ -600,30 +633,36 @@ class AddUser extends React.Component {
                         </Text>
                     </TextContent>
                 </div>
-                <div className="ds-indent">
+                <div className="ds-indent ds-margin-top">
                     <Select
                         id="user-type-select"
                         aria-label="Select user type"
                         toggle={(toggleRef) => (
-                            <SelectToggle
+                            <MenuToggle
                                 ref={toggleRef}
-                                onToggle={(event, isOpen) => this.handleToggleType(event, isOpen)}
+                                onClick={this.handleToggleType}
                                 isExpanded={this.state.isOpenType}
                             >
                                 {this.state.accountType}
-                            </SelectToggle>
+                            </MenuToggle>
                         )}
                         onSelect={this.handleSelectType}
                         selected={this.state.accountType}
                         isOpen={this.state.isOpenType}
                     >
-                        <SelectOption key="user" value="Basic Account" />
-                        <SelectOption key="posix" value="Posix Account" />
-                        <SelectOption key="service" value="Service Account" />
+                        <SelectList>
+                            <SelectOption value="Basic Account">Basic Account</SelectOption>
+                            <SelectOption value="Traditional Account" >Traditional Account</SelectOption>
+                            <SelectOption value="Posix Account" >Posix Account</SelectOption>
+                            <SelectOption value="Service Account" >Service Account</SelectOption>
+                        </SelectList>
                     </Select>
                     <TextContent className="ds-margin-top-xlg">
                         <Text component={TextVariants.h6} className="ds-margin-top-lg ds-font-size-md">
                             <b>{_("Basic Account")}</b>{_(" - This type of user entry uses a common set of objectclasses (nsPerson, nsAccount, and nsOrgPerson).")}
+                        </Text>
+                        <Text component={TextVariants.h6} className="ds-margin-top-lg ds-font-size-md">
+                            <b>Traditional Account</b> - This type of user entry uses a traditional/legacy set of objectclasses (person, organizationalPerson, and inetOrgPerson).
                         </Text>
                         <Text component={TextVariants.h6} className="ds-margin-top-lg ds-font-size-md">
                             <b>{_("Posix Account")}</b>{_(" - This type of user entry uses a similar set of objectclasses as the ")}<i>{_("Basic Account")}</i> {_("(nsPerson, nsAccount, nsOrgPerson, and posixAccount), but it includes POSIX attributes like:")}
@@ -871,6 +910,11 @@ class AddUser extends React.Component {
         const title = (
             <>
                 {_("Parent DN: ")}&nbsp;&nbsp;<strong>{this.props.wizardEntryDn}</strong>
+                {stepIdReached >= 2 &&
+                    <>
+                        <br />Entry type:&nbsp;&nbsp;&nbsp;<strong>{this.state.accountType}</strong>
+                    </>
+                }
             </>
         );
 

--- a/src/cockpit/389-console/src/lib/monitor/monitorTables.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorTables.jsx
@@ -5,29 +5,25 @@ import {
     Grid,
     GridItem,
     Pagination,
-    PaginationVariant,
     SearchInput,
     Text,
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
 import {
-	expandable,
-	TableVariant,
-	sortable,
-	SortByDirection,
-	Table,
-	Thead,
-	Tr,
-	Th,
-	Tbody,
-	Td,
-	ExpandableRowContent,
+    SortByDirection,
+    Table,
+    Thead,
+    Tr,
+    Th,
+    Tbody,
+    Td,
+    ExpandableRowContent,
     ActionsColumn
 } from '@patternfly/react-table';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import PropTypes from "prop-types";
-import { get_date_string } from "../tools.jsx";
+import { get_date_string, numToCommas } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -72,9 +68,9 @@ class AbortCleanALLRUVTable extends React.Component {
     getLog(log) {
         return (
             <TextContent>
-                <Text 
+                <Text
                     component={TextVariants.pre}
-                    style={{ 
+                    style={{
                         whiteSpace: 'pre-wrap',
                         wordBreak: 'break-word'
                     }}
@@ -88,7 +84,7 @@ class AbortCleanALLRUVTable extends React.Component {
     createRows(tasks) {
         let rows = [];
         let columns = [...this.state.columns];
-        
+
         for (const task of tasks) {
             rows.push({
                 isOpen: false,
@@ -101,12 +97,12 @@ class AbortCleanALLRUVTable extends React.Component {
                 originalData: task
             });
         }
-        
+
         if (rows.length === 0) {
             rows = [{ cells: [_("No Tasks")] }];
             columns = [{ title: _("Abort CleanAllRUV Tasks") }];
         }
-        
+
         return { rows, columns };
     }
 
@@ -189,7 +185,7 @@ class AbortCleanALLRUVTable extends React.Component {
                         <Tr>
                             {!hasNoTasks && <Th screenReaderText="Row expansion" />}
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -207,7 +203,7 @@ class AbortCleanALLRUVTable extends React.Component {
                             <React.Fragment key={rowIndex}>
                                 <Tr>
                                     {!hasNoTasks && (
-                                        <Td 
+                                        <Td
                                             expand={{
                                                 rowIndex,
                                                 isExpanded: row.isOpen,
@@ -222,7 +218,7 @@ class AbortCleanALLRUVTable extends React.Component {
                                 {row.isOpen && row.originalData && (
                                     <Tr isExpanded={true}>
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -291,9 +287,9 @@ class CleanALLRUVTable extends React.Component {
     getLog(log) {
         return (
             <TextContent>
-                <Text 
+                <Text
                     component={TextVariants.pre}
-                    style={{ 
+                    style={{
                         whiteSpace: 'pre-wrap',
                         wordBreak: 'break-word'
                     }}
@@ -307,7 +303,7 @@ class CleanALLRUVTable extends React.Component {
     createRows(tasks) {
         let rows = [];
         let columns = [...this.state.columns];
-        
+
         for (const task of tasks) {
             rows.push({
                 isOpen: false,
@@ -320,12 +316,12 @@ class CleanALLRUVTable extends React.Component {
                 originalData: task
             });
         }
-        
+
         if (rows.length === 0) {
             rows = [{ cells: [_("No Tasks")] }];
             columns = [{ title: _("CleanAllRUV Tasks") }];
         }
-        
+
         return { rows, columns };
     }
 
@@ -408,7 +404,7 @@ class CleanALLRUVTable extends React.Component {
                         <Tr>
                             {!hasNoTasks && <Th screenReaderText="Row expansion" />}
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -426,7 +422,7 @@ class CleanALLRUVTable extends React.Component {
                             <React.Fragment key={rowIndex}>
                                 <Tr>
                                     {!hasNoTasks && (
-                                        <Td 
+                                        <Td
                                             expand={{
                                                 rowIndex,
                                                 isExpanded: row.isOpen,
@@ -441,7 +437,7 @@ class CleanALLRUVTable extends React.Component {
                                 {row.isOpen && row.originalData && (
                                     <Tr isExpanded={true}>
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -512,7 +508,7 @@ class WinsyncAgmtTable extends React.Component {
                     <GridItem span={3}>{_("Session In Progress:")}</GridItem>
                     <GridItem span={9}><b>{ agmt['update-in-progress'][0] }</b></GridItem>
                     <GridItem span={3}>{_("Changes Sent:")}</GridItem>
-                    <GridItem span={9}><b>{ agmt['number-changes-sent'][0] }</b></GridItem>
+                    <GridItem span={9}><b>{ numToCommas(agmt['number-changes-sent'][0]) }</b></GridItem>
                     <hr />
                     <GridItem span={3}>{_("Last Init Started:")}</GridItem>
                     <GridItem span={9}><b>{ get_date_string(agmt['last-init-start'][0]) }</b></GridItem>
@@ -550,7 +546,7 @@ class WinsyncAgmtTable extends React.Component {
         let rows = [];
         let columns = [...this.state.columns];
         let count = 0;
-        
+
         for (const agmt of this.props.agmts) {
             rows.push({
                 isOpen: false,
@@ -564,12 +560,12 @@ class WinsyncAgmtTable extends React.Component {
             });
             count += 1;
         }
-        
+
         if (rows.length === 0) {
             rows = [{ cells: [_("No Agreements")] }];
             columns = [{ title: _("Winsync Agreements") }];
         }
-        
+
         this.setState({
             rows,
             columns
@@ -599,7 +595,7 @@ class WinsyncAgmtTable extends React.Component {
         if (direction !== SortByDirection.asc) {
             sorted_agmts.reverse();
         }
-        
+
         for (let agmt of sorted_agmts) {
             agmt = agmt.agmt;
             rows.push({
@@ -613,7 +609,7 @@ class WinsyncAgmtTable extends React.Component {
                 originalData: agmt
             });
         }
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -640,7 +636,7 @@ class WinsyncAgmtTable extends React.Component {
                         <Tr>
                             {!hasNoAgreements && <Th screenReaderText="Row expansion" />}
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -658,7 +654,7 @@ class WinsyncAgmtTable extends React.Component {
                             <React.Fragment key={rowIndex}>
                                 <Tr>
                                     {!hasNoAgreements && (
-                                        <Td 
+                                        <Td
                                             expand={{
                                                 rowIndex,
                                                 isExpanded: row.isOpen,
@@ -673,7 +669,7 @@ class WinsyncAgmtTable extends React.Component {
                                 {row.isOpen && row.originalData && (
                                     <Tr isExpanded={true}>
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -742,9 +738,9 @@ class AgmtTable extends React.Component {
                     <GridItem span={3}>{_("Session In Progress:")}</GridItem>
                     <GridItem span={9}><b>{ agmt['update-in-progress'][0] }</b></GridItem>
                     <GridItem span={3}>{_("Changes Sent:")}</GridItem>
-                    <GridItem span={9}><b>{ agmt['number-changes-sent'][0] }</b></GridItem>
+                    <GridItem span={9}><b>{ numToCommas(agmt['number-changes-sent'][0]) }</b></GridItem>
                     <GridItem span={3}>{_("Changes Skipped:")}</GridItem>
-                    <GridItem span={9}><b>{ agmt['number-changes-skipped'][0] }</b></GridItem>
+                    <GridItem span={9}><b>{ numToCommas(agmt['number-changes-skipped'][0]) }</b></GridItem>
                     <GridItem span={3}>{_("Reap Active:")}</GridItem>
                     <GridItem span={9}><b>{ agmt['reap-active'][0] }</b></GridItem>
                     <hr />
@@ -784,7 +780,7 @@ class AgmtTable extends React.Component {
         let rows = [];
         let columns = [...this.state.columns];
         let count = 0;
-        
+
         for (const agmt of this.props.agmts) {
             rows.push({
                 isOpen: false,
@@ -798,12 +794,12 @@ class AgmtTable extends React.Component {
             });
             count += 1;
         }
-        
+
         if (rows.length === 0) {
             rows = [{ cells: [_("No Agreements")] }];
             columns = [{ title: _("Replication Agreements") }];
         }
-        
+
         this.setState({
             rows,
             columns
@@ -833,7 +829,7 @@ class AgmtTable extends React.Component {
         if (direction !== SortByDirection.asc) {
             sorted_agmts.reverse();
         }
-        
+
         for (let agmt of sorted_agmts) {
             agmt = agmt.agmt;
             rows.push({
@@ -847,7 +843,7 @@ class AgmtTable extends React.Component {
                 originalData: agmt
             });
         }
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -874,7 +870,7 @@ class AgmtTable extends React.Component {
                         <Tr>
                             {!hasNoAgreements && <Th screenReaderText="Row expansion" />}
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -893,7 +889,7 @@ class AgmtTable extends React.Component {
                             <React.Fragment key={rowIndex}>
                                 <Tr>
                                     {!hasNoAgreements && (
-                                        <Td 
+                                        <Td
                                             expand={{
                                                 rowIndex,
                                                 isExpanded: row.isOpen,
@@ -908,7 +904,7 @@ class AgmtTable extends React.Component {
                                 {row.isOpen && row.originalData && (
                                     <Tr isExpanded={true}>
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -983,7 +979,7 @@ class ConnectionTable extends React.Component {
 
     getExpandedRow(ip, conn_date, parts) {
         return (
-            <Grid className="ds-indent">
+            <Grid className="ds-indent ds-margin-top ds-margin-bottom">
                 <GridItem span={3}>{_("IP Address:")}</GridItem>
                 <GridItem span={4}><b>{ip}</b></GridItem>
                 <GridItem span={3}>{_("File Descriptor:")}</GridItem>
@@ -991,22 +987,21 @@ class ConnectionTable extends React.Component {
                 <GridItem span={3}>{_("Connection Opened:")}</GridItem>
                 <GridItem span={4}><b>{conn_date}</b></GridItem>
                 <GridItem span={3}>{_("Operations Started:")}</GridItem>
-                <GridItem span={2}><b>{parts[2]}</b></GridItem>
+                <GridItem span={2}><b>{numToCommas(parts[2])}</b></GridItem>
                 <GridItem span={3}>{_("Connection ID:")}</GridItem>
                 <GridItem span={4}><b>{parts[9]}</b></GridItem>
                 <GridItem span={3}>{_("Operations Finished:")}</GridItem>
-                <GridItem span={2}><b>{parts[3]}</b></GridItem>
+                <GridItem span={2}><b>{numToCommas(parts[3])}</b></GridItem>
                 <GridItem span={3}>{_("Bind DN:")}</GridItem>
                 <GridItem span={4}><b>{parts[5]}</b></GridItem>
                 <GridItem span={3}>{_("Read/write Blocked:")}</GridItem>
-                <GridItem span={2}><b>{parts[4]}</b></GridItem>
-                <hr />
-                <GridItem span={6}>{_("Connection Currently At Max Threads:")}</GridItem>
-                <GridItem span={6}><b>{parts[6] === "1" ? _("Yes") : _("No")}</b></GridItem>
-                <GridItem span={6}>{_("Number Of Times Connection Hit Max Threads:")}</GridItem>
-                <GridItem span={6}><b>{parts[7]}</b></GridItem>
-                <GridItem span={6}>{_("Number Of Operations Blocked By Max Threads:")}</GridItem>
-                <GridItem span={6}><b>{parts[8]}</b></GridItem>
+                <GridItem span={2}><b>{numToCommas(parts[4])}</b></GridItem>
+                <GridItem className="ds-margin-top-lg" span={5}>{_("Connection Currently At Max Threads:")}</GridItem>
+                <GridItem className="ds-margin-top-lg" span={7}><b>{parts[6] === "1" ? _("Yes") : _("No")}</b></GridItem>
+                <GridItem span={5}>{_("Number Of Times Connection Hit Max Threads:")}</GridItem>
+                <GridItem span={7}><b>{numToCommas(parts[7])}</b></GridItem>
+                <GridItem span={5}>{_("Number Of Operations Blocked By Max Threads:")}</GridItem>
+                <GridItem span={7}><b>{numToCommas(parts[8])}</b></GridItem>
             </Grid>
         );
     }
@@ -1185,7 +1180,7 @@ class ConnectionTable extends React.Component {
             <div className="ds-margin-top-xlg">
                 <TextContent>
                     <Text component={TextVariants.h4}>
-                        {_("Client Connections:")}<b className="ds-left-margin">{this.props.conns.length}</b>
+                        {_("Client Connections:")}<b className="ds-left-margin">{numToCommas(this.props.conns.length)}</b>
                     </Text>
                 </TextContent>
                 <SearchInput
@@ -1203,7 +1198,7 @@ class ConnectionTable extends React.Component {
                         <Tr>
                             <Th screenReaderText="Row expansion" />
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -1222,12 +1217,12 @@ class ConnectionTable extends React.Component {
                             if (row.parent !== undefined) {
                                 // This is an expanded row
                                 return (
-                                    <Tr 
+                                    <Tr
                                         key={rowIndex}
                                         isExpanded={tableRows[row.parent].isOpen}
                                     >
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -1242,7 +1237,7 @@ class ConnectionTable extends React.Component {
                             // This is a regular row
                             return (
                                 <Tr key={rowIndex}>
-                                    <Td 
+                                    <Td
                                         expand={{
                                             rowIndex,
                                             isExpanded: row.isOpen,
@@ -1321,7 +1316,7 @@ class GlueTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedGlues = [...this.state.rows];
-        
+
         sortedGlues.sort((a, b) => {
             const aValue = a[index];
             const bValue = b[index];
@@ -1358,7 +1353,7 @@ class GlueTable extends React.Component {
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
         const hasRows = this.props.glues.length > 0;
-        
+
         // Calculate pagination
         const startIdx = (perPage * page) - perPage;
         let tableRows = [...rows].splice(startIdx, perPage);
@@ -1401,7 +1396,7 @@ class GlueTable extends React.Component {
                                 ))}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -1496,7 +1491,7 @@ class ConflictTable extends React.Component {
 
     handleSort(_event, index, direction) {
         const sortedConflicts = [...this.state.rows];
-        
+
         sortedConflicts.sort((a, b) => {
             const aValue = a[index];
             const bValue = b[index];
@@ -1522,7 +1517,7 @@ class ConflictTable extends React.Component {
 
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
-        
+
         // Calculate pagination
         const startIdx = (perPage * page) - perPage;
         const tableRows = [...rows].splice(startIdx, perPage);
@@ -1673,7 +1668,7 @@ class ReportAliasesTable extends React.Component {
         let columns = this.state.columns;
         let rows = JSON.parse(JSON.stringify(this.props.rows)); // Deep copy
         const hasRows = rows.length > 0;
-        
+
         if (!hasRows) {
             rows = [[_("No Aliases")]];
             columns = [{ title: _("Instance Aliases") }];
@@ -1710,7 +1705,7 @@ class ReportAliasesTable extends React.Component {
                     <Tbody>
                         {rows.map((row, rowIndex) => (
                             <Tr key={rowIndex}>
-                                {Array.isArray(row) ? 
+                                {Array.isArray(row) ?
                                     row.map((cell, cellIndex) => (
                                         <Td key={cellIndex}>{cell}</Td>
                                     ))
@@ -1719,7 +1714,7 @@ class ReportAliasesTable extends React.Component {
                                 }
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -1773,7 +1768,7 @@ class ReportCredentialsTable extends React.Component {
                 const rowCopy = JSON.parse(JSON.stringify(row)); // Deep copy
                 const pwInteractive = rowCopy.pwInputInterractive;
                 let pwField = <i>{_("Interactive Input is set")}</i>;
-                
+
                 if (!pwInteractive) {
                     if (rowCopy.credsBindpw === "") {
                         pwField = <i>{_("Both Password or Interactive Input flag are not set")}</i>;
@@ -1824,7 +1819,7 @@ class ReportCredentialsTable extends React.Component {
                     <Tbody>
                         {tableRows.map((row, rowIndex) => (
                             <Tr key={rowIndex}>
-                                {Array.isArray(row) ? 
+                                {Array.isArray(row) ?
                                     row.map((cell, cellIndex) => (
                                         <Td key={cellIndex}>{cell}</Td>
                                     ))
@@ -1833,7 +1828,7 @@ class ReportCredentialsTable extends React.Component {
                                 }
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActions(row)}
                                         />
                                     </Td>
@@ -1856,8 +1851,8 @@ class ReportSingleTable extends React.Component {
             sortBy: {},
             rows: [],
             columns: [
-                { 
-                    title: _("Supplier"), 
+                {
+                    title: _("Supplier"),
                     sortable: true
                 },
                 { title: _("Agreement"), sortable: true },
@@ -1904,9 +1899,9 @@ class ReportSingleTable extends React.Component {
                 <GridItem span={3}>{_("Consumer:")}</GridItem>
                 <GridItem span={9}><b>{ agmt.replica[0] }</b></GridItem>
                 <GridItem span={3}>{_("Changes Sent:")}</GridItem>
-                <GridItem span={9}><b>{ agmt['number-changes-sent'][0] }</b></GridItem>
+                <GridItem span={9}><b>{ numToCommas(agmt['number-changes-sent'][0]) }</b></GridItem>
                 <GridItem span={3}>{_("Changes Skipped:")}</GridItem>
-                <GridItem span={9}><b>{ agmt['number-changes-skipped'][0] }</b></GridItem>
+                <GridItem span={9}><b>{ numToCommas(agmt['number-changes-skipped'][0]) }</b></GridItem>
                 <GridItem span={3}>{_("Reap Active:")}</GridItem>
                 <GridItem span={9}><b>{ agmt['reap-active'][0] }</b></GridItem>
                 <hr />
@@ -2066,7 +2061,7 @@ class ReportSingleTable extends React.Component {
                         <Tr>
                             <Th screenReaderText="Row expansion" />
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -2084,12 +2079,12 @@ class ReportSingleTable extends React.Component {
                             if (row.parent !== undefined) {
                                 // Expanded row
                                 return (
-                                    <Tr 
+                                    <Tr
                                         key={rowIndex}
                                         isExpanded={rows[row.parent].isOpen}
                                     >
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -2103,7 +2098,7 @@ class ReportSingleTable extends React.Component {
                             // Regular row
                             return (
                                 <Tr key={rowIndex}>
-                                    <Td 
+                                    <Td
                                         expand={{
                                             rowIndex,
                                             isExpanded: row.isOpen,
@@ -2177,9 +2172,9 @@ class ReportConsumersTable extends React.Component {
                 <GridItem span={3}>{_("Consumer:")}</GridItem>
                 <GridItem span={9}><b>{ agmt.replica[0] }</b></GridItem>
                 <GridItem span={3}>{_("Changes Sent:")}</GridItem>
-                <GridItem span={9}><b>{ agmt['number-changes-sent'][0] }</b></GridItem>
+                <GridItem span={9}><b>{ numToCommas(agmt['number-changes-sent'][0]) }</b></GridItem>
                 <GridItem span={3}>{_("Changes Skipped:")}</GridItem>
-                <GridItem span={9}><b>{ agmt['number-changes-skipped'][0] }</b></GridItem>
+                <GridItem span={9}><b>{ numToCommas(agmt['number-changes-skipped'][0]) }</b></GridItem>
                 <GridItem span={3}>{_("Reap Active:")}</GridItem>
                 <GridItem span={9}><b>{ agmt['reap-active'][0] }</b></GridItem>
                 <hr />
@@ -2336,7 +2331,7 @@ class ReportConsumersTable extends React.Component {
                         <Tr>
                             <Th screenReaderText="Row expansion" />
                             {columns.map((column, columnIndex) => (
-                                <Th 
+                                <Th
                                     key={columnIndex}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -2353,12 +2348,12 @@ class ReportConsumersTable extends React.Component {
                         {rows.map((row, rowIndex) => {
                             if (row.parent !== undefined) {
                                 return (
-                                    <Tr 
+                                    <Tr
                                         key={rowIndex}
                                         isExpanded={rows[row.parent].isOpen}
                                     >
                                         <Td />
-                                        <Td 
+                                        <Td
                                             colSpan={columns.length + 1}
                                             noPadding
                                         >
@@ -2371,7 +2366,7 @@ class ReportConsumersTable extends React.Component {
                             }
                             return (
                                 <Tr key={rowIndex}>
-                                    <Td 
+                                    <Td
                                         expand={{
                                             rowIndex,
                                             isExpanded: row.isOpen,
@@ -2460,7 +2455,7 @@ class ReplDSRCTable extends React.Component {
 
         return (
             <div className="ds-margin-top-xlg">
-                <Table 
+                <Table
                     aria-label="Sortable DSRC Table"
                     variant="compact"
                 >
@@ -2552,7 +2547,7 @@ class ReplDSRCAliasTable extends React.Component {
 
         return (
             <div className="ds-margin-top-xlg">
-                <Table 
+                <Table
                     aria-label="Sortable DSRC Table"
                     variant="compact"
                 >

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -1582,7 +1582,7 @@ export class ChangeReplRoleModal extends React.Component {
     }
 }
 
-export class AddManagerModal extends React.Component {
+export class AddEditManagerModal extends React.Component {
     render() {
         const {
             showModal,
@@ -1593,18 +1593,19 @@ export class AddManagerModal extends React.Component {
             manager,
             manager_passwd,
             manager_passwd_confirm,
-            error
+            error,
+            edit,
         } = this.props;
-        let saveBtnName = _("Add Replication Manager");
+        let saveBtnName = this.props.edit ? "Save Replication Manager" : _("Add Replication Manager");
         const extraPrimaryProps = {};
         if (spinning) {
-            saveBtnName = _("Adding Replication Manager ...");
+            saveBtnName = this.props.edit ? "Saving Replication Manager ..." : _("Adding Replication Manager ...");
         }
 
         return (
             <Modal
                 variant={ModalVariant.medium}
-                title={_("Add Replication Manager")}
+                title={this.props.edit ? "Edit Replication Manager" : _("Add Replication Manager")}
                 aria-labelledby="ds-modal"
                 isOpen={showModal}
                 onClose={closeHandler}
@@ -1628,7 +1629,10 @@ export class AddManagerModal extends React.Component {
                 <Form isHorizontal autoComplete="off">
                     <TextContent>
                         <Text component={TextVariants.h3}>
-                            {_("Create a Replication Manager entry, and add it to the replication configuration for this suffix.  If the entry already exists it will be overwritten with the new credentials.")}
+                            {this.props.edit ?
+                                ""
+                            :
+                                _("Create a Replication Manager entry, and add it to the replication configuration for this suffix.  If the entry already exists it will be overwritten with the new credentials.")}
                         </Text>
                     </TextContent>
                     <Grid className="ds-margin-top-lg" title={_("The DN of the replication manager")}>
@@ -1645,13 +1649,14 @@ export class AddManagerModal extends React.Component {
                                 onChange={(e, str) => {
                                     handleChange(e);
                                 }}
+                                isDisabled={this.props.edit}
                                 validated={error.manager ? ValidatedOptions.error : ValidatedOptions.default}
                             />
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Replication Manager password")}>
                         <GridItem className="ds-label" span={3}>
-                            {_("Password")}
+                            {this.props.edit ? "New password" : _("Password")}
                         </GridItem>
                         <GridItem span={9}>
                             <TextInput
@@ -1669,7 +1674,7 @@ export class AddManagerModal extends React.Component {
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Replication Manager password")}>
                         <GridItem className="ds-label" span={3}>
-                            {_("Confirm Password")}
+                            {this.props.edit ? "Confirm new password" : _("Confirm Password")}
                         </GridItem>
                         <GridItem span={9}>
                             <TextInput
@@ -2041,16 +2046,17 @@ EnableReplModal.defaultProps = {
     error: {},
 };
 
-AddManagerModal.propTypes = {
+AddEditManagerModal.propTypes = {
     showModal: PropTypes.bool,
     closeHandler: PropTypes.func,
     handleChange: PropTypes.func,
     saveHandler: PropTypes.func,
     spinning: PropTypes.bool,
     error: PropTypes.object,
+    edit: PropTypes.bool,
 };
 
-AddManagerModal.defaultProps = {
+AddEditManagerModal.defaultProps = {
     showModal: false,
     spinning: false,
     error: {},

--- a/src/cockpit/389-console/src/lib/replication/replTables.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replTables.jsx
@@ -14,9 +14,8 @@ import {
     Tbody,
     Td,
     ActionsColumn,
-    SortByDirection
+    SortByDirection,
 } from '@patternfly/react-table';
-import { TrashAltIcon } from '@patternfly/react-icons/dist/js/icons/trash-alt-icon';
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -196,30 +195,18 @@ class ManagerTable extends React.Component {
                 {
                     title: 'Manager Name',
                     sortable: true
-                },
-                {
-                    title: 'Actions',
-                    screenReaderText: 'Manager actions'
                 }
             ],
         };
 
         this.handleSort = this.handleSort.bind(this);
-        this.getDeleteButton = this.getDeleteButton.bind(this);
     }
 
     componentDidMount() {
-        let rows = [];
+        let rows = [...this.props.rows];
         let columns = this.state.columns;
 
-        for (const managerRow of this.props.rows) {
-            rows.push([
-                managerRow,
-                this.getDeleteButton(managerRow)
-            ]);
-        }
-
-        if (rows.length === 0) {
+        if (this.props.rows.length === 0) {
             rows = [[_("No Replication Managers")]];
             columns = [{ title: '' }];
         }
@@ -244,19 +231,19 @@ class ManagerTable extends React.Component {
         });
     }
 
-    getDeleteButton(name) {
-        return (
-            <a>
-                <TrashAltIcon
-                    className="ds-center"
-                    onClick={() => {
-                        this.props.confirmDelete(name);
-                    }}
-                    title={_("Delete Replication Manager")}
-                />
-            </a>
-        );
-    }
+    getRowActions = (row) => [
+        {
+            title: 'Change password',
+            onClick: () => this.props.showEditManager(row)
+        },
+        {
+            isSeparator: true
+        },
+        {
+            title: 'Delete manager',
+            onClick: () => this.props.confirmDelete(row)
+        },
+    ];
 
     render() {
         return (
@@ -285,14 +272,16 @@ class ManagerTable extends React.Component {
                 <Tbody>
                     {this.state.rows.map((row, rowIndex) => (
                         <Tr key={rowIndex}>
-                            {row.map((cell, cellIndex) => (
-                                <Td
-                                    key={cellIndex}
-                                    textCenter={cellIndex === 1}
-                                >
-                                    {cell}
+                            <Td key={row}>
+                                {row}
+                            </Td>
+                            {this.props.rows.length !== 0 &&
+                                <Td isActionCell textCenter key={row +"action"}>
+                                    <ActionsColumn
+                                        items={this.getRowActions(row)}
+                                    />
                                 </Td>
-                            ))}
+                            }
                         </Tr>
                     ))}
                 </Tbody>

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -297,14 +297,18 @@ export function valid_filter(filter) {
 
 export function numToCommas(num) {
     //  Convert a number to have human friendly commas
+    if (num === undefined || num === "") {
+        return num;
+    }
     return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
 export function displayBytes(bytes) {
     // Convert bytes into a more human readable value/unit
-    if (bytes === 0 || isNaN(bytes)) {
+    if (bytes === 0 || bytes === "0" || isNaN(bytes)) {
         return '0 Bytes';
     }
+
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1367,7 +1367,7 @@ class DirSrv(SimpleLDAPObject, object):
         # First check it if already exists a backup file
         backup_dir, backup_pattern = self._infoBackupFS()
         if not os.path.exists(backup_dir):
-                os.makedirs(backup_dir)
+            os.makedirs(backup_dir)
         # make the backup directory accessible for anybody so that any user can
         # run the tests even if it existed a backup created by somebody else
         os.chmod(backup_dir, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
@@ -3586,3 +3586,13 @@ class DirSrv(SimpleLDAPObject, object):
         if self._containerised or container_result.returncode == 0:
             return True
         return False
+
+    def get_pid(self):
+        """
+        Get the pid of the running server
+        """
+        pid = pid_from_file(self.pid_file())
+        if pid == 0 or pid is None:
+            return 0
+        else:
+            return pid

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -181,6 +181,17 @@ def _format_status(log, mtype, json=False):
                 log.info('{}: {}'.format(k, vi))
 
 
+def _format_status_with_option(log, mtype, json=False, option=False):
+    if json:
+        print(mtype.get_status_json(option))
+    else:
+        status_dict = mtype.get_status(option)
+        log.info('dn: ' + mtype._dn)
+        for k, v in list(status_dict.items()):
+            # For each value in the multivalue attr
+            for vi in v:
+                log.info('{}: {}'.format(k, vi))
+
 def _generic_list(inst, basedn, log, manager_class, args=None):
     mc = manager_class(inst, basedn)
     ol = mc.list()
@@ -388,14 +399,14 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         if len(actions) > 0:
             # Check if this is the main options section by looking for the help action
             is_main_section = any(
-                isinstance(action, argparse._HelpAction) 
+                isinstance(action, argparse._HelpAction)
                 for action in actions
             )
-            
+
             # Only add parent arguments to the main options section
             if is_main_section:
                 actions = parent_arguments + actions
-        
+
         super(CustomHelpFormatter, self).add_arguments(actions)
 
     def _format_usage(self, usage, actions, groups, prefix):

--- a/src/lib389/lib389/cli_conf/monitor.py
+++ b/src/lib389/lib389/cli_conf/monitor.py
@@ -1,6 +1,6 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -10,16 +10,20 @@
 import datetime
 import json
 import os
-from lib389.monitor import (Monitor, MonitorLDBM, MonitorSNMP, MonitorDiskSpace)
+from lib389.monitor import (Monitor, MonitorLDBM, MonitorSNMP,
+                            MonitorDiskSpace)
 from lib389.chaining import (ChainingLinks)
 from lib389.backend import Backends
 from lib389.utils import convert_bytes
-from lib389.cli_base import _format_status, CustomHelpFormatter
+from lib389.cli_base import (_format_status, _format_status_with_option,
+                             CustomHelpFormatter)
 
 
 def monitor(inst, basedn, log, args):
-    monitor = Monitor(inst)
-    _format_status(log, monitor, args.json)
+    """Server monitor"""
+    server_monitor = Monitor(inst)
+    _format_status_with_option(log, server_monitor, args.json,
+                               args.just_resources)
 
 
 def backend_monitor(inst, basedn, log, args):
@@ -302,6 +306,9 @@ def create_parser(subparsers):
 
     server_parser = subcommands.add_parser('server', help="Displays the server statistics, connections, and operations", formatter_class=CustomHelpFormatter)
     server_parser.set_defaults(func=monitor)
+    server_parser.add_argument('-r', '--just-resources', action='store_true',
+                               default=False,
+                               help="Just display the server resources being consumed")
 
     dbmon_parser = subcommands.add_parser('dbmon', help="Monitor all database statistics in a single report", formatter_class=CustomHelpFormatter)
     dbmon_parser.set_defaults(func=db_monitor)

--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -7,3 +7,4 @@ python-ldap
 setuptools
 distro
 cryptography
+psutil

--- a/src/lib389/setup.py.in
+++ b/src/lib389/setup.py.in
@@ -98,7 +98,8 @@ setup(
         'python-ldap',
         'setuptools',
         'distro',
-        'cryptography'
+        'cryptography',
+        'psutil'
         ],
 
     cmdclass={


### PR DESCRIPTION
Description:

This PR addresses the following issues:

- Add new user type "traditional" for legacy objectclasses
- Display entry types in wizard header when adding new users, groups, and roles
- Update lib389 and monitor charts to use psutil instead of the UI directly calling "ps", "netstat", and "top"
- Improved format of numbers displayed in monitor: adding commas and converting bytes to more readable values
- Improved replication manager table to allow password edits

Relates: https://github.com/389ds/389-ds-base/issues/6625

