### PR TITLE
Issue 7032 - The new ipahealthcheck test ipahealthcheck.ds.backends.B…

### DIFF
--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -703,7 +703,7 @@ class Backend(DSLdapObject):
                             reindex_attrs.add(attr_name)
 
                     # Check fine grain definitions for parentid ONLY
-                    expected_scanlimit = expected_config['scanlimit']
+                    expected_scanlimit = expected_config.get('scanlimit')
                     if (attr_name.lower() == "parentid") and expected_scanlimit and (len(actual_scanlimit) == 0):
                             discrepancies.append(f"Index {attr_name} missing fine grain definition of IDs limit: {expected_mr}")
                             # Add the missing scanlimit


### PR DESCRIPTION
…ackendsCheck raises CRITICAL issue

Bug description:
	The bug fix #6966 adds a 'scanlimit' to one of the system
	index ('parentid'). So not all of them have such attribute.
	In healthcheck such attribute (i.e. key) can miss but
	the code assumes it is present

Fix description:
	Get 'parentid' from the dict with the proper routine
	(Thanks Florence Renaud for the debug/fix)

fixes: #7032

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Avoid KeyError in ipahealthcheck by safely retrieving 'scanlimit' from expected_config