### PR TITLE
Issue 6954 - do not delete referrals on chain_on_update backend

### DIFF
--- a/ldap/servers/plugins/replication/replutil.c
+++ b/ldap/servers/plugins/replication/replutil.c
@@ -668,7 +668,6 @@ repl_set_mtn_state_and_referrals(
         }
         /* We should delete referral only if we want to set the
            replica database in backend state mode */
-        /* if chain on update mode, go ahead and set the referrals anyway */
         if (strcasecmp(mtn_state, STATE_BACKEND) == 0 || chain_on_update) {
             rc = slapi_mtn_set_referral(repl_root_sdn, referrals_to_set);
             if (rc == LDAP_NO_SUCH_ATTRIBUTE) {

--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -1189,10 +1189,12 @@ mapping_tree_entry_modify_callback(Slapi_PBlock *pb,
                 node->mtn_referral_entry = referral2entry(referral, subtree);
             } else if (SLAPI_IS_MOD_DELETE(mods[i]->mod_op)) {
                 /* it is not OK to delete the referrals if they are still
-                 * used
-                 */
-                if ((node->mtn_state == MTN_REFERRAL) ||
-                    (node->mtn_state == MTN_REFERRAL_ON_UPDATE)) {
+                 * used */
+                Slapi_Attr *ref_attr = NULL;
+                if (((node->mtn_state == MTN_REFERRAL) ||
+                    (node->mtn_state == MTN_REFERRAL_ON_UPDATE)) &&
+                    !slapi_entry_attr_find(entryAfter, "nsslapd-referral", &ref_attr)) {
+
                     PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
                                 "cannot delete referrals in this state\n");
                     *returncode = LDAP_UNWILLING_TO_PERFORM;

--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -556,7 +556,7 @@ def generate_lag_report(inst, basedn, log, args):
                 formats.append('csv')
             else:
                 log.warning(f"Ignoring unknown format: {fmt}")
-    
+
     if not formats:  # Fallback to html if no valid formats specified
         formats.append('html')
 
@@ -577,7 +577,7 @@ def generate_lag_report(inst, basedn, log, args):
         # Initialize ReplicationLogAnalyzer with enhanced options
         if not json_output_only:
             log.info("Initializing replication log analysis...")
-        
+
         repl_analyzer = ReplicationLogAnalyzer(
             log_dirs=args.log_dirs,
             suffixes=args.suffixes,
@@ -594,14 +594,14 @@ def generate_lag_report(inst, basedn, log, args):
         # Parse logs
         if not json_output_only:
             log.info("Analyzing replication logs...")
-        
+
         repl_analyzer.parse_logs()
 
         # Generate reports
         if not json_output_only:
             log.info("Generating analysis reports...")
             log.info(f"Creating reports in formats: {formats}")  # Debug message
-        
+
         generated_files = repl_analyzer.generate_report(
             output_dir=args.output_dir,
             formats=formats,
@@ -687,7 +687,7 @@ def set_per_backend_cl(inst, basedn, log, args):
     did_something = False
 
     if (is_replica_role_consumer(inst, suffix)):
-        log.info("Warning: Changelogs are not supported for consumer replicas. You may run into undefined behavior.")
+        log.error("Warning: Changelogs are not supported for consumer replicas. You may run into undefined behavior.")
 
     if args.encrypt:
         cl.replace('nsslapd-encryptionalgorithm', 'AES')
@@ -720,7 +720,7 @@ def get_per_backend_cl(inst, basedn, log, args):
     suffix = args.suffix
 
     if (is_replica_role_consumer(inst, suffix)):
-        log.info("Warning: Changelogs are not supported for consumer replicas. You may run into undefined behavior.")
+        log.error("Warning: Changelogs are not supported for consumer replicas. You may run into undefined behavior.")
 
     cl = Changelog(inst, suffix)
     if args and args.json:
@@ -829,10 +829,10 @@ def del_repl_manager(inst, basedn, log, args):
 
     log.info("Successfully deleted replication manager: " + manager_dn)
 
-def is_replica_role_consumer(inst, suffix): 
-    """Helper function for get_per_backend_cl and set_per_backend_cl. 
-    Makes sure the instance in question is not a consumer, which is a role that 
-    does not support changelogs. 
+def is_replica_role_consumer(inst, suffix):
+    """Helper function for get_per_backend_cl and set_per_backend_cl.
+    Makes sure the instance in question is not a consumer, which is a role that
+    does not support changelogs.
     """
     replicas = Replicas(inst)
     try:


### PR DESCRIPTION
Description:

The server does not allow deleting referrals on a backend with "referral on update" backend state.  You can replace referrals but not delete them. Trying to delete just leads to a harmless but alarming error 53 in the errors log.

This happens when doing an online init of a read-only consumer that is setup for chain-on-update. At the start of the init the referrals are successfully replaced, but after the init it tries to delete them and this needs to be skipped.

Also changed lib389 warning about consumers and changelogs because UI expects successful operations to be in JSON but the warning is in standard text. Changing the warning to be written to stderr avoids the UI crash.

Relates: https://github.com/389ds/389-ds-base/issues/6954

## Summary by Sourcery

Prevent deletion of referrals on chain-on-update backends and convert changelog warnings to error-level logs to avoid UI JSON parsing issues, with minor whitespace and formatting cleanup in the replication CLI.

Bug Fixes:
- Skip deleting referrals for backends in referral-on-update state when chain-on-update is enabled in the replication plugin
- Change changelog support warnings for consumer replicas from info to error level to prevent UI JSON parsing errors

Enhancements:
- Clean up trailing whitespace and adjust docstring formatting in the replication CLI code