### PR TITLE
Issue 6715 - dsconf backend replication monitor fails if replica id starts with 0

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -1258,14 +1258,14 @@ def test_normalized_rid_dict():
         nrd[key] = val
 
     # Check that normalization do something
-    assert nkeys != [ sd.keys() ]
+    assert nkeys != list(sd.keys())
 
     # Check that key stored in NormalizedRidDict are normalized
     for key in nrd.keys():
         assert key in nkeys
 
     # Check that normalized and non normalized keys have the same value
-    for keyl in sd.items():
+    for key,val in sd.items():
         nkey = NormalizedRidDict.normalize_rid(key)
         assert nrd[key] == val
         assert nrd[nkey] == val

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -30,7 +30,10 @@ from lib389.idm.group import Groups, Group
 from lib389.idm.domain import Domain
 from lib389.idm.directorymanager import DirectoryManager
 from lib389.idm.services import ServiceAccounts, ServiceAccount
-from lib389.replica import Replicas, ReplicationManager, ReplicationMonitor, ReplicaRole, BootstrapReplicationManager
+from lib389.replica import (
+    Replicas, ReplicationManager, ReplicationMonitor, ReplicaRole,
+    BootstrapReplicationManager, NormalizedRidDict
+)
 from lib389.agreement import Agreements
 from lib389 import pid_from_file
 from lib389.dseldif import *
@@ -1226,6 +1229,46 @@ def test_rid_starting_with_0(topo_m2, request):
 
     # Get replication monitoring results
     check_monitoring_status(S1)
