### PR TITLE
Issue 6758 - Fix failing webUI tests

### DIFF
--- a/dirsrvtests/tests/suites/webui/monitoring/monitoring_test.py
+++ b/dirsrvtests/tests/suites/webui/monitoring/monitoring_test.py
@@ -7,14 +7,17 @@
 # --- END COPYRIGHT BLOCK ---
 #
 import time
-import subprocess
 import pytest
+import logging
+import os
 
 from lib389.cli_idm.account import *
 from lib389.tasks import *
 from lib389.utils import *
 from lib389.topologies import topology_st
 from .. import setup_page, check_frame_assignment, setup_login, enable_replication
+
+log = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(os.getenv('WEBUI') is None, reason="These tests are only for WebUI environment")
 pytest.importorskip('playwright')

--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -1750,18 +1750,19 @@ export class EnableReplModal extends React.Component {
                             {_("Replication Role")}
                         </GridItem>
                         <GridItem span={2}>
-                            <FormSelect
-                                id="enableRole"
-                                value={enableRole}
-                                onChange={(e, str) => {
-                                    handleChange(e);
+                            <TypeaheadSelect
+                                selected={enableRole}
+                                onSelect={(e, selection) => {
+                                    const syntheticEvent = { target: { id: 'enableRole', value: selection } };
+                                    handleChange(syntheticEvent);
                                 }}
-                                aria-label="FormSelect Input"
-                            >
-                                <FormSelectOption key={0} value="Supplier" label={_("Supplier")} />
-                                <FormSelectOption key={1} value="Hub" label={_("Hub")} />
-                                <FormSelectOption key={2} value="Consumer" label={_("Consumer")} />
-                            </FormSelect>
+                                options={[_("Supplier"), _("Hub"), _("Consumer")]}
+                                isOpen={false}
+                                onToggle={() => {}}
+                                placeholder={_("Select role...")}
+                                ariaLabel="Replication role selection"
+                                isMulti={false}
+                            />
                         </GridItem>
                     </Grid>
                     {replicaIDRow}


### PR DESCRIPTION
Description: Fixes the failing test_replication_visibility test by adding a missing UI navigation step to correctly assert element visibility.

Relates: https://github.com/389ds/389-ds-base/issues/6758

Reviewed by: ???

## Summary by Sourcery

Fix failing webUI replication tests by enhancing the enable_replication helper with proper navigation steps, waits, and dialog handling, and update the replication modal to use a TypeaheadSelect for role selection.

Bug Fixes:
- Add missing suffix navigation and explicit wait_for calls in enable_replication helper to resolve test_replication_visibility failures.

Enhancements:
- Replace FormSelect with TypeaheadSelect for replication role selection in EnableReplModal component.

Tests:
- Import and configure logging in monitoring tests for improved debug output.