### PR TITLE
Issue 6922 - AddressSanitizer: leaks found by acl test suite

### DIFF
--- a/ldap/servers/plugins/acl/aclgroup.c
+++ b/ldap/servers/plugins/acl/aclgroup.c
@@ -50,8 +50,20 @@ aclgroup_init()
 void
 aclgroup_free()
 {
-    slapi_destroy_rwlock(aclUserGroups->aclg_rwlock);
-    slapi_ch_free((void **)&aclUserGroups);
+    aclUserGroup *u_group, *next_group;
+
+    if (aclUserGroups) {
+        /* Clean up all user groups */
+        u_group = aclUserGroups->aclg_first;
+        while (u_group) {
+            next_group = u_group->aclug_next;
+            __aclg__delete_userGroup(u_group);
+            u_group = next_group;
+        }
+
+        slapi_destroy_rwlock(aclUserGroups->aclg_rwlock);
+        slapi_ch_free((void **)&aclUserGroups);
+    }
 }
 
 /*

--- a/ldap/servers/plugins/acl/aclinit.c
+++ b/ldap/servers/plugins/acl/aclinit.c
@@ -409,6 +409,7 @@ __aclinit__RegisterAttributes(void)
     rv = ACL_MethodRegister(&errp, DS_METHOD, &methodinfo);
     if (rv < 0) {
         acl_print_acllib_err(&errp, NULL);
+        nserrDispose(&errp);
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "__aclinit__RegisterAttributes - Unable to Register the methods\n");
         return ACL_ERR;
@@ -416,6 +417,7 @@ __aclinit__RegisterAttributes(void)
     rv = ACL_MethodSetDefault(&errp, methodinfo);
     if (rv < 0) {
         acl_print_acllib_err(&errp, NULL);
+        nserrDispose(&errp);
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "__aclinit__RegisterAttributes - Unable to Set the default method\n");
         return ACL_ERR;
@@ -424,6 +426,7 @@ __aclinit__RegisterAttributes(void)
                                 methodinfo, ACL_DBTYPE_ANY, ACL_AT_FRONT, NULL);
     if (rv < 0) {
         acl_print_acllib_err(&errp, NULL);
+        nserrDispose(&errp);
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "__aclinit__RegisterAttributes - Unable to Register Attr ip\n");
         return ACL_ERR;
@@ -432,6 +435,7 @@ __aclinit__RegisterAttributes(void)
                                 methodinfo, ACL_DBTYPE_ANY, ACL_AT_FRONT, NULL);
     if (rv < 0) {
         acl_print_acllib_err(&errp, NULL);
+        nserrDispose(&errp);
         slapi_log_err(SLAPI_LOG_ERR, plugin_name,
                       "__aclinit__RegisterAttributes - Unable to Register Attr dns\n");
         return ACL_ERR;

--- a/ldap/servers/plugins/acl/acllas.c
+++ b/ldap/servers/plugins/acl/acllas.c
@@ -258,6 +258,7 @@ DS_LASIpGetter(NSErr_t *errp, PList_t subject, PList_t resource, PList_t auth_in
     rv = ACL_GetAttribute(errp, DS_PROP_ACLPB, (void **)&aclpb, subject, resource, auth_info, global_auth);
     if (rv != LAS_EVAL_TRUE || (NULL == aclpb)) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "DS_LASIpGetter: Unable to get the ACLPB(%d)\n", rv);
         return LAS_EVAL_FAIL;
@@ -334,6 +335,7 @@ DS_LASDnsGetter(NSErr_t *errp, PList_t subject, PList_t resource, PList_t auth_i
                           subject, resource, auth_info, global_auth);
     if (rv != LAS_EVAL_TRUE || (NULL == aclpb)) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "DS_LASDnsGetter - Unable to get the ACLPB(%d)\n", rv);
         return LAS_EVAL_FAIL;
@@ -3743,6 +3745,7 @@ __acllas_setup(NSErr_t *errp, char *attr_name, CmpOp_t comparator, int allow_ran
 
     if (rc != LAS_EVAL_TRUE) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "__acllas_setup - %s:Unable to get the clientdn attribute(%d)\n", lasName, rc);
         return LAS_EVAL_FAIL;
@@ -3762,6 +3765,7 @@ __acllas_setup(NSErr_t *errp, char *attr_name, CmpOp_t comparator, int allow_ran
     if ((rc = PListFindValue(subject, DS_ATTR_ENTRY,
                              (void **)&linfo->resourceEntry, NULL)) < 0) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "__acllas_setup - %s:Unable to get the Slapi_Entry attr(%d)\n", lasName, rc);
         return LAS_EVAL_FAIL;
@@ -3772,6 +3776,7 @@ __acllas_setup(NSErr_t *errp, char *attr_name, CmpOp_t comparator, int allow_ran
                           subject, resource, auth_info, global_auth);
     if (rc != LAS_EVAL_TRUE) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "__acllas_setup - %s:Unable to get the ACLPB(%d)\n", lasName, rc);
         return LAS_EVAL_FAIL;
@@ -3795,6 +3800,7 @@ __acllas_setup(NSErr_t *errp, char *attr_name, CmpOp_t comparator, int allow_ran
     if ((rc = PListFindValue(subject, DS_ATTR_AUTHTYPE,
                              (void **)&linfo->authType, NULL)) < 0) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "__acllas_setup - %s:Unable to get the auth type(%d)\n", lasName, rc);
         return LAS_EVAL_FAIL;
@@ -3804,6 +3810,7 @@ __acllas_setup(NSErr_t *errp, char *attr_name, CmpOp_t comparator, int allow_ran
     if ((rc = PListFindValue(subject, DS_ATTR_SSF,
                              (void **)&linfo->ssf, NULL)) < 0) {
         acl_print_acllib_err(errp, NULL);
+        nserrDispose(errp);
         slapi_log_err(SLAPI_LOG_ACL, plugin_name,
                       "__acllas_setup - %s:Unable to get the ssf(%d)\n", lasName, rc);
     }

--- a/ldap/servers/plugins/acl/acllist.c
+++ b/ldap/servers/plugins/acl/acllist.c
@@ -526,6 +526,8 @@ acllist_free_aci(aci_t *item)
 
     slapi_sdn_free(&item->aci_sdn);
     slapi_filter_free(item->target, 1);
+    slapi_filter_free(item->target_to, 1);
+    slapi_filter_free(item->target_from, 1);
 
     /* slapi_filter_free(item->targetAttr, 1); */
     attrArray = item->targetAttr;

--- a/ldap/servers/plugins/acl/aclparse.c
+++ b/ldap/servers/plugins/acl/aclparse.c
@@ -423,6 +423,9 @@ __aclp__parse_aci(char *str, aci_t *aci_item, char **errbuf)
             }
             f = slapi_str2filter(tstr);
             slapi_ch_free_string(&tstr);
+            if (rv > 0) {
+                slapi_ch_free_string(&tmpstr);
+            }
         } else if (strncmp(str, aci_targetdn, targetdnlen) == 0) {
             char *tstr = NULL;
             size_t LDAP_URL_prefix_len = 0;
@@ -706,6 +709,7 @@ __aclp__sanity_check_acltxt(aci_t *aci_item, char *str)
     /* check for acl syntax error */
     if ((handle = (ACLListHandle_t *)ACL_ParseString(&errp, newstr)) == NULL) {
         acl_print_acllib_err(&errp, str);
+        nserrDispose(&errp);
         slapi_ch_free_string(&newstr);
         return ACL_SYNTAX_ERR;
     } else {
@@ -1147,13 +1151,16 @@ normalize_nextACERule:
             if (nextACE && *nextACE != '\0')
                 aclutil_str_append(&ret_str, nextACE);
             slapi_ch_free_string(&s_aclstr);
+            slapi_ch_free_string(&s_acestr);
             return (ret_str);
         }
         acestr = nextACE;
+        slapi_ch_free_string(&s_acestr);
         goto normalize_nextACERule;
     }
 
     slapi_ch_free_string(&s_aclstr);
+    slapi_ch_free_string(&s_acestr);
     return (ret_str);
 
 error:

