### PR TITLE
Issue 6676 - Add Rust Tests workflow action and fix PBKDF2 tests

### DIFF
--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -1,0 +1,36 @@
+name: Rust Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+permissions: 
+  actions: read
+  packages: read
+  contents: read
+
+jobs:
+  rust-tests:
+    name: Cargo Tests
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/389ds/ci-images:fedora
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      
+      - name: Setup and build
+        run: |
+          autoreconf -fvi
+          ./configure --enable-debug
+          make V=0
+        
+      - name: Run Rust tests
+        run: make check-local


### PR DESCRIPTION
Description: Implement a GitHub workflow for CI to run Rust tests. The workflow triggers on push, pull request, daily schedule, and can be triggered manually.

Fix PBKDF2 test reliability issues by implementing thread-local storage for test environments to prevent test interference. Add proper test reset functions to ensure each test starts with clean state.

Fixes: https://github.com/389ds/389-ds-base/issues/6676

Reviewed by: ?