### PR TITLE
Issue 6977 - UI - Show error message when trying to use unavailable ports

### DIFF
--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -21,7 +21,6 @@ import {
 	Text,
 	TextContent,
 	TextVariants,
-    Tooltip,
 	ValidatedOptions
 } from '@patternfly/react-core';
 import {
@@ -1190,15 +1189,6 @@ async validateSaveBtn(nav_tab, attr, value) {
                                             {_("LDAP Port")}
                                         </GridItem>
                                         <GridItem span={10}>
-                                            <Tooltip
-                                                content={
-                                                    this.state.errObjConfig['nsslapd-port']
-                                                        ? _("This port is already in use, please choose another.")
-                                                        : ""
-                                                }
-                                                position="top"
-                                                isVisible={!!this.state.errObjConfig['nsslapd-port']}
-                                            >
                                             <NumberInput
                                                 value={this.state['nsslapd-port']}
                                                 min={1}
@@ -1211,9 +1201,14 @@ async validateSaveBtn(nav_tab, attr, value) {
                                                 minusBtnAriaLabel="minus"
                                                 plusBtnAriaLabel="plus"
                                                 widthChars={8}
-                                                validated={this.state.errObjConfig['nsslapd-port'] ? ValidatedOptions.error : ValidatedOptions.default}
                                             />
-                                            </Tooltip>
+                                            {this.state.errObjConfig['nsslapd-port'] &&
+                                                <HelperText>
+                                                    <HelperTextItem variant="error">
+                                                        This port is already in use, please choose another.
+                                                    </HelperTextItem>
+                                                </HelperText>
+                                            }
                                         </GridItem>
                                     </Grid>
                                     <Grid
@@ -1223,15 +1218,6 @@ async validateSaveBtn(nav_tab, attr, value) {
                                             {_("LDAPS Port")}
                                         </GridItem>
                                         <GridItem span={10}>
-                                            <Tooltip
-                                                content={
-                                                    this.state.errObjConfig['nsslapd-secureport']
-                                                    ? _("This port is already in use, please choose another.")
-                                                    : ""
-                                                }
-                                                position="top"
-                                                isVisible={!!this.state.errObjConfig['nsslapd-secureport']}
-                                            >
                                             <NumberInput
                                                 value={this.state['nsslapd-secureport']}
                                                 min={1}
@@ -1244,10 +1230,15 @@ async validateSaveBtn(nav_tab, attr, value) {
                                                 minusBtnAriaLabel="minus"
                                                 plusBtnAriaLabel="plus"
                                                 widthChars={8}
-                                                validated={this.state.errObjConfig['nsslapd-secureport'] ? ValidatedOptions.error : ValidatedOptions.default}
 
                                             />
-                                            </Tooltip>
+                                            {this.state.errObjConfig['nsslapd-secureport'] &&
+                                                <HelperText>
+                                                    <HelperTextItem variant="error">
+                                                        This port is already in use, please choose another.
+                                                    </HelperTextItem>
+                                                </HelperText>
+                                            }
                                         </GridItem>
                                     </Grid>
                                     <Grid

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -21,6 +21,7 @@ import {
 	Text,
 	TextContent,
 	TextVariants,
+    Tooltip,
 	ValidatedOptions
 } from '@patternfly/react-core';
 import {
@@ -1189,6 +1190,15 @@ async validateSaveBtn(nav_tab, attr, value) {
                                             {_("LDAP Port")}
                                         </GridItem>
                                         <GridItem span={10}>
+                                            <Tooltip
+                                                content={
+                                                    this.state.errObjConfig['nsslapd-port']
+                                                        ? _("This port is already in use, please choose another.")
+                                                        : ""
+                                                }
+                                                position="top"
+                                                isVisible={!!this.state.errObjConfig['nsslapd-port']}
+                                            >
                                             <NumberInput
                                                 value={this.state['nsslapd-port']}
                                                 min={1}
@@ -1203,6 +1213,7 @@ async validateSaveBtn(nav_tab, attr, value) {
                                                 widthChars={8}
                                                 validated={this.state.errObjConfig['nsslapd-port'] ? ValidatedOptions.error : ValidatedOptions.default}
                                             />
+                                            </Tooltip>
                                         </GridItem>
                                     </Grid>
                                     <Grid
@@ -1212,6 +1223,15 @@ async validateSaveBtn(nav_tab, attr, value) {
                                             {_("LDAPS Port")}
                                         </GridItem>
                                         <GridItem span={10}>
+                                            <Tooltip
+                                                content={
+                                                    this.state.errObjConfig['nsslapd-secureport']
+                                                    ? _("This port is already in use, please choose another.")
+                                                    : ""
+                                                }
+                                                position="top"
+                                                isVisible={!!this.state.errObjConfig['nsslapd-secureport']}
+                                            >
                                             <NumberInput
                                                 value={this.state['nsslapd-secureport']}
                                                 min={1}
@@ -1225,7 +1245,9 @@ async validateSaveBtn(nav_tab, attr, value) {
                                                 plusBtnAriaLabel="plus"
                                                 widthChars={8}
                                                 validated={this.state.errObjConfig['nsslapd-secureport'] ? ValidatedOptions.error : ValidatedOptions.default}
+
                                             />
+                                            </Tooltip>
                                         </GridItem>
                                     </Grid>
                                     <Grid


### PR DESCRIPTION
Bug description:
When trying to change the ports an instance is using to ports, that are already used, a red exclamation mark symbol is shown, but no message. A clear message (e.g. in a tooltip) that the ports are already used would improve user experience.

Fix description:
Added a Tooltip to inform the user that the selected port is in use, please choose another.

Fixes: https://github.com/389ds/389-ds-base/issues/6977

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Show an error tooltip when users select an already in-use port on LDAP and LDAPS port fields