### PR TITLE
Issue 6481 - When ports that are in use are used to update a DS instance the error message is not helpful

### DIFF
--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -221,7 +221,7 @@ export function is_port_in_use(port) {
             return;
         }
 
-        let cmd = ['bash', '-c', `sudo lsof -i :${port} || echo "free"`];
+        let cmd = ['bash', '-c', `ss -ntplu | grep -w :${port} || echo "free"`];
         log_cmd("is_port_in_use", cmd);
 
         cockpit


### PR DESCRIPTION
Bug description: The initial fix for this issue used sudo lsof to determineif a server port was in use. lsof is not installed by default and using sudo can ask for a password.

Fix description: Use ss -ntplu (which is installed by default) to detect if a port is taken.

Fixes: https://github.com/389ds/389-ds-base/issues/6481

Fix Author:  Viktor Ashirov <vashirov@redhat.com>

Reviewed by: