### PR TITLE
Issue 7008 - Prevent NULL deref of in dbmdb_open_all_files()

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -515,7 +515,7 @@ error:
         ctx->dbis_treeroot = NULL;
         for (i=0; i < ctx->startcfg.max_dbs; i++) {
             if (ctx->dbi_slots[i].dbname) {
-                if (valid_slots[i]) {
+                if (!valid_slots || valid_slots[i]) {
                     /* Insert the dbi in tree */
                     tsearch(&ctx->dbi_slots[i], &ctx->dbis_treeroot, cmp_dbi_names);
                 } else {


### PR DESCRIPTION
In `dbmdb_open_all_files()`, an early jump to the `error:` label can occur before the `valid_slots` array is allocated and initialized, which led to indexing `valid_slots[i]` and a NULL dereference in the rollback block. An early `error:` jump is possible if `START_TXN()` (or any subsequent call wrapped in `TST(...)`) fails before `valid_slots` is set up. The fix replaces `if (valid_slots[i])` with the safer `if (!valid_slots || valid_slots[i])`.

Issue: #7008 

## Summary by Sourcery

Bug Fixes:
- Guard against valid_slots being NULL when iterating in dbmdb_open_all_files to prevent invalid memory access