### PR TITLE
Issue 6713 - ns-slapd crash during mdb offline import

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -372,7 +372,9 @@ void dbmdb_dup_worker_slot(struct importqueue *q, void *from_slot, void *to_slot
     char *from = from_slot;
     char *to = to_slot;
     int offset = offsetof(WorkerQueueData_t, wait_id);
+    pthread_mutex_lock(&q->mutex);
     memcpy(to+offset, from+offset, (sizeof (WorkerQueueData_t))-offset);
+    pthread_mutex_unlock(&q->mutex);
 }
 
 /* Find a free slot once used_slots == max_slots */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -372,9 +372,7 @@ void dbmdb_dup_worker_slot(struct importqueue *q, void *from_slot, void *to_slot
     char *from = from_slot;
     char *to = to_slot;
     int offset = offsetof(WorkerQueueData_t, wait_id);
-    pthread_mutex_lock(&q->mutex);
     memcpy(to+offset, from+offset, (sizeof (WorkerQueueData_t))-offset);
-    pthread_mutex_unlock(&q->mutex);
 }
 
 /* Find a free slot once used_slots == max_slots */
@@ -419,13 +417,14 @@ dbmdb_import_workerq_push(ImportQueue_t *q, WorkerQueueData_t *data)
             safe_cond_wait(&q->cv, &q->mutex);
         }
     }
-    pthread_mutex_unlock(&q->mutex);
     if (q->job->flags & FLAG_ABORT) {
         /* in this case worker thread does not free the data so we should do it */
         dbmdb_import_workerq_free_data(data);
+        pthread_mutex_unlock(&q->mutex);
         return -1;
     }
     dbmdb_dup_worker_slot(q, data, slot);
+    pthread_mutex_unlock(&q->mutex);
     return 0;
 }
 


### PR DESCRIPTION
Bug description: A segmentation fault is triggered in dbmdb_import_prepare_worker_entry() during an mdb offline import.

The import producer thread parses, validates and writes ldif entries to the worker queue, while the import worker threads simultaneously read, format and index entries before adding them to the DB. A race condition occurs when a worker thread reads an entry before the producer has fully written it, leading to a segmentation fault.

Fix description: Ensure thread safe access by locking the worker queue before writing entries.

Fixes: https://github.com/389ds/389-ds-base/issues/6713

Reviewed by: