### PR TITLE
Issue 6825 - RootDN Access Control Plugin with wildcards for IP addre…

### DIFF
--- a/src/lib389/lib389/cli_conf/plugins/rootdn_ac.py
+++ b/src/lib389/lib389/cli_conf/plugins/rootdn_ac.py
@@ -8,7 +8,7 @@
 
 import socket
 from lib389.plugins import RootDNAccessControlPlugin
-from lib389.utils import is_valid_hostname
+from lib389.utils import is_valid_hostname, is_valid_ip
 from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit
 from lib389.cli_base import CustomHelpFormatter
 
@@ -62,19 +62,13 @@ def validate_args(args):
 
     if args.allow_ip is not None:
         for ip in args.allow_ip:
-            if ip != "delete":
-                try:
-                    socket.inet_aton(ip)
-                except socket.error:
-                    raise ValueError(f"Invalid IP address ({ip}) for '--allow-ip'")
+            if ip != "delete" and not is_valid_ip(ip):
+                raise ValueError(f"Invalid IP address ({ip}) for '--allow-ip'")
 
     if args.deny_ip is not None and args.deny_ip != "delete":
         for ip in args.deny_ip:
-            if ip != "delete":
-                try:
-                    socket.inet_aton(ip)
-                except socket.error:
-                    raise ValueError(f"Invalid IP address ({ip}) for '--deny-ip'")
+            if ip != "delete" and not is_valid_ip(ip):
+                raise ValueError(f"Invalid IP address ({ip}) for '--deny-ip'")
 
     if args.allow_host is not None:
         for hostname in args.allow_host:

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1713,6 +1713,23 @@ def is_valid_hostname(hostname):
     allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))
 
+def is_valid_ip(ip):
+    """ Validate an IP address or wildcard pattern """
+    if '*' in ip:
+        pattern = r'^(\d{1,3}|\*)(\.(\d{1,3}|\*)){0,3}$'
+        if not re.match(pattern, ip):
+            return False
+        # Make sure each octet is between 0-255
+        octets = ip.split('.')
+        for octet in octets:
+            if octet != '*' and not (0 <= int(octet) <= 255):
+                return False
+        return True
+    try:
+        socket.inet_aton(ip)
+        return True
+    except socket.error:
+        return False
 
 def parse_size(size):
     """


### PR DESCRIPTION
…sses fails with an error

Bug description:
RootDN Access Control Plugin with wildcards for IP addresses fails withi an error "Invalid IP address"

socket.inet_aton() validates IPv4 IP addresses and does not support wildcards.

Fix description:
Add a regex pattern to match wildcard IP addresses, check each octet is between 0-255

Fixes: https://github.com/389ds/389-ds-base/issues/6825

Reviewed by: