### PR TITLE
Issue 6859 - str2filter is not fully applying matching rules

### DIFF
--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1178,6 +1178,10 @@ preop_modify(Slapi_PBlock *pb)
     for (; mods && *mods; mods++) {
         mod = *mods;
         for (i = 0; attrNames && attrNames[i]; i++) {
+            char *attr_match = strchr(attrNames[i], ':');
+            if (attr_match != NULL) {
+                attr_match[0] = '\0';
+            }
             if ((slapi_attr_type_cmp(mod->mod_type, attrNames[i], 1) == 0) && /* mod contains target attr */
                 (mod->mod_op & LDAP_MOD_BVALUES) &&                           /* mod is bval encoded (not string val) */
                 (mod->mod_bvalues && mod->mod_bvalues[0]) &&                  /* mod actually contains some values */
@@ -1185,6 +1189,9 @@ preop_modify(Slapi_PBlock *pb)
                  SLAPI_IS_MOD_REPLACE(mod->mod_op)))                          /* mod is replace */
             {
                 addMod(&checkmods, &checkmodsCapacity, &modcount, mod);
+            }
+            if (attr_match != NULL) {
+                attr_match[0] = ':';
             }
         }
     }

--- a/ldap/servers/slapd/plugin_mr.c
+++ b/ldap/servers/slapd/plugin_mr.c
@@ -625,7 +625,7 @@ attempt_mr_filter_create(mr_filter_t *f, struct slapdplugin *mrp, Slapi_PBlock *
     int rc;
     int32_t  (*mrf_create)(Slapi_PBlock *) = NULL;
     f->mrf_match = NULL;
-    pblock_init(pb);
+    slapi_pblock_init(pb);
     if (!(rc = slapi_pblock_set(pb, SLAPI_PLUGIN, mrp)) &&
         !(rc = slapi_pblock_get(pb, SLAPI_PLUGIN_MR_FILTER_CREATE_FN, &mrf_create)) &&
         mrf_create != NULL &&

--- a/ldap/servers/slapd/str2filter.c
+++ b/ldap/servers/slapd/str2filter.c
@@ -344,6 +344,14 @@ str2simple(char *str, int unescape_filter)
                 return NULL; /* error */
             } else {
                 f->f_choice = LDAP_FILTER_EXTENDED;
+                if (f->f_mr_oid) {
+                    /* apply the MR indexers */
+                    rc = plugin_mr_filter_create(&f->f_mr);
+                    if (rc) {
+                        slapi_filter_free(f, 1);
+                        return NULL; /* error */
+                    }
+                }
             }
         } else if (str_find_star(value) == NULL) {
             f->f_choice = LDAP_FILTER_EQUALITY;


### PR DESCRIPTION
Description:

When we have an extended filter, one with a MR applied, it is ignored during internal searches:

    "(cn:CaseExactMatch:=Value)"

For internal searches we use str2filter() and it doesn't fully apply extended search filter matching rules

Relates: https://github.com/389ds/389-ds-base/issues/6857
Relates: https://github.com/389ds/389-ds-base/issues/6859

