### PR TITLE
Issue 6663 - CLI - add error log JSON settings to dsconf

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_logging.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_logging.py
@@ -124,7 +124,7 @@ def test_log_settings(topo):
             assert rc == 0
 
         # Log formats
-        if log_type in ["access", "audit"]:
+        if log_type in ["access", "audit", "error"]:
             output, rc = execute_dsconf_command(dsconf_cmd,
                                                 [log_type, 'set',
                                                  'time-format', '%D'])

--- a/src/lib389/lib389/cli_conf/logging.py
+++ b/src/lib389/lib389/cli_conf/logging.py
@@ -186,6 +186,8 @@ ERROR_ATTR_MAP = {
     'nsslapd-errorlog-maxlogsize': 'Max log size',
     'nsslapd-errorlog-logbuffering': 'Buffering enabled',
     'nsslapd-errorlog-logminfreediskspace': 'Minimum free disk space',
+    'nsslapd-errorlog-time-format': 'Time format for JSON logging (strftime)',
+    'nsslapd-errorlog-log-format': 'Logging format',
 }
 
 SECURITY_ATTR_MAP = {
@@ -677,7 +679,7 @@ def create_parser(subparsers):
             + "the server to delete rotated log files.",
         )
 
-        if log_type in ['access', 'audit']:
+        if log_type in ['access', 'audit', 'error']:
             # JSON logging
             set_log_format_parser = set_parsers.add_parser(
                 "log-format",


### PR DESCRIPTION
Description:

Add the new error log json settings to dsconf "logging"

Relates: https://github.com/389ds/389-ds-base/issues/6663
