### PR TITLE
Issue 7012 - improve dscrl dbverify result when backend does not exists

### DIFF
--- a/dirsrvtests/tests/suites/clu/dbverify_test.py
+++ b/dirsrvtests/tests/suites/clu/dbverify_test.py
@@ -31,6 +31,7 @@ def set_log_file(request):
 
     def fin():
         log.info('Delete log file')
+        log.removeHandler(fh)
         os.remove(LOG_FILE)
 
     request.addfinalizer(fin)
@@ -66,6 +67,49 @@ def test_dsctl_dbverify(topology_st, set_log_file):
     with open(LOG_FILE, 'r+') as f:
         file_content = f.read()
         assert message in file_content
+
+
+def run_dbverify(inst, bename, rc=0):
+    # Run dsctl inst dbverify bename and check it returns rc
+    cmd = [ 'dsctl', inst.serverid, 'dbverify', bename ]
+    log.info(f'Run: {cmd}')
+    result =  subprocess.run(cmd, encoding='utf-8', capture_output=True, text=True)
+    log.info(f'Returned: {result.returncode} stdout: {result.stdout} stderr: {result.stderr}')
+    assert result.returncode == rc
+    return result
+
+
+
+def test_dbverify_bad_bename(topology_st, set_log_file):
+    """Test dbverify tool when backend does not exists
+
+    :id: da79a4cc-956c-11f0-8220-c85309d5c3e3
+    :setup: Standalone instance
+    :steps:
+         1. Create DS instance
+         2. Run dbverify
+         3. Check if dbverify provides the expected messages
+    :expectedresults:
+         1. Success
+         2. Success
+         3. Success
+    """
+
+    standalone = topology_st.standalone
+    if get_default_db_lib() == 'bdb':
+        message = "dbverify failed"
+        logmessage = "Backend 'userFoot' does not exist."
+        rc = 1
+    else:
+        message = "dbverify successful"
+        logmessage = "db_verify feature is meaningless"
+        rc = 0
+
+    standalone.stop()
+    result = run_dbverify(standalone, 'userFoot', rc)
+    assert message in result.stdout
+    assert logmessage in result.stderr
+
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c
@@ -195,6 +195,8 @@ bdb_verify(Slapi_PBlock *pb)
                 }
                 rval_main |= bdb_dbverify_ext(inst, verbose);
             } else {
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_verify",
+                              "Backend '%s' does not exist.\n", *inp);
                 rval_main |= 1; /* no such instance */
             }
         }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
@@ -17,6 +17,6 @@
 int
 dbmdb_verify(Slapi_PBlock *pb)
 {
-    slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_verify", "With lmdb, db_verify feature is meaningless and always successfull.\n");
+    slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_verify", "With lmdb, db_verify feature is meaningless and is always successfull.\n");
     return 0;  /* Fonction useless with lmdb - as we can verify the db when doing a backup */
 }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
@@ -17,5 +17,6 @@
 int
 dbmdb_verify(Slapi_PBlock *pb)
 {
+    slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_verify", "With lmdb, db_verify feature is meaningless and always successfull.\n");
     return 0;  /* Fonction useless with lmdb - as we can verify the db when doing a backup */
 }


### PR DESCRIPTION
Improve error message when running dsctl instance dbverify wrongBeName
To tell explicitly that the backend does not exists in bdb case
To tell explicitly that dbverify is useless and always successfull in lmdb case

Issue: #7012 

Reviewed by: @mreynolds389 and @tbordaz  (Thanks!)

## Summary by Sourcery

Improve the dbverify command to explicitly report missing BDB backends and warn for LMDB always-successful checks, and add a test covering both cases

Enhancements:
- Log an explicit error when dbverify is invoked on a non-existent BDB backend
- Emit a warning in the LMDB verify implementation that the feature is always successful and effectively meaningless
- Ensure the test teardown removes its file handler to prevent log handler leaks

Tests:
- Add a run_dbverify helper to invoke dsctl dbverify and validate its exit code and output
- Introduce test_dbverify_bad_bename to verify correct exit codes and messages for missing backends in both BDB and LMDB scenarios