### PR TITLE
Issue 6915 - DSRetroclPlugin - An error occured while adding change n…

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -552,6 +552,22 @@ retrocl_start(Slapi_PBlock *pb)
         slapi_ch_array_free(values);
     }
 
+#ifdef DEBUG
+    /* Process debug changenumber configuration attribute */
+    values = slapi_entry_attr_get_charray(e, CONFIG_CHANGELOG_DEBUG_CHANGENUMBER);
+    if (values != NULL) {
+        if (values[1] != NULL) {
+            slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME,
+                          "retrocl_start - Multiple values specified for attribute: %s\n", CONFIG_CHANGELOG_DEBUG_CHANGENUMBER);
+        } else {
+            slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME,
+                          "retrocl_start - Processing debug changenumber command: %s\n", values[0]);
+            retrocl_set_debug_changenumber(values[0]);
+        }
+        slapi_ch_array_free(values);
+    }
+#endif
+
     return 0;
 }
 

--- a/ldap/servers/plugins/retrocl/retrocl.h
+++ b/ldap/servers/plugins/retrocl/retrocl.h
@@ -70,6 +70,9 @@ typedef struct _cnumRet
 #define CONFIG_CHANGELOG_INCLUDE_SUFFIX      "nsslapd-include-suffix"
 #define CONFIG_CHANGELOG_EXCLUDE_SUFFIX      "nsslapd-exclude-suffix"
 #define CONFIG_CHANGELOG_EXCLUDE_ATTRS       "nsslapd-exclude-attrs"
+#ifdef DEBUG
+#define CONFIG_CHANGELOG_DEBUG_CHANGENUMBER  "nsslapd-retrocl-debug-changenumber"
+#endif
 
 #define RETROCL_CHANGELOG_DN   "cn=changelog"
 #define RETROCL_MAPPINGTREE_DN "cn=\"cn=changelog\",cn=mapping tree,cn=config"
@@ -136,6 +139,10 @@ extern void retrocl_commit_changenumber(void);
 extern void retrocl_release_changenumber(void);
 extern void retrocl_set_check_changenumber(void);
 extern changeNumber retrocl_assign_changenumber(void);
+extern int retrocl_changenumber_exists(changeNumber cn);
+#ifdef DEBUG
+extern int retrocl_set_debug_changenumber(const char *value);
+#endif
 extern int retrocl_get_changenumbers(void);
 extern void retrocl_forget_changenumbers(void);
 extern time_t retrocl_getchangetime(int type, int *err);


### PR DESCRIPTION
…umber

Bug Description:
Under certain circumstances RetroCL plugin can experience an issue that can cause errors such as:

```
ERR - DSRetroclPlugin - retrocl_postob - Operation failure [68]
WARN - flush_hash - Upon BETXN callback failure, entry cache is flushed during 0.015972218
WARN - flush_hash - Upon BETXN callback failure, entry cache is flushed during 0.000910450
ERR - DSRetroclPlugin - write_replog_db - An error occured while adding change number 100, dn = changenumber=100,cn=changelog: Already exists.
```

It was observed when ldapmodify was importing ldif file with changes. Some changes (replace) were for non-existent entries. After the first err=32 all the following changes were not applied and returned err=68. The error was not for the modified entry, but for the creation of the RetroCL changenumber=NNN entry in cn=changelog.

Another possible accelerator - memberOf fixup task for entries that didn't have OC that provides memberOf attribute. It would cause schema validation errors and follow with the entry repair by adding OC. If the ldapmodify was running at the same time, it started to return err=68.

Fix Description:
* Added additional plugin logging for better troubleshooting.

* Implemented `retrocl_changenumber_exists()` function to verify change number availability in the database.

* Added duplicate detection in `retrocl_assign_changenumber()` that checks for existing change numbers in the changelog db and skips to the next available number when duplicates are found.

* Added debug-only configuration attribute `nsslapd-retrocl-debug-changenumber`, available only in debug builds. Supported commands:
    - "reset" - reset internal_cn to match database
    - "set:N" - set internal_cn to specific number N
    - "dec:N" - decrement internal_cn by N (simulate rollback)
    - "sync" - force resynchronization with database

Fixes: https://github.com/389ds/389-ds-base/issues/6915