### PR TITLE
Issue 6735 - CLI - dsidm provide option to set decription when creating an entry

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_group_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_group_test.py
@@ -80,6 +80,7 @@ def test_dsidm_group_create(topology_st):
 
     args = FakeArgs()
     args.cn = group_name
+    args.description = "my description"
 
     log.info('Test dsidm group create')
     create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -89,6 +90,7 @@ def test_dsidm_group_create(topology_st):
     groups = Groups(standalone, DEFAULT_SUFFIX)
     new_group = groups.get(group_name)
     assert new_group.exists()
+    assert new_group.present('description', 'my description')
 
     log.info('Clean up for next test')
     new_group.delete()

--- a/src/lib389/lib389/cli_idm/__init__.py
+++ b/src/lib389/lib389/cli_idm/__init__.py
@@ -74,7 +74,7 @@ def _get_basedn_arg(inst, args, basedn, log, msg=None):
 
 
 # This is really similar to get_args, but generates from an array
-def _get_attributes(args, attrs):
+def _get_attributes(args, attrs, optional_attrs=None):
     kwargs = {}
     for attr in attrs:
         # Python can't represent a -, so it replaces it to _
@@ -87,6 +87,13 @@ def _get_attributes(args, attrs):
                 kwargs[attr] = getpass("Enter value for %s : " % attr)
             else:
                 kwargs[attr] = input("Enter value for %s : " % attr)
+
+    if optional_attrs is not None:
+        for attr in optional_attrs:
+            attr_normal = attr.replace('-', '_')
+            if hasattr(args, attr_normal) and getattr(args, attr_normal) is not None:
+                kwargs[attr] = getattr(args, attr_normal)
+
     return kwargs
 
 

--- a/src/lib389/lib389/cli_idm/group.py
+++ b/src/lib389/lib389/cli_idm/group.py
@@ -8,7 +8,7 @@
 # --- END COPYRIGHT BLOCK ---
 
 import json
-from lib389.idm.group import Group, Groups, MUST_ATTRIBUTES
+from lib389.idm.group import Group, Groups, MAY_ATTRIBUTES, MUST_ATTRIBUTES
 from lib389.cli_base import populate_attr_arguments, _generic_modify, CustomHelpFormatter
 from lib389.cli_idm import (
     _generic_list,
@@ -44,7 +44,7 @@ def get_dn(inst, basedn, log, args):
 
 
 def create(inst, basedn, log, args):
-    kwargs = _get_attributes(args, MUST_ATTRIBUTES)
+    kwargs = _get_attributes(args, MUST_ATTRIBUTES, MAY_ATTRIBUTES)
     _generic_create(inst, basedn, log.getChild('_generic_create'), MANY, kwargs, args)
 
 
@@ -123,9 +123,10 @@ def create_parser(subparsers):
     get_dn_parser.set_defaults(func=get_dn)
     get_dn_parser.add_argument('dn', nargs='?', help='The dn to get')
 
-    create_parser = subcommands.add_parser('create', help='create', formatter_class=CustomHelpFormatter)
-    create_parser.set_defaults(func=create)
-    populate_attr_arguments(create_parser, MUST_ATTRIBUTES)
+    create_group_parser = subcommands.add_parser('create', help='create',
+                                                 formatter_class=CustomHelpFormatter)
+    create_group_parser.set_defaults(func=create)
+    populate_attr_arguments(create_group_parser, MUST_ATTRIBUTES + MAY_ATTRIBUTES)
 
     delete_parser = subcommands.add_parser('delete', help='deletes the object', formatter_class=CustomHelpFormatter)
     delete_parser.set_defaults(func=delete)

--- a/src/lib389/lib389/idm/group.py
+++ b/src/lib389/lib389/idm/group.py
@@ -15,6 +15,9 @@ from lib389._constants import DSRC_HOME
 MUST_ATTRIBUTES = [
     'cn',
 ]
+MAY_ATTRIBUTES = [
+    'description'
+]
 RDN = 'cn'
 DEFAULT_BASEDN_RDN = 'ou=Groups'
 DEFAULT_BASEDN_RDN_ADMIN_GROUPS = 'ou=People'


### PR DESCRIPTION
Description:

In the Web UI when you create a group, and other entries, you can set the description during the "add", but dsidm only allows you to set it after creating the entry. To be consistent UI and CLI should work the same way

Relates: https://github.com/389ds/389-ds-base/issues/6735
