### PR TITLE
Issue 6181 - RFE - Allow system to manage uid/gid at startup

### DIFF
--- a/wrappers/systemd.template.service.in
+++ b/wrappers/systemd.template.service.in
@@ -29,7 +29,7 @@ MemoryAccounting=yes
 
 # Allow non-root instances to bind to low ports.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_CHOWN
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_CHOWN CAP_FOWNER
 
 PrivateTmp=on
 # https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort


### PR DESCRIPTION
Description:
Expand CapabilityBoundingSet to include CAP_FOWNER

Relates: https://github.com/389ds/389-ds-base/issues/6181
Relates: https://github.com/389ds/389-ds-base/issues/6906