### PR TITLE
Issue 6857 - uiduniq: allow specifying match rules in the filter

### DIFF
--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1030,7 +1030,14 @@ preop_add(Slapi_PBlock *pb)
     }
 
     for (i = 0; attrNames && attrNames[i]; i++) {
+        char *attr_match = strchr(attrNames[i], ':');
+        if (attr_match != NULL) {
+            attr_match[0] = '\0';
+        }
         err = slapi_entry_attr_find(e, attrNames[i], &attr);
+        if (attr_match != NULL) {
+            attr_match[0] = ':';
+        }
         if (!err) {
             /*
                  * Passed all the requirements - this is an operation we


### PR DESCRIPTION
Allow uniqueness plugin to work with attributes where uniqueness should be enforced using different matching rule than the one defined for the attribute itself.

Since uniqueness plugin configuration can contain multiple attributes, add matching rule right to the attribute as it is used in the LDAP rule (e.g. 'attribute:caseIgnoreMatch:' to force 'attribute' to be searched with case-insensitive matching rule instead of the original matching rule.

Fixes: https://github.com/389ds/389-ds-base/issues/6857