### PR TITLE
Issue 6515 - CLI - dsidm get_dn does not return JSON format

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_account_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_test.py
@@ -1,21 +1,24 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
-import ldap
-import time
-import subprocess
-import pytest
 import logging
 import os
-
+import json
+import pytest
+import ldap
 from lib389 import DEFAULT_SUFFIX
-from lib389.cli_idm.account import list, get_dn, lock, unlock, delete, modify, rename, entry_status, \
-    subtree_status, reset_password, change_password
+from lib389.cli_idm.account import (
+    get_dn,
+    lock,
+    unlock,
+    entry_status,
+    subtree_status,
+)
 from lib389.topologies import topology_st
 from lib389.cli_base import FakeArgs
 from lib389.utils import ds_is_older
@@ -33,6 +36,7 @@ def create_test_user(topology_st, request):
     log.info('Create test user')
     users = nsUserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
     test_user = users.create_test_user()
+    log.info('Created test user: %s', test_user.dn)
 
     def fin():
         log.info('Delete test user')
@@ -77,7 +81,7 @@ def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
                   'Entry Modification Date']
 
     state_lock = 'Entry State: directly locked through nsAccountLock'
-    state_unlock= 'Entry State: activated'
+    state_unlock = 'Entry State: activated'
 
     lock_msg = 'Entry {} is locked'.format(test_user.dn)
     unlock_msg = 'Entry {} is unlocked'.format(test_user.dn)
@@ -94,7 +98,8 @@ def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
 
     log.info('Test dsidm account entry-status')
     entry_status(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
-    check_value_in_log_and_reset(topology_st, content_list=entry_list, check_value=state_unlock)
+    check_value_in_log_and_reset(topology_st, content_list=entry_list,
+                                 check_value=state_unlock)
 
     log.info('Test dsidm account lock')
     lock(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -102,11 +107,13 @@ def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
 
     log.info('Test dsidm account subtree-status with locked account')
     subtree_status(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
-    check_value_in_log_and_reset(topology_st, content_list=entry_list, check_value=state_lock)
+    check_value_in_log_and_reset(topology_st, content_list=entry_list,
+                                 check_value=state_lock)
 
     log.info('Test dsidm account entry-status with locked account')
     entry_status(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
-    check_value_in_log_and_reset(topology_st, content_list=entry_list, check_value=state_lock)
+    check_value_in_log_and_reset(topology_st, content_list=entry_list,
+                                 check_value=state_lock)
 
     log.info('Test dsidm account unlock')
     unlock(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -114,11 +121,53 @@ def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
 
     log.info('Test dsidm account subtree-status with unlocked account')
     subtree_status(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
-    check_value_in_log_and_reset(topology_st, content_list=entry_list, check_value=state_unlock)
+    check_value_in_log_and_reset(topology_st, content_list=entry_list,
+                                 check_value=state_unlock)
 
     log.info('Test dsidm account entry-status with unlocked account')
     entry_status(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
-    check_value_in_log_and_reset(topology_st, content_list=entry_list, check_value=state_unlock)
+    check_value_in_log_and_reset(topology_st, content_list=entry_list,
+                                 check_value=state_unlock)
+
+
+def test_dsidm_account_entry_get_by_dn(topology_st, create_test_user):
+    """ Test dsidm account get_dn works with non-json and json
+
+    :id: dd848f67c-9944-48a4-ae5e-98dce4fbc364
+    :setup: Standalone instance
+    :steps:
+        1. Get user by DN (non-json)
+        2. Get user by DN (json)
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+
+    inst = topology_st.standalone
+    user_dn = "uid=test_user_1000,ou=people,dc=example,dc=com"
+
+    args = FakeArgs()
+    args.dn = user_dn
+    args.json = False
+    args.basedn = DEFAULT_SUFFIX
+    args.scope = ldap.SCOPE_SUBTREE
+    args.filter = "(uid=*)"
+    args.become_inactive_on = False
+    args.inactive_only = False
+
+    # Test non-json result
+    check_val = "homeDirectory: /home/test_user_1000"
+    get_dn(inst, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    check_value_in_log_and_reset(topology_st, check_value=check_val)
+
+    # Test json
+    args.json = True
+    get_dn(inst, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+
+    result = topology_st.logcap.get_raw_outputs()
+    json_result = json.loads(result[0])
+    assert json_result['dn'] == user_dn
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/dirsrvtests/tests/suites/clu/dsidm_group_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_group_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -8,6 +8,7 @@
 #
 
 import pytest
+import json
 import logging
 import os
 
@@ -445,6 +446,7 @@ def test_dsidm_group_members_add_remove(topology_st, create_test_group):
 
     args = FakeArgs()
     args.cn = group_name
+    args.json = False
 
     log.info('Test dsidm group members to show no associated members')
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -459,6 +461,14 @@ def test_dsidm_group_members_add_remove(topology_st, create_test_group):
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_with_member)
 
+    # Test json
+    args.json = True
+    members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    result = topology_st.logcap.get_raw_outputs()
+    json_result = json.loads(result[0])
+    assert len(json_result['members']) == 1
+    args.json = False
+
     log.info('Test dsidm group remove_member')
     remove_member(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_remove_member)
@@ -466,6 +476,14 @@ def test_dsidm_group_members_add_remove(topology_st, create_test_group):
     log.info('Verify the added member is no longer associated with the group')
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_no_member)
+
+    # Test json
+    args.json = True
+    members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    result = topology_st.logcap.get_raw_outputs()
+    json_result = json.loads(result[0])
+    assert len(json_result['members']) == 0
+    args.json = False
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/clu/dsidm_uniquegroup_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_uniquegroup_test.py
@@ -8,6 +8,7 @@
 #
 
 import pytest
+import json
 import logging
 import os
 
@@ -445,6 +446,7 @@ def test_dsidm_uniquegroup_members_add_remove(topology_st, create_test_uniquegro
 
     args = FakeArgs()
     args.cn = uniquegroup_name
+    args.json = False
 
     log.info('Test dsidm uniquegroup members to show no associated members')
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -459,6 +461,14 @@ def test_dsidm_uniquegroup_members_add_remove(topology_st, create_test_uniquegro
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_with_member)
 
+    # Test json
+    args.json = True
+    members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    result = topology_st.logcap.get_raw_outputs()
+    json_result = json.loads(result[0])
+    assert len(json_result['members']) == 1
+    args.json = False
+
     log.info('Test dsidm uniquegroup remove_member')
     remove_member(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_remove_member)
@@ -466,6 +476,14 @@ def test_dsidm_uniquegroup_members_add_remove(topology_st, create_test_uniquegro
     log.info('Verify the added member is no longer associated with the uniquegroup')
     members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
     check_value_in_log_and_reset(topology_st, check_value=output_no_member)
+
+    # Test json
+    args.json = True
+    members(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    result = topology_st.logcap.get_raw_outputs()
+    json_result = json.loads(result[0])
+    assert len(json_result['members']) == 0
+    args.json = False
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/cli_idm/__init__.py
+++ b/src/lib389/lib389/cli_idm/__init__.py
@@ -1,6 +1,6 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2016, William Brown <william at blackhats.net.au>
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -140,9 +140,12 @@ def _generic_get(inst, basedn, log, manager_class, selector, args=None):
 
 def _generic_get_dn(inst, basedn, log, manager_class, dn, args=None):
     mc = manager_class(inst, basedn)
-    o = mc.get(dn=dn)
-    o_str = o.display()
-    log.info(o_str)
+    if args is not None and args.json:
+        o = mc.get(dn=dn, json=True)
+        log.info(o)
+    else:
+        o = mc.get(dn=dn)
+        log.info(o.display())
 
 
 def _generic_create(inst, basedn, log, manager_class, kwargs, args=None):

--- a/src/lib389/lib389/cli_idm/account.py
+++ b/src/lib389/lib389/cli_idm/account.py
@@ -91,7 +91,7 @@ def entry_status(inst, basedn, log, args):
 
 
 def subtree_status(inst, basedn, log, args):
-    filter = ""
+    filter = "(objectclass=*)"
     scope = ldap.SCOPE_SUBTREE
     epoch_inactive_time = None
     if args.scope == "one":

--- a/src/lib389/lib389/cli_idm/group.py
+++ b/src/lib389/lib389/cli_idm/group.py
@@ -1,12 +1,13 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2016, William Brown <william at blackhats.net.au>
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import json
 from lib389.idm.group import Group, Groups, MUST_ATTRIBUTES
 from lib389.cli_base import populate_attr_arguments, _generic_modify, CustomHelpFormatter
 from lib389.cli_idm import (
@@ -71,10 +72,18 @@ def members(inst, basedn, log, args):
     # Display members?
     member_list = group.list_members()
     if len(member_list) == 0:
-        log.info('No members to display')
+        if args is not None and args.json:
+            json_result = {"type": "list", "members": []}
+            log.info(json.dumps(json_result, indent=4))
+        else:
+            log.info('No members to display')
     else:
-        for m in member_list:
-            log.info('dn: %s' % m)
+        if args is not None and args.json:
+            json_result = {"type": "list", "members": member_list}
+            log.info(json.dumps(json_result, indent=4))
+        else:
+            for m in member_list:
+                log.info('dn: %s' % m)
 
 
 def add_member(inst, basedn, log, args):

--- a/src/lib389/lib389/cli_idm/role.py
+++ b/src/lib389/lib389/cli_idm/role.py
@@ -108,17 +108,25 @@ def entry_status(inst, basedn, log, args):
 
 def subtree_status(inst, basedn, log, args):
     basedn = _get_dn_arg(args.basedn, msg="Enter basedn to check")
-    filter = ""
-    scope = ldap.SCOPE_SUBTREE
-
-    role_list = Roles(inst, basedn).filter(filter, scope)
+    role_list = Roles(inst, basedn).list()
     if not role_list:
         raise ValueError(f"No entries were found under {basedn} or the user doesn't have an access")
 
+    if args.json:
+        json_result = {"type": "status", "entries": []}
+
     for entry in role_list:
         status = entry.status()
-        log.info(f'Entry DN: {entry.dn}')
-        log.info(f'Entry State: {status["state"].describe(status["role_dn"])}\n')
+        if args.json:
+            json_result['entries'].append({
+                "dn": entry.dn,
+                "state": status["state"].describe(status["role_dn"])
+            })
+        else:
+            log.info(f'Entry DN: {entry.dn}')
+            log.info(f'Entry State: {status["state"].describe(status["role_dn"])}\n')
+    if args.json:
+        log.info(json.dumps(json_result))
 
 
 def lock(inst, basedn, log, args):

--- a/src/lib389/lib389/cli_idm/uniquegroup.py
+++ b/src/lib389/lib389/cli_idm/uniquegroup.py
@@ -6,6 +6,7 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import json
 from lib389.idm.group import UniqueGroup, UniqueGroups, MUST_ATTRIBUTES
 from lib389.cli_base import populate_attr_arguments, _generic_modify, CustomHelpFormatter
 from lib389.cli_idm import (
@@ -70,10 +71,18 @@ def members(inst, basedn, log, args):
     # Display members?
     member_list = group.list_members()
     if len(member_list) == 0:
-        log.info('No members to display')
+        if args is not None and args.json:
+            json_result = {"type": "list", "members": []}
+            log.info(json.dumps(json_result, indent=4))
+        else:
+            log.info('No members to display')
     else:
-        for m in member_list:
-            log.info('dn: %s' % m)
+        if args is not None and args.json:
+            json_result = {"type": "list", "members": member_list}
+            log.info(json.dumps(json_result, indent=4))
+        else:
+            for m in member_list:
+                log.info('dn: %s' % m)
 
 
 def add_member(inst, basedn, log, args):


### PR DESCRIPTION
Description:

The get_dn() functions do not check for the JSON flag.  Also added a LogCapture function to return the the raw results so we can do json validation.  Also did some other minor python lint cleanup.

Relates: https://github.com/389ds/389-ds-base/issues/6515

