### PR TITLE
Issue 6755 - RFE use of Session Tracking Control in replication agree…

### DIFF
--- a/dirsrvtests/tests/suites/replication/acceptance_test.py
+++ b/dirsrvtests/tests/suites/replication/acceptance_test.py
@@ -616,13 +616,19 @@ def test_password_repl_error(topo_m4, create_entry):
 
     m1 = topo_m4.ms["supplier1"]
     m2 = topo_m4.ms["supplier2"]
+    m3 = topo_m4.ms["supplier3"]
+    m4 = topo_m4.ms["supplier4"]
     TEST_ENTRY_NEW_PASS = 'new_{}'.format(TEST_ENTRY_NAME)
 
     log.info('Clean the error log')
     m2.deleteErrorLogs()
 
     log.info('Set replication loglevel')
+    m1.config.loglevel((ErrorLog.REPLICA,))
     m2.config.loglevel((ErrorLog.REPLICA,))
+    m3.config.loglevel((ErrorLog.REPLICA,))
+    m4.config.loglevel((ErrorLog.REPLICA,))
+
 
     log.info('Modifying entry {} - change userpassword on supplier 2'.format(TEST_ENTRY_DN))
     test_user_m1 = UserAccount(topo_m4.ms["supplier1"], TEST_ENTRY_DN)

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -433,6 +433,8 @@ int agmt_set_transportinfo_from_entry(Repl_Agmt *ra, const Slapi_Entry *e, PRBoo
 int agmt_set_port_from_entry(Repl_Agmt *ra, const Slapi_Entry *e);
 int agmt_set_host_from_entry(Repl_Agmt *ra, const Slapi_Entry *e);
 const char *agmt_get_long_name(const Repl_Agmt *ra);
+void agmt_set_session_id(Repl_Agmt *ra);
+char *agmt_get_session_id(Repl_Agmt *ra);
 int agmt_initialize_replica(const Repl_Agmt *agmt);
 void agmt_replica_init_done(const Repl_Agmt *agmt);
 void agmt_notify_change(Repl_Agmt *ra, Slapi_PBlock *pb);
@@ -634,6 +636,7 @@ void conn_set_agmt_changed(Repl_Connection *conn);
 ConnResult conn_read_result(Repl_Connection *conn, int *message_id);
 ConnResult conn_read_result_ex(Repl_Connection *conn, char **retoidp, struct berval **retdatap, LDAPControl ***returned_controls, int send_msgid, int *resp_msgid, int noblock);
 LDAP *conn_get_ldap(Repl_Connection *conn);
+const Repl_Agmt *conn_get_agmt(Repl_Connection *conn);
 void conn_lock(Repl_Connection *conn);
 void conn_unlock(Repl_Connection *conn);
 void conn_delete_internal_ext(Repl_Connection *conn);

--- a/ldap/servers/slapd/control.c
+++ b/ldap/servers/slapd/control.c
@@ -167,6 +167,37 @@ slapi_get_supported_controls_copy(char ***ctrloidsp, unsigned long **ctrlopsp)
     return (0);
 }
 
+int
+create_sessiontracking_ctrl(const char *session_tracking_id, LDAPControl **session_tracking_ctrl)
+{
+    BerElement *ctrlber = NULL;
+    char *undefined_sid = "undefined sid";
+    char *sid;
+    int rc = 0;
+    int tag;
+    LDAPControl *ctrl = NULL;
+
+    if (session_tracking_id) {
+        sid = session_tracking_id;
+    } else {
+        sid = undefined_sid;
+    }
+    ctrlber = ber_alloc();
+    tag = ber_printf( ctrlber, "{nnno}", sid, strlen(sid));
+    if (rc == LBER_ERROR) {
+        tag = -1;
+        goto done;
+    }
+    slapi_build_control(LDAP_CONTROL_X_SESSION_TRACKING, ctrlber, 0, &ctrl);
+    *session_tracking_ctrl = ctrl;
+
+done:
+    if (ctrlber) {
+        ber_free(ctrlber, 1);
+    }
+    return rc;
+}
+
 /* Parse the Session Tracking control
  * see https://datatracker.ietf.org/doc/html/draft-wahl-ldap-session-03
  *    LDAPString ::= OCTET STRING -- UTF-8 encoded

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5599,6 +5599,7 @@ int slapi_get_supported_controls_copy(char ***ctrloidsp,
                                       unsigned long **ctrlopsp);
 int slapi_build_control(char *oid, BerElement *ber, char iscritical, LDAPControl **ctrlp);
 int slapi_build_control_from_berval(char *oid, struct berval *bvp, char iscritical, LDAPControl **ctrlp);
+int create_sessiontracking_ctrl(const char *session_tracking_id, LDAPControl **session_tracking_ctrl);
 
 /* Given an array of controls e.g. LDAPControl **ctrls, add the given
    control to the end of the array, growing the array with realloc


### PR DESCRIPTION
…ment

Bug description:
	Replication agreement can use Session Tracking Control
	to correlated replication sessions between suppliers
	and consumers.
	Since https://github.com/389ds/389-ds-base/issues/6367 the
	server sides (consumer) logs session tracking control in
	access logs.
	This ticket is to implement the client side (supplier)

Fix description:
	This is described  https://www.port389.org/docs/389ds/design/session-identifier-clients.html
	Each replication agreement implement a session identifier
	string that is sent for each replicated operation
	including extended op.
	The session identifier is logged, on client side,
	if the replication debug log is turned on

fixes: #6755

Reviewed by: