### PR TITLE
Lint rust plugins

### DIFF
--- a/src/librnsslapd/build.rs
+++ b/src/librnsslapd/build.rs
@@ -10,7 +10,7 @@ fn main() {
                 .with_crate(crate_dir)
                 .generate()
                 .expect("Unable to generate bindings")
-                .write_to_file(format!("{}/rust-nsslapd-private.h", out_dir));
+                .write_to_file(format!("{out_dir}/rust-nsslapd-private.h"));
         }
     }
 }

--- a/src/librslapd/build.rs
+++ b/src/librslapd/build.rs
@@ -10,7 +10,7 @@ fn main() {
                 .with_crate(crate_dir)
                 .generate()
                 .expect("Unable to generate bindings")
-                .write_to_file(format!("{}/rust-slapi-private.h", out_dir));
+                .write_to_file(format!("{out_dir}/rust-slapi-private.h"));
         }
     }
 }

--- a/src/plugins/entryuuid_syntax/src/lib.rs
+++ b/src/plugins/entryuuid_syntax/src/lib.rs
@@ -17,7 +17,7 @@ impl SlapiSyntaxPlugin1 for EntryUuidSyntax {
     }
 
     fn attr_compat_oids() -> Vec<&'static str> {
-        Vec::new()
+        vec![]
     }
 
     fn attr_supported_names() -> Vec<&'static str> {
