### PR TITLE
Issue 6940 - dsconf monitor server fails with ldapi:// due to absent server ID

### DIFF
--- a/src/lib389/lib389/cli_base/dsrc.py
+++ b/src/lib389/lib389/cli_base/dsrc.py
@@ -56,7 +56,7 @@ def dsrc_arg_concat(args, dsrc_inst):
         new_dsrc_inst['args'][SER_ROOT_DN] = new_dsrc_inst['binddn']
         if new_dsrc_inst['uri'][0:8] == 'ldapi://':
             new_dsrc_inst['args'][SER_LDAPI_ENABLED] = "on"
-            new_dsrc_inst['args'][SER_LDAPI_SOCKET] = new_dsrc_inst['uri'][9:]
+            new_dsrc_inst['args'][SER_LDAPI_SOCKET] = new_dsrc_inst['uri'][8:]
             new_dsrc_inst['args'][SER_LDAPI_AUTOBIND] = "on"
 
         # Make new
@@ -170,7 +170,7 @@ def dsrc_to_ldap(path, instance_name, log):
     dsrc_inst['args'][SER_ROOT_DN] = dsrc_inst['binddn']
     if dsrc_inst['uri'][0:8] == 'ldapi://':
         dsrc_inst['args'][SER_LDAPI_ENABLED] = "on"
-        dsrc_inst['args'][SER_LDAPI_SOCKET] = dsrc_inst['uri'][9:]
+        dsrc_inst['args'][SER_LDAPI_SOCKET] = dsrc_inst['uri'][8:]
         dsrc_inst['args'][SER_LDAPI_AUTOBIND] = "on"
 
     # Return the dict.


### PR DESCRIPTION
    Description: The dsconf monitor server command fails when using ldapi://
    protocol because the server ID is not set, preventing PID retrieval from
    defaults.inf. This causes the Web console to fail displaying the "Server
    Version" field and potentially other CLI/WebUI issues.

    The fix attempts to derive the server ID from the LDAPI socket path when
    not explicitly provided. This covers the common case where the socket name
    contains the instance name (e.g., slapd-instance.socket).
    If that's not possible, it also attempts to derive the server ID from the
    nsslapd-instancedir configuration attribute. The derived server ID
    is validated against actual system instances to ensure it exists.
    Note that socket names can vary and nsslapd-instancedir can be changed.
    This is a best-effort approach for the common naming pattern.

    Also fixes the LDAPI socket path extraction which was incorrectly using
    offset 9 instead of 8 for ldapi:// URIs.

    The monitor command now handles missing PIDs gracefully, returning zero
    values for process-specific stats instead of failing completely.

Fixes: https://github.com/389ds/389-ds-base/issues/6940

Reviewed by: ?