### PR TITLE
Issue 6872 - compressed log rotation creates files with world readable permission

### DIFF
--- a/dirsrvtests/tests/suites/logging/logging_compression_test.py
+++ b/dirsrvtests/tests/suites/logging/logging_compression_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -22,12 +22,21 @@ log = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.tier1
 
+
 def log_rotated_count(log_type, log_dir, check_compressed=False):
-    # Check if the log was rotated
+    """
+    Check if the log was rotated and has the correct permissions
+    """
     log_file = f'{log_dir}/{log_type}.2*'
     if check_compressed:
         log_file += ".gz"
-    return len(glob.glob(log_file))
+    log_files = glob.glob(log_file)
+    for logf in log_files:
+        # Check permissions
+        st = os.stat(logf)
+        assert oct(st.st_mode) == '0o100600'  # 0600
+
+    return len(log_files)
 
 
 def update_and_sleep(inst, suffix, sleep=True):

--- a/ldap/servers/slapd/schema.c
+++ b/ldap/servers/slapd/schema.c
@@ -903,7 +903,7 @@ oc_check_allowed_sv(Slapi_PBlock *pb, Slapi_Entry *e, const char *type, struct o
 
         if (pb) {
             PR_snprintf(errtext, sizeof(errtext),
-                        "attribute \"%s\" not allowed\n",
+                        "attribute \"%s\" not allowed",
                         escape_string(type, ebuf));
             slapi_pblock_set(pb, SLAPI_PB_RESULT_TEXT, errtext);
         }


### PR DESCRIPTION
Description:

When compressing a log file, first create the empty file using PR_Open
so we can set the correct permissions right from the start. gzopen()
always uses permission 644 and that is not safe. So after creating it
with PR_Open(), with the correct permissions, then reopen it with gzopen()
and write the compressed content.


relates: https://github.com/389ds/389-ds-base/issues/6872
