### PR TITLE
Issue 6958 - Backport variable definition to fix test plan. 

### DIFF
--- a/dirsrvtests/tests/suites/plugins/attruniq_test.py
+++ b/dirsrvtests/tests/suites/plugins/attruniq_test.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.tier1
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 MAIL_ATTR_VALUE = 'non-uniq@value.net'
+MAIL_ATTR_VALUE_ALT = 'alt-mail@value.net'
 
 
 def test_modrdn_attr_uniqueness(topology_st):


### PR DESCRIPTION
The test dirsrvtests/tests/suites/plugins/attruniq_test.py::test_multiple_attr_uniqueness fails on multiple branches due to the variable MAIL_ATTR_VALUE_ALT being undefined. This takes the definition of MAIL_ATTR_VALUE_ALT from e61de564ea33a1fa528a58241e90b663a44c4639 and places it in attruniq_test.py.

I've manually verified this fix on 389-ds-base-3.0, 2.7, 2.6, 2.5, 2.4, 2.3, 2.0, and 1.4.3. 

Resolves: https://github.com/389ds/389-ds-base/issues/6958

## Summary by Sourcery

Tests:
- Define MAIL_ATTR_VALUE_ALT in attruniq_test.py to resolve test_multiple_attr_uniqueness failure