### PR TITLE
lib389: Remove unused runtime requirement on setuptools

### DIFF
--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -4,7 +4,6 @@ python-dateutil
 argcomplete
 argparse-manpage
 python-ldap
-setuptools
 distro
 cryptography
 psutil

--- a/src/lib389/setup.py.in
+++ b/src/lib389/setup.py.in
@@ -96,7 +96,6 @@ setup(
         'argcomplete',
         'argparse-manpage',
         'python-ldap',
-        'setuptools',
         'distro',
         'cryptography',
         'psutil'


### PR DESCRIPTION
The dependency was dropped in c0e2f68423ddde9bb91250d3f96dfc8617889514

Issue: #5642

Reviewed by: @progier389 (Thanks!)