+
+
+def test_normalized_rid_dict():
+    """Check that lib389.replica NormalizedRidDict class behaves as expected
+
+    :id: 0f88a29c-0fcd-11f0-b5df-482ae39447e5
+    :setup: None
+    :steps:
+        1. Initialize a NormalizedRidDict
+        2. Check that normalization do something
+        3. Check that key stored in NormalizedRidDict are normalized
+        4. Check that normalized and non normalized keys have the same value
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    sd = { '1': 'v1', '020': 'v2' }
+    nsd = { NormalizedRidDict.normalize_rid(key): val for key,val in sd.items() }
+    nkeys = list(nsd.keys())
+
+    # Initialize a NormalizedRidDict
+    nrd = NormalizedRidDict()
+    for key,val in sd.items():
+        nrd[key] = val
+
+    # Check that normalization do something
+    assert nkeys != [ sd.keys() ]
+
+    # Check that key stored in NormalizedRidDict are normalized
+    for key in nrd.keys():
+        assert key in nkeys
+
+    # Check that normalized and non normalized keys have the same value
+    for keyl in sd.items():
+        nkey = NormalizedRidDict.normalize_rid(key)
+        assert nrd[key] == val
+        assert nrd[nkey] == val
 
 
 def test_online_reinit_may_hang(topo_with_sigkill):

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -12,6 +12,7 @@ import time
 import logging
 import ldif
 import ldap
+import pprint
 import pytest
 import subprocess
 import time
@@ -29,7 +30,7 @@ from lib389.idm.group import Groups, Group
 from lib389.idm.domain import Domain
 from lib389.idm.directorymanager import DirectoryManager
 from lib389.idm.services import ServiceAccounts, ServiceAccount
-from lib389.replica import Replicas, ReplicationManager, ReplicaRole, BootstrapReplicationManager
+from lib389.replica import Replicas, ReplicationManager, ReplicationMonitor, ReplicaRole, BootstrapReplicationManager
 from lib389.agreement import Agreements
 from lib389 import pid_from_file
 from lib389.dseldif import *
@@ -1142,6 +1143,89 @@ def test_bulk_import(preserve_topo_m2):
     users_s2 =  s2.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(uid=*)", escapehatch='i am sure')
     log.info(f"{len(users_s2)} user entries found on supplier2")
     assert len(users_s1) == len(users_s2)
+
+
+def check_monitoring_status(inst):
+    creds = { 'binddn': DN_DM, 'bindpw': PW_DM }
+    repl_monitor = ReplicationMonitor(inst)
+    report_dict = repl_monitor.generate_report(lambda h,p: creds, use_json=True)
+    log.debug(f'(Monitoring status: {pprint.pformat(report_dict)}')
+
+    agmts_status = {}
+    for inst_status in report_dict.values():
+        for replica_status in inst_status:
+            suffix = replica_status['replica_root']
+            rid = replica_status['replica_id']
+            for agmt_status in replica_status['agmts_status']:
+                rag_status = agmt_status['replication-status'][0]
+                if 'Unavailable' in rag_status:
+                    aname = agmt_status['agmt-name'][0]
+                    url = f'{agmt_status["replica"][0]}/{suffix}'
+                    assert False, f"'Unavailable' found in agreement {aname} of replica {url} : {rag_status}"
+
+    assert 'Unavailable' not in str(report_dict)
+
+
+def reinit_replica(S1, S2):
+    # Reinit replication
+    agmt = Agreements(S1).list()[0]
+    agmt.begin_reinit()
+    (done, error) = agmt.wait_reinit()
+    assert done is True
+    assert error is False
+
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.wait_for_replication(S1, S2)
+    repl.wait_for_replication(S2, S1)
+
+
+def test_rid_starting_with_0(topo_m2, request):
+    """Check that replication monitoring works if replica
+       id starts with 0
+
+    :id: ed0176e6-0bf7-11f0-9846-482ae39447e5
+    :setup: 2 Supplier Instances
+    :steps:
+        1. Initialize replication to ensure that init status is set
+        2. Check that monitoring status does not contains 'Unavailable'
+        3. Change replica ids to 001 and 002
+        4. Initialize replication to ensure that init status is set
+        5. Check that monitoring status does not contains 'Unavailable'
+        6. Restore the replica ids to 1 and 2
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+    S1 = topo_m2.ms["supplier1"]
+    S2 = topo_m2.ms["supplier2"]
+    replicas = [ Replicas(inst).get(DEFAULT_SUFFIX) for inst in topo_m2 ]
+
+    # Reinit replication (to ensure that init status is set)
+    reinit_replica(S1, S2)
+
+    # Get replication monitoring results
+    check_monitoring_status(S1)
+
+    # Change replica id
+    for replica,rid in zip(replicas, ['010', '020']):
+        replica.replace('nsDS5ReplicaId', rid)
+
+    # Restore replica id in finalizer
+    def fin():
+        for replica,rid in zip(replicas, ['1', '2']):
+            replica.replace('nsDS5ReplicaId', rid)
+        reinit_replica(S1, S2)
+
+    request.addfinalizer(fin)
+    # Reinit replication
+    reinit_replica(S1, S2)
+
+    # Get replication monitoring results
+    check_monitoring_status(S1)
 
 
 def test_online_reinit_may_hang(topo_with_sigkill):

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -60,6 +60,7 @@ from lib389.utils import (
     normalizeDN,
     escapeDNValue,
     ensure_bytes,
+    ensure_int,
     ensure_str,
     ensure_list_str,
     format_cmd_list,
@@ -3424,7 +3425,7 @@ class DirSrv(SimpleLDAPObject, object):
                 # Error
                 consumer.close()
                 return None
-            rid = ensure_str(replica_entries[0].getValue(REPL_ID))
+            rid = ensure_int(replica_entries[0].getValue(REPL_ID))
         except:
             # Error
             consumer.close()
@@ -3441,7 +3442,7 @@ class DirSrv(SimpleLDAPObject, object):
                 return error_msg
             elements = ensure_list_str(entry[0].getValues('nsds50ruv'))
             for ruv in elements:
-                if ('replica %s ' % rid) in ruv:
+                if ('replica %d ' % rid) in ruv:
                     ruv_parts = ruv.split()
                     if len(ruv_parts) == 5:
                         return ruv_parts[4]

--- a/src/lib389/lib389/agreement.py
+++ b/src/lib389/lib389/agreement.py
@@ -161,7 +161,7 @@ class Agreement(DSLdapObject):
         from lib389.replica import Replicas
         replicas = Replicas(self._instance)
         replica = replicas.get(suffix)
-        rid = replica.get_attr_val_utf8(REPL_ID)
+        rid = int(replica.get_attr_val_utf8(REPL_ID))
 
         # Open a connection to the consumer
         consumer = DirSrv(verbose=self._instance.verbose)
@@ -191,12 +191,15 @@ class Agreement(DSLdapObject):
             else:
                 elements = ensure_list_str(entry[0].getValues('nsds50ruv'))
                 for ruv in elements:
-                    if ('replica %s ' % rid) in ruv:
+                    if ('replica %d ' % rid) in ruv:
                         ruv_parts = ruv.split()
                         if len(ruv_parts) == 5:
                             result_msg = ruv_parts[4]
                         break
         except ldap.INVALID_CREDENTIALS as e:
+            self._log.debug('Failed to search for the suffix ' +
+                                     '({}) consumer ({}:{}) failed, error: {}'.format(
+                                         suffix, host, port, e))
             raise(e)
         except ldap.LDAPError as e:
             self._log.debug('Failed to search for the suffix ' +

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -822,23 +822,24 @@ class ReplicaLegacy(object):
             raise ValueError('Failed to update replica: ' + str(e))
 
 
-class _rdict(dict):
+class NormalizedRidDict(dict):
     """A dict whose key is a Normalized Replica ID
     """
 
-    def __init__(self, log):
-        self.d = {}
-        self._log = log
+    @staticmethod
+    def normalize_rid(rid):
+        return int(rid)
+
+    def __init__(self):
+        super().__init__()
 
     def __getitem__(self, key):
-        nkey = int(key)
-        self._log.debug(f'MYDBG: __getitem__ {key} {nkey} {self.__getitem__(nkey)}')
-        return self.__getitem__(nkey)
+        nkey = NormalizedRidDict.normalize_rid(key)
+        return super().__getitem__(nkey)
 
     def __setitem__(self, key, value):
-        nkey = int(key)
-        self._log.debug(f'MYDBG: __setitem__ {key} {nkey} {value}')
-        self.d.__setitem__(nkey, value)
+        nkey = NormalizedRidDict.normalize_rid(key)
+        super().__setitem__(nkey, value)
 
 
 class RUV(object):
@@ -858,11 +859,11 @@ class RUV(object):
         else:
             self._log = logging.getLogger(__name__)
         self._rids = []
-        self._rid_url = _rdict(self._log)
-        self._rid_rawruv = _rdict(self._log)
-        self._rid_csn = _rdict(self._log)
-        self._rid_maxcsn = _rdict(self._log)
-        self._rid_modts = _rdict(self._log)
+        self._rid_url = NormalizedRidDict()
+        self._rid_rawruv = NormalizedRidDict()
+        self._rid_csn = NormalizedRidDict()
+        self._rid_maxcsn = NormalizedRidDict()
+        self._rid_modts = NormalizedRidDict()
         self._data_generation = None
         self._data_generation_csn = None
         # Process the array of data


### PR DESCRIPTION
lib389 fails to retrioeve the csn if the replicaid is not exactly the normalized form of a number
Typically because 010 does not match with the RUV value.
Solution: Ensure that rid get normalized before comparing them or using them in a dict

Issue: #6715 

Reviewed by: @droideck, @tbordaz (Thanks!)