### PR TITLE
Issue 6997 - Logic error in get_bdb_impl_status prevents bdb2mdb exec…

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_dblib_test.py
@@ -16,6 +16,7 @@ from lib389.backend import DatabaseConfig
 from lib389.cli_ctl.dblib import (
     FakeArgs,
     dblib_bdb2mdb,
+    dblib_mdb2bdb,
     dblib_cleanup,
     is_bdb_supported)
 from lib389.idm.user import UserAccounts

--- a/src/lib389/lib389/cli_ctl/dblib.py
+++ b/src/lib389/lib389/cli_ctl/dblib.py
@@ -146,20 +146,27 @@ def get_bdb_impl_status():
     bundledbdb_plugin = 'libback-bdb'
     libdb = 'libdb-'
     plgstrs = check_plugin_strings(backldbm, [bundledbdb_plugin, libdb])
-    if has_robdb is True:
-        # read-only bdb build
-        return BDB_IMPL_STATUS.READ_ONLY
-    if plgstrs[bundledbdb_plugin] is True:
-        # bundled bdb build
-        if find_plugin_path(bundledbdb_plugin):
-            return BDB_IMPL_STATUS.BUNDLED
-        return BDB_IMPL_STATUS.NONE
-    if plgstrs[libdb] is True:
-        # standard bdb package build
-        return BDB_IMPL_STATUS.STANDARD
-    # Unable to find libback-ldbm plugin
-    return BDB_IMPL_STATUS.UNKNOWN
+    has_bundled_strings = plgstrs[bundledbdb_plugin] is True
+    has_standard_strings = plgstrs[libdb] is True
 
+    # Check read-only BDB
+    if has_robdb:
+        return BDB_IMPL_STATUS.READ_ONLY
+
+    # Check bundled BDB
+    if has_bundled_strings and find_plugin_path(bundledbdb_plugin):
+        return BDB_IMPL_STATUS.BUNDLED
+
+    # Check standard (provided by system) BDB
+    if has_standard_strings:
+        return BDB_IMPL_STATUS.STANDARD
+
+    # If bundled strings found but no working implementation
+    if has_bundled_strings:
+        return BDB_IMPL_STATUS.NONE
+
+    # Unable to find any BDB indicators in libback-ldbm plugin
+    return BDB_IMPL_STATUS.UNKNOWN
 
 def is_bdb_supported(read_write=True):
     bdbok = [BDB_IMPL_STATUS.BUNDLED, BDB_IMPL_STATUS.STANDARD]


### PR DESCRIPTION
…ution

Bug Description:
On F41 and F42 migration to MDB fails:
```
dsctl localhost dblib bdb2mdb
Berkeley Database library is not available. Maybe 389-ds-base-bdb rpm should be installed.
Error: Berkeley Database library is not available
```

This happens because `BDB_IMPL_STATUS.NONE` gets returned earlier than we check for presence of the standard libdb provided by the system.

Fix Description:
Rewrite the logic to return `BDB_IMPL_STATUS.NONE` only when no working BDB implementation is found.

Fixes: https://github.com/389ds/389-ds-base/issues/6997

## Summary by Sourcery

Fix get_bdb_impl_status logic to correctly detect the system-provided BDB library and only return NONE when a bundled indicator exists without a valid plugin path

Bug Fixes:
- Prevent premature NONE status return in get_bdb_impl_status so that the standard libdb is properly detected and bdb2mdb can execute
- Restructure the implementation status checks in order: read-only, bundled, standard, none (for found strings without plugin), and unknown