### PR TITLE
Issue 6979 - Improve the way to detect asynchronous operations in the…

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -493,6 +493,72 @@ def test_basic_ops(topology_st, import_example_ldif):
     check_db_sanity(topology_st)
     log.info('test_basic_ops: PASSED')
 
+def test_basic_search_asynch(topology_st, request):
+    """
+    Tests asynchronous searches generate string 'notes=B'
+    and 'notes=N' in access logs
+
+    :id: 1b761421-d2bb-487b-813e-2278123fd13c
+    :parametrized: no
+    :setup: Standalone instance, create test user to search with filter (uid=*).
+
+    :steps:
+        1. Create a test user
+        2. trigger async searches
+        3. Verify access logs contains 'notes=B' up to 10 attempts
+        4. Verify access logs contains 'notes=N' up to 10 attempts
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+
+    """
+
+    log.info('Running test_basic_search_asynch...')
+
+    search_filter = "(uid=*)"
+    topology_st.standalone.restart()
+    topology_st.standalone.config.set("nsslapd-accesslog-logbuffering", "off")
+    topology_st.standalone.config.set("nsslapd-maxthreadsperconn", "3")
+
+    try:
+        users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX, rdn=None)
+        user = users.create_test_user()
+    except ldap.LDAPError as e:
+        log.fatal('Failed to create test user: error ' + e.args[0]['desc'])
+        assert False
+
+    for attempt in range(10):
+        msgids = []
+        for i in range(5):
+            searchid = topology_st.standalone.search(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, search_filter)
+            msgids.append(searchid)
+
+        for msgid in msgids:
+            rtype, rdata = topology_st.standalone.result(msgid)
+
+        # verify if some operations got blocked
+        error_lines = topology_st.standalone.ds_access_log.match('.*notes=.*B.* details.*')
+        if len(error_lines) > 0:
+            log.info('test_basic_search_asynch: found "notes=B" after %d attempt(s)' % (attempt + 1))
+            break
+
+    assert attempt < 10
+
+    # verify if some operations got flagged Not synchronous
+    error_lines = topology_st.standalone.ds_access_log.match('.*notes=.*N.* details.*')
+    assert len(error_lines) > 0
+
+    def fin():
+        user.delete()
+        topology_st.standalone.config.set("nsslapd-accesslog-logbuffering", "on")
+        topology_st.standalone.config.set("nsslapd-maxthreadsperconn", "5")
+
+    request.addfinalizer(fin)
+
+    log.info('test_basic_search_asynch: PASSED')
 
 def test_basic_import_export(topology_st, import_example_ldif):
     """Test online and offline LDIF import & export
@@ -2390,7 +2456,6 @@ def dscreate_with_numlistener(request, dscreate_custom_instance):
     inst.open()
     return inst
 
-
 @pytest.mark.skipif(ds_is_older('2.2.0.0'),
                     reason="This test is only required with multiple listener support.")
 def test_conn_limits(dscreate_with_numlistener):
@@ -2450,6 +2515,7 @@ def test_conn_limits(dscreate_with_numlistener):
         c.unbind()
 
     # Step 6 is done in teardown phase by dscreate_instance finalizer
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -23,6 +23,7 @@
 #include "prlog.h" /* for PR_ASSERT */
 #include "fe.h"
 #include <sasl/sasl.h>
+#include <stdbool.h>
 #if defined(LINUX)
 #include <netinet/tcp.h> /* for TCP_CORK */
 #endif
@@ -610,6 +611,19 @@ connection_dispatch_operation(Connection *conn, Operation *op, Slapi_PBlock *pb)
     /* Set the start time */
     slapi_operation_set_time_started(op);
 
+    /* difficult to detect false asynch operations
+     * Indeed because of scheduling of threads a previous
+     * operation may have sent its result but not yet updated
+     * the completed count.
+     * To avoid false positive lets set a limit of 2.
+     */
+    if ((conn->c_opsinitiated - conn->c_opscompleted) > 2) {
+        unsigned int opnote;
+        opnote = slapi_pblock_get_operation_notes(pb);
+        opnote |= SLAPI_OP_NOTE_ASYNCH_OP; /* the operation is dispatch while others are running */
+        slapi_pblock_set_operation_notes(pb, opnote);
+    }
+
     /* If the minimum SSF requirements are not met, only allow
      * bind and extended operations through.  The bind and extop
      * code will ensure that only SASL binds and startTLS are
@@ -1074,10 +1088,16 @@ connection_wait_for_new_work(Slapi_PBlock *pb, int32_t interval)
         slapi_log_err(SLAPI_LOG_TRACE, "connection_wait_for_new_work", "no work to do\n");
         ret = CONN_NOWORK;
     } else {
+        Connection *conn = wqitem;
         /* make new pb */
-        slapi_pblock_set(pb, SLAPI_CONNECTION, wqitem);
+        slapi_pblock_set(pb, SLAPI_CONNECTION, conn);
         slapi_pblock_set_op_stack_elem(pb, op_stack_obj);
         slapi_pblock_set(pb, SLAPI_OPERATION, op_stack_obj->op);
+        if (conn->c_flagblocked) {
+            /* flag this new operation that it was blocked by maxthreadperconn */
+            slapi_pblock_set_operation_notes(pb, SLAPI_OP_NOTE_ASYNCH_BLOCKED);
+            conn->c_flagblocked = false;
+        }
     }
 
     pthread_mutex_unlock(&work_q_lock);
@@ -1977,6 +1997,7 @@ connection_threadmain(void *arg)
                 } else {
                     /* keep count of how many times maxthreads has blocked an operation */
                     conn->c_maxthreadsblocked++;
+                    conn->c_flagblocked = true;
                     if (conn->c_maxthreadsblocked == 1 && connection_has_psearch(conn)) {
                         slapi_log_err(SLAPI_LOG_NOTICE, "connection_threadmain",
                                 "Connection (conn=%" PRIu64 ") has a running persistent search "

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -25,6 +25,7 @@
 #include <sys/wait.h>
 #include <pthread.h>
 #include <stdint.h>
+#include <stdbool.h>
 #if defined(HAVE_MNTENT_H)
 #include <mntent.h>
 #endif
@@ -1826,6 +1827,7 @@ setup_pr_read_pds(Connection_Table *ct, int listnum)
                 } else {
                     if (c->c_threadnumber >= c->c_max_threads_per_conn) {
                         c->c_maxthreadsblocked++;
+                        c->c_flagblocked = true;
                         if (c->c_maxthreadsblocked == 1 && connection_has_psearch(c)) {
                             slapi_log_err(SLAPI_LOG_NOTICE, "connection_threadmain",
                                     "Connection (conn=%" PRIu64 ") has a running persistent search "

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1946,6 +1946,8 @@ static struct slapi_note_map notemap[] = {
     {SLAPI_OP_NOTE_FULL_UNINDEXED, "A", "Fully Unindexed Filter"},
     {SLAPI_OP_NOTE_FILTER_INVALID, "F", "Filter Element Missing From Schema"},
     {SLAPI_OP_NOTE_MFA_AUTH, "M", "Multi-factor Authentication"},
+    {SLAPI_OP_NOTE_ASYNCH_OP, "N", "Not synchronous operation"},
+    {SLAPI_OP_NOTE_ASYNCH_BLOCKED, "B", "Blocked because too many operations"},
 };
 
 #define SLAPI_NOTEMAP_COUNT (sizeof(notemap) / sizeof(struct slapi_note_map))

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1772,6 +1772,7 @@ typedef struct conn
     int32_t c_anon_access;
     int32_t c_max_threads_per_conn;
     int32_t c_bind_auth_token;
+    bool c_flagblocked;            /* Flag the next read operation as blocked */
 } Connection;
 #define CONN_FLAG_SSL 1     /* Is this connection an SSL connection or not ?         \
                            * Used to direct I/O code when SSL is handled differently \

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -7330,6 +7330,8 @@ typedef enum _slapi_op_note_t {
     SLAPI_OP_NOTE_FULL_UNINDEXED = 0x04,
     SLAPI_OP_NOTE_FILTER_INVALID = 0x08,
     SLAPI_OP_NOTE_MFA_AUTH = 0x10,
+    SLAPI_OP_NOTE_ASYNCH_OP = 0x20,
+    SLAPI_OP_NOTE_ASYNCH_BLOCKED = 0x40,
 } slapi_op_note_t;
 
 /**


### PR DESCRIPTION
… access logs

Bug description:
	Asynch operations are prone to make the server unresponsive.
	The detection of those operations is not easy.
	Access logs should contain a way to retrieve easilly the
	operations (an the connections) with async searches

Fix description:
	When dispatching a new operation, if the count of
	uncompleted operations on the connection overpass
	a threshold (2) then add a note to the 'notes='
	in the access log
	between the

fixes: #6979

Reviewed by:

## Summary by Sourcery

Introduce asynchronous operation detection and logging for operations dispatched on busy connections.

New Features:
- Detect asynchronous operations by marking operations when more than two uncompleted operations exist on a connection.

Enhancements:
- Add SLAPI_OP_NOTE_ASYNCH_OP to the operation note enum and include its mapping in the note map for access logs.