### PR TITLE
Issue 6800 - Check for minimal supported Python version

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validate tests
+name: Validate tests and minimal Python version
 
 on:
   push:
@@ -25,3 +25,11 @@ jobs:
       - name: Check for duplicate IDs
         if: always()
         run: python3 dirsrvtests/check_for_duplicate_ids.py dirsrvtests/tests/suites
+
+      - name: Check for minimal Python version for lib389
+        if: always()
+        run: uv tool run vermin --target=3.8 src/lib389
+
+      - name: Check for minimal Python version for dirsrvtests
+        if: always()
+        run: uv tool run vermin --target=3.8 dirsrvtests

--- a/src/lib389/lib389/instance/options.py
+++ b/src/lib389/lib389/instance/options.py
@@ -16,10 +16,7 @@ from lib389.utils import get_default_db_lib, get_default_mdb_max_size, socket_ch
 
 MAJOR, MINOR, _, _, _ = sys.version_info
 
-if MAJOR >= 3:
-    import configparser
-else:
-    import ConfigParser as configparser
+import configparser
 
 format_keys = [
     'prefix',

--- a/src/lib389/lib389/paths.py
+++ b/src/lib389/lib389/paths.py
@@ -14,10 +14,7 @@ from lib389._constants import DIRSRV_STATE_ONLINE, DSRC_CONTAINER
 
 MAJOR, MINOR, _, _, _ = sys.version_info
 
-if MAJOR >= 3:
-    import configparser
-else:
-    import ConfigParser as configparser
+import configparser
 
 # Read the paths from default.inf
 

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -11,19 +11,6 @@
 
     TODO put them in a module!
 """
-try:
-    from subprocess import Popen as my_popen, PIPE
-except ImportError:
-    from popen2 import popen2
-
-    def my_popen(cmd_l, stdout=None):
-        class MockPopenResult(object):
-            def wait(self):
-                pass
-        p = MockPopenResult()
-        p.stdout, p.stdin = popen2(cmd_l)
-        return p
-
 import json
 import re
 import os
@@ -859,7 +846,7 @@ def isLocalHost(host_name):
 
     # next, see if this IP addr is one of our
     # local addresses
-    p = my_popen(['/sbin/ip', 'addr'], stdout=PIPE)
+    p = subprocess.Popen(['/sbin/ip', 'addr'], stdout=subprocess.PIPE)
     child_stdout = p.stdout.read()
     found = ('inet %s' % ip_addr).encode() in child_stdout
     p.wait()


### PR DESCRIPTION
Description:
Add a new check for minimal supported Python version for lib389 and dirsrvtests

Fixes:
https://github.com/389ds/389-ds-base/issues/6800