### PR TITLE
Issue 6494 - (3rd) Various errors when using extended matching rule on vlv sort filter

### DIFF
--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2023 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -9,18 +9,104 @@
 import pytest, time
 from lib389.tasks import *
 from lib389.utils import *
-from lib389.topologies import topology_m2
+from lib389.topologies import topology_m2, topology_st
 from lib389.replica import *
 from lib389._constants import *
+from lib389.properties import TASK_WAIT
 from lib389.index import *
 from lib389.mappingTree import *
 from lib389.backend import *
+from lib389.idm.user import UserAccounts
+from ldap.controls.vlv import VLVRequestControl
+from ldap.controls.sss import SSSRequestControl
 
 pytestmark = pytest.mark.tier1
 
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
+
+def open_new_ldapi_conn(dsinstance):
+    ldapurl, certdir = get_ldapurl_from_serverid(dsinstance)
+    assert 'ldapi://' in ldapurl
+    conn = ldap.initialize(ldapurl)
+    conn.sasl_interactive_bind_s("", ldap.sasl.external())
+    return conn
+
+
+def check_vlv_search(conn):
+    before_count=1
+    after_count=3
+    offset=3501
+
+    vlv_control = VLVRequestControl(criticality=True,
+        before_count=before_count,
+        after_count=after_count,
+        offset=offset,
+        content_count=0,
+        greater_than_or_equal=None,
+        context_id=None)
+
+    sss_control = SSSRequestControl(criticality=True, ordering_rules=['cn'])
+    result = conn.search_ext_s(
+        base='dc=example,dc=com',
+        scope=ldap.SCOPE_SUBTREE,
+        filterstr='(uid=*)',
+        serverctrls=[vlv_control, sss_control]
+    )
+    imin = offset + 998 - before_count
+    imax = offset + 998 + after_count
+
+    for i, (dn, entry) in enumerate(result, start=imin):
+        assert i <= imax
+        expected_dn = f'uid=testuser{i},ou=People,dc=example,dc=com'
+        log.debug(f'found {dn} expected {expected_dn}')
+        assert dn.lower() == expected_dn.lower()
+
+
+def add_users(inst, users_num):
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    log.info(f'Adding {users_num} users')
+    for i in range(0, users_num):
+        uid = 1000 + i
+        user_properties = {
+            'uid': f'testuser{uid}',
+            'cn': f'testuser{uid}',
+            'sn': 'user',
+            'uidNumber': str(uid),
+            'gidNumber': str(uid),
+            'homeDirectory': f'/home/testuser{uid}'
+        }
+        users.create(properties=user_properties)
+
+
+
+def create_vlv_search_and_index(inst, basedn=DEFAULT_SUFFIX, bename='userRoot',
+                                scope=ldap.SCOPE_SUBTREE, prefix="vlv", vlvsort="cn"):
+    vlv_searches = VLVSearch(inst)
+    vlv_search_properties = {
+        "objectclass": ["top", "vlvSearch"],
+        "cn": f"{prefix}Srch",
+        "vlvbase": basedn,
+        "vlvfilter": "(uid=*)",
+        "vlvscope": str(scope),
+    }
+    vlv_searches.create(
+        basedn=f"cn={bename},cn=ldbm database,cn=plugins,cn=config",
+        properties=vlv_search_properties
+    )
+
+    vlv_index = VLVIndex(inst)
+    vlv_index_properties = {
+        "objectclass": ["top", "vlvIndex"],
+        "cn": f"{prefix}Idx",
+        "vlvsort": vlvsort,
+    }
+    vlv_index.create(
+        basedn=f"cn={prefix}Srch,cn={bename},cn=ldbm database,cn=plugins,cn=config",
+        properties=vlv_index_properties
+    )
+    return vlv_searches, vlv_index
 
 class BackendHandler:
     def __init__(self, inst, bedict, scope=ldap.SCOPE_ONELEVEL):
@@ -99,34 +185,6 @@ class BackendHandler:
                                  'vlv_search' : vlv_search,
                                  'vlv_index' : vlv_index,
                                  'dn' : dn}
-
-
-def create_vlv_search_and_index(inst, basedn=DEFAULT_SUFFIX, bename='userRoot',
-                                scope=ldap.SCOPE_SUBTREE, prefix="vlv", vlvsort="cn"):
-    vlv_searches = VLVSearch(inst)
-    vlv_search_properties = {
-        "objectclass": ["top", "vlvSearch"],
-        "cn": f"{prefix}Srch",
-        "vlvbase": basedn,
-        "vlvfilter": "(uid=*)",
-        "vlvscope": str(scope),
-    }
-    vlv_searches.create(
-        basedn=f"cn={bename},cn=ldbm database,cn=plugins,cn=config",
-        properties=vlv_search_properties
-    )
-
-    vlv_index = VLVIndex(inst)
-    vlv_index_properties = {
-        "objectclass": ["top", "vlvIndex"],
-        "cn": f"{prefix}Idx",
-        "vlvsort": vlvsort,
-    }
-    vlv_index.create(
-        basedn=f"cn={prefix}Srch,cn={bename},cn=ldbm database,cn=plugins,cn=config",
-        properties=vlv_index_properties
-    )
-    return vlv_searches, vlv_index
 
 
 @pytest.fixture
@@ -245,6 +303,62 @@ def test_bulk_import_when_the_backend_with_vlv_was_recreated(topology_m2):
     entries = M2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(objectclass=*)")
 
 
+def test_vlv_recreation_reindex(topology_st):
+    """Test VLV recreation and reindexing.
+
+    :id: 29f4567f-4ac0-410f-bc99-a32e217a939f
+    :setup: Standalone instance.
+    :steps:
+        1. Create new VLVs and do the reindex.
+        2. Test the new VLVs.
+        3. Remove the existing VLVs.
+        4. Create new VLVs (with the same name).
+        5. Perform online re-indexing of the new VLVs.
+        6. Test the new VLVs.
+    :expectedresults:
+        1. Should Success.
+        2. Should Success.
+        3. Should Success.
+        4. Should Success.
+        5. Should Success.
+        6. Should Success.
+    """
+
+    inst = topology_st.standalone
+    reindex_task = Tasks(inst)
+
+    # Create and test VLVs
+    vlv_search, vlv_index = create_vlv_search_and_index(inst)
+    assert reindex_task.reindex(
+        suffix=DEFAULT_SUFFIX,
+        attrname=vlv_index.rdn,
+        args={TASK_WAIT: True},
+        vlv=True
+    ) == 0
+
+    add_users(inst, 5000)
+
+    conn = open_new_ldapi_conn(inst.serverid)
+    assert len(conn.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(cn=*)")) > 0
+    check_vlv_search(conn)
+
+    # Remove and recreate VLVs
+    vlv_index.delete()
+    vlv_search.delete()
+
+    vlv_search, vlv_index = create_vlv_search_and_index(inst)
+    assert reindex_task.reindex(
+        suffix=DEFAULT_SUFFIX,
+        attrname=vlv_index.rdn,
+        args={TASK_WAIT: True},
+        vlv=True
+    ) == 0
+
+    conn = open_new_ldapi_conn(inst.serverid)
+    assert len(conn.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(cn=*)")) > 0
+    check_vlv_search(conn)
+
+
 def test_vlv_with_mr(vlv_setup_with_uid_mr):
     """
     Testing vlv having specific matching rule
@@ -286,6 +400,7 @@ def test_vlv_with_mr(vlv_setup_with_uid_mr):
     user = users.create(properties=user_properties)
     user.delete()
     assert inst.status()
+
 
 
 if __name__ == "__main__":

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -16,11 +16,15 @@ from lib389.properties import TASK_WAIT
 from lib389.index import *
 from lib389.mappingTree import *
 from lib389.backend import *
-from lib389.idm.user import UserAccounts
+from lib389.idm.user import UserAccounts, UserAccount
+from lib389.idm.organization import Organization
+from lib389.idm.organizationalunit import OrganizationalUnits
 from ldap.controls.vlv import VLVRequestControl
 from ldap.controls.sss import SSSRequestControl
 
 pytestmark = pytest.mark.tier1
+
+DEMO_PW = 'secret12'
 
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
@@ -169,7 +173,7 @@ class BackendHandler:
                     'loginShell': '/bin/false',
                     'userpassword': DEMO_PW })
             # Add regular user
-            add_users(self.inst, 10, suffix=suffix)
+            add_users(self.inst, 10)
             # Removing ou2
             ou2.delete()
             # And export


### PR DESCRIPTION
Bug description:

The following tests failed on 389-ds-base-1.4.3.

- dirsrvtests/tests/suites/vlv/regression_test.py::test_vlv_with_mr
- dirsrvtests/tests/suites/indexes/regression_test.py::test_reindex_extended_matching_rule

This is similar fix to https://github.com/389ds/389-ds-base/pull/6685
The 2nd commit (in issue 6494) is required to add a missing definition add_backend_and_ldif_50K_users, which is required for test_reindex_extended_matching_rule .
The 3rd commit (in Issue 6494) is required for 389-ds-base-2.2, since DEMO_PW definition is missing.
Also, topology_st is used without import. It's fixed in Issue 1925.

Fixes: https://github.com/389ds/389-ds-base/issues/6494
Related: https://github.com/389ds/389-ds-base/issues/1925