### PR TITLE
Issue 6827: Backports commit that regression test test_suffix_entryid is dependent on. 

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -16,6 +16,9 @@ import pprint
 import pytest
 import subprocess
 import time
+import random
+import string
+from shutil import rmtree
 from lib389.dbgen import dbgen_users
 from lib389.backend import DatabaseConfig
 from lib389.idm.user import TEST_USER_PROPERTIES, UserAccount, UserAccounts
@@ -262,6 +265,46 @@ def topo_with_sigkill(request):
     request.addfinalizer(fin)
 
     return topology
+
+
+@pytest.fixture(scope="function")
+def preserve_topo_m2(topo_m2, request):
+    """Backup the topology and restore it at the end."""
+
+    saves = []
+
+    def fin():
+        for inst,backup_dir in saves:
+            inst.tasks.bak2db(backup_dir=backup_dir, args={TASK_WAIT: True})
+            rmtree(backup_dir)
+
+    if not DEBUGGING:
+        request.addfinalizer(fin)
+
+    bindcn = "replication manager"
+    binddn = f"cn={bindcn},cn=config"
+    bindpw = ''.join(random.choices(string.ascii_letters + string.digits, k=15))
+    for inst in topo_m2:
+        backup_dir = f'{inst.ds_paths.backup_dir}/topo_bak'
+        try:
+            rmtree(backup_dir)
+        except FileNotFoundError:
+            pass
+        inst.tasks.db2bak(backup_dir=backup_dir, args={TASK_WAIT: True})
+        # Ensure that we are not using group bind dn
+        # because the test may delete credentials
+        replmgr = BootstrapReplicationManager(inst, dn=binddn)
+        if replmgr.exists():
+            replmgr.replace('userPassword', bindpw)
+        else:
+            replmgr.create(properties={'cn':bindcn, 'userPassword':bindpw})
+        replica = Replicas(inst).get(DEFAULT_SUFFIX)
+        replica.replace(REPL_BINDDN, binddn);
+        replica.remove_all(REPL_BIND_GROUP);
+        for agmt in replica.get_agreements().list():
+            agmt.replace_many((AGMT_CRED, bindpw), (REPL_BINDDN, binddn))
+        saves.append((inst, backup_dir))
+    return topo_m2
 
 
 @pytest.fixture()


### PR DESCRIPTION
Commit in question is https://github.com/389ds/389-ds-base/commit/f75b5e24ee4ef366be1cca0b099871d3540b29fb, meant to resolve issue https://github.com/389ds/389-ds-base/issues/6265. 

Resolves: https://github.com/389ds/389-ds-base/issues/6827

## Summary by Sourcery

Isolate multi-master replication regression tests by using temporary credentials and restoring each topology after execution.

Bug Fixes:
- Prevent replication regression tests from depending on group-based replication credentials that may be removed during test execution.

Enhancements:
- Add a fixture that backs up the multi-master topology, assigns temporary dedicated replication credentials, and restores the topology after each test.

Tests:
- Improve replication regression test isolation by preserving and restoring topology state around individual tests.