### PR TITLE
Issue #6844 nsslapd-external-libs-debug-enable flag is not automatica…

### DIFF
--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -446,7 +446,7 @@ disk_monitoring_thread(void *nothing __attribute__((unused)))
     int using_accesslog = 0;
     int using_auditlog = 0;
     int using_auditfaillog = 0;
-    int using_external_libs_debug = 0;
+    static int using_external_libs_debug = 0;
     int logs_disabled = 0;
     int grace_period = 0;
     int first_pass = 1;


### PR DESCRIPTION
…lly set to on

In the disk monitoring thread, the using_external_libs_debug variable is set at the beginning of each monitoring cycle:

if (config_get_external_libs_debug_enabled()) {
    using_external_libs_debug = 1;
}
But here's the problem: After the disk monitoring disables external libs debug, config_get_external_libs_debug_enabled() returns false in subsequent monitoring cycles. So when disk space is recovered, the restoration logic checks:

if (logs_disabled && using_external_libs_debug) {
    // Restore external libs debug
}
Since using_external_libs_debug is now 0 (because the current config shows it's disabled), the restoration never happens!

The disk monitoring code needs to remember the original state of external libs debug when it first disables it, not re-read the current configuration in each cycle. Other parts of the code do this correctly by setting the flag once when logs are disabled, but this particular logic has the bug.

The _withouterrorlog function waits 31 seconds for:

"topo.standalone.config.get_attr_val_utf8('nsslapd-external-libs-debug-enabled') != 'on'" to become false (i.e., waiting for the value to become 'on').

But, the external libs debug is never restored to 'on', so the assertion fails after the 31-second timeout.

This fix sets the variable using_external_libs_debug as a static int instead of int so that the value is retained and not calculated at each step in the test

Relates : #6844