### PR TITLE
Issue 6430 - Fix build with bundled libdb

### DIFF
--- a/m4/bundle_libdb.m4
+++ b/m4/bundle_libdb.m4
@@ -27,7 +27,10 @@ else
   AC_MSG_RESULT([libdb-${db_ver_maj}.${db_ver_min}-389ds.so])
 fi
 
+db_bdb_srcdir="ldap/servers/slapd/back-ldbm/db-bdb"
 
+AM_CONDITIONAL([WITH_LIBBDB_RO],[false])
+AC_SUBST(db_bdb_srcdir)
 AC_SUBST(db_inc)
 AC_SUBST(db_lib)
 AC_SUBST(db_libver)


### PR DESCRIPTION
Description:
The libbdb_ro change (#6431) added a `WITH_LIBBDB_RO` automake conditional and a `db_bdb_srcdir` autoconf substitution which must also be defined when building --with-bundle-libdb.

Related: https://github.com/389ds/389-ds-base/pull/6431

/cc @vashirov 