### PR TITLE
Issue 4253 - Container bind mount schema

### DIFF
--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -18,7 +18,7 @@ import socket
 import subprocess
 import getpass
 import configparser
-from lib389 import _ds_shutil_copytree, DirSrv
+from lib389 import DirSrv
 from lib389._constants import *
 from lib389.properties import *
 from lib389.passwd import password_hash, password_generate
@@ -900,7 +900,13 @@ class SetupDs(object):
         #  This is a little fragile, make it better.
         # It won't matter when we move schema to usr anyway ...
 
-        _ds_shutil_copytree(os.path.join(slapd['sysconf_dir'], 'dirsrv/schema'), slapd['schema_dir'])
+        shutil.copytree(
+            os.path.join(slapd["sysconf_dir"], "dirsrv/schema"),
+            slapd["schema_dir"],
+            copy_function=shutil.copy,
+            # Schema directory might be bind mounted, ingore it
+            dirs_exist_ok=True,
+        )
         os.chown(slapd['schema_dir'], slapd['user_uid'], slapd['group_gid'])
         os.chmod(slapd['schema_dir'], 0o770)
 


### PR DESCRIPTION
Bug Description:
When you mount a volume with schema into container, instance creation fails with:
```
Traceback (most recent call last):
  File "/usr/libexec/dirsrv/dscontainer", line 489, in <module>
    begin_magic()
    ~~~~~~~~~~~^^
  File "/usr/libexec/dirsrv/dscontainer", line 279, in begin_magic
    if not sds.create_from_args(g2b.collect(), s2b.collect()):
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/lib389/instance/setup.py", line 759, in create_from_args
    self._install_ds(general, slapd, backends)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/lib389/instance/setup.py", line 903, in _install_ds
    _ds_shutil_copytree(os.path.join(slapd['sysconf_dir'], 'dirsrv/schema'), slapd['schema_dir'])
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/lib389/__init__.py", line 230, in _ds_shutil_copytree
    os.makedirs(dst)
    ~~~~~~~~~~~^^^^^
  File "<frozen os>", line 227, in makedirs
FileExistsError: [Errno 17] File exists: '/etc/dirsrv/slapd-localhost/schema'
```

`_ds_shutil_copytree()` is an outdated copy of the `shutil.copytree()` from Python 3.5. In the later versions `dirs_exist_ok` parameter was introduced, but it was never backported to our implementation.

Fix Description:
Instead of the custom implementation, use standard `shutil.copytree()` function, but ignore existing directories (`dirs_exist_ok=True`) and use `copy` instead of `copy2` to ignore file metadata.

Fixes: https://github.com/389ds/389-ds-base/issues/4253