### PR TITLE
Issue 6736 - Exception thrown by dsconf instance repl get_ruv

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -1271,6 +1271,47 @@ def test_normalized_rid_dict():
         assert nrd[nkey] == val
 
 
+def test_get_with_normalized_rid_dict():
+    """Check lib389.replica NormalizedRidDict.get() function
+
+    :id: 4422e1be-1619-11f0-a37a-482ae39447e5
+    :setup: None
+    :steps:
+        1. Initialize a NormalizedRidDict
+        2. Check that normalization do something
+        3. Check that get() returns the expected value
+        4. Check get() with wrong key
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Should return the default value if it is provided
+           otherwise it should raise a KeyError exception
+    """
+
+    sd = { '1': 'v1', '020': 'v2' }
+    nsd = { NormalizedRidDict.normalize_rid(key): val for key,val in sd.items() }
+    nkeys = list(nsd.keys())
+
+    # Initialize a NormalizedRidDict
+    nrd = NormalizedRidDict()
+    for key,val in sd.items():
+        nrd[key] = val
+
+    # Check that get() returns the expected value
+    for key,val in sd.items():
+        nkey = NormalizedRidDict.normalize_rid(key)
+        assert nrd.get(key) == val
+        assert nrd.get(nkey) == val
+        assert nrd.get(key, 'foo') == val
+        assert nrd.get(nkey, 'foo') == val
+
+    # Check get() with wrong key
+    assert nrd.get('99', 'foo2') == 'foo2'
+    with pytest.raises(KeyError):
+        nrd.get('bad')
+
+
 def test_online_reinit_may_hang(topo_with_sigkill):
     """Online reinitialization may hang when the first
        entry of the DB is RUV entry instead of the suffix

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -1286,7 +1286,7 @@ def test_get_with_normalized_rid_dict():
         2. Success
         3. Success
         4. Should return the default value if it is provided
-           otherwise it should raise a KeyError exception
+           otherwise it should return None
     """
 
     sd = { '1': 'v1', '020': 'v2' }
@@ -1308,8 +1308,9 @@ def test_get_with_normalized_rid_dict():
 
     # Check get() with wrong key
     assert nrd.get('99', 'foo2') == 'foo2'
-    with pytest.raises(KeyError):
-        nrd.get('bad')
+    assert nrd.get('099', 'foo2') == 'foo2'
+    assert nrd.get('99') is None
+    assert nrd.get('099') is None
 
 
 def test_online_reinit_may_hang(topo_with_sigkill):

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -841,13 +841,11 @@ class NormalizedRidDict(dict):
         nkey = NormalizedRidDict.normalize_rid(key)
         super().__setitem__(nkey, value)
 
-    def get(self, key, *args):
-        if len(args) > 0:
-            try:
-                return self[key]
-            except KeyError:
-                return args[0]
-        return self[key]
+    def get(self, key, vdef=None):
+        try:
+            return self[key]
+        except KeyError:
+            return vdef
 
 
 class RUV(object):
@@ -919,7 +917,7 @@ class RUV(object):
             ValueError("Wrong CSN value was supplied")
 
         timestamp = int(csn[:8], 16)
-        time_str = datetime.datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+        time_str = datetime.datetime.fromtimestamp(timestamp, datetime.UTC).strftime('%Y-%m-%d %H:%M:%S')
         # We are parsing shorter CSN which contains only timestamp
         if len(csn) == 8:
             return time_str

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -841,6 +841,14 @@ class NormalizedRidDict(dict):
         nkey = NormalizedRidDict.normalize_rid(key)
         super().__setitem__(nkey, value)
 
+    def get(self, key, *args):
+        if len(args) > 0:
+            try:
+                return self[key]
+            except KeyError:
+                return args[0]
+        return self[key]
+
 
 class RUV(object):
     """Represents the server in memory RUV object. The RUV contains each
@@ -986,6 +994,10 @@ class RUV(object):
             if my_csn < other_csn:
                 return False
         return True
+
+    def __str__(self):
+        return str(self.format_ruv())
+
 
 
 class ChangelogLDIF(object):


### PR DESCRIPTION
After issue #6715 commit `dsconf instance replication get_ruv` fails with error
because by default NormalizedRidDict does not calling __getitem__ as I expected.
The solution is to overwrite the get function to do things properly.

Issue: #6736
Relates: #6715 

Reviewed by: @droideck (Thanks!)