### PR TITLE
Issue 6966 - On large DB, unlimited IDL scan limit reduce the SRCH pe…

### DIFF
--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -503,17 +503,19 @@ def test_ndn_cache_enabled(topo):
         topo.standalone.config.set('nsslapd-ndn-cache-max-size', 'invalid_value')
 
 
-def test_require_index(topo):
+def test_require_index(topo, request):
     """Validate that unindexed searches are rejected
 
     :id: fb6e31f2-acc2-4e75-a195-5c356faeb803
     :setup: Standalone instance
     :steps:
         1. Set "nsslapd-require-index" to "on"
-        2. Test an unindexed search is rejected
+        2. ancestorid/idlscanlimit to 100
+        3. Test an unindexed search is rejected
     :expectedresults:
         1. Success
         2. Success
+        3. Success
     """
 
     # Set the config
@@ -524,6 +526,10 @@ def test_require_index(topo):
 
     db_cfg = DatabaseConfig(topo.standalone)
     db_cfg.set([('nsslapd-idlistscanlimit', '100')])
+    backend = Backends(topo.standalone).get_backend(DEFAULT_SUFFIX)
+    ancestorid_index = backend.get_index('ancestorid')
+    ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
+    topo.standalone.restart()
 
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     for i in range(101):
@@ -534,10 +540,15 @@ def test_require_index(topo):
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         raw_objects.filter("(description=test*)")
 
+    def fin():
+        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
+
+    request.addfinalizer(fin)
+
 
 
 @pytest.mark.skipif(ds_is_older('1.4.2'), reason="The config setting only exists in 1.4.2 and higher")
-def test_require_internal_index(topo):
+def test_require_internal_index(topo, request):
     """Ensure internal operations require indexed attributes
 
     :id: 22b94f30-59e3-4f27-89a1-c4f4be036f7f
@@ -568,6 +579,10 @@ def test_require_internal_index(topo):
     # Create a bunch of users
     db_cfg = DatabaseConfig(topo.standalone)
     db_cfg.set([('nsslapd-idlistscanlimit', '100')])
+    backend = Backends(topo.standalone).get_backend(DEFAULT_SUFFIX)
+    ancestorid_index = backend.get_index('ancestorid')
+    ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
+    topo.standalone.restart()
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     for i in range(102, 202):
         users.create_test_user(uid=i)
@@ -591,6 +606,12 @@ def test_require_internal_index(topo):
     # Deletion of user should be rejected
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         user.delete()
+
+    def fin():
+        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
+
+    request.addfinalizer(fin)
+
 
 
 def get_pstack(pid):

--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -306,19 +306,19 @@ def test_search_success(topology_st, create_user, page_size, users_num):
     del_users(users_list)
 
 
-@pytest.mark.parametrize("page_size,users_num,suffix,attr_name,attr_value,expected_err", [
+@pytest.mark.parametrize("page_size,users_num,suffix,attr_name,attr_value,expected_err, restart", [
     (50, 200, 'cn=config,%s' % DN_LDBM, 'nsslapd-idlistscanlimit', '100',
-     ldap.UNWILLING_TO_PERFORM),
+     ldap.UNWILLING_TO_PERFORM, True),
     (5, 15, DN_CONFIG, 'nsslapd-timelimit', '20',
-     ldap.UNAVAILABLE_CRITICAL_EXTENSION),
+     ldap.UNAVAILABLE_CRITICAL_EXTENSION, False),
     (21, 50, DN_CONFIG, 'nsslapd-sizelimit', '20',
-     ldap.SIZELIMIT_EXCEEDED),
+     ldap.SIZELIMIT_EXCEEDED, False),
     (21, 50, DN_CONFIG, 'nsslapd-pagedsizelimit', '5',
-     ldap.SIZELIMIT_EXCEEDED),
+     ldap.SIZELIMIT_EXCEEDED, False),
     (5, 50, 'cn=config,%s' % DN_LDBM, 'nsslapd-lookthroughlimit', '20',
-     ldap.ADMINLIMIT_EXCEEDED)])
+     ldap.ADMINLIMIT_EXCEEDED, False)])
 def test_search_limits_fail(topology_st, create_user, page_size, users_num,
-                            suffix, attr_name, attr_value, expected_err):
+                            suffix, attr_name, attr_value, expected_err, restart):
     """Verify that search with a simple paged results control
     throws expected exceptoins when corresponding limits are
     exceeded.
@@ -341,6 +341,15 @@ def test_search_limits_fail(topology_st, create_user, page_size, users_num,
 
     users_list = add_users(topology_st, users_num, DEFAULT_SUFFIX)
     attr_value_bck = change_conf_attr(topology_st, suffix, attr_name, attr_value)
+    ancestorid_index = None
+    if attr_name == 'nsslapd-idlistscanlimit':
+        backend = Backends(topology_st.standalone).get_backend(DEFAULT_SUFFIX)
+        ancestorid_index = backend.get_index('ancestorid')
+        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
+
+    if (restart):
+        log.info('Instance restarted')
+        topology_st.standalone.restart()
     conf_param_dict = {attr_name: attr_value}
     search_flt = r'(uid=test*)'
     searchreq_attrlist = ['dn', 'sn']
@@ -393,6 +402,8 @@ def test_search_limits_fail(topology_st, create_user, page_size, users_num,
             else:
                 break
     finally:
+        if ancestorid_index:
+            ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
         del_users(users_list)
         change_conf_attr(topology_st, suffix, attr_name, attr_value_bck)
 

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -548,6 +548,7 @@ struct ldbminfo
     int li_mode;
     int li_lookthroughlimit;
     int li_allidsthreshold;
+    int li_system_allidsthreshold;
     char *li_directory;
     int li_reslimit_lookthrough_handle;
     uint64_t li_dbcachesize;

--- a/ldap/servers/slapd/back-ldbm/index.c
+++ b/ldap/servers/slapd/back-ldbm/index.c
@@ -997,6 +997,8 @@ index_read_ext_allids(
     }
     if (pb) {
         slapi_pblock_get(pb, SLAPI_SEARCH_IS_AND, &is_and);
+    } else if (strcasecmp(type, LDBM_ANCESTORID_STR) == 0) {
+        is_and = 1;
     }
     ai_flags = is_and ? INDEX_ALLIDS_FLAG_AND : 0;
     /* the caller can pass in a value of 0 - just ignore those - but if the index

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -16,7 +16,7 @@
 
 /* Forward declarations */
 static void ldbm_instance_destructor(void **arg);
-Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4, char *mr);
+Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4, char *mr, char *scanlimit);
 
 
 /* Creates and initializes a new ldbm_instance structure.
@@ -126,7 +126,7 @@ done:
  * Take a bunch of strings, and create a index config entry
  */
 Slapi_Entry *
-ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4, char *mr)
+ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4, char *mr, char *scanlimit)
 {
     Slapi_Entry *e = slapi_entry_alloc();
     struct berval *vals[2];
@@ -167,6 +167,11 @@ ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3
         slapi_entry_add_values(e, "nsMatchingRule", vals);
     }
 
+    if (scanlimit) {
+        val.bv_val = scanlimit;
+        val.bv_len = strlen(scanlimit);
+        slapi_entry_add_values(e, "nsIndexIDListScanLimit", vals);
+    }
     return e;
 }
 
@@ -179,8 +184,59 @@ ldbm_instance_create_default_indexes(backend *be)
 {
     Slapi_Entry *e;
     ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
+    struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
     /* write the dse file only on the final index */
     int flags = LDBM_INSTANCE_CONFIG_DONT_WRITE;
+    char *ancestorid_indexes_limit = NULL;
+    char *parentid_indexes_limit = NULL;
+    struct attrinfo *ai = NULL;
+    struct index_idlistsizeinfo *iter;
+    int cookie;
+    int limit;
+
+    ainfo_get(be, (char *)LDBM_ANCESTORID_STR, &ai);
+    if (ai && ai->ai_idlistinfo) {
+        iter = (struct index_idlistsizeinfo *)dl_get_first(ai->ai_idlistinfo, &cookie);
+        if (iter) {
+            limit = iter->ai_idlistsizelimit;
+            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set ancestorid limit to %d from attribute index\n",
+                      limit);
+        } else {
+            limit = li->li_system_allidsthreshold;
+            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set ancestorid limit to %d from default (fail to read limit)\n",
+                      limit);
+        }
+        ancestorid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", limit);
+    } else {
+        ancestorid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", li->li_system_allidsthreshold);
+        slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set ancestorid limit to %d from default (no attribute or limit)\n",
+                      li->li_system_allidsthreshold);
+    }
+
+    ainfo_get(be, (char *)LDBM_PARENTID_STR, &ai);
+    if (ai && ai->ai_idlistinfo) {
+        iter = (struct index_idlistsizeinfo *)dl_get_first(ai->ai_idlistinfo, &cookie);
+        if (iter) {
+            limit = iter->ai_idlistsizelimit;
+            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set parentid limit to %d from attribute index\n",
+                      limit);
+        } else {
+            limit = li->li_system_allidsthreshold;
+            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set parentid limit to %d from default (fail to read limit)\n",
+                      limit);
+        }
+        parentid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", limit);
+    } else {
+        parentid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", li->li_system_allidsthreshold);
+        slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
+                      "set parentid limit to %d from default (no attribute or limit)\n",
+                      li->li_system_allidsthreshold);
+    }
 
     /*
      * Always index (entrydn or entryrdn), parentid, objectclass,
@@ -188,42 +244,43 @@ ldbm_instance_create_default_indexes(backend *be)
      * since they are used by some searches, replication and the
      * ACL routines.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
+    e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0, "integerOrderingMatch", parentid_indexes_limit);
+    ldbm_instance_config_add_index_entry(inst, e, flags);
+    attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
+    slapi_entry_free(e);
+
+    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0, 0);
-    ldbm_instance_config_add_index_entry(inst, e, flags);
-    slapi_entry_free(e);
-
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* For MMR, we need this attribute (to replace use of dncomp in delete). */
-    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0, 0);
+    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* write the dse file only on the final index */
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* ldbm_instance_config_add_index_entry(inst, 2, argv); */
-    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0, 0, 0);
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 
@@ -231,9 +288,13 @@ ldbm_instance_create_default_indexes(backend *be)
      * ancestorid is special, there is actually no such attr type
      * but we still want to use the attr index file APIs.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
