### PR TITLE
Issue 6784 - Support of Entry cache pinned entries

### DIFF
--- a/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
+++ b/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
@@ -16,7 +16,7 @@ from contextlib import suppress
 from lib389.backend import Backends
 from lib389.cli_base import FakeArgs
 from lib389.cli_ctl.dbgen import dbgen_create_groups
-from lib389.config import BDB_LDBMConfig
+from lib389.config import BDB_LDBMConfig, LMDB_LDBMConfig
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.dirsrv_log import DirsrvErrorLog
 from lib389.tasks import ImportTask
@@ -137,6 +137,10 @@ def prepare_be(topology_st, request):
     if get_default_db_lib() == 'bdb':
         config_ldbm = BDB_LDBMConfig(inst)
         config_ldbm.set('nsslapd-cache-autosize', '0')
+    else:
+        config_ldbm = LMDB_LDBMConfig(inst)
+        config_ldbm.set('nsslapd-cache-autosize', '0')
+
     # Set entry cache large enough to hold all the large groups
     # and with a limited number of entries to trigger eviction
     be1.replace('nsslapd-cachememsize',  '8000000' )

--- a/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
+++ b/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
@@ -32,6 +32,8 @@ os.environ['DS389_MDB_MAX_SIZE'] = str(200 * 1024 * 1024)
 
 SEED = 195707
 
+CONFIG_ATTR_PINNED_ENTRIES = 'nsslapd-cache-pinned-entries'
+
 # Ensure that the dn, attributes and values are not sorted
 class LdifScrambler(ldif.LDIFParser):
 
@@ -187,7 +189,7 @@ def test_entry_cache_eviction(topology_st, prepare_be):
     inst = topology_st.standalone
     bename, suffix, be1, people_base, groups_base = prepare_be
 
-    be1.replace('nsslapd-cache-preserved-entries', '10')
+    be1.replace(CONFIG_ATTR_PINNED_ENTRIES, '10')
     # Search all groups then all people to try to evict the groups from entrycache
     inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
     inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
@@ -198,8 +200,7 @@ def test_entry_cache_eviction(topology_st, prepare_be):
     assert len(adds) == 5
     assert len(dels) == 0
 
-
-    be1.replace('nsslapd-cache-preserved-entries', '0')
+    be1.replace(CONFIG_ATTR_PINNED_ENTRIES, '0')
     # Search all people to evict groups from entrycache
     inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
     # Check error logs
@@ -217,7 +218,7 @@ def test_entry_cache_eviction(topology_st, prepare_be):
     assert len(adds) == 5+5
     assert len(dels) == 5+5
 
-    be1.replace('nsslapd-cache-preserved-entries', '4')
+    be1.replace(CONFIG_ATTR_PINNED_ENTRIES, '4')
     # Search all groups then all people to try to evict the groups from entrycache
     inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
     inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')