--- a/lib/libaccess/aclscan.l
+++ b/lib/libaccess/aclscan.l
@@ -64,11 +64,18 @@ variable	[\*a-zA-Z0-9\.\-\_][\*a-zA-Z0-9\.\-\_]*
 
 <<EOF>>		{	
 			yylval.string = NULL;
-			last_string = yylval.string;
+			if (last_string) {
+				PERM_FREE(last_string);
+				last_string = NULL;
+			}
 			return(0);
 		}
 
 {qstring}	{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+				last_string = NULL;
+			}
 			yylval.string = PERM_STRDUP( yytext+1 );
 			last_string = yylval.string;
 			if ( yylval.string[yyleng-2] != '"' )
@@ -81,96 +88,144 @@ variable	[\*a-zA-Z0-9\.\-\_][\*a-zA-Z0-9\.\-\_]*
 
 
 absolute	{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_ABSOLUTE_TOK; 
 		}
 
 acl		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_ACL_TOK; 
 		}
 
 allow		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_ALLOW_TOK; 
 		}
 
 always		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_ALWAYS_TOK; 
 		}
 
 at		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_AT_TOK; 
 		}
 
 authenticate	{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_AUTHENTICATE_TOK; 
 		}
 
 content		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_CONTENT_TOK; 
 		}
 
 default		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_DEFAULT_TOK; 
 		}
 
 deny		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_DENY_TOK; 
 		}
 
 in		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_IN_TOK; 
 		}
 
 inherit		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_INHERIT_TOK; 
 		}
 
 terminal	{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_TERMINAL_TOK; 
 		}
 
 version		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_VERSION_TOK; 
 		}
 
 with		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_WITH_TOK; 
 		}
 
 not		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return ACL_NOT_TOK; 
 		}
 
 and 		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = ACL_EXPR_OP_AND;
 			acl_tokenpos += yyleng; 
@@ -178,6 +233,9 @@ and 		{
 		}
 
 or		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = ACL_EXPR_OP_OR;
 			acl_tokenpos += yyleng; 
@@ -185,6 +243,9 @@ or		{
 		}
 
 "="		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_EQ;
 			acl_tokenpos += yyleng; 
@@ -192,6 +253,9 @@ or		{
 		}
 
 ">="		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_GE; 
 			acl_tokenpos += yyleng; 
@@ -199,6 +263,9 @@ or		{
 		}
 
 ">"		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_GT; 
 			acl_tokenpos += yyleng; 
