### PR TITLE
Issue 6791 - crash in liblmdb during instance shutdown

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -504,6 +504,7 @@ int dbmdb_cmp_vals(MDB_val *v1, MDB_val *v2);
 dbmdb_stats_t *dbdmd_gather_stats(dbmdb_ctx_t *conf, backend *be);
 void dbmdb_free_stats(dbmdb_stats_t **stats);
 int dbmdb_reset_vlv_file(backend *be, const char *filename);
+bool dbmdb_is_env_open(void);
 
 /* mdb_txn.c */
 void shutdown_mdbtxn(void);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_txn.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_txn.c
@@ -47,7 +47,9 @@ cleanup_mdbtxn_stack(void *arg)
     slapi_ch_free((void**)&anchor);
     while (txn) {
         txn2 = txn->parent;
-        TXN_ABORT(TXN(txn));
+        if (dbmdb_is_env_open()) {
+            TXN_ABORT(TXN(txn));
+        }
         slapi_ch_free((void**)&txn);
         txn = txn2;
     }


### PR DESCRIPTION
Sometime ns-slapd process crashes during the shutdown.
The core stacks shows that a thread attempts to use liblmdb after lmdb environment get closed 
in one of thread specific data destructor callback.
The fix ensure that lmdb is not called after its environment get closed

Issue: #6791 

Reviewed by: @droideck, @tbordaz (Thanks!)