### PR TITLE
Issue 6850 - AddressSanitizer: memory leak in mdb_init

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -146,7 +146,9 @@ dbmdb_compute_limits(struct ldbminfo *li)
 int mdb_init(struct ldbminfo *li, config_info *config_array)
 {
     dbmdb_ctx_t *conf = (dbmdb_ctx_t *)slapi_ch_calloc(1, sizeof(dbmdb_ctx_t));
-    dbmdb_componentid = generate_componentid(NULL, "db-mdb");
+    if (dbmdb_componentid == NULL) {
+        dbmdb_componentid = generate_componentid(NULL, "db-mdb");
+    }
 
     li->li_dblayer_config = conf;
     strncpy(conf->home, li->li_directory, MAXPATHLEN-1);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -19,7 +19,7 @@
 #include <prclist.h>
 #include <glob.h>
 
-Slapi_ComponentId *dbmdb_componentid;
+Slapi_ComponentId *dbmdb_componentid = NULL;
 
 #define BULKOP_MAX_RECORDS  100 /* Max records handled by a single bulk operations */
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_misc.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_misc.c
@@ -49,6 +49,11 @@ dbmdb_cleanup(struct ldbminfo *li)
     }
     slapi_ch_free((void **)&(li->li_dblayer_config));
 
+    if (dbmdb_componentid != NULL) {
+        release_componentid(dbmdb_componentid);
+        dbmdb_componentid = NULL;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Bug Description:
`dbmdb_componentid` can be allocated multiple times. To avoid a memory leak, allocate it only once, and free at the cleanup.

Fixes: https://github.com/389ds/389-ds-base/issues/6850