@@ -206,6 +273,9 @@ or		{
 		}
 
 "<"		{ 	
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_LT; 
 			acl_tokenpos += yyleng; 
@@ -213,6 +283,9 @@ or		{
 		}
 
 "<="		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_LE; 
 			acl_tokenpos += yyleng; 
@@ -220,6 +293,9 @@ or		{
 		}
 
 "!="		{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			yylval.ival = CMP_OP_NE;
 			acl_tokenpos += yyleng; 
@@ -227,6 +303,9 @@ or		{
 		}
 
 [(){},;]	{ 
+			if (last_string) {
+				PERM_FREE(last_string);
+			}
 			last_string = NULL;
 			acl_tokenpos += yyleng; 
 			return yytext[0]; 
@@ -234,6 +313,10 @@ or		{
 
 {variable}	{ 
 			acl_tokenpos += yyleng; 
+			if (last_string) {
+				PERM_FREE(last_string);
+				last_string = NULL;
+			}
 			yylval.string = PERM_STRDUP( yytext );
 			last_string = yylval.string;
 			return ACL_VARIABLE_TOK;
@@ -272,8 +355,10 @@ char	errorStr[256];
 #if defined(UTEST) || defined(ACL_COMPILER)
 	printf("ACL file: %s\n", acl_filename);
 	printf("Syntax error at line: %d, token: %s\n", acl_lineno, yytext);
-	if ( last_string )
-		free(last_string);
+	if ( last_string ) {
+		PERM_FREE(last_string);
+		last_string = NULL;
+	}
 #else
 	sprintf(errorStr, "%d", acl_lineno);
 	if (yytext) {
@@ -283,8 +368,10 @@ char	errorStr[256];
 		nserrGenerate(acl_errp, ACLERRPARSE, ACLERR1780, ACL_Program,
                       2, acl_filename, errorStr);
 	}
-	if ( last_string )
-		free(last_string);
+	if ( last_string ) {
+		PERM_FREE(last_string);
+		last_string = NULL;
+	}
 #endif
 
 }
@@ -294,6 +381,7 @@ acl_InitScanner(NSErr_t *errp, char *filename, char *buffer)
 {
 	acl_errp = errp;
 	acl_lineno = 1;
+	last_string = NULL;
 	acl_use_buffer = (filename == NULL) ? 1 : 0 ;
 	if ( filename != NULL ) {
 		PL_strncpyz(acl_filename, filename, sizeof(acl_filename));
@@ -342,6 +430,12 @@ acl_EndScanner()
 #endif
 		yyin = NULL ;
 	}
+
+	if ( last_string ) {
+		PERM_FREE(last_string);
+		last_string = NULL;
+	}
+
 	return(0);
 }
 

--- a/lib/libaccess/acltext.y
+++ b/lib/libaccess/acltext.y
@@ -80,7 +80,7 @@ acl_free_args(char **args_list)
 
 	for (ii = 0; ii < MAX_LIST_SIZE; ii++) {
 		if ( args_list[ii] )
-			free(args_list[ii]);
+			PERM_FREE(args_list[ii]);
 		else
 			break;
 	}
@@ -240,7 +240,7 @@ acl_set_ip_dns(ACLExprHandle_t *expr, char **ip_dns)
 start:	| start_acl_v2
 	| ACL_VERSION_TOK ACL_VARIABLE_TOK 
 	{
-		free($<string>2);
+		PERM_FREE($<string>2);
 	}
 	';' start_acl_v3
 	;
@@ -267,7 +267,7 @@ acl_v2: ACL_ACL_TOK acl_name_v2
 acl_name_v2: ACL_VARIABLE_TOK
 	{
 		curr_acl = ACL_AclNew(NULL, $<string>1);
-		free($<string>1);
+		PERM_FREE($<string>1);
 		if ( ACL_ListAppend(NULL, curr_acl_list, curr_acl, 0) < 0 ) {
 			yyerror("Couldn't add ACL to list.");
 			return(-1);
@@ -289,7 +289,7 @@ acl_name_v2: ACL_VARIABLE_TOK
 	| ACL_QSTRING_TOK
 	{
 		curr_acl = ACL_AclNew(NULL, $<string>1);
-		free($<string>1);
+		PERM_FREE($<string>1);
 		if ( ACL_ListAppend(NULL, curr_acl_list, curr_acl, 0) < 0 ) {
 			yyerror("Couldn't add ACL to list.");
 			return(-1);
@@ -503,8 +503,8 @@ ip_spec_v2: ACL_VARIABLE_TOK ACL_VARIABLE_TOK
 		char tmp_str[255];
 
 		util_sprintf(tmp_str, "%s+%s", $<string>1, $<string>2);
-		free($<string>1);
-		free($<string>2);
+		PERM_FREE($<string>1);
+		PERM_FREE($<string>2);
 		acl_add_arg(curr_ip_dns_list, PERM_STRDUP(tmp_str));
 	}
 	;
@@ -538,26 +538,26 @@ method_v2: ACL_VARIABLE_TOK ACL_VARIABLE_TOK ';'
 	{
 		acl_string_lower($<string>1);
 		if (strcmp($<string>1, "database") == 0) {
-			free($<string>1);
-			free($<string>2);
+			PERM_FREE($<string>1);
+			PERM_FREE($<string>2);
 		} else {
 			if ( PListInitProp(curr_auth_info, 
 				   ACL_Attr2Index($<string>1), $<string>1, $<string>2, NULL) < 0 ) {
 			}
-			free($<string>1);
+			PERM_FREE($<string>1);
 		}
 	}
 	| ACL_VARIABLE_TOK ACL_QSTRING_TOK ';'
 	{
 		acl_string_lower($<string>1);
 		if (strcmp($<string>1, "database") == 0) {
-			free($<string>1);
-			free($<string>2);
+			PERM_FREE($<string>1);
+			PERM_FREE($<string>2);
 		} else {
 			if ( PListInitProp(curr_auth_info, 
 				   ACL_Attr2Index($<string>1), $<string>1, $<string>2, NULL) < 0 ) {
 			}
-			free($<string>1);
+			PERM_FREE($<string>1);
 		}
 	}
 	;
@@ -586,7 +586,7 @@ acl:	named_acl ';' body_list
 named_acl: ACL_ACL_TOK ACL_VARIABLE_TOK 
 	{
 		curr_acl = ACL_AclNew(NULL, $<string>2);
-		free($<string>2);
+		PERM_FREE($<string>2);
 		if ( ACL_ListAppend(NULL, curr_acl_list, curr_acl, 0) < 0 ) {
 			yyerror("Couldn't add ACL to list.");
 			return(-1);
@@ -595,7 +595,7 @@ named_acl: ACL_ACL_TOK ACL_VARIABLE_TOK
 	| ACL_ACL_TOK ACL_QSTRING_TOK 
 	{
 		curr_acl = ACL_AclNew(NULL, $<string>2);
-		free($<string>2);
+		PERM_FREE($<string>2);
 		if ( ACL_ListAppend(NULL, curr_acl_list, curr_acl, 0) < 0 ) {
 			yyerror("Couldn't add ACL to list.");
 			return(-1);
@@ -654,8 +654,8 @@ deny_common: ACL_VARIABLE_TOK ACL_EQ_TOK ACL_QSTRING_TOK
                         yyerror("ACL_ExprSetDenyWith() failed");
                         return(-1);
                 }
-                free($<string>1);
-                free($<string>3);
+                PERM_FREE($<string>1);
+                PERM_FREE($<string>3);
 	}
 	;
 
@@ -692,7 +692,7 @@ attribute: ACL_VARIABLE_TOK
 			yyerror("ACL_ExprAddArg() failed");
 			return(-1);
 		}
-		free($<string>1);
+		PERM_FREE($<string>1);
 	}
 	;
 
@@ -706,7 +706,7 @@ parameter: ACL_VARIABLE_TOK ACL_EQ_TOK ACL_QSTRING_TOK
 		if ( PListInitProp(curr_auth_info, 
                                    ACL_Attr2Index($<string>1), $<string>1, $<string>3, NULL) < 0 ) {
 		}
-		free($<string>1);
+		PERM_FREE($<string>1);
 	}
 	| ACL_VARIABLE_TOK ACL_EQ_TOK ACL_VARIABLE_TOK
 	{
@@ -714,7 +714,7 @@ parameter: ACL_VARIABLE_TOK ACL_EQ_TOK ACL_QSTRING_TOK
 		if ( PListInitProp(curr_auth_info, 
                                    ACL_Attr2Index($<string>1), $<string>1, $<string>3, NULL) < 0 ) {
 		}
-		free($<string>1);
+		PERM_FREE($<string>1);
 	}
 	;
 
@@ -896,12 +896,12 @@ base_expr: ACL_VARIABLE_TOK relop ACL_QSTRING_TOK
 		if ( ACL_ExprTerm(NULL, curr_expr,
 				$<string>1, (CmpOp_t) $<ival>2, $<string>3) < 0 ) {
 			yyerror("ACL_ExprTerm() failed");
-			free($<string>1);
-			free($<string>3);	
+			PERM_FREE($<string>1);
+			PERM_FREE($<string>3);
 			return(-1);
 		}
-		free($<string>1);
-		free($<string>3);	
+		PERM_FREE($<string>1);
+		PERM_FREE($<string>3);
 	}
 	| ACL_VARIABLE_TOK relop ACL_VARIABLE_TOK 
 	{
@@ -909,12 +909,12 @@ base_expr: ACL_VARIABLE_TOK relop ACL_QSTRING_TOK
 		if ( ACL_ExprTerm(NULL, curr_expr,
 				$<string>1, (CmpOp_t) $<ival>2, $<string>3) < 0 ) {
 			yyerror("ACL_ExprTerm() failed");
-			free($<string>1);
-			free($<string>3);	
+			PERM_FREE($<string>1);
+			PERM_FREE($<string>3);
 			return(-1);
 		}
-		free($<string>1);
-		free($<string>3);	
+		PERM_FREE($<string>1);
+		PERM_FREE($<string>3);
 	}
 	;
 


### PR DESCRIPTION
Description:
Fix multiple memory leaks in ACL plugin:

* aclgroup.c: Fix memory leak in `aclgroup_free()` by properly cleaning up all user groups before destroying the rwlock and freeing the main structure
* aclscan.l & acltext.y: use `PERM_FREE` macro instead of `free()`
* Add cleanups in aclparse.c, aclinit.c, acllist.c, acllas.c

Fixes: https://github.com/389ds/389-ds-base/issues/6922