### PR TITLE
Issue 6768 - ns-slapd crashes when a referral is added

### DIFF
--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -902,7 +902,9 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                         /* Free the results if not "no_such_object" */
                         void *sr = NULL;
                         slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_SET, &sr);
-                        be->be_search_results_release(&sr);
+                        if (be->be_search_results_release != NULL) {
+                            be->be_search_results_release(&sr);
+                        }
                     }
                     pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
                     rc = pagedresults_set_current_be(pb_conn, NULL, pr_idx, 1);


### PR DESCRIPTION
Bug description: When a paged result search is successfully run on a referred suffix, we retrieve the search result set from the pblock and try to release it. In this case the search result set is NULL, which triggers a SEGV during the release.

Fix description: If the search result code is LDAP_REFERRAL, skip deletion of the search result set. Added test case.

Fixes: https://github.com/389ds/389-ds-base/issues/6768

Reviewed by: @progier389, @tbordaz 