### PR TITLE
Issue 5356 - Set DEFAULT_PASSWORD_STORAGE_SCHEME to PBKDF2-SHA512 in tests

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -99,14 +99,10 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
-    if is_fips():
-        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to SSHA512 in FIPS mode')
-        standalone.config.set('passwordStorageScheme', 'SSHA512')
-        standalone.config.set('nsslapd-rootpwstoragescheme', 'SSHA512')
-    else:
-        log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512')
-        standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
-        standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
+
+    log.info('Set passwordStorageScheme and nsslapd-rootpwstoragescheme to PBKDF2-SHA512')
+    standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
+    standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)

--- a/dirsrvtests/tests/suites/password/pwp_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_test.py
@@ -15,7 +15,7 @@ from lib389.idm.user import UserAccounts, UserAccount
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.config import Config
 from lib389.idm.group import Group
-from lib389.utils import ds_is_older, is_fips
+from lib389.utils import ds_is_older
 import ldap
 import time
 
@@ -24,10 +24,7 @@ pytestmark = pytest.mark.tier1
 if ds_is_older('1.4'):
     DEFAULT_PASSWORD_STORAGE_SCHEME = 'SSHA512'
 else:
-    if is_fips():
-        DEFAULT_PASSWORD_STORAGE_SCHEME = 'SSHA512'
-    else:
-        DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2-SHA512'
+    DEFAULT_PASSWORD_STORAGE_SCHEME = 'PBKDF2-SHA512'
 
 
 def _create_user(topo, uid, cn, uidNumber, userpassword):


### PR DESCRIPTION
Now the default password storage scheme is PBKDF2-SHA512
Hence updating it in the test to reflect current state.
DEFAULT_PASSWORD_STORAGE_SCHEME is now set to PBKDF2-SHA512