### PR TITLE
Issue 6990 - UI - Replace deprecated Select components with new TypeaheadSelect

### DIFF
--- a/src/cockpit/389-console/po/ja.po
+++ b/src/cockpit/389-console/po/ja.po
@@ -8903,7 +8903,7 @@ msgid "uniqueMember"
 msgstr "uniqueMember"
 
 #: src/lib/ldap_editor/search.jsx:1087
-msgid "Enter space or comma separateed list of attributes to search."
+msgid "Enter space or comma separated list of attributes to search."
 msgstr "検索する属性のリストをスペースまたはカンマで区切って入力してください。"
 
 #: src/lib/ldap_editor/search.jsx:1098

--- a/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
+++ b/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
@@ -7,11 +7,7 @@ import {
 	Grid,
 	GridItem
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { log_cmd } from "../tools.jsx";
 
@@ -25,7 +21,6 @@ export class AttrEncryption extends React.Component {
             showConfirmAttrDelete: false,
             addAttr: "",
             delAttr: "",
-            isSelectOpen: false,
             modalSpinning: false,
             modalChecked: false,
             saving: false,
@@ -39,7 +34,6 @@ export class AttrEncryption extends React.Component {
         this.onHandleModalChange = this.onHandleModalChange.bind(this);
         // Select Typeahead
         this.handleSelect = this.handleSelect.bind(this);
-        this.handleSelectToggle = this.handleSelectToggle.bind(this);
         this.handleSelectClear = this.handleSelectClear.bind(this);
     }
 
@@ -69,21 +63,13 @@ export class AttrEncryption extends React.Component {
 
     handleSelect = (event, selection) => {
         this.setState({
-            addAttr: selection,
-            isSelectOpen: false
-        });
-    };
-
-    handleSelectToggle = isSelectOpen => {
-        this.setState({
-            isSelectOpen
+            addAttr: selection
         });
     };
 
     handleSelectClear = () => {
         this.setState({
-            addAttr: "",
-            isSelectOpen: false
+            addAttr: ""
         });
     };
 
@@ -159,15 +145,15 @@ export class AttrEncryption extends React.Component {
         const {
             addAttr,
             saving,
-            isSelectOpen,
             modalSpinning,
         } = this.state;
 
         // Update the available list of attrs for the Typeahead
         const fullList = [];
         const attrs = [];
-        for (const attrProp of this.props.rows) {
-            fullList.push(attrProp.name);
+        // this.props.rows contains strings, not objects
+        for (const attrName of this.props.rows) {
+            fullList.push(attrName);
         }
         for (const attr of this.props.attrs) {
             if (fullList.indexOf(attr) === -1) {
@@ -191,24 +177,16 @@ export class AttrEncryption extends React.Component {
                 />
                 <Grid className="ds-margin-top">
                     <GridItem span={6}>
-                        <Select
-                            variant={SelectVariant.typeahead}
-                            onToggle={(_event, isSelectOpen) => this.handleSelectToggle(isSelectOpen)}
+                        <TypeaheadSelect
+                            selected={addAttr}
                             onSelect={this.handleSelect}
                             onClear={this.handleSelectClear}
-                            selections={addAttr}
-                            isOpen={isSelectOpen}
-                            aria-labelledby="typeAhead-AttrEnc"
-                            placeholderText={_("Type attribute name to be encrypted")}
-                            noResultsFoundText={_("There are no matching entries")}
-                        >
-                            {attrs.map((attr, index) => (
-                                <SelectOption
-                                    key={index}
-                                    value={attr}
-                                />
-                            ))}
-                        </Select>
+                            options={attrs}
+                            placeholder={_("Type attribute name to be encrypted")}
+                            noResultsText={_("There are no matching entries")}
+                            ariaLabel="Type attribute name to be encrypted"
+                            openOnClick={false}
+                        />
                     </GridItem>
                     <GridItem span={3} className="ds-no-padding">
                         <Button

--- a/src/cockpit/389-console/src/lib/database/chaining.jsx
+++ b/src/cockpit/389-console/src/lib/database/chaining.jsx
@@ -22,11 +22,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import {
     SyncAltIcon,
@@ -1360,7 +1356,7 @@ export class ChainingConfig extends React.Component {
                             <Text className="ds-suffix-header" component={TextVariants.h3}>
                                 <LinkIcon />
                                 &nbsp;&nbsp;{this.props.suffix} (<i>{this.props.bename}</i>)
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh database link")}
                                     onClick={() => this.props.reload(this.props.suffix)}
@@ -1471,19 +1467,14 @@ export class ChainingConfig extends React.Component {
                         {_("Bind Method")}
                     </GridItem>
                     <GridItem span={9}>
-                        <Select
-                            variant={SelectVariant.single}
-                            aria-label="Select Input"
-                            onToggle={(event, isOpen) => this.handleSelectToggle(event, isOpen)}
+                        <TypeaheadSelect
+                            selected={this.state.nsbindmechanism}
                             onSelect={this.handleSelect}
-                            selections={this.state.nsbindmechanism}
+                            options={["Simple", "SASL/DIGEST-MD5", "SASL/GSSAPI"]}
                             isOpen={this.state.isOpen}
-                            aria-labelledby="UID"
-                        >
-                            <SelectOption key="Simple" value="Simple" />
-                            <SelectOption key="SASL/DIGEST-MD5" value="SASL/DIGEST-MD5" />
-                            <SelectOption key="SASL/GSSAPI" value="SASL/GSSAPI" />
-                        </Select>
+                            onToggle={this.handleSelectToggle}
+                            ariaLabel="Select Input"
+                        />
                     </GridItem>
                 </Grid>
                 <Grid

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -20,11 +20,7 @@ import {
 	TextContent,
 	TextVariants
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { SyncAltIcon } from '@patternfly/react-icons';
 
@@ -542,23 +538,11 @@ export class GlobalPwPolicy extends React.Component {
             }
         }
         if (selection) {
-            if (this.state[attr].includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: prevState[attr].filter((item) => item !== selection),
-                        isSelectOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: [...prevState[attr], selection],
-                        saveSyntaxDisabled: disableSaveBtn,
-                        isSelectOpen: false
-
-                    }),
-                );
-            }
+            this.setState({
+                [attr]: Array.isArray(selection) ? selection : [],
+                saveSyntaxDisabled: disableSaveBtn,
+                isSelectOpen: false
+            });
         } else {
             this.setState({
                 [attr]: value,
@@ -1211,25 +1195,18 @@ export class GlobalPwPolicy extends React.Component {
                             {_("Check User Attributes")}
                         </GridItem>
                         <GridItem span={9}>
-                            <Select
-                                variant={SelectVariant.typeaheadMulti}
-                                typeAheadAriaLabel="Type an attribute to check"
-                                onToggle={(_event, isSelectOpen) => this.handleSelectToggle(isSelectOpen)}
-                                onClear={this.handleSelectClear}
+                            <TypeaheadSelect
+                                selected={this.state.passworduserattributes}
                                 onSelect={this.handleSyntaxChange}
-                                selections={this.state.passworduserattributes}
+                                onClear={this.handleSelectClear}
+                                options={this.props.attrs}
                                 isOpen={this.state.isSelectOpen}
-                                aria-labelledby="typeAhead-user-attr"
-                                placeholderText={_("Type attributes to check...")}
-                                noResultsFoundText="There are no matching entries"
-                            >
-                                {this.props.attrs.map((attr, index) => (
-                                    <SelectOption
-                                        key={index}
-                                        value={attr}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={this.handleSelectToggle}
+                                placeholder={_("Type attributes to check...")}
+                                noResultsText="There are no matching entries"
+                                ariaLabel="Type an attribute to check"
+                                isMulti={true}
+                            />
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top-lg" title={_("Check the password against the system's CrackLib dictionary (passwordDictCheck).")}>

--- a/src/cockpit/389-console/src/lib/database/indexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/indexes.jsx
@@ -18,11 +18,7 @@ import {
 	TextContent,
 	TextVariants
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -74,21 +70,9 @@ export class SuffixIndexes extends React.Component {
 
         // Select Attribute
         this.handleAttributeSelect = (event, selection) => {
-            if (this.state.indexName.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        indexName: prevState.indexName.filter((item) => item !== selection),
-                        isAttributeOpen: false
-                    }), () => { this.validateSaveBtn() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        indexName: [...prevState.indexName, selection],
-                        isAttributeOpen: false
-                    }), () => { this.validateSaveBtn() }
-                );
-            }
+            this.setState({
+                indexName: Array.isArray(selection) ? selection : [selection],
+            }, () => { this.validateSaveBtn() });
         };
         this.handleAttributeToggle = (_event, isAttributeOpen) => {
             this.setState({
@@ -302,21 +286,9 @@ export class SuffixIndexes extends React.Component {
 
     // Edit Matching Rules
     handleMatchingruleSelect(event, selection) {
-        const new_mrs = [...this.state.mrs];
-        if (new_mrs.includes(selection)) {
-            const index = new_mrs.indexOf(selection);
-            new_mrs.splice(index, 1);
-            this.setState({
-                mrs: new_mrs,
-                isMatchingruleOpen: false,
-            }, () => { this.validateSaveBtn() });
-        } else {
-            new_mrs.push(selection);
-            this.setState({
-                mrs: new_mrs,
-                isMatchingruleOpen: false,
-            }, () => { this.validateSaveBtn() });
-        }
+        this.setState({
+            mrs: Array.isArray(selection) ? selection : [],
+        }, () => { this.validateSaveBtn() });
     }
 
     saveIndex() {
@@ -838,26 +810,18 @@ class AddIndexModal extends React.Component {
                             {_("Select An Attribute")}
                         </Text>
                     </TextContent>
-                    <Select
-                        variant={SelectVariant.typeahead}
-                        typeAheadAriaLabel={_("Type a attribute name to index")}
-                        onToggle={onAttributeToggle}
-                        onClear={onAttributeClear}
+                    <TypeaheadSelect
+                        selected={attributeName}
                         onSelect={onAttributeSelect}
-                        selections={attributeName}
+                        onClear={onAttributeClear}
+                        options={availAttrs}
                         isOpen={isAttributeOpen}
-                        aria-labelledby="typeAhead-attr-add"
-                        placeholderText={_("Type a attribute name to index..")}
-                        noResultsFoundText={_("There are no matching entries")}
+                        onToggle={onAttributeToggle}
+                        placeholder={_("Type a attribute name to index..")}
+                        noResultsText={_("There are no matching entries")}
+                        ariaLabel={_("Type a attribute name to index")}
                         validated={attributeName.length === 0 || attributeName[0] === "" ? "error" : "default"}
-                    >
-                        {availAttrs.map((attr, index) => (
-                            <SelectOption
-                                key={index}
-                                value={attr}
-                            />
-                        ))}
-                    </Select>
+                    />
                     <TextContent className="ds-margin-top">
                         <Text component={TextVariants.h4}>
                             {_("Index Types")}
@@ -921,26 +885,18 @@ class AddIndexModal extends React.Component {
                                 </Text>
                             </TextContent>
                             <div className="ds-indent ds-margin-top">
-                                <Select
-                                    id="addMatchingRules"
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a matching rule name"
-                                    onToggle={onMatchingruleAddToggle}
+                                <TypeaheadSelect
+                                    selected={mrs}
                                     onSelect={onMatchingruleSelect}
                                     onClear={onMatchingruleAddClear}
-                                    selections={mrs}
+                                    options={availMR}
                                     isOpen={isMatchingruleOpen}
-                                    aria-labelledby="typeAhead-mr-add"
-                                    placeholderText={_("Type a matching rule name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {availMR.map((mrs, index) => (
-                                        <SelectOption
-                                           key={index}
-                                           value={mrs}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onMatchingruleAddToggle}
+                                    placeholder={_("Type a matching rule name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a matching rule name"
+                                    isMulti={true}
+                                />
                             </div>
                         </GridItem>
                     </Grid>
@@ -1173,25 +1129,18 @@ class EditIndexModal extends React.Component {
                                 </Text>
                             </TextContent>
                             <div className="ds-indent ds-margin-top">
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a matching rule name"
-                                    onToggle={onMatchingruleEditToggle}
+                                <TypeaheadSelect
+                                    selected={currentMrs}
                                     onSelect={onMatchingruleSelect}
                                     onClear={onMatchingruleEditClear}
-                                    selections={currentMrs}
+                                    options={availMR}
                                     isOpen={isMatchingruleOpen}
-                                    aria-labelledby="typeAhead-mr-edit"
-                                    placeholderText={_("Type a matching rule name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {availMR.map((mr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={mr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onMatchingruleEditToggle}
+                                    placeholder={_("Type a matching rule name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a matching rule name"
+                                    isMulti={true}
+                                />
                             </div>
                         </GridItem>
                     </Grid>

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -25,11 +25,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SyncAltIcon } from "@patternfly/react-icons";
 import PropTypes from "prop-types";
 
@@ -757,26 +753,19 @@ class CreatePolicy extends React.Component {
                                         {_("Check User Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type a attribute name to check"
-                                            onToggle={(event, isOpen) => this.props.onUserAttrsCreateToggle(event, isOpen)}
+                                        <TypeaheadSelect
+                                            selected={this.props.passworduserattributes}
                                             onSelect={this.props.handleChange}
                                             onClear={this.props.onUserAttrsCreateClear}
-                                            selections={this.props.passworduserattributes}
+                                            options={this.props.attrs}
                                             isOpen={this.props.isUserAttrsCreateOpen}
-                                            aria-labelledby="typeAhead-user-attr-create"
-                                            placeholderText={_("Type attributes to check...")}
-                                            noResultsFoundText={_("There are no matching entries")}
+                                            onToggle={this.props.onUserAttrsCreateToggle}
+                                            placeholder={_("Type attributes to check...")}
+                                            noResultsText={_("There are no matching entries")}
+                                            ariaLabel="Type a attribute name to check"
+                                            isMulti={true}
                                             isDisabled={!this.props.passwordchecksyntax}
-                                        >
-                                            {this.props.attrs.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                        />
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Check the password against the system's CrackLib dictionary (passwordDictCheck).")}>
@@ -1325,25 +1314,12 @@ export class LocalPwPolicy extends React.Component {
 
         // Select Typeahead
         if (selection) {
-            if (this.state[attr].includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: prevState[attr].filter((item) => item !== selection),
-                        createDisabled: disableSaveBtn,
-                        invalid_dn,
-                        isUserAttrsCreateOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: [...prevState[attr], selection],
-                        createDisabled: disableSaveBtn,
-                        invalid_dn,
-                        isUserAttrsCreateOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                [attr]: Array.isArray(selection) ? selection : [],
+                createDisabled: disableSaveBtn,
+                invalid_dn,
+                isUserAttrsCreateOpen: false
+            });
         } else { // Checkbox
             this.setState({
                 [attr]: value,
@@ -1691,23 +1667,11 @@ export class LocalPwPolicy extends React.Component {
         }
 
         if (selection) {
-            if (this.state[attr].includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: prevState[attr].filter((item) => item !== selection),
-                        isSelectOpen: false,
-                        isUserAttrsEditOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: [...prevState[attr], selection],
-                        saveSyntaxDisabled: disableSaveBtn,
-                        isUserAttrsEditOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                [attr]: Array.isArray(selection) ? selection : [],
+                saveSyntaxDisabled: disableSaveBtn,
+                isUserAttrsEditOpen: false
+            });
         } else {
             this.setState({
                 [attr]: value,
@@ -2620,25 +2584,18 @@ export class LocalPwPolicy extends React.Component {
                             {_("Check User Attributes")}
                         </GridItem>
                         <GridItem span={9}>
-                            <Select
-                                variant={SelectVariant.typeaheadMulti}
-                                typeAheadAriaLabel="Type an attribute to check"
-                                onToggle={(event, isOpen) => this.handleSelectToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                selected={this.state.passworduserattributes}
                                 onSelect={this.handleSyntaxChange}
                                 onClear={this.handleSelectClear}
-                                selections={this.state.passworduserattributes}
+                                options={this.props.attrs}
                                 isOpen={this.state.isSelectOpen}
-                                aria-labelledby="typeAhead-user-attr"
-                                placeholderText={_("Type attributes to check...")}
-                                noResultsFoundText={_("There are no matching entries")}
-                            >
-                                {this.props.attrs.map((attr, index) => (
-                                    <SelectOption
-                                        key={index}
-                                        value={attr}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={this.handleSelectToggle}
+                                placeholder={_("Type attributes to check...")}
+                                noResultsText={_("There are no matching entries")}
+                                ariaLabel="Type an attribute to check"
+                                isMulti={true}
+                            />
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top-lg" title={_("Check the password against the system's CrackLib dictionary (passwordDictCheck).")}>

--- a/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
@@ -19,11 +19,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -528,21 +524,9 @@ class AddVLVIndexModal extends React.Component {
     }
 
     onTypeaheadChange(e, selection) {
-        if (this.state.sortValue.includes(selection)) {
-            this.setState(
-                (prevState) => ({
-                    sortValue: prevState.sortValue.filter((item) => item !== selection),
-                    isVLVSortOpen: false
-                }),
-            );
-        } else {
-            this.setState(
-                (prevState) => ({
-                    sortValue: [...prevState.sortValue, selection],
-                    isVLVSortOpen: false
-                }),
-            );
-        }
+        this.setState({
+            sortValue: Array.isArray(selection) ? selection : [],
+        });
     }
 
     render() {
@@ -591,27 +575,19 @@ class AddVLVIndexModal extends React.Component {
                         <GridItem className="ds-label" span={12}>
                             {_("Build a list of attributes to form the \"Sort\" index")}
                         </GridItem>
-                        <Select
-                            variant={SelectVariant.typeaheadMulti}
-                            typeAheadAriaLabel={_("Type an attribute names to create a sort index")}
-                            className="ds-margin-top-lg"
-                            onToggle={(event, isOpen) => this.handleVLVSortToggle(event, isOpen)}
+                        <TypeaheadSelect
+                            selected={this.state.sortValue}
+                            onSelect={this.onTypeaheadChange}
                             onClear={this.handleVLVSortClear}
-                            onSelect={this.handleTypeaheadChange}
-                            maxHeight={1000}
-                            selections={this.state.sortValue}
+                            options={attrs}
                             isOpen={this.state.isVLVSortOpen}
-                            aria-labelledby="typeAhead-vlv-sort-index"
-                            placeholderText={_("Type an attribute name ...")}
-                            noResultsFoundText={_("There are no matching entries")}
-                        >
-                            {attrs.map((attr, index) => (
-                                <SelectOption
-                                    key={index}
-                                    value={attr}
-                                />
-                            ))}
-                        </Select>
+                            onToggle={this.handleVLVSortToggle}
+                            placeholder={_("Type an attribute name ...")}
+                            noResultsText={_("There are no matching entries")}
+                            ariaLabel={_("Type an attribute names to create a sort index")}
+                            isMulti={true}
+                            className="ds-margin-top-lg"
+                        />
                         <GridItem className="ds-margin-top-xlg" span={12}>
                             <Checkbox
                                 id="reindexVLV"

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -28,11 +28,7 @@ import {
 	Tooltip,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import {
     expandable
 } from '@patternfly/react-table';
@@ -152,22 +148,10 @@ export class SearchDatabase extends React.Component {
         };
 
         this.handleCustomAttrChange = (event, selection) => {
-            const { customSearchAttrs } = this.state;
-            if (customSearchAttrs.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        customSearchAttrs: prevState.customSearchAttrs.filter(item => item !== selection),
-                        isCustomAttrOpen: false
-                    }), () => { this.buildSearchFilter(this.state.searchText) }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        customSearchAttrs: [...prevState.customSearchAttrs, selection],
-                        isCustomAttrOpen: false,
-                    }), () => { this.buildSearchFilter(this.state.searchText) }
-                );
-            }
+            this.setState({
+                customSearchAttrs: Array.isArray(selection) ? selection : [],
+                isCustomAttrOpen: false,
+            }, () => { this.buildSearchFilter(this.state.searchText) });
         };
 
         this.buildSearchFilter = (value) => {
@@ -1082,27 +1066,20 @@ export class SearchDatabase extends React.Component {
                                         />
                                     </GridItem>
                                 </Grid>
-                                <Grid className="ds-margin-left ds-margin-top" title={_("Enter space or comma separateed list of attributes to search.")}>
+                                <Grid className="ds-margin-left ds-margin-top" title={_("Enter space or comma separated list of attributes to search.")}>
                                     <GridItem span={8}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type attributes to include in filter ..."
-                                            onToggle={(event, isOpen) => this.handleCustomAttrToggle(event, isOpen)}
+                                        <TypeaheadSelect
+                                            selected={this.state.customSearchAttrs}
                                             onSelect={this.handleCustomAttrChange}
                                             onClear={this.handleCustomAttrClear}
-                                            selections={this.state.customSearchAttrs}
+                                            options={this.props.attributes}
                                             isOpen={this.state.isCustomAttrOpen}
-                                            aria-labelledby="typeAhead-attr-filter"
-                                            placeholderText={_("Type attributes to include in the filter ...")}
-                                            noResultsFoundText="There are no matching attributes"
-                                        >
-                                            {this.props.attributes.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            onToggle={this.handleCustomAttrToggle}
+                                            placeholder={_("Type attributes to include in the filter ...")}
+                                            noResultsText="There are no matching attributes"
+                                            ariaLabel="Type attributes to include in filter ..."
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                             </div>

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
@@ -39,11 +39,9 @@ import {
 	ValidatedOptions
 } from '@patternfly/react-core';
 import {
-	Select,
-	SelectOption,
-	SelectVariant,
 	Wizard
 } from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../../../dsBasicComponents.jsx";
 import {
     Table,
     Thead,
@@ -957,18 +955,15 @@ class AddNewAci extends React.Component {
                         </Tooltip>
                     </Text>
                 </TextContent>
-                <Select
-                    variant={SelectVariant.single}
+                <TypeaheadSelect
                     className="ds-margin-top-lg"
-                    aria-label="Select rights"
+                    ariaLabel="Select rights"
                     onToggle={(event, isOpen) => this.handleToggleRights(event, isOpen)}
                     onSelect={this.handleSelectRights}
-                    selections={this.state.rightType}
+                    selected={this.state.rightType}
                     isOpen={this.state.isOpenRights}
-                >
-                    <SelectOption key="allow" value="allow" />
-                    <SelectOption key="deny" value="deny" />
-                </Select>
+                    options={["allow", "deny"]}
+                />
                 <Table
                     aria-label="Selectable Table User Rights"
                     variant="compact"
@@ -1026,17 +1021,14 @@ class AddNewAci extends React.Component {
                         <b>{_("Comparison Operator")}</b>
                     </div>
                     <div className="ds-inline ds-left-margin ds-raise-field-md">
-                        <Select
-                            variant={SelectVariant.single}
-                            aria-label="Select auth compare operator"
+                        <TypeaheadSelect
+                            ariaLabel="Select auth compare operator"
                             onToggle={(event, isOpen) => this.handleToggleTargetAttrOp(event, isOpen)}
                             onSelect={this.handleSelectTargetAttrOp}
-                            selections={this.state.targetAttrCompOp}
+                            selected={this.state.targetAttrCompOp}
                             isOpen={this.state.isOpenTargetAttrOperator}
-                        >
-                            <SelectOption key="targetattrequals" value="=" />
-                            <SelectOption key="targetattrequals" value="!=" />
-                        </Select>
+                            options={["=", "!="]}
+                        />
                     </div>
                 </div>
                 <GenericPagination

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addGroup.jsx
@@ -25,11 +25,9 @@ import {
 	ValidatedOptions
 } from '@patternfly/react-core';
 import {
-	Select,
-	SelectOption,
-	SelectVariant,
 	Wizard
 } from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../../../dsBasicComponents.jsx";
 import LdapNavigator from '../../lib/ldapNavigator.jsx';
 import {
     createLdapEntry,
@@ -336,18 +334,15 @@ class AddGroup extends React.Component {
 
                 </div>
                 <div className="ds-indent">
-                    <Select
-                        variant={SelectVariant.single}
+                    <TypeaheadSelect
                         className="ds-margin-top-lg"
-                        aria-label="Select group type"
+                        ariaLabel="Select group type"
                         onToggle={(event, isOpen) => this.handleToggleType(event, isOpen)}
                         onSelect={this.handleSelectType}
-                        selections={this.state.groupType}
+                        selected={this.state.groupType}
                         isOpen={this.state.isOpenType}
-                    >
-                        <SelectOption key="group" value="Basic Group" />
-                        <SelectOption key="posix" value="Posix Group" />
-                    </Select>
+                        options={["Basic Group", "Posix Group"]}
+                    />
                     <TextContent className="ds-margin-top-xlg">
                         <Text component={TextVariants.h6} className="ds-margin-top-lg ds-font-size-md">
                             <b>{_("Basic Group")}</b>{_("- This type of group can use membership attributes: member, or uniqueMember common set of objectclasses and attributes.")}

--- a/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
@@ -12,11 +12,7 @@ import {
 	TextInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { log_cmd, valid_dn } from "../tools.jsx";
@@ -877,25 +873,17 @@ class AccountPolicy extends React.Component {
                                 {_("Always Record Login Attribute")}
                             </GridItem>
                             <GridItem span={4}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel={_("Type an attribute name")}
-                                    onToggle={(event, isOpen) => this.handleRecordLoginToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={alwaysRecordLoginAttr}
                                     onSelect={this.handleRecordLoginSelect}
                                     onClear={this.handleRecordLoginClear}
-                                    selections={alwaysRecordLoginAttr}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isRecordLoginOpen}
-                                    aria-labelledby="typeAhead-record-login"
-                                    placeholderText={_("Type an attribute name ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleRecordLoginToggle}
+                                    placeholder={_("Type an attribute name ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel={_("Type an attribute name")}
+                                />
                             </GridItem>
                             <GridItem span={4}>
                                 <Checkbox
@@ -913,25 +901,17 @@ class AccountPolicy extends React.Component {
                                 {_("Specific Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel={_("Type an attribute name")}
-                                    onToggle={(event, isOpen) => this.handleSpecificAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={specAttrName}
                                     onSelect={this.handleSpecificAttrSelect}
                                     onClear={this.handleSpecificAttrClear}
-                                    selections={specAttrName}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isSpecificAttrOpen}
-                                    aria-labelledby="typeAhead-specific-attr"
-                                    placeholderText={_("Type an attribute name ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {this.props.attributes.map((attr) => (
-                                        <SelectOption
-                                            key={attr}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleSpecificAttrToggle}
+                                    placeholder={_("Type an attribute name ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel={_("Type an attribute name")}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Specifies the attribute within the policy to use for the account inactivation limit (limitAttrName)")}>
@@ -939,25 +919,17 @@ class AccountPolicy extends React.Component {
                                 {_("Limit Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel={_("Type an attribute name")}
-                                    onToggle={(event, isOpen) => this.handleLimitAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={limitAttrName}
                                     onSelect={this.handleLimitAttrSelect}
                                     onClear={this.handleLimitAttrClear}
-                                    selections={limitAttrName}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isLimitAttrOpen}
-                                    aria-labelledby="typeAhead-limit-attr"
-                                    placeholderText={_("Type an attribute name ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleLimitAttrToggle}
+                                    placeholder={_("Type an attribute name ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel={_("Type an attribute name")}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title="Specifies the primary time attribute used to evaluate an account policy (stateAttrName)">
@@ -965,26 +937,18 @@ class AccountPolicy extends React.Component {
                                 {_("State Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel={_("Type an attribute name")}
-                                    onToggle={(event, isOpen) => this.handleStateAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={stateAttrName}
                                     onSelect={this.handleStateAttrSelect}
                                     onClear={this.handleStateAttrClear}
-                                    selections={stateAttrName}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isStateAttrOpen}
-                                    aria-labelledby="typeAhead-state-attr"
-                                    placeholderText={_("Type an attribute name ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleStateAttrToggle}
+                                    placeholder={_("Type an attribute name ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel={_("Type an attribute name")}
+                                    isCreatable={true}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Provides a backup attribute to evaluate the expiration time if the main state attribute is not present (altStateAttrName)")}>
@@ -992,26 +956,18 @@ class AccountPolicy extends React.Component {
                                 {_("Alternative State Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel={_("Type an attribute name")}
-                                    onToggle={(event, isOpen) => this.handleAlternativeStateToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={altStateAttrName}
                                     onSelect={this.handleAlternativeStateSelect}
                                     onClear={this.handleAlternativeStateClear}
-                                    selections={altStateAttrName}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isAltStateAttrOpen}
-                                    aria-labelledby="typeAhead-alt-state-attr"
-                                    placeholderText={_("Type an attribute name ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleAlternativeStateToggle}
+                                    placeholder={_("Type an attribute name ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel={_("Type an attribute name")}
+                                    isCreatable={true}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Check both the 'state attribute', and the 'alternate state attribute' regaredless if the main state attribute is present")}>

--- a/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
@@ -19,11 +19,7 @@ import {
 	Switch,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { AttrUniqConfigTable } from "./pluginTables.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
@@ -103,21 +99,9 @@ class AttributeUniqueness extends React.Component {
 
         // Attribute Name
         this.handleAttributeNameSelect = (event, selection) => {
-            if (this.state.attrNames.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        attrNames: prevState.attrNames.filter((item) => item !== selection),
-                        isAttributeNameOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        attrNames: [...prevState.attrNames, selection],
-                        isAttributeNameOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                attrNames: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleAttributeNameToggle = (_event, isAttributeNameOpen) => {
             this.setState({
@@ -137,21 +121,9 @@ class AttributeUniqueness extends React.Component {
                 this.setState({isSubtreesOpen: false});
                 return;
             }
-            if (this.state.subtrees.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        subtrees: prevState.subtrees.filter((item) => item !== selection),
-                        isSubtreesOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        subtrees: [...prevState.subtrees, selection],
-                        isSubtreesOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                subtrees: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleSubtreesToggle = (_event, isSubtreesOpen) => {
             this.setState({
@@ -178,21 +150,9 @@ class AttributeUniqueness extends React.Component {
                 this.setState({isExcludeSubtreesOpen: false});
                 return;
             }
-            if (this.state.excludeSubtrees.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        excludeSubtrees: prevState.excludeSubtrees.filter((item) => item !== selection),
-                        isExcludeSubtreesOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        excludeSubtrees: [...prevState.excludeSubtrees, selection],
-                        isExcludeSubtreesOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                excludeSubtrees: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleExcludeSubtreesToggle = (_event, isExcludeSubtreesOpen) => {
             this.setState({
@@ -782,26 +742,19 @@ class AttributeUniqueness extends React.Component {
                                 {_("Attribute Names")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute"
-                                    onToggle={(event, isOpen) => this.handleAttributeNameToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={attrNames}
                                     onSelect={this.handleAttributeNameSelect}
                                     onClear={this.handleAttributeNameClear}
-                                    selections={attrNames}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isAttributeNameOpen}
-                                    aria-labelledby="typeAhead-attr-name"
-                                    placeholderText={_("Type an attribute name...")}
-                                    noResultsFoundText={_("There are no matching attributes")}
+                                    onToggle={this.handleAttributeNameToggle}
+                                    placeholder={_("Type an attribute name...")}
+                                    noResultsText={_("There are no matching attributes")}
+                                    ariaLabel="Type an attribute"
                                     validated={this.state.error.attrNames ? "error" : "default"}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    isMulti={true}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets the DN under which the plug-in checks for uniqueness of the attributes value. This attribute is multi-valued (uniqueness-subtrees)")}>
@@ -809,28 +762,21 @@ class AttributeUniqueness extends React.Component {
                                 {_("Subtrees")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a subtree DN"
-                                    onToggle={(event, isOpen) => this.handleSubtreesToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={subtrees}
                                     onSelect={this.handleSubtreesSelect}
                                     onClear={this.handleSubtreesClear}
-                                    selections={subtrees}
+                                    options={[""]}
                                     isOpen={this.state.isSubtreesOpen}
-                                    aria-labelledby="typeAhead-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
-                                    onCreateOption={this.handleSubtreesCreateOption}
+                                    onToggle={this.handleSubtreesToggle}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a subtree DN"
                                     validated={this.state.error.subtrees ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    isMulti={true}
+                                    isCreatable={true}
+                                    onCreateOption={this.handleSubtreesCreateOption}
+                                />
                                 {this.state.error.subtrees &&
                                     <FormHelperText >
                                         <HelperText>
@@ -847,28 +793,21 @@ class AttributeUniqueness extends React.Component {
                                 Excluded Subtrees
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an exclude subtree DN"
-                                    onToggle={(event, isOpen) => this.handleExcludeSubtreesToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={excludeSubtrees}
                                     onSelect={this.handleExcludeSubtreesSelect}
                                     onClear={this.handleExcludeSubtreesClear}
-                                    selections={excludeSubtrees}
+                                    options={[""]}
                                     isOpen={this.state.isExcludeSubtreesOpen}
-                                    aria-labelledby="typeAhead-exclude-subtrees"
-                                    placeholderText={_("Type a subtree DN...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
-                                    onCreateOption={this.handleExcludeSubtreesCreateOption}
+                                    onToggle={this.handleExcludeSubtreesToggle}
+                                    placeholder={_("Type a subtree DN...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an exclude subtree DN"
                                     validated={this.state.error.excludeSubtrees ? "error" : "default"}
-                                >
-                                    {[""].map((dn, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={dn}
-                                        />
-                                    ))}
-                                </Select>
+                                    isMulti={true}
+                                    isCreatable={true}
+                                    onCreateOption={this.handleExcludeSubtreesCreateOption}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Verifies that the value of the attribute set in uniqueness-attribute-name is unique in this subtree (uniqueness-top-entry-oc)")}>

--- a/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
@@ -15,11 +15,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import {
     ArrowRightIcon,
 } from '@patternfly/react-icons';
@@ -101,22 +97,9 @@ class AutoMembership extends React.Component {
         ));
 
         this.handleRegexExcludeSelect = (event, selection) => {
-            const { regexExclusive } = this.state;
-            if (regexExclusive.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        regexExclusive: prevState.regexExclusive.filter(item => item !== selection),
-                        isRegexExcludeOpen: false
-                    }), () => { this.validateRegex() }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        regexExclusive: [...prevState.regexExclusive, selection],
-                        isRegexExcludeOpen: false,
-                    }), () => { this.validateRegex() }
-                );
-            }
+            this.setState({
+                regexExclusive: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateRegex() });
         };
         this.handleCreateRegexExcludeOption = newValue => {
             if (!this.state.excludeOptions.includes(newValue)) {
@@ -139,22 +122,9 @@ class AutoMembership extends React.Component {
         };
 
         this.handleRegexIncludeSelect = (event, selection) => {
-            const { regexInclusive } = this.state;
-            if (regexInclusive.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        regexInclusive: prevState.regexInclusive.filter(item => item !== selection),
-                        isRegexIncludeOpen: false
-                    }), () => { this.validateRegex() }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        regexInclusive: [...prevState.regexInclusive, selection],
-                        isRegexIncludeOpen: false
-                    }), () => { this.validateRegex() }
-                );
-            }
+            this.setState({
+                regexInclusive: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateRegex() });
         };
         this.handleCreateRegexIncludeOption = newValue => {
             if (!this.state.includeOptions.includes(newValue)) {
@@ -1280,26 +1250,19 @@ class AutoMembership extends React.Component {
                                 {_("Exclusive Regex")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a regex"
-                                    onToggle={(event, isOpen) => this.handleRegexExcludeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={regexExclusive}
                                     onSelect={this.handleRegexExcludeSelect}
                                     onClear={this.handleClearRegexExcludeSelection}
-                                    selections={regexExclusive}
+                                    options={[]}
                                     isOpen={this.state.isRegexExcludeOpen}
-                                    aria-labelledby="typeAhead-excl-regex"
-                                    placeholderText={_("Type a regex...")}
-                                    isCreatable
+                                    onToggle={this.handleRegexExcludeToggle}
+                                    placeholder={_("Type a regex...")}
+                                    ariaLabel="Type a regex"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleCreateRegexExcludeOption}
-                                >
-                                    {[].map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets a single regular expression to use to identify entries to exclude (autoMemberExclusiveRegex)")}>
@@ -1307,26 +1270,19 @@ class AutoMembership extends React.Component {
                                 {_("Inclusive Regex")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a regex"
-                                    onToggle={(event, isOpen) => this.handleRegexIncludeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={regexInclusive}
                                     onSelect={this.handleRegexIncludeSelect}
                                     onClear={this.handleClearRegexIncludeSelection}
-                                    selections={regexInclusive}
+                                    options={[]}
                                     isOpen={this.state.isRegexIncludeOpen}
-                                    aria-labelledby="typeAhead-incl-regex"
-                                    placeholderText={_("Type a regex...")}
-                                    isCreatable
+                                    onToggle={this.handleRegexIncludeToggle}
+                                    placeholder={_("Type a regex...")}
+                                    ariaLabel="Type a regex"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleCreateRegexIncludeOption}
-                                >
-                                    {[].map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets which group to add the entry to as a member, if it meets the regular expression conditions (autoMemberTargetGroup)")}>

--- a/src/cockpit/389-console/src/lib/plugins/dna.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/dna.jsx
@@ -21,11 +21,7 @@ import {
 	Tooltip,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { DNATable, DNASharedTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
@@ -104,22 +100,9 @@ class DNAPlugin extends React.Component {
         };
 
         this.handleSelect = (event, selection) => {
-            const { selected } = this.state;
-            if (selected.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        selected: prevState.selected.filter(item => item !== selection),
-                        isOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        selected: [...prevState.selected, selection],
-                        isOpen: false,
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                selected: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
 
         this.maxValue = 20000000;
@@ -1089,25 +1072,18 @@ class DNAPlugin extends React.Component {
                                         {_("DNA Managed Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type an attribute"
-                                            onToggle={(event, isOpen) => this.handleToggle(event, isOpen)}
+                                        <TypeaheadSelect
+                                            selected={selected}
                                             onSelect={this.handleSelect}
                                             onClear={this.handleClearSelection}
-                                            selections={selected}
+                                            options={this.props.attributes}
                                             isOpen={this.state.isOpen}
-                                            aria-labelledby="typeAhead-1"
-                                            placeholderText={_("Type an attribute...")}
+                                            onToggle={this.handleToggle}
+                                            placeholder={_("Type an attribute...")}
+                                            ariaLabel="Type an attribute"
                                             validated={selected.length === 0 ? 'error' : 'default'}
-                                        >
-                                            {this.props.attributes.map((attr) => (
-                                                <SelectOption
-                                                    key={attr}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                                 <Grid title={_("Sets an LDAP filter to use to search for and identify the entries to which to apply the distributed numeric assignment range (dnaFilter)")}>

--- a/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
@@ -10,11 +10,7 @@ import {
 	TextInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { LinkedAttributesTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
@@ -58,21 +54,9 @@ class LinkedAttributes extends React.Component {
 
         // Link Type
         this.handleLinkTypeSelect = (event, selection) => {
-            if (this.state.linkType.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        linkType: prevState.linkType.filter((item) => item !== selection),
-                        isLinkTypeOpen: false
-                    }), () => { this.validate() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        linkType: [...prevState.linkType, selection],
-                        isLinkTypeOpen: false
-                    }), () => { this.validate() }
-                );
-            }
+            this.setState({
+                linkType: selection ? [selection] : [],
+            }, () => { this.validate() });
         };
         this.handleLinkTypeToggle = (_event, isLinkTypeOpen) => {
             this.setState({
@@ -88,21 +72,9 @@ class LinkedAttributes extends React.Component {
 
         // Managed Type
         this.handleManagedTypeSelect = (event, selection) => {
-            if (this.state.managedType.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        managedType: prevState.managedType.filter((item) => item !== selection),
-                        isManagedTypeOpen: false
-                    }), () => { this.validate() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        managedType: [...prevState.managedType, selection],
-                        isManagedTypeOpen: false
-                    }), () => { this.validate() }
-                );
-            }
+            this.setState({
+                managedType: selection ? [selection] : [],
+            }, () => { this.validate() });
         };
         this.handleManagedTypeToggle = (_event, isManagedTypeOpen) => {
             this.setState({
@@ -490,25 +462,17 @@ class LinkedAttributes extends React.Component {
                                 {_("Link Type")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type an attribute name"
-                                    onToggle={(event, isOpen) => this.handleLinkTypeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={linkType.length > 0 ? linkType[0] : ''}
                                     onSelect={this.handleLinkTypeSelect}
                                     onClear={this.handleLinkTypeClear}
-                                    selections={linkType}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isLinkTypeOpen}
-                                    aria-labelledby="typeAhead-link-type"
-                                    placeholderText={_("Type an attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleLinkTypeToggle}
+                                    placeholder={_("Type an attribute...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute name"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets the attribute that is created dynamically by the plugin (managedType)")}>
@@ -516,25 +480,17 @@ class LinkedAttributes extends React.Component {
                                 {_("Managed Type")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type an attribute name"
-                                    onToggle={(event, isOpen) => this.handleManagedTypeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={managedType.length > 0 ? managedType[0] : ''}
                                     onSelect={this.handleManagedTypeSelect}
                                     onClear={this.handleManagedTypeClear}
-                                    selections={managedType}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isManagedTypeOpen}
-                                    placeholderText={_("Type an attribute...")}
-                                    aria-labelledby="typeAhead-managed-type"
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleManagedTypeToggle}
+                                    placeholder={_("Type an attribute...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute name"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets the base DN that restricts the plugin to a specific part of the directory tree (linkScope)")}>

--- a/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
@@ -24,11 +24,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import {
     ExclamationCircleIcon,
 } from '@patternfly/react-icons';
@@ -1189,24 +1185,16 @@ class ManagedEntries extends React.Component {
                             title={_("DN of the template entry")}
                             isRequired
                         >
-                            <Select
-                                variant={SelectVariant.typeahead}
-                                typeAheadAriaLabel="Type an attribute"
-                                onToggle={(event, isOpen) => this.handleRDNToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                selected={templateRDNAttr}
                                 onSelect={this.handleRDNSelect}
                                 onClear={this.handleClearRDNSelection}
-                                selections={templateRDNAttr}
+                                options={attributes}
                                 isOpen={this.state.isRDNOpen}
-                                aria-labelledby="typeAhead-rdn"
-                                placeholderText={_("Type an attribute...")}
-                            >
-                                {attributes.map((attr) => (
-                                    <SelectOption
-                                        key={attr}
-                                        value={attr}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={this.handleRDNToggle}
+                                placeholder={_("Type an attribute...")}
+                                ariaLabel="Type an attribute"
+                            />
                         </FormGroup>
                     </Form>
                     <Form className="ds-margin-top-lg" autoComplete="off">
@@ -1323,24 +1311,16 @@ class ManagedEntries extends React.Component {
                             fieldId="staticAttr"
                             title={_("The attribute that is set in the managed entry")}
                         >
-                            <Select
-                                variant={SelectVariant.typeahead}
-                                typeAheadAriaLabel="Type an attribute"
-                                onToggle={(event, isOpen) => this.handleStaticToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                selected={this.state.staticAttr}
                                 onSelect={this.handleStaticSelect}
                                 onClear={this.handleClearStaticSelection}
-                                selections={this.state.staticAttr}
+                                options={attributes}
                                 isOpen={this.state.isStaticOpen}
-                                aria-labelledby="typeAhead-static"
-                                placeholderText={_("Type an attribute...")}
-                            >
-                                {attributes.map((attr) => (
-                                    <SelectOption
-                                        key={attr}
-                                        value={attr}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={this.handleStaticToggle}
+                                placeholder={_("Type an attribute...")}
+                                ariaLabel="Type an attribute"
+                            />
                         </FormGroup>
                         <FormGroup
                             className="ds-margin-top-lg"
@@ -1388,24 +1368,16 @@ class ManagedEntries extends React.Component {
                             fieldId="mappedAttr"
                             title={_("The attribute that is set in the managed entry")}
                         >
-                            <Select
-                                variant={SelectVariant.typeahead}
-                                typeAheadAriaLabel="Type an attribute"
-                                onToggle={(event, isOpen) => this.handleMappedToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                selected={this.state.mappedAttr}
                                 onSelect={this.handleMappedSelect}
                                 onClear={this.handleClearMappedSelection}
-                                selections={this.state.mappedAttr}
+                                options={attributes}
                                 isOpen={this.state.isMappedOpen}
-                                aria-labelledby="typeAhead-static"
-                                placeholderText={_("Type an attribute...")}
-                            >
-                                {attributes.map((attr) => (
-                                    <SelectOption
-                                        key={attr}
-                                        value={attr}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={this.handleMappedToggle}
+                                placeholder={_("Type an attribute...")}
+                                ariaLabel="Type an attribute"
+                            />
                         </FormGroup>
                         <FormGroup
                             label={_("Mapped Value")}

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -17,11 +17,6 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
@@ -143,21 +138,9 @@ class MemberOf extends React.Component {
 
         // Config Group Attribute
         this.handleConfigGroupAttrSelect = (event, selection) => {
-            if (this.state.configGroupAttr.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        configGroupAttr: prevState.configGroupAttr.filter((item) => item !== selection),
-                        isConfigGroupAttrOpen: false
-                    }), () => { this.validateModal() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        configGroupAttr: [...prevState.configGroupAttr, selection],
-                        isConfigGroupAttrOpen: false
-                    }), () => { this.validateModal() }
-                );
-            }
+            this.setState({
+                configGroupAttr: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateModal() });
         };
         this.handleConfigGroupAttrToggle = (_event, isConfigGroupAttrOpen) => {
             this.setState({
@@ -173,14 +156,9 @@ class MemberOf extends React.Component {
 
         // MemberOf Attribute
         this.handleMemberOfAttrSelect = (event, selection) => {
-            if (selection === this.state.configAttr) {
-                this.handleMemberOfAttrClear();
-            } else {
-                this.setState({
-                    memberOfAttr: selection,
-                    isMemberOfAttrOpen: false
-                }, () => { this.validateModal() });
-            }
+            this.setState({
+                memberOfAttr: selection || '',
+            }, () => { this.validateConfig() });
         };
         this.handleMemberOfAttrToggle = (_event, isMemberOfAttrOpen) => {
             this.setState({
@@ -189,28 +167,15 @@ class MemberOf extends React.Component {
         };
         this.handleMemberOfAttrClear = () => {
             this.setState({
-                memberOfAttr: [],
-                isMemberOfAttrOpen: false
+                memberOfAttr: '',
             }, () => { this.validateConfig() });
         };
 
         // MemberOf Group Attribute
         this.handleMemberOfGroupAttrSelect = (event, selection) => {
-            if (this.state.memberOfGroupAttr.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        memberOfGroupAttr: prevState.memberOfGroupAttr.filter((item) => item !== selection),
-                        isMemberOfGroupAttrOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        memberOfGroupAttr: [...prevState.memberOfGroupAttr, selection],
-                        isMemberOfGroupAttrOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                memberOfGroupAttr: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleMemberOfGroupAttrToggle = (_event, isMemberOfGroupAttrOpen) => {
             this.setState({
@@ -220,31 +185,14 @@ class MemberOf extends React.Component {
         this.handleMemberOfGroupAttrClear = () => {
             this.setState({
                 memberOfGroupAttr: [],
-                isMemberOfGroupAttrOpen: false
             }, () => { this.validateConfig() });
         };
 
         // Handle scope subtree
         this.handleSubtreeScopeSelect = (event, selection) => {
-            if (!selection.trim() || !valid_dn(selection)) {
-                this.setState({isSubtreeScopeOpen: false});
-                return;
-            }
-            if (this.state.memberOfEntryScope.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        memberOfEntryScope: prevState.memberOfEntryScope.filter((item) => item !== selection),
-                        isSubtreeScopeOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        memberOfEntryScope: [...prevState.memberOfEntryScope, selection],
-                        isSubtreeScopeOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                memberOfEntryScope: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleSubtreeScopeToggle = (_event, isSubtreeScopeOpen) => {
             this.setState({
@@ -254,39 +202,21 @@ class MemberOf extends React.Component {
         this.handleSubtreeScopeClear = () => {
             this.setState({
                 memberOfEntryScope: [],
-                isSubtreeScopeOpen: false
             }, () => { this.validateConfig() });
         };
         this.handleSubtreeScopeCreateOption = newValue => {
             if (newValue.trim() && valid_dn(newValue) && !this.state.memberOfEntryScopeOptions.includes(newValue)) {
                 this.setState({
                     memberOfEntryScopeOptions: [...this.state.memberOfEntryScopeOptions, newValue],
-                    isSubtreeScopeOpen: false
                 }, () => { this.validateConfig() });
             }
         };
 
         // Handle Exclude Scope subtree
         this.handleExcludeScopeSelect = (event, selection) => {
-            if (!selection.trim() || !valid_dn(selection)) {
-                this.setState({isExcludeScopeOpen: false});
-                return;
-            }
-            if (this.state.memberOfEntryScopeExcludeSubtree.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        memberOfEntryScopeExcludeSubtree: prevState.memberOfEntryScopeExcludeSubtree.filter((item) => item !== selection),
-                        isExcludeScopeOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        memberOfEntryScopeExcludeSubtree: [...prevState.memberOfEntryScopeExcludeSubtree, selection],
-                        isExcludeScopeOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                memberOfEntryScopeExcludeSubtree: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleExcludeScopeToggle = (_event, isExcludeScopeOpen) => {
             this.setState({
@@ -296,14 +226,12 @@ class MemberOf extends React.Component {
         this.handleExcludeScopeClear = () => {
             this.setState({
                 memberOfEntryScopeExcludeSubtree: [],
-                isExcludeScopeOpen: false
             }, () => { this.validateConfig() });
         };
         this.handleExcludeCreateOption = newValue => {
-            if (newValue.trim() && valid_dn(newValue) && !this.state.memberOfEntryScopeOptions.includes(newValue)) {
+            if (newValue.trim() && valid_dn(newValue) && !this.state.memberOfEntryScopeExcludeOptions.includes(newValue)) {
                 this.setState({
                     memberOfEntryScopeExcludeOptions: [...this.state.memberOfEntryScopeExcludeOptions, newValue],
-                    isExcludeScopeOpen: false
                 }, () => { this.validateConfig() });
             }
         };
@@ -311,25 +239,9 @@ class MemberOf extends React.Component {
         // Modal scope and exclude Scope
         // Handle scope subtree
         this.handleConfigScopeSelect = (event, selection) => {
-            if (selection.trim() === "" || !valid_dn(selection)) {
-                this.setState({isConfigSubtreeScopeOpen: false});
-                return;
-            }
-            if (this.state.configEntryScope.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        configEntryScope: prevState.configEntryScope.filter((item) => item !== selection),
-                        isConfigSubtreeScopeOpen: false
-                    }), () => { this.validateModal() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        configEntryScope: [...prevState.configEntryScope, selection],
-                        isConfigSubtreeScopeOpen: false
-                    }), () => { this.validateModal() }
-                );
-            }
+            this.setState({
+                configEntryScope: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateModal() });
         };
         this.handleConfigScopeToggle = (_event, isConfigSubtreeScopeOpen) => {
             this.setState({
@@ -339,39 +251,21 @@ class MemberOf extends React.Component {
         this.handleConfigScopeClear = () => {
             this.setState({
                 configEntryScope: [],
-                isConfigSubtreeScopeOpen: false
             }, () => { this.validateModal() });
         };
         this.handleConfigCreateOption = newValue => {
             if (newValue.trim() && valid_dn(newValue) && !this.state.configEntryScopeOptions.includes(newValue)) {
                 this.setState({
                     configEntryScopeOptions: [...this.state.configEntryScopeOptions, newValue],
-                    isConfigSubtreeScopeOpen: false
                 }, () => { this.validateModal() });
             }
         };
 
         // Handle Exclude Scope subtree
         this.handleConfigExcludeScopeSelect = (event, selection) => {
-            if (selection.trim() === "" || !valid_dn(selection)) {
-                this.setState({isConfigExcludeScopeOpen: false});
-                return;
-            }
-            if (this.state.configEntryScopeExcludeSubtree.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        configEntryScopeExcludeSubtree: prevState.configEntryScopeExcludeSubtree.filter((item) => item !== selection),
-                        isConfigExcludeScopeOpen: false
-                    }), () => { this.validateModal() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        configEntryScopeExcludeSubtree: [...prevState.configEntryScopeExcludeSubtree, selection],
-                        isConfigExcludeScopeOpen: false
-                    }), () => { this.validateModal() }
-                );
-            }
+            this.setState({
+                configEntryScopeExcludeSubtree: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateModal() });
         };
         this.handleConfigExcludeScopeToggle = (_event, isConfigExcludeScopeOpen) => {
             this.setState({
@@ -381,14 +275,12 @@ class MemberOf extends React.Component {
         this.handleConfigExcludeScopeClear = () => {
             this.setState({
                 configEntryScopeExcludeSubtree: [],
-                isConfigExcludeScopeOpen: false
             }, () => { this.validateModal() });
         };
         this.handleConfigExcludeCreateOption = newValue => {
             if (newValue.trim() && valid_dn(newValue) &&  !this.state.configEntryScopeExcludeOptions.includes(newValue)) {
                 this.setState({
                     configEntryScopeExcludeOptions: [...this.state.configEntryScopeExcludeOptions, newValue],
-                    isConfigExcludeScopeOpen: false
                 }, () => { this.validateModal() });
             }
         };
@@ -1326,9 +1218,7 @@ class MemberOf extends React.Component {
                             <GridItem span={9}>
                                 <TypeaheadSelect
                                     selected={configAttr}
-                                    onSelect={(event, value) => {
-                                        this.setState({ configAttr: typeof value === 'string' ? value : '' }, () => { this.validateModal(); });
-                                    }}
+                                    onSelect={this.handleConfigAttrSelect}
                                     onClear={this.handleConfigAttrClear}
                                     options={["memberOf"]}
                                     placeholder={_("Type a member attribute...")}
@@ -1347,9 +1237,7 @@ class MemberOf extends React.Component {
                                     isMulti
                                     hasCheckbox
                                     selected={configGroupAttr}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ configGroupAttr: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
-                                    }}
+                                    onSelect={this.handleConfigGroupAttrSelect}
                                     onClear={this.handleConfigGroupAttrClear}
                                     options={["member", "memberCertificate", "uniqueMember"]}
                                     placeholder={_("Type a member group attribute...")}
@@ -1367,9 +1255,7 @@ class MemberOf extends React.Component {
                                 <TypeaheadSelect
                                     isMulti
                                     selected={configEntryScope}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ configEntryScope: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
-                                    }}
+                                    onSelect={this.handleConfigScopeSelect}
                                     onClear={this.handleConfigScopeClear}
                                     options={this.state.configEntryScopeOptions}
                                     isCreatable
@@ -1404,9 +1290,7 @@ class MemberOf extends React.Component {
                                 <TypeaheadSelect
                                     isMulti
                                     selected={configEntryScopeExcludeSubtree}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ configEntryScopeExcludeSubtree: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateModal(); });
-                                    }}
+                                    onSelect={this.handleConfigExcludeScopeSelect}
                                     onClear={this.handleConfigExcludeScopeClear}
                                     options={this.state.configEntryScopeExcludeOptions}
                                     isCreatable
@@ -1472,9 +1356,7 @@ class MemberOf extends React.Component {
                             <GridItem span={8}>
                                 <TypeaheadSelect
                                     selected={memberOfAttr}
-                                    onSelect={(event, value) => {
-                                        this.setState({ memberOfAttr: typeof value === 'string' ? value : '' }, () => { this.validateConfig(); });
-                                    }}
+                                    onSelect={this.handleMemberOfAttrSelect}
                                     onClear={this.handleMemberOfAttrClear}
                                     options={["memberOf"]}
                                     placeholder={_("Type a member attribute...")}
@@ -1493,9 +1375,7 @@ class MemberOf extends React.Component {
                                     isMulti
                                     hasCheckbox
                                     selected={memberOfGroupAttr}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ memberOfGroupAttr: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
-                                    }}
+                                    onSelect={this.handleMemberOfGroupAttrSelect}
                                     onClear={this.handleMemberOfGroupAttrClear}
                                     options={["member", "memberCertificate", "uniqueMember"]}
                                     placeholder={_("Type a member group attribute...")}
@@ -1513,9 +1393,7 @@ class MemberOf extends React.Component {
                                 <TypeaheadSelect
                                     isMulti
                                     selected={memberOfEntryScope}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ memberOfEntryScope: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
-                                    }}
+                                    onSelect={this.handleSubtreeScopeSelect}
                                     onClear={this.handleSubtreeScopeClear}
                                     options={this.state.memberOfEntryScopeOptions}
                                     isCreatable
@@ -1550,9 +1428,7 @@ class MemberOf extends React.Component {
                                 <TypeaheadSelect
                                     isMulti
                                     selected={memberOfEntryScopeExcludeSubtree}
-                                    onSelect={(event, newSelections) => {
-                                        this.setState({ memberOfEntryScopeExcludeSubtree: Array.isArray(newSelections) ? newSelections : [] }, () => { this.validateConfig(); });
-                                    }}
+                                    onSelect={this.handleExcludeScopeSelect}
                                     onClear={this.handleExcludeScopeClear}
                                     options={this.state.memberOfEntryScopeExcludeOptions}
                                     isCreatable

--- a/src/cockpit/389-console/src/lib/plugins/pamPassThru.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pamPassThru.jsx
@@ -13,11 +13,7 @@ import {
 	TextInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { PassthroughAuthConfigsTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
@@ -80,21 +76,9 @@ class PAMPassthroughAuthentication extends React.Component {
             }, () => { this.validatePAM() });
         };
         this.handleExcludeSelect = (event, selection) => {
-            if (this.state.pamExcludeSuffix.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        pamExcludeSuffix: prevState.pamExcludeSuffix.filter(item => item !== selection),
-                        isExcludeOpen: false
-                    }), () => { this.validatePAM() }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        pamExcludeSuffix: [...prevState.pamExcludeSuffix, selection],
-                        isExcludeOpen: false
-                    }), () => { this.validatePAM() }
-                );
-            }
+            this.setState({
+                pamExcludeSuffix: Array.isArray(selection) ? selection : [],
+            }, () => { this.validatePAM() });
         };
         this.handleCreateExcludeOption = newValue => {
             if (!this.state.excludeOptions.includes(newValue)) {
@@ -117,21 +101,9 @@ class PAMPassthroughAuthentication extends React.Component {
             }, () => { this.validatePAM() });
         };
         this.handleIncludeSelect = (event, selection) => {
-            if (this.state.pamIncludeSuffix.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        pamIncludeSuffix: prevState.pamIncludeSuffix.filter(item => item !== selection),
-                        isIncludeOpen: false
-                    })
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        pamIncludeSuffix: [...prevState.pamIncludeSuffix, selection],
-                        isIncludeOpen: false
-                    })
-                );
-            }
+            this.setState({
+                pamIncludeSuffix: Array.isArray(selection) ? selection : [],
+            });
         };
         this.handleCreateIncludeOption = newValue => {
             if (!this.state.includeOptions.includes(newValue)) {
@@ -705,26 +677,19 @@ class PAMPassthroughAuthentication extends React.Component {
                                 {_("Exclude Suffix")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    isCreatable
-                                    onCreateOption={this.handleCreateExcludeOption}
-                                    typeAheadAriaLabel="Add a suffix"
-                                    onToggle={(event, isOpen) => this.handleExcludeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={pamExcludeSuffix}
                                     onSelect={this.handleExcludeSelect}
                                     onClear={this.handleClearExcludeSelection}
-                                    selections={pamExcludeSuffix}
+                                    options={this.state.excludeOptions}
                                     isOpen={this.state.isExcludeOpen}
-                                    aria-labelledby="Add a suffix"
-                                    placeholderText={_("Type a suffix DN ...")}
-                                >
-                                    {this.state.excludeOptions.map((suffix, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={suffix}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleExcludeToggle}
+                                    placeholder={_("Type a suffix DN ...")}
+                                    ariaLabel="Add a suffix"
+                                    isMulti={true}
+                                    isCreatable={true}
+                                    onCreateOption={this.handleCreateExcludeOption}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid>
@@ -736,26 +701,19 @@ class PAMPassthroughAuthentication extends React.Component {
                                 {_("Include Suffix")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    isCreatable
-                                    onCreateOption={this.handleCreateIncludeOption}
-                                    typeAheadAriaLabel="Add an include suffix"
-                                    onToggle={(event, isOpen) => this.handleIncludeToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={pamIncludeSuffix}
                                     onSelect={this.handleIncludeSelect}
                                     onClear={this.handleClearIncludeSelection}
-                                    selections={pamIncludeSuffix}
+                                    options={this.state.includeOptions}
                                     isOpen={this.state.isIncludeOpen}
-                                    aria-labelledby="Add an include suffix"
-                                    placeholderText={_("Type a suffix DN ...")}
-                                >
-                                    {this.state.includeOptions.map((suffix, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={suffix}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleIncludeToggle}
+                                    placeholder={_("Type a suffix DN ...")}
+                                    ariaLabel="Add an include suffix"
+                                    isMulti={true}
+                                    isCreatable={true}
+                                    onCreateOption={this.handleCreateIncludeOption}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid>

--- a/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
@@ -12,11 +12,7 @@ import {
 	NumberInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { listsEqual, log_cmd, valid_dn, file_is_path } from "../tools.jsx";
@@ -94,21 +90,9 @@ class ReferentialIntegrity extends React.Component {
 
         // Config Membership Attribute
         this.handleConfigMembershipAttrSelect = (event, selection) => {
-            if (this.state.configMembershipAttr.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        configMembershipAttr: prevState.configMembershipAttr.filter((item) => item !== selection),
-                        isConfigMembershipAttrOpen: false
-                    }), () => { this.validateModal() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        configMembershipAttr: [...prevState.configMembershipAttr, selection],
-                        isConfigMembershipAttrOpen: false
-                    }), () => { this.validateModal() }
-                );
-            }
+            this.setState({
+                configMembershipAttr: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateModal() });
         };
         this.handleConfigMembershipAttrToggle = (_event, isConfigMembershipAttrOpen) => {
             this.setState({
@@ -124,22 +108,9 @@ class ReferentialIntegrity extends React.Component {
 
         // Membership Attribute
         this.handleMembershipAttrSelect = (event, selection) => {
-            if (this.state.membershipAttr.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        membershipAttr: prevState.membershipAttr.filter((item) => item !== selection),
-                        isMembershipAttrOpen: false
-                    }), () => { this.validateConfig() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        membershipAttr: [...prevState.membershipAttr, selection],
-                        isMembershipAttrOpen: false
-                    }),
-                    () => { this.validateConfig() }
-                );
-            }
+            this.setState({
+                membershipAttr: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateConfig() });
         };
         this.handleMembershipAttrToggle = (_event, isMembershipAttrOpen) => {
             this.setState({
@@ -883,26 +854,19 @@ class ReferentialIntegrity extends React.Component {
                                 {_("Membership Attribute")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute"
-                                    onToggle={(event, isOpen) => this.handleConfigMembershipAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={configMembershipAttr}
                                     onSelect={this.handleConfigMembershipAttrSelect}
                                     onClear={this.handleConfigMembershipAttrClear}
-                                    selections={configMembershipAttr}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isConfigMembershipAttrOpen}
-                                    aria-labelledby="typeAhead-config-membership-attr"
-                                    placeholderText={_("Type an attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    onToggle={this.handleConfigMembershipAttrToggle}
+                                    placeholder={_("Type an attribute...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute"
                                     validated={errorModal.configMembershipAttr ? 'error' : 'default'}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    isMulti={true}
+                                />
                                 <FormHelperText  >
                                     {_("At least one attribute must be specified")}
                                 </FormHelperText>
@@ -1030,26 +994,19 @@ class ReferentialIntegrity extends React.Component {
                                 {_("Membership Attribute")}
                             </GridItem>
                             <GridItem span={8}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute"
-                                    onToggle={(event, isOpen) => this.handleMembershipAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={membershipAttr}
                                     onSelect={this.handleMembershipAttrSelect}
                                     onClear={this.handleMembershipAttrClear}
-                                    selections={membershipAttr}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isMembershipAttrOpen}
-                                    aria-labelledby="typeAhead-membership-attr"
-                                    placeholderText={_("Type an attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
+                                    onToggle={this.handleMembershipAttrToggle}
+                                    placeholder={_("Type an attribute...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute"
                                     validated={error.membershipAttr ? 'error' : 'default'}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    isMulti={true}
+                                />
                                 <FormHelperText  >
                                     {_("At least one attribute needs to be specified")}
                                 </FormHelperText>

--- a/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
@@ -12,11 +12,7 @@ import {
 	NumberInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
@@ -101,21 +97,9 @@ class RetroChangelog extends React.Component {
         };
 
         this.handleExcludeAttrSelect = (event, selection) => {
-            if (this.state.excludeAttrs.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        excludeAttrs: prevState.excludeAttrs.filter((item) => item !== selection),
-                        isExcludeAttrOpen: false
-                    }), () => { this.validate() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        excludeAttrs: [...prevState.excludeAttrs, selection],
-                        isExcludeAttrOpen: false
-                    }), () => { this.validate() }
-                );
-            }
+            this.setState({
+                excludeAttrs: Array.isArray(selection) ? selection : [],
+            }, () => { this.validate() });
         };
         this.handleExcludeAttrToggle = (_event, isExcludeAttrOpen) => {
             this.setState({
@@ -130,21 +114,9 @@ class RetroChangelog extends React.Component {
         };
 
         this.handleExcludeSuffixSelect = (event, selection) => {
-            if (this.state.excludeSuffix.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        excludeSuffix: prevState.excludeSuffix.filter((item) => item !== selection),
-                        isExcludeSuffixOpen: false
-                    }), () => { this.validate() }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        excludeSuffix: [...prevState.excludeSuffix, selection],
-                        isExcludeSuffixOpen: false
-                    }), () => { this.validate() }
-                );
-            }
+            this.setState({
+                excludeSuffix: Array.isArray(selection) ? selection : [],
+            }, () => { this.validate() });
         };
         this.handleExcludeSuffixToggle = (_event, isExcludeSuffixOpen) => {
             this.setState({
@@ -381,28 +353,21 @@ class RetroChangelog extends React.Component {
                                 {_("Exclude Suffix")}
                             </GridItem>
                             <GridItem span={5}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a suffix"
-                                    onToggle={(event, isOpen) => this.handleExcludeSuffixToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={excludeSuffix}
                                     onSelect={this.handleExcludeSuffixSelect}
                                     onClear={this.handleExcludeSuffixClear}
-                                    selections={excludeSuffix}
+                                    options={[""]}
                                     isOpen={this.state.isExcludeSuffixOpen}
-                                    aria-labelledby="typeAhead-config-exclude-suffix"
-                                    placeholderText={_("Type a suffix...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={this.handleExcludeSuffixToggle}
+                                    placeholder={_("Type a suffix...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a suffix"
+                                    validated={error.excludeSuffix ? "error" : "default"}
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleOnExcludeSuffixCreateOption}
-                                    validated={error.excludeSuffix ? ValidatedOptions.error : ValidatedOptions.default}
-                                >
-                                    {[""].map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                                 <FormHelperText  >
                                     {_("Values must be valid DN !")}
                                 </FormHelperText>
@@ -422,26 +387,19 @@ class RetroChangelog extends React.Component {
                                 {_("Exclude attribute")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute"
-                                    onToggle={(event, isOpen) => this.handleExcludeAttrToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={excludeAttrs}
                                     onSelect={this.handleExcludeAttrSelect}
                                     onClear={this.handleExcludeAttrClear}
-                                    selections={excludeAttrs}
+                                    options={this.props.attributes}
                                     isOpen={this.state.isExcludeAttrOpen}
-                                    aria-labelledby="typeAhead-config-exclude-attr"
-                                    placeholderText={_("Type an attribute...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    validated={error.excludeAttrs ? ValidatedOptions.error : ValidatedOptions.default}
-                                >
-                                    {this.props.attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleExcludeAttrToggle}
+                                    placeholder={_("Type an attribute...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute"
+                                    validated={error.excludeAttrs ? "error" : "default"}
+                                    isMulti={true}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Specifies the maximum age of any entry in the changelog before it is trimmed from the database (nsslapd-changelogmaxage)")}>

--- a/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
@@ -9,11 +9,7 @@ import {
 	GridItem,
 	TimePicker
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { log_cmd, listsEqual } from "../tools.jsx";
@@ -82,21 +78,9 @@ class RootDNAccessControl extends React.Component {
 
         // Allow Host
         this.handleAllowHostSelect = (event, selection) => {
-            if (this.state.allowHost.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        allowHost: prevState.allowHost.filter((item) => item !== selection),
-                        isAllowHostOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        allowHost: [...prevState.allowHost, selection],
-                        isAllowHostOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                allowHost: Array.isArray(selection) ? selection : [],
+            });
         };
         this.handleAllowHostToggle = (_event, isAllowHostOpen) => {
             this.setState({
@@ -120,21 +104,9 @@ class RootDNAccessControl extends React.Component {
 
         // Deny Host
         this.handleDenyHostSelect = (event, selection) => {
-            if (this.state.denyHost.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        denyHost: prevState.denyHost.filter((item) => item !== selection),
-                        isDenyHostOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        denyHost: [...prevState.denyHost, selection],
-                        isDenyHostOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                denyHost: Array.isArray(selection) ? selection : [],
+            });
         };
         this.handleDenyHostToggle = (_event, isDenyHostOpen) => {
             this.setState({
@@ -158,21 +130,9 @@ class RootDNAccessControl extends React.Component {
 
         // Allow IP Adddress
         this.handleAllowIPSelect = (event, selection) => {
-            if (this.state.allowIP.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        allowIP: prevState.allowIP.filter((item) => item !== selection),
-                        isAllowIPOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        allowIP: [...prevState.allowIP, selection],
-                        isAllowIPOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                allowIP: Array.isArray(selection) ? selection : [],
+            });
         };
         this.handleAllowIPToggle = (_event, isAllowIPOpen) => {
             this.setState({
@@ -196,21 +156,9 @@ class RootDNAccessControl extends React.Component {
 
         // Deny IP Adddress
         this.handleDenyIPSelect = (event, selection) => {
-            if (this.state.denyIP.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        denyIP: prevState.denyIP.filter((item) => item !== selection),
-                        isDenyIPOpen: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        denyIP: [...prevState.denyIP, selection],
-                        isDenyIPOpen: false
-                    }),
-                );
-            }
+            this.setState({
+                denyIP: Array.isArray(selection) ? selection : [],
+            });
         };
         this.handleDenyIPToggle = (_event, isDenyIPOpen) => {
             this.setState({
@@ -519,27 +467,20 @@ class RootDNAccessControl extends React.Component {
                                 {_("Allow Host")}
                             </GridItem>
                             <GridItem span={10}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a hostname "
-                                    onToggle={(event, isOpen) => this.handleAllowHostToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={allowHost}
                                     onSelect={this.handleAllowHostSelect}
                                     onClear={this.handleAllowHostClear}
-                                    selections={allowHost}
+                                    options={this.state.allowHostOptions}
                                     isOpen={this.state.isAllowHostOpen}
-                                    aria-labelledby="typeAhead-allow-host"
-                                    placeholderText={_("Type a hostname ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={this.handleAllowHostToggle}
+                                    placeholder={_("Type a hostname ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a hostname "
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleAllowHostCreateOption}
-                                >
-                                    {this.state.allowHostOptions.map((host, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={host}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets what hosts, by fully-qualified domain name, the root user is not allowed to use to access the Directory Server.  Wildcards are accepted.  Any hosts not listed are implicitly allowed (rootdn-deny-host). If a host address is listed in both the rootdn-allow-host and rootdn-deny-host attributes, it is denied access.")}>
@@ -547,27 +488,20 @@ class RootDNAccessControl extends React.Component {
                                 {_("Deny Host")}
                             </GridItem>
                             <GridItem span={10}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type a hostname "
-                                    onToggle={(event, isOpen) => this.handleDenyHostToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={denyHost}
                                     onSelect={this.handleDenyHostSelect}
                                     onClear={this.handleDenyHostClear}
-                                    selections={denyHost}
+                                    options={this.state.denyHostOptions}
                                     isOpen={this.state.isDenyHostOpen}
-                                    aria-labelledby="typeAhead-deny-host"
-                                    placeholderText={_("Type a hostname ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={this.handleDenyHostToggle}
+                                    placeholder={_("Type a hostname ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type a hostname "
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleDenyHostCreateOption}
-                                >
-                                    {this.state.denyHostOptions.map((host, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={host}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets what IP addresses, either IPv4 or IPv6, for machines the root user is allowed to use to access the Directory Server. Wildcards are accepted.  Any IP addresses not listed are implicitly denied (rootdn-allow-ip)")}>
@@ -575,27 +509,20 @@ class RootDNAccessControl extends React.Component {
                                 {_("Allow IP address")}
                             </GridItem>
                             <GridItem span={10}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an IP address"
-                                    onToggle={(event, isOpen) => this.handleDenyHostToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={allowIP}
                                     onSelect={this.handleAllowIPSelect}
                                     onClear={this.handleAllowIPClear}
-                                    selections={allowIP}
+                                    options={this.state.allowIPOptions}
                                     isOpen={this.state.isAllowIPOpen}
-                                    aria-labelledby="typeAhead-allow-ip"
-                                    placeholderText={_("Type an IP address ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={this.handleAllowIPToggle}
+                                    placeholder={_("Type an IP address ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an IP address"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleAllowIPCreateOption}
-                                >
-                                    {this.state.allowIPOptions.map((ip, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={ip}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets what IP addresses, either IPv4 or IPv6, for machines the root user is not allowed to use to access the Directory Server. Wildcards are accepted. Any IP addresses not listed are implicitly allowed (rootdn-deny-ip) If an IP address is listed in both the rootdn-allow-ip and rootdn-deny-ip attributes, it is denied access.")}>
@@ -603,27 +530,20 @@ class RootDNAccessControl extends React.Component {
                                 {_("Deny IP address")}
                             </GridItem>
                             <GridItem span={10}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an IP address"
-                                    onToggle={(event, isOpen) => this.handleDenyIPToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={denyIP}
                                     onSelect={this.handleDenyIPSelect}
                                     onClear={this.handleDenyIPClear}
-                                    selections={denyIP}
+                                    options={this.state.denyIPOptions}
                                     isOpen={this.state.isDenyIPOpen}
-                                    aria-labelledby="typeAhead-deny-ip"
-                                    placeholderText={_("Type an IP address ...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={this.handleDenyIPToggle}
+                                    placeholder={_("Type an IP address ...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an IP address"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={this.handleDenyIPCreateOption}
-                                >
-                                    {this.state.denyIPOptions.map((ip, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={ip}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("Sets part of a time period or range when the root user is allowed to access the Directory Server. This sets when the time-based access begins (rootdn-open-time)")}>

--- a/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
@@ -698,23 +698,11 @@ export class ReplAgmts extends React.Component {
 
         // We handle strings and arrays here, need to find a better way to differentiate.
         if (attr.endsWith('Attrs')) {
-            if (this.state[attr].includes(value)) {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: prevState[attr].filter((item) => item !== e.target.value),
-                        errObj,
-                        [e.target.toggle]: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: [...prevState[attr], value],
-                        errObj,
-                        [e.target.toggle]: false
-                    }),
-                );
-            }
+            this.setState({
+                [attr]: Array.isArray(value) ? value : [],
+                errObj,
+                [e.target.toggle]: false
+            });
         } else {
             this.setState({
                 [attr]: value,
@@ -725,64 +713,33 @@ export class ReplAgmts extends React.Component {
     }
 
     onTAStripAttrChangeEdit (selection) {
-        // TypeAhead handling
-        const { agmtStripAttrs } = this.state;
         const e = { target: { id: 'dummy', value: "", type: 'input' } };
-        if (agmtStripAttrs.includes(selection)) {
-            const new_values = this.state.agmtStripAttrs.filter(item => item !== selection);
-            this.setState({
-                agmtStripAttrs: new_values,
-                isStripAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        } else {
-            const new_values = [...this.state.agmtStripAttrs, selection];
-            this.setState({
-                agmtStripAttrs: new_values,
-                isStripAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        }
+        const newStripAttrs = Array.isArray(selection) ? selection : [];
+        this.setState({
+            agmtStripAttrs: newStripAttrs,
+            isStripAttrsEditOpen: false,
+        }, () => { this.onEditChange(e) });
     }
 
     onTAFracAttrChangeEdit (selection) {
-        // TypeAhead handling
-        const { agmtFracAttrs } = this.state;
         const e = { target: { id: 'dummy', value: "", type: 'input' } };
-        if (agmtFracAttrs.includes(selection)) {
-            const new_values = this.state.agmtFracAttrs.filter(item => item !== selection);
-            this.setState({
-                agmtFracAttrs: new_values,
-                isExcludeAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        } else {
-            const new_values = [...this.state.agmtFracAttrs, selection];
-            this.setState({
-                agmtFracAttrs: new_values,
-                isExcludeAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        }
+        const newFracAttrs = Array.isArray(selection) ? selection : [];
+        this.setState({
+            agmtFracAttrs: newFracAttrs,
+            isExcludeAttrsEditOpen: false,
+        }, () => { this.onEditChange(e) });
     }
 
     onTAFracInitAttrChangeEdit (selection) {
-        // TypeAhead handling
         const e = { target: { id: 'dummy', value: "", type: 'input' } };
-        const { agmtFracInitAttrs } = this.state;
-        if (agmtFracInitAttrs.includes(selection)) {
-            const new_values = this.state.agmtFracInitAttrs.filter(item => item !== selection);
-            this.setState({
-                agmtFracInitAttrs: new_values,
-                isExcludeInitAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        } else {
-            const new_values = [...this.state.agmtFracInitAttrs, selection];
-            this.setState({
-                agmtFracInitAttrs: new_values,
-                isExcludeInitAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        }
+        const newFracInitAttrs = Array.isArray(selection) ? selection : [];
+        this.setState({
+            agmtFracInitAttrs: newFracInitAttrs,
+            isExcludeInitAttrsEditOpen: false,
+        }, () => { this.onEditChange(e) });
     }
 
     onTAStripAttrChange (values) {
-        // TypeAhead handling
         const e = {
             target: {
                 name: 'agmt-modal',
@@ -796,7 +753,6 @@ export class ReplAgmts extends React.Component {
     }
 
     onTAFracAttrChange (values) {
-        // TypeAhead handling
         const e = {
             target: {
                 name: 'agmt-modal',
@@ -810,7 +766,6 @@ export class ReplAgmts extends React.Component {
     }
 
     onTAFracInitAttrChange (values) {
-        // TypeAhead handling
         const e = {
             target: {
                 name: 'agmt-modal',
@@ -1632,13 +1587,13 @@ export class ReplAgmts extends React.Component {
                     handleChange={this.onCreateChange}
                     handleTimeChange={this.onTimeChange}
                     handleStripChange={this.onTAStripAttrChange}
-                    handleFracChange={this.onTAFracInitAttrChange}
+                    handleFracChange={this.onTAFracAttrChange}
                     handleFracInitChange={this.onTAFracInitAttrChange}
                     onExcludeAttrsToggle={this.handleExcludeAttrsCreateToggle}
                     onExcludeAttrsClear={this.handleExcludeAttrsCreateClear}
                     onExcludeAttrsInitToggle={this.handleExcludeAttrsInitCreateToggle}
                     onExcludeAttrsInitClear={this.handleExcludeAttrsInitCreateClear}
-                    handleStripAttrsToggle={this.onStripAttrsCreateToggle}
+                    onStripAttrsToggle={this.onStripAttrsCreateToggle}
                     onStripAttrsClear={this.handleStripAttrsCreateClear}
                     isExcludeAttrsOpen={this.state.isExcludeAttrsCreateOpen}
                     isExcludeInitAttrsOpen={this.state.isExcludeInitAttrsCreateOpen}
@@ -1692,7 +1647,7 @@ export class ReplAgmts extends React.Component {
                     onExcludeAttrsClear={this.handleExcludeAttrsEditClear}
                     onExcludeAttrsInitToggle={this.handleExcludeAttrsInitEditToggle}
                     onExcludeAttrsInitClear={this.handleExcludeAttrsInitEditClear}
-                    handleStripAttrsToggle={this.onStripAttrsEditToggle}
+                    onStripAttrsToggle={this.onStripAttrsEditToggle}
                     onStripAttrsClear={this.handleStripAttrsEditClear}
                     isExcludeAttrsOpen={this.state.isExcludeAttrsEditOpen}
                     isExcludeInitAttrsOpen={this.state.isExcludeInitAttrsEditOpen}

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -25,11 +25,7 @@ import {
 	TimePicker,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
@@ -607,25 +603,18 @@ export class WinsyncAgmtModal extends React.Component {
                                         {_("Exclude Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type an attribute"
-                                            onToggle={onSelectToggle}
+                                        <TypeaheadSelect
+                                            selected={agmtFracAttrs}
                                             onSelect={(e, selection) => { handleFracChange(selection) }}
                                             onClear={onSelectClear}
-                                            selections={agmtFracAttrs}
+                                            options={availAttrs}
                                             isOpen={isExcludeAttrOpen}
-                                            aria-labelledby="typeAhead-exclude-attrs"
-                                            placeholderText={_("Start typing an attribute...")}
-                                            noResultsFoundText={_("There are no matching entries")}
-                                        >
-                                            {availAttrs.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            onToggle={onSelectToggle}
+                                            placeholder={_("Start typing an attribute...")}
+                                            noResultsText={_("There are no matching entries")}
+                                            ariaLabel="Type an attribute"
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top-med">
@@ -1311,24 +1300,17 @@ export class ReplAgmtModal extends React.Component {
                                         {_("Exclude Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type an attribute"
-                                            onToggle={onExcludeAttrsToggle}
+                                        <TypeaheadSelect
+                                            selected={agmtFracAttrs}
                                             onSelect={(e, selection) => { handleFracChange(selection) }}
                                             onClear={onExcludeAttrsClear}
-                                            selections={agmtFracAttrs}
+                                            options={availAttrs}
                                             isOpen={isExcludeAttrsOpen}
-                                            aria-labelledby="typeAhead-exclude-attrs"
-                                            placeholderText={_("Start typing an attribute...")}
-                                        >
-                                            {availAttrs.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            onToggle={onExcludeAttrsToggle}
+                                            placeholder={_("Start typing an attribute...")}
+                                            ariaLabel="Type an attribute"
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Attribute to exclude from replica Initializations")}>
@@ -1336,25 +1318,18 @@ export class ReplAgmtModal extends React.Component {
                                         {_("Exclude Init Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type an attribute"
-                                            onToggle={onExcludeAttrsInitToggle}
+                                        <TypeaheadSelect
+                                            selected={agmtFracInitAttrs}
                                             onSelect={(e, selection) => { handleFracInitChange(selection) }}
                                             onClear={onExcludeAttrsInitClear}
-                                            selections={agmtFracInitAttrs}
+                                            options={availAttrs}
                                             isOpen={isExcludeInitAttrsOpen}
-                                            aria-labelledby="typeAhead-exclude-init-attrs"
-                                            placeholderText={_("Start typing an attribute...")}
-                                            noResultsFoundText={_("There are no matching entries")}
-                                        >
-                                            {availAttrs.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            onToggle={onExcludeAttrsInitToggle}
+                                            placeholder={_("Start typing an attribute...")}
+                                            noResultsText={_("There are no matching entries")}
+                                            ariaLabel="Type an attribute"
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Attributes to strip from a replication update")}>
@@ -1362,25 +1337,18 @@ export class ReplAgmtModal extends React.Component {
                                         {_("Strip Attributes")}
                                     </GridItem>
                                     <GridItem span={9}>
-                                        <Select
-                                            variant={SelectVariant.typeaheadMulti}
-                                            typeAheadAriaLabel="Type an attribute"
-                                            onToggle={onStripAttrsToggle}
+                                        <TypeaheadSelect
+                                            selected={agmtStripAttrs}
                                             onSelect={(e, selection) => { handleStripChange(selection) }}
                                             onClear={onStripAttrsClear}
-                                            selections={agmtStripAttrs}
+                                            options={availAttrs}
                                             isOpen={isStripAttrsOpen}
-                                            aria-labelledby="typeAhead-strip-attrs"
-                                            placeholderText={_("Start typing an attribute...")}
-                                            noResultsFoundText={_("There are no matching entries")}
-                                        >
-                                            {availAttrs.map((attr, index) => (
-                                                <SelectOption
-                                                    key={index}
-                                                    value={attr}
-                                                />
-                                            ))}
-                                        </Select>
+                                            onToggle={onStripAttrsToggle}
+                                            placeholder={_("Start typing an attribute...")}
+                                            noResultsText={_("There are no matching entries")}
+                                            ariaLabel="Type an attribute"
+                                            isMulti={true}
+                                        />
                                     </GridItem>
                                 </Grid>
                             </Tab>

--- a/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
@@ -437,23 +437,11 @@ export class WinsyncAgmts extends React.Component {
 
         // We handle strings and arrays here, need to find a better way to differentiate.
         if (attr.endsWith('Attrs')) {
-            if (this.state[attr].includes(value)) {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: prevState[attr].filter((item) => item !== e.target.value),
-                        errObj,
-                        [e.target.toggle]: false
-                    }),
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        [attr]: [...prevState[attr], value],
-                        errObj,
-                        [e.target.toggle]: false
-                    }),
-                );
-            }
+            this.setState({
+                [attr]: Array.isArray(value) ? value : [],
+                errObj,
+                [e.target.toggle]: false
+            });
         } else {
             this.setState({
                 [attr]: value,
@@ -464,26 +452,15 @@ export class WinsyncAgmts extends React.Component {
     }
 
     onTAFracAttrChangeEdit (selection) {
-        // TypeAhead handling
-        const { agmtFracAttrs } = this.state;
         const e = { target: { id: 'dummy', value: "", type: 'input' } };
-        if (agmtFracAttrs.includes(selection)) {
-            const new_values = this.state.agmtFracAttrs.filter(item => item !== selection);
-            this.setState({
-                agmtFracAttrs: new_values,
-                isExcludeAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        } else {
-            const new_values = [...this.state.agmtFracAttrs, selection];
-            this.setState({
-                agmtFracAttrs: new_values,
-                isExcludeAttrsEditOpen: false,
-            }, () => { this.onEditChange(e) });
-        }
+        const newFracAttrs = Array.isArray(selection) ? selection : [];
+        this.setState({
+            agmtFracAttrs: newFracAttrs,
+            isExcludeAttrsEditOpen: false,
+        }, () => { this.onEditChange(e) });
     }
 
     onTAFracAttrChange (values) {
-        // TypeAhead handling
         const e = {
             target: {
                 name: 'agmt-modal',

--- a/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaModals.jsx
@@ -13,11 +13,7 @@ import {
 	TextInput,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -197,30 +193,20 @@ class ObjectClassModal extends React.Component {
                                 {_("Required Attributes")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute name"
-                                    onToggle={onRequiredAttrsToggle}
+                                <TypeaheadSelect
+                                    selected={ocMust}
                                     onSelect={onRequiredAttrsSelect}
                                     onClear={onRequiredAttrsClear}
-                                    selections={ocMust}
-                                    id="ocMust"
+                                    options={attributes}
                                     isOpen={isRequiredAttrsOpen}
-                                    aria-labelledby="typeAhead-required-attrs"
-                                    placeholderText={_("Type an attribute name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={onRequiredAttrsToggle}
+                                    placeholder={_("Type an attribute name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute name"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={onRequiredAttrsCreateOption}
-                                    direction="up"
-                                    maxHeight="225px"
-                                >
-                                    {attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("A may attribute name")}>
@@ -228,30 +214,20 @@ class ObjectClassModal extends React.Component {
                                 {_("Allowed Attributes")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an attribute name"
-                                    onToggle={onAllowedAttrsToggle}
+                                <TypeaheadSelect
+                                    selected={ocMay}
                                     onSelect={onAllowedAttrsSelect}
                                     onClear={onAllowedAttrsClear}
-                                    selections={ocMay}
-                                    id="ocMay"
+                                    options={attributes}
                                     isOpen={isAllowedAttrsOpen}
-                                    aria-labelledby="typeAhead-allowed-attrs"
-                                    placeholderText={_("Type an attribute name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={onAllowedAttrsToggle}
+                                    placeholder={_("Type an attribute name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute name"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={onAllowedAttrsCreateOption}
-                                    direction="up"
-                                    maxHeight="225px"
-                                >
-                                    {attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
                     </Form>
@@ -454,25 +430,17 @@ class AttributeTypeModal extends React.Component {
                                 {_("Parent Attribute")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type an attribute name"
-                                    onToggle={onParentAttrToggle}
+                                <TypeaheadSelect
+                                    selected={atParent}
                                     onSelect={onParentAttrSelect}
                                     onClear={onParentAttrClear}
-                                    selections={atParent}
+                                    options={attributes}
                                     isOpen={isParentAttrOpen}
-                                    aria-labelledby="typeAhead-parent-attr"
-                                    placeholderText={_("Type an attribute name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                >
-                                    {attributes.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onParentAttrToggle}
+                                    placeholder={_("Type an attribute name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an attribute name"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("An attribute's syntax")}>
@@ -549,27 +517,20 @@ class AttributeTypeModal extends React.Component {
                                 {_("Alias Names")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type an alias name"
-                                    onToggle={onAliasNameToggle}
+                                <TypeaheadSelect
+                                    selected={atAlias}
                                     onSelect={onAliasNameSelect}
                                     onClear={onAliasNameClear}
-                                    selections={atAlias}
+                                    options={atAlias}
                                     isOpen={isAliasNameOpen}
-                                    aria-labelledby="typeAhead-alias-name"
-                                    placeholderText={_("Type an alias name...")}
-                                    noResultsFoundText={_("There are no matching entries")}
-                                    isCreatable
+                                    onToggle={onAliasNameToggle}
+                                    placeholder={_("Type an alias name...")}
+                                    noResultsText={_("There are no matching entries")}
+                                    ariaLabel="Type an alias name"
+                                    isMulti={true}
+                                    isCreatable={true}
                                     onCreateOption={onAliasNameCreateOption}
-                                >
-                                    {atAlias.map((alias, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={alias}
-                                        />
-                                    ))}
-                                </Select>
+                                />
                             </GridItem>
                         </Grid>
 
@@ -578,25 +539,17 @@ class AttributeTypeModal extends React.Component {
                                 {_("Equality Matching Rule")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type a matching rule"
-                                    onToggle={onEqualityMRToggle}
+                                <TypeaheadSelect
+                                    selected={atEqMr}
                                     onSelect={onEqualityMRSelect}
                                     onClear={onEqualityMRClear}
-                                    selections={atEqMr}
+                                    options={matchingrules}
                                     isOpen={isEqualityMROpen}
-                                    aria-labelledby="typeAhead-equality-mr"
-                                    placeholderText={_("Type an Equality matching rule...")}
-                                    noResultsFoundText={_("There are no matching rules")}
-                                >
-                                    {matchingrules.map((mr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={mr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onEqualityMRToggle}
+                                    placeholder={_("Type an Equality matching rule...")}
+                                    noResultsText={_("There are no matching rules")}
+                                    ariaLabel="Type a matching rule"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("An order matching rule")}>
@@ -604,25 +557,17 @@ class AttributeTypeModal extends React.Component {
                                 {_("Order Matching Rule")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type a matching rule"
-                                    onToggle={onOrderMRToggle}
+                                <TypeaheadSelect
+                                    selected={atOrder}
                                     onSelect={onOrderMRSelect}
                                     onClear={onOrderMRClear}
-                                    selections={atOrder}
+                                    options={matchingrules}
                                     isOpen={isOrderMROpen}
-                                    aria-labelledby="typeAhead-order-mr"
-                                    placeholderText={_("Type an Ordering matching rule..")}
-                                    noResultsFoundText={_("There are no matching rules")}
-                                >
-                                    {matchingrules.map((mr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={mr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onOrderMRToggle}
+                                    placeholder={_("Type an Ordering matching rule..")}
+                                    noResultsText={_("There are no matching rules")}
+                                    ariaLabel="Type a matching rule"
+                                />
                             </GridItem>
                         </Grid>
                         <Grid title={_("A substring matching rule")}>
@@ -630,24 +575,17 @@ class AttributeTypeModal extends React.Component {
                                 {_("Substring Matching Rule")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeahead}
-                                    typeAheadAriaLabel="Type a matching rule"
-                                    onToggle={onSubstringMRToggle}
+                                <TypeaheadSelect
+                                    selected={atSubMr}
                                     onSelect={onSubstringMRSelect}
                                     onClear={onSubstringMRClear}
-                                    selections={atSubMr}
+                                    options={matchingrules}
                                     isOpen={isSubstringMROpen}
-                                    placeholderText={_("Type a Substring matching rule...")}
-                                    noResultsFoundText={_("There are no matching rules")}
-                                >
-                                    {matchingrules.map((mr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={mr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={onSubstringMRToggle}
+                                    placeholder={_("Type a Substring matching rule...")}
+                                    noResultsText={_("There are no matching rules")}
+                                    ariaLabel="Type a matching rule"
+                                />
                             </GridItem>
                         </Grid>
                     </Form>

--- a/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
+++ b/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
@@ -140,18 +140,9 @@ export class CertificateManagement extends React.Component {
         };
 
         this.csrOnSelect = (e, selection) => {
-            if (this.state.csrAltNames.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        csrAltNames: prevState.csrAltNames.filter((item) => item !== selection),
-                        csrIsSelectOpen: false
-                    }),
-                );
-            } else {
-                this.setState({
-                    csrIsSelectOpen: false,
-                });
-            }
+            this.setState({
+                csrAltNames: Array.isArray(selection) ? selection : [],
+            });
         };
 
         this.csrOnToggle = isOpen => {
@@ -162,7 +153,6 @@ export class CertificateManagement extends React.Component {
 
         this.onChange = this.onChange.bind(this);
         this.onCSRChange = this.onCSRChange.bind(this);
-        this.onAltNameChange = this.onAltNameChange.bind(this);
         this.addCert = this.addCert.bind(this);
         this.showAddModal = this.showAddModal.bind(this);
         this.showAddCAModal = this.showAddCAModal.bind(this);
@@ -956,23 +946,6 @@ export class CertificateManagement extends React.Component {
         }, this.buildSubject);
     }
 
-    onAltNameChange (altName) {
-        if (this.state.csrAltNames.includes(altName)) {
-            this.setState(
-                (prevState) => ({
-                    csrAltNames: prevState.csrAltNames.filter((item) => item !== altName),
-                    csrIsSelectOpen: false
-                }),
-            );
-        } else {
-            this.setState(
-                (prevState) => ({
-                    csrAltNames: [...prevState.csrAltNames, altName],
-                    csrIsSelectOpen: false,
-                }),
-            );
-        }
-    }
 
     buildSubject () {
         let subject = "";
@@ -1398,7 +1371,6 @@ export class CertificateManagement extends React.Component {
                     showModal={this.state.showAddCSRModal}
                     closeHandler={this.closeAddCSRModal}
                     handleChange={this.onCSRChange}
-                    handleAltNameChange={this.onAltNameChange}
                     saveHandler={this.addCSR}
                     previewValue={this.state.csrSubject}
                     csrName={this.state.csrName}

--- a/src/cockpit/389-console/src/lib/security/securityModals.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityModals.jsx
@@ -24,11 +24,7 @@ import {
 	Tooltip,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import PropTypes from "prop-types";
 import { bad_file_name, validHostname } from "../tools.jsx";
@@ -354,13 +350,18 @@ export class SecurityAddCertModal extends React.Component {
     }
 }
 
+const EMPTY_OPTIONS = [];
+
 export class SecurityAddCSRModal extends React.Component {
+    validateCreateHostname = (hostname) => {
+        return validHostname(hostname) !== null;
+    };
+
     render() {
         const {
             showModal,
             closeHandler,
             handleChange,
-            handleAltNameChange,
             saveHandler,
             previewValue,
             spinning,
@@ -440,27 +441,19 @@ export class SecurityAddCSRModal extends React.Component {
                             {_("Subject Alternative Names")}
                         </GridItem>
                         <GridItem span={9}>
-                            <Select
-                                variant={SelectVariant.typeaheadMulti}
-                                typeAheadAriaLabel="Type a host name"
-                                onToggle={handleOnToggle}
+                            <TypeaheadSelect
+                                selected={csrAltNames}
                                 onSelect={handleOnSelect}
-                                selections={csrAltNames}
-                                aria-labelledby="typeAhead-alt-names"
-                                placeholderText={_("Type an alternative host name")}
+                                options={EMPTY_OPTIONS}
                                 isOpen={csrIsSelectOpen}
-                                isCreatable
-                                isCreateOptionOnTop
-                                onCreateOption={handleAltNameChange}
-                                validated={validAltNames ? ValidatedOptions.default : ValidatedOptions.error}
-                            >
-                                {csrAltNames.map((hostname, index) => (
-                                    <SelectOption
-                                        key={index}
-                                        value={hostname}
-                                    />
-                                ))}
-                            </Select>
+                                onToggle={handleOnToggle}
+                                placeholder={_("Type an alternative host name")}
+                                ariaLabel="Type a host name"
+                                isMulti={true}
+                                isCreatable={true}
+                                validateCreate={this.validateCreateHostname}
+                                validated={validAltNames ? "default" : "error"}
+                            />
                             <div className={validAltNames ? "ds-hidden" : ""}>
                                 <HelperText>
                                     <HelperTextItem variant="error">{_("Invalid host names: ")}{invalidNames}</HelperTextItem>

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -22,11 +22,7 @@ import {
 	TextVariants,
 	TimePicker
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SyncAltIcon } from '@patternfly/react-icons';
 import PropTypes from "prop-types";
 
@@ -92,21 +88,9 @@ export class ServerAuditLog extends React.Component {
         };
 
         this.handleOnDisplayAttrSelect = (event, selection) => {
-            if (this.state.displayAttrs.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        displayAttrs: prevState.displayAttrs.filter((item) => item !== selection),
-                        isDisplayAttrOpen: false
-                    }), () => { this.validateSaveBtn("settings", "none", "none") }
-                );
-            } else {
-                this.setState(
-                    (prevState) => ({
-                        displayAttrs: [...prevState.displayAttrs, selection],
-                        isDisplayAttrOpen: false
-                    }), () => { this.validateSaveBtn("settings", "none", "none") }
-                );
-            }
+            this.setState({
+                displayAttrs: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateSaveBtn("settings", "none", "none") });
         };
         this.handleOnDisplayAttrToggle = (_event, isDisplayAttrOpen) => {
             this.setState({
@@ -610,25 +594,18 @@ export class ServerAuditLog extends React.Component {
                                 title={_("Display attributes from the entry in the audit log (nsslapd-auditlog-display-attrs).")}
                             >
                                 <div className={this.state.displayAllAttrs ? "ds-hidden" : "ds-margin-bottom"}>
-                                    <Select
-                                        variant={SelectVariant.typeaheadMulti}
-                                        typeAheadAriaLabel="Type an attribute"
-                                        onToggle={(event, isOpen) => this.handleOnDisplayAttrToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        isMulti={true}
+                                        ariaLabel="Type an attribute"
+                                        onToggle={this.handleOnDisplayAttrToggle}
                                         onSelect={this.handleOnDisplayAttrSelect}
                                         onClear={this.handleOnDisplayAttrClear}
-                                        selections={this.state.displayAttrs}
+                                        selected={this.state.displayAttrs}
                                         isOpen={this.state.isDisplayAttrOpen}
-                                        aria-labelledby="typeAhead-audit-display-attr"
-                                        placeholderText={_("Type an attribute...")}
-                                        noResultsFoundText={_("There are no matching attributes")}
-                                    >
-                                        {this.state.attributes.map((attr, index) => (
-                                            <SelectOption
-                                                key={index}
-                                                value={attr}
-                                            />
-                                        ))}
-                                    </Select>
+                                        placeholder={_("Type an attribute...")}
+                                        noResultsText={_("There are no matching attributes")}
+                                        options={this.state.attributes}
+                                    />
                                 </div>
                                 <Checkbox
                                     className="ds-lower-field-md"

--- a/src/cockpit/389-console/src/lib/server/ldapi.jsx
+++ b/src/cockpit/389-console/src/lib/server/ldapi.jsx
@@ -13,11 +13,7 @@ import {
 	TextContent,
 	TextVariants
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SyncAltIcon } from "@patternfly/react-icons";
 import PropTypes from "prop-types";
 
@@ -254,9 +250,6 @@ export class ServerLDAPI extends React.Component {
         }
 
         if (this.state['nsslapd-ldapimaptoentries']) {
-            const attributes = this.state.attributes.map((option, index) => (
-                <SelectOption key={index} value={option} />
-            ));
             mapUserAttrs = (
                 <div className="ds-margin-left">
                     <Grid
@@ -267,17 +260,14 @@ export class ServerLDAPI extends React.Component {
                             {_("LDAPI UID Number Attribute")}
                         </GridItem>
                         <GridItem span={9}>
-                            <Select
-                                variant={SelectVariant.single}
-                                aria-label="Select UID Input"
-                                onToggle={(event, isOpen) => this.handleUIDToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                ariaLabel="Select UID Input"
+                                onToggle={this.handleUIDToggle}
                                 onSelect={this.handleUIDSelect}
-                                selections={this.state['nsslapd-ldapiuidnumbertype']}
+                                selected={this.state['nsslapd-ldapiuidnumbertype']}
                                 isOpen={this.state.isUIDOpen}
-                                aria-labelledby="UID"
-                            >
-                                {attributes}
-                            </Select>
+                                options={this.state.attributes}
+                            />
                         </GridItem>
                     </Grid>
                     <Grid
@@ -288,17 +278,14 @@ export class ServerLDAPI extends React.Component {
                             {_("LDAPI GID Number Attribute")}
                         </GridItem>
                         <GridItem span={9}>
-                            <Select
-                                variant={SelectVariant.single}
-                                aria-label="Select GID Input"
-                                onToggle={(event, isOpen) => this.handleGIDToggle(event, isOpen)}
+                            <TypeaheadSelect
+                                ariaLabel="Select GID Input"
+                                onToggle={this.handleGIDToggle}
                                 onSelect={this.handleGIDSelect}
-                                selections={this.state['nsslapd-ldapigidnumbertype']}
+                                selected={this.state['nsslapd-ldapigidnumbertype']}
                                 isOpen={this.state.isGIDOpen}
-                                aria-labelledby="GID"
-                            >
-                                {attributes}
-                            </Select>
+                                options={this.state.attributes}
+                            />
                         </GridItem>
                     </Grid>
                     <Grid
@@ -405,7 +392,7 @@ export class ServerLDAPI extends React.Component {
                         <TextContent>
                             <Text component={TextVariants.h3}>
                                 {_("LDAPI & AutoBind Settings")}
-                                <Button 
+                                <Button
                                     variant="plain"
                                     aria-label={_("Refresh LDAPI settings")}
                                     onClick={this.handleLoadConfig}

--- a/src/cockpit/389-console/src/lib/server/sasl.jsx
+++ b/src/cockpit/389-console/src/lib/server/sasl.jsx
@@ -14,11 +14,7 @@ import {
 	TextContent,
 	TextVariants
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SASLTable } from "./serverTables.jsx";
 import { SASLMappingModal } from "./serverModals.jsx";
 import { SyncAltIcon } from "@patternfly/react-icons";
@@ -66,22 +62,9 @@ export class ServerSASL extends React.Component {
             });
         };
         this.handleOnSelect = (event, selection) => {
-            const { allowedMechs } = this.state;
-            if (allowedMechs.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        allowedMechs: prevState.allowedMechs.filter(item => item !== selection),
-                        isAllowedMechOpen: false
-                    }), () => { this.validateSaveBtn() }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        allowedMechs: [...prevState.allowedMechs, selection],
-                        isAllowedMechOpen: false,
-                    }), () => { this.validateSaveBtn() }
-                );
-            }
+            this.setState({
+                allowedMechs: Array.isArray(selection) ? selection : [],
+            }, () => { this.validateSaveBtn() });
         };
         this.handleOnAllowedMechClear = () => {
             this.setState({
@@ -624,7 +607,7 @@ export class ServerSASL extends React.Component {
                             <TextContent>
                                 <Text component={TextVariants.h3}>
                                     {_("SASL Settings")}
-                                    <Button 
+                                    <Button
                                         variant="plain"
                                         aria-label={_("Refresh SASL settings")}
                                         onClick={this.handleLoadConfig}
@@ -660,25 +643,18 @@ export class ServerSASL extends React.Component {
                                 {_("Allowed SASL Mechanisms")}
                             </GridItem>
                             <GridItem span={9}>
-                                <Select
-                                    variant={SelectVariant.typeaheadMulti}
-                                    typeAheadAriaLabel="Type SASL mechanism to allow"
-                                    onToggle={(event, isOpen) => this.handleOnAllowedMechToggle(event, isOpen)}
+                                <TypeaheadSelect
+                                    selected={this.state.allowedMechs}
                                     onSelect={this.handleOnSelect}
                                     onClear={this.handleOnAllowedMechClear}
-                                    selections={this.state.allowedMechs}
+                                    options={this.state.supportedMechs}
                                     isOpen={this.state.isAllowedMechOpen}
-                                    aria-labelledby="typeAhead-sasl-mechs"
-                                    placeholderText={_("Type SASL mechanism to allow...")}
-                                    noResultsFoundText="There are no matching entries"
-                                >
-                                    {this.state.supportedMechs.map((attr, index) => (
-                                        <SelectOption
-                                            key={index}
-                                            value={attr}
-                                        />
-                                    ))}
-                                </Select>
+                                    onToggle={this.handleOnAllowedMechToggle}
+                                    placeholder={_("Type SASL mechanism to allow...")}
+                                    noResultsText="There are no matching entries"
+                                    ariaLabel="Type SASL mechanism to allow"
+                                    isMulti={true}
+                                />
                             </GridItem>
                         </Grid>
                         <Grid

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -23,11 +23,7 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SyncAltIcon } from '@patternfly/react-icons';
 import PropTypes from "prop-types";
 
@@ -115,22 +111,11 @@ export class ServerSettings extends React.Component {
         };
         this.handleOnHaproxyIPsSelect = (event, selection, nav_tab) => {
             const id = 'nsslapd-haproxy-trusted-ip';
-            const { haproxyIPs } = this.state;
-            // The first if-block is when removing an item from the list
-            if (haproxyIPs.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        haproxyIPs: prevState.haproxyIPs.filter(item => item !== selection),
-                        isHaproxyIPsOpen: false
-                    }), () => { this.validateSaveBtn(nav_tab, id, haproxyIPs.filter(item => item !== selection)) });
-            // The second if-block is when adding an item to the list
-            } else {
-                this.setState(
-                    prevState => ({
-                        haproxyIPs: [...prevState.haproxyIPs, selection],
-                        isHaproxyIPsOpen: false,
-                    }), () => { this.validateSaveBtn(nav_tab, id, [...haproxyIPs, selection]) });
-            }
+            const newHaproxyIPs = Array.isArray(selection) ? selection : [];
+            this.setState({
+                haproxyIPs: newHaproxyIPs,
+                isHaproxyIPsOpen: false,
+            }, () => { this.validateSaveBtn(nav_tab, id, newHaproxyIPs) });
         };
 
         this.handleOnHaproxyIPsClear = (event, nav_tab) => {
@@ -1129,7 +1114,7 @@ async validateSaveBtn(nav_tab, attr, value) {
                             <TextContent>
                                 <Text component={TextVariants.h3}>
                                     {_("Server Settings")}
-                                    <Button 
+                                    <Button
                                         variant="plain"
                                         aria-label={_("Refresh configuration settings")}
                                         onClick={this.handleReloadConfig}
@@ -1665,32 +1650,24 @@ async validateSaveBtn(nav_tab, attr, value) {
                                             Trusted HAProxy Server IPs
                                         </GridItem>
                                         <GridItem span={9}>
-                                            <Select
-                                                variant={SelectVariant.typeaheadMulti}
-                                                id="nsslpad-haproxy-trusted-ip"
-                                                typeAheadAriaLabel="Type trusted HAProxy server IP address"
-                                                onToggle={(event, isOpen) => this.handleOnHaproxyIPsToggle(event, isOpen)}
-                                                onSelect={(e, selection) => {
-                                                    this.handleOnHaproxyIPsSelect(e, selection, "adv");
-                                                }}
-                                                onClear={(e) => {
-                                                    this.handleOnHaproxyIPsClear(e, "adv");
-                                                }}
-                                                selections={this.state.haproxyIPs}
-                                                isOpen={this.state.isHaproxyIPsOpen}
-                                                aria-labelledby="typeAhead-haproxy-ips"
-                                                placeholderText="Type trusted HAProxy server IP address"
-                                                isCreatable
-                                                onCreateOption={this.handleOnCreateHaproxyIP}
-                                                validated={this.state.invalidIP ? ValidatedOptions.error : ValidatedOptions.default}
-                                            >
-                                                {[].map((attr, index) => (
-                                                    <SelectOption
-                                                        key={index}
-                                                        value={attr}
-                                                    />
-                                                ))}
-                                            </Select>
+                            <TypeaheadSelect
+                                selected={this.state.haproxyIPs}
+                                onSelect={(e, selection) => {
+                                    this.handleOnHaproxyIPsSelect(e, selection, "adv");
+                                }}
+                                onClear={(e) => {
+                                    this.handleOnHaproxyIPsClear(e, "adv");
+                                }}
+                                options={[]}
+                                isOpen={this.state.isHaproxyIPsOpen}
+                                onToggle={this.handleOnHaproxyIPsToggle}
+                                placeholder="Type trusted HAProxy server IP address"
+                                ariaLabel="Type trusted HAProxy server IP address"
+                                validated={this.state.invalidIP ? "error" : "default"}
+                                isMulti={true}
+                                isCreatable={true}
+                                onCreateOption={this.handleOnCreateHaproxyIP}
+                            />
                                             {(this.state.invalidIP) &&
                                                 <HelperText className="ds-left-margin">
                                                     <HelperTextItem variant="error">Invalid format for IP address</HelperTextItem>

--- a/src/cockpit/389-console/src/schema.jsx
+++ b/src/cockpit/389-console/src/schema.jsx
@@ -206,21 +206,10 @@ export class Schema extends React.Component {
         };
         this.handleAliasNameSelect = (event, selection) => {
             const e = { target: { id: 'dummy', value: "", type: 'input' } };
-            if (this.state.atAlias.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        atAlias: prevState.atAlias.filter((item) => item !== selection),
-                        isAliasNameOpen: false
-                    }), () => { this.onAttrChange(e) }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        atAlias: [...prevState.atAlias, selection],
-                        isAliasNameOpen: false
-                    }), () => { this.onAttrChange(e) }
-                );
-            }
+            this.setState({
+                atAlias: Array.isArray(selection) ? selection : [],
+                isAliasNameOpen: false
+            }, () => { this.onAttrChange(e) });
         };
         this.handleAliasNameCreateOption = (_event, newValue) => {
             if (!this.state.atAliasOptions.includes(newValue)) {
@@ -275,21 +264,10 @@ export class Schema extends React.Component {
         };
         this.handleRequiredAttrsSelect = (event, selection) => {
             const e = { target: { id: 'dummy', value: "", type: 'input' } };
-            if (this.state.ocMust.includes(selection)) {
-                this.setState(
-                    (prevState) => ({
-                        ocMust: prevState.ocMust.filter((item) => item !== selection),
-                        isRequiredAttrsOpen: false
-                    }), () => { this.onOCChange(e) }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        ocMust: [...prevState.ocMust, selection],
-                        isRequiredAttrsOpen: false
-                    }), () => { this.onOCChange(e) }
-                );
-            }
+            this.setState({
+                ocMust: Array.isArray(selection) ? selection : [],
+                isRequiredAttrsOpen: false
+            }, () => { this.onOCChange(e) });
         };
         this.handleRequiredAttrsCreateOption = newValue => {
             if (!this.state.ocMustOptions.includes(newValue)) {
@@ -314,21 +292,10 @@ export class Schema extends React.Component {
         };
         this.handleAllowedAttrsSelect = (event, selection) => {
             const e = { target: { id: 'dummy', value: "", type: 'input' } };
-            if (this.state.ocMay.includes(selection)) {
-                this.setState(
-                    prevState => ({
-                        ocMay: prevState.ocMay.filter((item) => item !== selection),
-                        isAllowedAttrsOpen: false
-                    }), () => { this.onOCChange(e) }
-                );
-            } else {
-                this.setState(
-                    prevState => ({
-                        ocMay: [...prevState.ocMay, selection],
-                        isAllowedAttrsOpen: false
-                    }), () => { this.onOCChange(e) }
-                );
-            }
+            this.setState({
+                ocMay: Array.isArray(selection) ? selection : [],
+                isAllowedAttrsOpen: false
+            }, () => { this.onOCChange(e) });
         };
         this.handleAllowedAttrsCreateOption = newValue => {
             if (!this.state.ocMayOptions.includes(newValue)) {

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -21,11 +21,7 @@ import {
 	TextContent,
 	TextVariants
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import TypeaheadSelect from "./dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { SyncAltIcon } from '@patternfly/react-icons';
 
@@ -1010,25 +1006,17 @@ export class Security extends React.Component {
                                     {_("Server Certificate Name")}
                                 </GridItem>
                                 <GridItem span={8}>
-                                    <Select
-                                        variant={SelectVariant.typeahead}
-                                        typeAheadAriaLabel="Type a server certificate nickname"
-                                        onToggle={(event, isOpen) => this.handleServerCertToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        selected={serverCert}
                                         onSelect={this.handleServerCertSelect}
                                         onClear={this.handleServerCertClear}
-                                        selections={serverCert}
+                                        options={this.state.serverCertNames}
                                         isOpen={this.state.isServerCertOpen}
-                                        aria-labelledby="typeAhead-server-cert"
-                                        placeholderText={_("Type a sever certificate nickname...")}
-                                        noResultsFoundText={_("There are no matching entries")}
-                                    >
-                                        {this.state.serverCertNames.map((cert, index) => (
-                                            <SelectOption
-                                                key={index}
-                                                value={cert}
-                                            />
-                                        ))}
-                                    </Select>
+                                        onToggle={this.handleServerCertToggle}
+                                        placeholder={_("Type a sever certificate nickname...")}
+                                        noResultsText={_("There are no matching entries")}
+                                        ariaLabel="Type a server certificate nickname"
+                                    />
                                 </GridItem>
                             </Grid>
                             <Grid
@@ -1038,21 +1026,14 @@ export class Security extends React.Component {
                                     {_("Minimum TLS Version")}
                                 </GridItem>
                                 <GridItem span={8}>
-                                    <Select
-                                        variant={SelectVariant.single}
-                                        aria-label="Select Input"
-                                        onToggle={(event, isOpen) => this.handleMinSSLToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        selected={this.state.sslVersionMin}
                                         onSelect={this.handleMinSSLSelect}
-                                        selections={this.state.sslVersionMin}
+                                        options={["TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0", "SSL3"]}
                                         isOpen={this.state.isMinSSLOpen}
-                                        aria-labelledby="minssl"
-                                    >
-                                        <SelectOption key={1} value="TLS1.3" />
-                                        <SelectOption key={2} value="TLS1.2" />
-                                        <SelectOption key={3} value="TLS1.1" />
-                                        <SelectOption key={4} value="TLS1.0" />
-                                        <SelectOption key={5} value="SSL3" />
-                                    </Select>
+                                        onToggle={this.handleMinSSLToggle}
+                                        ariaLabel="Select Input"
+                                    />
                                 </GridItem>
                             </Grid>
                             <Grid
@@ -1062,21 +1043,14 @@ export class Security extends React.Component {
                                     {_("Maximum TLS Version")}
                                 </GridItem>
                                 <GridItem span={8}>
-                                    <Select
-                                        variant={SelectVariant.single}
-                                        aria-label="Select Input"
-                                        onToggle={(event, isOpen) => this.handleMaxSSLToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        selected={this.state.sslVersionMax}
                                         onSelect={this.handleMaxSSLSelect}
-                                        selections={this.state.sslVersionMax}
+                                        options={["TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0", "SSL3"]}
                                         isOpen={this.state.isMaxSSLOpen}
-                                        aria-labelledby="maxssl"
-                                    >
-                                        <SelectOption key={1} value="TLS1.3" />
-                                        <SelectOption key={2} value="TLS1.2" />
-                                        <SelectOption key={3} value="TLS1.1" />
-                                        <SelectOption key={4} value="TLS1.0" />
-                                        <SelectOption key={5} value="SSL3" />
-                                    </Select>
+                                        onToggle={this.handleMaxSSLToggle}
+                                        ariaLabel="Select Input"
+                                    />
                                 </GridItem>
                             </Grid>
                             <Grid
@@ -1086,19 +1060,14 @@ export class Security extends React.Component {
                                     {_("Client Authentication")}
                                 </GridItem>
                                 <GridItem span={8}>
-                                    <Select
-                                        variant={SelectVariant.single}
-                                        aria-label="Select Input"
-                                        onToggle={(event, isOpen) => this.handleClientAuthToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        selected={this.state.clientAuth}
                                         onSelect={this.handleClientAuthSelect}
-                                        selections={this.state.clientAuth}
+                                        options={["off", "allowed", "required"]}
                                         isOpen={this.state.isClientAuthOpen}
-                                        aria-labelledby="clientAuth"
-                                    >
-                                        <SelectOption key={1} value="off" />
-                                        <SelectOption key={2} value="allowed" />
-                                        <SelectOption key={3} value="required" />
-                                    </Select>
+                                        onToggle={this.handleClientAuthToggle}
+                                        ariaLabel="Select Input"
+                                    />
                                 </GridItem>
                             </Grid>
                             <Grid
@@ -1108,19 +1077,14 @@ export class Security extends React.Component {
                                     {_("Validate Certificate")}
                                 </GridItem>
                                 <GridItem span={8}>
-                                    <Select
-                                        variant={SelectVariant.single}
-                                        aria-label="Select Input"
-                                        onToggle={(event, isOpen) => this.handleValidateCertToggle(event, isOpen)}
+                                    <TypeaheadSelect
+                                        selected={this.state.validateCert}
                                         onSelect={this.handleValidateCertSelect}
-                                        selections={this.state.validateCert}
+                                        options={["warn", "on", "off"]}
                                         isOpen={this.state.isValidateCertOpen}
-                                        aria-labelledby="validateCert"
-                                    >
-                                        <SelectOption key={1} value="warn" />
-                                        <SelectOption key={2} value="on" />
-                                        <SelectOption key={3} value="off" />
-                                    </Select>
+                                        onToggle={this.handleValidateCertToggle}
+                                        ariaLabel="Select Input"
+                                    />
                                 </GridItem>
                             </Grid>
                             <Grid
@@ -1225,7 +1189,7 @@ export class Security extends React.Component {
                             <TextContent>
                                 <Text component={TextVariants.h3}>
                                     {_("Security Settings")}
-                                    <Button 
+                                    <Button
                                         variant="plain"
                                         aria-label={_("Refresh settings")}
                                         onClick={this.handleReloadConfig}


### PR DESCRIPTION
Description: Make sure that the created TypeaheadSelect component in dsBasicComponents.jsx that properly handles:
- Single and multi-select functionality
- Keyboard navigation including Enter key for creating/selecting values
- Creation of new options with validation
- Proper state management to prevent value loss
- Controlled and uncontrolled component modes

Replace all instances of the deprecated Select components across the entire 389-console codebase with the new TypeaheadSelect component, including:
- Database configuration (indexes, VLV indexes, password policies)
- Plugin configurations (MemberOf, DNA, Account Policy, etc.)
- Server settings (SASL, LDAPI, audit logging)
- Security settings (certificates, ciphers)
- Schema management (object classes, attribute types)
- Replication agreements and LDAP editor

Also fix a typo (separateed -> separated).

Fixes: https://github.com/389ds/389-ds-base/issues/6990

Reviewed by: ?