### PR TITLE
Issues 6913, 6886, 6250 - Adjust xfail marks

### DIFF
--- a/dirsrvtests/tests/suites/acl/syntax_test.py
+++ b/dirsrvtests/tests/suites/acl/syntax_test.py
@@ -190,10 +190,9 @@ FAILED = [('test_targattrfilters_18',
            f'(all)userdn="ldap:///anyone";)'), ]
 
 
-@pytest.mark.xfail(reason='https://bugzilla.redhat.com/show_bug.cgi?id=1691473')
 @pytest.mark.parametrize("real_value", [a[1] for a in FAILED],
                          ids=[a[0] for a in FAILED])
-def test_aci_invalid_syntax_fail(topo, real_value):
+def test_aci_invalid_syntax_fail(topo, real_value, request):
     """Try to set wrong ACI syntax.
 
         :id: 83c40784-fff5-49c8-9535-7064c9c19e7e
@@ -206,6 +205,16 @@ def test_aci_invalid_syntax_fail(topo, real_value):
             1. It should pass
             2. It should not pass
         """
+    # Mark specific test cases as xfail
+    xfail_cases = [
+        'test_targattrfilters_18',
+        'test_targattrfilters_20',
+        'test_bind_rule_set_with_more_than_three'
+    ]
+
+    if request.node.callspec.id in xfail_cases:
+        pytest.xfail("DS6913 - This test case is expected to fail")
+
     domain = Domain(topo.standalone, DEFAULT_SUFFIX)
     with pytest.raises(ldap.INVALID_SYNTAX):
         domain.add("aci", real_value)

--- a/dirsrvtests/tests/suites/logging/audit_password_masking_test.py
+++ b/dirsrvtests/tests/suites/logging/audit_password_masking_test.py
@@ -117,10 +117,10 @@ def check_password_masked(inst, log_format, expected_password, actual_password):
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "userPassword"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "userPassword")
 ])
 def test_password_masking_add_operation(topo, log_format, display_attrs):
@@ -173,10 +173,10 @@ def test_password_masking_add_operation(topo, log_format, display_attrs):
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "userPassword"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "userPassword")
 ])
 def test_password_masking_modify_operation(topo, log_format, display_attrs):
@@ -242,10 +242,10 @@ def test_password_masking_modify_operation(topo, log_format, display_attrs):
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "nsslapd-rootpw"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "nsslapd-rootpw")
 ])
 def test_password_masking_rootpw_modify_operation(topo, log_format, display_attrs):
@@ -297,10 +297,10 @@ def test_password_masking_rootpw_modify_operation(topo, log_format, display_attr
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "nsmultiplexorcredentials"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "nsmultiplexorcredentials")
 ])
 def test_password_masking_multiplexor_credentials(topo, log_format, display_attrs):
@@ -368,10 +368,10 @@ def test_password_masking_multiplexor_credentials(topo, log_format, display_attr
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "nsDS5ReplicaCredentials"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "nsDS5ReplicaCredentials")
 ])
 def test_password_masking_replica_credentials(topo, log_format, display_attrs):
@@ -432,10 +432,10 @@ def test_password_masking_replica_credentials(topo, log_format, display_attrs):
 
 @pytest.mark.parametrize("log_format,display_attrs", [
     ("default", None),
-    ("default", "*"),
+    pytest.param("default", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("default", "nsDS5ReplicaBootstrapCredentials"),
     ("json", None),
-    ("json", "*"),
+    pytest.param("json", "*", marks=pytest.mark.xfail(reason="DS6886")),
     ("json", "nsDS5ReplicaBootstrapCredentials")
 ])
 def test_password_masking_bootstrap_credentials(topo, log_format, display_attrs):

--- a/dirsrvtests/tests/suites/plugins/entryusn_overflow_test.py
+++ b/dirsrvtests/tests/suites/plugins/entryusn_overflow_test.py
@@ -81,6 +81,7 @@ def setup_usn_test(topology_st, request):
     return created_users
 
 
+@pytest.mark.xfail(reason="DS6250")
 def test_entryusn_overflow_on_add_existing_entries(topology_st, setup_usn_test):
     """Test that reproduces entryUSN overflow when adding existing entries
 
@@ -232,6 +233,7 @@ def test_entryusn_overflow_on_add_existing_entries(topology_st, setup_usn_test):
     log.info("EntryUSN overflow test completed successfully")
 
 
+@pytest.mark.xfail(reason="DS6250")
 def test_entryusn_consistency_after_failed_adds(topology_st, setup_usn_test):
     """Test that entryUSN remains consistent after failed add operations
 


### PR DESCRIPTION
Description: Some of the ACI invalid syntax issues were fixed, so we need to remove xfail marks.
Disk space issue should have a 'skipif' mark.
Display all attrs (nsslapd-auditlog-display-attrs: *) fails because of a bug. EntryUSN inconsistency and overflow bugs were exposed with the tests.

Related: https://github.com/389ds/389-ds-base/issues/6913
Related: https://github.com/389ds/389-ds-base/issues/6886
Related: https://github.com/389ds/389-ds-base/issues/6250

Reviewed by: ?