### PR TITLE
Issue 6990 - UI - Fix typeahead Select fields losing values on Enter keypress

### DIFF
--- a/src/cockpit/389-console/src/dsBasicComponents.jsx
+++ b/src/cockpit/389-console/src/dsBasicComponents.jsx
@@ -1,0 +1,421 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+    Select,
+    SelectOption,
+    SelectList,
+    MenuToggle,
+    TextInputGroup,
+    TextInputGroupMain,
+    TextInputGroupUtilities,
+    Button,
+    Label,
+    LabelGroup,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+
+const TypeaheadSelect = ({
+    selected,
+    onSelect,
+    onClear,
+    options = [],
+    isMulti = false,
+    isCreatable = false,
+    onCreateOption,
+    validateCreate,
+    hasCheckbox = false,
+    placeholder = "Select an option...",
+    noResultsText = "No results found",
+    isDisabled = false,
+    validated = 'default',
+    ariaLabel = "Select input",
+    className,
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [inputValue, setInputValue] = useState('');
+    const [selectOptions, setSelectOptions] = useState([]);
+    const [focusedItemIndex, setFocusedItemIndex] = useState(null);
+    const [activeItemId, setActiveItemId] = useState(null);
+    const textInputRef = useRef();
+
+    const CREATE_NEW = 'create-new';
+
+    // Normalize options
+    const normalizeOptions = (opts) => {
+        if (!Array.isArray(opts)) return [];
+        return opts.map(opt => {
+            if (typeof opt === 'string') {
+                return { value: opt, children: opt };
+            }
+            return { ...opt, children: opt.label || opt.value };
+        });
+    };
+
+    // Update select options based on input
+    useEffect(() => {
+        const normalizedOptions = normalizeOptions(options);
+        const currentSelections = isMulti ? (Array.isArray(selected) ? selected : []) : [];
+        let newSelectOptions = normalizedOptions;
+
+        // Always ensure selected values are available in options, even if not in original options
+        if (isMulti && currentSelections.length > 0) {
+            const selectedNotInOptions = currentSelections
+                .filter(selectedValue => !normalizedOptions.some(opt => opt.value === selectedValue))
+                .map(selectedValue => ({ value: selectedValue, children: selectedValue }));
+
+            newSelectOptions = [...normalizedOptions, ...selectedNotInOptions];
+        }
+
+        if (inputValue) {
+            // Filter options based on input
+            newSelectOptions = newSelectOptions.filter(option =>
+                String(option.children).toLowerCase().includes(inputValue.toLowerCase())
+            );
+
+            // Add create option if applicable
+            if (isCreatable && inputValue) {
+                const isValid = validateCreate ? validateCreate(inputValue) : true;
+                const alreadyExists = normalizedOptions.some(opt => opt.value === inputValue);
+                const alreadySelected = isMulti ? currentSelections.includes(inputValue) : selected === inputValue;
+
+                if (isValid && !alreadyExists && !alreadySelected) {
+                    newSelectOptions = [...newSelectOptions, {
+                        children: `Create "${inputValue}"`,
+                        value: CREATE_NEW,
+                        isCreatable: true
+                    }];
+                }
+            }
+
+            if (!isOpen) {
+                setIsOpen(true);
+            }
+        }
+
+        setSelectOptions(newSelectOptions);
+        setFocusedItemIndex(null);
+        setActiveItemId(null);
+    }, [inputValue, options, isCreatable, validateCreate, selected, isMulti]);
+
+    const createItemId = (value) => `select-typeahead-${value}`.replace(/\s+/g, '-');
+
+    const setActiveAndFocusedItem = (itemIndex) => {
+        setFocusedItemIndex(itemIndex);
+        const focusedItem = selectOptions[itemIndex];
+        if (focusedItem) {
+            setActiveItemId(createItemId(focusedItem.value));
+        }
+    };
+
+    const resetActiveAndFocusedItem = () => {
+        setFocusedItemIndex(null);
+        setActiveItemId(null);
+    };
+
+    const closeMenu = () => {
+        setIsOpen(false);
+        resetActiveAndFocusedItem();
+    };
+
+    const onInputClick = () => {
+        if (!isOpen) {
+            setIsOpen(true);
+        } else if (!inputValue) {
+            closeMenu();
+        }
+    };
+
+    const handleSelect = (value) => {
+        if (!value) return;
+
+        if (value === CREATE_NEW) {
+            if (isCreatable && inputValue && (!validateCreate || validateCreate(inputValue))) {
+                if (onCreateOption) {
+                    onCreateOption(inputValue);
+                }
+
+                if (isMulti) {
+                    const currentSelections = Array.isArray(selected) ? selected : [];
+                    if (!currentSelections.includes(inputValue)) {
+                        onSelect(null, [...currentSelections, inputValue]);
+                    }
+                } else {
+                    onSelect(null, inputValue);
+                }
+
+                setInputValue('');
+                resetActiveAndFocusedItem();
+                if (!isMulti) {
+                    closeMenu();
+                }
+            }
+        } else {
+            if (isMulti) {
+                const currentSelections = Array.isArray(selected) ? selected : [];
+                const newSelections = currentSelections.includes(value)
+                    ? currentSelections.filter(selection => selection !== value)
+                    : [...currentSelections, value];
+                onSelect(null, newSelections);
+                setInputValue('');
+            } else {
+                onSelect(null, value);
+                setInputValue('');
+                closeMenu();
+            }
+        }
+
+        textInputRef.current?.focus();
+    };
+
+    const onTextInputChange = (_event, value) => {
+        setInputValue(value);
+        resetActiveAndFocusedItem();
+    };
+
+    const handleMenuArrowKeys = (key) => {
+        let indexToFocus = 0;
+        if (!isOpen) {
+            setIsOpen(true);
+        }
+
+        if (selectOptions.every(option => option.isDisabled)) {
+            return;
+        }
+
+        if (key === 'ArrowUp') {
+            if (focusedItemIndex === null || focusedItemIndex === 0) {
+                indexToFocus = selectOptions.length - 1;
+            } else {
+                indexToFocus = focusedItemIndex - 1;
+            }
+            while (selectOptions[indexToFocus]?.isDisabled) {
+                indexToFocus--;
+                if (indexToFocus === -1) {
+                    indexToFocus = selectOptions.length - 1;
+                }
+            }
+        }
+
+        if (key === 'ArrowDown') {
+            if (focusedItemIndex === null || focusedItemIndex === selectOptions.length - 1) {
+                indexToFocus = 0;
+            } else {
+                indexToFocus = focusedItemIndex + 1;
+            }
+            while (selectOptions[indexToFocus]?.isDisabled) {
+                indexToFocus++;
+                if (indexToFocus === selectOptions.length) {
+                    indexToFocus = 0;
+                }
+            }
+        }
+
+        setActiveAndFocusedItem(indexToFocus);
+    };
+
+    const onInputKeyDown = (event) => {
+        const focusedItem = focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
+
+        switch (event.key) {
+            case 'Enter':
+                event.preventDefault();
+                if (isOpen && focusedItem && !focusedItem.isDisabled) {
+                    handleSelect(focusedItem.value);
+                } else if (isOpen && isCreatable && inputValue && (!validateCreate || validateCreate(inputValue))) {
+                    // Create new entry when Enter is pressed and input is valid
+                    handleSelect(CREATE_NEW);
+                } else if (!isOpen) {
+                    setIsOpen(true);
+                }
+                break;
+
+            case 'ArrowUp':
+            case 'ArrowDown':
+                event.preventDefault();
+                handleMenuArrowKeys(event.key);
+                break;
+
+            case 'Escape':
+                event.preventDefault();
+                closeMenu();
+                setInputValue('');
+                break;
+
+            case 'Tab':
+                closeMenu();
+                break;
+        }
+    };
+
+    const onToggleClick = () => {
+        setIsOpen(!isOpen);
+        textInputRef?.current?.focus();
+    };
+
+    const onClearButtonClick = () => {
+        if (onClear) {
+            onClear();
+        } else if (isMulti) {
+            onSelect(null, []);
+        } else {
+            onSelect(null, '');
+        }
+        setInputValue('');
+        resetActiveAndFocusedItem();
+        textInputRef?.current?.focus();
+    };
+
+    const getChildren = (value) => {
+        const option = normalizeOptions(options).find(opt => opt.value === value);
+        return option?.children || value;
+    };
+
+    // Get validation status
+    const getStatus = () => {
+        switch (validated) {
+            case 'error': return 'danger';
+            case 'warning': return 'warning';
+            case 'success': return 'success';
+            default: return undefined;
+        }
+    };
+
+    const currentSelections = isMulti ? (Array.isArray(selected) ? selected : []) : [];
+    const displayValue = !isMulti && selected && !isOpen ? selected : inputValue;
+
+    const toggle = (toggleRef) => (
+        <MenuToggle
+            variant="typeahead"
+            aria-label={ariaLabel}
+            onClick={onToggleClick}
+            innerRef={toggleRef}
+            isExpanded={isOpen}
+            isFullWidth
+            isDisabled={isDisabled}
+            status={getStatus()}
+        >
+            <TextInputGroup isPlain>
+                <TextInputGroupMain
+                    value={displayValue}
+                    onClick={onInputClick}
+                    onChange={onTextInputChange}
+                    onKeyDown={onInputKeyDown}
+                    id="typeahead-select-input"
+                    autoComplete="off"
+                    innerRef={textInputRef}
+                    placeholder={currentSelections.length === 0 || !isMulti ? placeholder : ''}
+                    {...(activeItemId && { 'aria-activedescendant': activeItemId })}
+                    role="combobox"
+                    isExpanded={isOpen}
+                    aria-controls="typeahead-select-listbox"
+                >
+                    {isMulti && currentSelections.length > 0 && (
+                        <LabelGroup aria-label="Current selections">
+                            {currentSelections.map((selection, index) => (
+                                <Label
+                                    key={index}
+                                    variant="outline"
+                                    onClose={(ev) => {
+                                        ev.stopPropagation();
+                                        handleSelect(selection);
+                                    }}
+                                >
+                                    {getChildren(selection)}
+                                </Label>
+                            ))}
+                        </LabelGroup>
+                    )}
+                </TextInputGroupMain>
+                <TextInputGroupUtilities
+                    {...((isMulti ? currentSelections.length === 0 : !selected) && !inputValue ? { style: { display: 'none' } } : {})}
+                >
+                    <Button
+                        variant="plain"
+                        onClick={onClearButtonClick}
+                        aria-label="Clear input value"
+                        icon={<TimesIcon />}
+                        isDisabled={isDisabled}
+                    />
+                </TextInputGroupUtilities>
+            </TextInputGroup>
+        </MenuToggle>
+    );
+
+    return (
+        <Select
+            id="typeahead-select"
+            isOpen={isOpen}
+            selected={isMulti ? currentSelections : selected}
+            onSelect={(_event, selection) => handleSelect(selection)}
+            onOpenChange={(nextOpen) => {
+                if (!nextOpen) {
+                    closeMenu();
+                }
+            }}
+            toggle={toggle}
+            variant="typeahead"
+            className={className}
+        >
+            <SelectList isAriaMultiselectable={isMulti} id="typeahead-select-listbox">
+                {selectOptions.length === 0 && !isCreatable ? (
+                    <SelectOption key="no-results" isDisabled>
+                        {noResultsText}
+                    </SelectOption>
+                ) : (
+                    selectOptions.map((option, index) => {
+                        const isSelected = isMulti
+                            ? currentSelections.includes(option.value)
+                            : selected === option.value;
+
+                        return (
+                            <SelectOption
+                                key={option.value}
+                                isFocused={focusedItemIndex === index}
+                                className={option.className}
+                                id={createItemId(option.value)}
+                                value={option.value}
+                                isSelected={isSelected}
+                                hasCheckbox={isMulti && hasCheckbox}
+                                ref={null}
+                            >
+                                {option.children}
+                            </SelectOption>
+                        );
+                    })
+                )}
+            </SelectList>
+        </Select>
+    );
+};
+
+TypeaheadSelect.propTypes = {
+    selected: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string)
+    ]),
+    onSelect: PropTypes.func.isRequired,
+    onClear: PropTypes.func,
+    options: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.shape({
+                value: PropTypes.string.isRequired,
+                label: PropTypes.string,
+                description: PropTypes.string
+            })
+        ])
+    ),
+    isMulti: PropTypes.bool,
+    isCreatable: PropTypes.bool,
+    onCreateOption: PropTypes.func,
+    validateCreate: PropTypes.func,
+    hasCheckbox: PropTypes.bool,
+    placeholder: PropTypes.string,
+    noResultsText: PropTypes.string,
+    isDisabled: PropTypes.bool,
+    validated: PropTypes.oneOf(['default', 'error', 'warning', 'success']),
+    ariaLabel: PropTypes.string,
+    className: PropTypes.string
+};
+
+export default TypeaheadSelect;

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -26,6 +26,7 @@ import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import {
     WrenchIcon,
 } from '@patternfly/react-icons';
