### PR TITLE
Issue 6960 - Add missing imports to test plan on 1.4.3. 

### DIFF
--- a/dirsrvtests/tests/suites/import/regression_test.py
+++ b/dirsrvtests/tests/suites/import/regression_test.py
@@ -19,6 +19,8 @@ from lib389._constants import DEFAULT_SUFFIX
 from lib389.tasks import *
 from lib389.idm.user import UserAccounts
 from lib389.idm.directorymanager import DirectoryManager
+from lib389.utils import get_default_db_lib
+from lib389.dbgen import dbgen_nested_ldif
 
 pytestmark = pytest.mark.tier1
 

--- a/ldap/servers/plugins/replication/cl5_config.c
+++ b/ldap/servers/plugins/replication/cl5_config.c
@@ -264,6 +264,8 @@ changelog5_config_modify(Slapi_PBlock *pb,
 
     *returncode = LDAP_SUCCESS;
 
+    slapi_log_err(SLAPI_LOG_INFO, "changelog5_config_modify", "we are in here! send help!");
+
     /* changelog must be open before its parameters can be modified */
     if (cl5GetState() != CL5_STATE_OPEN) {
         if (returntext) {
@@ -356,6 +358,7 @@ changelog5_config_modify(Slapi_PBlock *pb,
                         config.maxAge = slapi_ch_strdup(config_attr_value);
                     } else {
                         if (returntext) {
+                            slapi_log_err(SLAPI_LOG_INFO, "changelog5_config_modify", "the value is invalid and we're in MAXAGE!");
                             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
                                         "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdD]",
                                         CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, config_attr_value ? config_attr_value : "null",
@@ -370,6 +373,7 @@ changelog5_config_modify(Slapi_PBlock *pb,
                         config.compactInterval = (long)slapi_parse_duration(config_attr_value);
                     } else {
                         if (returntext) {
+                            slapi_log_err(SLAPI_LOG_INFO, "changelog5_config_modify", "the value is invalid and we're in COMPACTDB!");
                             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
                                         "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdD]",
                                         CONFIG_CHANGELOG_COMPACTDB_ATTRIBUTE, config_attr_value,


### PR DESCRIPTION
The regression test dirsrvtests/tests/suites/import/regression_test.py::test_ldif2db_after_backend_create errors out on 389-ds-base-1.4.3 due to missing two imports. This restores the two imports and allows the test to run to completion. 

Manually verified on 389-ds-base-1.4.3. The test either passes (2.x) or is skipped (3.x, main) on all other branches. 

Resolves: https://github.com/389ds/389-ds-base/issues/6960

## Summary by Sourcery

Restore missing imports in the LDIF-to-DB regression test and enhance changelog5_config_modify with additional info-level logging for better debugging.

Bug Fixes:
- Add missing imports get_default_db_lib and dbgen_nested_ldif to regression_test.py

Enhancements:
- Insert info-level slapi_log_err logging at key points in changelog5_config_modify for debugging invalid parameter values

Tests:
- Fix regression test import errors by restoring the two missing imports