### PR TITLE
Issue 6776 - Enabling audit log makes slapd coredump

### DIFF
--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5813,7 +5813,7 @@ char *slapi_ch_malloc(unsigned long size) __ATTRIBUTE__((returns_nonnull));
 char *slapi_ch_memalign(uint32_t size, uint32_t alignment) __ATTRIBUTE__((returns_nonnull));
 char *slapi_ch_realloc(char *block, unsigned long size) __ATTRIBUTE__((returns_nonnull));
 char *slapi_ch_calloc(unsigned long nelem, unsigned long size) __ATTRIBUTE__((returns_nonnull));
-char *slapi_ch_strdup(const char *s) __ATTRIBUTE__((returns_nonnull));
+char *slapi_ch_strdup(const char *s);
 void slapi_ch_free(void **ptr);
 void slapi_ch_free_string(char **s);
 struct berval *slapi_ch_bvdup(const struct berval *);


### PR DESCRIPTION
Bug description:
`slapi_ch_strdup` function is declared with the `returns_nonnull` attribute, indicating that it can never return NULL.
However, its implementation explicitly returns NULL when the input is NULL. This contradicts the attribute and misleads the compiler, which results in a removed NULL check.

Fix Description:
Remove the `returns_nonnull` attribute from the `slapi_ch_strdup` declaration to align with its actual behavior.

Fixes: https://github.com/389ds/389-ds-base/issues/6776

Reviewed by: