### PR TITLE
Issue 6639 - Fix crash in upgrade when removing subtree name attribute

### DIFF
--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -309,6 +309,7 @@ upgrade_remove_subtree_rename(void)
         LDAPMod *mods[2];
         mod_delete.mod_op = LDAP_MOD_DELETE;
         mod_delete.mod_type = attr;
+        mod_delete.mod_values = NULL;
         mods[0] = &mod_delete;
         mods[1] = 0;
 


### PR DESCRIPTION
Description:

Needed to set the deleted values to NULL before issuing the delete operation

Relates: https://github.com/389ds/389-ds-base/issues/6639

