### PR TITLE
Issue 6841 - Cancel Actions when PR is updated

### DIFF
--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: 
   actions: read
   packages: read

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,6 +3,10 @@ on:
   - pull_request
   - push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: 
   actions: read
   packages: read

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   packages: read

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: 
   actions: read
   packages: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   packages: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: 
   actions: read
   packages: read


### PR DESCRIPTION
Description
GH Actions take some time to run, and updating PR before the previous run has completed makes the new runs wait.

Instead we should cancel the previous runs for this PR to save time and don't waste computing resources.

Fixes: https://github.com/389ds/389-ds-base/issues/6841