### PR TITLE
Issue 6933 - When deferred memberof update is enabled after the serve…

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
@@ -119,7 +119,10 @@ def test_fixup_task_repair_entry_erroneously_set_as_member(topology_st, prepare_
     assert not group.present('member', member.dn)
 
     log.info('Run the fixup task')
-    memberof.fixup(basedn=DEFAULT_SUFFIX)
+    task = memberof.fixup(basedn=DEFAULT_SUFFIX)
+
+    # Wait for task to complete before reading entries
+    task.wait()
 
     log.info('Verify the memberOf attribute is no longer present')
     try:

--- a/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
@@ -1278,22 +1278,26 @@ def _kill_instance(inst, sig=signal.SIGTERM, delay=None):
         time.sleep(delay)
     os.kill(pid, signal.SIGKILL)
 
-def test_shutdown_on_deferred_memberof(topology_st):
+def test_shutdown_on_deferred_memberof(topology_st, request):
     """This test checks that shutdown is handled properly if memberof updayes are deferred.
 
     :id: c5629cae-15a0-11ee-8807-482ae39447e5
     :setup: Standalone Instance
     :steps:
         1. Enable memberof plugin to scope SUFFIX
-        2. create 1000 users
-        3. Create a large groups with 500 members
+        2. create 500 users
+        3. Create a large groups with 250 members
         4. Restart the instance (using the default 2 minutes timeout)
         5. Check that users memberof and group members are in sync.
-        6. Modify the group to have 10 members.
+        6. Modify the group to have 250 others members.
         7. Restart the instance with short timeout
-        8. Check that fixup task is in progress
-        9. Wait until fixup task is completed
-        10. Check that users memberof and group members are in sync.
+        8. Check that the instance needs fixup
+        9. Check that deferred thread did not run fixup
+        10. Allow deferred thread to run fixup
+        11. Modify the group to have 250 others members.
+        12. Restart the instance with short timeout
+        13. Check that the instance needs fixup
+        14. Check that deferred thread did run fixup
     :expectedresults:
         1. should succeed
         2. should succeed
@@ -1304,13 +1308,17 @@ def test_shutdown_on_deferred_memberof(topology_st):
         7. should succeed
         8. should succeed
         9. should succeed
-        10. should succeed
     """
 
     inst = topology_st.standalone
+    inst.stop()
+    lpath = inst.ds_error_log._get_log_path()
+    os.unlink(lpath)
+    inst.start()
     inst.config.loglevel(vals=(ErrorLog.DEFAULT,ErrorLog.PLUGIN))
     errlog = DirsrvErrorLog(inst)
     test_timeout = 900
+
 
     # Step 1. Enable memberof plugin to scope SUFFIX
     memberof = MemberOfPlugin(inst)
@@ -1332,8 +1340,8 @@ def test_shutdown_on_deferred_memberof(topology_st):
     #Creates users and groups
     users_dn = []
 
-    # Step 2. create 1000 users
-    for i in range(1000):
+    # Step 2. create 500 users
+    for i in range(500):
         CN = '%s%d' % (USER_CN, i)
         users = UserAccounts(inst, SUFFIX)
         user_props = TEST_USER_PROPERTIES.copy()
@@ -1343,7 +1351,7 @@ def test_shutdown_on_deferred_memberof(topology_st):
 
     # Step 3. Create a large groups with 250 members
     groups = Groups(inst, SUFFIX)
-    testgroup = groups.create(properties={'cn': 'group500', 'member': users_dn[0:249]})
+    testgroup = groups.create(properties={'cn': 'group50', 'member': users_dn[0:249]})
 
     # Step 4. Restart the instance (using the default 2 minutes timeout)
     time.sleep(10)
@@ -1357,7 +1365,7 @@ def test_shutdown_on_deferred_memberof(topology_st):
     check_memberof_consistency(inst, testgroup)
 
     # Step 6. Modify the group to get another big group.
-    testgroup.replace('member', users_dn[500:999])
+    testgroup.replace('member', users_dn[250:499])
 
     # Step 7. Restart the instance with short timeout
     pattern = 'deferred_thread_func - thread has stopped'
@@ -1370,38 +1378,69 @@ def test_shutdown_on_deferred_memberof(topology_st):
     nbcleanstop = len(errlog.match(pattern))
     assert nbcleanstop == original_nbcleanstop
 
-    original_nbfixupmsg = count_global_fixup_message(errlog)
     log.info(f'Instance restarted after timeout at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
     inst.restart()
     assert inst.status()
     log.info(f'Restart completed at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
 
+    # Step 9.
     # Check that memberofneedfixup is present
-    dse = DSEldif(inst)
-    assert dse.get(memberof.dn, 'memberofneedfixup', single=True)
+    # and fixup task was not launched because by default launch_fixup is no
+    memberof = MemberOfPlugin(inst)
+    memberof.set_memberofdeferredupdate("on")
+    if (memberof.get_memberofdeferredupdate() and memberof.get_memberofdeferredupdate().lower() != "on"):
+        pytest.skip("Memberof deferred update not enabled or not supported.");
+    else:
+        delay=10
+    value = memberof.get_memberofneedfixup()
+    assert ((str(value).lower() == "yes") or (str(value).lower() == "true"))
+    assert len(errlog.match('.*It is recommended to launch memberof fixup task.*')) == 1
 
-    # Step 8. Check that fixup task is in progress
-    # Note we have to wait as there may be some delay
-    elapsed_time = 0
-    nbfixupmsg = count_global_fixup_message(errlog)
-    while nbfixupmsg[0] == original_nbfixupmsg[0]:
-        assert elapsed_time <= test_timeout
-        assert inst.status()
-        time.sleep(5)
-        elapsed_time += 5
-        nbfixupmsg = count_global_fixup_message(errlog)
+    # Step 10. allow the server to launch the fixup task
+    inst.stop()
+    inst.deleteErrorLogs()
+    inst.start()
+    log.info(f'set memberoflaunchfixup=ON')
+    memberof.set_memberoflaunchfixup('on')
+    inst.restart()
 
-    # Step 9. Wait until fixup task is completed
-    while nbfixupmsg[1] == original_nbfixupmsg[1]:
-        assert elapsed_time <= test_timeout
-        assert inst.status()
-        time.sleep(10)
-        elapsed_time += 10
-        nbfixupmsg = count_global_fixup_message(errlog)
+    # Step 11. Modify the group to get another big group.
+    testgroup.replace('member', users_dn[250:499])
 
-    # Step 10. Check that users memberof and group members are in sync.
+    # Step 12. then kill/reset errorlog/restart
+    _kill_instance(inst, sig=signal.SIGKILL, delay=5)
+    log.info(f'Instance restarted after timeout at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
+    inst.restart()
+    assert inst.status()
+    log.info(f'Restart completed at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
+
+    # step 13. Check that memberofneedfixup is present
+    memberof = MemberOfPlugin(inst)
+    value = memberof.get_memberofneedfixup()
+    assert ((str(value).lower() == "yes") or (str(value).lower() == "true"))
+
+    # step 14. fixup task was not launched because by default launch_fixup is no
+    assert len(errlog.match('.*It is recommended to launch memberof fixup task.*')) == 0
+
+    # Check that users memberof and group members are in sync.
     time.sleep(delay)
     check_memberof_consistency(inst, testgroup)
+
+
+    def fin():
+
+        for dn in users_dn:
+            try:
+                inst.delete_s(dn)
+            except ldap.NO_SUCH_OBJECT:
+                pass
+
+        try:
+            inst.delete_s(testgroup.dn)
+        except ldap.NO_SUCH_OBJECT:
+                pass
+
+    request.addfinalizer(fin)
 
 
 if __name__ == '__main__':

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -1020,9 +1020,16 @@ deferred_thread_func(void *arg)
      * keep running this thread until plugin is signaled to close
      */
     g_incr_active_threadcnt();
-    if (memberof_get_config()->need_fixup && perform_needed_fixup()) {
-        slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failure occured during global fixup task: memberof values are invalid\n");
+    if (memberof_get_config()->need_fixup) {
+        if (memberof_get_config()->launch_fixup) {
+            if (perform_needed_fixup()) {
+                slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
+                        "Failure occurred during global fixup task: memberof values are invalid\n");
+            }
+        } else {
+            slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
+                          "It is recommended to launch memberof fixup task\n");
+        }
     }
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
                   "deferred_thread_func - thread is starting "

--- a/ldap/servers/plugins/memberof/memberof.h
+++ b/ldap/servers/plugins/memberof/memberof.h
@@ -44,6 +44,7 @@
 #define MEMBEROF_DEFERRED_UPDATE_ATTR "memberOfDeferredUpdate"
 #define MEMBEROF_AUTO_ADD_OC      "memberOfAutoAddOC"
 #define MEMBEROF_NEED_FIXUP       "memberOfNeedFixup"
+#define MEMBEROF_LAUNCH_FIXUP     "memberOfLaunchFixup"
 #define NSMEMBEROF                "nsMemberOf"
 #define MEMBEROF_ENTRY_SCOPE_EXCLUDE_SUBTREE "memberOfEntryScopeExcludeSubtree"
 #define DN_SYNTAX_OID             "1.3.6.1.4.1.1466.115.121.1.12"
@@ -138,6 +139,7 @@ typedef struct memberofconfig
     PLHashTable *fixup_cache;
     Slapi_Task *task;
     int need_fixup;
+    PRBool launch_fixup;
 } MemberOfConfig;
 
 /* The key to access the hash table is the normalized DN

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -472,6 +472,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     const char *deferred_update = NULL;
     char *auto_add_oc = NULL;
     const char *needfixup = NULL;
+    const char *launchfixup = NULL;
     int num_vals = 0;
 
     *returncode = LDAP_SUCCESS;
@@ -508,6 +509,7 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
     deferred_update = slapi_entry_attr_get_ref(e, MEMBEROF_DEFERRED_UPDATE_ATTR);
     auto_add_oc = slapi_entry_attr_get_charptr(e, MEMBEROF_AUTO_ADD_OC);
     needfixup = slapi_entry_attr_get_ref(e, MEMBEROF_NEED_FIXUP);
+    launchfixup = slapi_entry_attr_get_ref(e, MEMBEROF_LAUNCH_FIXUP);
 
     if (auto_add_oc == NULL) {
         auto_add_oc = slapi_ch_strdup(NSMEMBEROF);
@@ -640,6 +642,15 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
             theConfig.deferred_update = PR_TRUE;
         } else {
             theConfig.deferred_update = PR_FALSE;
+        }
+    }
+    theConfig.launch_fixup = PR_FALSE;
+    if (theConfig.deferred_update) {
+        /* The automatic fixup task is only triggered when
+         * deferred update is on
+         */
+        if (launchfixup && (strcasecmp(launchfixup, "on") == 0)) {
+            theConfig.launch_fixup = PR_TRUE;
         }
     }
 

--- a/src/lib389/lib389/cli_conf/plugins/memberof.py
+++ b/src/lib389/lib389/cli_conf/plugins/memberof.py
@@ -23,6 +23,8 @@ arg_to_attr = {
     'scope': 'memberOfEntryScope',
     'exclude': 'memberOfEntryScopeExcludeSubtree',
     'autoaddoc': 'memberOfAutoAddOC',
+    'deferredupdate': 'memberOfDeferredUpdate',
+    'launchfixup': 'memberOfLaunchFixup',
     'config_entry': 'nsslapd-pluginConfigArea'
 }
 
@@ -122,6 +124,13 @@ def _add_parser_args(parser):
                         help='If an entry does not have an object class that allows the memberOf attribute '
                              'then the memberOf plugin will automatically add the object class listed '
                              'in the memberOfAutoAddOC parameter')
+    parser.add_argument('--deferredupdate', choices=['on', 'off'], type=str.lower,
+                        help='Specifies that the updates of the members are done after the completion '
+                             'of the update of the target group. In addition each update (group/members) '
+                             'uses its own transaction')
+    parser.add_argument('--launchfixup', choices=['on', 'off'], type=str.lower,
+                        help='Specify that if the server disorderly shutdown (crash, kill,..) then '
+                             'at restart the memberof fixup task is launched automatically')
 
 
 def create_parser(subparsers):

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -972,6 +972,36 @@ class MemberOfPlugin(Plugin):
 
         self.remove_all('memberofdeferredupdate')
 
+    def get_memberofneedfixup(self):
+        """Get memberofneedfixup attribute"""
+
+        return self.get_attr_val_utf8_l('memberofneedfixup')
+
+    def get_memberofneedfixup_formatted(self):
+        """Display memberofneedfixup attribute"""
+
+        return self.display_attr('memberofneedfixup')
+
+    def get_memberoflaunchfixup(self):
+        """Get memberoflaunchfixup attribute"""
+
+        return self.get_attr_val_utf8_l('memberoflaunchfixup')
+
+    def get_memberoflaunchfixup_formatted(self):
+        """Display memberoflaunchfixup attribute"""
+
+        return self.display_attr('memberoflaunchfixup')
+
+    def set_memberoflaunchfixup(self, value):
+        """Set memberoflaunchfixup attribute"""
+
+        self.set('memberoflaunchfixup', value)
+
+    def remove_memberoflaunchfixup(self):
+        """Remove all memberoflaunchfixup attributes"""
+
+        self.remove_all('memberoflaunchfixup')
+
     def get_autoaddoc(self):
         """Get memberofautoaddoc attribute"""
 


### PR DESCRIPTION
…r crashed it should not launch memberof fixup task by default

Bug description:
	When deferred memberof update is enabled, the updates of the
	group and the members is done with different TXN.
	So there is a risk that at the time of a crash the membership
	('memberof') are invalid.
	To repair this we should run a memberof fixup task.
	The problem is that this task is resource intensive and
	should be, by default, scheduled by the administrator.

Fix description:
	The fix introduces a new memberof config parameter 'launchFixup'
	that is 'off' by default.
	After a crash, when it is 'on' the server launch the fixup
	task. If it is 'off' it logs a warning.

fixes: #6933

Reviewed by: