### PR TITLE
Issue 6727 - RFE - database compaction interval should be persistent

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_config.c
@@ -805,6 +805,32 @@ done:
 }
 
 static void *
+bdb_config_db_compactdb_starttime_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)((uintptr_t)(BDB_CONFIG(li)->bdb_compactdb_starttime));
+}
+
+static int32_t
+bdb_config_db_compactdb_starttime_set(void *arg,
+                                      void *value,
+                                      char *errorbuf __attribute__((unused)),
+                                      int phase __attribute__((unused)),
+                                      int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    int32_t retval = LDAP_SUCCESS;
+    uint64_t val = (uint64_t)((uintptr_t)value);
+
+    if (apply) {
+        BDB_CONFIG(li)->bdb_compactdb_starttime = val;
+    }
+
+    return retval;
+}
+
+static void *
 bdb_config_db_page_size_get(void *arg)
 {
     struct ldbminfo *li = (struct ldbminfo *)arg;
@@ -1600,6 +1626,7 @@ static config_info bdb_config_param[] = {
     {CONFIG_DB_CHECKPOINT_INTERVAL, CONFIG_TYPE_INT, "60", &bdb_config_db_checkpoint_interval_get, &bdb_config_db_checkpoint_interval_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_COMPACTDB_INTERVAL, CONFIG_TYPE_INT, "2592000" /*30days*/, &bdb_config_db_compactdb_interval_get, &bdb_config_db_compactdb_interval_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_COMPACTDB_TIME, CONFIG_TYPE_STRING, "23:59", &bdb_config_db_compactdb_time_get, &bdb_config_db_compactdb_time_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_DB_COMPACTDB_STARTTIME, CONFIG_TYPE_UINT64, "0" , &bdb_config_db_compactdb_starttime_get, &bdb_config_db_compactdb_starttime_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH, CONFIG_TYPE_INT, "0", &bdb_get_batch_transactions, &bdb_set_batch_transactions, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH_MIN_SLEEP, CONFIG_TYPE_INT, "50", &bdb_get_batch_txn_min_sleep, &bdb_set_batch_txn_min_sleep, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DB_TRANSACTION_BATCH_MAX_SLEEP, CONFIG_TYPE_INT, "50", &bdb_get_batch_txn_max_sleep, &bdb_set_batch_txn_max_sleep, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.h
@@ -91,8 +91,9 @@ typedef struct bdb_config
     int bdb_previous_lock_config;  /* Max lock count when we last shut down--
                                       * used to determine if we delete the mpool */
     u_int32_t bdb_deadlock_policy; /* i.e. the atype to DB_ENV->lock_detect in bdb_deadlock_threadmain */
-    int bdb_compactdb_interval;    /* interval to execute compact id2entry dbs */
-    char *bdb_compactdb_time;       /* time of day to execute compact id2entry dbs */
+    int bdb_compactdb_interval;       /* interval to execute compact id2entry dbs */
+    char *bdb_compactdb_time;         /* time of day to execute compact id2entry dbs */
+    uint64_t bdb_compactdb_starttime; /* the time the interval was started */
 } bdb_config;
 
 int bdb_init(struct ldbminfo *li, config_info *config_array);
@@ -226,7 +227,7 @@ int bdb_dse_conf_verify(struct ldbminfo *li, char *src_dir);
 int bdb_import_file_check_fn_t(ldbm_instance *inst);
 dbi_dbslist_t *bdb_list_dbs(const char *dbhome);
 int bdb_public_in_import(ldbm_instance *inst);
-int bdb_dblayer_cursor_iterate(dbi_cursor_t *cursor, 
+int bdb_dblayer_cursor_iterate(dbi_cursor_t *cursor,
                            int (*action_cb)(dbi_val_t *key, dbi_val_t *data, void *ctx),
                            const dbi_val_t *startingkey, void *ctx);
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -85,6 +85,7 @@ struct config_info
 #define CONFIG_DB_CHECKPOINT_INTERVAL "nsslapd-db-checkpoint-interval"
 #define CONFIG_DB_COMPACTDB_INTERVAL "nsslapd-db-compactdb-interval"
 #define CONFIG_DB_COMPACTDB_TIME "nsslapd-db-compactdb-time"
+#define CONFIG_DB_COMPACTDB_STARTTIME "nsslapd-db-compactdb-starttime"
 #define CONFIG_DB_TRANSACTION_BATCH "nsslapd-db-transaction-batch-val"
 #define CONFIG_DB_TRANSACTION_BATCH_MIN_SLEEP "nsslapd-db-transaction-batch-min-wait"
 #define CONFIG_DB_TRANSACTION_BATCH_MAX_SLEEP "nsslapd-db-transaction-batch-max-wait"


### PR DESCRIPTION
Description:

Record when we start the compaction interval in the ldbm config entry so if we restart the server compaction will still take place at the intended interval

Relates: https://github.com/389ds/389-ds-base/issues/6727

