### PR TITLE
Issue 6951 - On line server certificate refresh

### DIFF
--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -173,7 +173,7 @@ class ECDSA_Certificate:
         self.dir = outdir
         self.prefix = prefix
         self.args = { **ECDSA_Certificate.VDEF, **kwargs }
-        if not 'organizationName' in kwargs:
+        if 'organizationName' not in kwargs:
             self.args['organizationName'] = f'{self.args["organizationName"]}-{prefix}'
         self.args['subject'] = self.get_subject()
         for name in ( 'conf', 'csr', 'key', 'p12', 'pem', 'pw1', 'pw2'):

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -292,7 +292,7 @@ def open_ldaps_conn(inst, ca):
 def open_ldapi_conn(inst, logfile=None):
     dse = DSEldif(inst)
     ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
-    url = "ldapi://%s" % (ldapurl.ldapUrlEscape(ensure_str(ldapi_socket)))
+    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
     ld = ldap.initialize(url)
     # Perform autobind
     sasl_auth = ldap.sasl.external()

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -316,7 +316,7 @@ def refresh_certs(inst, timeout=60):
     ld = open_ldapi_conn(inst)
     ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
     # Now lets wait until the config value is off again
-    for i in range(timeout):
+    for _ in range(timeout):
         result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
         log.info(f'cn=config result: {result}')
         attrs = result[0][1]

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -419,6 +419,7 @@ def test_refresh_ecdsa(topo, capsys):
 
         install_certs(ca2, cert2, inst)
         refresh_certs(inst)
+        time.sleep(1)
 
         # if we restart the next tls_search is OK and ld.search_s fails as expected
         # if we dont the tls_search fails ==> something is down

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -6,11 +6,21 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
-import logging
-import pytest
 import os
+import sys
+import pytest
+import ldap
+import ldapurl
+import logging
+import secrets
+import socket
+import time
 import subprocess
-from lib389.utils import ds_is_older
+import textwrap
+from lib389.cli_base import FakeArgs
+from lib389.cli_ctl.tls import import_key_cert_pair
+from lib389.dseldif import DSEldif
+from lib389.utils import ds_is_older, ensure_str
 from lib389._constants import DN_DM, PW_DM
 from lib389.topologies import topology_st as topo
 from tempfile import TemporaryDirectory
@@ -24,148 +34,238 @@ else:
     logging.getLogger(__name__).setLevel(logging.INFO)
 log = logging.getLogger(__name__)
 
-script_content="""
-#!/bin/bash
-set -e  # Exit if a command fails
-set -x  # Log the commands
+tls_enabled = False
 
-cd {dir}
-inst={instname}
-url={url}
-rootdn="{rootdn}"
-rootpw="{rootpw}"
 
 ################################
 ###### GENERATE CA CERT ########
 ################################
+class ECDSA_Certificate:
+    # Generate ecdsa certificate
 
-echo "
-[ req ]
-distinguished_name = req_distinguished_name
-policy             = policy_match
-x509_extensions     = v3_ca
+    PEM_PASSWORD_LEN = 15
 
-# For the CA policy
-[ policy_match ]
-countryName             = optional
-stateOrProvinceName     = optional
-organizationName        = optional
-organizationalUnitName  = optional
-commonName              = supplied
-emailAddress            = optional
+    # For the CA policy
+    CONF_CA_HEADER = textwrap.dedent("""\
+        [ req ]
+        distinguished_name = req_distinguished_name
+        policy             = policy_match
+        x509_extensions     = v3_ca
 
