### PR TITLE
Issue 6342 - buffer owerflow in the function parseVariant

### DIFF
--- a/ldap/servers/slapd/tools/ldclt/ldclt.c
+++ b/ldap/servers/slapd/tools/ldclt/ldclt.c
@@ -189,7 +189,7 @@ copyVersObject(
     /*
    * Initiates the variables
    */
-    for (size_t i = 0; i + VAR_MIN < VAR_MAX; i++)
+    for (size_t i = 0; i + VAR_MIN < VAR_MAX + 1; i++) /*25-08-07*/
         if (srcobj->var[i] == NULL)
             newobj->var[i] = NULL;
         else
@@ -2321,7 +2321,7 @@ main(
    */
     mctx.object.attribsNb = 0;              /*JLS 23-03-01*/
     mctx.object.rdn = NULL;                 /*JLS 23-03-01*/
-    for (size_t i = 0; i + VAR_MIN < VAR_MAX; i++)
+    for (size_t i = 0; i + VAR_MIN < VAR_MAX + 1; i++) /*25-08-07*/
         mctx.object.var[i] = NULL;          /*JLS 23-03-01*/
 
     /*

--- a/ldap/servers/slapd/tools/ldclt/ldclt.h
+++ b/ldap/servers/slapd/tools/ldclt/ldclt.h
@@ -326,7 +326,7 @@ typedef struct vers_object
     int attribsNb;
     vers_attribute *rdn; /* Object's rdn */ /*JLS 23-03-01*/
     char *rdnName; /* Attrib. name */       /*JLS 23-03-01*/
-    char *var[VAR_MAX - VAR_MIN];           /*JLS 21-03-01*/
+    char *var[VAR_MAX - VAR_MIN + 1];       /*25-08-07*/
     char *fname;                            /* Object definition */
 } vers_object;
 


### PR DESCRIPTION
Bug Description:

The expression var = variant0 - VAR_MIN; calculates the difference between variant0 and a constant VAR_MIN, resulting in a value of 7 in this specific example. Attempting to access the array using the calculated index 7 would lead to an out-of-bounds access, causing an array overflow.

Found by Linux Verification Center (linuxtesting.org) with SVACE. Reporter: Dmitriy Fedin (d.fedin@fobos-nt.ru).
Organization: Fobos-NT (info@fobos-nt.ru).

Fix Description:

It is necessary to increase the size of the array and increase the bounds when it is initialized.

Organization: altlinux.org

Fixes: https://github.com/389ds/389-ds-base/issues/6342

Author: Denis Rastyogin

Reviewed by: @mreynolds389 (Thanks!)