### PR TITLE
Issue 7021 - Units for changing MDB max size are not consistent across different tools

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -1097,7 +1097,7 @@ def create_parser(subparsers):
     set_db_config_parser.add_argument('--deadlock-policy', help='Adjusts the backend database deadlock policy (Advanced setting)')
     set_db_config_parser.add_argument('--db-home-directory', help='Sets the directory for the database mmapped files (Advanced setting)')
     set_db_config_parser.add_argument('--db-lib', help='Sets which db lib is used. Valid values are: bdb or mdb')
-    set_db_config_parser.add_argument('--mdb-max-size', help='Sets the mdb database maximum size (accepts bytes, or with unit suffix: k, m, g, t)')
+    set_db_config_parser.add_argument('--mdb-max-size', help='Sets the lmdb database maximum size (accepts bytes, or with unit suffix: k, m, g, t)')
     set_db_config_parser.add_argument('--mdb-max-readers', help='Sets the lmdb database maximum number of readers (Advanced setting)')
     set_db_config_parser.add_argument('--mdb-max-dbs', help='Sets the lmdb database maximum number of sub databases (Advanced setting)')
 

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1490,9 +1490,7 @@ def ensure_dict_str(val):
 
 def align_to_page_size(size):
     page_size = os.sysconf("SC_PAGE_SIZE")
-    if size % page_size == 0:
-        return size
-    return ((size // page_size) + 1) * page_size
+    return ((size + page_size - 1) // page_size) * page_size
 
 
 def pseudolocalize(string):

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1488,6 +1488,13 @@ def ensure_dict_str(val):
     return retdict
 
 
+def align_to_page_size(size):
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    if size % page_size == 0:
+        return size
+    return ((size // page_size) + 1) * page_size
+
+
 def pseudolocalize(string):
     pseudo_string = u""
     for char in string:


### PR DESCRIPTION
Description: nsslapd-mdb-max-size accepts value in bytes. But it can't be any value, it should be a multiple of the page size, which can vary (4K, 16K, 64K on different architectures). dscreate accepts unit suffix but this value is not pagesize aligned. dsconf sets the lmdb database maximum size (in bytes) and is also not pagesize aligned.

Update dscreate a page align the mdb max size and dsconf to accept unit suffix and page size align the value

Fixes: https://github.com/389ds/389-ds-base/issues/7021

Reviewed by:

## Summary by Sourcery

Normalize mdb max size handling by parsing unit suffixes and enforcing system page-size alignment in both dsconf and dscreate workflows

New Features:
- Support byte unit suffixes (k, m, g, t) for the --mdb-max-size flag in dsconf

Bug Fixes:
- Enforce page-size alignment on nsslapd-mdb-max-size values during dsconf operations and initial dscreate setup

Enhancements:
- Add align_to_page_size utility to round sizes up to the OS page boundary