### PR TITLE
Issue 7016 - fix NULL deref in send_referrals_from_entry()

### DIFF
--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -3887,9 +3887,7 @@ send_referrals_from_entry(Slapi_PBlock *pb, Slapi_Entry *referral)
     slapi_entry_attr_find(referral, "ref", &attr);
     if (attr != NULL) {
         slapi_attr_get_numvalues(attr, &numValues);
-        if (numValues > 0) {
-            url = (struct berval **)slapi_ch_malloc((numValues + 1) * sizeof(struct berval *));
-        }
+        url = (struct berval **)slapi_ch_malloc((numValues + 1) * sizeof(struct berval *));
         for (i = slapi_attr_first_value(attr, &val); i != -1;
              i = slapi_attr_next_value(attr, i, &val)) {
             url[i] = (struct berval *)slapi_value_get_berval(val);


### PR DESCRIPTION
Static analysis (DEREF_OF_NULL.EX) flagged a possible null-pointer dereference at `entry.c` where `url[numValues] = NULL;` is written even when `numValues == 0`. If `attr != NULL` but the attribute has no values, `url` remains `NULL` because allocation was guarded by `if (numValues > 0)`, and writing the terminator dereferences `url[0]`. Fix by always allocating `(numValues + 1)` pointers when `attr != NULL`, ensuring `url[numValues]` is valid even for an empty list.

Edit:
Issue #7016 

## Summary by Sourcery

Bug Fixes:
- Ensure the url array is allocated unconditionally to prevent dereferencing a NULL pointer when an attribute has no values