### PR TITLE
Issue 6740 - Fix FIPS mode test failures in syncrepl, mapping tree, a…

### DIFF
--- a/dirsrvtests/tests/suites/mapping_tree/referral_during_tot_init_test.py
+++ b/dirsrvtests/tests/suites/mapping_tree/referral_during_tot_init_test.py
@@ -8,6 +8,7 @@
 #
 import ldap
 import pytest
+import os
 from lib389.topologies import topology_m2
 from lib389._constants import (DEFAULT_SUFFIX)
 from lib389.agreement import Agreements
@@ -65,9 +66,11 @@ def test_referral_during_tot(topology_m2):
     # While that's happening try to bind as a user to supplier 2
     # This should trigger the referral code.
     referred = False
+    ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, os.path.join(supplier2.get_config_dir(), "ca.crt"))
     for i in range(0, 100):
         conn = ldap.initialize(supplier2.toLDAPURL())
         conn.set_option(ldap.OPT_REFERRALS, False)
+        conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
         try:
             conn.simple_bind_s(binddn, bindpw)
             conn.unbind_s()

--- a/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
+++ b/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
@@ -14,7 +14,7 @@ import resource
 from lib389.backend import Backends
 from lib389._constants import *
 from lib389.topologies import topology_st
-from lib389.utils import ds_is_older, ensure_str
+from lib389.utils import ds_is_older, ensure_str, is_fips
 from subprocess import check_output
 
 pytestmark = pytest.mark.tier1
@@ -109,7 +109,7 @@ def test_reserve_descriptor_validation(topology_st):
     A standalone instance contains a single backend with default indexes
     so we only check these. TODO add tests for repl, chaining, PTA, SSL
     """
-    STANDALONE_INST_RESRV_DESCS = 20 # 20 = Reserve descriptor constant
+    STANDALONE_INST_RESRV_DESCS = 25 if is_fips() else 20 # Reserve descriptor constant (higher in FIPS mode)
     backends = Backends(topology_st.standalone)
     STANDALONE_INST_RESRV_DESCS += (len(backends.list()) * 4) # 4 = Backend descriptor constant
     for be in backends.list() :

--- a/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
@@ -8,6 +8,7 @@
 
 import logging
 import ldap
+import os
 import time
 import threading
 from ldap.syncrepl import SyncreplConsumer
@@ -213,7 +214,10 @@ class Sync_persist(threading.Thread, ReconnectLDAPObject, SyncreplConsumer):
 
     def run(self):
         """Start a sync repl client"""
+        ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, os.path.join(self.inst.get_config_dir(), "ca.crt"))
         ldap_connection = TestSyncer(self.inst.toLDAPURL())
+        ldap_connection.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
+        ldap_connection.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
         ldap_connection.simple_bind_s('cn=directory manager', 'password')
         ldap_search = ldap_connection.syncrepl_search(
             "dc=example,dc=com",
@@ -617,7 +621,7 @@ def test_sync_repl_dynamic_plugin(topology, request):
     topology.standalone.modify_s(DN_CONFIG, [(ldap.MOD_REPLACE, 'nsslapd-dynamic-plugins', b'off')])
     topology.standalone.restart()
 
-    # Now start the test 
+    # Now start the test
     # Enable dynamic plugins
     try:
         topology.standalone.modify_s(DN_CONFIG, [(ldap.MOD_REPLACE, 'nsslapd-dynamic-plugins', b'on')])


### PR DESCRIPTION
…nd resource limits

Description: FIPS mode requires SSL certificate bypass for LDAP connections and higher reserve descriptor constants due to mandatory SSL descriptors.

Relates: https://github.com/389ds/389-ds-base/issues/6740

Reviewed by: ???

## Summary by Sourcery

Fix FIPS mode test failures by bypassing LDAP SSL certificate verification in tests and adjusting file descriptor limits for FIPS mode

Bug Fixes:
- Bypass LDAP SSL certificate verification in syncrepl and mapping tree tests to support FIPS mode
- Increase the standalone instance reserve descriptor constant in resource limits tests when running in FIPS mode

Tests:
- Set OPT_X_TLS_REQUIRE_CERT to OPT_X_TLS_NEVER in syncrepl and mapping tree LDAP connections
- Use is_fips check to conditionally raise the reserve descriptor count in fdlimits_test