### PR TITLE
Issue 6917 - dsconf config add fails with '_config_display_ldapimapro…

### DIFF
--- a/src/lib389/lib389/cli_conf/config.py
+++ b/src/lib389/lib389/cli_conf/config.py
@@ -102,8 +102,6 @@ def config_add_attr(inst, basedn, log, args):
         # Missing value
         raise ValueError("Missing attribute to add")    
 
-    _config_display_ldapimaprootdn_warning(log, args)
-
 
 def config_del_attr(inst, basedn, log, args):
     conf = Config(inst, basedn)


### PR DESCRIPTION
…otdn_warning' is not defined

Bug Description:
`dsconf config add` fails:
```
dsconf localhost config add nsslapd-referral-check-period=5
Error: name '_config_display_ldapimaprootdn_warning' is not defined
```

Fix Description:
Remove `_config_display_ldapimaprootdn_warning` as it was brought as part of another fix.

Fixes: https://github.com/389ds/389-ds-base/issues/6917