### PR TITLE
Issue 6756 - CLI, UI - Properly handle disabled NDN cache

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -198,7 +198,7 @@ export class Database extends React.Component {
         });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "config", "get", "nsslapd-ndn-cache-max-size"
+            "config", "get", "nsslapd-ndn-cache-max-size", "nsslapd-ndn-cache-enabled"
         ];
         log_cmd("loadNDN", "Load NDN cache size", cmd);
         cockpit
@@ -206,10 +206,12 @@ export class Database extends React.Component {
                 .done(content => {
                     const config = JSON.parse(content);
                     const attrs = config.attrs;
+                    const ndn_cache_enabled = attrs['nsslapd-ndn-cache-enabled'][0] === "on";
                     this.setState(prevState => ({
                         globalDBConfig: {
                             ...prevState.globalDBConfig,
                             ndncachemaxsize: attrs['nsslapd-ndn-cache-max-size'][0],
+                            ndn_cache_enabled: ndn_cache_enabled,
                         },
                         configUpdated: 0,
                         loaded: true,

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -2,12 +2,16 @@ import cockpit from "cockpit";
 import React from "react";
 import { log_cmd } from "../tools.jsx";
 import {
+    Alert,
     Button,
     Checkbox,
+    Form,
     Grid,
     GridItem,
+    Hr,
     NumberInput,
     Spinner,
+    Switch,
     Tab,
     Tabs,
     TabTitleText,
@@ -853,11 +857,28 @@ export class GlobalDatabaseConfig extends React.Component {
                             <Tab eventKey={3} title={<TabTitleText>{_("NDN Cache")}</TabTitleText>}>
                                 <div className="ds-left-indent-md">
                                     <Grid
+                                        title={_("Warning: Normalized DN Cache is disabled")}
+                                        className="ds-margin-top-xlg"
+                                    >
+                                        {this.props.data.ndn_cache_enabled === false && (
+                                            <GridItem span={8}>
+                                                <Alert
+                                                    variant="warning"
+                                                    isInline
+                                                    title={_("Normalized DN Cache is disabled")}
+                                                    className="ds-margin-bottom"
+                                                >
+                                                    {_("The Normalized DN Cache is currently disabled. To enable it, go to Server Settings → Tuning & Limits and enable 'Normalized DN Cache', then restart the server for the changes to take effect.")}
+                                                </Alert>
+                                            </GridItem>
+                                        )}
+                                    </Grid>
+                                    <Grid
                                         title={_("Set the maximum size in bytes for the Normalized DN Cache (nsslapd-ndn-cache-max-size).")}
                                         className="ds-margin-top-xlg"
                                     >
                                         <GridItem className="ds-label" span={4}>
-                                            {_("Normalized DN Cache Max Size")}
+                                            {_("Normalized DN Cache Max Size") }
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
@@ -873,9 +894,9 @@ export class GlobalDatabaseConfig extends React.Component {
                                                 plusBtnAriaLabel="plus"
                                                 widthChars={10}
                                                 validated={'ndncachemaxsize' in this.state.error &&
-                                                    this.state.error['ndncachemaxsize']
-                                                     ? ValidatedOptions.error
-                                                     : ValidatedOptions.default}
+                                                           this.state.error['ndncachemaxsize']
+                                                            ? ValidatedOptions.error
+                                                            : ValidatedOptions.default}
                                             />
                                         </GridItem>
                                     </Grid>
@@ -1470,7 +1491,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                             <Tab eventKey={0} title={<TabTitleText>{_("Database Size")}</TabTitleText>}>
                                 <div className="ds-left-indent-md">
                                     <Grid
-                                        title={_("Database maximum size in megabytes. The practical maximum size of an LMDB database is limited by the system’s addressable memory (nsslapd-mdb-max-size).")}
+                                        title={_("Database maximum size in megabytes. The practical maximum size of an LMDB database is limited by the system's addressable memory (nsslapd-mdb-max-size).")}
                                         className="ds-margin-top-xlg"
                                     >
                                         <GridItem className="ds-label" span={4}>
@@ -1641,6 +1662,23 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
                             <Tab eventKey={4} title={<TabTitleText>{_("NDN Cache")}</TabTitleText>}>
                                 <div className="ds-left-indent-md">
+                                    <Grid
+                                        title={_("Warning: Normalized DN Cache is disabled")}
+                                        className="ds-margin-top-xlg"
+                                    >
+                                        {this.props.data.ndn_cache_enabled === false && (
+                                            <GridItem span={8}>
+                                                <Alert
+                                                    variant="warning"
+                                                    isInline
+                                                    title={_("Normalized DN Cache is disabled")}
+                                                    className="ds-margin-bottom"
+                                                >
+                                                    {_("The Normalized DN Cache is currently disabled. To enable it, go to Server Settings → Tuning & Limits and enable 'Normalized DN Cache', then restart the server for the changes to take effect.")}
+                                                </Alert>
+                                            </GridItem>
+                                        )}
+                                    </Grid>
                                     <Grid
                                         title={_("Set the maximum size in bytes for the Normalized DN Cache (nsslapd-ndn-cache-max-size).")}
                                         className="ds-margin-top-xlg"


### PR DESCRIPTION
Description: Fix the db_monitor function in monitor.py to check if nsslapd-ndn-cache-enabled is off and conditionally include NDN cache statistics only when enabled.

Update dbMonitor.jsx components to detect when NDN cache is disabled and conditionally render NDN cache tabs, charts, and related content with proper fallback display when disabled.

Add test_ndn_cache_disabled to verify both JSON and non-JSON output formats correctly handle when NDN cache is turned off and on.

Fixes: https://github.com/389ds/389-ds-base/issues/6756

Reviewed by: ?