### PR TITLE
Issue 6928 - The parentId attribute is indexed with improper matching…

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -734,7 +734,7 @@ def test_basic_db2index(topology_st):
     topology_st.standalone.db2index(bename=DEFAULT_BENAME, attrs=indexes)
     log.info('Checking the server logs for %d backend indexes INFO' % numIndexes)
     for indexNum, index in enumerate(indexes):
-        if index in "entryrdn":
+        if index in ["entryrdn", "ancestorid"]:
             assert topology_st.standalone.searchErrorsLog(
                 f'INFO - {dbprefix}_db2index - {DEFAULT_BENAME}: Indexing {index}')
         else:

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -1,0 +1,456 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+
+import pytest
+import os
+
+from lib389.backend import Backends
+from lib389.index import Index
+from lib389.plugins import (
+    USNPlugin,
+    RetroChangelogPlugin,
+)
+from lib389.utils import logging, ds_is_newer
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_st
+from lib389.cli_ctl.health import health_check_run
+
+pytestmark = pytest.mark.tier1
+
+CMD_OUTPUT = "No issues found."
+JSON_OUTPUT = "[]"
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def usn_plugin_enabled(topology_st, request):
+    """Fixture to enable USN plugin and ensure cleanup after test"""
+    standalone = topology_st.standalone
+
+    log.info("Enable USN plugin")
+    usn_plugin = USNPlugin(standalone)
+    usn_plugin.enable()
+    standalone.restart()
+
+    def cleanup():
+        log.info("Disable USN plugin")
+        usn_plugin.disable()
+        standalone.restart()
+
+    request.addfinalizer(cleanup)
+    return usn_plugin
+
+
+@pytest.fixture(scope="function")
+def retrocl_plugin_enabled(topology_st, request):
+    """Fixture to enable RetroCL plugin and ensure cleanup after test"""
+    standalone = topology_st.standalone
+
+    log.info("Enable RetroCL plugin")
+    retrocl_plugin = RetroChangelogPlugin(standalone)
+    retrocl_plugin.enable()
+    standalone.restart()
+
+    def cleanup():
+        log.info("Disable RetroCL plugin")
+        retrocl_plugin.disable()
+        standalone.restart()
+
+    request.addfinalizer(cleanup)
+    return retrocl_plugin
+
+
+@pytest.fixture(scope="function")
+def log_buffering_enabled(topology_st, request):
+    """Fixture to enable log buffering and restore original setting after test"""
+    standalone = topology_st.standalone
+
+    original_value = standalone.config.get_attr_val_utf8("nsslapd-accesslog-logbuffering")
+
+    log.info("Enable log buffering")
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
+
+    def cleanup():
+        log.info("Restore original log buffering setting")
+        standalone.config.set("nsslapd-accesslog-logbuffering", original_value)
+
+    request.addfinalizer(cleanup)
+    return standalone
+
+
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = [
+        "config",
+        "refint",
+        "backends",
+        "monitor-disk-space",
+        "logs",
+        "memberof",
+    ]
+    args.dry_run = False
+
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
+    if (
+        ds_is_newer("3.0.0")
+        and instance.get_db_lib() == "bdb"
+        and (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT)
+    ):
+        searched_code = "DSBLE0006"
+
+    if json:
+        log.info("Use healthcheck with --json option")
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+        assert topology.logcap.contains(searched_code)
+        log.info("healthcheck returned searched code: %s" % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info("healthcheck returned searched code: %s" % searched_code2)
+    else:
+        log.info("Use healthcheck without --json option")
+        args.json = json
+        health_check_run(instance, topology.logcap.log, args)
+
+        assert topology.logcap.contains(searched_code)
+        log.info("healthcheck returned searched code: %s" % searched_code)
+
+        if searched_code2 is not None:
+            assert topology.logcap.contains(searched_code2)
+            log.info("healthcheck returned searched code: %s" % searched_code2)
+
+    log.info("Clear the log")
+    topology.logcap.flush()
+
+
+def test_missing_parentid(topology_st, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when parentId system index is missing
+
+    :id: 2653f16f-cc9c-4fad-9d8c-86a3457c6d0d
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Remove parentId index
+        3. Use healthcheck without --json option
+        4. Use healthcheck with --json option
+        5. Re-add the parentId index
+        6. Use healthcheck without --json option
+        7. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. healthcheck reports DSBLE0007 code and related details
+        4. healthcheck reports DSBLE0007 code and related details
+        5. Success
+        6. healthcheck reports no issues found
+        7. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove parentId index")
+    parentid_index = Index(standalone, PARENTID_DN)
+    parentid_index.delete()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the parentId index")
+    backend = Backends(standalone).get("userRoot")
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_missing_matching_rule(topology_st, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when parentId index is missing integerOrderingMatch
+
+    :id: 7ffa71db-8995-430a-bed8-59bce944221c
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Remove integerOrderingMatch matching rule from parentId index
+        3. Use healthcheck without --json option
+        4. Use healthcheck with --json option
+        5. Re-add the matching rule
+        6. Use healthcheck without --json option
+        7. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. healthcheck reports DSBLE0007 code and related details
+        4. healthcheck reports DSBLE0007 code and related details
+        5. Success
+        6. healthcheck reports no issues found
+        7. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove integerOrderingMatch matching rule from parentId index")
+    parentid_index = Index(standalone, PARENTID_DN)
+    parentid_index.remove("nsMatchingRule", "integerOrderingMatch")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the integerOrderingMatch matching rule")
+    parentid_index = Index(standalone, PARENTID_DN)
+    parentid_index.add("nsMatchingRule", "integerOrderingMatch")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_usn_plugin_missing_entryusn(topology_st, usn_plugin_enabled, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when USN plugin is enabled but entryusn index is missing
+
+    :id: 4879dfc8-cd96-43e6-9ebc-053fc8e64ad0
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Enable USN plugin
+        3. Remove entryusn index
+        4. Use healthcheck without --json option
+        5. Use healthcheck with --json option
+        6. Re-add the entryusn index
+        7. Use healthcheck without --json option
+        8. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. healthcheck reports DSBLE0007 code and related details
+        5. healthcheck reports DSBLE0007 code and related details
+        6. Success
+        7. healthcheck reports no issues found
+        8. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+    ENTRYUSN_DN = "cn=entryusn,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove entryusn index")
+    entryusn_index = Index(standalone, ENTRYUSN_DN)
+    entryusn_index.delete()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the entryusn index")
+    backend = Backends(standalone).get("userRoot")
+    backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"])
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_usn_plugin_missing_matching_rule(topology_st, usn_plugin_enabled, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when USN plugin is enabled but entryusn index is missing integerOrderingMatch
+
+    :id: b00b419f-2ca6-451f-a9b2-f22ad6b10718
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Enable USN plugin
+        3. Remove integerOrderingMatch matching rule from entryusn index
+        4. Use healthcheck without --json option
+        5. Use healthcheck with --json option
+        6. Re-add the matching rule
+        7. Use healthcheck without --json option
+        8. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. healthcheck reports DSBLE0007 code and related details
+        5. healthcheck reports DSBLE0007 code and related details
+        6. Success
+        7. healthcheck reports no issues found
+        8. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+    ENTRYUSN_DN = "cn=entryusn,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    standalone = topology_st.standalone
+
+    log.info("Create or modify entryusn index without integerOrderingMatch")
+    entryusn_index = Index(standalone, ENTRYUSN_DN)
+    entryusn_index.remove("nsMatchingRule", "integerOrderingMatch")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the integerOrderingMatch matching rule")
+    entryusn_index = Index(standalone, ENTRYUSN_DN)
+    entryusn_index.add("nsMatchingRule", "integerOrderingMatch")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_retrocl_plugin_missing_changenumber(topology_st, retrocl_plugin_enabled, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when RetroCL plugin is enabled but changeNumber index is missing from changelog backend
+
+    :id: 3e1a3625-4e6f-4e23-868d-6f32e018ad7e
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Enable RetroCL plugin
+        3. Remove changeNumber index from changelog backend
+        4. Use healthcheck without --json option
+        5. Use healthcheck with --json option
+        6. Re-add the changeNumber index
+        7. Use healthcheck without --json option
+        8. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. healthcheck reports DSBLE0007 code and related details
+        5. healthcheck reports DSBLE0007 code and related details
+        6. Success
+        7. healthcheck reports no issues found
+        8. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove changeNumber index from changelog backend")
+    changenumber_dn = "cn=changenumber,cn=index,cn=changelog,cn=ldbm database,cn=plugins,cn=config"
+    changenumber_index = Index(standalone, changenumber_dn)
+    changenumber_index.delete()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the changeNumber index")
+    backends = Backends(standalone)
+    changelog_backend = backends.get("changelog")
+    changelog_backend.add_index("changenumber", ["eq"], matching_rules=["integerOrderingMatch"])
+    log.info("Successfully re-added changeNumber index")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_retrocl_plugin_missing_matching_rule(topology_st, retrocl_plugin_enabled, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when RetroCL plugin is enabled but changeNumber index is missing integerOrderingMatch
+
+    :id: 1c68b1b2-90a9-4ec0-815a-a626b20744fe
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Enable RetroCL plugin
+        3. Remove integerOrderingMatch matching rule from changeNumber index
+        4. Use healthcheck without --json option
+        5. Use healthcheck with --json option
+        6. Re-add the matching rule
+        7. Use healthcheck without --json option
+        8. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. healthcheck reports DSBLE0007 code and related details
+        5. healthcheck reports DSBLE0007 code and related details
+        6. Success
+        7. healthcheck reports no issues found
+        8. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove integerOrderingMatch matching rule from changeNumber index")
+    changenumber_dn = "cn=changenumber,cn=index,cn=changelog,cn=ldbm database,cn=plugins,cn=config"
+    changenumber_index = Index(standalone, changenumber_dn)
+    changenumber_index.remove("nsMatchingRule", "integerOrderingMatch")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the integerOrderingMatch matching rule")
+    changenumber_index = Index(standalone, changenumber_dn)
+    changenumber_index.add("nsMatchingRule", "integerOrderingMatch")
+    log.info("Successfully re-added integerOrderingMatch to changeNumber index")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
+    """Check if healthcheck returns DSBLE0007 code when multiple system indexes are missing
+
+    :id: f7cfcd6e-3c47-4ba5-bb2b-1f8e7a29c899
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Remove multiple system indexes (parentId, nsUniqueId)
+        3. Use healthcheck without --json option
+        4. Use healthcheck with --json option
+        5. Re-add the missing indexes
+        6. Use healthcheck without --json option
+        7. Use healthcheck with --json option
+    :expectedresults:
+        1. Success
+        2. Success
+        3. healthcheck reports DSBLE0007 code and related details
+        4. healthcheck reports DSBLE0007 code and related details
+        5. Success
+        6. healthcheck reports no issues found
+        7. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0007"
+    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+    NSUNIQUEID_DN = "cn=nsuniqueid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    standalone = topology_st.standalone
+
+    log.info("Remove multiple system indexes")
+    for index_dn in [PARENTID_DN, NSUNIQUEID_DN]:
+        index = Index(standalone, index_dn)
+        index.delete()
+        log.info(f"Successfully removed index: {index_dn}")
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Re-add the missing system indexes")
+    backend = Backends(standalone).get("userRoot")
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
+    backend.add_index("nsuniqueid", ["eq"])
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
+if __name__ == "__main__":
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -998,6 +998,14 @@ cn: aci
 nssystemindex: true
 nsindextype: pres
 
+dn: cn=ancestorid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+objectclass: top
+objectclass: nsIndex
+cn: ancestorid
+nssystemindex: true
+nsindextype: eq
+nsmatchingrule: integerOrderingMatch
+
 dn: cn=cn,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsIndex

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -16,7 +16,7 @@
 
 /* Forward declarations */
 static void ldbm_instance_destructor(void **arg);
-Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4);
+Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4, char *mr);
 
 
 /* Creates and initializes a new ldbm_instance structure.
@@ -126,7 +126,7 @@ done:
  * Take a bunch of strings, and create a index config entry
  */
 Slapi_Entry *
-ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4)
+ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4, char *mr)
 {
     Slapi_Entry *e = slapi_entry_alloc();
     struct berval *vals[2];
@@ -161,6 +161,12 @@ ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3
         slapi_entry_add_values(e, "nsIndexType", vals);
     }
 
+    if (mr) {
+        val.bv_val = mr;
+        val.bv_len = strlen(mr);
+        slapi_entry_add_values(e, "nsMatchingRule", vals);
+    }
+
     return e;
 }
 
@@ -182,42 +188,42 @@ ldbm_instance_create_default_indexes(backend *be)
      * since they are used by some searches, replication and the
      * ACL routines.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0);
+    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0);
+    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* For MMR, we need this attribute (to replace use of dncomp in delete). */
-    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0);
+    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* write the dse file only on the final index */
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* ldbm_instance_config_add_index_entry(inst, 2, argv); */
-    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0, 0);
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 
@@ -225,7 +231,7 @@ ldbm_instance_create_default_indexes(backend *be)
      * ancestorid is special, there is actually no such attr type
      * but we still want to use the attr index file APIs.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -34,7 +34,8 @@ from lib389.encrypted_attributes import EncryptedAttr, EncryptedAttrs
 # This is for sample entry creation.
 from lib389.configurations import get_sample_entries
 
-from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSVIRTLE0001, DSCLLE0001
+from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSVIRTLE0001, DSCLLE0001
+from lib389.plugins import USNPlugin
 
 
 class BackendLegacy(object):
@@ -606,6 +607,136 @@ class Backend(DSLdapObject):
             # Suffix is not replicated
             self._log.debug(f"_lint_cl_trimming - backend ({suffix}) is not replicated")
             pass
+
+    def _lint_system_indexes(self):
+        """Check that system indexes are correctly configured"""
+        bename = self.lint_uid()
+        suffix = self.get_attr_val_utf8('nsslapd-suffix')
+        indexes = self.get_indexes()
+
+        # Default system indexes taken from ldap/servers/slapd/back-ldbm/instance.c
+        expected_system_indexes = {
+            'entryrdn': {'types': ['subtree'], 'matching_rule': None},
+            'parentId': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'},
+            'ancestorId': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'},
+            'objectClass': {'types': ['eq'], 'matching_rule': None},
+            'aci': {'types': ['pres'], 'matching_rule': None},
+            'nscpEntryDN': {'types': ['eq'], 'matching_rule': None},
+            'nsUniqueId': {'types': ['eq'], 'matching_rule': None},
+            'nsds5ReplConflict': {'types': ['eq', 'pres'], 'matching_rule': None}
+        }
+
+        # Default system indexes taken from ldap/ldif/template-dse.ldif.in
+        expected_system_indexes.update({
+            'nsCertSubjectDN': {'types': ['eq'], 'matching_rule': None},
+            'numsubordinates': {'types': ['pres'], 'matching_rule': None},
+            'nsTombstoneCSN': {'types': ['eq'], 'matching_rule': None},
+            'targetuniqueid': {'types': ['eq'], 'matching_rule': None}
+        })
+
+
+        # RetroCL plugin creates its own backend with an additonal index for changeNumber
+        # See ldap/servers/plugins/retrocl/retrocl_create.c
+        if suffix.lower() == 'cn=changelog':
+            expected_system_indexes.update({
+                'changeNumber': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'}
+            })
+
+        # USN plugin requires entryusn attribute indexed for equality with integerOrderingMatch rule
+        # See ldap/ldif/template-dse.ldif.in
+        try:
+            usn_plugin = USNPlugin(self._instance)
+            if usn_plugin.status():
+                expected_system_indexes.update({
+                    'entryusn': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'}
+                })
+        except Exception as e:
+            self._log.debug(f"_lint_system_indexes - Error checking USN plugin: {e}")
+
+        discrepancies = []
+        remediation_commands = []
+        reindex_attrs = set()
+
+        for attr_name, expected_config in expected_system_indexes.items():
+            try:
+                index = indexes.get(attr_name)
+                # Check if index exists
+                if index is None:
+                    discrepancies.append(f"Missing system index: {attr_name}")
+                    # Generate remediation command
+                    index_types = ' '.join([f"--add-type {t}" for t in expected_config['types']])
+                    cmd = f"dsconf YOUR_INSTANCE backend index add {bename} --attr {attr_name} {index_types}"
+                    if expected_config['matching_rule']:
+                        cmd += f" --add-mr {expected_config['matching_rule']}"
+                    remediation_commands.append(cmd)
+                    reindex_attrs.add(attr_name)  # New index needs reindexing
+                else:
+                    # Index exists, check configuration
+                    actual_types = index.get_attr_vals_utf8('nsIndexType') or []
+                    actual_mrs = index.get_attr_vals_utf8('nsMatchingRule') or []
+
+                    # Normalize to lowercase for comparison
+                    actual_types = [t.lower() for t in actual_types]
+                    expected_types = [t.lower() for t in expected_config['types']]
+
+                    # Check index types
+                    missing_types = set(expected_types) - set(actual_types)
+                    if missing_types:
+                        discrepancies.append(f"Index {attr_name} missing types: {', '.join(missing_types)}")
+                        missing_type_args = ' '.join([f"--add-type {t}" for t in missing_types])
+                        cmd = f"dsconf YOUR_INSTANCE backend index set {bename} --attr {attr_name} {missing_type_args}"
+                        remediation_commands.append(cmd)
+                        reindex_attrs.add(attr_name)
+
+                    # Check matching rules
+                    expected_mr = expected_config['matching_rule']
+                    if expected_mr:
+                        actual_mrs_lower = [mr.lower() for mr in actual_mrs]
+                        if expected_mr.lower() not in actual_mrs_lower:
+                            discrepancies.append(f"Index {attr_name} missing matching rule: {expected_mr}")
+                            # Add the missing matching rule
+                            cmd = f"dsconf YOUR_INSTANCE backend index set {bename} --attr {attr_name} --add-mr {expected_mr}"
+                            remediation_commands.append(cmd)
+                            reindex_attrs.add(attr_name)
+
+            except Exception as e:
+                self._log.debug(f"_lint_system_indexes - Error checking index {attr_name}: {e}")
+                discrepancies.append(f"Unable to check index {attr_name}: {str(e)}")
+
+        if discrepancies:
+            report = copy.deepcopy(DSBLE0007)
+            report['check'] = f'backends:{bename}:system_indexes'
+            report['items'] = [suffix]
+
+            expected_indexes_list = []
+            for attr_name, config in expected_system_indexes.items():
+                types_str = "', '".join(config['types'])
+                index_desc = f"- {attr_name}: index type{'s' if len(config['types']) > 1 else ''} '{types_str}'"
+                if config['matching_rule']:
+                    index_desc += f" with matching rule '{config['matching_rule']}'"
+                expected_indexes_list.append(index_desc)
+
+            formatted_expected_indexes = '\n'.join(expected_indexes_list)
+            report['detail'] = report['detail'].replace('EXPECTED_INDEXES', formatted_expected_indexes)
+            report['detail'] = report['detail'].replace('DISCREPANCIES', '\n'.join([f"- {d}" for d in discrepancies]))
+
+            formatted_commands = '\n'.join([f"    # {cmd}" for cmd in remediation_commands])
+            report['fix'] = report['fix'].replace('REMEDIATION_COMMANDS', formatted_commands)
+
+            # Generate specific reindex commands for affected attributes
+            if reindex_attrs:
+                reindex_commands = []
+                for attr in sorted(reindex_attrs):
+                    reindex_cmd = f"dsconf YOUR_INSTANCE backend index reindex {bename} --attr {attr}"
+                    reindex_commands.append(f"    # {reindex_cmd}")
+                formatted_reindex_commands = '\n'.join(reindex_commands)
+            else:
+                formatted_reindex_commands = "    # No reindexing needed"
+
+            report['fix'] = report['fix'].replace('REINDEX_COMMANDS', formatted_reindex_commands)
+            report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+            report['fix'] = report['fix'].replace('BACKEND_NAME', bename)
+            yield report
 
     def create_sample_entries(self, version):
         """Creates sample entries under nsslapd-suffix value

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -86,6 +86,35 @@ DSBLE0006 = {
     'fix': 'Migrate the backend to MDB.'
 }
 
+DSBLE0007 = {
+    'dsle': 'DSBLE0007',
+    'severity': 'HIGH',
+    'description': 'Missing or incorrect system indexes.',
+    'items': [],
+    'detail': """System indexes are essential for proper directory server operation. Missing or
+incorrectly configured system indexes can lead to poor search performance, replication
+issues, and other operational problems.
+
+The following system indexes should be present with correct configuration:
+EXPECTED_INDEXES
+
+Current discrepancies:
+DISCREPANCIES
+""",
+    'fix': """Add the missing system indexes or fix the incorrect configurations using dsconf:
+
+REMEDIATION_COMMANDS
+
+After adding or modifying indexes, you may need to reindex the affected attributes:
+
+REINDEX_COMMANDS
+
+WARNING: Reindexing can be resource-intensive and may impact server performance on a live system.
+Consider scheduling reindexing during maintenance windows or periods of low activity. For production
+systems, you may want to reindex offline or use the --wait option to monitor task completion.
+"""
+}
+
 # Config checks
 DSCLE0002 = {
     'dsle': 'DSCLE0002',


### PR DESCRIPTION
… rule

Bug Description:
`parentId` attribute contains integer values and needs to be indexed with `integerOrderingMatch` matching rule. This attribute is a system attribute and the configuration entry for this attribute is created when a backend is created. The bug is that the per backend configuration entry does not contain `nsMatchingRule: integerOrderingMatch`.

Fix Description:
* Update `ldbm_instance_create_default_indexes` to support matching rules and update default system index configuration for `parentId` to include `integerOrderingMatch` matching rule.
* Add healthcheck linter for default system indexes and indexes created by RetroCL and USN plugins.

Fixes: https://github.com/389ds/389-ds-base/issues/6928
Fixes: https://github.com/389ds/389-ds-base/issues/6915