### PR TITLE
Issue 6660 - UI - Fix minor issues

### DIFF
--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -2015,7 +2015,7 @@ class LagReportModal extends React.Component {
                                     {csvPreview ? (
                                         <TextContent>
                                             <Text component={TextVariants.h3}>{_("First 20 lines of CSV data:")}</Text>
-                                            <pre className="ds-code-block ds-no-margin-bottom">{data}</pre>
+                                            <pre className="ds-code-block ds-no-margin-bottom">{csvPreview}</pre>
                                         </TextContent>
                                     ) : (
                                         <EmptyState>


### PR DESCRIPTION
Description: CSV report tab crashes because of the type. Use corrent variable to display the data.

Fixes: https://github.com/389ds/389-ds-base/issues/6660

Reviewed by: ?

## Summary by Sourcery

Bug Fixes:
- Replace incorrect data reference with csvPreview in CSV report preview component