### PR TITLE
Issue 7023 - UI - if first instance that is loaded is stopped it brea…

### DIFF
--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -371,6 +371,14 @@ export class LDAPEditor extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (this.props.serverId !== prevProps.serverId) {
+            getAllObjectClasses(this.props.serverId, (ocs) => {
+                this.setState({
+                    allObjectclasses: ocs,
+                }, () => { this.getAttributes(this.showSuffixes) });
+            });
+        }
+
         if (this.props.wasActiveList.includes(7)) {
             if (this.state.firstLoad) {
                 this.handleReload(true);

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -303,8 +303,6 @@ export class Database extends React.Component {
                         if ('nsslapd-directory' in attrs) {
                             dbhome = attrs['nsslapd-directory'][0];
                         }
-                        console.log("MARK loaded attrs: ",attrs);
-
 
                         if (attrs['nsslapd-cache-autosize'][0] !== "-1") {
                             db_cache_auto = true;

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -131,6 +131,7 @@ export class Monitor extends React.Component {
             } else {
                 if (this.props.serverId !== prevProps.serverId) {
                     this.loadSuffixTree(false);
+                    this.getDBEngine();
                 }
             }
         }
@@ -643,10 +644,7 @@ export class Monitor extends React.Component {
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
-                    this.props.addNotification(
-                        "error",
-                        cockpit.format("Error detecting DB implementation type - $0", errMsg.desc)
-                    );
+                    console.log("getDBEngine - Error detecting DB implementation type -", errMsg.desc);
                 });
     }
 


### PR DESCRIPTION
…ks parts of the UI

Description:

When checking for DB implementation or loading objectclasses for the LDAP editor if the first instance is stopped then these settings are not loaded, and when you switch to a new instance that is running they are not reloaded. This causes things to unexpectedly break for valid instances that are running.

Relates: https://github.com/389ds/389-ds-base/issues/7023

## Summary by Sourcery

Reload LDAP object classes and database engine information when switching server instances to prevent stale UI data when the initial instance is stopped

Bug Fixes:
- Reload object classes in the LDAP editor component on serverId change
- Invoke database engine detection in monitor component when switching to a new instance

Enhancements:
- Replace DB detection error notification with console log
- Remove leftover debug console logs from the database component