-[ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= FR
-countryName_min			= 2
-countryName_max			= 2
+        # For the CA policy""")
 
-stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= test
+    CONF_CA_TRAILER = textwrap.dedent("""\
+        [ v3_ca ]
+        subjectKeyIdentifier = hash
+        authorityKeyIdentifier = keyid:always,issuer
+        basicConstraints = critical,CA:true
+        #nsComment = "OpenSSL Generated Certificate"
+        keyUsage=critical, keyCertSign
+        """)
 
-localityName			= Locality Name (eg, city)
+    # For the other certificates policy
+    CONF_CERT_HEADER = textwrap.dedent("""\
+        distinguished_name = req_distinguished_name
+        policy             = policy_match
+        x509_extensions     = v3_cert
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= test-ECDSA-CA
+        # For the cert policy""")
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
+    CONF_CERT_TRAILER = textwrap.dedent("""\
+        [ v3_cert ]
+        basicConstraints = critical,CA:false
+        subjectAltName=DNS:progier-thinkpadt14gen5.rmtfr.csb
+        keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+        #nsComment = OpenSSL Generated Certificate
+        extendedKeyUsage=clientAuth, serverAuth
+        nsCertType=client, server
+        """)
 
-commonName			= Common Name (e.g. server FQDN or YOUR name)
-commonName_max			= 64
+    # Shared by all certificates (CA included)
+    CONF_COMMOM = textwrap.dedent("""\
+        [ policy_match ]
+        countryName             = optional
+        stateOrProvinceName     = optional
+        organizationName        = optional
+        organizationalUnitName  = optional
+        commonName              = supplied
+        emailAddress            = optional
 
+        [ req_distinguished_name ]
+        countryName			= Country Name (2 letter code)
+        countryName_default		= FR
+        countryName_min			= 2
+        countryName_max			= 2
 
-[ v3_ca ]
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = critical,CA:true
-#nsComment = "OpenSSL Generated Certificate"
-keyUsage=critical, keyCertSign
-" >ca.conf
+        stateOrProvinceName		= State or Province Name (full name)
+        stateOrProvinceName_default	= test
 
+        localityName			= Locality Name (eg, city)
 
-openssl ecparam -genkey -name prime256v1 -out ca.key
-openssl req -x509 -new -sha256 -key ca.key -nodes -days 3650 -config ca.conf -subj "/CN=`hostname`/O=test-ECDSA-CA/C=FR"  -out ca.pem -keyout ca.key
-openssl x509 -outform der -in ca.pem -out ca.crt
+        0.organizationName		= Organization Name (eg, company)
+        0.organizationName_default	= {organizationName}
 
-openssl x509 -text -in ca.pem
+        organizationalUnitName		= Organizational Unit Name (eg, section)
+        #organizationalUnitName_default	=
 
-####################################
-###### GENERATE SERVER CERT ########
-####################################
+        commonName			= Common Name (e.g. server FQDN or YOUR name)
+        commonName_max			= 64
 
-echo "
-[ req ]
-distinguished_name = req_distinguished_name
-policy             = policy_match
-x509_extensions     = v3_cert
-
-# For the cert policy
-[ policy_match ]
-countryName             = optional
-stateOrProvinceName     = optional
-organizationName        = optional
-organizationalUnitName  = optional
-commonName              = supplied
-emailAddress            = optional
-
-[ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= FR
-countryName_min			= 2
-countryName_max			= 2
-
-stateOrProvinceName		= State or Province Name (full name)
-
-localityName			= Locality Name (eg, city)
-
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= test-ECDSA
-
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
-
-commonName			= Common Name (e.g. server FQDN or YOUR name)
-commonName_max			= 64
+        """)
 
 
-[ v3_cert ]
-basicConstraints = critical,CA:false
-subjectAltName=DNS:`hostname`
-keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-#nsComment = "OpenSSL Generated Certificate"
-extendedKeyUsage=clientAuth, serverAuth
-nsCertType=client, server
-" >cert.conf
+    VDEF = {
+        "countryName": "FR",
+        "stateOrProvinceName": "test",
+        "organizationName": "test-ECDSA",
+        "organizationalUnitName": None,
+        "localityName": None,
+        "commonName": socket.gethostname(),
+        "maxAge": "3",
+    }
 
-openssl ecparam -genkey -name prime256v1 -out cert.key
-openssl req -new -sha256 -key cert.key -nodes  -config cert.conf -subj "/CN=`hostname`/O=test-ECDSA/C=FR" -out cert.csr 
-openssl x509 -req -sha256 -days 3650 -extensions v3_cert -extfile cert.conf -in cert.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out cert.pem 
-openssl pkcs12 -export -inkey cert.key -in cert.pem -name ecdsacert -out cert.p12 -passout pass:secret12
 
-openssl x509 -text -in cert.pem
+    SUBJECT_ATTR = ( "commonName", "organizationName", "countryName" )
+    SUBJECT_MAP = {
+        "countryName": "C",
+        "commonName": "CN",
+        "organizationName": "O",
+    }
+
+
+    def __init__(self, prefix, outdir, **kwargs):
+        self.dir = outdir
+        self.prefix = prefix
+        self.args = { **ECDSA_Certificate.VDEF, **kwargs }
+        if not 'organizationName' in kwargs:
+            self.args['organizationName'] = f'{self.args["organizationName"]}-{prefix}'
+        self.args['subject'] = self.get_subject()
+        for name in ( 'conf', 'csr', 'key', 'p12', 'pem', 'pw1', 'pw2'):
+            setattr(self, name, f'{outdir}/{prefix}.{name}')
+        for path in ( self.pw1, self.pw2 ):
+            with open(path, 'wt') as fd:
+                fd.write(secrets.token_urlsafe(ECDSA_Certificate.PEM_PASSWORD_LEN))
+                fd.write('\n')
+
+
+    def get_subject(self, **kwargs):
+        args = { **self.args, **kwargs }
+        subject = ""
+        for arg in ECDSA_Certificate.SUBJECT_ATTR:
+            if arg in args and arg in ECDSA_Certificate.SUBJECT_MAP:
+                subject += f"/{ECDSA_Certificate.SUBJECT_MAP[arg]}={args[arg]}"
+        # return f"/CN={args['commonName']}/DC=example/DC=com"
+        return subject
+
+    def generate_conf(self, isCA):
+        if isCA:
+            confl = ( ECDSA_Certificate.CONF_CA_HEADER,
+                      ECDSA_Certificate.CONF_COMMOM,
+                      ECDSA_Certificate.CONF_CA_TRAILER )
+        else:
+            confl = ( ECDSA_Certificate.CONF_CERT_HEADER,
+                      ECDSA_Certificate.CONF_COMMOM,
+                      ECDSA_Certificate.CONF_CERT_TRAILER )
+        conf_path = f'{self.dir}/{self.prefix}.conf'
+        conf_data = "\n".join(confl).format(dir=self.dir, prefix=self.prefix, **self.args)
+        with open(conf_path, "wt") as fd:
+            for line in conf_data.split('\n'):
+                sep = "#" if " = None" in line else ""
+                fd.write(f'{sep}{line}\n')
+
+    def run(self, cmd):
+        log.info(f'Running: {" ".join(cmd)}')
+        res = subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        assert res
+        log.info(f'Stdout+Stderr:{res.stdout}')
+        res.check_returncode()
+
+    def generate_CA(self):
+        self.generate_conf(True)
+        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
+        self.run(("openssl", "req", "-x509", "-new", "-sha256", "-key", self.key, "-days", self.args['maxAge'], "-config", self.conf, "-subj", self.get_subject(), "-out", self.pem, "-keyout", self.key, "-passout", f"file:{self.pw1}"))
+        self.run(("openssl", "x509", "-text", "-in", self.pem))
+        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
+
+    def generate_cert(self, ca):
+        self.generate_conf(False)
+        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
+        self.run(("openssl", "req", "-new", "-sha256", "-key", self.key, "-config", self.conf, "-subj", self.get_subject(), "-out", self.csr))
+        self.run(("openssl", "x509", "-req", "-sha256", "-days", self.args['maxAge'], "-extensions", "v3_cert", "-extfile", self.conf, "-in", self.csr, "-CA", ca.pem, "-CAkey", ca.key, "-CAcreateserial", "-out", self.pem,  "-passin", f"file:{ca.pw1}"))
+        self.run(("openssl", "x509", "-text", "-in", self.pem))
+        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
+
+
 
 
 #############################
 ###### INSTALL CERTS ########
 #############################
+def install_certs(ca, cert, inst):
+    prefix = os.environ.get('PREFIX', "/")
+    certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
+    pwfile = f'{certdbdir}/pwdfile.txt'
+    for f in ('cert9.db', 'key4.db'):
+        try:
+            os.remove(f'{certdbdir}/{f}')
+        except OSError:
+            pass
 
-certdbdir=$PREFIX/etc/dirsrv/slapd-$inst
-rm -f $certdbdir/cert9.db $certdbdir/key4.db
-certutil -N -d $certdbdir -f $certdbdir/pwdfile.txt 
-
-certutil -A -n Self-Signed-CA -t CT,, -f $certdbdir/pwdfile.txt -d $certdbdir -a -i ca.pem
-
-dsctl $inst tls import-server-key-cert cert.pem cert.key
-
-dsctl $inst restart
+    ca.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile))
+    ca.run(('certutil', '-A', '-n', 'Self-Signed-CA', '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', ca.pem))
+    args = FakeArgs()
+    for k,v in { 'key_path': cert.key, 'cert_path': cert.pem }.items():
+        setattr(args, k, v)
+    import_key_cert_pair(inst, log, args)
 
 
 #########################
 ###### TEST CERT ########
 #########################
