### PR TITLE
Issue 6846 - Attribute uniqueness is not enforced with modrdn

### DIFF
--- a/dirsrvtests/tests/suites/plugins/attruniq_test.py
+++ b/dirsrvtests/tests/suites/plugins/attruniq_test.py
@@ -21,7 +21,6 @@ from lib389._constants import DEFAULT_SUFFIX
 from lib389.topologies import topology_st
 from lib389.utils import ds_is_older
 
-
 pytestmark = [pytest.mark.tier1,
               pytest.mark.skipif(ds_is_older('1.3.3'), reason="Not implemented")]
 
@@ -638,7 +637,6 @@ def test_one_container_mod(topology_st, attruniq, containers,
         active_user_2.replace('cn', ACTIVE_USER_1_CN)
 
 
-@pytest.mark.xfail(reason="DS6846")
 def test_one_container_modrdn(topology_st, attruniq, containers,
                               active_user_1, active_user_2):
     """Test MODRDN operations with attribute uniqueness in a single container.
@@ -848,7 +846,6 @@ def test_multiple_containers_mod_across_subtrees(topology_st, attruniq, containe
         stage_user_1.replace('cn', ACTIVE_USER_1_CN)
 
 
-@pytest.mark.xfail(reason="DS6846")
 def test_multiple_containers_modrdn(topology_st, attruniq, containers,
                            active_user_1, active_user_2, stage_user_1, stage_user_2):
     """Test MODRDN operations with attribute uniqueness across multiple containers.
@@ -890,7 +887,6 @@ def test_multiple_containers_modrdn(topology_st, attruniq, containers,
     stage_user_2.rename(f'cn={ACTIVE_USER_1_CN}', deloldrdn=False)
 
 
-@pytest.mark.xfail(reason="DS6846")
 def test_multiple_containers_modrdn_across_subtrees(topology_st, attruniq, containers,
                                         active_user_1, active_user_2, stage_user_1, stage_user_2):
         """Test MODRDN operations with attribute uniqueness across multiple containers with cross-subtree enforcement.

--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1342,9 +1342,11 @@ preop_modrdn(Slapi_PBlock *pb)
      * its current level in the tree.  Use the source SDN for
      * determining which managed tree this belongs to
      */
-    if (!destinationSDN || slapi_sdn_get_dn(destinationSDN) == NULL) {
-        /* If no superior was specified fall back to the parent of source */
+    if (!destinationSDN) {
         destinationSDN = slapi_sdn_new();
+    }
+    if (slapi_sdn_get_dn(destinationSDN) == NULL) {
+        /* If no superior was specified fall back to the parent of source */
         slapi_sdn_get_parent(sourceSDN, destinationSDN);
     }
 

--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1342,8 +1342,11 @@ preop_modrdn(Slapi_PBlock *pb)
      * its current level in the tree.  Use the source SDN for
      * determining which managed tree this belongs to
      */
-    if (!destinationSDN)
+    if (!destinationSDN || slapi_sdn_get_dn(destinationSDN) == NULL) {
+        /* If no superior was specified fall back to the parent of source */
+        destinationSDN = slapi_sdn_new();
         slapi_sdn_get_parent(sourceSDN, destinationSDN);
+    }
 
     /* Get the new RDN - this has the attribute values */
     err = slapi_pblock_get(pb, SLAPI_MODRDN_NEWRDN, &rdn);


### PR DESCRIPTION
Description: The attribute uniqueness plugin fails to enforce uniqueness on the CN attribute during a MODRDN operation. If no new superior DN is specified, the destinationSDN is an empty SDN struct, breaking marker and subtree searches later.

In this case we fall back to using the parent of the source entry as the destination.

Fixes: https://github.com/389ds/389-ds-base/issues/6846

Reviewed by:

## Summary by Sourcery

Ensure the attribute uniqueness plugin handles MODRDN operations without a specified superior DN by using the parent of the source entry, and enable the corresponding tests to validate this fix.

Bug Fixes:
- Enforce attribute uniqueness for MODRDN operations when no new superior DN is specified by falling back to the source entry's parent DN

Tests:
- Remove xfail markers from MODRDN tests in attruniq_test.py to enable validation of the fixed behavior