### PR TITLE
Issue 6852 - Move ds* CLI tools back to /sbin

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -486,6 +486,11 @@ cp -r %{_builddir}/%{name}-%{version}/man/man3 $RPM_BUILD_ROOT/%{_mandir}/man3
 # lib389
 pushd src/lib389
 %pyproject_install
+%if 0%{?fedora} <= 41 || (0%{?rhel} && 0%{?rhel} <= 10)
+for clitool in dsconf dscreate dsctl dsidm openldap_to_ds; do
+    mv %{buildroot}%{_bindir}/$clitool %{buildroot}%{_sbindir}/
+done
+%endif
 %pyproject_save_files -l lib389
 popd
 
@@ -743,11 +748,11 @@ fi
 %doc src/lib389/README.md
 %license LICENSE LICENSE.GPLv3+
 # Binaries
-%{_bindir}/dsconf
-%{_bindir}/dscreate
-%{_bindir}/dsctl
-%{_bindir}/dsidm
-%{_bindir}/openldap_to_ds
+%{_sbindir}/dsconf
+%{_sbindir}/dscreate
+%{_sbindir}/dsctl
+%{_sbindir}/dsidm
+%{_sbindir}/openldap_to_ds
 %{_libexecdir}/%{pkgname}/dscontainer
 # Man pages
 %{_mandir}/man8/dsconf.8.gz


### PR DESCRIPTION
Bug Description:
After #6767 ds* CLI tools are packaged in /bin instead of /sbin. Even though Fedora 42 has unified /bin and /sbin, some tools (ipa-backup) and our tests still rely on hardcoded paths.

Fix Description:
Move ds* tools back to /sbin

Fixes: https://github.com/389ds/389-ds-base/issues/6852