-LDAPTLS_CACERT=$PWD/ca.pem ldapsearch -x -H $url -D "$rootdn" -w "$rootpw" -b "" -s base
-"""
+
+def open_ldaps_conn(inst, ca):
+    url = inst.toLDAPURL()
+    log.info(f'Attempt to connect to {url} using {ca.pem}')
+    ld = ldap.initialize(url, trace_level=0, trace_file=sys.stderr)
+    ld.protocol_version=ldap.VERSION3
+    ld.set_option(ldap.OPT_DEBUG_LEVEL, 255 )
+    ld.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+    #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+    ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
+    ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
+    ld.set_option(ldap.OPT_X_TLS_NEWCTX,0)
+    ld.simple_bind_s(DN_DM, PW_DM)
+    return ld
+
+
+def open_ldapi_conn(inst):
+    dse = DSEldif(inst)
+    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
+    url = "ldapi://%s" % (ldapurl.ldapUrlEscape(ensure_str(ldapi_socket)))
+    ld = ldap.initialize(url, trace_level=0, trace_file=sys.stderr)
+    ld.protocol_version=ldap.VERSION3
+    ld.set_option(ldap.OPT_DEBUG_LEVEL, 255 )
+    ld.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+    # Perform autobind
+    sasl_auth = ldap.sasl.external()
+    ld.sasl_interactive_bind_s("", sasl_auth)
+    return ld
+
+
+def tls_search(inst, ca):
+    ld = open_ldaps_conn(inst, ca)
+    results = ld.search_s('', ldap.SCOPE_BASE)
+    log.info(f'search returned {len(results)} entries')
+    ld.unbind()
+    return results
+
+#
+#  Ideally There should be a dsctl/dsconf subcommand
+#
+def refresh_certs(inst):
+    ld = open_ldapi_conn(inst)
+    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
+    ld.unbind()
 
 
 def test_ecdsa(topo):
@@ -174,37 +274,100 @@ def test_ecdsa(topo):
     :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
     :setup: Standalone Instance
     :steps:
-        1. Generate the test script
-        2. Run the test script
-        3. Check that ldapsearch returned the namingcontext
+        1. Generate ECDSA CA and User Cert
+        2. Install the certificates
+        3. Restart the server
+        4. Open ldaps connection with server CA certificate and search root entry
     :expectedresults:
         1. No error
-        2. No error and exit code should be 0
-        3. namingcontext should be in the script output
+        2. No error
+        3. No error
+        4. No error
     """
 
     inst=topo.standalone
