### PR TITLE
Issue 7035 - RFE - memberOf - adding scoping for specific groups

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_memberof_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_memberof_test.py
@@ -1,0 +1,468 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+"""Test dsconf CLI with MemberOf plugin configuration"""
+
+import json
+import subprocess
+import logging
+import pytest
+from lib389._constants import DN_DM
+from lib389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+# MemberOf plugin configuration options to test
+MEMBEROF_SETTINGS = [
+    # ('attr', 'memberOf'), Already set by default
+    ('groupattr', ['member', 'uniquemember']),
+    ('allbackends', 'on'),
+    ('allbackends', 'off'),
+    ('skipnested', 'on'),
+    ('skipnested', 'off'),
+    ('scope', ['dc=example,dc=com', 'ou=groups,dc=example,dc=com']),
+    ('exclude', ['ou=excluded,dc=example,dc=com']),
+    ('autoaddoc', 'inetuser'),
+    ('deferredupdate', 'on'),
+    ('deferredupdate', 'off'),
+    ('launchfixup', 'on'),
+    ('launchfixup', 'off'),
+    ('specific-group-filter', ['(entrydn=cn=group1,ou=groups,dc=example,dc=com)']),
+    ('exclude-specific-group-filter', ['(entrydn=cn=excluded,ou=groups,dc=example,dc=com)']),
+    ('specific-group-oc', ['groupofnames', 'groupofuniquenames']),
+]
+
+# Config entry specific settings
+CONFIG_ENTRY_SETTINGS = [
+    ('attr', 'memberOf'),
+    ('groupattr', ['member', 'uniquemember']),
+    ('allbackends', 'on'),
+    ('skipnested', 'on'),
+    ('scope', ['dc=example,dc=com']),
+    ('exclude', ['ou=excluded,dc=example,dc=com']),
+    ('autoaddoc', 'inetuser'),
+    ('specific-group-filter', ['(entrydn=cn=group1,ou=groups,dc=example,dc=com)']),
+    ('exclude-specific-group-filter', ['(entrydn=cn=excluded,ou=groups,dc=example,dc=com)']),
+    ('specific-group-oc', ['groupofnames']),
+]
+
+
+def execute_dsconf_command(dsconf_cmd, subcommands):
+    """Execute dsconf command and return output and return code"""
+
+    cmdline = dsconf_cmd + subcommands
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+
+    if proc.returncode != 0 and err:
+        log.error(f"Command failed: {' '.join(cmdline)}")
+        log.error(f"Stderr: {err.decode('utf-8')}")
+
+    return out.decode('utf-8'), proc.returncode
+
+
+def get_dsconf_base_cmd(topo):
+    """Return base dsconf command list"""
+    return ['/usr/sbin/dsconf', topo.standalone.serverid,
+            '-j', '-D', DN_DM, '-w', 'password', 'plugin', 'memberof']
+
+
+def test_memberof_plugin_status(topo):
+    """Test memberof plugin status and basic operations
+
+    :id: memberof-status-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Check plugin status
+        2. Enable plugin if needed
+        3. Verify plugin is enabled
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Check plugin status
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    log.info(f"Plugin status: {output}")
+
+    # Enable plugin if not already enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['enable'])
+    assert rc == 0
+    log.info(f"Plugin enable result: {output}")
+
+    # Verify plugin is enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'enabled'
+
+
+def test_memberof_plugin_get(topo):
+    """Test memberof plugin get command
+
+    :id: memberof-get-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Get plugin configuration
+    :expectedresults:
+        1. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    output, rc = execute_dsconf_command(dsconf_cmd, ['show'])
+    assert rc == 0
+    log.info(f"Plugin configuration: {output}")
+
+    # Parse JSON output to verify structure
+    json_result = json.loads(output)
+    assert json_result.get('type') == 'entry'
+
+
+@pytest.mark.parametrize("attr,value", MEMBEROF_SETTINGS)
+def test_memberof_plugin_set(topo, attr, value):
+    """Test memberof plugin set command with various configuration options
+
+    :id: memberof-set-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Set various memberof plugin configuration options
+        2. Verify the setting was applied
+        3. Reset to default values
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Build the set command
+    set_cmd = ['set', f'--{attr}']
+    if isinstance(value, list):
+        set_cmd.extend(value)
+    else:
+        set_cmd.append(value)
+
+    # Set the configuration
+    output, rc = execute_dsconf_command(dsconf_cmd, set_cmd)
+    assert rc == 0, f"Failed to set {attr}={value}: {output}"
+    log.info(f"Set {attr}={value} successfully")
+
+    # Verify the setting was applied by getting the configuration
+    output, rc = execute_dsconf_command(dsconf_cmd, ['show'])
+    assert rc == 0
+    json_result = json.loads(output)
+
+    # Check if the attribute was set correctly
+    if attr == 'groupattr' and isinstance(value, list):
+        # For multi-valued attributes, check if all values are present
+        config_value = json_result['attrs']['memberofgroupattr']
+        if isinstance(config_value, str):
+            config_value = [config_value]
+        for val in value:
+            assert val in config_value, f"Expected {val} in {config_value}"
+    elif attr in ['scope', 'exclude', 'specific-group-filter', 'exclude-specific-group-filter', 'specific-group-oc'] and isinstance(value, list):
+        # For multi-valued attributes
+        config_attr = f'memberof{attr.title().replace("-", "")}'
+        if attr == 'scope':
+            config_attr = 'memberofentryscope'
+        elif attr == 'exclude':
+            config_attr = 'memberofentryscopeexcludesubtree'
+        elif attr == 'specific-group-filter':
+            config_attr = 'memberofspecificgroupfilter'
+        elif attr == 'exclude-specific-group-filter':
+            config_attr = 'memberofexcludespecificgroupfilter'
+        elif attr == 'specific-group-oc':
+            config_attr = 'memberofspecificgroupoc'
+
+        config_value = json_result['attrs'][config_attr]
+        if isinstance(config_value, str):
+            config_value = [config_value]
+        for val in value:
+            assert val in config_value, f"Expected {val} in {config_value}"
+    else:
+        # For single-valued attributes
+        config_attr = f'memberof{attr.title().replace("-", "")}'
+        if attr == 'attr':
+            config_attr = 'memberofattr'
+        elif attr == 'groupattr':
+            config_attr = 'memberofgroupattr'
+        elif attr == 'allbackends':
+            config_attr = 'memberofallbackends'
+        elif attr == 'skipnested':
+            config_attr = 'memberofskipnested'
+        elif attr == 'autoaddoc':
+            config_attr = 'memberofautoaddoc'
+        elif attr == 'deferredupdate':
+            config_attr = 'memberofdeferredupdate'
+        elif attr == 'launchfixup':
+            config_attr = 'memberoflaunchfixup'
+
+        if config_attr not in json_result['attrs']:
+            config_value = ""
+        else:
+            config_value = json_result['attrs'][config_attr][0].lower()
+        if attr in ['allbackends', 'skipnested', 'deferredupdate', 'launchfixup']:
+            expected_value = 'on' if value == 'on' else 'off'
+            assert config_value == expected_value, f"Expected {expected_value}, got {config_value}"
+        else:
+            assert config_value == value.lower(), f"Expected {value}, got {config_value}"
+
+    # Reset to default values (delete the attribute)
+    reset_cmd = ['set', f'--{attr}', 'delete']
+
+    output, rc = execute_dsconf_command(dsconf_cmd, reset_cmd)
+    # Some attributes might not be deletable, so we don't assert on return code
+    log.info(f"Reset {attr}: {output}")
+
+
+def test_memberof_config_entry_operations(topo):
+    """Test memberof config-entry operations
+
+    :id: memberof-config-entry-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Add a config entry
+        2. Show the config entry
+        3. Edit the config entry
+        4. Delete the config entry
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    config_dn = 'cn=test-config,cn=memberof plugin,cn=plugins,cn=config'
+
+    # Add config entry
+    add_cmd = ['config-entry', 'add', config_dn, '--attr', 'memberOf', '--groupattr', 'member']
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    assert rc == 0, f"Failed to add config entry: {output}"
+    log.info(f"Added config entry: {output}")
+
+    # Show config entry
+    show_cmd = ['config-entry', 'show', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show config entry: {output}"
+    log.info(f"Config entry details: {output}")
+
+    # Edit config entry
+    edit_cmd = ['config-entry', 'set', config_dn, '--attr', 'memberOf', '--groupattr', 'uniqueMember']
+    output, rc = execute_dsconf_command(dsconf_cmd, edit_cmd)
+    assert rc == 0, f"Failed to edit config entry: {output}"
+    log.info(f"Edited config entry: {output}")
+
+    # Show config entry again to verify changes
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show updated config entry: {output}"
+    json_result = json.loads(output)
+    assert json_result['attrs']['memberofgroupattr'][0] == 'uniqueMember'
+
+    # Delete config entry
+    delete_cmd = ['config-entry', 'delete', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, delete_cmd)
+    assert rc == 0, f"Failed to delete config entry: {output}"
+    log.info(f"Deleted config entry: {output}")
+
+
+@pytest.mark.parametrize("attr,value", CONFIG_ENTRY_SETTINGS)
+def test_memberof_config_entry_set(topo, attr, value):
+    """Test memberof config-entry set command with various configuration options
+
+    :id: memberof-config-entry-set-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Add a config entry with specific settings
+        2. Verify the settings were applied
+        3. Delete the config entry
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    config_dn = f'cn=test-config-{attr},cn=memberof plugin,cn=plugins,cn=config'
+
+    # Build the add command
+    add_cmd = ['config-entry', 'add', config_dn, '--attr', 'memberOf']
+    if attr != 'groupattr':
+        add_cmd.extend(['--groupattr', 'memberof'] )
+
+    if isinstance(value, list):
+        add_cmd.extend([f'--{attr}'] + value)
+    else:
+        add_cmd.extend([f'--{attr}', value])
+
+    # Add config entry
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    assert rc == 0, f"Failed to add config entry with {attr}={value}: {output}"
+    log.info(f"Added config entry with {attr}={value}")
+
+    # Show config entry to verify
+    show_cmd = ['config-entry', 'show', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show config entry: {output}"
+    json_result = json.loads(output)
+
+    # Verify the setting was applied
+    if attr == 'groupattr':
+        config_attr = 'memberofgroupattr'
+    else:
+        config_attr = f'memberof{attr.replace("-", "")}'
+        if attr == 'scope':
+            config_attr = 'memberofentryscope'
+        elif attr == 'exclude':
+            config_attr = 'memberofentryscopeexcludesubtree'
+        elif attr == 'specific-group-filter':
+            config_attr = 'memberofspecificgroupfilter'
+        elif attr == 'exclude-specific-group-filter':
+            config_attr = 'memberofexcludespecificgroupfilter'
+        elif attr == 'specific-group-oc':
+            config_attr = 'memberofspecificgroupoc'
+
+    config_value = json_result['attrs'][config_attr]
+    if isinstance(value, list):
+        if isinstance(config_value, str):
+            config_value = [config_value]
+        for val in value:
+            assert val in config_value, f"Expected {val} in {config_value}"
+    else:
+        assert config_value[0] == value, f"Expected {value}, got {config_value}"
+
+    # Delete config entry
+    delete_cmd = ['config-entry', 'delete', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, delete_cmd)
+    assert rc == 0, f"Failed to delete config entry: {output}"
+    log.info(f"Deleted config entry: {output}")
+
+
+def test_memberof_fixup_operations(topo):
+    """Test memberof fixup operations
+
+    :id: memberof-fixup-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Test fixup command with a base DN
+        2. Test fixup-status command
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    base_dn = 'dc=example,dc=com'
+
+    # Test fixup command (this will create a task entry)
+    fixup_cmd = ['fixup', base_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, fixup_cmd)
+    # Fixup might fail if the base DN doesn't exist, which is expected
+    log.info(f"Fixup command result: {output}")
+
+    # Test fixup-status command
+    status_cmd = ['fixup-status']
+    output, rc = execute_dsconf_command(dsconf_cmd, status_cmd)
+    # Status command should work even if no tasks exist
+    log.info(f"Fixup status: {output}")
+
+
+def test_memberof_invalid_configurations(topo):
+    """Test memberof plugin with invalid configurations
+
+    :id: memberof-invalid-config-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Test with invalid attribute values
+        2. Test with invalid DN values
+        3. Test with missing required parameters
+    :expectedresults:
+        1. Should fail gracefully
+        2. Should fail gracefully
+        3. Should fail gracefully
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Test with invalid attribute value
+    output, rc = execute_dsconf_command(dsconf_cmd, ['set', '--attr', ''])
+    # This might succeed or fail depending on validation
+    log.info(f"Empty attr test: {output}")
+
+    # Test with invalid DN in config entry
+    invalid_dn = 'invalid-dn-format'
+    add_cmd = ['config-entry', 'add', invalid_dn, '--attr', 'memberOf']
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    # This should fail
+    assert rc != 0, f"Expected failure for invalid DN, but got success: {output}"
+    log.info(f"Invalid DN test failed as expected: {output}")
+
+    # Test with missing required parameters in config entry
+    config_dn = 'cn=test-invalid,cn=memberof config,cn=plugins,cn=config'
+    add_cmd = ['config-entry', 'add', config_dn]  # Missing --attr
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    # This should fail
+    assert rc != 0, f"Expected failure for missing required parameters, but got success: {output}"
+    log.info(f"Missing parameters test failed as expected: {output}")
+
+
+def test_memberof_plugin_disable_enable(topo):
+    """Test memberof plugin disable and enable operations
+
+    :id: memberof-disable-enable-test
+    :setup: Standalone DS instance
+    :steps:
+        1. Disable the plugin
+        2. Verify plugin is disabled
+        3. Enable the plugin
+        4. Verify plugin is enabled
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Disable plugin
+    output, rc = execute_dsconf_command(dsconf_cmd, ['disable'])
+    assert rc == 0, f"Failed to disable plugin: {output}"
+    log.info(f"Disabled plugin: {output}")
+
+    # Verify plugin is disabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'disabled'
+
+    # Enable plugin
+    output, rc = execute_dsconf_command(dsconf_cmd, ['enable'])
+    assert rc == 0, f"Failed to enable plugin: {output}"
+    log.info(f"Enabled plugin: {output}")
+
+    # Verify plugin is enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'enabled'
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
@@ -20,7 +20,7 @@ from lib389.plugins import USNPlugin, POSIXWinsyncPlugin, LinkedAttributesPlugin
 from lib389.dbgen import dbgen_users
 from lib389.idm.user import UserAccount
 from lib389.idm.group import Groups
-from lib389.idm.posixgroup import PosixGroups  # not sure if this is need yet MARK
+from lib389.idm.posixgroup import PosixGroups
 
 log = logging.getLogger(__name__)
 

--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_specific_group_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_specific_group_test.py
@@ -1,0 +1,294 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import time
+import ldap
+from lib389._constants import *
+from lib389.topologies import topology_st as topo
+from lib389.utils import ensure_str
+from lib389.plugins import MemberOfPlugin
+from lib389.idm.user import UserAccounts, UserAccount
+from lib389.idm.group import Group, Groups, UniqueGroup, UniqueGroups
+
+log = logging.getLogger(__name__)
+
+# Constants
+PLUGIN_MEMBER_OF = 'MemberOf Plugin'
+MEMBEROF_PLUGIN_DN = ('cn=' + PLUGIN_MEMBER_OF + ',cn=plugins,cn=config')
+PLUGIN_ENABLED = 'nsslapd-pluginEnabled'
+
+# Test data
+USER1_DN = 'uid=testuser1,ou=people,' + DEFAULT_SUFFIX
+USER2_DN = 'uid=testuser2,ou=people,' + DEFAULT_SUFFIX
+USER3_DN = 'uid=testuser3,ou=people,' + DEFAULT_SUFFIX
+UNIQGROUP1_DN = 'cn=testugroup1,ou=groups,' + DEFAULT_SUFFIX
+UNIQGROUP2_DN = 'cn=testugroup2,ou=groups,' + DEFAULT_SUFFIX
+GROUP1_DN = 'cn=testgroup1,ou=groups,' + DEFAULT_SUFFIX
+GROUP2_DN = 'cn=testgroup2,ou=groups,' + DEFAULT_SUFFIX
+GROUP3_DN = 'cn=testgroup3,ou=groups,' + DEFAULT_SUFFIX
+
+
+@pytest.fixture(scope="function")
+def users_and_groups(request, topo):
+    """
+    Add users and groups to the default suffix
+    """
+
+    log.info('Adding users and groups')
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    for user_name in ["testuser1", "testuser2", "testuser3"]:
+        users.create(properties={
+            'uid':  user_name,
+            'cn': user_name,
+            'sn': user_name,
+            'uidNumber': '1234',
+            'gidNumber': '1234',
+            'homeDirectory': '/home/test',
+        })
+
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    for group_name in ["testgroup1", "testgroup2", "testgroup3"]:
+        groups.create(properties={'cn': group_name})
+
+    uniquegroups = UniqueGroups(topo.standalone, DEFAULT_SUFFIX)
+    uniquegroups.create(properties={'cn': 'testugroup1'})
+    uniquegroups.create(properties={'cn': 'testugroup2'})
+
+    def fin():
+        log.info('Cleanup')
+        UserAccount(topo.standalone, USER1_DN).delete()
+        UserAccount(topo.standalone, USER2_DN).delete()
+        UserAccount(topo.standalone, USER3_DN).delete()
+        Group(topo.standalone, GROUP1_DN).delete()
+        Group(topo.standalone, GROUP2_DN).delete()
+        Group(topo.standalone, GROUP3_DN).delete()
+        UniqueGroup(topo.standalone, UNIQGROUP1_DN).delete()
+        UniqueGroup(topo.standalone, UNIQGROUP2_DN).delete()
+
+    request.addfinalizer(fin)
+
+
+def _memberof_checking_delay(inst):
+    """Get appropriate delay for memberof checking based on plugin configuration"""
+    memberof = MemberOfPlugin(inst)
+    if (memberof.get_memberofdeferredupdate() and memberof.get_memberofdeferredupdate().lower() == "on"):
+        # In case of deferred update then a safe delay to let the deferred thread processing is 3 sec
+        delay = 3
+    else:
+        # Else it is the same TXN, no reason to wait
+        delay = 0
+    return delay
+
+
+def _check_memberof(inst, member, group):
+    """Check if member has memberof attribute pointing to group"""
+    log.info("Lookup memberof from %s" % member)
+    entry = inst.getEntry(ensure_str(member), ldap.SCOPE_BASE, '(objectclass=*)', ['memberof'])
+    if not entry.hasAttr('memberof'):
+        return False
+
+    found = False
+    for val in entry.getValues('memberof'):
+        log.info("memberof: %s" % ensure_str(val))
+        if ensure_str(group.lower()) == ensure_str(val.lower()):
+            found = True
+            log.info("--> membership verified")
+            break
+    return found
+
+
+def test_user_to_group_membership(topo, users_and_groups):
+    """Test that including and excluding groups works as expected with users
+
+    :id: 1561e082-b2cf-4863-b3b3-6af2398c545d
+    :setup: Standalone Instance
+    :steps:
+        1. Enable and configure memberof plugin
+        2. Add users to various groups
+        3. Check that users have, or do not have the memberof attribute
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Success
+        3. Success
+    """
+
+    inst = topo.standalone
+
+    # Enable memberof plugin
+    log.info("Enable MemberOf plugin")
+    memberof = MemberOfPlugin(inst)
+    memberof.enable()
+    memberof.remove_all_specific_group_filters()
+    memberof.remove_all_exclude_specific_group_filters()
+    memberof.add_specific_group_filter("(entrydn=" + GROUP1_DN + ")")
+    memberof.add_exclude_specific_group_filter("(entrydn=" + GROUP3_DN + ")")
+    inst.restart()
+
+    # Add user to group
+    log.info("Add user to group 1")
+    group1 = Group(inst, GROUP1_DN)
+    group1.add_member(USER1_DN)
+    group2 = Group(inst, GROUP2_DN)
+    group2.add_member(USER2_DN)
+    group3 = Group(inst, GROUP3_DN)
+    group3.add_member(USER3_DN)
+
+    # Wait for memberof processing
+    delay = _memberof_checking_delay(inst)
+    if delay > 0:
+        time.sleep(delay)
+
+    # Check memberof attribute
+    log.info("Check memberof attribute")
+    assert _check_memberof(inst, USER1_DN, GROUP1_DN)
+    assert not _check_memberof(inst, USER2_DN, GROUP2_DN)
+    assert not _check_memberof(inst, USER3_DN, GROUP3_DN)
+
+
+def test_group_to_group_membership(topo, users_and_groups):
+    """Test that including and excluding groups works as expected with nested
+    groups
+
+    :id: 1561e082-b2cf-4863-b3b3-6af2398c545e
+    :setup: Standalone Instance
+    :steps:
+        1. Enable and configure memberof plugin
+        2. Add groups to other groups
+        3. Check that users have, or do not have the memberof attribute
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Success
+        3. Success
+    """
+
+    inst = topo.standalone
+
+    # Enable memberof plugin
+    log.info("Enable MemberOf plugin")
+    memberof = MemberOfPlugin(inst)
+    memberof.enable()
+    memberof.remove_all_specific_group_filters()
+    memberof.remove_all_exclude_specific_group_filters()
+    memberof.add_exclude_specific_group_filter("(entrydn=" + GROUP3_DN + ")")
+    inst.restart()
+
+    # Add user to group
+    log.info("Add user to group 1")
+    group1 = Group(inst, GROUP1_DN)
+    group1.add_member(USER1_DN)
+    group2 = Group(inst, GROUP2_DN)
+    group2.add_member(GROUP2_DN)
+    group2.add_member(GROUP3_DN)
+    group3 = Group(inst, GROUP3_DN)
+    group3.add_member(GROUP2_DN)
+
+    # _check_memberof (member, group)
+    assert _check_memberof(inst, USER1_DN, GROUP1_DN)
+    assert not _check_memberof(inst, GROUP3_DN, GROUP2_DN)
+    assert not _check_memberof(inst, GROUP2_DN, GROUP3_DN)
+
+
+def test_group_oc_membership(topo, users_and_groups):
+    """Test that including and excluding groups works as expected with custom
+    objectclasses. The specific objectclasses are used to distinguish if entries
+    are "groups" or "not groups"
+
+    :id: 42714d25-be6d-4aa0-831d-0f4cf91fac86
+    :setup: Standalone Instance
+    :steps:
+        1. Enable and configure memberof plugin (exclude groups only and
+        objectclass groupofuniquenames)
+        2. Add user to an excluded group but the group has objectclass groupofnames
+        3. Add user to an excluded group but the group has objectclass groupofuniquenames
+        4. Memberof config remove exclude rules and add include ones
+        5. Add user to a group that is in the include list
+        6. Add group to a group that is not in the include list
+        7. Add group that is not in the include list to a group that is in the include list
+        8. Add group with unknown objectclass to a group that is in the include list
+        9. Add group with known objectclass to a group that is in the include list
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Membership is not updated
+        3. Membership is not updated
+        4. Success
+        5. Success
+        6. Membership is not updated
+        7. Membership is not updated
+        8. Success
+        9. Membership is not updated
+    """
+
+    inst = topo.standalone
+
+    # Enable memberof plugin
+    log.info("Enable MemberOf plugin")
+    memberof = MemberOfPlugin(inst)
+    memberof.enable()
+    memberof.add_groupattr('uniquemember')
+    memberof.remove_all_specific_group_filters()
+    memberof.remove_all_exclude_specific_group_filters()
+    memberof.add_exclude_specific_group_filter("(entrydn=" + UNIQGROUP1_DN + ")")
+    memberof.add_exclude_specific_group_filter("(entrydn=" + GROUP1_DN + ")")
+    memberof.add_specific_group_oc("groupofuniquenames")
+    inst.restart()
+
+    # Add user to an excluded group but the group has objectclass groupofnames
+    # but since we are excluding specifc DN's we don't care about the entry's
+    # objectclasses
+    log.info("Add user to group")
+    group = Group(inst, GROUP1_DN)
+    group.add_member(USER1_DN)
+    assert not _check_memberof(inst, USER1_DN, GROUP1_DN)
+
+    # Add user to an excluded group that does match specifc group objectclass
+    unique_group = UniqueGroup(inst, UNIQGROUP1_DN)
+    unique_group.add_member(USER1_DN)
+    assert not _check_memberof(inst, USER1_DN, UNIQGROUP1_DN)
+
+    #
+    # Switch over to just allowing specific groups
+    #
+    memberof.remove_all_exclude_specific_group_filters()
+    memberof.add_specific_group_filter("(entrydn=" + UNIQGROUP1_DN + ")")
+    memberof.add_specific_group_filter("(entrydn=" + GROUP1_DN + ")")
+    time.sleep(1)
+    # Update group that should allow the update
+    unique_group.add_member(USER2_DN)
+    assert _check_memberof(inst, USER2_DN, UNIQGROUP1_DN)
+
+    # Update a valid "group" but that is not in the specified list
+    unique_group2 = UniqueGroup(inst, UNIQGROUP2_DN)
+    unique_group2.add_member(USER3_DN)
+    assert not _check_memberof(inst, USER3_DN, GROUP1_DN)
+
+    # uniquegroup2 should not be listed as memberof uniquegroup1 since its not
+    # in the allowed group list
+    unique_group.add_member(UNIQGROUP2_DN)
+    assert not _check_memberof(inst, UNIQGROUP2_DN, UNIQGROUP1_DN)
+
+    # uniquegroup1 is an allowed group, and group2 is not seen a group because
+    # of the specific group objectclass setting. So the MO update should be
+    # allowed in this case
+    unique_group.add_member(GROUP2_DN)
+    assert _check_memberof(inst, GROUP2_DN, UNIQGROUP1_DN)
+
+    # Now add groupOfNames oc to the MO config, and try adding a group as a
+    # member that is not in the specific group list
+    memberof.add_specific_group_oc("groupofnames")
+    unique_group.add_member(GROUP3_DN)
+    assert not _check_memberof(inst, GROUP3_DN, UNIQGROUP1_DN)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -107,6 +107,13 @@ typedef struct _task_data
     char *filter_str;
 } task_data;
 
+typedef struct _MemberofEntryInfo
+{
+    Slapi_Entry *e;
+    Slapi_DN *sdn;
+    bool group;
+} MemberofEntryInfo;
+
 /*** function prototypes ***/
 
 /* exported functions */
@@ -144,18 +151,18 @@ static void memberof_set_plugin_id(void *plugin_id);
 static int memberof_compare(MemberOfConfig *config, const void *a, const void *b);
 static int memberof_qsort_compare(const void *a, const void *b);
 static void memberof_load_array(Slapi_Value **array, Slapi_Attr *attr);
-static int memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *sdn);
-static int memberof_call_foreach_dn(Slapi_PBlock *pb, Slapi_DN *sdn, MemberOfConfig *config, char **types, plugin_search_entry_callback callback, void *callback_data, int *cached, PRBool use_grp_cache);
+static int memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *sdn);
+static int memberof_call_foreach_dn(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_DN *sdn, MemberOfConfig *config, char **types, plugin_search_entry_callback callback, void *callback_data, int *cached, PRBool use_grp_cache);
 static int memberof_is_direct_member(MemberOfConfig *config, Slapi_Value *groupdn, Slapi_Value *memberdn);
 static int memberof_is_grouping_attr(char *type, MemberOfConfig *config);
-static Slapi_ValueSet *memberof_get_groups(MemberOfConfig *config, Slapi_DN *member_sdn);
-static int memberof_get_groups_r(MemberOfConfig *config, Slapi_DN *member_sdn, memberof_get_groups_data *data);
+static Slapi_ValueSet *memberof_get_groups(MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *member_sdn);
+static int memberof_get_groups_r(MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *member_sdn, memberof_get_groups_data *data);
 static int memberof_get_groups_callback(Slapi_Entry *e, void *callback_data);
 static int memberof_test_membership(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *group_sdn);
 static int memberof_test_membership_callback(Slapi_Entry *e, void *callback_data);
 static int memberof_del_dn_type_callback(Slapi_Entry *e, void *callback_data);
 static int memberof_replace_dn_type_callback(Slapi_Entry *e, void *callback_data);
