### PR TITLE
Issue 6744 - BUG - memory accounting is not always enabled

### DIFF
--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -23,6 +23,10 @@ ExecStartPre=+@libexecdir@/ds_systemd_ask_password_acl @instconfigdir@/slapd-%i/
 ExecStartPre=+@libexecdir@/ds_selinux_restorecon.sh @instconfigdir@/slapd-%i/dse.ldif
 ExecStart=@sbindir@/ns-slapd -D @instconfigdir@/slapd-%i -i /run/@package_name@/slapd-%i.pid
 
+# Not all distributions enable the memory accounting cgroup hierachy by default. Ensure that it
+# is present so that automatic database tuning works as expected
+MemoryAccounting=yes
+
 # Allow non-root instances to bind to low ports.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_CHOWN


### PR DESCRIPTION
Bug Description: On some distributions memory account is not enabled by default. This leads to a number of warnings from db autotuning that the cgroup memory limit can not be read

Fix Description: Explicitly request memory accounting is enabled in our service file to ensure that it is available at runtime.

fixes: https://github.com/389ds/389-ds-base/issues/6744

Author: William Brown <william@blackhats.net.au>

Review by: ???