### PR TITLE
Issue 6641 - modrdn fails when a user is member of multiple groups

### DIFF
--- a/dirsrvtests/tests/suites/plugins/modrdn_test.py
+++ b/dirsrvtests/tests/suites/plugins/modrdn_test.py
@@ -123,8 +123,8 @@ def test_modrdn_of_a_member_of_2_automember_groups(topology_st):
 
     # Create groups
     groups = Groups(inst, DEFAULT_SUFFIX)
-    groups.create(properties={"cn": "userswithA"})
-    groups.create(properties={"cn": "userswithZ"})
+    groupA = groups.create(properties={"cn": "userswithA"})
+    groupZ = groups.create(properties={"cn": "userswithZ"})
 
     # Create users
     users = nsUserAccounts(inst, DEFAULT_SUFFIX)
@@ -156,7 +156,18 @@ def test_modrdn_of_a_member_of_2_automember_groups(topology_st):
         }
     )
     user = users.create(properties=user_props)
+    user_orig_dn = user.dn
 
     # Rename userwithaz
     user.rename(new_rdn="uid=userwith")
+    user_new_dn = user.dn
+
     assert user.get_attr_val_utf8("uid") != "userwithaz"
+
+    # Check groups contain renamed username
+    assert groupA.is_member(user_new_dn)
+    assert groupZ.is_member(user_new_dn)
+
+    # Check groups dont contain original username
+    assert not groupA.is_member(user_orig_dn)
+    assert not groupZ.is_member(user_orig_dn)

--- a/dirsrvtests/tests/suites/plugins/modrdn_test.py
+++ b/dirsrvtests/tests/suites/plugins/modrdn_test.py
@@ -1,0 +1,162 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import pytest
+from lib389.topologies import topology_st
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.idm.group import Groups
+from lib389.idm.user import nsUserAccounts
+from lib389.plugins import (
+    AutoMembershipDefinitions,
+    AutoMembershipPlugin,
+    AutoMembershipRegexRules,
+    MemberOfPlugin,
+    ReferentialIntegrityPlugin,
+)
+
+pytestmark = pytest.mark.tier1
+
+USER_PROPERTIES = {
+    "uid": "userwith",
+    "cn": "userwith",
+    "uidNumber": "1000",
+    "gidNumber": "2000",
+    "homeDirectory": "/home/testuser",
+    "displayName": "test user",
+}
+
+
+def test_modrdn_of_a_member_of_2_automember_groups(topology_st):
+    """Test that a member of 2 automember groups can be renamed
+    :id: 0e40bdc4-a2d2-4bb8-8368-e02c8920bad2
+
+    :setup: Standalone instance
+
+    :steps:
+        1. Enable automember plugin
+        2. Create definiton for users with A in the name
+        3. Create regex rule for users with A in the name
+        4. Create definiton for users with Z in the name
+        5. Create regex rule for users with Z in the name
+        6. Enable memberof plugin
+        7. Enable referential integrity plugin
+        8. Restart the instance
+        9. Create groups
+        10. Create users userwitha, userwithz, userwithaz
+        11. Rename userwithaz
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Success
+        10. Success
+        11. Success
+    """
+    inst = topology_st.standalone
+
+    # Enable automember plugin
+    automember_plugin = AutoMembershipPlugin(inst)
+    automember_plugin.enable()
+
+    # Create definiton for users with A in the name
+    automembers = AutoMembershipDefinitions(inst)
+    automember = automembers.create(
+        properties={
+            "cn": "userswithA",
+            "autoMemberScope": DEFAULT_SUFFIX,
+            "autoMemberFilter": "objectclass=posixAccount",
+            "autoMemberGroupingAttr": "member:dn",
+        }
+    )
+
+    # Create regex rule for users with A in the name
+    automembers_regex_rule = AutoMembershipRegexRules(inst, f"{automember.dn}")
+    automembers_regex_rule.create(
+        properties={
+            "cn": "userswithA",
+            "autoMemberInclusiveRegex": ["cn=.*a.*"],
+            "autoMemberTargetGroup": [f"cn=userswithA,ou=Groups,{DEFAULT_SUFFIX}"],
+        }
+    )
+
+    # Create definiton for users with Z in the name
+    automember = automembers.create(
+        properties={
+            "cn": "userswithZ",
+            "autoMemberScope": DEFAULT_SUFFIX,
+            "autoMemberFilter": "objectclass=posixAccount",
+            "autoMemberGroupingAttr": "member:dn",
+        }
+    )
+
+    # Create regex rule for users with Z in the name
+    automembers_regex_rule = AutoMembershipRegexRules(inst, f"{automember.dn}")
+    automembers_regex_rule.create(
+        properties={
+            "cn": "userswithZ",
+            "autoMemberInclusiveRegex": ["cn=.*z.*"],
+            "autoMemberTargetGroup": [f"cn=userswithZ,ou=Groups,{DEFAULT_SUFFIX}"],
+        }
+    )
+
+    # Enable memberof plugin
+    memberof_plugin = MemberOfPlugin(inst)
+    memberof_plugin.enable()
+
+    # Enable referential integrity plugin
+    referint_plugin = ReferentialIntegrityPlugin(inst)
+    referint_plugin.enable()
+
+    # Restart the instance
+    inst.restart()
+
+    # Create groups
+    groups = Groups(inst, DEFAULT_SUFFIX)
+    groups.create(properties={"cn": "userswithA"})
+    groups.create(properties={"cn": "userswithZ"})
+
+    # Create users
+    users = nsUserAccounts(inst, DEFAULT_SUFFIX)
+
+    # userwitha
+    user_props = USER_PROPERTIES.copy()
+    user_props.update(
+        {
+            "uid": USER_PROPERTIES["uid"] + "a",
+            "cn": USER_PROPERTIES["cn"] + "a",
+        }
+    )
+    user = users.create(properties=user_props)
+
+    # userwithz
+    user_props.update(
+        {
+            "uid": USER_PROPERTIES["uid"] + "z",
+            "cn": USER_PROPERTIES["cn"] + "z",
+        }
+    )
+    user = users.create(properties=user_props)
+
+    # userwithaz
+    user_props.update(
+        {
+            "uid": USER_PROPERTIES["uid"] + "az",
+            "cn": USER_PROPERTIES["cn"] + "az",
+        }
+    )
+    user = users.create(properties=user_props)
+
+    # Rename userwithaz
+    user.rename(new_rdn="uid=userwith")
+    assert user.get_attr_val_utf8("uid") != "userwithaz"

