### PR TITLE
Issue 6817 - Add missing import to test_repl_after_reindex

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -34,6 +34,7 @@ from lib389.agreement import Agreements
 from lib389 import pid_from_file
 from lib389.dseldif import *
 from lib389.topologies import topology_m2 as topo_m2, TopologyMain, create_topology, _remove_ssca_db
+from lib389.tasks import Tasks
 
 
 pytestmark = pytest.mark.tier1


### PR DESCRIPTION
Description:
Fixes regression test test_repl_after_reindex that was throwing an error due to a missing Tasks import. This is a one line fix to add said import.

Resolves: https://github.com/389ds/389-ds-base/issues/6817