### PR TITLE
Issue 5120 - Fix compilation error

### DIFF
--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -285,14 +285,6 @@ main_setuid(char *username)
     return 0;
 }
 
-/* set good defaults for front-end config in referral mode */
-static void
-referral_set_defaults(void)
-{
-    char errorbuf[SLAPI_DSE_RETURNTEXT_SIZE];
-    config_set_maxdescriptors(CONFIG_MAXDESCRIPTORS_ATTRIBUTE, "1024", errorbuf, 1);
-}
-
 static int
 name2exemode(char *progname, char *s, int exit_if_unknown)
 {


### PR DESCRIPTION
Bug Description:
Compilation fails with `-Wunused-function`:

```
ldap/servers/slapd/main.c:290:1: warning: ‘referral_set_defaults’ defined but not used [-Wunused-function]
  290 | referral_set_defaults(void)
      | ^~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:4148: all] Error 2
```

Fix Description:
Remove unused function `referral_set_defaults`.

Fixes: https://github.com/389ds/389-ds-base/issues/5120