### PR TITLE
Issue 7014 - memberOf - ignored deferred updates with LMDB

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_lmdb_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_lmdb_test.py
@@ -1,0 +1,128 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import time
+import ldap
+from lib389._constants import *
+from lib389.topologies import topology_st as topo
+from lib389.plugins import MemberOfPlugin
+from lib389.config import LMDB_LDBMConfig
+from lib389.utils import get_default_db_lib
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups
+
+log = logging.getLogger(__name__)
+
+DEBUGGING = os.getenv('DEBUGGING', False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+
+
+@pytest.mark.skipif(get_default_db_lib() != "mdb", reason="Not supported over mdb")
+def test_memberof_deferred_update_lmdb_rejection(topo):
+    """Test that memberOf plugin rejects deferred update configuration with LMDB backend
+
+    :id: a7f079dd-d269-41ca-95ec-91428e77626f
+    :setup: Standalone Instance with LMDB backend
+    :steps:
+        1. Enable memberOf plugin
+        2. Try to set deferred_update to "on"
+        3. Check error log for appropriate error message
+    :expectedresults:
+        1. Plugin enables successfully
+        2. Setting deferred_update fails
+        3. Error log contains "deferred_update is not supported with LMDB backend"
+    """
+
+    inst = topo.standalone
+
+    # Enable memberOf plugin
+    log.info("Step 1: Enabling memberOf plugin")
+    memberof_plugin = MemberOfPlugin(inst)
+    memberof_plugin.enable()
+    log.info("✓ MemberOf plugin enabled")
+    inst.deleteErrorLogs(restart=True)
+
+    # Try to set deferred_update to "on"
+    log.info("Step 2: Attempting to set deferred_update to 'on'")
+
+    # Try to modify the plugin configuration
+    plugin_dn = f"cn={PLUGIN_MEMBER_OF},cn=plugins,cn=config"
+    memberof_plugin.set_memberofdeferredupdate('on')
+
+    # Check error log for appropriate error message
+    log.info("Step 3: Checking error log for LMDB-specific error message")
+    assert inst.ds_error_log.match(".*deferred_update is not supported with LMDB backend.*")
+
+    log.info("✓ Test completed successfully - memberOf plugin correctly rejects deferred update with LMDB backend")
+
+
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
+def test_memberof_deferred_update_non_lmdb_success(topo):
+    """Test that memberOf plugin allows deferred update configuration with non-LMDB backends
+
+    :id: a4b640c8-ef54-4cbf-8d1a-8b29fcdd59d1
+    :setup: Standalone Instance with non-LMDB backend (BDB)
+    :steps:
+        1. Enable memberOf plugin
+        2. Set deferred_update to "on"
+        3. Verify the operation succeeds
+        4. Verify deferred_update remains "on"
+    :expectedresults:
+        1. Plugin enables successfully
+        2. Setting deferred_update succeeds
+        3. No error occurs
+        4. deferred_update is "on"
+    """
+
+    inst = topo.standalone
+
+    # Enable memberOf plugin
+    log.info("Step 1: Enabling memberOf plugin")
+    memberof_plugin = MemberOfPlugin(inst)
+    memberof_plugin.enable()
+    log.info("✓ MemberOf plugin enabled")
+    inst.deleteErrorLogs(restart=True)
+
+    # Set deferred_update to "on"
+    log.info("Step 2: Setting deferred_update to 'on'")
+
+    # Try to modify the plugin configuration
+    try:
+        memberof_plugin.set_memberofdeferredupdate('on')
+        log.info("✓ Successfully set deferred_update to 'on'")
+    except Exception as e:
+        assert False, f"Expected success when setting deferred_update with non-LMDB backend, got: {type(e).__name__}: {e}"
+
+    # Verify no error occurred
+    log.info("Step 3: Verifying no error occurred")
+    assert not inst.ds_error_log.match(".*deferred_update is not supported with LMDB backend.*")
+
+    log.info("✓ No LMDB-related error messages found")
+
+    # Verify deferred_update remains "on"
+    log.info("Step 4: Verifying deferred_update is 'on'")
+    current_deferred = memberof_plugin.get_memberofdeferredupdate()
+    assert current_deferred is None or current_deferred.lower() == 'on', \
+        f"Expected deferred_update to be 'on', got: {current_deferred}"
+    log.info("✓ deferred_update is 'on'")
+
+    log.info("✓ Test completed successfully - memberOf plugin correctly allows deferred update with non-LMDB backend")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_repl_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_repl_test.py
@@ -17,10 +17,12 @@ from lib389.replica import Replicas
 from lib389.plugins import MemberOfPlugin
 from lib389.idm.user import UserAccounts
 from lib389.idm.group import Groups
+from lib389.utils import get_default_db_lib
 
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 def test_repl_deferred_updates(topo_m2):
     """Test memberOf plugin deferred updates work in different types of
     replicated environments

--- a/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -26,9 +26,9 @@ from lib389.tasks import *
 from lib389.idm.nscontainer import nsContainers
 from lib389.idm.domain import Domain
 from lib389.dirsrv_log import DirsrvErrorLog
-from lib389.dseldif import DSEldif
-from contextlib import suppress
+from lib389.utils import get_default_db_lib
 from . import check_membership
+
 
 # Skip on older versions
 pytestmark = [pytest.mark.tier1,
@@ -1278,6 +1278,7 @@ def _kill_instance(inst, sig=signal.SIGTERM, delay=None):
         time.sleep(delay)
     os.kill(pid, signal.SIGKILL)
 
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 def test_shutdown_on_deferred_memberof(topology_st, request):
     """This test checks that shutdown is handled properly if memberof updayes are deferred.
 
@@ -1470,6 +1471,10 @@ def test_memberof_modrdn_to_itself(topology_st, user1, group1):
 
     # Enable the MemberOf plugin
     memberof = MemberOfPlugin(topology_st.standalone)
+    memberof.remove_all_entryscope()
+    memberof.remove_all_excludescope()
+    memberof.remove_configarea()
+    memberof.remove_autoaddoc()
     memberof.enable()
     topology_st.standalone.restart()
 

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -1184,7 +1184,7 @@ memberof_postop_start(Slapi_PBlock *pb)
     memberof_rlock_config();
     mainConfig = memberof_get_config();
     /* if the update of the members is deferred then allocate mutex/cv */
-    if (mainConfig->deferred_update) {
+    if (mainConfig->deferred_update && !mainConfig->is_lmdb) {
         MemberofDeferredList *deferred_list;
         pthread_condattr_t condAttr;
 
@@ -1367,7 +1367,7 @@ memberof_postop_del(Slapi_PBlock *pb)
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-        deferred_update = mainConfig->deferred_update;
+        deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -1743,7 +1743,7 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-        deferred_update = mainConfig->deferred_update;
+        deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2062,7 +2062,8 @@ memberof_postop_modify(Slapi_PBlock *pb)
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-        deferred_update = mainConfig->deferred_update;
+
+        deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2322,7 +2323,7 @@ memberof_postop_add(Slapi_PBlock *pb)
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-        deferred_update = mainConfig->deferred_update;
+        deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
         if (deferred_update) {

--- a/ldap/servers/plugins/memberof/memberof.h
+++ b/ldap/servers/plugins/memberof/memberof.h
@@ -140,6 +140,7 @@ typedef struct memberofconfig
     Slapi_Task *task;
     int need_fixup;
     PRBool launch_fixup;
+    bool is_lmdb;
 } MemberOfConfig;
 
 /* The key to access the hash table is the normalized DN

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -521,6 +521,8 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
      */
     memberof_wlock_config();
     theConfig.need_fixup = (needfixup != NULL);
+    /* DB implementation */
+    theConfig.is_lmdb = slapi_db_is_lmdb();
 
     if (groupattrs) {
         int i = 0;
@@ -636,12 +638,16 @@ memberof_apply_config(Slapi_PBlock *pb __attribute__((unused)),
         }
     }
 
-
     if (deferred_update) {
+        theConfig.deferred_update = PR_FALSE;
         if (strcasecmp(deferred_update, "on") == 0) {
-            theConfig.deferred_update = PR_TRUE;
-        } else {
-            theConfig.deferred_update = PR_FALSE;
+            if (theConfig.is_lmdb) {
+                slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
+                              "memberof_apply_config - "
+                              "deferred_update is not supported with LMDB backend and will be ignored\n");
+            } else {
+                theConfig.deferred_update = PR_TRUE;
+            }
         }
     }
     theConfig.launch_fixup = PR_FALSE;

--- a/ldap/servers/plugins/posix-winsync/posix-wsp-ident.h
+++ b/ldap/servers/plugins/posix-winsync/posix-wsp-ident.h
@@ -12,8 +12,6 @@
 #define PLUGIN_MAGIC_VENDOR_STR "contac Datentechnik GmbH"
 #define PRODUCTTEXT "1.1"
 #define null NULL
-#define true - 1
-#define false 0
 #define POSIX_WINSYNC_MSSFU_SCHEMA "posixWinsyncMsSFUSchema"
 #define POSIX_WINSYNC_MAP_MEMBERUID "posixWinsyncMapMemberUID"
 #define POSIX_WINSYNC_CREATE_MEMBEROFTASK "posixWinsyncCreateMemberOfTask"

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "nspr.h"
 #include "portable.h"
 #include "slapi-plugin.h"
+#include <stdbool.h>
 /*
  * XXXmcs: we can stop including slapi-plugin-compat4.h once we stop using
  * deprecated functions internally.
@@ -1265,6 +1266,7 @@ int mkdir_p(char *dir, unsigned int mode);
 const char *ldif_getline_ro( const char **next);
 void dup_ldif_line(struct berval *copy, const char *line, const char *endline);
 const char *get_oid_name(const char *oid);
+bool slapi_db_is_lmdb(void);
 
 /* slapi-memberof.c */
 int slapi_memberof(Slapi_MemberOfConfig *config, Slapi_DN *member_sdn, Slapi_MemberOfResult *result);


### PR DESCRIPTION
Description:

When processing the memberOf plugin conifguration simply ignore the deferred update settings if LMDB is in use.  Log a message in the error log but do not reject the update because rejecting the update causes the server to not start up.

Relates: https://github.com/389ds/389-ds-base/issues/7014

## Summary by Sourcery

Ignore the memberOf plugin’s deferred_update setting when using an LMDB backend to avoid startup failures, while preserving the setting for other backends and logging a notice. Add a detection helper and update build configuration, and include tests covering both LMDB and non‐LMDB scenarios.

Bug Fixes:
- Prevent server startup failures by ignoring memberOf deferred_update on LMDB instead of rejecting the update

Enhancements:
- Add slapi_db_is_lmdb() helper to detect LMDB backend
- Link memberOf plugin against libback-ldbm in the build configuration

Tests:
- Add pytest tests verifying deferred_update is ignored with LMDB and honored with other backends