### PR TITLE
Issue 6492/6493 - CLI - dsdim can not create nested/filtered roles

### DIFF
--- a/dirsrvtests/tests/suites/acl/roledn_test.py
+++ b/dirsrvtests/tests/suites/acl/roledn_test.py
@@ -88,7 +88,7 @@ def _add_user(request, topo):
     nestedroles = NestedRoles(topo.standalone, OU_ROLE)
     for i in [('role2', [ROLE1, ROLE21]), ('role3', [ROLE2, ROLE31])]:
         nestedroles.create(properties={'cn': i[0],
-                                       'nsRoleDN': i[1]})
+                                       'nsroledn': i[1]})
 
     managedroles = ManagedRoles(topo.standalone, OU_ROLE)
     for i in ['ROLE1', 'ROLE21', 'ROLE31']:
@@ -111,7 +111,7 @@ def _add_user(request, topo):
             'gidNumber': '2000',
             'homeDirectory': '/home/' + i[0],
             'userPassword': PW_DM,
-            'nsRoleDN': i[1],
+            'nsroledn': i[1],
             'Description': i[2]
         })
 

--- a/dirsrvtests/tests/suites/acl/userattr_test.py
+++ b/dirsrvtests/tests/suites/acl/userattr_test.py
@@ -109,7 +109,7 @@ def _add_user(topo):
             'facsimiletelephonenumber': "+1 408 555 9751",
             'roomnumber': i[3],
             'Description': i[3],
-            'nsRoleDN': i[2]
+            'nsroledn': i[2]
         })
 
     for demo1 in [('ROLEDNACCESS', ROLE1),

--- a/dirsrvtests/tests/suites/clu/dsidm_role_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_role_test.py
@@ -151,7 +151,6 @@ def test_dsidm_role_create_managed(topology_st):
     log.info('Clean up for next test')
     new_managed_role.delete()
 
-@pytest.mark.xfail(reason="DS6492")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_role_create_filtered(topology_st):
     """ Test dsidm role create-filtered option
@@ -173,6 +172,7 @@ def test_dsidm_role_create_filtered(topology_st):
 
     args = FakeArgs()
     args.cn = filtered_role_name
+    args.nsrolefilter = "(cn=*)"
 
     log.info('Test dsidm role create-filtered')
     create_filtered(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -189,7 +189,6 @@ def test_dsidm_role_create_filtered(topology_st):
     new_filtered_role.delete()
 
 
-@pytest.mark.xfail(reason="DS6493")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_role_create_nested(topology_st, create_test_managed_role):
     """ Test dsidm role create-nested option
@@ -214,7 +213,7 @@ def test_dsidm_role_create_nested(topology_st, create_test_managed_role):
 
     args = FakeArgs()
     args.cn = nested_role_name
-    args.nsRoleDN = managed_role.dn
+    args.nsroledn = managed_role.dn
 
     log.info('Test dsidm role create-nested')
     create_nested(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -231,7 +230,6 @@ def test_dsidm_role_create_nested(topology_st, create_test_managed_role):
     new_nested_role.delete()
 
 
-@pytest.mark.xfail(reason="DS6488")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_role_delete(topology_st, create_test_managed_role):
     """ Test dsidm role delete
@@ -266,7 +264,6 @@ def test_dsidm_role_delete(topology_st, create_test_managed_role):
     assert not test_managed_role.exists()
 
 
-@pytest.mark.xfail(reason="DS6488")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 def test_dsidm_role_list(topology_st, create_test_managed_role):
     """ Test dsidm role list option
@@ -405,7 +402,6 @@ def test_dsidm_role_get(topology_st, role_name, fixture, objectclasses, request)
     check_value_in_log_and_reset(topology_st, content_list=json_content)
 
 
-@pytest.mark.xfail(reason="DS6503")
 @pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
 @pytest.mark.parametrize(
     "role_name, fixture, objectclasses",

--- a/dirsrvtests/tests/suites/roles/basic_test.py
+++ b/dirsrvtests/tests/suites/roles/basic_test.py
@@ -296,17 +296,17 @@ def test_nestedrole(topo, _final):
     # Create nested role entry
     nested_roles = NestedRoles(topo.standalone, DEFAULT_SUFFIX)
     nested_role = nested_roles.create(properties={"cn": 'nested_role',
-                                                  "nsRoleDN": [managed_role1.dn, managed_role2.dn]})
+                                                  "nsroledn": [managed_role1.dn, managed_role2.dn]})
 
     # Create user and assign managed role to it
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     user1 = users.create_test_user(uid=1, gid=1)
-    user1.set('nsRoleDN', managed_role1.dn)
+    user1.set('nsroledn', managed_role1.dn)
     user1.set('userPassword', PW_DM)
 
     # Create another user and assign managed role to it
     user2 = users.create_test_user(uid=2, gid=2)
-    user2.set('nsRoleDN', managed_role2.dn)
+    user2.set('nsroledn', managed_role2.dn)
     user2.set('userPassword', PW_DM)
 
     # Create another user and do not assign any role to it

--- a/src/lib389/lib389/cli_idm/role.py
+++ b/src/lib389/lib389/cli_idm/role.py
@@ -16,6 +16,7 @@ from lib389.idm.role import (
     FilteredRoles,
     NestedRoles,
     MUST_ATTRIBUTES,
+    MUST_ATTRIBUTES_FILTERED,
     MUST_ATTRIBUTES_NESTED,
     RDN,
     )
@@ -61,7 +62,7 @@ def create_managed(inst, basedn, log, args):
 
 
 def create_filtered(inst, basedn, log, args):
-    kwargs = _get_attributes(args, MUST_ATTRIBUTES)
+    kwargs = _get_attributes(args, MUST_ATTRIBUTES_FILTERED)
     _generic_create(inst, basedn, log.getChild('_generic_create'), FilteredRoles, kwargs, args)
 
 
@@ -74,7 +75,7 @@ def delete(inst, basedn, log, args, warn=True):
     dn = _get_dn_arg(args.dn, msg="Enter dn to delete")
     if warn:
         _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
-    _generic_delete(inst, basedn, log.getChild('_generic_delete'), SINGULAR, dn, args)
+    _generic_delete(inst, basedn, log.getChild('_generic_delete'), Role, dn, args)
 
 
 def modify(inst, basedn, log, args, warn=True):

--- a/src/lib389/lib389/idm/role.py
+++ b/src/lib389/lib389/idm/role.py
@@ -19,9 +19,14 @@ MUST_ATTRIBUTES = [
 ]
 MUST_ATTRIBUTES_NESTED = [
     'cn',
-    'nsRoleDN'
+    'nsroledn'
+]
+MUST_ATTRIBUTES_FILTERED = [
+    'cn',
+    'nsrolefilter'
 ]
 RDN = 'cn'
+
 
 class RoleState(Enum):
     ACTIVATED = "activated"
@@ -54,6 +59,7 @@ class Role(DSLdapObject):
             'LDAPsubentry',
             'nsRoleDefinition',
         ]
