### PR TITLE
Issue 6352 - Fix DeprecationWarning

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -138,7 +138,7 @@ def pytest_runtest_makereport(item, call):
                         log_name = os.path.basename(f)
                         instance_name = os.path.basename(os.path.dirname(f)).split("slapd-",1)[1]
                         extra.append(pytest_html.extras.text(text, name=f"{instance_name}-{log_name}"))
-            report.extra = extra
+            report.extras = extra
 
     # Make a screenshot if WebUI test fails
     if call.when == "call" and "WEBUI" in os.environ:


### PR DESCRIPTION
Bug Description:
When pytest is used on ASAN build, pytest-html plugin collects `*asan*` files, which results in the following deprecation warning:

```
The 'report.extra' attribute is deprecated and will be removed in a
future release, use 'report.extras' instead.
```

Fixes: https://github.com/389ds/389-ds-base/issues/6352