### PR TITLE
Issue 6838 - lib389/replica.py is using nonexistent datetime.UTC in P…

### DIFF
--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -917,7 +917,7 @@ class RUV(object):
             ValueError("Wrong CSN value was supplied")
 
         timestamp = int(csn[:8], 16)
-        time_str = datetime.datetime.fromtimestamp(timestamp, datetime.UTC).strftime('%Y-%m-%d %H:%M:%S')
+        time_str = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
         # We are parsing shorter CSN which contains only timestamp
         if len(csn) == 8:
             return time_str


### PR DESCRIPTION
…ython 3.9

Bug Description:
389-ds-base-2.x is supposed to be used with Python 3.9. But lib389/replica.py is using `datetime.UTC`, which is an alias to `datetime.timezone.utc` was added only in Python 3.11.

Fix Description:
Use `datetime.timezone.utc` instead.

Fixes: https://github.com/389ds/389-ds-base/issues/6838