### PR TITLE
Issue 6947 - Revise time skew check in healthcheck tool

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -10,7 +10,7 @@
 import pytest
 import os
 import subprocess
-
+import time
 from lib389.backend import Backends, DatabaseConfig
 from lib389.cos import CosTemplates, CosPointerDefinitions
 from lib389.dbgen import dbgen_users
@@ -41,6 +41,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.list_checks = False
     args.check = ['config', 'refint', 'backends', 'monitor-disk-space', 'logs', 'memberof']
     args.dry_run = False
+    args.exclude_check = []
 
     # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
     if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \

--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -101,7 +101,7 @@ def assert_is_in_result(result, searched_code, isnot=False):
     # Assert if searched_code is not in logcap
     if searched_code is None:
         return
-    
+
     # Handle positive and negative tests:
     nomatch, match, f = LOGIC_DICT[bool(isnot)]
     try:
@@ -316,6 +316,7 @@ def test_healthcheck_non_replicated_suffixes(topology_m2):
     args.check = ['backends']
     args.dry_run = False
     args.json = False
+    args.exclude_check = []
 
     health_check_run(inst, topology_m2.logcap.log, args)
 

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -39,6 +39,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.list_checks = False
     args.check = ['config', 'encryption', 'tls', 'fschecks']
     args.dry_run = False
+    args.exclude_check = []
 
     if json:
         log.info('Use healthcheck with --json option')

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -90,6 +90,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.verbose = instance.verbose
     args.list_errors = False
     args.list_checks = False
+    args.exclude_check = []
     args.check = [
         "config",
         "refint",

--- a/dirsrvtests/tests/suites/healthcheck/health_tunables_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_tunables_test.py
@@ -32,6 +32,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=F
     args.verbose = instance.verbose
     args.list_errors = list_errors
     args.list_checks = list_checks
+    args.exclude_check = []
     args.check = check
     args.dry_run = False
     args.json = json

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -30,18 +30,22 @@ ds_paths = Paths()
 log = logging.getLogger(__name__)
 
 
-def run_healthcheck_and_flush_log(logcap, instance, searched_code=None, json=False, searched_code2=None,
-                                  list_checks=False, list_errors=False, check=None, searched_list=None):
+def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
+                                  json=False, searched_code2=None,
+                                  list_checks=False, list_errors=False,
+                                  check=None, searched_list=None):
     args = FakeArgs()
     args.instance = instance.serverid
     args.verbose = instance.verbose
     args.list_errors = list_errors
     args.list_checks = list_checks
     args.check = check
+    args.exclude_check = []
     args.dry_run = False
     args.json = json
 
-    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new
+    # versions
     if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
        (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
         searched_code = 'DSBLE0006'
@@ -52,18 +56,38 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None, json=Fal
     if searched_list is not None:
         for item in searched_list:
             assert logcap.contains(item)
-            log.info('Healthcheck returned searched item: %s' % item)
+            log.info('Healthcheck returned searched item: %s', item)
     else:
         assert logcap.contains(searched_code)
-        log.info('Healthcheck returned searched code: %s' % searched_code)
+        log.info('Healthcheck returned searched code: %s', searched_code)
 
     if searched_code2 is not None:
         if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-        (searched_code2 is CMD_OUTPUT or searched_code2 is JSON_OUTPUT):
+           (searched_code2 is CMD_OUTPUT or searched_code2 is JSON_OUTPUT):
             searched_code = 'DSBLE0006'
 
         assert logcap.contains(searched_code2)
-        log.info('Healthcheck returned searched code: %s' % searched_code2)
+        log.info('Healthcheck returned searched code: %s', searched_code2)
+
+    log.info('Clear the log')
+    logcap.flush()
+
+
+def run_healthcheck_exclude(logcap, instance, unwanted, wanted, exclude_check):
+    args = FakeArgs()
+    args.instance = instance.serverid
+    args.verbose = instance.verbose
+    args.list_errors = False
+    args.list_checks = False
+    args.check = None
+    args.exclude_check = [exclude_check]
+    args.dry_run = False
+    args.json = False
+
+    health_check_run(instance, logcap.log, args)
+
+    assert not logcap.contains(unwanted)
+    assert logcap.contains(wanted)
 
     log.info('Clear the log')
     logcap.flush()
@@ -126,7 +150,7 @@ def test_healthcheck_standalone(topology_st):
 
     standalone = topology_st.standalone
 
-    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT,json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
 
@@ -266,6 +290,40 @@ def test_healthcheck_check_option(topology_st):
         log.info('Check {}'.format(item))
         run_healthcheck_and_flush_log(topology_st.logcap, standalone, searched_code=pattern, json=False, check=[item],
                                       searched_code2=CMD_OUTPUT)
+
+
+def test_healthcheck_exclude_option(topology_st):
+    """Check functionality of HealthCheck Tool with --exclude-check option
+
+    :id: a4e2103c-67b8-4359-a8ba-67a8650cd3b7
+    :setup: Standalone instance
+    :steps:
+        1. Set check to exclude from list
+        2. Run HealthCheck
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+
+    inst = topology_st.standalone
+
+    exclude_list = [
+        ('config:passwordscheme', 'config:passwordscheme',
+         'config:securitylog_buffering'),
+        ('config', 'config:', 'backends:userroot:mappingtree')
+    ]
+
+    for exclude, unwanted, wanted in exclude_list:
+        unwanted_pattern = 'Checking ' + unwanted
+        wanted_pattern = 'Checking ' + wanted
+
+        log.info('Exclude check: %s unwanted: %s wanted: %s',
+                 exclude, unwanted, wanted)
+
+        run_healthcheck_exclude(topology_st.logcap, inst,
+                                unwanted=unwanted_pattern,
+                                wanted=wanted_pattern,
+                                exclude_check=exclude)
 
 
 @pytest.mark.skipif(ds_is_older("1.4.1"), reason="Not implemented")

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -557,6 +557,17 @@ Also look at https://access.redhat.com/documentation/en-us/red_hat_directory_ser
 and find the paragraph "Too much time skew"."""
 }
 
+DSSKEWLE0004 = {
+    'dsle': 'DSSKEWLE0004',
+    'severity': 'Low',
+    'description': 'Extensive time skew.',
+    'items': ['Replication'],
+    'detail': """The time skew is over 365 days. If the time skew continues to
+increase eventually serious replication problems can occur.""",
+    'fix': """Avoid making changes to the system time, and make sure the clocks
+on all the replicas are correct."""
+}
+
 DSLOGNOTES0001 = {
     'dsle': 'DSLOGNOTES0001',
     'severity': 'Medium',


### PR DESCRIPTION
Description:

The current check reports a critical warning if time skew is greater than 1 day - even if "nsslapd-ignore-time-skew" is set to "on". If we are ignoring time skew we should still report a warning if it's very significant like 30 days.

Relates: https://github.com/389ds/389-ds-base/issues/6947

The 30 day check is debatable.   It could be set higher like 6 months...  Thoughts?