@@ -50,12 +50,12 @@ impl SlapiSyntaxPlugin1 for EntryUuidSyntax {
         bval_filter: &BerValRef,
         vals: &ValueArrayRef,
     ) -> Result<bool, PluginError> {
-        let u = match bval_filter.try_into() {
+        let u: Uuid = match bval_filter.try_into() {
             Ok(u) => u,
             Err(_e) => return Ok(false),
         };
 
-        let r = vals.iter().fold(false, |acc, va| {
+        let r: bool = vals.iter().fold(false, |acc, va| {
             if acc {
                 acc
             } else {
@@ -114,7 +114,7 @@ impl SlapiOrdMr for EntryUuidSyntax {
             Err(_e) => return Ok(None),
         };
 
-        let r = vals.iter().fold(None, |acc, va| {
+        let r: Option<Ordering> = vals.iter().fold(None, |acc, va| {
             if acc.is_some() {
                 acc
             } else {

--- a/src/slapi_r_plugin/build.rs
+++ b/src/slapi_r_plugin/build.rs
@@ -3,7 +3,7 @@ use std::env;
 fn main() {
     if let Ok(lib_dir) = env::var("SLAPD_DYLIB_DIR") {
         println!("cargo:rustc-link-lib=dylib=slapd");
-        println!("cargo:rustc-link-search=native={}", lib_dir);
-        println!("cargo:rustc-link-search=native={}/.libs", lib_dir);
+        println!("cargo:rustc-link-search=native={lib_dir}");
+        println!("cargo:rustc-link-search=native={lib_dir}/.libs");
     }
 }

--- a/src/slapi_r_plugin/src/charray.rs
+++ b/src/slapi_r_plugin/src/charray.rs
@@ -15,7 +15,7 @@ impl Charray {
             .map(|s| CString::new(*s).map_err(|_e| ()))
             .collect();
 
-        let pin = pin?;
+        let pin: Vec<CString> = pin?;
 
         let charray: Vec<_> = pin
             .iter()
@@ -23,7 +23,7 @@ impl Charray {
             .chain(once(ptr::null()))
             .collect();
 
-        Ok(Charray { _pin: pin, charray })
+        Ok(Self { _pin: pin, charray })
     }
 
     pub fn as_ptr(&self) -> *const *const c_char {

--- a/src/slapi_r_plugin/src/constants.rs
+++ b/src/slapi_r_plugin/src/constants.rs
@@ -9,130 +9,128 @@ pub const PLUGIN_DEFAULT_PRECEDENCE: i32 = 50;
 /// The set of possible function handles we can register via the pblock. These
 /// values correspond to slapi-plugin.h.
 pub enum PluginFnType {
-    /// SLAPI_PLUGIN_DESTROY_FN
+    /// `SLAPI_PLUGIN_DESTROY_FN`
     Destroy = 11,
-    /// SLAPI_PLUGIN_CLOSE_FN
+    /// `SLAPI_PLUGIN_CLOSE_FN`
     Close = 210,
-    /// SLAPI_PLUGIN_START_FN
+    /// `SLAPI_PLUGIN_START_FN`
     Start = 212,
-    /// SLAPI_PLUGIN_PRE_BIND_FN
+    /// `SLAPI_PLUGIN_PRE_BIND_FN`
     PreBind = 401,
-    /// SLAPI_PLUGIN_PRE_UNBIND_FN
+    /// `SLAPI_PLUGIN_PRE_UNBIND_FN`
     PreUnbind = 402,
-    /// SLAPI_PLUGIN_PRE_SEARCH_FN
+    /// `SLAPI_PLUGIN_PRE_SEARCH_FN`
     PreSearch = 403,
-    /// SLAPI_PLUGIN_PRE_COMPARE_FN
+    /// `SLAPI_PLUGIN_PRE_COMPARE_FN`
     PreCompare = 404,
-    /// SLAPI_PLUGIN_PRE_MODIFY_FN
+    /// `SLAPI_PLUGIN_PRE_MODIFY_FN`
     PreModify = 405,
-    /// SLAPI_PLUGIN_PRE_MODRDN_FN
+    /// `SLAPI_PLUGIN_PRE_MODRDN_FN`
     PreModRDN = 406,
-    /// SLAPI_PLUGIN_PRE_ADD_FN
+    /// `SLAPI_PLUGIN_PRE_ADD_FN`
     PreAdd = 407,
-    /// SLAPI_PLUGIN_PRE_DELETE_FN
+    /// `SLAPI_PLUGIN_PRE_DELETE_FN`
     PreDelete = 408,
-    /// SLAPI_PLUGIN_PRE_ABANDON_FN
+    /// `SLAPI_PLUGIN_PRE_ABANDON_FN`
     PreAbandon = 409,
-    /// SLAPI_PLUGIN_PRE_ENTRY_FN
+    /// `SLAPI_PLUGIN_PRE_ENTRY_FN`
     PreEntry = 410,
-    /// SLAPI_PLUGIN_PRE_REFERRAL_FN
+    /// `SLAPI_PLUGIN_PRE_REFERRAL_FN`
     PreReferal = 411,
-    /// SLAPI_PLUGIN_PRE_RESULT_FN
+    /// `SLAPI_PLUGIN_PRE_RESULT_FN`
     PreResult = 412,
-    /// SLAPI_PLUGIN_PRE_EXTOP_FN
+    /// `SLAPI_PLUGIN_PRE_EXTOP_FN`
     PreExtop = 413,
-    /// SLAPI_PLUGIN_BE_PRE_ADD_FN
+    /// `SLAPI_PLUGIN_BE_PRE_ADD_FN`
     BeTxnPreAdd = 460,
-    /// SLAPI_PLUGIN_BE_TXN_PRE_MODIFY_FN
+    /// `SLAPI_PLUGIN_BE_TXN_PRE_MODIFY_FN`
     BeTxnPreModify = 461,
-    /// SLAPI_PLUGIN_BE_TXN_PRE_MODRDN_FN
+    /// `SLAPI_PLUGIN_BE_TXN_PRE_MODRDN_FN`
     BeTxnPreModRDN = 462,
-    /// SLAPI_PLUGIN_BE_TXN_PRE_DELETE_FN
+    /// `SLAPI_PLUGIN_BE_TXN_PRE_DELETE_FN`
     BeTxnPreDelete = 463,
-    /// SLAPI_PLUGIN_BE_TXN_PRE_DELETE_TOMBSTONE_FN
+    /// `SLAPI_PLUGIN_BE_TXN_PRE_DELETE_TOMBSTONE_FN`
     BeTxnPreDeleteTombstone = 464,
-    /// SLAPI_PLUGIN_POST_SEARCH_FN
+    /// `SLAPI_PLUGIN_POST_SEARCH_FN`
     PostSearch = 503,
-    /// SLAPI_PLUGIN_BE_POST_ADD_FN
+    /// `SLAPI_PLUGIN_BE_POST_ADD_FN`
     BeTxnPostAdd = 560,
-    /// SLAPI_PLUGIN_BE_POST_MODIFY_FN
+    /// `SLAPI_PLUGIN_BE_POST_MODIFY_FN`
     BeTxnPostModify = 561,
-    /// SLAPI_PLUGIN_BE_POST_MODRDN_FN
+    /// `SLAPI_PLUGIN_BE_POST_MODRDN_FN`
     BeTxnPostModRDN = 562,
-    /// SLAPI_PLUGIN_BE_POST_DELETE_FN
+    /// `SLAPI_PLUGIN_BE_POST_DELETE_FN`
     BeTxnPostDelete = 563,
 
-    /// SLAPI_PLUGIN_MR_FILTER_CREATE_FN
+    /// `SLAPI_PLUGIN_MR_FILTER_CREATE_FN`
     MRFilterCreate = 600,
-    /// SLAPI_PLUGIN_MR_INDEXER_CREATE_FN
+    /// `SLAPI_PLUGIN_MR_INDEXER_CREATE_FN`
     MRIndexerCreate = 601,
-    /// SLAPI_PLUGIN_MR_FILTER_AVA
+    /// `SLAPI_PLUGIN_MR_FILTER_AVA`
     MRFilterAva = 618,
-    /// SLAPI_PLUGIN_MR_FILTER_SUB
+    /// `SLAPI_PLUGIN_MR_FILTER_SUB`
     MRFilterSub = 619,
-    /// SLAPI_PLUGIN_MR_VALUES2KEYS
+    /// `SLAPI_PLUGIN_MR_VALUES2KEYS`
     MRValuesToKeys = 620,
-    /// SLAPI_PLUGIN_MR_ASSERTION2KEYS_AVA
+    /// `SLAPI_PLUGIN_MR_ASSERTION2KEYS_AVA`
     MRAssertionToKeysAva = 621,
-    /// SLAPI_PLUGIN_MR_ASSERTION2KEYS_SUB
+    /// `SLAPI_PLUGIN_MR_ASSERTION2KEYS_SUB`
     MRAssertionToKeysSub = 622,
-    /// SLAPI_PLUGIN_MR_COMPARE
+    /// `SLAPI_PLUGIN_MR_COMPARE`
     MRCompare = 625,
-    /// SLAPI_PLUGIN_MR_NORMALIZE
+    /// `SLAPI_PLUGIN_MR_NORMALIZE`
     MRNormalize = 626,
 
-    /// SLAPI_PLUGIN_SYNTAX_FILTER_AVA
+    /// `SLAPI_PLUGIN_SYNTAX_FILTER_AVA`
     SyntaxFilterAva = 700,
-    /// SLAPI_PLUGIN_SYNTAX_FILTER_SUB
+    /// `SLAPI_PLUGIN_SYNTAX_FILTER_SUB`
     SyntaxFilterSub = 701,
-    /// SLAPI_PLUGIN_SYNTAX_VALUES2KEYS
+    /// `SLAPI_PLUGIN_SYNTAX_VALUES2KEYS`
     SyntaxValuesToKeys = 702,
-    /// SLAPI_PLUGIN_SYNTAX_ASSERTION2KEYS_AVA
+    /// `SLAPI_PLUGIN_SYNTAX_ASSERTION2KEYS_AVA`
     SyntaxAssertion2KeysAva = 703,
-    /// SLAPI_PLUGIN_SYNTAX_ASSERTION2KEYS_SUB
+    /// `SLAPI_PLUGIN_SYNTAX_ASSERTION2KEYS_SUB`
     SyntaxAssertion2KeysSub = 704,
-    /// SLAPI_PLUGIN_SYNTAX_FLAGS
+    /// `SLAPI_PLUGIN_SYNTAX_FLAGS`
     SyntaxFlags = 707,
-    /// SLAPI_PLUGIN_SYNTAX_COMPARE
+    /// `SLAPI_PLUGIN_SYNTAX_COMPARE`
     SyntaxCompare = 708,
-    /// SLAPI_PLUGIN_SYNTAX_VALIDATE
+    /// `SLAPI_PLUGIN_SYNTAX_VALIDATE`
     SyntaxValidate = 710,
-    /// SLAPI_PLUGIN_SYNTAX_NORMALIZE
+    /// `SLAPI_PLUGIN_SYNTAX_NORMALIZE`
     SyntaxNormalize = 711,
 
-    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_ENC_FN
+    /// `SLAPI_PLUGIN_PWD_STORAGE_SCHEME_ENC_FN`
     PwdStorageEncrypt = 800,
-    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_CMP_FN
+    /// `SLAPI_PLUGIN_PWD_STORAGE_SCHEME_CMP_FN`
     PwdStorageCompare = 802,
 }
 
-static SV01: [u8; 3] = [b'0', b'1', b'\0'];
-static SV02: [u8; 3] = [b'0', b'2', b'\0'];
-static SV03: [u8; 3] = [b'0', b'3', b'\0'];
+static SV01: &[u8; 3] = b"01\0";
+static SV02: &[u8; 3] = b"02\0";
+static SV03: &[u8; 3] = b"03\0";
 
 /// Corresponding plugin versions
 pub enum PluginVersion {
-    /// SLAPI_PLUGIN_VERSION_01
+    /// `SLAPI_PLUGIN_VERSION_01`
     V01,
-    /// SLAPI_PLUGIN_VERSION_02
+    /// `SLAPI_PLUGIN_VERSION_02`
     V02,
-    /// SLAPI_PLUGIN_VERSION_03
+    /// `SLAPI_PLUGIN_VERSION_03`
     V03,
 }
 
 impl PluginVersion {
     pub fn to_char_ptr(&self) -> *const c_char {
-        match self {
-            PluginVersion::V01 => &SV01 as *const _ as *const c_char,
-            PluginVersion::V02 => &SV02 as *const _ as *const c_char,
-            PluginVersion::V03 => &SV03 as *const _ as *const c_char,
+        match *self {
+            Self::V01 => SV01.as_ptr().cast(),
+            Self::V02 => SV02.as_ptr().cast(),
+            Self::V03 => SV03.as_ptr().cast(),
         }
     }
 }
 
-static SMATCHINGRULE: [u8; 13] = [
-    b'm', b'a', b't', b'c', b'h', b'i', b'n', b'g', b'r', b'u', b'l', b'e', b'\0',
-];
+static SMATCHINGRULE: &[u8; 13] = b"matchingrule\0";
 
 pub enum PluginType {
     MatchingRule,
@@ -140,8 +138,8 @@ pub enum PluginType {
 
 impl PluginType {
     pub fn to_char_ptr(&self) -> *const c_char {
-        match self {
-            PluginType::MatchingRule => &SMATCHINGRULE as *const _ as *const c_char,
+        match *self {
+            Self::MatchingRule => SMATCHINGRULE.as_ptr().cast(),
         }
     }
 }
@@ -150,34 +148,34 @@ impl PluginType {
 /// data types that we can get or retrieve from the pblock. This is only
 /// used internally.
 pub(crate) enum PblockType {
-    /// SLAPI_PLUGIN_PRIVATE
+    /// `SLAPI_PLUGIN_PRIVATE`
     _PrivateData = 4,
-    /// SLAPI_PLUGIN_VERSION
+    /// `SLAPI_PLUGIN_VERSION`
     Version = 8,
-    /// SLAPI_PLUGIN_DESCRIPTION
+    /// `SLAPI_PLUGIN_DESCRIPTION`
     _Description = 12,
-    /// SLAPI_PLUGIN_IDENTITY
+    /// `SLAPI_PLUGIN_IDENTITY`
     Identity = 13,
-    /// SLAPI_PLUGIN_INTOP_RESULT
+    /// `SLAPI_PLUGIN_INTOP_RESULT`
     OpResult = 15,
-    /// SLAPI_ADD_ENTRY
+    /// `SLAPI_ADD_ENTRY`
     AddEntry = 60,
-    /// SLAPI_BACKEND
+    /// `SLAPI_BACKEND`
     Backend = 130,
-    /// SLAPI_IS_REPLICATED_OPERATION
+    /// `SLAPI_IS_REPLICATED_OPERATION`
     IsReplicationOperation = 142,
-    /// SLAPI_PLUGIN_MR_NAMES
+    /// `SLAPI_PLUGIN_MR_NAMES`
     MRNames = 624,
-    /// SLAPI_PLUGIN_SYNTAX_NAMES
+    /// `SLAPI_PLUGIN_SYNTAX_NAMES`
     SyntaxNames = 705,
-    /// SLAPI_PLUGIN_SYNTAX_OID
+    /// `SLAPI_PLUGIN_SYNTAX_OID`
     SyntaxOid = 706,
-    /// SLAPI_PLUGIN_PWD_STORAGE_SCHEME_NAME
+    /// `SLAPI_PLUGIN_PWD_STORAGE_SCHEME_NAME`
     PwdStorageSchemeName = 810,
 }
 
 /// See ./ldap/include/ldaprot.h
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum FilterType {
     And = 0xa0,
     Or = 0xa1,
@@ -196,17 +194,17 @@ impl TryFrom<i32> for FilterType {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
-            0xa0 => Ok(FilterType::And),
-            0xa1 => Ok(FilterType::Or),
-            0xa2 => Ok(FilterType::Not),
-            0xa3 => Ok(FilterType::Equality),
-            0xa4 => Ok(FilterType::Substring),
-            0xa5 => Ok(FilterType::Ge),
-            0xa6 => Ok(FilterType::Le),
-            0x87 => Ok(FilterType::Present),
-            0xa8 => Ok(FilterType::Approx),
-            0xa9 => Ok(FilterType::Extended),
-            _ => Err(RPluginError::FilterType),
+            0xa0 => Ok(Self::And),
+            0xa1 => Ok(Self::Or),
+            0xa2 => Ok(Self::Not),
+            0xa3 => Ok(Self::Equality),
+            0xa4 => Ok(Self::Substring),
+            0xa5 => Ok(Self::Ge),
+            0xa6 => Ok(Self::Le),
+            0x87 => Ok(Self::Present),
+            0xa8 => Ok(Self::Approx),
+            0xa9 => Ok(Self::Extended),
+            _ => Err(Self::Error::FilterType),
         }
     }
 }

--- a/src/slapi_r_plugin/src/error.rs
+++ b/src/slapi_r_plugin/src/error.rs
@@ -41,11 +41,11 @@ pub enum LDAPError {
 impl From<i32> for LDAPError {
     fn from(value: i32) -> Self {
         match value {
-            0 => LDAPError::Success,
-            1 => LDAPError::Operation,
-            65 => LDAPError::ObjectClassViolation,
-            80 => LDAPError::Other,
-            _ => LDAPError::Unknown,
+            0 => Self::Success,
+            1 => Self::Operation,
+            65 => Self::ObjectClassViolation,
+            80 => Self::Other,
+            _ => Self::Unknown,
         }
     }
 }

--- a/src/slapi_r_plugin/src/log.rs
+++ b/src/slapi_r_plugin/src/log.rs
@@ -4,8 +4,8 @@ use std::os::raw::c_char;
 use crate::constants;
 use crate::error::LoggingError;
 
-extern "C" {
-    fn slapi_log_error(level: i32, system: *const c_char, message: *const c_char) -> i32;
+unsafe extern "C" {
+    unsafe fn slapi_log_error(level: i32, system: *const c_char, message: *const c_char) -> i32;
 }
 
 pub fn log_error(
@@ -13,10 +13,10 @@ pub fn log_error(
     subsystem: String,
     message: String,
 ) -> Result<(), LoggingError> {
-    let c_subsystem = CString::new(subsystem)
-        .map_err(|e| LoggingError::CString(format!("failed to convert subsystem -> {:?}", e)))?;
-    let c_message = CString::new(message)
-        .map_err(|e| LoggingError::CString(format!("failed to convert message -> {:?}", e)))?;
+    let c_subsystem: CString = CString::new(subsystem)
+        .map_err(|e| LoggingError::CString(format!("failed to convert subsystem -> {e:?}")))?;
+    let c_message: CString = CString::new(message)
+        .map_err(|e| LoggingError::CString(format!("failed to convert message -> {e:?}")))?;
 
     match unsafe { slapi_log_error(level as i32, c_subsystem.as_ptr(), c_message.as_ptr()) } {
         constants::LDAP_SUCCESS => Ok(()),
@@ -27,7 +27,7 @@ pub fn log_error(
 #[repr(i32)]
 #[derive(Debug)]
 /// This is a safe rust representation of the values from slapi-plugin.h
-/// such as SLAPI_LOG_FATAL, SLAPI_LOG_TRACE, SLAPI_LOG_ ... These vaulues
+/// such as `SLAPI_LOG_FATAL`, `SLAPI_LOG_TRACE`, `SLAPI_LOG_` ... These vaulues
 /// must matche their counter parts in slapi-plugin.h
 pub enum ErrorLevel {
     /// Always log messages at this level. Soon to go away, see EMERG, ALERT, CRIT, ERR, WARNING, NOTICE, INFO, DEBUG

--- a/src/slapi_r_plugin/src/macros.rs
+++ b/src/slapi_r_plugin/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! slapi_r_plugin_hooks {
                 let mut pb = PblockRef::new(raw_pb);
                 log_error!(ErrorLevel::Trace, "it's alive!\n");
 
-                match pb.set_plugin_version(PluginVersion::V03) {
+                match pb.set_plugin_version(&PluginVersion::V03) {
                     0 => {},
                     e => return e,
                 };
@@ -372,7 +372,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
                 let mut pb = PblockRef::new(raw_pb);
                 log_error!(ErrorLevel::Trace, "slapi_r_syntax_plugin_hooks => begin");
                 // Setup our plugin
-                match pb.set_plugin_version(PluginVersion::V01) {
+                match pb.set_plugin_version(&PluginVersion::V01) {
                     0 => {},
                     e => return e,
                 };
@@ -398,7 +398,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
 
                 // Now setup the MR's
                 match register_plugin_ext(
-                    PluginType::MatchingRule,
+                    &PluginType::MatchingRule,
                     $hooks_ident::eq_mr_name(),
                     concat!(stringify!($mod_ident), "_plugin_eq_mr_init"),
                     [<$mod_ident _plugin_eq_mr_init>]
@@ -409,7 +409,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
 
                 if $hooks_ident::sub_mr_oid().is_some() {
                     match register_plugin_ext(
-                        PluginType::MatchingRule,
+                        &PluginType::MatchingRule,
                         $hooks_ident::sub_mr_name(),
                         concat!(stringify!($mod_ident), "_plugin_ord_mr_init"),
                         [<$mod_ident _plugin_ord_mr_init>]
@@ -421,7 +421,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
 
                 if $hooks_ident::ord_mr_oid().is_some() {
                     match register_plugin_ext(
-                        PluginType::MatchingRule,
+                        &PluginType::MatchingRule,
                         $hooks_ident::ord_mr_name(),
                         concat!(stringify!($mod_ident), "_plugin_ord_mr_init"),
                         [<$mod_ident _plugin_ord_mr_init>]
@@ -542,7 +542,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
             ) -> i32 {
                 let mut pb = PblockRef::new(raw_pb);
                 log_error!(ErrorLevel::Trace, concat!(stringify!($mod_ident), "_plugin_eq_mr_init => begin"));
-                match pb.set_plugin_version(PluginVersion::V01) {
+                match pb.set_plugin_version(&PluginVersion::V01) {
                     0 => {},
                     e => return e,
                 };
@@ -785,7 +785,7 @@ macro_rules! slapi_r_syntax_plugin_hooks {
             ) -> i32 {
                 let mut pb = PblockRef::new(raw_pb);
                 log_error!(ErrorLevel::Trace, concat!(stringify!($mod_ident), "_plugin_ord_mr_init => begin"));
-                match pb.set_plugin_version(PluginVersion::V01) {
+                match pb.set_plugin_version(&PluginVersion::V01) {
                     0 => {},
                     e => return e,
                 };

--- a/src/slapi_r_plugin/src/syntax_plugin.rs
+++ b/src/slapi_r_plugin/src/syntax_plugin.rs
@@ -11,8 +11,8 @@ use std::ptr;
 
 // need a call to slapi_register_plugin_ext
 
-extern "C" {
-    fn slapi_matchingrule_register(mr: *const slapi_matchingRuleEntry) -> i32;
+unsafe extern "C" {
+    unsafe fn slapi_matchingrule_register(mr: *const slapi_matchingRuleEntry) -> i32;
 }
 
 #[repr(C)]
@@ -40,15 +40,15 @@ pub unsafe fn matchingrule_register(
 ) -> i32 {
     // Make everything CStrings that live long enough.
 
-    let oid_cs = CString::new(oid).expect("invalid oid");
-    let name_cs = CString::new(name).expect("invalid name");
-    let desc_cs = CString::new(desc).expect("invalid desc");
-    let syntax_cs = CString::new(syntax).expect("invalid syntax");
+    let oid_cs: CString = CString::new(oid).expect("invalid oid");
+    let name_cs: CString = CString::new(name).expect("invalid name");
+    let desc_cs: CString = CString::new(desc).expect("invalid desc");
+    let syntax_cs: CString = CString::new(syntax).expect("invalid syntax");
 
     // We have to do this so the cstrings live long enough.
-    let compat_syntax_ca = Charray::new(compat_syntax).expect("invalid compat_syntax");
+    let compat_syntax_ca: Charray = Charray::new(compat_syntax).expect("invalid compat_syntax");
 
-    let new_mr = slapi_matchingRuleEntry {
+    let new_mr: slapi_matchingRuleEntry = slapi_matchingRuleEntry {
         mr_oid: oid_cs.as_ptr(),
         _mr_oidalias: ptr::null(),
         mr_name: name_cs.as_ptr(),
@@ -58,7 +58,7 @@ pub unsafe fn matchingrule_register(
         mr_compat_syntax: compat_syntax_ca.as_ptr(),
     };
 
-    let new_mr_ptr = &new_mr as *const _;
+    let new_mr_ptr: *const slapi_matchingRuleEntry = &new_mr;
     slapi_matchingrule_register(new_mr_ptr)
 }
 


### PR DESCRIPTION
No features added or removed, mostly lint changes from clippy
I might add a few modules for `slapi_r_plugin` later on, so as a first step to get familiar with your workflow and contrubiton I opened this PR

I used https://www.port389.org/docs/389ds/contributing.html for reference, sorry if i did something wrong

## Summary by Sourcery

Apply lint and style improvements across Rust plugins, modernizing FFI declarations, pointer handling, and general Rust idioms while maintaining existing functionality.

Enhancements:
- Modernize FFI declarations to unsafe extern "C" and simplify pointer casts with .cast(), const fn constructors, and explicit type annotations
- Refine Rust idioms by using Self in enum matches, range syntax for validation, let Ok(...) patterns, vec![] and vec![0; len], and format string interpolation in log messages
- Improve const correctness by marking constructors and pointer-returning methods as const and deriving Eq for FilterType

Build:
- Modernize build.rs scripts with inline variable interpolation for cargo directives and file paths

Tests:
- Update PBKDF2 tests to remove Result wrappers, simplify assertions, and adjust get_pbkdf2_rounds return type