### PR TITLE
Issue 6534 - CI fails with Fedora 41 and DNF5

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -94,7 +94,7 @@ jobs:
         do
           echo "Waiting for container to be ready..."
         done
-        sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
+        sudo docker exec $CID sh -c "dnf install -y dist/rpms/*rpm"
         export PASSWD=$(openssl rand -base64 32)
         sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"
         sudo docker exec $CID sh -c "systemctl start dbus.service"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -94,7 +94,7 @@ jobs:
         do
           echo "Waiting for container to be ready..."
         done
-        sudo docker exec $CID sh -c "dnf install -y -v dist/rpms/*rpm"
+        sudo docker exec $CID sh -c "dnf install -y dist/rpms/*rpm"
         export PASSWD=$(openssl rand -base64 32)
         sudo docker exec $CID sh -c "echo \"${PASSWD}\" | passwd --stdin root"
         sudo docker exec $CID sh -c "systemctl start dbus.service"


### PR DESCRIPTION
Bug Description:
DNF5 no longer supports verbose option.

Fix Description:
Remove `-v` flag.

Fixes: https://github.com/389ds/389-ds-base/issues/6534