### PR TITLE
Issue 6668 - Fix build break on 1.4.3 branch

### DIFF
--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -2891,7 +2891,7 @@ slapi_entry_attr_get_valuearray(const Slapi_Entry *e, const char *attrname)
         return NULL;
     }
 
-    return attr->a_present_values.va;
+    return (const struct slapi_value **)(attr->a_present_values.va);
 }
 
 /*

--- a/ldap/servers/slapd/pw_verify.c
+++ b/ldap/servers/slapd/pw_verify.c
@@ -26,6 +26,8 @@
 #include "slap.h"
 #include "fe.h"
 
+int fernet_verify_token(const char *dn, const char *token, const char *raw_key, uint64_t ttl);
+
 int
 pw_verify_root_dn(const char *dn, const Slapi_Value *cred)
 {

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -16,6 +16,13 @@
 #include <config.h>
 #endif
 
+/*
+ * Make sure to define statvfs struct before defining f_type macro
+ * otherwise there may be a conflict
+ */
+#include <sys/statvfs.h>
+
+
 /* slap.h - stand alone ldap server include file */
 
 #ifndef _SLDAPD_H_

--- a/src/lib389/setup.py
+++ b/src/lib389/setup.py
@@ -13,7 +13,8 @@
 #
 
 from setuptools import setup, find_packages
-from os import path
+from os import path, environ
+from sys import argv
 import build_manpages as bm
 if bm.__version__ < '2.1':
     from build_manpages import build_manpages as bm
@@ -29,6 +30,18 @@ version = "1.4.0.1"
 
 with open(path.join(here, 'README.md'), 'r') as f:
     long_description = f.read()
+
+#
+# For some historical reason when using prefix install
+#  files that should be in /usr/sbin/, /usr/share/ are
+#  in $PREFIX/sbin, $PREFIX/share
+# So lets mimick this behavior
+
+prefix=environ.get('INSTALL_PREFIX', '/usr')
+print(f"argv={argv}")
+if prefix != "/usr" and 'install' in argv and '--prefix' not in argv:
+    argv.append('--prefix')
+    argv.append(prefix)
 
 setup(
     name='lib389',
@@ -59,19 +72,19 @@ setup(
 
     # find lib389/clitools -name ds\* -exec echo \''{}'\', \;
     data_files=[
-        ('/usr/sbin/', [
+        (prefix+'/sbin/', [
             'cli/dsctl',
             'cli/dsconf',
             'cli/dscreate',
             'cli/dsidm',
             ]),
-        ('/usr/share/man/man8', [
+        (prefix+'/share/man/man8', [
             'man/dsctl.8',
             'man/dsconf.8',
             'man/dscreate.8',
             'man/dsidm.8',
             ]),
-        ('/usr/libexec/dirsrv/', [
+        (prefix+'/libexec/dirsrv/', [
             'cli/dscontainer',
             ]),
     ],


### PR DESCRIPTION
Fixing four issues preventing to build 1.4.3 branch.
  - A missing cast
  - A nasty conflict between statvfs struct and slapd.h f_type macro
  - A missing external declaration in pw_verify.c preventing make -f rpm.mk rpms to complete
  - PREFIX environment variable not taken in account by setup.py 
Now both local build and rpm.mk builds on Fedora should work.

Issue: #6668 

Reviewed by: @droideck 
    