-static int memberof_replace_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *pre_sdn, Slapi_DN *post_sdn);
+static int memberof_replace_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_Entry *pre_e, Slapi_DN *pre_sdn, Slapi_DN *post_sdn);
 static int memberof_modop_one_replace_r(Slapi_PBlock *pb, MemberOfConfig *config, int mod_op, Slapi_DN *group_sdn, Slapi_DN *op_this_sdn, Slapi_DN *replace_with_sdn, Slapi_DN *op_to_sdn, memberofstringll *stack);
 static int memberof_task_add(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eAfter, int *returncode, char *returntext, void *arg);
 static void memberof_task_destructor(Slapi_Task *task);
@@ -163,13 +170,14 @@ static void memberof_fixup_task_thread(void *arg);
 static int memberof_fix_memberof(MemberOfConfig *config, Slapi_Task *task, task_data *td);
 static int memberof_fix_memberof_callback(Slapi_Entry *e, void *callback_data);
 static int memberof_fixup_memberof_callback(Slapi_Entry *e, void *callback_data);
-static int memberof_entry_in_scope(MemberOfConfig *config, Slapi_DN *sdn);
+static int memberof_entry_in_scope(MemberOfConfig *config, MemberofEntryInfo *entry_info);
 static int memberof_add_objectclass(char *auto_add_oc, const char *dn);
 static int memberof_add_memberof_attr(LDAPMod **mods, const char *dn, char *add_oc);
 static memberof_cached_value *ancestors_cache_lookup(MemberOfConfig *config, const char *ndn);
 static PRBool ancestors_cache_remove(MemberOfConfig *config, const char *ndn);
 static PLHashEntry *ancestors_cache_add(MemberOfConfig *config, const void *key, void *value);
