### PR TITLE
Issue  6653 - Cleanup error messages

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_version.c
@@ -53,7 +53,12 @@ bdb_version_write(struct ldbminfo *li, const char *directory, const char *datave
     /* Open the file */
     if ((prfd = PR_Open(filename, PR_RDWR | PR_CREATE_FILE | PR_TRUNCATE,
                         SLAPD_DEFAULT_FILE_MODE)) == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "bdb_version_write",
+        int sev_level = SLAPI_LOG_ERR;
+        if (PR_GetError() == -5950 /* not found */ && strstr("/dev/shm/", filename)) {
+            /* After a server reboot it is expected for this file to not be present */
+            sev_level = SLAPI_LOG_DEBUG;
+        }
+        slapi_log_err(sev_level, "bdb_version_write",
                       "Could not open file \"%s\" for writing " SLAPI_COMPONENT_NAME_NSPR " %d (%s)\n",
                       filename, PR_GetError(), slapd_pr_strerror(PR_GetError()));
         rc = -1;

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -458,7 +458,7 @@ attrcrypt_cipher_init(ldbm_instance *li, attrcrypt_cipher_entry *ace, SECKEYPriv
     /* Try to get the symmetric key for this cipher */
     ret = attrcrypt_keymgmt_get_key(li, acs, private_key, &symmetric_key);
     if (KEYMGMT_ERR_NO_ENTRY == ret) {
-        slapi_log_err(SLAPI_LOG_ERR, "attrcrypt_cipher_init",
+        slapi_log_err(SLAPI_LOG_NOTICE, "attrcrypt_cipher_init",
                       "No symmetric key found for cipher %s in backend %s, "
                       "attempting to create one...\n",
                       acs->cipher_display_name, li->inst_name);

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1535,7 +1535,6 @@ slapd_ssl_init2(PRFileDesc **fd, int startTLS)
     int slapd_SSLclientAuth;
     char *tmpDir;
     Slapi_Entry *e = NULL;
-    PRBool fipsMode = PR_FALSE;
     PRUint16 NSSVersionMin = defaultNSSVersions.min;
     PRUint16 NSSVersionMax = defaultNSSVersions.max;
     char mymin[VERSION_STR_LENGTH], mymax[VERSION_STR_LENGTH];
@@ -1624,7 +1623,6 @@ slapd_ssl_init2(PRFileDesc **fd, int startTLS)
                               errorCode, slapd_pr_strerror(errorCode));
                 return -1;
             }
-            fipsMode = PR_TRUE;
         }
 
         slapd_pk11_setSlotPWValues(slot, 0, 0);


### PR DESCRIPTION
Description:

Change the attr encryption symmetric key error message to use a notice severity level instead of a full blown error.

Do not log by default an error when the DBVERSION file is missing as this is expected after a system reboot.

And fix compiler warning in ssl.c

Relates: https://github.com/389ds/389-ds-base/issues/6653

