### PR TITLE
Issue 7027 - 389-ds-base OpenScanHub Leaks Detected

### DIFF
--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -193,8 +193,12 @@ compress_log_file(char *log_name, int32_t mode)
      * compressed content.
      */
     if ((fd = open(gzip_log, O_WRONLY|O_CREAT|O_TRUNC, mode)) >= 0) {
-        /* FIle successfully created, now pass the FD to gzdopen() */
+        /* File successfully created, now pass the FD to gzdopen() */
         outfile = gzdopen(fd, "ab");
+        if (outfile == NULL) {
+            close(fd);
+            return -1;
+        }
     } else {
         return -1;
     }


### PR DESCRIPTION
Description: A file is opened using open() and then wrapped in a zlib gzFile with gzdopen(). If gzdopen() fails, it never takes ownership of the fd, so it remains open.

Fix: Ensure fd is explicitly closed when gzdopen() returns NULL.

Fixes: https://github.com/389ds/389-ds-base/issues/7027

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Close the opened file descriptor if gzdopen returns NULL to avoid leaking the file descriptor.