### PR TITLE
Issue 6904 - Fix config_test.py::test_lmdb_config

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1786,7 +1786,7 @@ def get_default_mdb_max_size(paths):
     """
     if paths is None:
         paths = Paths()
-    mdb_max_size = DEFAULT_LMDB_SIZE
+    mdb_max_size = format_size(parse_size(DEFAULT_LMDB_SIZE))
     size = parse_size(mdb_max_size)
     # Make sure that there is enough available disk space
     # otherwise decrease the value


### PR DESCRIPTION
Description:
Update get_default_mdb_max_size to format DEFAULT_LMDB_SIZE from '20Gb' to '20.0 GB'

Relates: https://github.com/389ds/389-ds-base/issues/6904

Reviewed by: ???