--- a/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
+++ b/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
@@ -1,0 +1,233 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import logging
+import pytest
+import ldap
+import ldif
+import random
+from contextlib import suppress
+from lib389.backend import Backends
+from lib389.cli_base import FakeArgs
+from lib389.cli_ctl.dbgen import dbgen_create_groups
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.dirsrv_log import DirsrvErrorLog
+from lib389.tasks import ImportTask
+from lib389.topologies import topology_st
+
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+logging.getLogger(__name__).setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+os.environ['DS389_MDB_MAX_SIZE'] = str(200 * 1024 * 1024)
+
+SEED = 195707
+
+# Ensure that the dn, attributes and values are not sorted
+class LdifScrambler(ldif.LDIFParser):
+
+    def __init__(self, ldifin, ldifout):
+        self.fdin = open(ldifin, 'rb')
+        self.fdout = open(ldifout, 'wt')
+        super().__init__(self.fdin)
+        self.writer = ldif.LDIFWriter(self.fdout)
+        self.others = []
+        self.users = []
+        self.user5 = []
+        self.groups = []
+        self.group5 = []
+
+    def close_fds(self):
+        self.fdin.close()
+        self.fdout.close()
+
+    def handle(self,dn,entry):
+        if 'cn=myGroup-5,ou=groups,dc=entrycache_test,dc=example,dc=com' in dn:
+            self.group5.append((dn, entry))
+        elif ',ou=groups,dc=entrycache_test,dc=example,dc=com' in dn:
+            self.groups.append((dn, entry))
+        elif 'uid=group_entry5-' in dn:
+            self.user5.append((dn, entry))
+        elif 'uid=group_entry' in dn:
+            self.users.append((dn, entry))
+        else:
+            self.others.append((dn, entry))
+
+    def scramble(self):
+        self.parse()
+        log.debug(f'{len(self.others)} entries in self.others')
+        log.debug(f'{len(self.users)} entries in self.users')
+        log.debug(f'{len(self.user5)} entries in self.user5')
+        log.debug(f'{len(self.groups)} entries in self.groups')
+        log.debug(f'{len(self.group5)} entries in self.group5')
+        for dn, entry in self.others:
+            self.writer.unparse(dn, entry)
+        self.scramble_entry(self.users)
+        self.scramble_entry(self.groups)
+        self.scramble_entry(self.user5)
+        self.scramble_entry(self.group5)
+
+    def scramble_entry(self, group):
+        random.shuffle(group)
+        for dn, entry in group:
+            for vals in entry.values():
+                random.shuffle(vals)
+            self.writer.unparse(dn, entry)
+
+
+@pytest.fixture(scope="function")
+def prepare_be(topology_st, request):
+
+    inst = topology_st.standalone
+    ldif_file = inst.get_ldif_dir() + '/30ku.ldif'
+    ldif_file_scrambled = inst.get_ldif_dir() + '/30ku-scrambled.ldif'
+    bename = 'entrycache_test'
+    suffix = 'dc=entrycache_test,dc=example,dc=com'
+    people_base = f'ou=people,{suffix}'
+    groups_base = f'ou=groups,{suffix}'
+
+    # Remove the backend if it exists
+    bes = Backends(inst)
+    with suppress(ldap.NO_SUCH_OBJECT):
+        be1 = bes.get(bename)
+        be1.delete()
+
+    # Creates the backend.
+    be1 = bes.create(properties={ 'cn': bename, 'nsslapd-suffix': suffix, })
+
+    # Prepare finalizer
+    def fin():
+        be1.delete()
+        if os.path.exists(ldif_file):
+            os.remove(ldif_file)
+
+    if not DEBUGGING:
+        request.addfinalizer(fin)
+
+    # Generates ldif file with a few clarge groups
+    # And preset random seed to have deterministic test
+    random.seed(SEED)
+    args = FakeArgs()
+    args.NAME = 'myGroup'
+    args.parent = groups_base
+    args.suffix = suffix
+    args.number = 5
+    args.num_members = 6000
+    args.create_members = True
+    args.member_attr = 'uniquemember'
+    args.member_parent = people_base
+    args.ldif_file = ldif_file
+    dbgen_create_groups(inst, log, args)
+    assert os.path.exists(ldif_file)
+
+    # Set entry cache large enough to hold all the large groups
+    # and with a limited number of entries to trigger eviction
+    be1.replace('nsslapd-cachememsize',  '8000000' )
+    be1.replace('nsslapd-cachesize',  '100' )
+    # Set debugging trace specific for this test
+    be1.replace('nsslapd-cache-debug-pattern',  f'cn=.*,ou=groups,{suffix}' )
+
+    # import the ldif
+    inst.stop()
+    LdifScrambler(ldif_file, ldif_file_scrambled).scramble()
+    if not inst.ldif2db(bename, None, None, None, ldif_file):
+        log.fatal('Failed to import {ldif_file}')
+        assert False
+    inst.start()
+
+    return (bename, suffix, be1, people_base, groups_base)
+
+
+def grab_debug_logs(inst):
+    errlog = DirsrvErrorLog(inst)
+    msgs = errlog.match('.*entrycache_.*_int')
+    adds = [ line for line in msgs if 'entrycache_add_int' in line ]
+    dels= [ line for line in msgs if 'entrycache_remove_int' in line ]
+    return (msgs, adds, dels)
+
+
+def test_entry_cache_eviction(topology_st, prepare_be):
+    """Test that large groups are not evicted
+
+            :id: 550b995e-1c76-11f0-93ed-482ae39447e5
+            :setup: Standalone instance
+            :steps:
+                 1. Create DS instance and prepare a test backend
+                 2. Search all entries
+                 3. Check error log that the group are added in cache but not removed
+                 4. Change the number of entries protected from eviction threshold
+                    so that no group is preserved.
+                 5. Search all entries
+                 6. Check error log that the group are removed except the last one
+                 7. Change the number of entries protected from eviction threshold
+                    so that one group is not preserved.
+                 8. Search all entries
+                 9. Check error log that the group are preserved except one
+            :expectedresults:
+                 1. Success
+                 2. Success
+                 3. Success
+                 4. Success
+                 5. Success
+                 6. Success
+                 7. Success
+                 8. Success
+                 9. Success
+            """
+
+    inst = topology_st.standalone
+    bename, suffix, be1, people_base, groups_base = prepare_be
+
+    # Search all groups then all people to try to evict the groups from entrycache
+    inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+
+    # Check error logs
+    msgs, adds, dels = grab_debug_logs(inst)
+    # Should have entrycache_add_int for each group and no entrycache_delete_int
+    assert len(adds) == 5
+    assert len(dels) == 0
+
+
+    be1.replace('nsslapd-cache-preserved-entries', '0')
+    # Search all people to evict groups from entrycache
+    inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    # Check error logs
+    msgs, adds, dels = grab_debug_logs(inst)
+    assert len(adds) == 5
+    assert len(dels) == 5
+
+    # Search all groups then all people to try to evict the groups from entrycache
+    inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    # Check error logs
+    msgs, adds, dels = grab_debug_logs(inst)
+    #  Should have the 5 add messages from previous searches + 5 new add
+    #  Should have the 5 del messages from previous searches + 5 new del
+    assert len(adds) == 5+5
+    assert len(dels) == 5+5
+
+    be1.replace('nsslapd-cache-preserved-entries', '4')
+    # Search all groups then all people to try to evict the groups from entrycache
+    inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
+    # Check error logs
+    msgs, adds, dels = grab_debug_logs(inst)
+    # Should have entrycache_add_int for each group and one group is removed
+    # because only 4 of them are preserved.
+    assert len(adds) == 10+5
+    assert len(dels) == 10+1
+
+if __name__ == "__main__":
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s -v %s" % CURRENT_FILE)
+

--- a/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
+++ b/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
@@ -187,6 +187,7 @@ def test_entry_cache_eviction(topology_st, prepare_be):
     inst = topology_st.standalone
     bename, suffix, be1, people_base, groups_base = prepare_be
 