@@ -1323,26 +1324,18 @@ class MemberOf extends React.Component {
                                 {_("Membership Attribute")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type a member attribute"
-                                    onToggle={(event, isOpen) => this.handleConfigAttrToggle(event, isOpen)}
-                                    onSelect={this.handleConfigAttrSelect}
+                                <TypeaheadSelect
+                                    selected={configAttr}
+                                    onSelect={(event, value) => {
+                                        this.setState({ configAttr: typeof value === 'string' ? value : '' }, () => { this.validateModal(); });
+                                    }}
                                     onClear={this.handleConfigAttrClear}
-                                    selections={configAttr}
-                                    isOpen={this.state.isConfigAttrOpen}
-                                    aria-labelledby="typeAhead-config-attr"
-                                    placeholderText={_("Type a member attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={["memberOf"]}
+                                    placeholder={_("Type a member attribute...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={errorModal.configAttr ? "error" : "default"}
-                                >
-                                    {["memberOf"].map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    ariaLabel="Type a member attribute"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid className="ds-margin-top" title={_("Specifies the attribute in the group entry to use to identify the DNs of group members (memberOfGroupAttr)")}>
@@ -1350,26 +1343,20 @@ class MemberOf extends React.Component {
                                 {_("Group Attribute")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a member group attribute"
-                                    onToggle={(event, isOpen) => this.handleConfigGroupAttrToggle(event, isOpen)}
-                                    onSelect={this.handleConfigGroupAttrSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    hasCheckbox
+                                    selected={configGroupAttr}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ configGroupAttr: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
+                                    }}
                                     onClear={this.handleConfigGroupAttrClear}
-                                    selections={configGroupAttr}
-                                    isOpen={this.state.isConfigGroupAttrOpen}
-                                    aria-labelledby="typeAhead-config-group-attr"
-                                    placeholderText={_("Type a member group attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={["member", "memberCertificate", "uniqueMember"]}
+                                    placeholder={_("Type a member group attribute...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={errorModal.configGroupAttr ? "error" : "default"}
-                                >
-                                    {["member", "memberCertificate", "uniqueMember"].map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    ariaLabel="Type a member group attribute"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid className="ds-margin-top" title={_("Specifies backends or multiple-nested suffixes for the MemberOf plug-in to work on (memberOfEntryScope)")}>
@@ -1377,28 +1364,24 @@ class MemberOf extends React.Component {
                                 {_("Subtree Scope")}
                             </GridItem>
                             <GridItem span={6}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a subtree DN"
-                                    onToggle={(event, isOpen) => this.handleConfigScopeToggle(event, isOpen)}
-                                    onSelect={this.handleConfigScopeSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    selected={configEntryScope}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ configEntryScope: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
+                                    }}
                                     onClear={this.handleConfigScopeClear}
-                                    selections={configEntryScope}
-                                    isOpen={isConfigSubtreeScopeOpen}
-                                    aria-labelledby="typeAhead-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={this.state.configEntryScopeOptions}
                                     isCreatable
                                     onCreateOption={this.handleConfigCreateOption}
+                                    validateCreate={(value) => valid_dn(value)}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={errorModal.configEntryScope ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleConfigScopeToggle}
+                                    isOpen={isConfigSubtreeScopeOpen}
+                                    ariaLabel="Type a subtree DN"
+                                />
                                 <FormHelperText  >
                                     {_("Values must be valid DN's")}
                                 </FormHelperText>
@@ -1418,28 +1401,22 @@ class MemberOf extends React.Component {
                                 {_("Exclude Subtree")}
                             </GridItem>
                             <GridItem span={6}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a subtree DN"
-                                    onToggle={(event, isOpen) => this.handleConfigExcludeScopeToggle(event, isOpen)}
-                                    onSelect={this.handleConfigExcludeScopeSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    selected={configEntryScopeExcludeSubtree}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ configEntryScopeExcludeSubtree: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
+                                    }}
                                     onClear={this.handleConfigExcludeScopeClear}
-                                    selections={configEntryScopeExcludeSubtree}
-                                    isOpen={isConfigExcludeScopeOpen}
-                                    aria-labelledby="typeAhead-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={this.state.configEntryScopeExcludeOptions}
                                     isCreatable
                                     onCreateOption={this.handleConfigExcludeCreateOption}
+                                    validateCreate={(value) => valid_dn(value)}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={errorModal.configEntryScopeExcludeSubtree ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    ariaLabel="Type a subtree DN"
+                                />
                                 <FormHelperText  >
                                     {_("Values must be valid DN's")}
                                 </FormHelperText>
@@ -1493,26 +1470,18 @@ class MemberOf extends React.Component {
                                 {_("Membership Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type a member attribute"
-                                    onToggle={(event, isOpen) => this.handleMemberOfAttrToggle(event, isOpen)}
-                                    onSelect={this.handleMemberOfAttrSelect}
+                                <TypeaheadSelect
+                                    selected={memberOfAttr}
+                                    onSelect={(event, value) => {
+                                        this.setState({ memberOfAttr: typeof value === 'string' ? value : '' }, () => { this.validateConfig(); });
+                                    }}
                                     onClear={this.handleMemberOfAttrClear}
-                                    selections={memberOfAttr}
-                                    isOpen={this.state.isMemberOfAttrOpen}
-                                    aria-labelledby="typeAhead-memberof-attr"
-                                    placeholderText={_("Type a member attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={["memberOf"]}
+                                    placeholder={_("Type a member attribute...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={error.memberOfAttr ? "error" : "default"}
-                                >
-                                    {["memberOf"].map((attr) => (
-                                        <SelectOption
-                                            key={attr}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    ariaLabel="Type a member attribute"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid className="ds-margin-top" title={_("Specifies the attribute in the group entry to use to identify the DNs of group members (memberOfGroupAttr)")}>
@@ -1520,26 +1489,20 @@ class MemberOf extends React.Component {
                                 {_("Group Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a member group attribute"
-                                    onToggle={(event, isOpen) => this.handleMemberOfGroupAttrToggle(event, isOpen)}
-                                    onSelect={this.handleMemberOfGroupAttrSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    hasCheckbox
+                                    selected={memberOfGroupAttr}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ memberOfGroupAttr: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
+                                    }}
                                     onClear={this.handleMemberOfGroupAttrClear}
-                                    selections={memberOfGroupAttr}
-                                    isOpen={this.state.isMemberOfGroupAttrOpen}
-                                    aria-labelledby="typeAhead-memberof-group-attr"
-                                    placeholderText={_("Type a member group attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={["member", "memberCertificate", "uniqueMember"]}
+                                    placeholder={_("Type a member group attribute...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={error.memberOfGroupAttr ? "error" : "default"}
-                                >
-                                    {["member", "memberCertificate", "uniqueMember"].map((attr) => (
-                                        <SelectOption
-                                            key={attr}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    ariaLabel="Type a member group attribute"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid className="ds-margin-top" title={_("Specifies backends or multiple-nested suffixes for the MemberOf plug-in to work on (memberOfEntryScope)")}>
@@ -1547,28 +1510,24 @@ class MemberOf extends React.Component {
                                 {_("Subtree Scope")}
                             </GridItem>
                             <GridItem span={6}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a subtree DN"
-                                    onToggle={(event, isOpen) => this.handleSubtreeScopeToggle(event, isOpen)}
-                                    onSelect={this.handleSubtreeScopeSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    selected={memberOfEntryScope}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ memberOfEntryScope: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
+                                    }}
                                     onClear={this.handleSubtreeScopeClear}
-                                    selections={memberOfEntryScope}
-                                    isOpen={isSubtreeScopeOpen}
-                                    aria-labelledby="typeAhead-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={this.state.memberOfEntryScopeOptions}
                                     isCreatable
                                     onCreateOption={this.handleSubtreeScopeCreateOption}
+                                    validateCreate={(value) => valid_dn(value)}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={error.memberOfEntryScope ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleSubtreeScopeToggle}
+                                    isOpen={isSubtreeScopeOpen}
+                                    ariaLabel="Type a subtree DN"
+                                />
                                 <FormHelperText  >
                                     {"Values must be valid DN's"}
                                 </FormHelperText>
@@ -1588,28 +1547,24 @@ class MemberOf extends React.Component {
                                 {_("Exclude Subtree")}
                             </GridItem>
                             <GridItem span={6}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a subtree DN"
-                                    onToggle={(event, isOpen) => this.handleExcludeScopeToggle(event, isOpen)}
-                                    onSelect={this.handleExcludeScopeSelect}
+                                <TypeaheadSelect
+                                    isMulti
+                                    selected={memberOfEntryScopeExcludeSubtree}
+                                    onSelect={(event, newSelections) => {
+                                        this.setState({ memberOfEntryScopeExcludeSubtree: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
+                                    }}
                                     onClear={this.handleExcludeScopeClear}
-                                    selections={memberOfEntryScopeExcludeSubtree}
-                                    isOpen={isExcludeScopeOpen}
-                                    aria-labelledby="typeAhead-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    options={this.state.memberOfEntryScopeExcludeOptions}
                                     isCreatable
                                     onCreateOption={this.handleExcludeCreateOption}
+                                    validateCreate={(value) => valid_dn(value)}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
                                     validated={error.memberOfEntryScopeExcludeSubtree ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleExcludeScopeToggle}
+                                    isOpen={isExcludeScopeOpen}
+                                    ariaLabel="Type a subtree DN"
+                                />
                                 <FormHelperText  >
                                     {_("Values must be valid DN's")}
                                 </FormHelperText>


### PR DESCRIPTION
Description: When typing values into typeahead Select fields (e.g., "Subtree scope" in MemberOf plugin), pressing Enter caused the entered value to disappear rather than confirming/saving it. The Enter key should properly create/save the value.

Created a new TypeaheadSelect component to replace the problematic and deprecated PatternFly Select components. The new component properly handles keyboard navigation, including Enter key functionality for creating and selecting values.

Updated the MemberOf plugin to use the new component.

Fixes: https://github.com/389ds/389-ds-base/issues/6990

Reviewed by: ?

## Summary by Sourcery

Replace deprecated PatternFly Select components in the MemberOf plugin with a new TypeaheadSelect component to fix Enter keypress issues and improve keyboard navigation.

New Features:
- Introduce TypeaheadSelect component with support for creatable options, multi-select, checkboxes, and enhanced keyboard interactions.

Bug Fixes:
- Fix typeahead fields losing entered values on Enter keypress by correctly handling selection and creation events.

Enhancements:
- Swap out PatternFly Select variants for TypeaheadSelect across MemberOf plugin forms.
- Add DN validation for creatable subtree entries to prevent invalid inputs.