-
+static void memberof_set_entry_info(Slapi_Entry *e, MemberOfConfig *config, MemberofEntryInfo *entry_info);
+static int memberof_test_specific_filters(MemberOfConfig *config, MemberofEntryInfo *entry_info);
 /*** implementation ***/
 
 
@@ -348,6 +356,30 @@ memberof_internal_postop_init(Slapi_PBlock *pb)
     return status;
 }
 
+static void
+memberof_set_entry_info(Slapi_Entry *e, MemberOfConfig *config, MemberofEntryInfo *entry_info)
+{
+    entry_info->e = e;
+    entry_info->sdn = slapi_entry_get_sdn(e);
+    entry_info->group = false;
+
+    if (!config) {
+        /* No config means to "always" treat this entry as a group */
+        entry_info->group = true;
+        return;
+    }
+
+    if (config->specificGroupFilter || config->excludeSpecificGroupFilter) {
+        /* Only set entry info if we have specific group filters defined */
+        for (size_t i = 0; config->specificGroupOC && config->specificGroupOC[i]; i++) {
+            if (slapi_entry_attr_hasvalue(e, "objectClass", config->specificGroupOC[i])) {
+                entry_info->group = true;
+                return;
+            }
+        }
+    }
+}
+
 /* Caller must hold deferred_list->deferred_list_mutex
  * deferred_list is FIFO
  */
@@ -428,6 +460,7 @@ typedef struct _memberof_del_dn_data
 {
     char *dn;
     char *type;
+    MemberOfConfig *config;
 } memberof_del_dn_data;
 
 int
@@ -436,6 +469,8 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
     Slapi_PBlock *pb;
     MemberOfConfig *mainConfig = 0;
     MemberOfConfig configCopy = {0};
+    MemberofEntryInfo pre_entry_info = {0};
+    MemberofEntryInfo post_entry_info = {0};
     struct slapi_entry *pre_e = NULL;
     struct slapi_entry *post_e = NULL;
     Slapi_DN *pre_sdn = 0;
@@ -471,8 +506,10 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
     memberof_unlock_config();
 
     /* Need to check both the pre/post entries */
