### PR TITLE
Issue 6639 - remove all the code related to entryrdn_get_switch

### DIFF
--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -626,7 +626,6 @@ objectclass: extensibleObject
 cn: config
 nsslapd-mode: 600
 nsslapd-directory: %db_dir%
-nsslapd-subtree-rename-switch: on
 
 dn: cn=monitor, cn=ldbm database, cn=plugins, cn=config
 objectclass: top

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -984,7 +984,6 @@ cn: config
 nsslapd-mode: 600
 nsslapd-directory: %db_dir%
 nsslapd-db-home-directory: %db_home_dir%
-nsslapd-subtree-rename-switch: on
 nsslapd-backend-implement: %db_lib%
 
 dn: cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config

--- a/ldap/servers/slapd/back-ldbm/ancestorid.c
+++ b/ldap/servers/slapd/back-ldbm/ancestorid.c
@@ -122,34 +122,16 @@ ldbm_ancestorid_index_update(
         }
 
         /* Get the id for that DN */
-        if (entryrdn_get_switch()) { /* subtree-rename: on */
-            node_id = 0;
-            err = entryrdn_index_read(be, &sdn, &node_id, txn);
-            if (err) {
-                if (DBI_RC_NOTFOUND != err) {
-                    ldbm_nasty("ldbm_ancestorid_index_update", sourcefile, 13141, err);
-                    slapi_log_err(SLAPI_LOG_ERR, "ldbm_ancestorid_index_update",
-                                  "entryrdn_index_read(%s)\n", slapi_sdn_get_dn(&sdn));
-                    ret = err;
-                }
-                break;
+        node_id = 0;
+        err = entryrdn_index_read(be, &sdn, &node_id, txn);
+        if (err) {
+            if (DBI_RC_NOTFOUND != err) {
+                ldbm_nasty("ldbm_ancestorid_index_update", sourcefile, 13141, err);
+                slapi_log_err(SLAPI_LOG_ERR, "ldbm_ancestorid_index_update",
+                              "entryrdn_index_read(%s)\n", slapi_sdn_get_dn(&sdn));
+                ret = err;
             }
-        } else {
-            IDList *idl = NULL;
-            struct berval ndnv;
-            ndnv.bv_val = (void *)slapi_sdn_get_ndn(&sdn);
-            ndnv.bv_len = slapi_sdn_get_ndn_len(&sdn);
-            err = 0;
-            idl = index_read(be, LDBM_ENTRYDN_STR, indextype_EQUALITY, &ndnv, txn, &err);
-            if (idl == NULL) {
-                if (err != 0 && err != DBI_RC_NOTFOUND) {
-                    ldbm_nasty("ldbm_ancestorid_index_update", sourcefile, 13140, err);
-                    ret = err;
-                }
-                break;
-            }
-            node_id = idl_firstid(idl);
-            idl_free(&idl);
+            break;
         }
 
         /* Update ancestorid for the base entry */

--- a/ldap/servers/slapd/back-ldbm/archive.c
+++ b/ldap/servers/slapd/back-ldbm/archive.c
@@ -77,9 +77,7 @@ ldbm_temporary_close_all_instances(Slapi_PBlock *pb)
         }
         slapi_mtn_be_disable(inst->inst_be);
         cache_clear(&inst->inst_cache, CACHE_TYPE_ENTRY);
-        if (entryrdn_get_switch()) {
-            cache_clear(&inst->inst_dncache, CACHE_TYPE_DN);
-        }
+        cache_clear(&inst->inst_dncache, CACHE_TYPE_DN);
     }
     plugin_call_plugins(pb, SLAPI_PLUGIN_BE_PRE_CLOSE_FN);
     /* now we know nobody's using any of the backend instances, so we

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -536,7 +536,6 @@ typedef struct _db_upgrade_info db_upgrade_info;
                                              */
 #define DBVERSION_UPGRADE_4_5       0x4000  /* bdb 4.X -> 5.X */
 #define DBVERSION_NEED_DN2RDN       0x1000  /* DN to RDN (subtree-rename) format */