--- a/dirsrvtests/tests/suites/plugins/modrdn_test.py
+++ b/dirsrvtests/tests/suites/plugins/modrdn_test.py
@@ -33,6 +33,7 @@ USER_PROPERTIES = {
 
 def test_modrdn_of_a_member_of_2_automember_groups(topology_st):
     """Test that a member of 2 automember groups can be renamed
+
     :id: 0e40bdc4-a2d2-4bb8-8368-e02c8920bad2
 
     :setup: Standalone instance

--- a/ldap/servers/plugins/automember/automember.c
+++ b/ldap/servers/plugins/automember/automember.c
@@ -1755,13 +1755,12 @@ automember_update_member_value(Slapi_Entry *member_e, const char *group_dn, char
         }
 
         mod_pb = slapi_pblock_new();
-        slapi_modify_internal_set_pb(mod_pb, group_dn,
-                                     mods, 0, 0, automember_get_plugin_id(), 0);
-        slapi_modify_internal_pb(mod_pb);
-        slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &result);
+
+        /* Perform modifications with error overrides for specific conditions */
+        result = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_dn_byval(group_dn), mods, automember_get_plugin_id(), 0);
 
         if(add){
-            if ((result != LDAP_SUCCESS) && (result != LDAP_TYPE_OR_VALUE_EXISTS)) {
+            if (result != LDAP_SUCCESS) {
                 slapi_log_err(SLAPI_LOG_ERR, AUTOMEMBER_PLUGIN_SUBSYSTEM,
                               "automember_update_member_value - Unable to add \"%s\" as "
                               "a \"%s\" value to group \"%s\" (%s).\n",
@@ -1771,7 +1770,7 @@ automember_update_member_value(Slapi_Entry *member_e, const char *group_dn, char
             }
         } else {
             /* delete value */
-            if ((result != LDAP_SUCCESS) && (result != LDAP_NO_SUCH_ATTRIBUTE)) {
+            if (result != LDAP_SUCCESS) {
                 slapi_log_err(SLAPI_LOG_ERR, AUTOMEMBER_PLUGIN_SUBSYSTEM,
                               "automember_update_member_value - Unable to delete \"%s\" as "
                               "a \"%s\" value from group \"%s\" (%s).\n",
@@ -1789,6 +1788,7 @@ automember_update_member_value(Slapi_Entry *member_e, const char *group_dn, char
 
 out:
     slapi_pblock_destroy(mod_pb);
+    slapi_sdn_free(&group_sdn);
 
     return rc;
 }

--- a/ldap/servers/plugins/automember/automember.c
+++ b/ldap/servers/plugins/automember/automember.c
@@ -1755,9 +1755,9 @@ automember_update_member_value(Slapi_Entry *member_e, const char *group_dn, char
         }
 
         mod_pb = slapi_pblock_new();
-
-        /* Perform modifications with error overrides for specific conditions */
-        result = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_dn_byval(group_dn), mods, automember_get_plugin_id(), 0);
+        /* Do a single mod with error overrides for DEL/ADD */
+        result = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_dn_byval(group_dn), mods,
+                                                        automember_get_plugin_id(), 0);
 
         if(add){
             if (result != LDAP_SUCCESS) {
@@ -1788,7 +1788,6 @@ automember_update_member_value(Slapi_Entry *member_e, const char *group_dn, char
 
 out:
     slapi_pblock_destroy(mod_pb);
-    slapi_sdn_free(&group_sdn);
 
     return rc;
 }

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -963,9 +963,6 @@ modify_need_fixup(int set)
         mod_pb, memberof_get_config_area(),
         mods, 0, 0,
         memberof_get_plugin_id(), SLAPI_OP_FLAG_FIXUP|SLAPI_OP_FLAG_BYPASS_REFERRALS);
-
-    slapi_modify_internal_pb(mod_pb);
-    slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
     slapi_pblock_destroy(mod_pb);
     if (rc) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
@@ -1491,18 +1488,9 @@ memberof_del_dn_type_callback(Slapi_Entry *e, void *callback_data)
     mod.mod_op = LDAP_MOD_DELETE;
     mod.mod_type = ((memberof_del_dn_data *)callback_data)->type;
     mod.mod_values = val;
-
-    slapi_modify_internal_set_pb_ext(
-        mod_pb, slapi_entry_get_sdn(e),
-        mods, 0, 0,
-        memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
-
-    slapi_modify_internal_pb(mod_pb);
-
-    slapi_pblock_get(mod_pb,
-                     SLAPI_PLUGIN_INTOP_RESULT,
-                     &rc);
-
+    /* Internal mod with error overrides for DEL/ADD */
+    rc = slapi_single_modify_internal_override(mod_pb, slapi_entry_get_sdn(e), mods,
+                                                memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
     slapi_pblock_destroy(mod_pb);
 
     if (rc == LDAP_NO_SUCH_ATTRIBUTE && val[0] == NULL) {
@@ -1949,10 +1937,8 @@ memberof_replace_dn_type_callback(Slapi_Entry *e, void *callback_data)
     char *delval[2];
     char *addval[2];
     char *dn = NULL;
-    char *add_oc = NULL;
 
     dn = slapi_entry_get_dn(e);
-    add_oc = ((replace_dn_data *)callback_data)->add_oc;
 
     mods[0] = &delmod;
     mods[1] = &addmod;
@@ -1972,38 +1958,12 @@ memberof_replace_dn_type_callback(Slapi_Entry *e, void *callback_data)
     addmod.mod_type = ((replace_dn_data *)callback_data)->type;
     addmod.mod_values = addval;
 
-    rc = memberof_add_memberof_attr(mods, dn, add_oc);
-
-    if (rc == LDAP_NO_SUCH_ATTRIBUTE || rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-        if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-            /*
-                * For some reason the new modrdn value is present, so retry
-                * the delete by itself and ignore the add op by tweaking
-                * the mod array.
-                */
-            mods[1] = NULL;
-            rc = memberof_add_memberof_attr(mods, dn, add_oc);
-        } else {
-            /*
-                * The memberof value to be replaced does not exist so just
-                * add the new value.  Shuffle the mod array to apply only
-                * the add operation.
-                */
-            mods[0] = mods[1];
-            mods[1] = NULL;
-            rc = memberof_add_memberof_attr(mods, dn, add_oc);
-            if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-                /*
-                    * The entry already has the expected memberOf value, no
-                    * problem just return success.
-                    */
-                rc = LDAP_SUCCESS;
-            }
-        }
-    }
+    rc = memberof_add_memberof_attr(mods, dn,
+                                    ((replace_dn_data *)callback_data)->add_oc);
 
     return rc;
 }
+
 LDAPMod **
 my_copy_mods(LDAPMod **orig_mods)
 {
@@ -2812,33 +2772,6 @@ memberof_modop_one_replace_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod_o
                 replace_mod.mod_values = replace_val;
             }
             rc = memberof_add_memberof_attr(mods, op_to, config->auto_add_oc);
-            if (rc == LDAP_NO_SUCH_ATTRIBUTE || rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-                if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-                    /*
-                     * For some reason the new modrdn value is present, so retry
-                     * the delete by itself and ignore the add op by tweaking
-                     * the mod array.
-                     */
-                    mods[1] = NULL;
-                    rc = memberof_add_memberof_attr(mods, op_to, config->auto_add_oc);
-                } else {
-                    /*
-                     * The memberof value to be replaced does not exist so just
-                     * add the new value.  Shuffle the mod array to apply only
-                     * the add operation.
-                     */
-                    mods[0] = mods[1];
-                    mods[1] = NULL;
-                    rc = memberof_add_memberof_attr(mods, op_to, config->auto_add_oc);
-                    if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-                        /*
-                         * The entry already has the expected memberOf value, no
-                         * problem just return success.
-                         */
-                        rc = LDAP_SUCCESS;
-                    }
-                }
-            }
         }
     }
 
@@ -4499,41 +4432,57 @@ memberof_add_memberof_attr(LDAPMod **mods, const char *dn, char *add_oc)
     Slapi_PBlock *mod_pb = NULL;
     int added_oc = 0;
     int rc = 0;
-    int bypass_referral = 1;
+    LDAPMod *single_mod[2];
 
-    while (1) {
-        mod_pb = slapi_pblock_new();
-        slapi_pblock_init(mod_pb);
-        /* Perform modifications with error overrides for specific conditions */
-        rc = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_normdn_byref(dn), mods, memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
-        if (rc == LDAP_OBJECT_CLASS_VIOLATION) {
-            if (!add_oc || added_oc) {
-                /*
-                 * We aren't auto adding an objectclass, or we already
-                 * added the objectclass, and we are still failing.
-                 */
+    if (!dn || !mods) {
+        slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
+                    "Invalid argument: %s%s is NULL\n",
+                    !dn ? "dn " : "",
+                    !mods ? "mods " : "");
+        return LDAP_PARAM_ERROR;
+    }
+
+
+    mod_pb = slapi_pblock_new();
+    /* Split multiple mods into individual mod operations */
+    for (size_t i = 0; (mods != NULL) && (mods[i] != NULL); i++) {
+        single_mod[0] = mods[i];
+        single_mod[1] = NULL;
+
+        while (1) {
+            slapi_pblock_init(mod_pb);
+
+            /* Internal mod with error overrides for DEL/ADD */
+            rc = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_normdn_byref(dn), single_mod,
+                                                        memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
+            if (rc == LDAP_OBJECT_CLASS_VIOLATION) {
+                if (!add_oc || added_oc) {
+                    /*
+                    * We aren't auto adding an objectclass, or we already
+                    * added the objectclass, and we are still failing.
+                    */
+                    break;
+                }
+                rc = memberof_add_objectclass(add_oc, dn);
+                slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
+                        "Entry %s - schema violation caught - repair operation %s\n",
+                        dn ? dn : "unknown",
+                        rc ? "failed" : "succeeded");
+                if (rc) {
+                    /* Failed to add objectclass */
+                    rc = LDAP_OBJECT_CLASS_VIOLATION;
+                    break;
+                }
+                added_oc = 1;
+            } else if (rc) {
+                /* Some other fatal error */
+                slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
+                            "memberof_add_memberof_attr - Internal modify failed. rc=%d\n", rc);
+                break;
+            } else {
+                /* success */
                 break;
             }
-            rc = memberof_add_objectclass(add_oc, dn);
-            slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
-                    "Entry %s - schema violation caught - repair operation %s\n",
-                    dn ? dn : "unknown",
-                    rc ? "failed" : "succeeded");
-            if (rc) {
-                /* Failed to add objectclass */
-                rc = LDAP_OBJECT_CLASS_VIOLATION;
-                break;
-            }
-            added_oc = 1;
-            slapi_pblock_destroy(mod_pb);
-        } else if (rc) {
-            /* Some other fatal error */
-            slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
-                          "memberof_add_memberof_attr - Internal modify failed. rc=%d\n", rc);
-            break;
-        } else {
-            /* success */
-            break;
         }
     }
     slapi_pblock_destroy(mod_pb);

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -963,6 +963,8 @@ modify_need_fixup(int set)
         mod_pb, memberof_get_config_area(),
         mods, 0, 0,
         memberof_get_plugin_id(), SLAPI_OP_FLAG_FIXUP|SLAPI_OP_FLAG_BYPASS_REFERRALS);
+    slapi_modify_internal_pb(mod_pb);
+    slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
     slapi_pblock_destroy(mod_pb);
     if (rc) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -4499,15 +4499,13 @@ memberof_add_memberof_attr(LDAPMod **mods, const char *dn, char *add_oc)
     Slapi_PBlock *mod_pb = NULL;
     int added_oc = 0;
     int rc = 0;
+    int bypass_referral = 1;
 
     while (1) {
         mod_pb = slapi_pblock_new();
-        slapi_modify_internal_set_pb(
-            mod_pb, dn, mods, 0, 0,
-            memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
-        slapi_modify_internal_pb(mod_pb);
-
-        slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+        slapi_pblock_init(mod_pb);
+        /* Perform modifications with error overrides for specific conditions */
+        rc = slapi_single_modify_internal_override(mod_pb, slapi_sdn_new_normdn_byref(dn), mods, memberof_get_plugin_id(), SLAPI_OP_FLAG_BYPASS_REFERRALS);
         if (rc == LDAP_OBJECT_CLASS_VIOLATION) {
             if (!add_oc || added_oc) {
                 /*

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -715,6 +715,21 @@ _do_modify(Slapi_PBlock *mod_pb, Slapi_DN *entrySDN, LDAPMod **mods)
 
     slapi_pblock_init(mod_pb);
 
+    for (size_t i = 0; mods && mods[i] != NULL; i++) {
+        int mod_type = mods[i]->mod_op & LDAP_MOD_OP;
+        slapi_log_err(SLAPI_LOG_ERR, REFERINT_PLUGIN_SUBSYSTEM, "jc - mod_type:%d \n", mod_type);
+
+        // if (mod_type == LDAP_MOD_DELETE) {
+        //     if (rc == LDAP_NO_SUCH_ATTRIBUTE) {
+        //         rc = LDAP_SUCCESS;
+        //     }
+        // } else if (mod_type == LDAP_MOD_ADD) {
+        //     if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
+        //         rc = LDAP_SUCCESS;
+        //     }
+        // }
+    }
+
     if (allow_repl) {
         /* Must set as a replicated operation */
         slapi_modify_internal_set_pb_ext(mod_pb, entrySDN, mods, NULL, NULL,
@@ -725,22 +740,6 @@ _do_modify(Slapi_PBlock *mod_pb, Slapi_DN *entrySDN, LDAPMod **mods)
     }
     slapi_modify_internal_pb(mod_pb);
     slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
-
-    /* Do we need to override the return value */
-    if (rc) {
-        for (size_t i = 0; mods && mods[i] != NULL; i++) {
-            int mod_type = mods[i]->mod_op & LDAP_MOD_OP;
-            if (mod_type == LDAP_MOD_DELETE) {
-                if (rc == LDAP_NO_SUCH_ATTRIBUTE) {
-                    rc = LDAP_SUCCESS;
-                }
-            } else if (mod_type == LDAP_MOD_ADD) {
-                if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-                    rc = LDAP_SUCCESS;
-                }
-            }
-        }
-    }
 
     return rc;
 }

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -715,31 +715,12 @@ _do_modify(Slapi_PBlock *mod_pb, Slapi_DN *entrySDN, LDAPMod **mods)
 
     slapi_pblock_init(mod_pb);
 
-    for (size_t i = 0; mods && mods[i] != NULL; i++) {
-        int mod_type = mods[i]->mod_op & LDAP_MOD_OP;
-        slapi_log_err(SLAPI_LOG_ERR, REFERINT_PLUGIN_SUBSYSTEM, "jc - mod_type:%d \n", mod_type);
-
-        // if (mod_type == LDAP_MOD_DELETE) {
-        //     if (rc == LDAP_NO_SUCH_ATTRIBUTE) {
-        //         rc = LDAP_SUCCESS;
-        //     }
-        // } else if (mod_type == LDAP_MOD_ADD) {
-        //     if (rc == LDAP_TYPE_OR_VALUE_EXISTS) {
-        //         rc = LDAP_SUCCESS;
-        //     }
-        // }
-    }
-
+    /* Perform modifications with error overrides for specific conditions */
     if (allow_repl) {
-        /* Must set as a replicated operation */
-        slapi_modify_internal_set_pb_ext(mod_pb, entrySDN, mods, NULL, NULL,
-                                         referint_plugin_identity, OP_FLAG_REPLICATED);
+        rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mods, referint_plugin_identity, OP_FLAG_REPLICATED);
     } else {
-        slapi_modify_internal_set_pb_ext(mod_pb, entrySDN, mods, NULL, NULL,
-                                         referint_plugin_identity, 0);
+        rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mods, referint_plugin_identity, 0);
     }
-    slapi_modify_internal_pb(mod_pb);
-    slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
 
     return rc;
 }

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -111,7 +111,7 @@ do_modify(Slapi_PBlock *pb)
     char *old_pw = NULL; /* remember the old password */
     char *rawdn = NULL;
     int minssf_exclude_rootdse = 0;
-    int ignored_some_mods = 0;
+    int intop_reset_some_mods = 0;
     int has_password_mod = 0; /* number of password mods */
     int pw_change = 0;        /* 0 = no password change */
     int err;
@@ -267,7 +267,7 @@ do_modify(Slapi_PBlock *pb)
              * For now we just ignore attributes that client is not allowed
              * to modify so not to break existing clients
              */
-            ++ignored_some_mods;
+            ++intop_reset_some_mods;
             ber_bvecfree(mod->mod_bvalues);
             slapi_ch_free((void **)&(mod->mod_type));
             slapi_ch_free((void **)&mod);
@@ -283,7 +283,7 @@ do_modify(Slapi_PBlock *pb)
         slapi_mods_add_ldapmod(&smods, mod);
     }
 
-    if (ignored_some_mods && (0 == smods.num_elements)) {
+    if (intop_reset_some_mods && (0 == smods.num_elements)) {
         if (pb_conn->c_isreplication_session) {
             uint64_t connid;
             int32_t opid;
@@ -305,7 +305,7 @@ do_modify(Slapi_PBlock *pb)
         if there were no elements read (empty modify) len will be 0
     */
     if (tag != LBER_END_OF_SEQORSET) {
-        if ((len == 0) && (0 == smods.num_elements) && !ignored_some_mods) {
+        if ((len == 0) && (0 == smods.num_elements) && !intop_reset_some_mods) {
             /* ok - empty modify - allow empty modifies */
         } else if (len != -1) {
             op_shared_log_error_access(pb, "MOD", rawdn, "decoding error");
@@ -489,6 +489,49 @@ slapi_modify_internal_set_pb_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod 
     slapi_pblock_set(pb, SLAPI_PLUGIN_IDENTITY, plugin_identity);
 }
 
+/* Perform a series of single mod operations, breaking down multiple mods into individual ops if required.
+ * For each mod op, certain error conditions are overriden and treated as successful:
+ *   - LDAP_MOD_ADD -> LDAP_TYPE_OR_VALUE_EXISTS
+ *   - LDAP_MOD_DELETE -> LDAP_NO_SUCH_ATTRIBUTE
+ * Any other errors encountered during the operation will be returned as-is.
+ */
+int 
+slapi_single_modify_internal_override(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mods, Slapi_ComponentId *plugin_id, int op_flags)
+{
+    int rc = -1;
+    LDAPMod *single_mod[2]; 
+    int intop_reset = 0;
+    int mod_op = 0;
+
+    for (size_t i = 0; (mods != NULL) && (mods[i] != NULL); i++) {
+        single_mod[0] = mods[i];
+        single_mod[1] = NULL;
+        
+        slapi_modify_internal_set_pb_ext(pb, sdn, single_mod, NULL, NULL, plugin_id, op_flags);
+        slapi_modify_internal_pb(pb);
+        slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+        if (rc != LDAP_SUCCESS) {
+            mod_op = single_mod[0]->mod_op & LDAP_MOD_OP;
+            /* Check if rc can be overridden */
+            if ((mod_op == LDAP_MOD_ADD && rc == LDAP_TYPE_OR_VALUE_EXISTS) ||
+                (mod_op == LDAP_MOD_DELETE && rc == LDAP_NO_SUCH_ATTRIBUTE)) {
+                    slapi_log_err(SLAPI_LOG_INFO, "slapi_single_modify_internal_override",
+                        "Ignoring return code from - plugin:%s dn:%s mod_op:%d intop result:%d\n",
+                        plugin_id ? plugin_id->sci_component_name : "Null",
+                        sdn ? sdn->udn : "Null", 
+                        mod_op, rc);
+                    slapi_pblock_set(pb, SLAPI_PLUGIN_INTOP_RESULT, &intop_reset);
+                    rc = LDAP_SUCCESS;
+                } else {
+                    return rc;
+                }
+        }
+    }
+
+    return rc;
+}
+
 /* Helper functions */
 
 static int
@@ -617,7 +660,7 @@ op_shared_modify(Slapi_PBlock *pb, int pw_change, char *old_pw)
     int32_t log_format = config_get_accesslog_log_format();
     slapd_log_pblock logpb = {0};
 
-    slapi_pblock_get(pb, SLAPI_ORIGINAL_TARGET, &dn);
+    slapi_pblock_get(pb, SLAPI_ORIGINAL_TARGET, &dn);//jc segv from here
     slapi_pblock_get(pb, SLAPI_MODIFY_TARGET_SDN, &sdn);
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &mods);
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &tmpmods);
@@ -1544,7 +1587,7 @@ optimize_mods(Slapi_Mods *smods)
                 mod_count++;
             }
             if (i > 0) {
-                /* Ok, we did optimize the "mod" values, so set the current mod to be ignored */
+                /* Ok, we did optimize the "mod" values, so set the current mod to be intop_reset */
                 mod->mod_op = LDAP_MOD_IGNORE;
             } else {
                 /* No mod values, probably a full delete of the attribute... reset counters and move on */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5956,7 +5956,7 @@ void slapi_add_entry_internal_set_pb(Slapi_PBlock *pb, Slapi_Entry *e, LDAPContr
 int slapi_add_internal_set_pb(Slapi_PBlock *pb, const char *dn, LDAPMod **attrs, LDAPControl **controls, Slapi_ComponentId *plugin_identity, int operation_flags);
 void slapi_modify_internal_set_pb(Slapi_PBlock *pb, const char *dn, LDAPMod **mods, LDAPControl **controls, const char *uniqueid, Slapi_ComponentId *plugin_identity, int operation_flags);
 void slapi_modify_internal_set_pb_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mods, LDAPControl **controls, const char *uniqueid, Slapi_ComponentId *plugin_identity, int operation_flags);
-int slapi_single_modify_internal_override(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mods, Slapi_ComponentId *plugin_identity, int operation_flags);
+int slapi_single_modify_internal_override(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mod, Slapi_ComponentId *plugin_identity, int operation_flags);
 /**
  * Set \c Slapi_PBlock to perform modrdn/rename internally
  *

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5956,6 +5956,7 @@ void slapi_add_entry_internal_set_pb(Slapi_PBlock *pb, Slapi_Entry *e, LDAPContr
 int slapi_add_internal_set_pb(Slapi_PBlock *pb, const char *dn, LDAPMod **attrs, LDAPControl **controls, Slapi_ComponentId *plugin_identity, int operation_flags);
 void slapi_modify_internal_set_pb(Slapi_PBlock *pb, const char *dn, LDAPMod **mods, LDAPControl **controls, const char *uniqueid, Slapi_ComponentId *plugin_identity, int operation_flags);
 void slapi_modify_internal_set_pb_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mods, LDAPControl **controls, const char *uniqueid, Slapi_ComponentId *plugin_identity, int operation_flags);
+int slapi_single_modify_internal_override(Slapi_PBlock *pb, const Slapi_DN *sdn, LDAPMod **mods, Slapi_ComponentId *plugin_identity, int operation_flags);
 /**
  * Set \c Slapi_PBlock to perform modrdn/rename internally
  *


### PR DESCRIPTION
Bug description:
Rename of a user that is member of multiple AM groups fail when MO and RI plugins are enabled.

Fix description:
MO plugin - After updating the entry member attribute, check the return value. Retry the delete if the attr value exists and retry the add if the attr value is missing.

RI plugin - A previous commit checked if the attr value was not present before adding a mod. This commit was reverted in favour of overriding the internal op return value, consistent with other plugins.

CI test from Viktor Ashirov <vashirov@redhat.com>

Fixes: https://github.com/389ds/389-ds-base/issues/6641
Relates: https://github.com/389ds/389-ds-base/issues/6566

Reviewed by: