### PR TITLE
Issue 6710 - test_vlv_scope_one_on_two_backends fails in 2.6

### DIFF
--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -608,6 +608,11 @@ def bootstrap_replication(M1, M2):
 def remove_database(inst):
     # remove the database
     inst.stop()
+    if inst.get_db_lib() == 'bdb':
+        for file in glob.glob(f'{inst.ds_paths.db_home_dir}/*'):
+            if os.path.basename(file) in ['__db.001', '__db.002', '__db.003', 'DBVERSION']:
+                os.remove(file)
+
     for file in glob.glob(f'{inst.dbdir}/*'):
         if os.path.islink(file):
             continue


### PR DESCRIPTION
Bug description:
	remove_database removes database files but with bdb
	it does not remove the DB_ENV (/dev/shm/slapd-inst).
	At startup the DB detect incoherency between ENV
	and (not) existing database files then fail

Fix description:
	remove_database also remove env files with bdb

fixes: #6710

Reviewed by: