### PR TITLE
Issue 6971 - bundle-rust-npm.py: TypeError: argument of type 'NoneTyp…

### DIFF
--- a/rpm/bundle-rust-npm.py
+++ b/rpm/bundle-rust-npm.py
@@ -118,7 +118,7 @@ def process_npm_license(license_data) -> str:
 
 def enclose_if_contains_or(license_str: str) -> str:
     """Enclose the license string in parentheses if it contains 'OR'."""
-    return f"({license_str})" if 'OR' in license_str and not license_str.startswith('(') else license_str
+    return f"({license_str})" if license_str is not None and 'OR' in license_str and not license_str.startswith('(') else license_str
 
 
 def build_provides_lines(rust_crates: Dict[str, Tuple[str, str]], npm_packages: Dict[str, Tuple[str, str]]) -> list[str]:


### PR DESCRIPTION
…e' is not iterable

Bug Description:
Some crates have an empty license, that bundle-rust-npm.py doesn't handle.

Fix Description:
Add a check if the license is empty (None)

Fixes: https://github.com/389ds/389-ds-base/issues/6971

## Summary by Sourcery

Bug Fixes:
- Add a None check in enclose_if_contains_or to prevent iterating over a None license string.