### PR TITLE
Issue 6895 - Crash if repl keep alive entry can not be created

### DIFF
--- a/ldap/servers/plugins/chainingdb/cb_config.c
+++ b/ldap/servers/plugins/chainingdb/cb_config.c
@@ -44,8 +44,7 @@ cb_config_add_dse_entries(cb_backend *cb, char **entries, char *string1, char *s
         slapi_pblock_get(util_pb, SLAPI_PLUGIN_INTOP_RESULT, &res);
         if (LDAP_SUCCESS != res && LDAP_ALREADY_EXISTS != res) {
             slapi_log_err(SLAPI_LOG_ERR, CB_PLUGIN_SUBSYSTEM,
-                          "cb_config_add_dse_entries - Unable to add config entry (%s) to the DSE: %s\n",
-                          slapi_entry_get_dn(e),
+                          "cb_config_add_dse_entries - Unable to add config entry to the DSE: %s\n",
                           ldap_err2string(res));
             rc = res;
             slapi_pblock_destroy(util_pb);

--- a/ldap/servers/plugins/posix-winsync/posix-winsync.c
+++ b/ldap/servers/plugins/posix-winsync/posix-winsync.c
@@ -1626,7 +1626,6 @@ posix_winsync_end_update_cb(void *cbdata __attribute__((unused)),
                           "posix_winsync_end_update_cb: "
                           "add task entry\n");
         }
-        /* slapi_entry_free(e_task); */
         slapi_pblock_destroy(pb);
         pb = NULL;
         posix_winsync_config_reset_MOFTaskCreated();

--- a/ldap/servers/plugins/replication/repl5_init.c
+++ b/ldap/servers/plugins/replication/repl5_init.c
@@ -682,7 +682,6 @@ create_repl_schema_policy(void)
                       repl_schema_top,
                       ldap_err2string(return_value));
         rc = -1;
-        slapi_entry_free(e); /* The entry was not consumed */
         goto done;
     }
     slapi_pblock_destroy(pb);
@@ -703,7 +702,6 @@ create_repl_schema_policy(void)
                       repl_schema_supplier,
                       ldap_err2string(return_value));
         rc = -1;
-        slapi_entry_free(e); /* The entry was not consumed */
         goto done;
     }
     slapi_pblock_destroy(pb);
@@ -724,7 +722,6 @@ create_repl_schema_policy(void)
                       repl_schema_consumer,
                       ldap_err2string(return_value));
         rc = -1;
-        slapi_entry_free(e); /* The entry was not consumed */
         goto done;
     }
     slapi_pblock_destroy(pb);

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -465,10 +465,10 @@ replica_subentry_create(const char *repl_root, ReplicaId rid)
     if (return_value != LDAP_SUCCESS &&
         return_value != LDAP_ALREADY_EXISTS &&
         return_value != LDAP_REFERRAL /* CONSUMER */) {
-        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "replica_subentry_create - Unable to "
-                                                       "create replication keep alive entry %s: error %d - %s\n",
-                      slapi_entry_get_dn_const(e),
-                      return_value, ldap_err2string(return_value));
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "replica_subentry_create - "
+                "Unable to create replication keep alive entry 'cn=%s %d,%s': error %d - %s\n",
+                KEEP_ALIVE_ENTRY, rid, repl_root,
+                return_value, ldap_err2string(return_value));
         rc = -1;
         goto done;
     }


### PR DESCRIPTION
Description:

Heap use after free when logging that the replicaton keep-alive entry can not be created. slapi_add_internal_pb() frees the slapi entry on error, then we try and get the dn from the entry and we get a use-after-free crash.

Relates: https://github.com/389ds/389-ds-base/issues/6895
