### PR TITLE
Issue 6468 - CLI - Fix default error log level

### DIFF
--- a/src/lib389/lib389/cli_conf/logging.py
+++ b/src/lib389/lib389/cli_conf/logging.py
@@ -44,7 +44,7 @@ ERROR_LEVELS = {
                 + "methods used for a SASL bind"
     },
     "default": {
-        "level": 6384,
+        "level": 16384,
         "desc": "Default logging level"
     },
     "filter": {


### PR DESCRIPTION
Description:
Default error log level is 16384

Relates: https://github.com/389ds/389-ds-base/issues/6468