### PR TITLE
Issue 6761 - Password modify extended operation should skip password policy checks when executed by root DN

### DIFF
--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -1374,6 +1374,15 @@ op_shared_allow_pw_change(Slapi_PBlock *pb, LDAPMod *mod, char **old_pw, Slapi_M
             rc = -1;
             goto done;
         }
+    } else if (pw_is_pwp_admin(pb, pwpolicy, PWP_ADMIN_OR_ROOTDN)) {
+        /* This is an internal operation, but we still need to check if this
+         * is a password admin */
+        if (!SLAPI_IS_MOD_DELETE(mod->mod_op) && pwpolicy->pw_history) {
+            /* Updating pw history, get the old password */
+            get_old_pw(pb, &sdn, old_pw);
+        }
+        rc = 1;
+        goto done;
     }
 
     /* check if password is within password minimum age;


### PR DESCRIPTION
Description:

When the LDAP password policy extended operation is executed by root DN on a regular user under constraints of a password policy, eg password history, it should skip password policy checks because the root DN should be allowed to set a regular user password to any value however this is currently not the case.

The fix is to check if the bind is a pwd admin and set SLAPI_REQUESTOR_ISROOT for the new internal operation that will update the password. This does not bypass aci evalaution.

relates: https://github.com/389ds/389-ds-base/issues/6761