-#define DBVERSION_NEED_RDN2DN       0x2000  /* RDN to DN (original) format */
 #define DBVERSION_NOT_SUPPORTED 0x10000000
 
 #define DBVERSION_TYPE   0x1

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -521,16 +521,16 @@ dbgec_test_if_entry_pointer_is_valid(void *e, void *prev, int slot, int line)
     /* Check if the entry pointer is rightly aligned and crash loudly otherwise */
     if ( ((uint64_t)e) & ((sizeof(long))-1) ) {
         /* If this message occurs, it means that we have reproduced the elusive entry cache corruption
-         * seen first while fixing replication conflict_resolution CI test 
+         * seen first while fixing replication conflict_resolution CI test
          * FYI some debug attempt have been stored in https://github.com/progier389/389-ds-base.git
          * in branches:
-         *  debug-stuff1 (older try with log of debugging trick in slapd/dbgec*) 
+         *  debug-stuff1 (older try with log of debugging trick in slapd/dbgec*)
          *  debug-stuff2: Log the dn associated with backentries in a mmap file and retrieve the
-         *  dn of the corrupted entry. 
+         *  dn of the corrupted entry.
          *   Note: if we are able to reproduce using this debug stuff and if it is always the same entry
-         *   we may catch the issue by adding a watchpoint when adding that backentry 
-         *   Note: you should disable the setuid to be able to use watchpoint 
-         */ 
+         *   we may catch the issue by adding a watchpoint when adding that backentry
+         *   Note: you should disable the setuid to be able to use watchpoint
+         */
         slapi_log_err(SLAPI_LOG_FATAL, "dbgec_test_if_entry_pointer_is_valid", "cache.c[%d]: Wrong entry address: %p Previous entry address is: %p hash table slot is %d\n", line, e, prev, slot);
         slapi_log_backtrace(SLAPI_LOG_FATAL);
 #pragma GCC diagnostic push
@@ -1786,10 +1786,6 @@ dncache_clear_int(struct cache *cache)
     struct backdn *dnflushtemp = NULL;
     size_t size = cache->c_maxsize;
 
-    if (!entryrdn_get_switch()) {
-        return;
-    }
-
     cache->c_maxsize = 0;
     dnflush = dncache_flush(cache);
     while (dnflush) {
@@ -1817,10 +1813,6 @@ dncache_set_max_size(struct cache *cache, uint64_t bytes)
 {
     struct backdn *dnflush = NULL;
     struct backdn *dnflushtemp = NULL;
-
-    if (!entryrdn_get_switch()) {
-        return;
-    }
 
     if (bytes < MINCACHESIZE) {
         bytes = MINCACHESIZE;
@@ -1866,10 +1858,6 @@ dncache_remove_int(struct cache *cache, struct backdn *bdn)
 {
     int ret = 1; /* assume not in cache */
 
-    if (!entryrdn_get_switch()) {
-        return 0;
-    }
-
     LOG("=> dncache_remove_int (%s)\n", slapi_sdn_get_dn(bdn->dn_sdn));
     if (bdn->ep_state & ENTRY_STATE_NOTINCACHE) {
         return ret;
@@ -1902,10 +1890,6 @@ dncache_return(struct cache *cache, struct backdn **bdn)
 {
     struct backdn *dnflush = NULL;
     struct backdn *dnflushtemp = NULL;
-
-    if (!entryrdn_get_switch()) {
-        return;
-    }
 
     LOG("=> dncache_return (%s) reference count: %d, dn in cache:%ld\n",
         slapi_sdn_get_dn((*bdn)->dn_sdn), (*bdn)->ep_refcnt, cache->c_curentries);
@@ -1948,10 +1932,6 @@ dncache_find_id(struct cache *cache, ID id)
 {
     struct backdn *bdn = NULL;
 
-    if (!entryrdn_get_switch()) {
-        return bdn;
-    }
-
     LOG("=> dncache_find_id (%lu)\n", (u_long)id);
 
     cache_lock(cache);
@@ -1985,10 +1965,6 @@ dncache_add_int(struct cache *cache, struct backdn *bdn, int state, struct backd
     struct backdn *dnflushtemp = NULL;
     struct backdn *my_alt;
     int already_in = 0;
-
-    if (!entryrdn_get_switch()) {
-        return 0;
-    }
 
     LOG("=> dncache_add_int( \"%s\", %ld )\n", slapi_sdn_get_dn(bdn->dn_sdn),
         (long int)bdn->ep_id);
@@ -2090,10 +2066,6 @@ dncache_replace(struct cache *cache, struct backdn *olddn, struct backdn *newdn)
 {
     int found;
 
-    if (!entryrdn_get_switch()) {
-        return 0;
-    }
-
     LOG("(%s) -> (%s)\n",
         slapi_sdn_get_dn(olddn->dn_sdn), slapi_sdn_get_dn(newdn->dn_sdn));
 
@@ -2149,10 +2121,6 @@ static struct backdn *
 dncache_flush(struct cache *cache)
 {
     struct backdn *dn = NULL;
-
-    if (!entryrdn_get_switch()) {
-        return dn;
-    }
 
     LOG("->\n");
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -2443,22 +2443,20 @@ bdb_public_bdb_import_main(void *arg)
     import_log_notice(job, SLAPI_LOG_INFO, "bdb_public_bdb_import_main",
                       "Generating numSubordinates complete.");
 
-    if (!entryrdn_get_noancestorid()) {
-        /* And the ancestorid index */
-        /* Creating ancestorid from the scratch; delete the index file first. */
-        struct attrinfo *ai = NULL;
+    /* And the ancestorid index */
+    /* Creating ancestorid from the scratch; delete the index file first. */
+    struct attrinfo *ai = NULL;
 
-        ainfo_get(be, "ancestorid", &ai);
-        dblayer_erase_index_file(be, ai, PR_TRUE, 0);
-        if ((ret = bdb_ancestorid_create_index(be, job)) != 0) {
-            import_log_notice(job, SLAPI_LOG_ERR, "bdb_public_bdb_import_main", "Failed to create ancestorid index");
-            goto error;
-        }
+    ainfo_get(be, "ancestorid", &ai);
+    dblayer_erase_index_file(be, ai, PR_TRUE, 0);
+    if ((ret = bdb_ancestorid_create_index(be, job)) != 0) {
+        import_log_notice(job, SLAPI_LOG_ERR, "bdb_public_bdb_import_main", "Failed to create ancestorid index");
+        goto error;
     }
 
     import_log_notice(job, SLAPI_LOG_INFO, "bdb_public_bdb_import_main", "Flushing caches...");
 
-/* New way to exit the routine: check the return code.
+    /* New way to exit the routine: check the return code.
      * If it's non-zero, delete the database files.
      * Otherwise don't, but always close the database layer properly.
      * Then return. This ensures that we can't make a half-good/half-bad
@@ -2469,15 +2467,13 @@ error:
        except dry run mode */
     import_log_notice(job, SLAPI_LOG_INFO, "bdb_public_bdb_import_main", "Closing files...");
     cache_clear(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
-    if (entryrdn_get_switch()) {
-        cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
-    }
+    cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
+
     if (aborted) {
         /* If aborted, it's safer to rebuild the caches. */
         cache_destroy_please(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
-        if (entryrdn_get_switch()) { /* subtree-rename: on */
-            cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
-        }
+        cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
+
         /* initialize the entry cache */
         if (!cache_init(&(inst->inst_cache), inst->inst_cache.c_maxsize,
                         DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
@@ -2700,17 +2696,7 @@ bdb_back_ldif2db(Slapi_PBlock *pb)
         } else {
             job->flags |= FLAG_REINDEXING; /* call bdb_index_producer */
             if (up_flags & SLAPI_UPGRADEDB_DN2RDN) {
-                if (entryrdn_get_switch()) {
-                    job->flags |= FLAG_DN2RDN; /* migrate to the rdn format */
-                } else {
-                    slapi_log_err(SLAPI_LOG_ERR, "bdb_back_ldif2db",
-                                  "DN to RDN option is specified, "
-                                  "but %s is not enabled\n",
-                                  CONFIG_ENTRYRDN_SWITCH);
-                    bdb_import_free_job(job);
-                    FREE(job);
-                    return -1;
-                }
+                job->flags |= FLAG_DN2RDN; /* migrate to the rdn format */
             }
         }
     }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -1563,17 +1563,9 @@ bdb_instance_start(backend *be, int mode)
                     goto errout;
                 } else if (rval & DBVERSION_NEED_DN2RDN) {
                     slapi_log_err(SLAPI_LOG_ERR,
-                                  "bdb_instance_start", "%s is on, while the instance %s is in the DN format. "
-                                                            "Please run dn2rdn to convert the database format.\n",
-                                  CONFIG_ENTRYRDN_SWITCH, inst->inst_name);
-                    slapi_ch_free_string(&dataversion);
-                    return_value = -1;
-                    goto errout;
-                } else if (rval & DBVERSION_NEED_RDN2DN) {
-                    slapi_log_err(SLAPI_LOG_ERR,
-                                  "bdb_instance_start", "%s is off, while the instance %s is in the RDN "
-                                                            "format. Please change the value to on in dse.ldif.\n",
-                                  CONFIG_ENTRYRDN_SWITCH, inst->inst_name);
+                                  "bdb_instance_start", "The instance %s is in the DN format. "
+                                  "Please run dn2rdn to convert the database format.\n",
+                                  inst->inst_name);
                     slapi_ch_free_string(&dataversion);
                     return_value = -1;
                     goto errout;
@@ -5737,16 +5729,9 @@ bdb_restore(struct ldbminfo *li, char *src_dir, Slapi_Task *task)
         dbmode = DBLAYER_RESTORE_MODE;
     } else if (action & DBVERSION_NEED_DN2RDN) {
         slapi_log_err(SLAPI_LOG_ERR,
-                      "bdb_restore", "%s is on, while the instance %s is in the DN format. "
-                                         "Please run dn2rdn to convert the database format.\n",
-                      CONFIG_ENTRYRDN_SWITCH, (inst != NULL) ? inst->inst_name : "<Null>");
-        return_value = -1;
-        goto error_out;
-    } else if (action & DBVERSION_NEED_RDN2DN) {
-        slapi_log_err(SLAPI_LOG_ERR,
-                      "bdb_restore", "%s is off, while the instance %s is in the RDN format. "
-                                         "Please change the value to on in dse.ldif.\n",
-                      CONFIG_ENTRYRDN_SWITCH, (inst != NULL) ? inst->inst_name : "<Null>");
+                      "bdb_restore", "The instance %s is in the DN format. "
+                      "Please run dn2rdn to convert the database format.\n",
+                      (inst != NULL) ? inst->inst_name : "<Null>");
         return_value = -1;
         goto error_out;
     } else {
@@ -6191,10 +6176,6 @@ bdb_get_info(Slapi_Backend *be, int cmd, void **info)
             *(char **)info = bdb_config_db_logdirectory_get_ext((void *)li);
             rc = 0;
         }
-        break;
-    }
-    case BACK_INFO_IS_ENTRYRDN: {
-        *(int *)info = entryrdn_get_switch();
         break;
     }
     case BACK_INFO_INDEX_KEY : {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c
@@ -102,25 +102,23 @@ bdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     sprintf(buf, "%" PRId64, maxentries);
     MSET("maxEntryCacheCount");
 
-    if (entryrdn_get_switch()) {
-        /* fetch cache statistics */
-        cache_get_stats(&(inst->inst_dncache), &hits, &tries,
-                        &nentries, &maxentries, &size, &maxsize);
-        sprintf(buf, "%" PRIu64, hits);
-        MSET("dnCacheHits");
-        sprintf(buf, "%" PRIu64, tries);
-        MSET("dnCacheTries");
-        sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
-        MSET("dnCacheHitRatio");
-        sprintf(buf, "%" PRIu64, size);
-        MSET("currentDnCacheSize");
-        sprintf(buf, "%" PRIu64, maxsize);
-        MSET("maxDnCacheSize");
-        sprintf(buf, "%" PRIu64, nentries);
-        MSET("currentDnCacheCount");
-        sprintf(buf, "%" PRId64, maxentries);
-        MSET("maxDnCacheCount");
-    }
+    /* fetch cache statistics */
+    cache_get_stats(&(inst->inst_dncache), &hits, &tries,
+                    &nentries, &maxentries, &size, &maxsize);
+    sprintf(buf, "%" PRIu64, hits);
+    MSET("dnCacheHits");
+    sprintf(buf, "%" PRIu64, tries);
+    MSET("dnCacheTries");
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    MSET("dnCacheHitRatio");
+    sprintf(buf, "%" PRIu64, size);
+    MSET("currentDnCacheSize");
+    sprintf(buf, "%" PRIu64, maxsize);
+    MSET("maxDnCacheSize");
+    sprintf(buf, "%" PRIu64, nentries);
+    MSET("currentDnCacheCount");
+    sprintf(buf, "%" PRId64, maxentries);
+    MSET("maxDnCacheCount");
 
 #ifdef DEBUG
     {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_upgrade.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_upgrade.c
@@ -155,19 +155,10 @@ bdb_check_db_version(struct ldbminfo *li, int *action)
         bdb_set_recovery_required(li);
         *action = DBVERSION_UPGRADE_4_5;
     }
-    if (value & DBVERSION_RDN_FORMAT) {
-        if (entryrdn_get_switch()) {
-            /* nothing to do */
-        } else {
-            *action |= DBVERSION_NEED_RDN2DN;
-        }
-    } else {
-        if (entryrdn_get_switch()) {
-            *action |= DBVERSION_NEED_DN2RDN;
-        } else {
-            /* nothing to do */
-        }
+    if (!(value & DBVERSION_RDN_FORMAT)) {
+        *action |= DBVERSION_NEED_DN2RDN;
     }
+
     slapi_ch_free_string(&ldbmversion);
     slapi_ch_free_string(&dataversion);
     return 0;
@@ -241,19 +232,10 @@ bdb_check_db_inst_version(ldbm_instance *inst)
     } else if (value & DBVERSION_UPGRADE_4_5) {
         rval |= DBVERSION_UPGRADE_4_5;
     }
-    if (value & DBVERSION_RDN_FORMAT) {
-        if (entryrdn_get_switch()) {
-            /* nothing to do */
-        } else {
-            rval |= DBVERSION_NEED_RDN2DN;
-        }
-    } else {
-        if (entryrdn_get_switch()) {
-            rval |= DBVERSION_NEED_DN2RDN;
-        } else {
-            /* nothing to do */
-        }
+    if (!(value & DBVERSION_RDN_FORMAT)) {
+        rval |= DBVERSION_NEED_DN2RDN;
     }
+
     if (inst_dirp != inst_dir)
         slapi_ch_free_string(&inst_dirp);
     slapi_ch_free_string(&ldbmversion);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c
@@ -72,12 +72,12 @@ bdb_version_write(struct ldbminfo *li, const char *directory, const char *datave
             len = strlen(buf);
             ptr = buf + len;
         }
-        if (entryrdn_get_switch() && (flags & DBVERSION_RDNFORMAT)) {
-            PR_snprintf(ptr, sizeof(buf) - len, "/%s-%s",
-                        BDB_RDNFORMAT, BDB_RDNFORMAT_VERSION);
-            len = strlen(buf);
-            ptr = buf + len;
-        }
+
+        PR_snprintf(ptr, sizeof(buf) - len, "/%s-%s",
+                    BDB_RDNFORMAT, BDB_RDNFORMAT_VERSION);
+        len = strlen(buf);
+        ptr = buf + len;
+
         if (flags & DBVERSION_DNFORMAT) {
             PR_snprintf(ptr, sizeof(buf) - len, "/%s-%s",
                         BDB_DNFORMAT, BDB_DNFORMAT_VERSION);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -937,15 +937,11 @@ error:
        except dry run mode */
     import_log_notice(job, SLAPI_LOG_INFO, "dbmdb_public_dbmdb_import_main", "Closing files...");
     cache_clear(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
-    if (entryrdn_get_switch()) {
-        cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
-    }
+    cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
     if (aborted) {
         /* If aborted, it's safer to rebuild the caches. */
         cache_destroy_please(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
-        if (entryrdn_get_switch()) { /* subtree-rename: on */
-            cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
-        }
+        cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
         /* initialize the entry cache */
         if (!cache_init(&(inst->inst_cache), inst->inst_cache.c_maxsize,
                         DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
@@ -1405,9 +1401,7 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
 
     /* shutdown this instance of the db */
     cache_clear(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
-    if (entryrdn_get_switch()) {
-        cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
-    }
+    cache_clear(&job->inst->inst_dncache, CACHE_TYPE_DN);
     dblayer_instance_close(be);
 
     /* Delete old database files */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -1368,10 +1368,6 @@ dbmdb_get_info(Slapi_Backend *be, int cmd, void **info)
         }
         break;
     }
-    case BACK_INFO_IS_ENTRYRDN: {
-        *(int *)info = entryrdn_get_switch();
-        break;
-    }
     case BACK_INFO_INDEX_KEY : {
         rc = get_suffix_key(be, (struct _back_info_index_key *)info);
         break;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
@@ -108,25 +108,23 @@ dbmdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     sprintf(buf, "%" PRId64, maxentries);
     MSET("maxEntryCacheCount");
 
-    if (entryrdn_get_switch()) {
-        /* fetch cache statistics */
-        cache_get_stats(&(inst->inst_dncache), &hits, &tries,
-                        &nentries, &maxentries, &size, &maxsize);
-        sprintf(buf, "%" PRIu64, hits);
-        MSET("dnCacheHits");
-        sprintf(buf, "%" PRIu64, tries);
-        MSET("dnCacheTries");
-        sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
-        MSET("dnCacheHitRatio");
-        sprintf(buf, "%" PRIu64, size);
-        MSET("currentDnCacheSize");
-        sprintf(buf, "%" PRIu64, maxsize);
-        MSET("maxDnCacheSize");
-        sprintf(buf, "%" PRIu64, nentries);
-        MSET("currentDnCacheCount");
-        sprintf(buf, "%" PRId64, maxentries);
-        MSET("maxDnCacheCount");
-    }
+    /* fetch cache statistics */
+    cache_get_stats(&(inst->inst_dncache), &hits, &tries,
+                    &nentries, &maxentries, &size, &maxsize);
+    sprintf(buf, "%" PRIu64, hits);
+    MSET("dnCacheHits");
+    sprintf(buf, "%" PRIu64, tries);
+    MSET("dnCacheTries");
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    MSET("dnCacheHitRatio");
+    sprintf(buf, "%" PRIu64, size);
+    MSET("currentDnCacheSize");
+    sprintf(buf, "%" PRIu64, maxsize);
+    MSET("maxDnCacheSize");
+    sprintf(buf, "%" PRIu64, nentries);
+    MSET("currentDnCacheCount");
+    sprintf(buf, "%" PRId64, maxentries);
+    MSET("maxDnCacheCount");
 
 #ifdef DEBUG
     {

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -667,7 +667,7 @@ range_candidates(
 
     /* Check if it is for bulk import. */
     slapi_pblock_get(pb, SLAPI_OPERATION, &op);
-    if (entryrdn_get_switch() && op && operation_is_flag_set(op, OP_FLAG_INTERNAL) &&
+    if (op && operation_is_flag_set(op, OP_FLAG_INTERNAL) &&
         operation_is_flag_set(op, OP_FLAG_BULK_IMPORT)) {
         /* parentid is treated specially that is needed for the bulk import. (See #48755) */
         operator= SLAPI_OP_RANGE_NO_IDL_SORT | SLAPI_OP_RANGE_NO_ALLIDS;

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -47,7 +47,6 @@ ldbm_instance_create(backend *be, char *name)
 
     /*
      * initialize the dn cache
-     * We do so, regardless of the subtree-rename value.
      * It is needed when converting the db from DN to RDN format.
      */
     if (!cache_init(&(inst->inst_dncache), DEFAULT_DNCACHE_SIZE,
@@ -183,15 +182,9 @@ ldbm_instance_create_default_indexes(backend *be)
      * since they are used by some searches, replication and the
      * ACL routines.
      */
-    if (entryrdn_get_switch()) { /* subtree-rename: on */
-        e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0);
-        ldbm_instance_config_add_index_entry(inst, e, flags);
-        slapi_entry_free(e);
-    } else {
-        e = ldbm_instance_init_config_entry(LDBM_ENTRYDN_STR, "eq", 0, 0, 0);
-        ldbm_instance_config_add_index_entry(inst, e, flags);
-        slapi_entry_free(e);
-    }
+    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0);
+    ldbm_instance_config_add_index_entry(inst, e, flags);
+    slapi_entry_free(e);
 
     e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
@@ -228,15 +221,13 @@ ldbm_instance_create_default_indexes(backend *be)
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 
-    if (!entryrdn_get_noancestorid()) {
-        /*
-         * ancestorid is special, there is actually no such attr type
-         * but we still want to use the attr index file APIs.
-         */
-        e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0);
-        attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
-        slapi_entry_free(e);
-    }
+    /*
+     * ancestorid is special, there is actually no such attr type
+     * but we still want to use the attr index file APIs.
+     */
+    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0);
+    attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
+    slapi_entry_free(e);
 
     return 0;
 }
@@ -274,9 +265,7 @@ ldbm_instance_stop_cache(backend *be)
     ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
 
     cache_destroy_please(&inst->inst_cache, CACHE_TYPE_ENTRY);
-    if (entryrdn_get_switch()) { /* subtree-rename: on */
-        cache_destroy_please(&inst->inst_dncache, CACHE_TYPE_DN);
-    }
+    cache_destroy_please(&inst->inst_dncache, CACHE_TYPE_DN);
 }
 
 static void

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.c
@@ -768,44 +768,6 @@ ldbm_config_serial_lock_set(void *arg,
 }
 
 static void *
-ldbm_config_entryrdn_switch_get(void *arg __attribute__((unused)))
-{
-    return (void *)((uintptr_t)entryrdn_get_switch());
-}
-
-static int
-ldbm_config_entryrdn_switch_set(void *arg __attribute__((unused)),
-                                void *value,
-                                char *errorbuf __attribute__((unused)),
-                                int phase __attribute__((unused)),
-                                int apply)
-{
-    if (apply) {
-        entryrdn_set_switch((int)((uintptr_t)value));
-    }
-    return LDAP_SUCCESS;
-}
-
-static void *
-ldbm_config_entryrdn_noancestorid_get(void *arg __attribute__((unused)))
-{
-    return (void *)((uintptr_t)entryrdn_get_noancestorid());
-}
-
-static int
-ldbm_config_entryrdn_noancestorid_set(void *arg __attribute__((unused)),
-                                      void *value,
-                                      char *errorbuf __attribute__((unused)),
-                                      int phase __attribute__((unused)),
-                                      int apply)
-{
-    if (apply) {
-        entryrdn_set_noancestorid((int)((uintptr_t)value));
-    }
-    return LDAP_SUCCESS;
-}
-
-static void *
 ldbm_config_legacy_errcode_get(void *arg)
 {
     struct ldbminfo *li = (struct ldbminfo *)arg;
@@ -980,8 +942,6 @@ static config_info ldbm_config[] = {
     {CONFIG_EXCLUDE_FROM_EXPORT, CONFIG_TYPE_STRING, CONFIG_EXCLUDE_FROM_EXPORT_DEFAULT_VALUE, &ldbm_config_exclude_from_export_get, &ldbm_config_exclude_from_export_set, CONFIG_FLAG_ALWAYS_SHOW},
     {CONFIG_SERIAL_LOCK, CONFIG_TYPE_ONOFF, "on", &ldbm_config_serial_lock_get, &ldbm_config_serial_lock_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_USE_LEGACY_ERRORCODE, CONFIG_TYPE_ONOFF, "off", &ldbm_config_legacy_errcode_get, &ldbm_config_legacy_errcode_set, 0},
-    {CONFIG_ENTRYRDN_SWITCH, CONFIG_TYPE_ONOFF, "on", &ldbm_config_entryrdn_switch_get, &ldbm_config_entryrdn_switch_set, CONFIG_FLAG_ALWAYS_SHOW},
-    {CONFIG_ENTRYRDN_NOANCESTORID, CONFIG_TYPE_ONOFF, "off", &ldbm_config_entryrdn_noancestorid_get, &ldbm_config_entryrdn_noancestorid_set, 0 /* no show */},
     {CONFIG_PAGEDLOOKTHROUGHLIMIT, CONFIG_TYPE_INT, "0", &ldbm_config_pagedlookthroughlimit_get, &ldbm_config_pagedlookthroughlimit_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_PAGEDIDLISTSCANLIMIT, CONFIG_TYPE_INT, "0", &ldbm_config_pagedallidsthreshold_get, &ldbm_config_pagedallidsthreshold_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_RANGELOOKTHROUGHLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_rangelookthroughlimit_get, &ldbm_config_rangelookthroughlimit_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -126,10 +126,6 @@ struct config_info
 #define CONFIG_SERIAL_LOCK "nsslapd-serial-lock"
 #define CONFIG_BACKEND_OPT_LEVEL "nsslapd-backend-opt-level"
 
-#define CONFIG_ENTRYRDN_SWITCH "nsslapd-subtree-rename-switch"
-/* nsslapd-noancestorid is ignored unless nsslapd-subtree-rename-switch is on */
-#define CONFIG_ENTRYRDN_NOANCESTORID "nsslapd-noancestorid"
-
 /* instance config options */
 #define CONFIG_INSTANCE_CACHESIZE "nsslapd-cachesize"
 #define CONFIG_INSTANCE_CACHEMEMSIZE "nsslapd-cachememsize"

--- a/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_entryrdn.c
@@ -19,9 +19,6 @@
 
 #include "back-ldbm.h"
 
-static int entryrdn_switch = 0;
-static int entryrdn_noancestorid = 0;
-
 #if LDAP_DEBUG_ENTRYRDN
 /* Lets use SLAPI_LOG_BACKLDBM which is less verbose than DEBUG or TRACE */
 #undef SLAPI_LOG_DEBUG
@@ -147,64 +144,6 @@ static int entryrdn_delete_key(entryrdn_db_ctx_t *ctx, Slapi_RDN *srdn, ID id);
 static int _entryrdn_resolve_redirect(entryrdn_db_ctx_t *ctx, rdn_elem **elem, int canfree);
 
 static int entryrdn_warning_on_encryption = 1;
-
-/*
- * This function sets the integer value val to entryrdn_switch.
- * If val is non-zero, the entryrdn index is used and moving subtree
- * and/or renaming an RDN which has children is enabled.
- * If val is zero, the entrydn index is used.
- */
-void
-entryrdn_set_switch(int val)
-{
-    entryrdn_switch = val;
-
-    if (entryrdn_switch) { /* entryrdn on */
-        /* Don't store entrydn in the db */
-        set_attr_to_protected_list(SLAPI_ATTR_ENTRYDN, 0);
-    } else { /* entryrdn off */
-        /* Store entrydn in the db */
-        set_attr_to_protected_list(SLAPI_ATTR_ENTRYDN, 1);
-    }
-
-    return;
-}
-
-/*
- * This function gets the value of entry_switch.
- * All the entryrdn related codes are supposed to be in the
- * if (entryrdn_get_switch()) clauses.
- */
-int
-entryrdn_get_switch()
-{
-    return entryrdn_switch;
-}
-
-/*
- * Note: nsslapd-noancestorid never be "on" unless nsslapd-subtree-rename-switch
- * is on.
- */
-void
-entryrdn_set_noancestorid(int val)
-{
-    if (entryrdn_switch) {
-        entryrdn_noancestorid = val;
-    } else {
-        entryrdn_noancestorid = 0;
-    }
-    return;
-}
-
-int
-entryrdn_get_noancestorid()
-{
-    if (entryrdn_switch) {
-        return entryrdn_noancestorid;
-    } else {
-        return 0;
-    }
-}
 
 /* Initialize the database resources needed for handling entryrdn index:
  *   database instances / cursor / ...

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -1159,9 +1159,8 @@ ldbm_instance_post_delete_instance_entry_callback(Slapi_PBlock *pb __attribute__
                   "Removing '%s'.\n", instance_name);
 
     cache_destroy_please(&inst->inst_cache, CACHE_TYPE_ENTRY);
-    if (entryrdn_get_switch()) { /* subtree-rename: on */
-        cache_destroy_please(&inst->inst_dncache, CACHE_TYPE_DN);
-    }
+    cache_destroy_please(&inst->inst_dncache, CACHE_TYPE_DN);
+
     /* call the backend implementation specific callbacks */
     priv = (dblayer_private *)li->li_dblayer_private;
     priv->instance_postdel_config_fn(li, inst);

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1321,7 +1321,7 @@ subtree_candidates(
     slapi_pblock_get(pb, SLAPI_REQUESTOR_ISROOT, &isroot);
     /* Check if it is for bulk import. */
     slapi_pblock_get(pb, SLAPI_OPERATION, &op);
-    if (op && entryrdn_get_switch() && operation_is_flag_set(op, OP_FLAG_INTERNAL) &&
+    if (op && operation_is_flag_set(op, OP_FLAG_INTERNAL) &&
         operation_is_flag_set(op, OP_FLAG_BULK_IMPORT)) {
         is_bulk_import = PR_TRUE;
     }
@@ -1348,20 +1348,8 @@ subtree_candidates(
         }
 
         slapi_pblock_get(pb, SLAPI_TXN, &txn.back_txn_txn);
-        if (entryrdn_get_noancestorid()) {
-            /* subtree-rename: on && no ancestorid */
-            *err = entryrdn_get_subordinates(be,
-                                             slapi_entry_get_sdn_const(e->ep_entry),
-                                             e->ep_id, &descendants, &txn, 0);
-            if (op_stat) {
-                /* record entryrdn lookups */
-                stat_add_srch_lookup(op_stat, LDBM_ENTRYRDN_STR, indextype_EQUALITY, key_value, descendants ? descendants->b_nids : 0);
-            }
-            idl_insert(&descendants, e->ep_id);
-            candidates = idl_intersection(be, candidates, descendants);
-            idl_free(&tmp);
-            idl_free(&descendants);
-        } else if (!has_tombstone_filter && !is_bulk_import) {
+
+        if (!has_tombstone_filter && !is_bulk_import) {
             *err = ldbm_ancestorid_read_ext(be, &txn, e->ep_id, &descendants, allidslimit);
             if (op_stat) {
                 /* records ancestorid lookups */
@@ -1371,7 +1359,7 @@ subtree_candidates(
             candidates = idl_intersection(be, candidates, descendants);
             idl_free(&tmp);
             idl_free(&descendants);
-        } /* else == has_tombstone_filter OR is_bulk_import: do nothing */
+        }
     }
 
     return (candidates);

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -631,10 +631,6 @@ int ldbm_set_last_usn(Slapi_Backend *be);
 /*
  * ldbm_entryrdn.c
  */
-void entryrdn_set_switch(int val);
-int entryrdn_get_switch(void);
-void entryrdn_set_noancestorid(int val);
-int entryrdn_get_noancestorid(void);
 int entryrdn_index_entry(backend *be, struct backentry *e, int flags, back_txn *txn);
 int entryrdn_index_read(backend *be, const Slapi_DN *sdn, ID *id, back_txn *txn);
 int

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -7850,7 +7850,6 @@ enum
     BACK_INFO_INDEX_KEY,           /* Get the status of a key in an index */
     BACK_INFO_DB_DIRECTORY,        /* Get the db directory */
     BACK_INFO_DBHOME_DIRECTORY,    /* Get the dbhome directory */
-    BACK_INFO_IS_ENTRYRDN,         /* Get the flag for entryrdn */
     BACK_INFO_CLDB_FILENAME        /* Get the backend replication changelog name */
 };
 

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -1145,7 +1145,6 @@ class DatabaseConfig(DSLdapObject):
             'nsslapd-search-use-vlv-index',
             'nsslapd-exclude-from-export',
             'nsslapd-serial-lock',
-            'nsslapd-subtree-rename-switch',
             'nsslapd-pagedlookthroughlimit',
             'nsslapd-pagedidlistscanlimit',
             'nsslapd-rangelookthroughlimit',


### PR DESCRIPTION
Description:

There is no real benefit to switching between entryrdn and entrydn formats so remove all the code related to this.

Relates: https://github.com/389ds/389-ds-base/issues/6639