+    be1.replace('nsslapd-cache-preserved-entries', '10')
     # Search all groups then all people to try to evict the groups from entrycache
     inst.search_s(groups_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')
     inst.search_s(people_base, ldap.SCOPE_SUBTREE, '(objectclass=top)', ['dn'], escapehatch='i am sure')

--- a/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
+++ b/dirsrvtests/tests/suites/features/entrycache_eviction_test.py
@@ -13,13 +13,14 @@ import ldap
 import ldif
 import random
 from contextlib import suppress
-from lib389.backend import Backends
+from lib389.backend import Backends, DatabaseConfig
 from lib389.cli_base import FakeArgs
 from lib389.cli_ctl.dbgen import dbgen_create_groups
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.dirsrv_log import DirsrvErrorLog
 from lib389.tasks import ImportTask
 from lib389.topologies import topology_st
+from lib389.utils import get_default_db_lib
 
 
 pytestmark = pytest.mark.tier1
@@ -131,10 +132,10 @@ def prepare_be(topology_st, request):
 
     # Set entry cache large enough to hold all the large groups
     # and with a limited number of entries to trigger eviction
+    if get_default_db_lib() == 'bdb':
+        DatabaseConfig(inst).set([('nsslapd-cache-autosize',  '0')])
     be1.replace('nsslapd-cachememsize',  '8000000' )
     be1.replace('nsslapd-cachesize',  '100' )
-    # Set debugging trace specific for this test
-    be1.replace('nsslapd-cache-debug-pattern',  f'cn=.*,ou=groups,{suffix}' )
 
     # import the ldif
     inst.stop()
@@ -143,6 +144,8 @@ def prepare_be(topology_st, request):
         log.fatal('Failed to import {ldif_file}')
         assert False
     inst.start()
+    # Set debugging trace specific for this test
+    be1.replace('nsslapd-cache-debug-pattern',  f'cn=.*,ou=groups,{suffix}' )
 
     return (bename, suffix, be1, people_base, groups_base)
 

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -145,7 +145,7 @@ typedef unsigned short u_int16_t;
 #define DEFAULT_CACHE_SIZE       (uint64_t)0
 #define DEFAULT_CACHE_SIZE_STR   "0"
 #define DEFAULT_CACHE_ENTRIES    -1 /* no limit */
-#define DEFAULT_CACHE_PRESERVED_ENTRIES_STR "10"
+#define DEFAULT_CACHE_PRESERVED_ENTRIES_STR "0"
 #define DEFAULT_DNCACHE_SIZE     (uint64_t)16777216
 #define DEFAULT_DNCACHE_SIZE_STR "16777216"
 #define DEFAULT_DNCACHE_MAXCOUNT -1 /* no limit */

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -59,7 +59,6 @@
 #define LOG(...)
 #endif
 #define LOGPATTERN(cache, dn, msg, ...) { if (debug_pattern_matches(cache, dn)) { slapi_log_err(SLAPI_LOG_INFO, (char *)__func__, "CACHE DEBUG: " msg, __VA_ARGS__); } }
-#define LOG2(...) slapi_log_err(SLAPI_LOG_INFO, (char *)__func__, __VA_ARGS__)
 
 
 struct pinned_ctx {

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -19,8 +19,6 @@
 #define LDAP_CACHE_DEBUG
 /* #define LDAP_CACHE_DEBUG_LRU * causes slowdown */
 /* #define CACHE_DEBUG * causes slowdown */
-#define LDAP_CACHE_DEBUG_LRU  1
-#define CACHE_DEBUG  1
 #endif
 
 
@@ -633,10 +631,8 @@ flush_hash(struct cache *cache, struct timespec *start_time, int32_t type)
                     entry->ep_refcnt++;
                     if (entry->ep_state & ENTRY_STATE_PINNED) {
                         pinned_remove(cache, laste);
-                        lru_delete(cache, laste);
-                    } else {
-                        lru_delete(cache, laste);
                     }
+                    lru_delete(cache, laste);
                     if (type == ENTRY_CACHE) {
                         entrycache_remove_int(cache, laste);
                         entrycache_return(cache, (struct backentry **)&laste, PR_TRUE);
@@ -681,10 +677,8 @@ flush_hash(struct cache *cache, struct timespec *start_time, int32_t type)
                         entry->ep_refcnt++;
                         if (entry->ep_state & ENTRY_STATE_PINNED) {
                             pinned_remove(cache, laste);
-                            lru_delete(cache, laste);
-                        } else {
-                            lru_delete(cache, laste);
                         }
+                        lru_delete(cache, laste);
                         entrycache_remove_int(cache, laste);
                         entrycache_return(cache, (struct backentry **)&laste, PR_TRUE);
                     } else {
@@ -730,7 +724,7 @@ cache_init(struct cache *cache, struct ldbm_instance *inst, uint64_t maxsize, in
     cache->c_lruhead = cache->c_lrutail = NULL;
     cache_make_hashes(cache, type);
     cache->c_pinned_ctx = (struct pinned_ctx*)slapi_ch_calloc(1, sizeof (struct pinned_ctx));
-    
+
     if (((cache->c_mutex = PR_NewMonitor()) == NULL) ||
         ((cache->c_emutexalloc_mutex = PR_NewLock()) == NULL)) {
         slapi_log_err(SLAPI_LOG_ERR, "cache_init", "PR_NewMonitor failed\n");
@@ -1185,7 +1179,7 @@ pinned_remove(struct cache *cache, void *ptr)
 }
 
 /* Ensure pinned entries respects the cache memory and maxentrie limits
- * May put entries back in the lru so this function should be called 
+ * May put entries back in the lru so this function should be called
  * just before calling entrycache_flush
  */
 void

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -1081,7 +1081,7 @@ entrycache_remove_int(struct cache *cache, struct backentry *e)
 
     LOGPATTERN(cache, backentry_get_ndn(e),
                "Cache average weight is %lu . Removing entry from "
-               " cache with size: %lu, weight: %lu, dn:%s\n",
+               "cache with size: %lu, weight: %lu, dn:%s\n",
                AV_WEIGHT(cache), e->ep_size, e->ep_weight,
                backentry_get_ndn(e));
     LOG("=> entrycache_remove_int (%s) (%u) (%u)\n", backentry_get_ndn(e), e->ep_id, e->ep_refcnt);

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -760,6 +760,7 @@ entrycache_flush(struct cache *cache)
 
     LOG("=> entrycache_flush\n");
 
+    pinned_flush(cache);
     /* all entries on the LRU list are guaranteed to have a refcnt = 0
      * (iow, nobody's using them), so just delete from the tail down
      * until the cache is a managable size again.
@@ -798,7 +799,6 @@ entrycache_clear_int(struct cache *cache)
     size_t size = cache->c_stats.maxsize;
 
     cache->c_stats.maxsize = 0;
-    pinned_flush(cache);
     eflush = entrycache_flush(cache);
     while (eflush) {
         eflushtemp = BACK_LRU_NEXT(eflush, struct backentry *);
@@ -889,7 +889,6 @@ entrycache_set_max_size(struct cache *cache, uint64_t bytes, bool autotuned)
     LOG("entry cache size set to %" PRIu64 "\n", bytes);
     /* check for full cache, and clear out if necessary */
     if (CACHE_FULL(cache)) {
-        pinned_flush(cache);
         eflush = entrycache_flush(cache);
     }
     while (eflush) {
@@ -939,7 +938,6 @@ cache_set_max_entries(struct cache *cache, int64_t entries, bool autotuned)
 
     /* check for full cache, and clear out if necessary */
     if (CACHE_FULL(cache)) {
-        pinned_flush(cache);
         eflush = entrycache_flush(cache);
     }
     cache_unlock(cache);
@@ -1573,7 +1571,6 @@ entrycache_return(struct cache *cache, struct backentry **bep, PRBool locked)
                 pinned_verify(cache, __LINE__);
                 /* the cache might be overfull... */
                 if (CACHE_FULL(cache)) {
-                    pinned_flush(cache);
                     eflush = entrycache_flush(cache);
                 }
                 pinned_verify(cache, __LINE__);
@@ -1877,7 +1874,6 @@ entrycache_add_int(struct cache *cache, struct backentry *e, int state, struct b
         }
         /* check for full cache, and clear out if necessary */
         if (CACHE_FULL(cache)) {
-            pinned_flush(cache);
             eflush = entrycache_flush(cache);
         }
     }

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -1443,15 +1443,20 @@ entrycache_replace(struct cache *cache, struct backentry *olde, struct backentry
             return 1;
         }
     }
-    /* Lets propagate the weight */
-    if (newe->ep_weight == 0) {
-        newe->ep_weight = olde->ep_weight;
-    }
-    if (olde->ep_weight) {
-        cache->c_stats.nehw--;
-    }
-    if (newe->ep_weight) {
-        cache->c_stats.nehw++;
+    if (olde->ep_weight != newe->ep_weight) {
+        /* Lets propagate the weight */
+        if (newe->ep_weight == 0) {
+            newe->ep_weight = olde->ep_weight;
+        }
+        /* Then update the cache statistics */
+        cache->c_stats.weight -= olde->ep_weight;
+        cache->c_stats.weight += newe->ep_weight;
+        if (olde->ep_weight) {
+            cache->c_stats.nehw--;
+        }
+        if (newe->ep_weight) {
+            cache->c_stats.nehw++;
+        }
     }
     /* now, add the new entry to the hashtables */
     /* (probably don't need such extensive error handling, once this has been

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -143,14 +143,14 @@ bdb_import_fifo_init(ImportJob *job)
     ldbm_instance *inst = job->inst;
 
     /* Work out how big the entry fifo can be */
-    if (inst->inst_cache.c_maxentries > 0)
-        job->fifo.size = inst->inst_cache.c_maxentries;
+    if (inst->inst_cache.c_stats.maxentries > 0)
+        job->fifo.size = inst->inst_cache.c_stats.maxentries;
     else
-        job->fifo.size = inst->inst_cache.c_maxsize / 1024; /* guess */
+        job->fifo.size = inst->inst_cache.c_stats.maxsize / 1024; /* guess */
 
     /* byte limit that should be respected to avoid memory starvation */
     /* Rather than cachesize * .8, we set it to cachesize for clarity */
-    job->fifo.bsize = inst->inst_cache.c_maxsize;
+    job->fifo.bsize = inst->inst_cache.c_stats.maxsize;
 
     job->fifo.c_bsize = 0;
 
@@ -2449,14 +2449,14 @@ error:
         cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
 
         /* initialize the entry cache */
-        if (!cache_init(&(inst->inst_cache), inst->inst_cache.c_maxsize,
+        if (!cache_init(&(inst->inst_cache), inst, inst->inst_cache.c_stats.maxsize,
                         DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
             slapi_log_err(SLAPI_LOG_ERR, "bdb_public_bdb_import_main",
                           "cache_init failed.  Server should be restarted.\n");
         }
 
         /* initialize the dn cache */
-        if (!cache_init(&(inst->inst_dncache), inst->inst_dncache.c_maxsize,
+        if (!cache_init(&(inst->inst_dncache), inst, inst->inst_dncache.c_stats.maxsize,
                         DEFAULT_DNCACHE_MAXCOUNT, CACHE_TYPE_DN)) {
             slapi_log_err(SLAPI_LOG_ERR, "bdb_public_bdb_import_main",
                           "dn cache_init failed.  Server should be restarted.\n");

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_monitor.c
@@ -45,16 +45,13 @@ bdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     struct berval val;
     struct berval *vals[2];
     char buf[BUFSIZ];
-    uint64_t hits, tries;
-    uint64_t nentries;
-    int64_t maxentries;
-    uint64_t size, maxsize;
     /* NPCTE fix for bugid 544365, esc 0. <P.R> <04-Jul-2001> */
     struct stat astat;
     /* end of NPCTE fix for bugid 544365 */
     DB_MPOOL_FSTAT **mpfstat = NULL;
     int i, j;
     char *absolute_pathname = NULL;
+    struct cache_stats cstats = {0};
 
     /* Get the LDBM Info structure for the ldbm backend */
     if (inst->inst_be->be_database == NULL) {
@@ -85,39 +82,40 @@ bdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     MSET("readOnly");
 
     /* fetch cache statistics */
-    cache_get_stats(&(inst->inst_cache), &hits, &tries,
-                    &nentries, &maxentries, &size, &maxsize);
-    sprintf(buf, "%" PRIu64, hits);
+    cache_get_stats(&(inst->inst_cache), &cstats);
+    sprintf(buf, "%" PRIu64, cstats.hits);
     MSET("entryCacheHits");
-    sprintf(buf, "%" PRIu64, tries);
+    sprintf(buf, "%" PRIu64, cstats.tries);
     MSET("entryCacheTries");
-    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)cstats.hits / (double)(cstats.tries > 0 ? cstats.tries : 1)));
     MSET("entryCacheHitRatio");
-    sprintf(buf, "%" PRIu64, size);
+    sprintf(buf, "%" PRIu64, cstats.size);
     MSET("currentEntryCacheSize");
-    sprintf(buf, "%" PRIu64, maxsize);
+    sprintf(buf, "%" PRIu64, cstats.maxsize);
     MSET("maxEntryCacheSize");
-    sprintf(buf, "%" PRIu64, nentries);
+    sprintf(buf, "%" PRIu64, cstats.nentries);
     MSET("currentEntryCacheCount");
-    sprintf(buf, "%" PRId64, maxentries);
+    sprintf(buf, "%" PRId64, cstats.maxentries);
     MSET("maxEntryCacheCount");
+    sprintf(buf, "%" PRId64, cstats.weight / ((cstats.nehw == 0) ? 1 : cstats.nehw));
+    MSET("entryCacheAverageLoadTime");
+
 
     /* fetch cache statistics */
-    cache_get_stats(&(inst->inst_dncache), &hits, &tries,
-                    &nentries, &maxentries, &size, &maxsize);
-    sprintf(buf, "%" PRIu64, hits);
+    cache_get_stats(&(inst->inst_dncache), &cstats);
+    sprintf(buf, "%" PRIu64, cstats.hits);
     MSET("dnCacheHits");
-    sprintf(buf, "%" PRIu64, tries);
+    sprintf(buf, "%" PRIu64, cstats.tries);
     MSET("dnCacheTries");
-    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)cstats.hits / (double)(cstats.tries > 0 ? cstats.tries : 1)));
     MSET("dnCacheHitRatio");
-    sprintf(buf, "%" PRIu64, size);
+    sprintf(buf, "%" PRIu64, cstats.size);
     MSET("currentDnCacheSize");
-    sprintf(buf, "%" PRIu64, maxsize);
+    sprintf(buf, "%" PRIu64, cstats.maxsize);
     MSET("maxDnCacheSize");
-    sprintf(buf, "%" PRIu64, nentries);
+    sprintf(buf, "%" PRIu64, cstats.nentries);
     MSET("currentDnCacheCount");
-    sprintf(buf, "%" PRId64, maxentries);
+    sprintf(buf, "%" PRId64, cstats.maxentries);
     MSET("maxDnCacheCount");
 
 #ifdef DEBUG

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -994,14 +994,14 @@ error:
         cache_destroy_please(&job->inst->inst_cache, CACHE_TYPE_ENTRY);
         cache_destroy_please(&job->inst->inst_dncache, CACHE_TYPE_DN);
         /* initialize the entry cache */
-        if (!cache_init(&(inst->inst_cache), inst->inst_cache.c_maxsize,
+        if (!cache_init(&(inst->inst_cache), inst, inst->inst_cache.c_stats.maxsize,
                         DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_public_dbmdb_import_main",
                           "cache_init failed.  Server should be restarted.\n");
         }
 
         /* initialize the dn cache */
-        if (!cache_init(&(inst->inst_dncache), inst->inst_dncache.c_maxsize,
+        if (!cache_init(&(inst->inst_dncache), inst, inst->inst_dncache.c_stats.maxsize,
                         DEFAULT_DNCACHE_MAXCOUNT, CACHE_TYPE_DN)) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_public_dbmdb_import_main",
                           "dn cache_init failed.  Server should be restarted.\n");

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_monitor.c
@@ -55,10 +55,8 @@ dbmdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     struct berval mval[3];
     struct berval *vals[4];
     char buf[BUFSIZ];
-    uint64_t hits, tries;
-    uint64_t nentries;
-    int64_t maxentries;
-    uint64_t size, maxsize;
+    struct cache_stats cstats = {0};
+
     dbmdb_stats_t *stats = NULL;
     int i, j, flags;
 
@@ -91,39 +89,39 @@ dbmdb_monitor_instance_search(Slapi_PBlock *pb __attribute__((unused)),
     MSET("readOnly");
 
     /* fetch cache statistics */
-    cache_get_stats(&(inst->inst_cache), &hits, &tries,
-                    &nentries, &maxentries, &size, &maxsize);
-    sprintf(buf, "%" PRIu64, hits);
+    cache_get_stats(&(inst->inst_cache), &cstats);
+    sprintf(buf, "%" PRIu64, cstats.hits);
     MSET("entryCacheHits");
-    sprintf(buf, "%" PRIu64, tries);
+    sprintf(buf, "%" PRIu64, cstats.tries);
     MSET("entryCacheTries");
-    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)cstats.hits / (double)(cstats.tries > 0 ? cstats.tries : 1)));
     MSET("entryCacheHitRatio");
-    sprintf(buf, "%" PRIu64, size);
+    sprintf(buf, "%" PRIu64, cstats.size);
     MSET("currentEntryCacheSize");
-    sprintf(buf, "%" PRIu64, maxsize);
+    sprintf(buf, "%" PRIu64, cstats.maxsize);
     MSET("maxEntryCacheSize");
-    sprintf(buf, "%" PRIu64, nentries);
+    sprintf(buf, "%" PRIu64, cstats.nentries);
     MSET("currentEntryCacheCount");
-    sprintf(buf, "%" PRId64, maxentries);
+    sprintf(buf, "%" PRId64, cstats.maxentries);
     MSET("maxEntryCacheCount");
+    sprintf(buf, "%" PRId64, cstats.weight / ((cstats.nehw == 0) ? 1 : cstats.nehw));
+    MSET("entryCacheAverageLoadTime");
 
     /* fetch cache statistics */
-    cache_get_stats(&(inst->inst_dncache), &hits, &tries,
-                    &nentries, &maxentries, &size, &maxsize);
-    sprintf(buf, "%" PRIu64, hits);
+    cache_get_stats(&(inst->inst_dncache), &cstats);
+    sprintf(buf, "%" PRIu64, cstats.hits);
     MSET("dnCacheHits");
-    sprintf(buf, "%" PRIu64, tries);
+    sprintf(buf, "%" PRIu64, cstats.tries);
     MSET("dnCacheTries");
-    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)hits / (double)(tries > 0 ? tries : 1)));
+    sprintf(buf, "%" PRIu64, (uint64_t)(100.0 * (double)cstats.hits / (double)(cstats.tries > 0 ? cstats.tries : 1)));
     MSET("dnCacheHitRatio");
-    sprintf(buf, "%" PRIu64, size);
+    sprintf(buf, "%" PRIu64, cstats.size);
     MSET("currentDnCacheSize");
-    sprintf(buf, "%" PRIu64, maxsize);
+    sprintf(buf, "%" PRIu64, cstats.maxsize);
     MSET("maxDnCacheSize");
-    sprintf(buf, "%" PRIu64, nentries);
+    sprintf(buf, "%" PRIu64, cstats.nentries);
     MSET("currentDnCacheCount");
-    sprintf(buf, "%" PRId64, maxentries);
+    sprintf(buf, "%" PRId64, cstats.maxentries);
     MSET("maxDnCacheCount");
 
 #ifdef DEBUG

--- a/ldap/servers/slapd/back-ldbm/id2entry.c
+++ b/ldap/servers/slapd/back-ldbm/id2entry.c
@@ -267,6 +267,7 @@ id2entry(backend *be, ID id, back_txn *txn, int *err)
     Slapi_Entry *ee;
     char temp_id[sizeof(ID)];
     uint32_t esize;
+    BackEntryWeightData t1 = {0};
 
     slapi_log_err(SLAPI_LOG_TRACE, ID2ENTRY,
                   "=> id2entry(%lu)\n", (u_long)id);
@@ -286,6 +287,7 @@ id2entry(backend *be, ID id, back_txn *txn, int *err)
     }
 
 
+    backentry_init_weight(&t1);
     id_internal_to_stored(id, temp_id);
 
     dblayer_value_set_buffer(be, &key, temp_id,  sizeof(temp_id));
@@ -438,6 +440,7 @@ id2entry(backend *be, ID id, back_txn *txn, int *err)
             slapi_ch_free_string(&entrydn);
         }
 
+        backentry_compute_weight(e, &t1);
         retval = CACHE_ADD(&inst->inst_cache, e, &imposter);
         if (1 == retval) {
             /* This means that someone else put the entry in the cache

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -38,7 +38,7 @@ ldbm_instance_create(backend *be, char *name)
     inst->inst_name = slapi_ch_strdup(name);
 
     /* initialize the entry cache */
-    if (!cache_init(&(inst->inst_cache), DEFAULT_CACHE_SIZE,
+    if (!cache_init(&(inst->inst_cache), inst, DEFAULT_CACHE_SIZE,
                     DEFAULT_CACHE_ENTRIES, CACHE_TYPE_ENTRY)) {
         slapi_log_err(SLAPI_LOG_ERR, "ldbm_instance_create", "cache_init failed\n");
         rc = -1;
@@ -49,7 +49,7 @@ ldbm_instance_create(backend *be, char *name)
      * initialize the dn cache
      * It is needed when converting the db from DN to RDN format.
      */
-    if (!cache_init(&(inst->inst_dncache), DEFAULT_DNCACHE_SIZE,
+    if (!cache_init(&(inst->inst_dncache), inst, DEFAULT_DNCACHE_SIZE,
                     DEFAULT_DNCACHE_MAXCOUNT, CACHE_TYPE_DN)) {
         slapi_log_err(SLAPI_LOG_ERR,
                       "ldbm_instance_create", "dn cache_init failed\n");

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -396,6 +396,10 @@ ldbm_instance_destructor(void **arg)
     PR_DestroyCondVar(inst->inst_indexer_cv);
     attrinfo_deletetree(inst);
     slapi_ch_free((void **)&inst->inst_dataversion);
+    slapi_ch_free_string(&inst->cache_debug_pattern);
+    slapi_re_free(inst->cache_debug_re);
+    inst->cache_debug_re = NULL;
+
     /* cache has already been destroyed */
 
     slapi_ch_free((void **)&inst);

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -130,6 +130,8 @@ struct config_info
 /* instance config options */
 #define CONFIG_INSTANCE_CACHESIZE "nsslapd-cachesize"
 #define CONFIG_INSTANCE_CACHEMEMSIZE "nsslapd-cachememsize"
+#define CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES "nsslapd-cache-preserved-entries"
+#define CONFIG_INSTANCE_CACHE_DEBUG_PATTERN "nsslapd-cache-debug-pattern"
 #define CONFIG_INSTANCE_DNCACHEMEMSIZE "nsslapd-dncachememsize"
 #define CONFIG_INSTANCE_SUFFIX "nsslapd-suffix"
 #define CONFIG_INSTANCE_READONLY "nsslapd-readonly"

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -130,7 +130,7 @@ struct config_info
 /* instance config options */
 #define CONFIG_INSTANCE_CACHESIZE "nsslapd-cachesize"
 #define CONFIG_INSTANCE_CACHEMEMSIZE "nsslapd-cachememsize"
-#define CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES "nsslapd-cache-preserved-entries"
+#define CONFIG_INSTANCE_CACHE_PINNED_ENTRIES "nsslapd-cache-pinned-entries"
 #define CONFIG_INSTANCE_CACHE_DEBUG_PATTERN "nsslapd-cache-debug-pattern"
 #define CONFIG_INSTANCE_DNCACHEMEMSIZE "nsslapd-dncachememsize"
 #define CONFIG_INSTANCE_SUFFIX "nsslapd-suffix"

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -350,7 +350,7 @@ ldbm_config_cache_preserved_entries_set(void *arg,
                               "Error: Invalid value for %s (%ld). The value must not be negative\n",
                               CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES, val);
         slapi_log_err(SLAPI_LOG_ERR, "ldbm_config_cache_weight_threshold_set",
-                      "Invalid value for %s (%ld). The value must be greater than \"100\"\n",
+                      "Invalid value for %s (%ld). The value must not be negative\n",
                       CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES, val);
         return LDAP_UNWILLING_TO_PERFORM;
     }

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -407,9 +407,11 @@ ldbm_config_cache_debug_pattern_set(void *arg,
             val = slapi_ch_strdup(val);
         }
         slapi_ch_free_string(&inst->cache_debug_pattern);
-        slapi_ch_free((void**)&inst->cache_debug_re);
+        slapi_re_free(inst->cache_debug_re);
         inst->cache_debug_pattern = val;
         inst->cache_debug_re = re;
+    } else {
+        slapi_re_free(re);
     }
     return LDAP_SUCCESS;
 }

--- a/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_instance_config.c
@@ -327,16 +327,16 @@ ldbm_instance_config_require_internalop_index_set(void *arg,
 }
 
 static void *
-ldbm_config_cache_preserved_entries_get(void *arg)
+ldbm_config_cache_pinned_entries_get(void *arg)
 {
     struct ldbm_instance *inst = (struct ldbm_instance *)arg;
 
-    return (void *)((uintptr_t)(inst->cache_preserved_entries));
+    return (void *)((uintptr_t)(inst->cache_pinned_entries));
 
 }
 
 static int
-ldbm_config_cache_preserved_entries_set(void *arg,
+ldbm_config_cache_pinned_entries_set(void *arg,
                                void *value,
                                char *errorbuf,
                                int phase __attribute__((unused)),
@@ -348,14 +348,14 @@ ldbm_config_cache_preserved_entries_set(void *arg,
     if (val < 0) {
         slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
                               "Error: Invalid value for %s (%ld). The value must not be negative\n",
-                              CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES, val);
+                              CONFIG_INSTANCE_CACHE_PINNED_ENTRIES, val);
         slapi_log_err(SLAPI_LOG_ERR, "ldbm_config_cache_weight_threshold_set",
                       "Invalid value for %s (%ld). The value must not be negative\n",
-                      CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES, val);
+                      CONFIG_INSTANCE_CACHE_PINNED_ENTRIES, val);
         return LDAP_UNWILLING_TO_PERFORM;
     }
     if (apply) {
-        inst->cache_preserved_entries = val;
+        inst->cache_pinned_entries = val;
     }
     return LDAP_SUCCESS;
 }
@@ -425,7 +425,7 @@ static config_info ldbm_instance_config[] = {
     {CONFIG_INSTANCE_REQUIRE_INDEX, CONFIG_TYPE_ONOFF, "off", &ldbm_instance_config_require_index_get, &ldbm_instance_config_require_index_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_INSTANCE_REQUIRE_INTERNALOP_INDEX, CONFIG_TYPE_ONOFF, "off", &ldbm_instance_config_require_internalop_index_get, &ldbm_instance_config_require_internalop_index_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_INSTANCE_DNCACHEMEMSIZE, CONFIG_TYPE_UINT64, DEFAULT_DNCACHE_SIZE_STR, &ldbm_instance_config_dncachememsize_get, &ldbm_instance_config_dncachememsize_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
-    {CONFIG_INSTANCE_CACHE_PRESERVED_ENTRIES, CONFIG_TYPE_INT, DEFAULT_CACHE_PRESERVED_ENTRIES_STR, &ldbm_config_cache_preserved_entries_get, &ldbm_config_cache_preserved_entries_set, CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_INSTANCE_CACHE_PINNED_ENTRIES, CONFIG_TYPE_INT, DEFAULT_CACHE_PINNED_ENTRIES_STR, &ldbm_config_cache_pinned_entries_get, &ldbm_config_cache_pinned_entries_set, CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_INSTANCE_CACHE_DEBUG_PATTERN, CONFIG_TYPE_STRING, NULL, &ldbm_config_cache_debug_pattern_get, &ldbm_config_cache_debug_pattern_set, CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {NULL, 0, NULL, NULL, NULL, 0}};
 

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -37,14 +37,14 @@ void attr_create_empty(backend *be, char *type, struct attrinfo **ai);
  * cache.c
  */
 void cache_disable(void);
-int cache_init(struct cache *cache, uint64_t maxsize, int64_t maxentries, int type);
+int cache_init(struct cache *cache, struct ldbm_instance *inst, uint64_t maxsize, int64_t maxentries, int type);
 void cache_clear(struct cache *cache, int type);
 void cache_destroy_please(struct cache *cache, int type);
 void cache_set_max_size(struct cache *cache, uint64_t bytes, int type, bool autotuned);
 void cache_set_max_entries(struct cache *cache, int64_t entries, bool autotuned);
 uint64_t cache_get_max_size(struct cache *cache);
 int64_t cache_get_max_entries(struct cache *cache);
-void cache_get_stats(struct cache *cache, uint64_t *hits, uint64_t *tries, uint64_t *entries, int64_t *maxentries, uint64_t *size, uint64_t *maxsize);
+void cache_get_stats(struct cache *cache, struct cache_stats *stats);
 void cache_debug_hash(struct cache *cache, char **out);
 int cache_remove(struct cache *cache, void *e);
 void cache_return(struct cache *cache, void **bep);
@@ -372,6 +372,8 @@ const Slapi_DN *backentry_get_sdn(const struct backentry *e);
 
 struct backdn *backdn_init(Slapi_DN *sdn, ID id, int to_remove_from_hash);
 void backdn_free(struct backdn **bdn);
+void backentry_init_weight(BackEntryWeightData *starttime);
+void backentry_compute_weight(struct backentry *e, const BackEntryWeightData *starttime);
 
 /*
  * parents.c

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -1388,6 +1388,7 @@ class BackendSuffixView(CompositeDSLdapObject):
         be_args = [
             'nsslapd-cachememsize',
             'nsslapd-cachesize',
+            'nsslapd-cache-preserved-entries',
             'nsslapd-dncachememsize',
             'nsslapd-readonly',
             'nsslapd-require-index',

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -504,6 +504,8 @@ def backend_set(inst, basedn, log, args):
         bev.set('nsslapd-cachesize', args.cache_size)
     if args.cache_memsize:
         bev.set('nsslapd-cachememsize', args.cache_memsize)
+    if args.cache_preserved_entries:
+        bev.set('nsslapd-cache-preserved-entries', args.cache_preserved_entries)
     if args.dncache_memsize:
         bev.set('nsslapd-dncachememsize', args.dncache_memsize)
     if args.require_index:
@@ -886,6 +888,7 @@ def create_parser(subparsers):
     set_backend_parser.add_argument('--disable', action='store_true', help='Disables the backend database')
     set_backend_parser.add_argument('--cache-size', help='Sets the maximum number of entries to keep in the entry cache')
     set_backend_parser.add_argument('--cache-memsize', help='Sets the maximum size in bytes that the entry cache can grow to')
+    set_backend_parser.add_argument('--cache-preserved-entries', help='Sets the maximum number of entries that are not evicted from the cache when trying to make space. This is typically used to keep very large groups in the cache')
     set_backend_parser.add_argument('--dncache-memsize', help='Sets the maximum size in bytes that the DN cache can grow to')
     set_backend_parser.add_argument('--state', help='Changes the backend state to: "backend", "disabled", "referral", or "referral on update"')
     set_backend_parser.add_argument('be_name', help='The backend name or suffix')

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -105,8 +105,13 @@ def _create_instances(topo_dict, suffix):
             args_instance[SER_PORT] = instance_data[SER_PORT]
             args_instance[SER_SECURE_PORT] = instance_data[SER_SECURE_PORT]
             args_instance[SER_SERVERID_PROP] = instance_data[SER_SERVERID_PROP]
-            if nbinsts > 3 and get_default_db_lib() == "mdb":
-                args_instance[SER_MDB_MAX_SIZE] = '10g'
+            # We may want to tune the db size if lmdb is used
+            if get_default_db_lib() == "mdb":
+                if nbinsts > 3:
+                    args_instance[SER_MDB_MAX_SIZE] = '10g'
+                db_size = os.getenv('DS389_MDB_MAX_SIZE')
+                if db_size is not None:
+                    args_instance[SER_MDB_MAX_SIZE] = db_size
             # It's required to be able to make a suffix-less install for
             # some cli tests. It's invalid to require replication with
             # no suffix however ....


### PR DESCRIPTION
Entry cache eviction improvement to limit large group evictions
Design is https://www.port389.org/docs/389ds/design/entrycache-pinned.html
Issue: #6784 

Reviewed by: @mreynolds389 , @tbordaz , @Firstyear  (Thanks!)

## Summary by Sourcery

Implement weighted, pinned-entry cache eviction and associated configuration, refactor cache statistics handling, enhance logging, and add integration tests for eviction behavior.

New Features:
- Add weighted, pinned-entry cache eviction supported by a new pinned-context list and entry weights computed from load time and group size.
- Introduce configuration options nsslapd-cache-pinned-entries and nsslapd-cache-debug-pattern (with regex) for controlling preserved entries and targeted cache logging.
- Expose average entry load time and pinned-entry metrics in cache monitoring output.

Enhancements:
- Replace individual counters and limits with a unified cache_stats structure and simplify cache_init to accept instance context.
- Refactor eviction logic to use cache_stats and pinned-context, with regex-filtered logging via LOGPATTERN and average weight details.
- Allow MDB backend size tuning in topology scripts via DS389_MDB_MAX_SIZE environment variable.

Tests:
- Add entrycache_eviction_test.py integration tests verifying pinned-entry caching and eviction thresholds.