### PR TITLE
Issue 6868 - UI - schema attribute table expansion break after moving to

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -8,7 +8,6 @@ import {
     Form,
     Grid,
     GridItem,
-    Hr,
     NumberInput,
     Spinner,
     Switch,

--- a/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
@@ -465,7 +465,7 @@ class AttributesTable extends React.Component {
 
     handleCollapse(event, rowKey, isOpen) {
         const { rows, perPage, page } = this.state;
-        const index = (perPage * (page - 1) * 2) + rowKey; // Adjust for page set
+        const index = (perPage * (page - 1)) + rowKey; // Adjust for page set
         rows[index].isOpen = isOpen;
         this.setState({
             rows
@@ -525,7 +525,7 @@ class AttributesTable extends React.Component {
     ];
 
     render() {
-        const { perPage, page, sortBy, rows, noRows, columns } = this.state;
+        const { perPage, page, sortBy, rows, columns } = this.state;
         const startIdx = (perPage * page) - perPage;
         const tableRows = rows.slice(startIdx, startIdx + perPage);
 


### PR DESCRIPTION
a new page

Description:

Used the wrong formula to select the expanded row for Attributes

Relates: https://github.com/389ds/389-ds-base/issues/6868