-    inst.enable_tls()
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
     with TemporaryDirectory() as dir:
-        scriptname = f"{dir}/doit"
-        scriptname = "/tmp/doit"
-        d = {
-            'dir': dir,
-            'instname': inst.serverid,
-            'url': f"ldaps://localhost:{inst.sslport}",
-            'rootdn': DN_DM,
-            'rootpw': PW_DM,
-        }
-        with open(scriptname, 'w') as f:
-            f.write(script_content.format(**d))
-        res = subprocess.run(('/bin/bash', scriptname), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
-        assert res
-        log.info(res.stdout)
-        res.check_returncode()
-        # If ldapsearch is successful then defaultnamingcontext should be in res.stdout
-        assert "defaultnamingcontext" in res.stdout
+        dir="/home/progier/sb/i1108/389-ds-base/dirsrvtests/tests/suites/tls/tmp"
+        ca = ECDSA_Certificate("CA", dir)
+        ca.generate_CA()
+        cert = ECDSA_Certificate("Cert", dir)
+        cert.generate_cert(ca)
+        install_certs(ca, cert, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca)
 
 
+def test_refresh_ecdsa(topo):
+    """Specify a test case purpose or name here
+
+    :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
+    :setup: Standalone Instance
+    :steps:
+        1. Generate ECDSA CA and User Cert
+        2. Generate a second ECDSA CA and User Cert pair
+        3. Install the first set of certificates
+        4. Restart the server
+        5. Open ldaps connection with server CA certificate and search root entry
+        6. Open a second ldaps connection with server CA certificate and keep it open
+        7. Install the second set of certificates
+        8. Set the certificate refresh attribute to true (using ldapi)
+        9. Wait a bit until certificates get replaced
+        10. Perform a search on the open connection
+        11. Open ldaps connection with new server CA certificate and search root entry
+        12. Open ldaps connection with old server CA certificate and search root entry
+        13. Close the open connection
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error
+        5. No error
+        6. No error
+        7. No error
+        8. No error
+        9. No error
+        10. No error
+        11. No error
+        12. LDAP_SERVER_DOWN because certificate could not be verified
+        13. No error
+    """
+
+    inst=topo.standalone
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
+    with TemporaryDirectory() as dir:
+        dir="/home/progier/sb/i1108/389-ds-base/dirsrvtests/tests/suites/tls/tmp"
+        ca = ECDSA_Certificate("CA", dir)
+        ca.generate_CA()
+        cert = ECDSA_Certificate("Cert", dir)
+        cert.generate_cert(ca)
+        ca2 = ECDSA_Certificate("CA2", dir)
+        ca2.generate_CA()
+        cert2 = ECDSA_Certificate("Cert2", dir)
+        cert2.generate_cert(ca2)
+
+        install_certs(ca2, cert2, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca2)
+
+        install_certs(ca, cert, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca)
+        ld = open_ldaps_conn(inst, ca)
+
+        install_certs(ca2, cert2, inst)
+        refresh_certs(inst)
+        time.sleep(1)
+        results = ld.search_s('', ldap.SCOPE_BASE)
+        assert len(results) == 1
+        tls_search(inst, ca2)
+        ld.unbind()
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -809,6 +809,7 @@ char *epoll_event_flags_to_string(PRUint32 events)
     static char buf[64];
     int len = 0;
 
+#ifdef ENABLE_EPOLL
     if (events & EPOLLIN) {
         len += snprintf(buf + len, sizeof(buf) - len, "EPOLLIN|");
     }
@@ -836,6 +837,7 @@ char *epoll_event_flags_to_string(PRUint32 events)
     if (events & EPOLLET) {
         len += snprintf(buf + len, sizeof(buf) - len, "EPOLLET|");
     }
+#endif
     if (len == 0) {
         len += snprintf(buf + len, sizeof(buf) - len, "EPOLLUNKNOWN|");
     }

--- a/ldap/servers/slapd/globals.c
+++ b/ldap/servers/slapd/globals.c
@@ -68,6 +68,7 @@ set_entry_points()
     sep->sep_disconnect_server = (caddr_t)disconnect_server;
     sep->sep_slapd_ssl_init = (caddr_t)slapd_ssl_init;
     sep->sep_slapd_ssl_init2 = (caddr_t)slapd_ssl_init2;
+    sep->sep_slapd_ssl_refresh_certs = (caddr_t)set_cert_refresh_asked;
     set_dll_entry_points(sep);
 
     /* To apply the nsslapd-counters config value properly,

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -2899,7 +2899,9 @@ slapd_do_all_nss_ssl_init(int slapd_exemode, int importexport_encrypt, int s_por
      */
     PRBool isFIPS = slapd_pk11_isFIPS();
     int init_ssl = config_get_security();
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
 
+    slapdFrontendConfig->ssl_refresh_certs = LDAP_OFF;
     if (isFIPS && !init_ssl) {
         slapi_log_err(SLAPI_LOG_WARNING, "slapd_do_all_nss_ssl_init",
                       "ERROR: TLS is not enabled, and the machine is in FIPS mode. "

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -650,6 +650,9 @@ int32_t config_set_referral_check_period(const char *attrname, char *value, char
 int32_t config_get_return_orig_dn(void);
 int32_t config_set_return_orig_dn(const char *attrname, char *value, char *errorbuf, int apply);
 
+int32_t config_get_refresh_certs();
+int32_t config_set_refresh_certs(const char *attrname, char *value, char *errorbuf, int apply);
+
 int config_set_tcp_fin_timeout(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_tcp_fin_timeout(void);
 int config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply);
@@ -684,6 +687,8 @@ void slapi_parse_control(LDAPControl *ctrl, char **oid, char **value, bool *isCr
  * daemon.c
  */
 int validate_num_config_reservedescriptors(void) ;
+void set_cert_refresh_asked(bool val);
+
 
 /*
  * delete.c
@@ -1179,6 +1184,7 @@ int slapd_security_library_is_initialized(void);
 int slapd_ssl_listener_is_initialized(void);
 int slapd_SSL_client_auth(LDAP *ld);
 SECKEYPrivateKey *slapd_get_unlocked_key_for_cert(CERTCertificate *cert, void *pin_arg);
+void refresh_certs(daemon_ports_t *ports);
 
 /*
  * security_wrappers.c

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2780,6 +2780,7 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t return_orig_dn;
     slapi_onoff_t pw_admin_skip_info;
     char *auditlog_display_attrs;
+    slapi_onoff_t ssl_refresh_certs;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2083,6 +2083,7 @@ struct snmp_vars_t
 #define ENTRY_POINT_SLAPD_SSL_CLIENT_INIT 108
 #define ENTRY_POINT_SLAPD_SSL_INIT 109
 #define ENTRY_POINT_SLAPD_SSL_INIT2 110
+#define ENTRY_POINT_SLAPD_CERT_REFRESH_ASKED 111
 
 typedef void (*ps_wakeup_all_fn_ptr)(void);
 typedef void (*ps_service_fn_ptr)(Slapi_Entry *, Slapi_Entry *, int, int);
@@ -2091,6 +2092,7 @@ typedef void (*get_disconnect_server_fn_ptr)(Connection *conn, PRUint64 opconnid
 typedef int (*modify_config_dse_fn_ptr)(Slapi_PBlock *pb);
 typedef int (*slapd_ssl_init_fn_ptr)(void);
 typedef int (*slapd_ssl_init_fn_ptr2)(PRFileDesc **s, int StartTLS);
+typedef void (*slapd_ssl_set_cert_refresh_asked_ptr)(bool val);
 
 /*
  * A structure of entry points in the NT exe which need
@@ -2103,6 +2105,7 @@ typedef struct _slapdEntryPoints
     caddr_t sep_disconnect_server;
     caddr_t sep_slapd_ssl_init;
     caddr_t sep_slapd_ssl_init2;
+    caddr_t sep_slapd_ssl_refresh_certs;
 } slapdEntryPoints;
 
 #define DLL_IMPORT_DATA
@@ -2408,6 +2411,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_RETURN_DEFAULT_OPATTR "nsslapd-return-default-opattr"
 #define CONFIG_REFERRAL_CHECK_PERIOD "nsslapd-referral-check-period"
 #define CONFIG_RETURN_ENTRY_DN "nsslapd-return-original-entrydn"
+#define CONFIG_REFRESH_CERTS "nsslapd-refresh-certificates"
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
 

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3080,10 +3080,14 @@ pop_ssl_layer(PRFileDesc *fd)
      * certificate
      */
     PRFileDesc *oldsock = PR_PopIOLayer(fd, PR_TOP_IO_LAYER);
-    PRDescIdentity id = PR_GetLayersIdentity(oldsock);
-    const char *name = PR_GetNameForIdentity(id);
-    slapi_log_err(SLAPI_LOG_DEBUG, "pop_ssl_layer", "Poping %s layer\n", name);
-    oldsock->dtor(oldsock); /* Call nspr layer destructor */
+    if (oldsock != NULL) {
+        PRDescIdentity id = PR_GetLayersIdentity(oldsock);
+        const char *name = PR_GetNameForIdentity(id);
+        slapi_log_err(SLAPI_LOG_DEBUG, "pop_ssl_layer", "Poping %s layer\n", name);
+        if (oldsock->dtor) {
+            oldsock->dtor(oldsock); /* Call nspr layer destructor */
+        }
+    }
 }
 
 void

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3099,6 +3099,7 @@ dbg_fd_stack(PRFileDesc *stack, const char *msg)
         slapd_SSL_info("dbg_fd_stack:    Subject is: %s", cert->subjectName);
         slapd_SSL_info("dbg_fd_stack:    Issuer is: %s", cert->issuerName);
     }
+    CERT_DestroyCertList(list);
     while (fd) {
         PRDescIdentity id = PR_GetLayersIdentity(fd);
         const char *name = PR_GetNameForIdentity(id);

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3069,7 +3069,7 @@ reset_nss_slot(void)
      */
     SECMODModule *module = SECMOD_GetInternalModule();
     int rv = SECMOD_DeleteInternalModule(module->commonName);
-    slapd_SSL_info("Reset nss intern al slot. rv=%d\n", rv);
+    slapd_SSL_info("Reset nss internal slot. rv=%d\n", rv);
 }
 
 static void

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3123,7 +3123,7 @@ refresh_certs(daemon_ports_t *ports)
     PRFileDesc **sock = NULL;
 
     slapi_log_err(SLAPI_LOG_WARNING, "Security certificates refresh",
-                  "Refresh in propgress.\n");
+                  "Refresh in progress.\n");
 
     /* Perform some cleanup */
     _nss_initialized = 0;

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -468,8 +468,9 @@ class LogCapture(logging.Handler):
 
 
 class FakeArgs(object):
-    def __init__(self):
-        pass
+    def __init__(self, **kwargs):
+        for k,v in kwargs.items():
+            setarg(self, k, v)
 
     def __len__(self):
         return len(self.__dict__.keys())

--- a/src/lib389/lib389/cli_conf/config.py
+++ b/src/lib389/lib389/cli_conf/config.py
@@ -150,6 +150,21 @@ def config_del_attr(inst, basedn, log, args):
     _config_display_ldapimaprootdn_warning(log, args)
 
 
+def config_refresh_certs(inst, basedn, log, args):
+    refresh_certs_attr = 'nsslapd-refresh-certificates'
+    timeout = 10
+    conf = Config(inst, basedn)
+    conf.replace(refresh_certs_attr, 'on')
+    while True:
+        for i in range(timeout):
+            if conf.get_attr_val_utf8_l(refresh_certs_attr) == 'off':
+                time.sleep(1)
+                log.info('Successfully refreshed the certificates')
+                return
+            time.sleep(1)
+        log.warning('Still waiting for certificate refresh completion. Maybe a very long operation is in progress ?')
+
+
 def create_parser(subparsers):
     config_parser = subparsers.add_parser('config', help="Manage the server configuration", formatter_class=CustomHelpFormatter)
 
@@ -170,3 +185,6 @@ def create_parser(subparsers):
     del_attr_parser = subcommands.add_parser('delete', help='Delete attribute value in configuration', formatter_class=CustomHelpFormatter)
     del_attr_parser.set_defaults(func=config_del_attr)
     del_attr_parser.add_argument('attr', nargs='*', help='Configuration attribute to delete')
+
+    refresh_certs_parser = subcommands.add_parser('refresh-certs', help='Refresh the server certificate after a changing the NSS certificate database', formatter_class=CustomHelpFormatter)
+    refresh_certs_parser.set_defaults(func=config_refresh_certs)

--- a/src/lib389/lib389/cli_conf/config.py
+++ b/src/lib389/lib389/cli_conf/config.py
@@ -156,7 +156,7 @@ def config_refresh_certs(inst, basedn, log, args):
     conf = Config(inst, basedn)
     conf.replace(refresh_certs_attr, 'on')
     while True:
-        for i in range(timeout):
+        for _ in range(timeout):
             if conf.get_attr_val_utf8_l(refresh_certs_attr) == 'off':
                 time.sleep(1)
                 log.info('Successfully refreshed the certificates')


### PR DESCRIPTION
Goal: be able to change the server certificate without restarting the server
Implementation:
Add a  new dsconf config refresh-certs subcommand  that set a new boolean attribute in cn=config entry 
(nsslapd-refresh-certificates)  then poll it until the server reset it after the certificate get refreshed.
The flag triggers a synchronisation mechanism that block the accept thread and the listener thread until all these threads are blocked then it reset the security system by clearing some SSL cache, poping SSL layer from the listening NSPR I/O stack (i.e: PR_Filedesc) and redo the security initialization from scratch.
Once everything thing is done, the  nsslapd-refresh-certificates is reset and the blocked threads get unblock
Usage: 
  Administrator may change/renew the server certificate with the NSS dtabase (cert9.db) using dsctl commands or certutil . Administrator may also change some of the security parameter (related to the certificate handling) then run the   'dsconf  instance config refresh-certs' command.
Beware that the connection using the old CA certificate will be broken  

Issue: #6951 

Reviewed by: ?