### PR TITLE
Issue 6880 - Fix ds_logs test suite failure

### DIFF
--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -356,6 +356,10 @@ def test_internal_log_server_level_4(topology_st, clean_access_logs, disable_acc
     log.info('Restart the server to flush the logs')
     topo.restart()
 
+    # After 947ee67 log dynamic has changed slightly
+    # Do another MOD to trigger the internal search
+    topo.config.set(LOG_ACCESS_LEVEL, access_log_level)
+
     try:
         # These comments contain lines we are trying to find without regex (the op numbers are just examples)
         log.info("Check if access log contains internal MOD operation in correct format")


### PR DESCRIPTION
Bug Description:
After 947ee67df6 ds_logs test suite started to fail in test_internal_log_server_level_4.  It slightly changed the order and timing of log messages.

Fix Description:
Do another MOD after restart to trigger the internal search.

Fixes: https://github.com/389ds/389-ds-base/issues/6880