### PR TITLE
Issue 6700 - CLI/UI - include superior objectclasses' allowed and requires attrs

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_schema_superior_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_schema_superior_test.py
@@ -1,0 +1,122 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import json
+import os
+import subprocess
+import pytest
+from lib389.topologies import topology_st as topo
+
+log = logging.getLogger(__name__)
+
+
+def execute_dsconf_command(dsconf_cmd, subcommands):
+    """Execute dsconf command and return output and return code"""
+
+    cmdline = dsconf_cmd + subcommands
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    return out.decode('utf-8'), proc.returncode
+
+
+def get_dsconf_base_cmd(topo):
+    """Return base dsconf command list"""
+    return ['/usr/sbin/dsconf', topo.standalone.serverid,
+            '-j', 'schema']
+
+
+def test_schema_oc_superior(topo):
+    """Specify a test case purpose or name here
+
+    :id: d12aab4a-1436-43eb-802a-0661281a13d0
+    :setup: Standalone Instance
+    :steps:
+        1. List all the schema
+        2. List all the schema and include superior OC's attrs
+        3. Get objectclass list
+        4. Get objectclass list and include superior OC's attrs
+        5. Get objectclass
+        6. Get objectclass and include superior OC's attrs
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Test default schema list
+    output, rc = execute_dsconf_command(dsconf_cmd, ['list'])
+    assert rc == 0
+    json_result = json.loads(output)
+    for schema_item in json_result:
+        if 'name' in schema_item and schema_item['name'] == 'inetOrgPerson':
+            assert len(schema_item['must']) == 0
+            break
+
+    # Test including the OC superior attributes
+    output, rc = execute_dsconf_command(dsconf_cmd, ['list',
+                                                     '--include-oc-sup'])
+    assert rc == 0
+    json_result = json.loads(output)
+    for schema_item in json_result:
+        if 'name' in schema_item and schema_item['name'] == 'inetOrgPerson':
+            assert len(schema_item['must']) > 0 and \
+                'cn' in schema_item['must'] and 'sn' in schema_item['must']
+            break
+
+    # Test default objectclass list
+    output, rc = execute_dsconf_command(dsconf_cmd, ['objectclasses', 'list'])
+    assert rc == 0
+    json_result = json.loads(output)
+    for schema_item in json_result:
+        if 'name' in schema_item and schema_item['name'] == 'inetOrgPerson':
+            assert len(schema_item['must']) == 0
+            break
+
+    # Test objectclass list and inslude superior attributes
+    output, rc = execute_dsconf_command(dsconf_cmd, ['objectclasses', 'list',
+                                                     '--include-sup'])
+    assert rc == 0
+    json_result = json.loads(output)
+    for schema_item in json_result:
+        if 'name' in schema_item and schema_item['name'] == 'inetOrgPerson':
+            assert len(schema_item['must']) > 0 and \
+                'cn' in schema_item['must'] and 'sn' in schema_item['must']
+            break
+
+    # Test default objectclass query
+    output, rc = execute_dsconf_command(dsconf_cmd, ['objectclasses', 'query',
+                                                     'inetOrgPerson'])
+    assert rc == 0
+    result = json.loads(output)
+    schema_item = result['oc']
+    assert 'names' in schema_item
+    assert schema_item['names'][0] == 'inetOrgPerson'
+    assert len(schema_item['must']) == 0
+
+    # Test objectclass query and include superior attributes
+    output, rc = execute_dsconf_command(dsconf_cmd, ['objectclasses', 'query',
+                                                     'inetOrgPerson',
+                                                     '--include-sup'])
+    assert rc == 0
+    result = json.loads(output)
+    schema_item = result['oc']
+    assert 'names' in schema_item
+    assert schema_item['names'][0] == 'inetOrgPerson'
+    assert len(schema_item['must']) > 0 and 'cn' in schema_item['must'] \
+        and 'sn' in schema_item['must']
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/schema/schema_test.py
+++ b/dirsrvtests/tests/suites/schema/schema_test.py
@@ -232,7 +232,7 @@ def test_gecos_mixed_definition_topo(topo_m2, request):
     repl = ReplicationManager(DEFAULT_SUFFIX)
     m1 = topo_m2.ms["supplier1"]
     m2 = topo_m2.ms["supplier2"]
-    
+
 
     # create a test user
     testuser_dn = 'uid={},{}'.format('testuser', DEFAULT_SUFFIX)
@@ -343,7 +343,7 @@ def test_gecos_directoryString_wins_M1(topo_m2, request):
     repl = ReplicationManager(DEFAULT_SUFFIX)
     m1 = topo_m2.ms["supplier1"]
     m2 = topo_m2.ms["supplier2"]
-    
+
 
     # create a test user
     testuser_dn = 'uid={},{}'.format('testuser', DEFAULT_SUFFIX)
@@ -471,7 +471,7 @@ def test_gecos_directoryString_wins_M2(topo_m2, request):
     repl = ReplicationManager(DEFAULT_SUFFIX)
     m1 = topo_m2.ms["supplier1"]
     m2 = topo_m2.ms["supplier2"]
-    
+
 
     # create a test user
     testuser_dn = 'uid={},{}'.format('testuser', DEFAULT_SUFFIX)
@@ -623,9 +623,8 @@ def test_definition_with_sharp(topology_st, request):
     # start the instances
     inst.start()
 
-    i# Check that server is really running.
+    # Check that server is really running.
     assert inst.status()
-
 
 
 if __name__ == '__main__':

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -873,7 +873,8 @@ export function getAllObjectClasses (serverId, allOcCallback) {
         'ldapi://%2fvar%2frun%2fslapd-' + serverId + '.socket',
         'schema',
         'objectclasses',
-        'list'
+        'list',
+        '--include-sup'
     ];
     const result = [];
     log_cmd("getAllObjectClasses", "", cmd);

--- a/src/cockpit/389-console/src/schema.jsx
+++ b/src/cockpit/389-console/src/schema.jsx
@@ -440,7 +440,8 @@ export class Schema extends React.Component {
             "-j",
             "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "schema",
-            "list"
+            "list",
+            "--include-oc-sup"
         ];
         log_cmd("loadSchemaData", "Get schema objects in one batch", cmd);
         cockpit
@@ -568,7 +569,8 @@ export class Schema extends React.Component {
                 "schema",
                 "objectclasses",
                 "query",
-                name
+                name,
+                "--include-sup"
             ];
 
             log_cmd("openObjectclassModal", "Fetch ObjectClass data from schema", cmd);

--- a/src/lib389/lib389/cli_conf/schema.py
+++ b/src/lib389/lib389/cli_conf/schema.py
@@ -31,7 +31,8 @@ def list_all(inst, basedn, log, args):
     if args is not None and args.json:
         json = True
 
-    objectclass_elems = schema.get_objectclasses(json=json)
+    objectclass_elems = schema.get_objectclasses(include_sup=args.include_oc_sup,
+                                                 json=json)
     attributetype_elems = schema.get_attributetypes(json=json)
     matchingrule_elems = schema.get_matchingrules(json=json)
 
@@ -67,7 +68,7 @@ def list_objectclasses(inst, basedn, log, args):
     log = log.getChild('list_objectclasses')
     schema = Schema(inst)
     if args is not None and args.json:
-        print(dump_json(schema.get_objectclasses(json=True), indent=4))
+        print(dump_json(schema.get_objectclasses(include_sup=args.include_sup, json=True), indent=4))
     else:
         for oc in schema.get_objectclasses():
             print(oc)
@@ -108,7 +109,7 @@ def query_objectclass(inst, basedn, log, args):
     schema = Schema(inst)
     # Need the query type
     oc = _get_arg(args.name, msg="Enter objectclass to query")
-    result = schema.query_objectclass(oc, json=args.json)
+    result = schema.query_objectclass(oc, include_sup=args.include_sup, json=args.json)
     if args.json:
         print(dump_json(result, indent=4))
     else:
@@ -339,6 +340,9 @@ def create_parser(subparsers):
     schema_subcommands = schema_parser.add_subparsers(help='schema')
     schema_list_parser = schema_subcommands.add_parser('list', help='List all schema objects on this system', formatter_class=CustomHelpFormatter)
     schema_list_parser.set_defaults(func=list_all)
+    schema_list_parser.add_argument('--include-oc-sup', action='store_true',
+                                    default=False,
+                                    help="Include the superior objectclasses' \"may\" and \"must\" attributes")
 
     attributetypes_parser = schema_subcommands.add_parser('attributetypes', help='Work with attribute types on this system', formatter_class=CustomHelpFormatter)
     attributetypes_subcommands = attributetypes_parser.add_subparsers(help='schema')
@@ -365,9 +369,11 @@ def create_parser(subparsers):
     objectclasses_subcommands = objectclasses_parser.add_subparsers(help='schema')
     oc_list_parser = objectclasses_subcommands.add_parser('list', help='List available objectClasses on this system', formatter_class=CustomHelpFormatter)
     oc_list_parser.set_defaults(func=list_objectclasses)
+    oc_list_parser.add_argument('--include-sup', action='store_true', default=False, help="Include the superior objectclasses' \"may\" and \"must\" attributes")
     oc_query_parser = objectclasses_subcommands.add_parser('query', help='Query an objectClass', formatter_class=CustomHelpFormatter)
     oc_query_parser.set_defaults(func=query_objectclass)
     oc_query_parser.add_argument('name', nargs='?', help='ObjectClass to query')
+    oc_query_parser.add_argument('--include-sup', action='store_true', default=False, help="Include the superior objectclasses' \"may\" and \"must\" attributes")
     oc_add_parser = objectclasses_subcommands.add_parser('add', help='Add an objectClass to this system', formatter_class=CustomHelpFormatter)
     oc_add_parser.set_defaults(func=add_objectclass)
     _add_parser_args(oc_add_parser, 'objectclasses')


### PR DESCRIPTION
Description:

When you get/list an objectclass it only lists its level of allowed and required objectclasses, but it should also include all its superior objectclasses' allowed and required attributes.

Added an option to the CLI to also include all the parent/superior required and allowed attributes

Relates: https://github.com/389ds/389-ds-base/issues/6700

