### PR TITLE
Issue 6800 - Rerun the check in verbose mode on failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,8 +32,17 @@ jobs:
 
       - name: Check for minimal Python version for lib389
         if: always()
-        run: uv tool run vermin --target=3.8 src/lib389
+        run: |
+          uv tool run vermin --target=3.8 src/lib389 || {
+            echo "Check failed, rerunning in verbose mode..."
+            uv tool run vermin -vv --target=3.8 src/lib389
+          }
 
       - name: Check for minimal Python version for dirsrvtests
         if: always()
-        run: uv tool run vermin --target=3.8 dirsrvtests
+        run: |
+          uv tool run vermin --target=3.8 dirsrvtests || {
+            echo "Check failed, rerunning in verbose mode..."
+            uv tool run vermin -vv --target=3.8 dirsrvtests
+          }
+


### PR DESCRIPTION
Bug Description:
By default vermin doesn't report line numbers where the check failed, it's available in verbose mode. But verbose mode is too noisy.

Fix Description:
Rerun vermin again in the verbose mode, only when the first run exited with error.

Relates: https://github.com/389ds/389-ds-base/issues/6800