### PR TITLE
Issue 6822 - Backend creation cleanup and Database UI tab error handling

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -478,6 +478,59 @@ export class Database extends React.Component {
     }
 
     loadSuffixTree(fullReset) {
+        const treeData = [
+            {
+                name: _("Global Database Configuration"),
+                icon: <CogIcon />,
+                id: "dbconfig",
+            },
+            {
+                name: _("Chaining Configuration"),
+                icon: <ExternalLinkAltIcon />,
+                id: "chaining-config",
+            },
+            {
+                name: _("Backups & LDIFs"),
+                icon: <CopyIcon />,
+                id: "backups",
+            },
+            {
+                name: _("Password Policies"),
+                id: "pwp",
+                icon: <KeyIcon />,
+                children: [
+                    {
+                        name: _("Global Policy"),
+                        icon: <HomeIcon />,
+                        id: "pwpolicy",
+                    },
+                    {
+                        name: _("Local Policies"),
+                        icon: <UsersIcon />,
+                        id: "localpwpolicy",
+                    },
+                ],
+                defaultExpanded: true
+            },
+            {
+                name: _("Suffixes"),
+                icon: <CatalogIcon />,
+                id: "suffixes-tree",
+                children: [],
+                defaultExpanded: true,
+                action: (
+                    <Button
+                        onClick={this.handleShowSuffixModal}
+                        variant="plain"
+                        aria-label="Create new suffix"
+                        title={_("Create new suffix")}
+                    >
+                        <PlusIcon />
+                    </Button>
+                ),
+            }
+        ];
+
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "backend", "get-tree",
@@ -491,58 +544,20 @@ export class Database extends React.Component {
                         suffixData = JSON.parse(content);
                         this.processTree(suffixData);
                     }
-                    const treeData = [
-                        {
-                            name: _("Global Database Configuration"),
-                            icon: <CogIcon />,
-                            id: "dbconfig",
-                        },
-                        {
-                            name: _("Chaining Configuration"),
-                            icon: <ExternalLinkAltIcon />,
-                            id: "chaining-config",
-                        },
-                        {
-                            name: _("Backups & LDIFs"),
-                            icon: <CopyIcon />,
-                            id: "backups",
-                        },
-                        {
-                            name: _("Password Policies"),
-                            id: "pwp",
-                            icon: <KeyIcon />,
-                            children: [
-                                {
-                                    name: _("Global Policy"),
-                                    icon: <HomeIcon />,
-                                    id: "pwpolicy",
-                                },
-                                {
-                                    name: _("Local Policies"),
-                                    icon: <UsersIcon />,
-                                    id: "localpwpolicy",
-                                },
-                            ],
-                            defaultExpanded: true
-                        },
-                        {
-                            name: _("Suffixes"),
-                            icon: <CatalogIcon />,
-                            id: "suffixes-tree",
-                            children: suffixData,
-                            defaultExpanded: true,
-                            action: (
-                                <Button
-                                    onClick={this.handleShowSuffixModal}
-                                    variant="plain"
-                                    aria-label="Create new suffix"
-                                    title={_("Create new suffix")}
-                                >
-                                    <PlusIcon />
-                                </Button>
-                            ),
-                        }
-                    ];
+
+                    let current_node = this.state.node_name;
+                    if (fullReset) {
+                        current_node = DB_CONFIG;
+                    }
+
+                    treeData[4].children = suffixData; // suffixes node
+                    this.setState(() => ({
+                        nodes: treeData,
+                        node_name: current_node,
+                    }), this.loadAttrs);
+                })
+                .fail(err => {
+                    // Handle backend get-tree failure gracefully
                     let current_node = this.state.node_name;
                     if (fullReset) {
                         current_node = DB_CONFIG;

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -177,6 +177,16 @@ export class Replication extends React.Component {
             loaded: false
         });
 
+        const basicData = [
+            {
+                name: _("Suffixes"),
+                icon: <TopologyIcon />,
+                id: "repl-suffixes",
+                children: [],
+                defaultExpanded: true
+            }
+        ];
+
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "backend", "get-tree",
@@ -199,15 +209,7 @@ export class Replication extends React.Component {
                             }
                         }
                     }
-                    const basicData = [
-                        {
-                            name: _("Suffixes"),
-                            icon: <TopologyIcon />,
-                            id: "repl-suffixes",
-                            children: [],
-                            defaultExpanded: true
-                        }
-                    ];
+
                     let current_node = this.state.node_name;
                     let current_type = this.state.node_type;
                     let replicated = this.state.node_replicated;
@@ -258,6 +260,19 @@ export class Replication extends React.Component {
                     }
 
                     basicData[0].children = treeData;
+                    this.setState({
+                        nodes: basicData,
+                        node_name: current_node,
+                        node_type: current_type,
+                        node_replicated: replicated,
+                    }, () => { this.update_tree_nodes() });
+                })
+                .fail(err => {
+                    // Handle backend get-tree failure gracefully
+                    let current_node = this.state.node_name;
+                    let current_type = this.state.node_type;
+                    let replicated = this.state.node_replicated;
+
                     this.setState({
                         nodes: basicData,
                         node_name: current_node,
@@ -905,18 +920,18 @@ export class Replication extends React.Component {
                                                             disableTree: false
                                                         });
                                                     });
-                                        })
-                                        .fail(err => {
-                                            const errMsg = JSON.parse(err);
-                                            this.props.addNotification(
-                                                "error",
-                                                cockpit.format(_("Error loading replication agreements configuration - $0"), errMsg.desc)
-                                            );
-                                            this.setState({
-                                                suffixLoading: false,
-                                                disableTree: false
+                                            })
+                                            .fail(err => {
+                                                const errMsg = JSON.parse(err);
+                                                this.props.addNotification(
+                                                    "error",
+                                                    cockpit.format(_("Error loading replication agreements configuration - $0"), errMsg.desc)
+                                                );
+                                                this.setState({
+                                                    suffixLoading: false,
+                                                    disableTree: false
+                                                });
                                             });
-                                        });
                             })
                             .fail(err => {
                                 // changelog failure


### PR DESCRIPTION
Description: Add rollback functionality when mapping tree creation fails during backend creation to prevent orphaned backends. Improve error handling in Database, Replication and Monitoring UI tabs to gracefully handle backend get-tree command failures.

Fixes: https://github.com/389ds/389-ds-base/issues/6822

Reviewed by: ?