### PR TITLE
Issue 6613 - test_reindex_task_creates_abandoned_index_file fails

### DIFF
--- a/dirsrvtests/tests/suites/clu/dbscan_test.py
+++ b/dirsrvtests/tests/suites/clu/dbscan_test.py
@@ -14,8 +14,8 @@ import subprocess
 import sys
 
 from lib389 import DirSrv
-from lib389._constants import DBSCAN
 from lib389.topologies import topology_m2 as topo_m2
+from lib389.cli_ctl.dblib import DbscanHelper
 from difflib import context_diff
 
 pytestmark = pytest.mark.tier0
@@ -24,80 +24,6 @@ logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 DEBUGGING = os.getenv("DEBUGGING", default=False)
-
-
-class CalledProcessUnexpectedReturnCode(subprocess.CalledProcessError):
-    def __init__(self, result, expected_rc):
-        super().__init__(cmd=result.args, returncode=result.returncode, output=result.stdout, stderr=result.stderr)
-        self.expected_rc = expected_rc
-        self.result = result
-
-    def __str__(self):
-        return f'Command {self.result.args} returned {self.result.returncode} instead of {self.expected_rc}'
-
-
-class DbscanPaths:
-    @staticmethod
-    def list_instances(inst, dblib, dbhome):
-        # compute db instance pathnames
-        instances = dbscan(['-D', dblib, '-L', dbhome], inst=inst).stdout
-        dbis = []
-        if dblib == 'bdb':
-            pattern = r'^ (.*) $'
-            prefix = f'{dbhome}/'
-        else:
-            pattern = r'^ (.*) flags:'
-            prefix = f''
-        for match in re.finditer(pattern, instances, flags=re.MULTILINE):
-            dbis.append(prefix+match.group(1))
-        return dbis
-
-    @staticmethod
-    def list_options(inst):
-        # compute supported options
-        options = []
-        usage = dbscan(['-h'], inst=inst, expected_rc=None).stdout
-        pattern = r'^\s+(?:(-[^-,]+), +)?(--[^ ]+).*$'
-        for match in re.finditer(pattern, usage, flags=re.MULTILINE):
-            for idx in range(1,3):
-                if match.group(idx) is not None:
-                    options.append(match.group(idx))
-        return options
-
-    def __init__(self, inst):
-        dblib = inst.get_db_lib()
-        dbhome = inst.ds_paths.db_home_dir
-        self.inst = inst
-        self.dblib = dblib
-        self.dbhome = dbhome
-        self.options = DbscanPaths.list_options(inst)
-        self.dbis = DbscanPaths.list_instances(inst, dblib, dbhome)
-        self.ldif_dir = inst.ds_paths.ldif_dir
-
-    def get_dbi(self, attr, backend='userroot'):
-        for dbi in self.dbis:
-            if f'{backend}/{attr}.'.lower() in dbi.lower():
-                return dbi
-        raise KeyError(f'Unknown dbi {backend}/{attr}')
-
-    def __repr__(self):
-        attrs = ['inst', 'dblib', 'dbhome', 'ldif_dir', 'options', 'dbis' ]
-        res = ", ".join(map(lambda x: f'{x}={self.__dict__[x]}', attrs))
-        return f'DbscanPaths({res})'
-
-
-def dbscan(args, inst=None, expected_rc=0):
-    if inst is None:
-        prefix = os.environ.get('PREFIX', "")
-        prog = f'{prefix}/bin/dbscan'
-    else:
-        prog = os.path.join(inst.ds_paths.bin_dir, DBSCAN)
-    args.insert(0, prog)
-    output = subprocess.run(args, encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    log.debug(f'{args} result is {output.returncode} output is {output.stdout}')
-    if expected_rc is not None and expected_rc != output.returncode:
-        raise CalledProcessUnexpectedReturnCode(output, expected_rc)
-    return output
 
 
 def log_export_file(filename):
@@ -109,18 +35,19 @@ def log_export_file(filename):
 
 
 @pytest.fixture(scope='module')
-def paths(topo_m2, request):
+def helper(topo_m2, request):
     inst = topo_m2.ms["supplier1"]
     if sys.version_info < (3,5):
         pytest.skip('requires python version >= 3.5')
-    paths = DbscanPaths(inst)
-    if '--do-it' not in paths.options:
+    dbsh = DbscanHelper(inst, log=log)
+    dbsh.resync()
+    if '--do-it' not in dbsh.options:
        pytest.skip('Not supported with this dbscan version')
     inst.stop()
-    return paths
+    return dbsh
 
 
-def test_dbscan_destructive_actions(paths, request):
+def test_dbscan_destructive_actions(helper, request):
     """Test that dbscan remove/import actions
 
     :id: f40b0c42-660a-11ef-9544-083a88554478
@@ -160,76 +87,78 @@ def test_dbscan_destructive_actions(paths, request):
     """
 
     # Export cn instance with dbscan
-    export_cn = f'{paths.ldif_dir}/dbscan_cn.data'
-    export_cn2 = f'{paths.ldif_dir}/dbscan_cn2.data'
-    cndbi = paths.get_dbi('replication_changelog')
-    inst = paths.inst
-    dblib = paths.dblib
+    export_cn = f'{helper.ldif_dir}/dbscan_cn.data'
+    export_cn2 = f'{helper.ldif_dir}/dbscan_cn2.data'
+    cndbi = helper.get_dbi('replication_changelog')
+    inst = helper.inst
+    dblib = helper.dblib
     exportok = False
     def fin():
-        if os.path.exists(export_cn):
-            # Restore cn if it was exported successfully but does not exists any more
-            if exportok and cndbi not in DbscanPaths.list_instances(inst, dblib, paths.dbhome):
-                    dbscan(['-D', dblib, '-f', cndbi, '-I', export_cn, '--do-it'], inst=inst)
+        if exportok and os.path.exists(export_cn):
+            try:
+                helper.resync()
+                dbi = helper.get_dbi('replication_changelog')
+            except KeyError:
+                # Restore cn if it was exported successfully but does not exists any more
+                helper.dbscan(['-D', dblib, '-f', cndbi, '-I', export_cn, '--do-it'])
             if not DEBUGGING:
                 os.remove(export_cn)
-        if os.path.exists(export_cn) and not DEBUGGING:
+        if os.path.exists(export_cn2) and not DEBUGGING:
             os.remove(export_cn2)
 
     fin()
     request.addfinalizer(fin)
-    dbscan(['-D', dblib,  '-f', cndbi, '-X', export_cn], inst=inst)
+    helper.dbscan(['-D', dblib,  '-f', cndbi, '-X', export_cn])
     exportok = True
 
     expected_msg = "without specifying '--do-it' parameter."
 
     # Run dbscan --remove ...
-    result = dbscan(['-D', paths.dblib, '--remove', '-f', cndbi],
-                    inst=paths.inst, expected_rc=1)
+    result = helper.dbscan(['-D', helper.dblib, '--remove', '-f', cndbi], expected_rc=1)
 
     # Check the error message about missing --do-it
     assert expected_msg in result.stdout
 
     # Check that cn instance is still present
-    curdbis = DbscanPaths.list_instances(paths.inst, paths.dblib, paths.dbhome)
-    assert cndbi in curdbis
+    helper.resync()
+    assert helper.get_dbi('replication_changelog') == cndbi
 
     # Run dbscan -I import_file ...
-    result = dbscan(['-D', paths.dblib, '-f', cndbi, '-I', export_cn],
-                    inst=paths.inst, expected_rc=1)
+    result = helper.dbscan(['-D', helper.dblib, '-f', cndbi, '-I', export_cn],
+                           expected_rc=1)
 
     # Check the error message about missing --do-it
     assert expected_msg in result.stdout
 
     # Check that cn instance is still present
-    curdbis = DbscanPaths.list_instances(paths.inst, paths.dblib, paths.dbhome)
-    assert cndbi in curdbis
+    helper.resync()
+    assert helper.get_dbi('replication_changelog') == cndbi
 
     # Run dbscan --remove ... --doit
-    result = dbscan(['-D', paths.dblib, '--remove', '-f', cndbi, '--do-it'],
-                    inst=paths.inst, expected_rc=0)
+    result = helper.dbscan(['-D', helper.dblib, '--remove', '-f', cndbi, '--do-it'],
+                           expected_rc=0)
 
     # Check the error message about missing --do-it
     assert expected_msg not in result.stdout
 
     # Check that cn instance is still present
-    curdbis = DbscanPaths.list_instances(paths.inst, paths.dblib, paths.dbhome)
-    assert cndbi not in curdbis
+    helper.resync()
+    with pytest.raises(KeyError):
+        helper.get_dbi('replication_changelog')
 
     # Run dbscan -I import_file ... --do-it
-    result = dbscan(['-D', paths.dblib, '-f', cndbi,
-                     '-I', export_cn, '--do-it'],
-                    inst=paths.inst, expected_rc=0)
+    result = helper.dbscan(['-D', helper.dblib, '-f', cndbi,
+                           '-I', export_cn, '--do-it'], expected_rc=0)
 
     # Check the error message about missing --do-it
     assert expected_msg not in result.stdout
 
     # Check that cn instance is still present
-    curdbis = DbscanPaths.list_instances(paths.inst, paths.dblib, paths.dbhome)
-    assert cndbi in curdbis
+    helper.resync()
+    assert helper.get_dbi('replication_changelog') == cndbi
 
     # Export again the database
-    dbscan(['-D', dblib,  '-f', cndbi, '-X', export_cn2], inst=inst)
+    helper.dbscan(['-D', dblib,  '-f', cndbi, '-X', export_cn2])
 
     # Check that content of export files are the same
     with open(export_cn) as f1:
@@ -246,7 +175,7 @@ def test_dbscan_destructive_actions(paths, request):
         assert diffs is None
 
 
-def test_dbscan_changelog_dump(paths, request):
+def test_dbscan_changelog_dump(helper, request):
     """Test that dbscan remove/import actions
 
     :id: b6cf7922-d4c7-11ef-a028-482ae39447e5
@@ -260,11 +189,11 @@ def test_dbscan_changelog_dump(paths, request):
     """
 
     # Export changelog with dbscan
-    cldbi = paths.get_dbi('replication_changelog')
-    inst = paths.inst
-    dblib = paths.dblib
+    cldbi = helper.get_dbi('replication_changelog')
+    inst = helper.inst
+    dblib = helper.dblib
     exportok = False
-    result = dbscan(['-D', dblib,  '-f', cldbi], inst=inst)
+    result = helper.dbscan(['-D', dblib,  '-f', cldbi])
     log.info(result.stdout)
     assert 'replace: description' in result.stdout
 

--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -164,7 +164,7 @@ def set_description_index(request, topo, add_a_group_with_users):
     return (indexes, attr)
 
 
-def chech_dbi(dbsh, attr_name, expected = True, lowercase=False):
+def check_dbi(dbsh, attr_name, expected = True, lowercase=False):
     dbsh.resync()
     # mdb dbi names are always lowercase while bdb names are case sensitive
     if dbsh.dblib == 'mdb':
@@ -260,9 +260,9 @@ def test_reindex_task_creates_abandoned_index_file(topo):
     backend.reindex()
     time.sleep(3)
     dbsh = DbscanHelper(inst)
-    chech_dbi(dbsh, attr_name,lowercase=True)
+    check_dbi(dbsh, attr_name,lowercase=True)
     index.delete()
-    chech_dbi(dbsh, attr_name, expected=False)
+    check_dbi(dbsh, attr_name, expected=False)
 
     index = indexes.create(properties={
         'cn': attr_name,
@@ -272,7 +272,7 @@ def test_reindex_task_creates_abandoned_index_file(topo):
 
     backend.reindex()
     time.sleep(3)
-    chech_dbi(dbsh, attr_name)
+    check_dbi(dbsh, attr_name)
 
     entries = inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, f"{attr_name}={attr_value}")
     assert len(entries) > 0
@@ -282,7 +282,7 @@ def test_reindex_task_creates_abandoned_index_file(topo):
 
     backend.reindex()
     time.sleep(3)
-    chech_dbi(dbsh, attr_name)
+    check_dbi(dbsh, attr_name)
 
 
 def test_unindexed_internal_search_crashes_server(topo, add_a_group_with_users, set_small_idlistscanlimit):

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -74,6 +74,7 @@ typedef struct
     dbi_dbslist_t *list;
     size_t maxdbs;               /* Number of files */
     size_t nbdbs;                /* Number of files */
+    const char *dbhome;
 } dbi_dbslist_ctx_t;
 
 static int bdb_perf_threadmain(void *param);
@@ -7112,7 +7113,7 @@ dbslist_store_a_db(const char * dbname, void *cbctx)
 {
     dbi_dbslist_ctx_t *ctx = cbctx;
     if (ctx->nbdbs < ctx->maxdbs) {
-        PL_strncpyz (ctx->list[ctx->nbdbs++].filename, dbname, MAXPATHLEN);
+        PR_snprintf (ctx->list[ctx->nbdbs++].filename, PATH_MAX, "%s/%s", ctx->dbhome, dbname);
     }
 }
 
@@ -7127,6 +7128,7 @@ bdb_list_dbs (const char * dbhome)
     cbctx.nbdbs++;              /* Reserve space for empty filename that marks end of list */
     cbctx.list = (dbi_dbslist_t *) slapi_ch_calloc (cbctx.nbdbs, sizeof (dbi_dbslist_t));
     cbctx.nbdbs = 0;
+    cbctx.dbhome = dbhome;
     bdb_walk_dbfiles (dbhome, NULL, dbslist_store_a_db, &cbctx);
     return cbctx.list;
 }

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -76,7 +76,7 @@ class DbscanHelper:
             return
         assert(self.inst)
         self.dblib = self.inst.get_db_lib()
