### PR TITLE
Issue 6728 - CLI - Issue with user rename operation

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_user_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_test.py
@@ -11,6 +11,7 @@ import subprocess
 import pytest
 import logging
 import os
+import ldap
 
 from lib389 import DEFAULT_SUFFIX
 from lib389.cli_idm.user import list, get, get_dn, create, delete, modify, rename
@@ -167,7 +168,7 @@ def test_dsidm_user_get_rdn(topology_st, create_test_user):
                     'entryid',
                     'entrydn',
                     testuser.dn]
-    
+
     args = FakeArgs()
     args.json = False
     args.selector = 'test_user_1000'
@@ -218,7 +219,7 @@ def test_dsidm_user_get_dn(topology_st, create_test_user):
     log.info('Test dsidm user get_dn without json')
     get_dn(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, content_list=user_name)
-    
+
     log.info('Test dsidm user get_dn with json')
     args.json = True
     get_dn(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -426,6 +427,471 @@ def test_dsidm_user_rename(topology_st, create_test_user):
     log.info('Clean up')
     my_user.delete()
 
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_rename_nonexistent(topology_st):
+    """Test dsidm user rename with nonexistent user
+
+    :id: 284f9cf7-53d4-4f5e-9d2e-ae38081cb4e0
+    :setup: Standalone instance
+    :steps:
+         1. Create a user
+         2. Rename the user from original name to new name
+         3. Try to rename the original name to new name again (should fail)
+         4. Verify the renamed user exists
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Failure - should report that the original user doesn't exist
+         4. Success
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    original_name = 'original_user'
+    new_name = 'renamed_user'
+    renamed_user = None
+
+    try:
+        log.info('Create a user')
+        args = FakeArgs()
+        args.uid = original_name
+        args.cn = original_name
+        args.displayName = original_name
+        args.uidNumber = '1050'
+        args.gidNumber = '2050'
+        args.homeDirectory = f'/home/{original_name}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
+
+        log.info('Rename the user')
+        args = FakeArgs()
+        args.selector = original_name
+        args.new_name = new_name
+        args.keep_old_rdn = False
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
+
+        log.info('Try to rename the nonexistent user')
+        try:
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert False, "The rename operation should have failed for a nonexistent user"
+        except ValueError as e:
+            assert "The entry does not exist" in str(e)
+
+        log.info('Verify the renamed user exists')
+        renamed_user = users.get(new_name)
+        assert renamed_user.exists()
+    finally:
+        log.info('Clean up')
+        for username in [original_name, new_name]:
+            try:
+                user = users.get(username)
+                if user.exists():
+                    user.delete()
+            except:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_rename_same_cn_displayname(topology_st):
+    """Test dsidm user rename when another user has same cn/displayName
+
+    :id: 4b65b68f-aeda-43a0-99b6-f4c65034ba4b
+    :setup: Standalone instance
+    :steps:
+         1. Create first user with uid=user1, cn=testuser, displayName=testuser
+         2. Create second user with uid=user2, cn=testuser, displayName=testuser
+         3. Rename user1 to new_user1
+         4. Try to rename user1 again - should fail as user1 no longer exists
+         5. Verify user2 still exists with original attributes
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Success - user1 is renamed despite shared cn/displayName
+         4. Failure - should report user1 doesn't exist
+         5. Success - user2 is unchanged
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    user1_uid = 'user1'
+    user2_uid = 'user2'
+    common_name = 'testuser'
+    new_name = 'new_user1'
+    renamed_user = None
+    user2 = None
+
+    try:
+        log.info('Create first user')
+        args = FakeArgs()
+        args.uid = user1_uid
+        args.cn = common_name
+        args.displayName = common_name
+        args.uidNumber = '1101'
+        args.gidNumber = '2101'
+        args.homeDirectory = f'/home/{user1_uid}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user1_uid}')
+
+        log.info('Create second user with same cn/displayName')
+        args = FakeArgs()
+        args.uid = user2_uid
+        args.cn = common_name
+        args.displayName = common_name
+        args.uidNumber = '1102'
+        args.gidNumber = '2102'
+        args.homeDirectory = f'/home/{user2_uid}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user2_uid}')
+
+        log.info('Rename first user')
+        args = FakeArgs()
+        args.selector = user1_uid
+        args.new_name = new_name
+        args.keep_old_rdn = False
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
+
+        log.info('Try to rename the first user again')
+        try:
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert False, "The rename operation should have failed since user1 no longer exists"
+        except ValueError as e:
+            assert "The entry does not exist" in str(e)
+
+        log.info('Verify second user still exists with original attributes')
+        user2 = users.get(user2_uid)
+        assert user2.exists()
+        assert user2.get_attr_val_utf8('cn') == common_name
+        assert user2.get_attr_val_utf8('displayName') == common_name
+    finally:
+        log.info('Clean up')
+        for username in [user1_uid, user2_uid, new_name]:
+            try:
+                user = users.get(username)
+                if user.exists():
+                    user.delete()
+            except:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_rename_to_existing_name(topology_st):
+    """Test dsidm user rename to an existing user name
+
+    :id: 410bec4f-ecfb-4662-917c-1e7bf97876f2
+    :setup: Standalone instance
+    :steps:
+         1. Create first user with uid=user1
+         2. Create second user with uid=user2
+         3. Try to rename user1 to user2
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Failure - should report name already in use
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    user1_uid = 'user1_duplicate'
+    user2_uid = 'user2_duplicate'
+    user1 = None
+    user2 = None
+
+    try:
+        log.info('Create first user')
+        args = FakeArgs()
+        args.uid = user1_uid
+        args.cn = user1_uid
+        args.displayName = user1_uid
+        args.uidNumber = '1201'
+        args.gidNumber = '2201'
+        args.homeDirectory = f'/home/{user1_uid}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user1_uid}')
+
+        log.info('Create second user')
+        args = FakeArgs()
+        args.uid = user2_uid
+        args.cn = user2_uid
+        args.displayName = user2_uid
+        args.uidNumber = '1202'
+        args.gidNumber = '2202'
+        args.homeDirectory = f'/home/{user2_uid}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user2_uid}')
+
+        log.info('Try to rename first user to second user name')
+        args = FakeArgs()
+        args.selector = user1_uid
+        args.new_name = user2_uid
+        args.keep_old_rdn = False
+
+        try:
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert False, "The rename operation should have failed"
+        except ldap.ALREADY_EXISTS as e:
+            assert "Already exists" in str(e)
+
+        log.info('Verify both original users still exist')
+        user1 = users.get(user1_uid)
+        user2 = users.get(user2_uid)
+        assert user1.exists()
+        assert user2.exists()
+    finally:
+        log.info('Clean up')
+        for username in [user1_uid, user2_uid]:
+            try:
+                user = users.get(username)
+                if user.exists():
+                    user.delete()
+            except:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_rename_keep_old_rdn_and_search(topology_st):
+    """Test dsidm user rename with keep-old-rdn and search behavior
+
+    :id: 7e9dd9dd-48a5-44c1-a5ec-9882d2bbae97
+    :setup: Standalone instance
+    :steps:
+         1. Create a user
+         2. Rename the user with keep-old-rdn=True
+         3. Verify the user has both the new and old uid values in its entry
+         4. Try to rename by using the old uid as selector
+    :expectedresults:
+         1. Success
+         2. Success - user is renamed with old RDN kept
+         3. Success - both uid values are present
+         4. Failure - should not be able to find the user by its old uid as the DN
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    original_name = 'keep_old_rdn_user'
+    new_name = 'new_keep_old_user'
+    renamed_user = None
+
+    try:
+        log.info('Create a user')
+        args = FakeArgs()
+        args.uid = original_name
+        args.cn = original_name
+        args.displayName = original_name
+        args.uidNumber = '1501'
+        args.gidNumber = '2501'
+        args.homeDirectory = f'/home/{original_name}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
+
+        log.info('Rename the user with keep-old-rdn=True')
+        args = FakeArgs()
+        args.selector = original_name
+        args.new_name = new_name
+        args.keep_old_rdn = True
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
+
+        log.info('Verify that both old and new uid values exist in the entry')
+        renamed_user = users.get(new_name)
+        assert renamed_user.exists()
+
+        # The entry should have both the new and old uid values
+        uid_values = renamed_user.get_attr_vals_utf8('uid')
+        assert new_name in uid_values
+        assert original_name in uid_values
+
+        # Other attributes should remain as they were
+        assert renamed_user.get_attr_val_utf8('cn') == original_name
+        assert renamed_user.get_attr_val_utf8('displayName') == original_name
+
+        log.info('Try to rename using the original name as selector - should fail because entry does not exist at that DN')
+        args.selector = original_name
+        args.new_name = 'another_new_name'
+        args.keep_old_rdn = False
+
+        try:
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert False, "The rename operation should have failed because the entry with original RDN doesn't exist"
+        except ValueError as e:
+            assert "The entry does not exist" in str(e)
+    finally:
+        log.info('Clean up')
+        for username in [original_name, new_name, 'another_new_name']:
+            try:
+                user = users.get(username)
+                if user.exists():
+                    user.delete()
+            except:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_list_rdn_after_rename(topology_st):
+    """Test dsidm user list displays correct RDN after renaming with keep-old-rdn
+
+    :id: 5d8b758d-ddca-427d-9aac-7e4d84d7537e
+    :setup: Standalone instance
+    :steps:
+         1. Create a user
+         2. Rename the user with keep-old-rdn=True
+         3. Run dsidm user list and check the output contains the new name
+         4. Run dsidm user list with json and check it also shows the new name
+         5. Directly verify that the RDN extraction using ldap.dn.str2dn works correctly
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Success - list should show the new name from the DN's RDN
+         4. Success - json output should also show the new name
+         5. Success - RDN value should match the new name, not the old one
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    original_name = 'original_rdn_user'
+    new_name = 'new_rdn_user'
+    renamed_user = None
+
+    try:
+        log.info('Create a user')
+        args = FakeArgs()
+        args.uid = original_name
+        args.cn = original_name
+        args.displayName = original_name
+        args.uidNumber = '1601'
+        args.gidNumber = '2601'
+        args.homeDirectory = f'/home/{original_name}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
+
+        log.info('Rename the user with keep-old-rdn=True')
+        args = FakeArgs()
+        args.selector = original_name
+        args.new_name = new_name
+        args.keep_old_rdn = True
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
+
+        log.info('Test dsidm user list without json')
+        args = FakeArgs()
+        args.json = False
+        list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        # Should show the new name, not the original name
+        check_value_in_log_and_reset(topology_st, check_value=new_name, check_value_not=original_name)
+
+        log.info('Test dsidm user list with json')
+        args.json = True
+        list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        # Should show the new name in JSON output as well
+        check_value_in_log_and_reset(topology_st, check_value=new_name, check_value_not=original_name)
+
+        log.info('Directly verify RDN extraction works correctly')
+        renamed_user = users.get(new_name)
+        # Get the RDN value using ldap.dn.str2dn
+        rdn_components = ldap.dn.str2dn(renamed_user.dn)[0]
+        rdn_value = rdn_components[0][1]  # Get the value part of the RDN
+        assert rdn_value == new_name, f"Expected RDN value '{new_name}' but got '{rdn_value}'"
+
+        # Check that both uid values exist in the entry
+        uid_values = renamed_user.get_attr_vals_utf8('uid')
+        assert new_name in uid_values, f"New uid value '{new_name}' not found in {uid_values}"
+        assert original_name in uid_values, f"Original uid value '{original_name}' not found in {uid_values}"
+    finally:
+        log.info('Clean up')
+        for username in [original_name, new_name]:
+            try:
+                user = users.get(username)
+                if user.exists():
+                    user.delete()
+            except:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_dsidm_user_rename_no_changes(topology_st):
+    """Test dsidm user rename reports no changes when renaming to an RDN value already present
+
+    :id: bda8eddf-1cad-45d6-a0d1-7dca6d1c315c
+    :setup: Standalone instance
+    :steps:
+         1. Create a user
+         2. Rename the user to a new name with keep-old-rdn=True
+         3. Try to rename the user again to the same new name with keep-old-rdn=True
+         4. Verify the message indicates no changes made
+         5. Try to rename the user again to the same new name with keep-old-rdn=False
+         6. Verify the message indicates no changes made again
+         7. Try to use the original name as selector (should fail)
+    :expectedresults:
+         1. Success
+         2. Success - user is renamed and keeps old RDN
+         3. Success - rename operation doesn't error
+         4. Success - message indicates no changes rather than success
+         5. Success - rename operation doesn't error
+         6. Success - message indicates no changes rather than success
+         7. Failure - entry with original name as RDN no longer exists
+    """
+
+    standalone = topology_st.standalone
+    users = nsUserAccounts(standalone, DEFAULT_SUFFIX)
+    original_name = 'no_change_user'
+    new_name = 'renamed_user'
+    test_user = None
+
+    try:
+        log.info('Create a user')
+        args = FakeArgs()
+        args.uid = original_name
+        args.cn = original_name
+        args.displayName = original_name
+        args.uidNumber = '1800'
+        args.gidNumber = '2800'
+        args.homeDirectory = f'/home/{original_name}'
+        create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
+
+        log.info('Rename the user with keep-old-rdn=True')
+        args = FakeArgs()
+        args.selector = original_name
+        args.new_name = new_name
+        args.keep_old_rdn = True
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value='Successfully renamed')
+
+        log.info('Try to rename the user again to the same name with keep-old-rdn=True')
+        # We must use the new name as the selector now, since that's the current RDN
+        args.selector = new_name
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value='No changes made', check_value_not='Successfully renamed')
+
+        log.info('Try to rename the user again with keep-old-rdn=False')
+        args.keep_old_rdn = False
+        rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+        check_value_in_log_and_reset(topology_st, check_value='No changes made', check_value_not='Successfully renamed')
+
+        log.info('Verify the user exists with both original and new RDNs')
+        test_user = users.get(new_name)
+        assert test_user.exists()
+        assert original_name in test_user.get_attr_vals_utf8('uid')
+        assert new_name in test_user.get_attr_vals_utf8('uid')
+
+        log.info('Try to use the original name as selector (should fail)')
+        args.selector = original_name
+        args.new_name = 'another_name'
+        try:
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert False, "The rename operation should have failed because the entry with original RDN doesn't exist"
+        except ValueError as e:
+            assert "The entry does not exist" in str(e)
+
+    finally:
+        log.info('Clean up')
+        try:
+            if test_user and test_user.exists():
+                test_user.delete()
+        except:
+            pass
 
 if __name__ == '__main__':
     # Run isolated

--- a/dirsrvtests/tests/suites/clu/dsidm_user_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_test.py
@@ -739,7 +739,7 @@ def test_dsidm_user_list_rdn_after_rename(topology_st):
          2. Rename the user with keep-old-rdn=True
          3. Run dsidm user list and check the output contains the new name
          4. Run dsidm user list with json and check it also shows the new name
-         5. Directly verify that the RDN extraction using ldap.dn.str2dn works correctly
+         5. Directly verify that the RDN extraction works correctly
     :expectedresults:
          1. Success
          2. Success
@@ -789,9 +789,7 @@ def test_dsidm_user_list_rdn_after_rename(topology_st):
 
         log.info('Directly verify RDN extraction works correctly')
         renamed_user = users.get(new_name)
-        # Get the RDN value using ldap.dn.str2dn
-        rdn_components = ldap.dn.str2dn(renamed_user.dn)[0]
-        rdn_value = rdn_components[0][1]  # Get the value part of the RDN
+        rdn_value = renamed_user.get_rdn_from_dn(renamed_user.dn)
         assert rdn_value == new_name, f"Expected RDN value '{new_name}' but got '{rdn_value}'"
 
         # Check that both uid values exist in the entry

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -301,7 +301,7 @@ class DSLdapObject(DSLogging, DSLint):
         if value is None:
             # We are just checking if SOMETHING is present ....
             return len(values) > 0
-        
+
         # Otherwise, we are checking a specific value
         if is_a_dn(value):
             normalized_value = normalizeDN(value)

--- a/src/lib389/lib389/cli_idm/__init__.py
+++ b/src/lib389/lib389/cli_idm/__init__.py
@@ -111,7 +111,10 @@ def _generic_list(inst, basedn, log, manager_class, args=None):
         if args and args.json:
             json_result = {"type": "list", "items": []}
         for o in ol:
-            o_str = o.__unicode__()
+            # Get the RDN value directly from the DN using ldap.dn.str2dn
+            # This ensures we get the actual RDN value even if keep-old-rdn was used
+            rdn_components = ldap.dn.str2dn(o.dn)[0]
+            o_str = rdn_components[0][1]  # Get the value part of the RDN
             if args and args.json:
                 json_result['items'].append(o_str)
             else:
@@ -152,8 +155,10 @@ def _generic_create(inst, basedn, log, manager_class, kwargs, args=None):
     except ldap.NO_SUCH_OBJECT:
         raise ValueError(f'The base DN "{mc._basedn}" does not exist')
 
-    o_str = o.__unicode__()
-    log.info('Successfully created %s' % o_str)
+    # Extract the RDN value directly from the DN using ldap.dn.str2dn
+    rdn_components = ldap.dn.str2dn(o.dn)[0]
+    rdn_value = rdn_components[0][1]  # Get the value part of the RDN
+    log.info('Successfully created %s' % rdn_value)
 
 
 def _generic_delete(inst, basedn, log, object_class, dn, args=None):
@@ -173,8 +178,18 @@ def _generic_rename_inner(log, o, new_rdn, newsuperior=None, deloldrdn=None):
         arguments['newsuperior'] = newsuperior
     if deloldrdn is not None:
         arguments['deloldrdn'] = deloldrdn
+
+    # Store original state for comparison
+    old_dn = o.dn
+
+    # Perform the rename operation
     o.rename(**arguments)
-    log.info('Successfully renamed to %s' % o.dn)
+
+    # Check if anything actually changed
+    if old_dn == o.dn:
+        log.info('No changes made - entry already has this name')
+    else:
+        log.info('Successfully renamed to %s' % o.dn)
 
 
 def _generic_rename(inst, basedn, log, manager_class, selector, args=None):
@@ -183,12 +198,16 @@ def _generic_rename(inst, basedn, log, manager_class, selector, args=None):
     # Here, we should have already selected the type etc. mc should be a
     # type of DSLdapObjects (plural)
     mc = manager_class(inst, basedn)
-    # Get the object singular by selector
     try:
-        o = mc.get(selector)
+        rdn_attr = mc._childobject(inst)._rdn_attribute
+        entry_dn = f"{rdn_attr}={selector},{mc._basedn}"
+        o = mc._childobject(inst, dn=entry_dn)
+
+        if not o.exists():
+            raise ldap.NO_SUCH_OBJECT()
     except ldap.NO_SUCH_OBJECT:
         raise ValueError(f'The entry does not exist')
-    rdn_attr = ldap.dn.str2dn(o.dn)[0][0][0]
+
     arguments = {'new_rdn': f'{rdn_attr}={args.new_name}'}
     if args.keep_old_rdn:
         arguments['deloldrdn'] = False

--- a/src/lib389/lib389/cli_idm/__init__.py
+++ b/src/lib389/lib389/cli_idm/__init__.py
@@ -111,10 +111,7 @@ def _generic_list(inst, basedn, log, manager_class, args=None):
         if args and args.json:
             json_result = {"type": "list", "items": []}
         for o in ol:
-            # Get the RDN value directly from the DN using ldap.dn.str2dn
-            # This ensures we get the actual RDN value even if keep-old-rdn was used
-            rdn_components = ldap.dn.str2dn(o.dn)[0]
-            o_str = rdn_components[0][1]  # Get the value part of the RDN
+            o_str = o.get_rdn_from_dn(o.dn)
             if args and args.json:
                 json_result['items'].append(o_str)
             else:
@@ -155,9 +152,7 @@ def _generic_create(inst, basedn, log, manager_class, kwargs, args=None):
     except ldap.NO_SUCH_OBJECT:
         raise ValueError(f'The base DN "{mc._basedn}" does not exist')
 
-    # Extract the RDN value directly from the DN using ldap.dn.str2dn
-    rdn_components = ldap.dn.str2dn(o.dn)[0]
-    rdn_value = rdn_components[0][1]  # Get the value part of the RDN
+    rdn_value = o.get_rdn_from_dn(o.dn)
     log.info('Successfully created %s' % rdn_value)
 
 


### PR DESCRIPTION
Description: Fix the RDN extraction method in _generic_list to correctly display renamed user entries regardless of keep-old-rdn status.

Improve the _generic_rename function to properly handle nonexistent users and detect when no actual changes are made.

Add test cases for various rename scenarios including nonexistent users, duplicate names, keep-old-rdn behavior, and listing after rename. Enhance error handling for edge cases like renaming to an existing username.

Fixes: https://github.com/389ds/389-ds-base/issues/6728

Reviewed by: ?