-    if ((pre_sdn && !memberof_entry_in_scope(&configCopy, pre_sdn)) &&
-        (post_sdn && !memberof_entry_in_scope(&configCopy, post_sdn)))
+    memberof_set_entry_info(pre_e, NULL, &pre_entry_info);
+    memberof_set_entry_info(post_e, NULL, &post_entry_info);
+    if ((pre_sdn && !memberof_entry_in_scope(&configCopy, &pre_entry_info)) &&
+        (post_sdn && !memberof_entry_in_scope(&configCopy, &post_entry_info)))
     {
         /* The entry is not in scope */
         goto bail;
@@ -502,17 +539,17 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
      * of other group entries.  We need to update any member
      * attributes to refer to the new name. */
     if (ret == LDAP_SUCCESS && pre_sdn && post_sdn) {
-        if (!memberof_entry_in_scope(&configCopy, post_sdn)) {
+        if (!memberof_entry_in_scope(&configCopy, &post_entry_info)) {
             /*
              * After modrdn the group contains both the pre and post DN's as
              * members, so we need to cleanup both in this case.
              */
-            if ((ret = memberof_del_dn_from_groups(pb, &configCopy, pre_sdn))) {
+            if ((ret = memberof_del_dn_from_groups(pb, &configCopy, pre_e, pre_sdn))) {
                 slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                               "deferred_modrdn_func - Delete dn failed for preop entry(%s), error (%d)\n",
                               slapi_sdn_get_dn(pre_sdn), ret);
             }
-            if ((ret = memberof_del_dn_from_groups(pb, &configCopy, post_sdn))) {
+            if ((ret = memberof_del_dn_from_groups(pb, &configCopy, post_e, post_sdn))) {
                 slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                               "deferred_modrdn_func - Delete dn failed for postop entry(%s), error (%d)\n",
                               slapi_sdn_get_dn(post_sdn), ret);
@@ -536,7 +573,7 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
                 }
             }
             if (ret == LDAP_SUCCESS) {
-                memberof_del_dn_data del_data = {0, configCopy.memberof_attr};
+                memberof_del_dn_data del_data = {0, configCopy.memberof_attr, &configCopy};
                 if ((ret = memberof_del_dn_type_callback(post_e, &del_data))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                                   "deferred_modrdn_func - Delete dn callback failed for (%s), error (%d)\n",
@@ -544,7 +581,7 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
                 }
             }
         } else {
-            if ((ret = memberof_replace_dn_from_groups(pb, &configCopy, pre_sdn, post_sdn))) {
+            if ((ret = memberof_replace_dn_from_groups(pb, &configCopy, pre_e, pre_sdn, post_sdn))) {
                 slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                               "deferred_modrdn_func - Replace dn failed for (%s), error (%d)\n",
                               slapi_sdn_get_dn(pre_sdn), ret);
@@ -580,6 +617,7 @@ deferred_del_func(MemberofDeferredDelTask *task)
     MemberOfConfig configCopy = {0};
     PRBool free_configCopy = PR_FALSE;
     MemberOfConfig *mainConfig;
+    MemberofEntryInfo entry_info = {0};
     int ret = SLAPI_PLUGIN_SUCCESS;
 
     pb = task->pb;
@@ -590,7 +628,8 @@ deferred_del_func(MemberofDeferredDelTask *task)
 
     memberof_rlock_config();
     mainConfig = memberof_get_config();
-    if (!memberof_entry_in_scope(mainConfig, slapi_entry_get_sdn(e))) {
+    memberof_set_entry_info(e, NULL, &entry_info);
+    if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
         /* The entry is not in scope, bail...*/
         memberof_unlock_config();
         goto bail;
@@ -602,7 +641,7 @@ deferred_del_func(MemberofDeferredDelTask *task)
     /* remove this DN from the
      * membership lists of groups
      */
-    if ((ret = memberof_del_dn_from_groups(pb, &configCopy, sdn))) {
+    if ((ret = memberof_del_dn_from_groups(pb, &configCopy, e, sdn))) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                 "deferred_del_func - Error deleting dn (%s) from group. Error (%d)\n",
                 slapi_sdn_get_dn(sdn), ret);
@@ -652,6 +691,7 @@ deferred_add_func(MemberofDeferredAddTask *task)
     Slapi_DN *sdn = 0;
     MemberOfConfig configCopy = {0};
     MemberOfConfig *mainConfig;
+    MemberofEntryInfo entry_info = {0};
     int interested = 0;
     int ret = SLAPI_PLUGIN_SUCCESS;
 
@@ -669,7 +709,8 @@ deferred_add_func(MemberofDeferredAddTask *task)
         0 == slapi_filter_test_simple(e, mainConfig->group_filter))
     {
         interested = 1;
-        if (!memberof_entry_in_scope(mainConfig, slapi_entry_get_sdn(e))) {
+        memberof_set_entry_info(e, NULL, &entry_info);
+        if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
             /* Entry is not in scope */
             memberof_unlock_config();
             goto bail;
@@ -726,6 +767,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
     int config_copied = 0;
     MemberOfConfig *mainConfig = 0;
     MemberOfConfig configCopy = {0};
+    MemberofEntryInfo entry_info = {0};
 
     pb = task->pb;
     slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
@@ -751,7 +793,8 @@ deferred_mod_func(MemberofDeferredModTask *task)
             mainConfig = memberof_get_config();
             if (memberof_is_grouping_attr(type, mainConfig)) {
                 interested = 1;
-                if (!memberof_entry_in_scope(mainConfig, sdn)) {
+                memberof_set_entry_info(pre_e, NULL, &entry_info);
+                if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
                     /* Entry is not in scope */
                     memberof_unlock_config();
                     goto bail;
@@ -1024,7 +1067,7 @@ deferred_thread_func(void *arg)
         if (memberof_get_config()->launch_fixup) {
             if (perform_needed_fixup()) {
                 slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                        "Failure occurred during global fixup task: memberof values are invalid\n");
+                              "Failure occurred during global fixup task: memberof values are invalid\n");
             }
         } else {
             slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
@@ -1345,6 +1388,7 @@ memberof_postop_del(Slapi_PBlock *pb)
     int ret = SLAPI_PLUGIN_SUCCESS;
     MemberOfConfig *mainConfig = NULL;
     MemberOfConfig configCopy = {0};
+    MemberofEntryInfo entry_info = {0};
     Slapi_DN *sdn;
     void *caller_id = NULL;
 
@@ -1401,7 +1445,8 @@ memberof_postop_del(Slapi_PBlock *pb)
         slapi_pblock_get(pb, SLAPI_ENTRY_PRE_OP, &e);
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-        if (!memberof_entry_in_scope(mainConfig, slapi_entry_get_sdn(e))) {
+        memberof_set_entry_info(e, NULL, &entry_info);
+        if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
             /* The entry is not in scope, bail...*/
             memberof_unlock_config();
             goto bail;
@@ -1412,7 +1457,7 @@ memberof_postop_del(Slapi_PBlock *pb)
         /* remove this DN from the
          * membership lists of groups
          */
-        if ((ret = memberof_del_dn_from_groups(pb, &configCopy, sdn))) {
+        if ((ret = memberof_del_dn_from_groups(pb, &configCopy, e, sdn))) {
             slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                           "memberof_postop_del - Error deleting dn (%s) from group. Error (%d)\n",
                           slapi_sdn_get_dn(sdn), ret);
@@ -1451,7 +1496,7 @@ done:
 
 /* Deletes a member dn from all groups that refer to it. */
 static int
-memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *sdn)
+memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *sdn)
 {
     char *groupattrs[2] = {0, 0};
     int rc = LDAP_SUCCESS;
@@ -1462,7 +1507,7 @@ memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *
      * same grouping attribute. */
     for (size_t i = 0; config->groupattrs && config->groupattrs[i] && rc == LDAP_SUCCESS; i++) {
         memberof_del_dn_data data = {(char *)slapi_sdn_get_dn(sdn),
-                                     config->groupattrs[i]};
+                                     config->groupattrs[i], config};
 
         groupattrs[0] = config->groupattrs[i];
 
@@ -1470,7 +1515,7 @@ memberof_del_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *
                 "memberof_del_dn_from_groups: Ancestors of %s   attr: %s\n",
                 slapi_sdn_get_dn(sdn),
                 groupattrs[0]);
-        rc = memberof_call_foreach_dn(pb, sdn, config, groupattrs,
+        rc = memberof_call_foreach_dn(pb, e, sdn, config, groupattrs,
                                       memberof_del_dn_type_callback, &data, &cached, PR_FALSE);
     }
 
@@ -1485,6 +1530,13 @@ memberof_del_dn_type_callback(Slapi_Entry *e, void *callback_data)
     LDAPMod *mods[2];
     char *val[2];
     Slapi_PBlock *mod_pb = 0;
+    MemberOfConfig *config = ((memberof_del_dn_data *)callback_data)->config;
+    MemberofEntryInfo entry_info = {0};
+
+    memberof_set_entry_info(e, config, &entry_info);
+    if (memberof_test_specific_filters(config, &entry_info) == 0) {
+        return 0;
+    }
 
     mod_pb = slapi_pblock_new();
 
@@ -1562,11 +1614,12 @@ add_ancestors_cbdata(memberof_cached_value *ancestors, void *callback_data)
  * could want type to be either "member" or "memberOf" depending on the case.
  */
 int
-memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_DN *sdn, MemberOfConfig *config, char **types, plugin_search_entry_callback callback, void *callback_data, int *cached, PRBool use_grp_cache)
+memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_Entry *e, Slapi_DN *sdn, MemberOfConfig *config, char **types, plugin_search_entry_callback callback, void *callback_data, int *cached, PRBool use_grp_cache)
 {
     Slapi_PBlock *search_pb = NULL;
     Slapi_DN *base_sdn = NULL;
     Slapi_Backend *be = NULL;
+    MemberofEntryInfo entry_info = {0};
     char *escaped_filter_val;
     char *filter_str = NULL;
     char *cookie = NULL;
@@ -1577,8 +1630,11 @@ memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_DN *sdn
 
     *cached = 0;
 
-    if (!memberof_entry_in_scope(config, sdn)) {
-        return (rc);
+    if (e) {
+        memberof_set_entry_info(e, config, &entry_info);
+    } else {
+        entry_info.sdn = sdn;
+        entry_info.group = false;
     }
 
     /* This flags indicates memberof_call_foreach_dn is called to retrieve ancestors (groups).
@@ -1608,6 +1664,11 @@ memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_DN *sdn
 #if MEMBEROF_CACHE_DEBUG
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM, "memberof_call_foreach_dn: Ancestors of %s not cached\n", slapi_sdn_get_ndn(sdn));
 #endif
+
+    /* After the cache is processed, check if the entry is in scope */
+    if (!memberof_entry_in_scope(config, &entry_info)) {
+        return (rc);
+    }
 
     /* Escape the dn, and build the search filter. */
     escaped_filter_val = slapi_escape_filter_value((char *)slapi_sdn_get_dn(sdn), dn_len);
@@ -1648,7 +1709,9 @@ memberof_call_foreach_dn(Slapi_PBlock *pb __attribute__((unused)), Slapi_DN *sdn
 
             search_pb = slapi_pblock_new();
             if (config->entryScopes || config->entryScopeExcludeSubtrees) {
-                if (memberof_entry_in_scope(config, base_sdn)) {
+                entry_info.sdn = base_sdn;
+                entry_info.group = false;
+                if (memberof_entry_in_scope(config, &entry_info)) {
                     /* do nothing, entry scope is spanning
                      * multiple suffixes, start at suffix */
                 } else if (config->entryScopes) {
@@ -1732,6 +1795,8 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
     if (memberof_oktodo(pb)) {
         MemberOfConfig *mainConfig = 0;
         MemberOfConfig configCopy = {0};
+        MemberofEntryInfo pre_entry_info = {0};
+        MemberofEntryInfo post_entry_info = {0};
         struct slapi_entry *pre_e = NULL;
         struct slapi_entry *post_e = NULL;
         Slapi_DN *pre_sdn = 0;
@@ -1805,8 +1870,10 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
         memberof_unlock_config();
 
         /* Need to check both the pre/post entries */
-        if ((pre_sdn && !memberof_entry_in_scope(&configCopy, pre_sdn)) &&
-            (post_sdn && !memberof_entry_in_scope(&configCopy, post_sdn))) {
+        memberof_set_entry_info(pre_e, NULL, &pre_entry_info);
+        memberof_set_entry_info(post_e, NULL, &post_entry_info);
+        if ((pre_sdn && !memberof_entry_in_scope(&configCopy, &pre_entry_info)) &&
+            (post_sdn && !memberof_entry_in_scope(&configCopy, &post_entry_info))) {
             /* The entry is not in scope */
             goto bail;
         }
@@ -1834,17 +1901,17 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
          * of other group entries.  We need to update any member
          * attributes to refer to the new name. */
         if (ret == LDAP_SUCCESS && pre_sdn && post_sdn) {
-            if (!memberof_entry_in_scope(&configCopy, post_sdn)) {
+            if (!memberof_entry_in_scope(&configCopy, &post_entry_info)) {
                 /*
                  * After modrdn the group contains both the pre and post DN's as
                  * members, so we need to cleanup both in this case.
                  */
-                if ((ret = memberof_del_dn_from_groups(pb, &configCopy, pre_sdn))) {
+                if ((ret = memberof_del_dn_from_groups(pb, &configCopy, pre_e, pre_sdn))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                                   "memberof_postop_modrdn - Delete dn failed for preop entry(%s), error (%d)\n",
                                   slapi_sdn_get_dn(pre_sdn), ret);
                 }
-                if ((ret = memberof_del_dn_from_groups(pb, &configCopy, post_sdn))) {
+                if ((ret = memberof_del_dn_from_groups(pb, &configCopy, post_e, post_sdn))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                                   "memberof_postop_modrdn - Delete dn failed for postop entry(%s), error (%d)\n",
                                   slapi_sdn_get_dn(post_sdn), ret);
@@ -1867,7 +1934,7 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
                     }
                 }
                 if (ret == LDAP_SUCCESS) {
-                    memberof_del_dn_data del_data = {0, configCopy.memberof_attr};
+                    memberof_del_dn_data del_data = {0, configCopy.memberof_attr, &configCopy};
                     if ((ret = memberof_del_dn_type_callback(post_e, &del_data))) {
                         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                                       "memberof_postop_modrdn - Delete dn callback failed for (%s), error (%d)\n",
@@ -1875,7 +1942,7 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
                     }
                 }
             } else {
-                if ((ret = memberof_replace_dn_from_groups(pb, &configCopy, pre_sdn, post_sdn))) {
+                if ((ret = memberof_replace_dn_from_groups(pb, &configCopy, pre_e, pre_sdn, post_sdn))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
                                   "memberof_postop_modrdn - Replace dn failed for (%s), error (%d)\n",
                                   slapi_sdn_get_dn(pre_sdn), ret);
@@ -1902,13 +1969,14 @@ typedef struct _replace_dn_data
     char *post_dn;
     char *type;
     char *add_oc;
+    MemberOfConfig *config;
 } replace_dn_data;
 
 
 /* Finds any groups that have pre_dn as a member and modifies them to
  * to use post_dn instead. */
 static int
-memberof_replace_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *pre_sdn, Slapi_DN *post_sdn)
+memberof_replace_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_Entry *pre_e, Slapi_DN *pre_sdn, Slapi_DN *post_sdn)
 {
     char *groupattrs[2] = {0, 0};
     int ret = LDAP_SUCCESS;
@@ -1921,12 +1989,12 @@ memberof_replace_dn_from_groups(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_
         replace_dn_data data = {(char *)slapi_sdn_get_dn(pre_sdn),
                                 (char *)slapi_sdn_get_dn(post_sdn),
                                 config->groupattrs[i],
-                                config->auto_add_oc};
+                                config->auto_add_oc,
+                                config};
 
         groupattrs[0] = config->groupattrs[i];
 
-        slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM, "memberof_replace_dn_from_groups: Ancestors of %s\n", slapi_sdn_get_dn(post_sdn));
-        if ((ret = memberof_call_foreach_dn(pb, pre_sdn, config, groupattrs,
+        if ((ret = memberof_call_foreach_dn(pb, pre_e, pre_sdn, config, groupattrs,
                                             memberof_replace_dn_type_callback,
                                             &data, &cached, PR_FALSE))) {
             break;
@@ -1947,6 +2015,13 @@ memberof_replace_dn_type_callback(Slapi_Entry *e, void *callback_data)
     char *delval[2];
     char *addval[2];
     char *dn = NULL;
+    MemberOfConfig *config = ((replace_dn_data *)callback_data)->config;
+    MemberofEntryInfo entry_info = {0};
+
+    memberof_set_entry_info(e, config, &entry_info);
+    if (memberof_test_specific_filters(config, &entry_info) == 0) {
+        return 0;
+    }
 
     dn = slapi_entry_get_dn(e);
 
@@ -1999,7 +2074,7 @@ my_copy_mods(LDAPMod **orig_mods)
  * Added members are retrieved and have the group DN added to their memberOf attribute
  * Deleted members are retrieved and have the group DN deleted from their memberOf attribute
  * On replace of the membership attribute values:
- *     1. Sort old and new values
+ *    1. Sort old and new values
  *    2. Iterate through both lists at same time
  *    3. Any value not in old list but in new list - add group DN to memberOf attribute
  *    4. Any value in old list but not in new list - remove group DN from memberOf attribute
@@ -2017,6 +2092,7 @@ memberof_postop_modify(Slapi_PBlock *pb)
     Slapi_Mod *smod = 0;
     LDAPMod **mods;
     Slapi_Mod *next_mod = 0;
+    Slapi_Entry *entry = NULL;
     void *caller_id = NULL;
 
     slapi_log_err(SLAPI_LOG_TRACE, MEMBEROF_PLUGIN_SUBSYSTEM,
@@ -2029,15 +2105,14 @@ memberof_postop_modify(Slapi_PBlock *pb)
         /* Just return without processing */
         return SLAPI_PLUGIN_SUCCESS;
     }
+    slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &entry);
 
     /* check if we are updating the shared config entry */
     slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
     if (memberof_sdn_config_cmp(sdn) == 0) {
-        Slapi_Entry *entry = NULL;
         char returntext[SLAPI_DSE_RETURNTEXT_SIZE];
         int result = 0;
 
-        slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &entry);
         if (entry) {
             if (SLAPI_DSE_CALLBACK_ERROR == memberof_apply_config(pb, NULL, entry, &result, returntext, NULL)) {
                 slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "%s\n", returntext);
@@ -2057,13 +2132,14 @@ memberof_postop_modify(Slapi_PBlock *pb)
         int config_copied = 0;
         MemberOfConfig *mainConfig = 0;
         MemberOfConfig configCopy = {0};
+        MemberofEntryInfo entry_info = {0};
         PRBool deferred_update;
 
         /* retrieve deferred update params that are valid until shutdown */
         memberof_rlock_config();
         mainConfig = memberof_get_config();
-
         deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
+        memberof_set_entry_info(entry, NULL, &entry_info);
         memberof_unlock_config();
 
         if (deferred_update) {
@@ -2130,7 +2206,7 @@ memberof_postop_modify(Slapi_PBlock *pb)
 
                 if (memberof_is_grouping_attr(type, mainConfig)) {
                     interested = 1;
-                    if (!memberof_entry_in_scope(mainConfig, sdn)) {
+                    if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
                         /* Entry is not in scope */
                         memberof_unlock_config();
                         goto bail;
@@ -2315,6 +2391,7 @@ memberof_postop_add(Slapi_PBlock *pb)
 
     if (memberof_oktodo(pb) && (sdn = memberof_getsdn(pb))) {
         struct slapi_entry *e = NULL;
+        MemberofEntryInfo entry_info = {0};
         MemberOfConfig configCopy = {0};
         MemberOfConfig *mainConfig;
         Slapi_DN *copied_sdn;
@@ -2364,7 +2441,8 @@ memberof_postop_add(Slapi_PBlock *pb)
 
         {
             interested = 1;
-            if (!memberof_entry_in_scope(mainConfig, slapi_entry_get_sdn(e))) {
+            memberof_set_entry_info(e, NULL, &entry_info);
+            if (!memberof_entry_in_scope(mainConfig, &entry_info)) {
                 /* Entry is not in scope */
                 memberof_unlock_config();
                 goto bail;
@@ -2447,20 +2525,52 @@ bail:
 }
 
 /*
+ * memberof_test_specific_filters()
+ *
+ * Test if the entry matches any of the specific group filters
+ * return 1 if the entry matches any of the specific group filters
+ * return 0 if the entry does not match any of the specific group filters
+ */
+static int
+memberof_test_specific_filters(MemberOfConfig *config, MemberofEntryInfo *entry_info)
+{
+    if (entry_info->e && entry_info->group) {
+        for (size_t i = 0; config->excludeSpecificGroupFilter && config->excludeSpecificGroupFilter[i]; i++) {
+            if (!slapi_filter_test_simple(entry_info->e, config->excludeSpecificGroupFilter[i])) {
+                return 0;
+            }
+        }
+        if (config->specificGroupFilter) {
+            for (size_t i = 0; config->specificGroupFilter && config->specificGroupFilter[i]; i++) {
+                int rc= 0;
+                if ((rc = slapi_filter_test_simple(entry_info->e, config->specificGroupFilter[i])) == 0) {
+                    return 1;
+                }
+            }
+            /* Entry does not match specific group filter */
+            return 0;
+        }
+    }
+
+    /* Entry is ok */
+    return 1;
+}
+
+/*
  * Return 1 if the entry is in the scope.
  * For MODRDN the caller should check both the preop
  * and postop entries.  If we are moving out of, or
  * into scope, we should process it.
  */
 static int
-memberof_entry_in_scope(MemberOfConfig *config, Slapi_DN *sdn)
+memberof_entry_in_scope(MemberOfConfig *config, MemberofEntryInfo *entry_info)
 {
     if (config->entryScopeExcludeSubtrees) {
         int i = 0;
 
         /* check the excludes */
         while (config->entryScopeExcludeSubtrees[i]) {
-            if (slapi_sdn_issuffix(sdn, config->entryScopeExcludeSubtrees[i])) {
+            if (slapi_sdn_issuffix(entry_info->sdn, config->entryScopeExcludeSubtrees[i])) {
                 return 0;
             }
             i++;
@@ -2471,7 +2581,7 @@ memberof_entry_in_scope(MemberOfConfig *config, Slapi_DN *sdn)
 
         /* check the excludes */
         while (config->entryScopes[i]) {
-            if (slapi_sdn_issuffix(sdn, config->entryScopes[i])) {
+            if (slapi_sdn_issuffix(entry_info->sdn, config->entryScopes[i])) {
                 return 1;
             }
             i++;
@@ -2479,7 +2589,8 @@ memberof_entry_in_scope(MemberOfConfig *config, Slapi_DN *sdn)
         return 0;
     }
 
-    return 1;
+    /* lastly check if there are specific filters */
+    return memberof_test_specific_filters(config, entry_info);
 }
 
 static Slapi_DN *
@@ -3062,7 +3173,7 @@ memberof_moddn_attr_list(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *pre
 
         slapi_sdn_set_normdn_byref(sdn, dn_str); /* dn_str is normalized */
         rc = memberof_modop_one_replace_r(pb, config, LDAP_MOD_REPLACE,
-                                     post_sdn, pre_sdn, post_sdn, sdn, 0);
+                                          post_sdn, pre_sdn, post_sdn, sdn, 0);
 
         hint = slapi_attr_next_value(attr, hint, &val);
     }
@@ -3082,7 +3193,7 @@ memberof_moddn_attr_list(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *pre
  * free it.
  */
 Slapi_ValueSet *
-memberof_get_groups(MemberOfConfig *config, Slapi_DN *member_sdn)
+memberof_get_groups(MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *member_sdn)
 {
     Slapi_ValueSet *groupvals = slapi_valueset_new();
     Slapi_ValueSet *group_norm_vals = slapi_valueset_new();
@@ -3093,7 +3204,7 @@ memberof_get_groups(MemberOfConfig *config, Slapi_DN *member_sdn)
 
     memberof_get_groups_data data = {config, memberdn_val, &groupvals, &group_norm_vals, &already_seen_ndn_vals, PR_TRUE};
 
-    memberof_get_groups_r(config, member_sdn, &data);
+    memberof_get_groups_r(config, e, member_sdn, &data);
 
     slapi_value_free(&memberdn_val);
     slapi_valueset_free(group_norm_vals);
@@ -3313,7 +3424,7 @@ merge_ancestors(Slapi_Value **member_ndn_val, memberof_get_groups_data *v1, memb
 }
 
 int
-memberof_get_groups_r(MemberOfConfig *config, Slapi_DN *member_sdn, memberof_get_groups_data *data)
+memberof_get_groups_r(MemberOfConfig *config, Slapi_Entry *e, Slapi_DN *member_sdn, memberof_get_groups_data *data)
 {
     Slapi_ValueSet *groupvals = slapi_valueset_new();
     Slapi_ValueSet *group_norm_vals = slapi_valueset_new();
@@ -3326,12 +3437,12 @@ memberof_get_groups_r(MemberOfConfig *config, Slapi_DN *member_sdn, memberof_get
 
     memberof_get_groups_data member_data = {config, member_ndn_val, &groupvals, &group_norm_vals, data->already_seen_ndn_vals, data->use_cache};
 
-/* Search for any grouping attributes that point to memberdn.
+    /* Search for any grouping attributes that point to memberdn.
      * For each match, add it to the list, recurse and do same search */
 #if MEMBEROF_CACHE_DEBUG
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM, "memberof_get_groups_r: Ancestors of %s\n", slapi_sdn_get_dn(member_sdn));
 #endif
-    rc = memberof_call_foreach_dn(NULL, member_sdn, config, config->groupattrs,
+    rc = memberof_call_foreach_dn(NULL, e, member_sdn, config, config->groupattrs,
                                   memberof_get_groups_callback, &member_data, &cached, member_data.use_cache);
 
     merge_ancestors(&member_ndn_val, &member_data, data);
@@ -3362,6 +3473,7 @@ memberof_get_groups_callback(Slapi_Entry *e, void *callback_data)
     Slapi_ValueSet *group_norm_vals = *((memberof_get_groups_data *)callback_data)->group_norm_vals;
     Slapi_ValueSet *already_seen_ndn_vals = *((memberof_get_groups_data *)callback_data)->already_seen_ndn_vals;
     MemberOfConfig *config = ((memberof_get_groups_data *)callback_data)->config;
+    MemberofEntryInfo entry_info = {0};
     int rc = 0;
 
     if (!config->deferred_update && slapi_is_shutting_down()) {
@@ -3398,9 +3510,10 @@ memberof_get_groups_callback(Slapi_Entry *e, void *callback_data)
     }
 
     /* if the group does not belong to an excluded subtree, adds it to the valueset */
-    if (memberof_entry_in_scope(config, group_sdn)) {
+    memberof_set_entry_info(e, config, &entry_info);
+    if (memberof_entry_in_scope(config, &entry_info)) {
         /* Push group_dn_val into the valueset.  This memory is now owned
-             * by the valueset. */
+         * by the valueset. */
         slapi_valueset_add_value_ext(group_norm_vals, group_ndn_val, SLAPI_VALUE_FLAG_PASSIN);
 
         group_dn_val = slapi_value_new_string(group_dn);
@@ -3421,11 +3534,14 @@ memberof_get_groups_callback(Slapi_Entry *e, void *callback_data)
             already_seen_ndn_val = slapi_value_new_string(group_ndn);
             slapi_valueset_add_value_ext(already_seen_ndn_vals, already_seen_ndn_val, SLAPI_VALUE_FLAG_PASSIN);
         }
+    } else {
+        /* Entry not in scope, val was not consumed must free it*/
+        slapi_value_free(&group_ndn_val);
     }
     if (!config->skip_nested || config->fixup_task) {
         /* now recurse to find ancestors groups of e */
         memberof_get_groups_r(((memberof_get_groups_data *)callback_data)->config,
-                              group_sdn, callback_data);
+                              e, group_sdn, callback_data);
     }
 
 bail:
@@ -3511,7 +3627,7 @@ memberof_test_membership(Slapi_PBlock *pb, MemberOfConfig *config, Slapi_DN *gro
     char *attrs[2] = {config->memberof_attr, 0};
     int cached = 0;
 
-    return memberof_call_foreach_dn(pb, group_sdn, config, attrs,
+    return memberof_call_foreach_dn(pb, NULL, group_sdn, config, attrs,
                                     memberof_test_membership_callback, config, &cached, PR_FALSE);
 }
 
@@ -3534,6 +3650,12 @@ memberof_test_membership_callback(Slapi_Entry *e, void *callback_data)
     Slapi_DN *entry_sdn = 0;
     MemberOfConfig *config = (MemberOfConfig *)callback_data;
     Slapi_DN *sdn = slapi_sdn_new();
+    MemberofEntryInfo entry_info = {0};
+
+    memberof_set_entry_info(e, config, &entry_info);
+    if (memberof_test_specific_filters(config, &entry_info) == 0) {
+        goto bail;
+    }
 
     entry_sdn = slapi_entry_get_sdn(e);
     entry_dn = slapi_value_new_string(slapi_entry_get_ndn(e));
@@ -4144,7 +4266,6 @@ memberof_fix_memberof(MemberOfConfig *config, Slapi_Task *task, task_data *td)
                                  0, 0,
                                  memberof_get_plugin_id(),
                                  0);
-
     rc = slapi_search_internal_callback_pb(search_pb,
                                            config,
                                            0, memberof_fixup_memberof_callback,
@@ -4285,7 +4406,7 @@ memberof_fix_memberof_callback(Slapi_Entry *e, void *callback_data)
     int rc = 0;
     Slapi_DN *sdn = slapi_entry_get_sdn(e);
     MemberOfConfig *config = (MemberOfConfig *)callback_data;
-    memberof_del_dn_data del_data = {0, config->memberof_attr};
+    memberof_del_dn_data del_data = {0, config->memberof_attr, config};
     Slapi_ValueSet *groups = 0;
     const char *ndn;
     char *dn_copy;
@@ -4309,7 +4430,7 @@ memberof_fix_memberof_callback(Slapi_Entry *e, void *callback_data)
     }
 
     /* get a list of all of the groups this user belongs to */
-    groups = memberof_get_groups(config, sdn);
+    groups = memberof_get_groups(config, e, sdn);
 #if MEMBEROF_CACHE_DEBUG
     {
         Slapi_Value *val = 0;

--- a/ldap/servers/plugins/memberof/memberof.h
+++ b/ldap/servers/plugins/memberof/memberof.h
@@ -50,6 +50,9 @@
 #define DN_SYNTAX_OID             "1.3.6.1.4.1.1466.115.121.1.12"
 #define NAME_OPT_UID_SYNTAX_OID   "1.3.6.1.4.1.1466.115.121.1.34"
 #define SHUTDOWN_TIMEOUT          60   /* systemctl timeout is by default 90s */
+#define MEMBEROF_SPECIFIC_GROUP_FILTER         "memberOfSpecificGroupFilter"
+#define MEMBEROF_EXCLUDE_SPECIFIC_GROUP_FILTER "memberOfExcludeSpecificGroupFilter"
+#define MEMBEROF_SPECIFIC_GROUP_OC "memberOfSpecificGroupOC"
 
 
 /*
@@ -128,6 +131,12 @@ typedef struct memberofconfig
     int entryScopeCount;
     Slapi_DN **entryScopeExcludeSubtrees;
     int entryExcludeScopeCount;
+    Slapi_Filter **specificGroupFilter;
+    Slapi_Filter **excludeSpecificGroupFilter;
+    int specificGroupFilterCount;
+    int excludeSpecificGroupFilterCount;
+    char **specificGroupOC;
+    int specificGroupOCCount;
     Slapi_Filter *group_filter;
     Slapi_Attr **group_slapiattrs;
     int skip_nested;

--- a/src/lib389/lib389/cli_conf/plugins/memberof.py
+++ b/src/lib389/lib389/cli_conf/plugins/memberof.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -7,7 +7,6 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-import json
 import ldap
 from lib389.plugins import MemberOfPlugin, MemberOfSharedConfig, MemberOfFixupTasks
 from lib389.utils import get_task_status
@@ -25,7 +24,10 @@ arg_to_attr = {
     'autoaddoc': 'memberOfAutoAddOC',
     'deferredupdate': 'memberOfDeferredUpdate',
     'launchfixup': 'memberOfLaunchFixup',
-    'config_entry': 'nsslapd-pluginConfigArea'
+    'config_entry': 'nsslapd-pluginConfigArea',
+    'specific_group_filter': 'memberOfSpecificGroupFilter',
+    'exclude_specific_group_filter': 'memberOfExcludeSpecificGroupFilter',
+    'specific_group_oc': 'memberOfSpecificGroupOC',
 }
 
 
@@ -89,7 +91,7 @@ def do_fixup(inst, basedn, log, args):
         fixup_task.wait(timeout=args.timeout)
         exitcode = fixup_task.get_exit_code()
         if exitcode != 0:
-            if existcode is None:
+            if exitcode is None:
                 raise ValueError(f'MemberOf fixup task "{fixup_task.dn}" for {args.DN} has not completed. Please, check logs')
             else:
                 raise ValueError(f'MemberOf fixup task "{fixup_task.dn}" for {args.DN} has failed (error {exitcode}). Please, check logs')
@@ -120,6 +122,12 @@ def _add_parser_args(parser):
                                                    'for the MemberOf plug-in to work on (memberOfEntryScope)')
     parser.add_argument('--exclude', nargs='+', help='Specifies backends or multiple-nested suffixes '
                                                      'for the MemberOf plug-in to exclude (memberOfEntryScopeExcludeSubtree)')
+    parser.add_argument('--specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to include. Otherwise all other groups will be excluded (memberOfSpecificGroup)')
+    parser.add_argument('--exclude-specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to exclude. Otherwise all other groups will be included (memberOfExcludeSpecificGroup)')
+    parser.add_argument('--specific-group-oc', nargs='+',
+                        help='Specifies the objectclasses for the specific groups to include/exclude. Otherwise all other groups will be excluded (memberOfSpecificGroupOC)')
     parser.add_argument('--autoaddoc', type=str.lower,
                         help='If an entry does not have an object class that allows the memberOf attribute '
                              'then the memberOf plugin will automatically add the object class listed '

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -166,7 +166,6 @@ def health_check_run(inst, log, args):
 
     checks = args.check or dict(_list_targets(inst)).keys()
     exclude_checks = args.exclude_check
-    print("MARK excl: " + str(exclude_checks))
     if args.list_checks or args.dry_run:
         _print_checks(inst, log, checks)
         return

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -1071,6 +1071,54 @@ class MemberOfPlugin(Plugin):
         """Remove all memberofentryscopeexcludesubtree attributes"""
 
         self.remove_all('memberofentryscopeexcludesubtree')
+
+    def get_exclude_specific_group_filters(self):
+        """Get memberofexcludespecificgroup attribute"""
+        return self.get_attr_vals_utf8_l('memberofexcludespecificgroupfilter')
+
+    def add_exclude_specific_group_filter(self, value):
+        """Add memberofexcludespecificgroups attribute"""
+        self.add('memberofexcludespecificgroupfilter', value)
+
+    def remove_exclude_specific_group_filter(self, value):
+        """Remove memberofexcludespecificgroups attribute"""
+        self.remove('memberofexcludespecificgroupfilter', value)
+
+    def remove_all_exclude_specific_group_filters(self):
+        """Remove all memberofexcludespecificgroups attributes"""
+        self.remove_all('memberofexcludespecificgroupfilter')
+
+    def get_specific_group_filters(self):
+        """Get memberofspecificgroup attribute"""
+        return self.get_attr_vals_utf8_l('memberofspecificgroupfilter')
+
+    def add_specific_group_filter(self, value):
+        """Add memberofspecificgroups attribute"""
+        self.add('memberofspecificgroupfilter', value)
+
+    def remove_specific_group_filter(self, value):
+        """Remove memberofspecificgroupfilter attribute"""
+        self.remove('memberofspecificgroupfilter', value)
+
+    def remove_all_specific_group_filters(self):
+        """Remove all memberofspecificgroupfilter attributes"""
+        self.remove_all('memberofspecificgroupfilter')
+
+    def get_specific_group_oc(self):
+        """Get memberofspecificgroupoc attribute"""
+        return self.get_attr_vals_utf8_l('memberofspecificgroupoc')
+
+    def add_specific_group_oc(self, value):
+        """Add memberofspecificgroupoc attribute"""
+        self.add('memberofspecificgroupoc', value)
+
+    def remove_specific_group_oc(self, value):
+        """Remove memberofspecificgroupoc attribute"""
+        self.remove('memberofspecificgroupoc', value)
+
+    def remove_all_specific_group_oc(self):
+        """Remove all memberofspecificgroupoc attributes"""
+        self.remove_all('memberofspecificgroupoc')
 
     def get_configarea(self):
         """Get nsslapd-pluginConfigArea attribute"""


### PR DESCRIPTION
Description:

Add ability to include/exclude specific groups that memberOf will act upon

Design doc: https://www.port389.org/docs/389ds/design/memberof-specific-group-scoping-design.html

Relates: https://github.com/389ds/389-ds-base/issues/7035

## Summary by Sourcery

Introduce scoping for specific groups in the MemberOf plugin by allowing users to explicitly include or exclude particular group DNs and restrict by object classes.

New Features:
- Add memberOfSpecificGroup, memberOfExcludeSpecificGroup and memberOfSpecificGroupOC attributes to plugin configuration
- Expose new "Specific Group", "Exclude Specific Group" and "Specific Group OC" fields in the cockpit UI

Enhancements:
- Extend core plugin scoping logic to respect include/exclude specific group lists and object class filters
- Update configuration validation and application to handle new scoping attributes
- Refactor various plugin functions to pass entry context for scoping checks

Tests:
- Add dsconf and plugin unit tests covering specific group inclusion, exclusion and objectClass-based scenarios