-        self.dbhome = self.inst.ds_paths.db_home_dir
+        self.dbhome = self.inst.ds_paths.db_dir
         self.dbis = self._list_instances()
         self.ldif_dir = self.inst.ds_paths.ldif_dir
 
@@ -100,12 +100,10 @@ class DbscanHelper:
         dbis = []
         if self.dblib == 'bdb':
             pattern = r'^ (.*) $'
-            prefix = f'{self.dbhome}/'
         else:
             pattern = r'^ (.*) flags:'
-            prefix = f''
         for match in re.finditer(pattern, instances, flags=re.MULTILINE):
-            dbis.append(prefix+match.group(1))
+            dbis.append(match.group(1))
         return dbis
 
     def get_dbi(self, attr, backend='userroot'):
@@ -258,7 +256,7 @@ def get_backends(log, dse, tmpdir):
     # now that we finish reading the dse.ldif we may update it if needed.
     for dn, dir in update_dse:
         dse.replace(dn, 'nsslapd-directory', dir)
-    self.log.debug(f'lib389.cli_ctl.dblib.get_backends returns: {str(res)}')
+    log.debug(f'lib389.cli_ctl.dblib.get_backends returns: {str(res)}')
     return (res, dbis)
 
 


### PR DESCRIPTION
Test is failing because it was marked as flaky and was never tried on lmdb.
Problem was that the database instance for an index existence was still tested  by looking at the files.
Solution: use dbscan to determine the dbi existence as it was done in clu/dbscan_test.py 
Was done by moving (and adapting) the helper class from clu/dbscan_test.py  to lib389 and reusing it in the test_reindex_task_creates_abandoned_index_file test.

Issue:  #6613

Reviewed by: @droideck (Thank!)