### PR TITLE
Issue 6819 - Incorrect pwdpolicysubentry returned for an entry with u…

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -85,7 +85,7 @@ def create_subtree_policy_custom(instance, dn, properties):
 
         # The CoS specification entry at the subtree level
         cos_pointer_defs = CosPointerDefinitions(instance, dn)
-        cos_pointer_defs.create(properties={'cosAttribute': 'pwdpolicysubentry default operational',
+        cos_pointer_defs.create(properties={'cosAttribute': 'pwdpolicysubentry default operational-default',
                                             'cosTemplateDn': cos_template.dn,
                                             'cn': 'nsPwPolicy_CoS'})
     except ldap.LDAPError as e:

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -168,7 +168,7 @@ class PwPolicyManager(object):
 
             # The CoS specification entry at the subtree level
             cos_pointer_defs = CosPointerDefinitions(self._instance, dn)
-            cos_pointer_defs.create(properties={'cosAttribute': 'pwdpolicysubentry default operational',
+            cos_pointer_defs.create(properties={'cosAttribute': 'pwdpolicysubentry default operational-default',
                                                 'cosTemplateDn': cos_template.dn,
                                                 'cn': 'nsPwPolicy_CoS'})
         except ldap.LDAPError as e:


### PR DESCRIPTION
…ser password policy

Bug Description:
When both subtree and user password policies exist, pwdpolicysubentry points to the subtree password policy instead of user password policy.

Fix Description:
Update the template for CoS pointer definition to use `operational-default` modifier instead of `operational`.

Fixes: https://github.com/389ds/389-ds-base/issues/6819