+        self._protected = False
 
     def _format_status_message(self, message, role_dn=None):
         return {"state": message, "role_dn": role_dn}
@@ -120,7 +126,7 @@ class Role(DSLdapObject):
             except ldap.NO_SUCH_OBJECT:
                 # We don't use "ensure_state" because we want to preserve the existing attributes
                 disabled_role = nested_roles.create(properties={"cn": "nsDisabledRole",
-                                                                "nsRoleDN": managed_role.dn})
+                                                                "nsroledn": managed_role.dn})
             disabled_role.add("nsRoleDN", self.dn)
 
             inact_containers = nsContainers(inst, basedn=root_suffix)
@@ -246,6 +252,7 @@ class Roles(DSLdapObjects):
 
         return result
 
+
 class FilteredRole(Role):
     """A single instance of FilteredRole entry to create FilteredRole role
 
@@ -259,9 +266,7 @@ class FilteredRole(Role):
         super(FilteredRole, self).__init__(instance, dn)
         self._rdn_attribute = RDN
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsFilteredRoleDefinition']
-
         self._protected = False
-
 
 
 class FilteredRoles(Roles):
@@ -276,6 +281,7 @@ class FilteredRoles(Roles):
     def __init__(self, instance, basedn):
         super(FilteredRoles, self).__init__(instance, basedn)
         self._objectclasses = ['LDAPsubentry', 'nsComplexRoleDefinition', 'nsFilteredRoleDefinition']
+        self._must_attributes = MUST_ATTRIBUTES_FILTERED
         self._filterattrs = ['cn']
         self._basedn = basedn
         self._childobject = FilteredRole
@@ -294,8 +300,8 @@ class ManagedRole(Role):
         super(ManagedRole, self).__init__(instance, dn)
         self._rdn_attribute = RDN
         self._create_objectclasses = ['nsSimpleRoleDefinition', 'nsManagedRoleDefinition']
-
         self._protected = False
+
 
 class ManagedRoles(Roles):
     """DSLdapObjects that represents all Managed Roles entries
@@ -330,8 +336,8 @@ class NestedRole(Role):
         self._must_attributes = MUST_ATTRIBUTES_NESTED
         self._rdn_attribute = RDN
         self._create_objectclasses = ['nsComplexRoleDefinition', 'nsNestedRoleDefinition']
-
         self._protected = False
+
 
 class NestedRoles(Roles):
     """DSLdapObjects that represents all NestedRoles entries in suffix.


### PR DESCRIPTION
Description:

Filtered role cannot be created using "dsidm role create-filtered" command, as it doesn't accept necessary attribute nsRoleFilter and fails with object class violation.

Nested role fails with an error:
DEBUG: Attribute nsRoleDN must not be None

This was caused by the case of the attirubte name, which needed to be set to all lowercase

Relates: https://github.com/389ds/389-ds-base/issues/6493
Relates: https://github.com/389ds/389-ds-base/issues/6492
