### PR TITLE
Issue 4835 - dsconf display an incomplete help with changelog setting

### DIFF
--- a/ldap/servers/plugins/replication/cl5_config.c
+++ b/ldap/servers/plugins/replication/cl5_config.c
@@ -286,7 +286,7 @@ cldb_config_modify(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *entryAfter, in
                     } else {
                         if (returntext) {
                             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
-                                        "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdD]",
+                                        "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdDwW]",
                                         CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, config_attr_value ? config_attr_value : "null",
                                         CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE,
                                         (long long int)LONG_MAX);
@@ -300,7 +300,7 @@ cldb_config_modify(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *entryAfter, in
                     } else {
                         if (returntext) {
                             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
-                                        "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdD]",
+                                        "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdDwW]",
                                         CONFIG_CHANGELOG_TRIM_ATTRIBUTE, config_attr_value,
                                         CONFIG_CHANGELOG_TRIM_ATTRIBUTE,
                                         (long long int)LONG_MAX);


### PR DESCRIPTION
Description:
	Upon entering an invalid max-age parameter into dsconf replication set-changelog, it displays an error message that doesn't contain all the valid time units.
	This adds the missing "week" unit to the error message.

Fixes: https://github.com/389ds/389-ds-base/issues/4835