### PR TITLE
Issue 6734 - BUG - format strings may not contain backslash

### DIFF
--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -1301,8 +1301,9 @@ class DSLdapObjects(DSLogging, DSLints):
             raise ldap.NO_SUCH_OBJECT(f"No object exists given the filter criteria: {criteria} {search_filter}")
         if len(results) > 1:
             entry_dn = [e.dn for e in results]
+            entry_dns_pretty = '\n    '.join(entry_dn)
             raise ldap.UNWILLING_TO_PERFORM(f"Too many objects matched selection criteria: {criteria} {search_filter}"
-                                            f" - Please use 'get-by-dn' to specify which entry to get:\n    {'\n    '.join(entry_dn)}")
+                                            f" - Please use 'get-by-dn' to specify which entry to get:\n    {entry_dns_pretty}")
         if json:
             return self._entry_to_instance(results[0].dn, results[0]).get_all_attrs_json()
         else:


### PR DESCRIPTION
Bug Description: Format strings may not contain backslashes in older versions of python 3 (3.6/3.9 for example).

Fix Description: pre-format the strings.

fixes: https://github.com/389ds/389-ds-base/issues/6734

Author: William Brown <william@blackhats.net.au>

Review by: ???