### PR TITLE
Issue 6929 - Compilation failure with rust-1.89 on Fedora ELN

### DIFF
--- a/src/slapi_r_plugin/src/value.rs
+++ b/src/slapi_r_plugin/src/value.rs
@@ -61,7 +61,7 @@ impl ValueArrayRef {
         ValueArrayRef { raw_slapi_val }
     }
 
-    pub fn iter(&self) -> ValueArrayRefIter {
+    pub fn iter(&self) -> ValueArrayRefIter<'_> {
         ValueArrayRefIter {
             idx: 0,
             va_ref: &self,


### PR DESCRIPTION
Bug Description:
The `ValueArrayRefIter` struct has a lifetime parameter `'a`. But in the `iter` method  the return type doesn't specify the lifetime parameter.

Fix Description:
Make the lifetime explicit.

Fixes: https://github.com/389ds/389-ds-base/issues/6929