+    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch", ancestorid_indexes_limit);
+    ldbm_instance_config_add_index_entry(inst, e, flags);
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
+
+    slapi_ch_free_string(&ancestorid_indexes_limit);
+    slapi_ch_free_string(&parentid_indexes_limit);
 
     return 0;
 }

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.c
@@ -386,6 +386,35 @@ ldbm_config_allidsthreshold_set(void *arg, void *value, char *errorbuf __attribu
 }
 
 static void *
+ldbm_config_system_allidsthreshold_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)((uintptr_t)(li->li_system_allidsthreshold));
+}
+
+static int
+ldbm_config_system_allidsthreshold_set(void *arg, void *value, char *errorbuf __attribute__((unused)), int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    int retval = LDAP_SUCCESS;
+    int val = (int)((uintptr_t)value);
+
+    /* Do whatever we can to make sure the data is ok. */
+
+    /* Catch attempts to configure a stupidly low ancestorid allidsthreshold */
+    if ((val > -1) && (val < 5000)) {
+        val = 5000;
+    }
+
+    if (apply) {
+        li->li_system_allidsthreshold = val;
+    }
+
+    return retval;
+}
+
+static void *
 ldbm_config_pagedallidsthreshold_get(void *arg)
 {
     struct ldbminfo *li = (struct ldbminfo *)arg;
@@ -926,6 +955,7 @@ static config_info ldbm_config[] = {
     {CONFIG_LOOKTHROUGHLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_lookthroughlimit_get, &ldbm_config_lookthroughlimit_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_MODE, CONFIG_TYPE_INT_OCTAL, "0600", &ldbm_config_mode_get, &ldbm_config_mode_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_IDLISTSCANLIMIT, CONFIG_TYPE_INT, "2147483646", &ldbm_config_allidsthreshold_get, &ldbm_config_allidsthreshold_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_SYSTEMIDLISTSCANLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_system_allidsthreshold_get, &ldbm_config_system_allidsthreshold_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DIRECTORY, CONFIG_TYPE_STRING, "", &ldbm_config_directory_get, &ldbm_config_directory_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE | CONFIG_FLAG_SKIP_DEFAULT_SETTING},
     {CONFIG_MAXPASSBEFOREMERGE, CONFIG_TYPE_INT, "100", &ldbm_config_maxpassbeforemerge_get, &ldbm_config_maxpassbeforemerge_set, 0},
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -60,6 +60,7 @@ struct config_info
 #define CONFIG_RANGELOOKTHROUGHLIMIT "nsslapd-rangelookthroughlimit"
 #define CONFIG_PAGEDLOOKTHROUGHLIMIT "nsslapd-pagedlookthroughlimit"
 #define CONFIG_IDLISTSCANLIMIT "nsslapd-idlistscanlimit"
+#define CONFIG_SYSTEMIDLISTSCANLIMIT "nsslapd-systemidlistscanlimit"
 #define CONFIG_PAGEDIDLISTSCANLIMIT "nsslapd-pagedidlistscanlimit"
 #define CONFIG_DIRECTORY "nsslapd-directory"
 #define CONFIG_MODE "nsslapd-mode"

--- a/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
@@ -384,6 +384,14 @@ ldbm_instance_config_add_index_entry(
         }
     }
 
+    /* get nsIndexIDListScanLimit and its values, and add them */
+    if (0 == slapi_entry_attr_find(e, "nsIndexIDListScanLimit", &attr)) {
+        for (j = slapi_attr_first_value(attr, &sval); j != -1; j = slapi_attr_next_value(attr, j, &sval)) {
+            attrValue = slapi_value_get_berval(sval);
+            eBuf = PR_sprintf_append(eBuf, "nsIndexIDListScanLimit: %s\n", attrValue->bv_val);
+        }
+    }
+
     ldbm_config_add_dse_entry(li, eBuf, flags);
     if (eBuf) {
         PR_smprintf_free(eBuf);

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -39,6 +39,7 @@ arg_to_attr = {
         'mode': 'nsslapd-mode',
         'state': 'nsslapd-state',
         'idlistscanlimit': 'nsslapd-idlistscanlimit',
+        'systemidlistscanlimit': 'nsslapd-systemidlistscanlimit',
         'directory': 'nsslapd-directory',
         'dbcachesize': 'nsslapd-dbcachesize',
         'logdirectory': 'nsslapd-db-logdirectory',
@@ -604,6 +605,21 @@ def backend_set_index(inst, basedn, log, args):
             except ldap.NO_SUCH_ATTRIBUTE:
                 raise ValueError('Can not delete matching rule type because it does not exist')
 
+    if args.replace_scanlimit is not None:
+        for replace_scanlimit in args.replace_scanlimit:
+            index.replace('nsIndexIDListScanLimit', replace_scanlimit)
+
+    if args.add_scanlimit is not None:
+        for add_scanlimit in args.add_scanlimit:
+            index.add('nsIndexIDListScanLimit', add_scanlimit)
+
+    if args.del_scanlimit is not None:
+        for del_scanlimit in args.del_scanlimit:
+            try:
+                index.remove('nsIndexIDListScanLimit', del_scanlimit)
+            except ldap.NO_SUCH_ATTRIBUTE:
+                raise ValueError('Can not delete a fine grain limit definition because it does not exist')
+
     if args.reindex:
         be.reindex(attrs=[args.attr])
     log.info("Index successfully updated")
@@ -925,6 +941,9 @@ def create_parser(subparsers):
     edit_index_parser.add_argument('--del-type', action='append', help='Removes an index type from the index: (eq, sub, pres, or approx)')
     edit_index_parser.add_argument('--add-mr', action='append', help='Adds a matching-rule to the index')
     edit_index_parser.add_argument('--del-mr', action='append', help='Removes a matching-rule from the index')
+    edit_index_parser.add_argument('--add-scanlimit', action='append', help='Adds a fine grain limit definiton to the index')
+    edit_index_parser.add_argument('--replace-scanlimit', action='append', help='Replaces a fine grain limit definiton to the index')
+    edit_index_parser.add_argument('--del-scanlimit', action='append', help='Removes a fine grain limit definiton to the index')
     edit_index_parser.add_argument('--reindex', action='store_true', help='Re-indexes the database after editing the index')
     edit_index_parser.add_argument('be_name', help='The backend name or suffix')
 
@@ -1051,6 +1070,7 @@ def create_parser(subparsers):
                                                                  'will check when examining candidate entries in response to a search request')
     set_db_config_parser.add_argument('--mode', help='Specifies the permissions used for newly created index files')
     set_db_config_parser.add_argument('--idlistscanlimit', help='Specifies the number of entry IDs that are searched during a search operation')
+    set_db_config_parser.add_argument('--systemidlistscanlimit', help='Specifies the number of entry IDs that are fetch from ancestorid/parentid indexes')
     set_db_config_parser.add_argument('--directory', help='Specifies absolute path to database instance')
     set_db_config_parser.add_argument('--dbcachesize', help='Specifies the database index cache size in bytes')
     set_db_config_parser.add_argument('--logdirectory', help='Specifies the path to the directory that contains the database transaction logs')


### PR DESCRIPTION
…rformance

Bug description:
	The RFE 2435, removed the limit of the IDList size.
	A side effect is that for subtree/on-level searches some IDL can be
	huge. For example a subtree search on the base suffix will build a
	IDL up to number of entries in the DB.
	Building such big IDL is accounting for +90% of the etime of the
	operation.

Fix description:
	Using fine grain indexing we can limit IDL for parentid
	(onelevel) and ancestorid (subtree) index.
	It adds ""limit=5000 type=eq flags=AND" to those indexes.
	On my tests it improves throughput and response time by ~50 times

fixes: #6966

Reviewed by:

## Summary by Sourcery

Cap IDList scans for parentid and ancestorid indices by adding a configurable scan limit and wiring it through configuration and search logic to restore performance on large databases

Bug Fixes:
- Prevent unbounded growth of IDList during subtree and one-level searches by capping scan results

Enhancements:
- Extend index configuration API to accept a scanlimit and include nsIndexIDListScanLimit in the DSE entries
- Initialize default parentid and ancestorid indices with a 5000-entry scan limit (limit=5000 type=eq flags=AND)
- Treat ancestorid index queries as AND in index_read_ext_allids to enforce scan limits