### PR TITLE
Issue 7010 - Fix certdir underflow in slapd_nss_init()

### DIFF
--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1045,10 +1045,16 @@ slapd_nss_init(int init_ssl __attribute__((unused)), int config_available __attr
        certdir is the path where the NSS database is located
      */
     certdir = config_get_certdir();
+    if (certdir == NULL || *certdir == '\0') {
+        slapi_log_err(SLAPI_LOG_ERR, "Security Initialization",
+                      "slapd_nss_init - Certificate directory is not configured");
+        slapi_ch_free_string(&certdir);
+        return -1;
+    }
 
     /* make sure path does not end in the path separator character */
     len = strlen(certdir);
-    if (certdir[len - 1] == '/' || certdir[len - 1] == '\\') {
+    if (len > 1 && (certdir[len - 1] == '/' || certdir[len - 1] == '\\')) {
         certdir[len - 1] = '\0';
     }
 


### PR DESCRIPTION
Static analysis flagged BUFFER_OVERFLOW.LEN at ssl.c. We were indexing `certdir[len - 1]` immediately after `len = strlen(certdir)` without guarding against `NULL` or an empty string. If `config_get_certdir()` returns `NULL`, `strlen()` is invalid; if it returns `""`, `certdir[-1]` is out of bounds. Trimming `"/"` also turned the path into an empty string.

Fix by validating `certdir` before calling `strlen()`, logging and failing early on `NULL`, and trimming trailing path separators only when `len > 1` (using a loop to handle multiple trailing separators). Free the string on error.

Issue: #7010

## Summary by Sourcery

Prevent buffer underflow in slapd_nss_init by adding certdir validation and adjusting the path-trimming logic

Bug Fixes:
- Validate certdir before calling strlen to guard against NULL or empty strings, log an error, free the string, and fail early
- Trim trailing path separators in a loop only when length > 1 to prevent buffer underflow