### PR TITLE
Issue 6810 - Deprecate PAM PTA plugin configuration attributes in bas…

### DIFF
--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -456,12 +456,12 @@ upgrade_pam_pta_default_config(void)
             slapi_pblock_destroy(add_pb);
             return UPGRADE_FAILURE;
         }
+        slapi_pblock_destroy(add_pb);
     } else {
         slapi_log_error(SLAPI_LOG_ERR, "upgrade_pam_pta_default_config",
                         "Failed to create child entry %s\n", child_dn);
 
         slapi_ch_free_string(&child_dn);
-        slapi_pblock_destroy(add_pb);
         return UPGRADE_FAILURE;
     }
 


### PR DESCRIPTION
…e entry - fix memleak

Bug Description:
ASAN reports a leak:
```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7fcd1dae68a3 in calloc (/usr/lib64/libasan.so.8+0xe68a3) (BuildId: 10b8ccd49f75c21babf1d7abe51bb63589d8471f)
    #1 0x7fcd1d61d25c in slapi_ch_calloc (/usr/lib64/dirsrv/libslapd.so.0+0x1d25c) (BuildId: f04e891fb4b70031e15759bc4baedf6701e59ccb)
    #2 0x7fcd1d6ca7af in upgrade_pam_pta_default_config ldap/servers/slapd/upgrade.c:447
    #3 0x55903428ecc3 in main (/usr/bin/ns-slapd+0x4cc3) (BuildId: 308e13b0030947aedc25e4ef4cf9c65bac6d6cc9)
    #4 0x7fcd1d412574 in __libc_start_call_main (/lib64/libc.so.6+0x3574) (BuildId: 126a08bf502f4950b215dc773e52df8dcf50c393)
    #5 0x7fcd1d412627 in __libc_start_main_alias_1 (/lib64/libc.so.6+0x3627) (BuildId: 126a08bf502f4950b215dc773e52df8dcf50c393)
    #6 0x559034290294 in _start (/usr/bin/ns-slapd+0x6294) (BuildId: 308e13b0030947aedc25e4ef4cf9c65bac6d6cc9)
```
`add_pb` was allocated, but not destroyed in the success path.

Fix Description:
Destroy `add_pb` right after the error check in the success path.

Relates: https://github.com/389ds/389-ds-base/issues/6810

## Summary by Sourcery

Fix a memory leak in upgrade_pam_pta_default_config by ensuring the allocated parameter block is destroyed on both success and failure paths.

Bug Fixes:
- Add slapi_pblock_destroy(add_pb) after the successful entry creation to prevent leaking the parameter block
- Remove the redundant slapi_pblock_destroy call in the failure branch to consolidate destruction logic