### PR TITLE
Issue - CLI/UI - Add option to delete all replication conflict entries

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_conflict_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_conflict_test.py
@@ -1,0 +1,148 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import time
+import json
+import subprocess
+from lib389._constants import DEFAULT_SUFFIX, DN_DM
+from lib389.topologies import topology_m2 as topo
+from lib389.idm.group import Groups
+from lib389.conflicts import ConflictEntries
+log = logging.getLogger(__name__)
+
+
+def execute_dsconf_command(dsconf_cmd, subcommands):
+    """Execute dsconf command and return output and return code"""
+
+    cmdline = dsconf_cmd + subcommands
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+
+    if proc.returncode != 0 and err:
+        log.error(f"Command failed: {' '.join(cmdline)}")
+        log.error(f"Stderr: {err.decode('utf-8')}")
+
+    return out.decode('utf-8'), proc.returncode
+
+
+def get_dsconf_base_cmd(inst):
+    """Return base dsconf command list"""
+    return ['/usr/sbin/dsconf', inst.serverid,
+            '-D', DN_DM, '-w', 'password', 'repl-conflict']
+
+
+def get_conflict_dn(output):
+    """Get the conflict DN from the output"""
+    return output.split("\n")[0].replace('dn: ', '')
+
+
+def test_dsconf_repl_coniflict(topo):
+    """Test all the dsconf repl-conflict features
+
+    :id: 2ef33fd8-dd5c-4fe6-858e-e8a00e707410
+    :setup: 2 Supplier Instances
+    :steps:
+        1. Create conflict entries
+        2. List conflicts
+        3. Compare conflict
+        4. Delete conflict
+        5. Convert conflict
+        6. Swap conflict
+        7. Delete all conflicts
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+    """
+
+    supplier1 = topo.ms["supplier1"]
+    supplier2 = topo.ms["supplier2"]
+    group1 = Groups(supplier1, DEFAULT_SUFFIX)
+    group2 = Groups(supplier2, DEFAULT_SUFFIX)
+    dsconf_cmd = get_dsconf_base_cmd(supplier1)
+
+    # Create conflict entries
+    supplier1.stop()
+    group2.create(properties={'cn': 'test', 'description': 'value1'})
+    group2.create(properties={'cn': 'test2', 'description': 'value1'})
+    group2.create(properties={'cn': 'test3', 'description': 'value1'})
+    group2.create(properties={'cn': 'test4', 'description': 'value1'})
+    group2.create(properties={'cn': 'test5', 'description': 'value1'})
+    supplier2.stop()
+    supplier1.start()
+    group1.create(properties={'cn': 'test', 'description': 'value2'})
+    group1.create(properties={'cn': 'test2', 'description': 'value2'})
+    group1.create(properties={'cn': 'test3', 'description': 'value2'})
+    group1.create(properties={'cn': 'test4', 'description': 'value2'})
+    group1.create(properties={'cn': 'test5', 'description': 'value2'})
+    supplier2.start()
+
+    time.sleep(2)  # Let replication catch up
+
+    # list conflicts
+    conflicts1 = ConflictEntries(supplier1, DEFAULT_SUFFIX)
+    assert len(conflicts1.list()) == 5
+
+    output, rc = execute_dsconf_command(dsconf_cmd, ["list", DEFAULT_SUFFIX])
+    assert rc == 0
+    assert len(output) > 0
+    assert output != "There were no conflict entries found under the suffix"
+    conflict_dn = get_conflict_dn(output)
+
+    # Compare a conflict
+    output, rc = execute_dsconf_command(dsconf_cmd, ["compare", conflict_dn])
+    assert rc == 0
+    assert len(output) > 0
+    assert "Conflict Entry" in output
+    assert "Valid Entry" in output
+
+    # Delete a single conflict
+    output, rc = execute_dsconf_command(dsconf_cmd, ["delete", conflict_dn])
+    assert rc == 0
+    assert len(conflicts1.list()) == 4
+    output, rc = execute_dsconf_command(dsconf_cmd, ["list", DEFAULT_SUFFIX])
+    assert rc == 0
+    conflict_dn = get_conflict_dn(output)
+
+    # Convert conflict
+    output, rc = execute_dsconf_command(dsconf_cmd, ["convert", conflict_dn,
+                                        "--new-rdn=cn=testtest"])
+    assert rc == 0
+    assert len(conflicts1.list()) == 3
+    output, rc = execute_dsconf_command(dsconf_cmd, ["list", DEFAULT_SUFFIX])
+    assert rc == 0
+    conflict_dn = get_conflict_dn(output)
+
+    # Swap conflict
+    output, rc = execute_dsconf_command(dsconf_cmd, ["swap", conflict_dn])
+    assert rc == 0
+    assert len(conflicts1.list()) == 2
+
+    # Delete all the remaining conflicts
+    output, rc = execute_dsconf_command(dsconf_cmd, ["delete-all", DEFAULT_SUFFIX])
+    assert rc == 0
+    assert "Deleted 2 conflict entries" in output
+
+    # Check conflicts are deleted
+    assert len(conflicts1.list()) == 0
+    output, rc = execute_dsconf_command(dsconf_cmd, ["list", DEFAULT_SUFFIX])
+    assert output.strip() == "There were no conflict entries found under the suffix"
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/src/cockpit/389-console/po/ja.po
+++ b/src/cockpit/389-console/po/ja.po
@@ -14584,7 +14584,7 @@ msgid "Loading Replication Monitor Information ..."
 msgstr "レプリケーション監視情報を読み込んでいます..."
 
 #: src/monitor.jsx:1107
-msgid "Loading Chaining Monitor Information For <b>$0 ...</b>"
+msgid "Loading Chaining Monitor Information for $0 ..."
 msgstr "$0のチェイン監視情報を読み込んでいます..."
 
 #: src/monitor.jsx:1162

--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -396,7 +396,7 @@ class ConflictCompareModal extends React.Component {
                             <TextInput
                                 placeholder={_("Enter new RDN here")}
                                 type="text"
-                                onChange={handleChange}
+                                onChange={(_event, value) => handleChange(_event)}
                                 aria-label="new rdn label"
                                 id="convertRDN"
                                 value={orig_rdn}

--- a/src/cockpit/389-console/src/lib/monitor/replMonConflict.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonConflict.jsx
@@ -32,6 +32,7 @@ export class ReplMonConflict extends React.Component {
             showConfirmConvertConflict: false,
             showConfirmSwapConflict: false,
             showConfirmDeleteConflict: false,
+            showConfirmDeleteAllConflicts: false,
             showCompareModal: false,
             showConfirmDeleteGlue: false,
             showConfirmConvertGlue: false,
@@ -56,6 +57,7 @@ export class ReplMonConflict extends React.Component {
         this.convertConflict = this.convertConflict.bind(this);
         this.swapConflict = this.swapConflict.bind(this);
         this.deleteConflict = this.deleteConflict.bind(this);
+        this.deleteAllConflicts = this.deleteAllConflicts.bind(this);
         this.resolveConflict = this.resolveConflict.bind(this);
         this.convertGlue = this.convertGlue.bind(this);
         this.deleteGlue = this.deleteGlue.bind(this);
@@ -64,6 +66,7 @@ export class ReplMonConflict extends React.Component {
         this.confirmConvertGlue = this.confirmConvertGlue.bind(this);
         this.closeConfirmDeleteGlue = this.closeConfirmDeleteGlue.bind(this);
         this.closeConfirmConvertGlue = this.closeConfirmConvertGlue.bind(this);
+        this.closeConfirmDeleteAllConflicts = this.closeConfirmDeleteAllConflicts.bind(this);
         this.onRadioChange = this.onRadioChange.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onConflictConversion = this.onConflictConversion.bind(this);
@@ -73,13 +76,14 @@ export class ReplMonConflict extends React.Component {
         this.closeConfirmDeleteConflict = this.closeConfirmDeleteConflict.bind(this);
         this.closeConfirmConvertConflict = this.closeConfirmConvertConflict.bind(this);
         this.closeConfirmSwapConflict = this.closeConfirmSwapConflict.bind(this);
+        this.confirmDeleteAllConflicts = this.confirmDeleteAllConflicts.bind(this);
     }
 
     componentDidMount() {
         this.props.enableTree();
     }
 
-    onRadioChange(_, value) {
+    onRadioChange(e, value) {
         // Handle the radio button changes
         const radioID = {
             swapConflictRadio: false,
@@ -87,7 +91,7 @@ export class ReplMonConflict extends React.Component {
             convertConflictRadio: false,
         };
 
-        radioID[evt.target.id] = value;
+        radioID[e.target.id] = value;
         this.setState({
             swapConflictRadio: radioID.swapConflictRadio,
             deleteConflictRadio: radioID.deleteConflictRadio,
@@ -95,17 +99,10 @@ export class ReplMonConflict extends React.Component {
         });
     }
 
-    onChange(value, evt) {
-        // PF 4 version
-        if (evt.target.type === 'number') {
-            if (value) {
-                value = parseInt(value);
-            } else {
-                value = 1;
-            }
-        }
+    onChange(e) {
+        const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
         this.setState({
-            [evt.target.id]: value
+            [e.target.id]: value
         });
     }
 
@@ -117,7 +114,7 @@ export class ReplMonConflict extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.props.reloadConflicts();
+                    this.props.reloadConflicts(this.props.suffix);
                     this.props.addNotification(
                         "success",
                         _("Replication conflict entry was converted into a valid entry")
@@ -145,7 +142,7 @@ export class ReplMonConflict extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.props.reloadConflicts();
+                    this.props.reloadConflicts(this.props.suffix);
                     this.props.addNotification(
                         "success",
                         _("Replication Conflict Entry is now the Valid Entry")
@@ -174,7 +171,7 @@ export class ReplMonConflict extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.props.reloadConflicts();
+                    this.props.reloadConflicts(this.props.suffix);
                     this.props.addNotification(
                         "success",
                         _("Replication conflict entry was deleted")
@@ -191,6 +188,39 @@ export class ReplMonConflict extends React.Component {
                         cockpit.format(_("Failed to delete conflict entry: $0 - $1"), this.state.conflictEntry, errMsg.desc)
                     );
                     this.closeConfirmDeleteConflict();
+                });
+    }
+
+    deleteAllConflicts () {
+        const cmd = ["dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+            "repl-conflict", "delete-all", this.props.suffix];
+        this.setState({
+            modalSpinning: true,
+        });
+        log_cmd("deleteAllConflicts", "Delete all conflict entries", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    this.props.reloadConflicts(this.props.suffix);
+                    this.props.addNotification(
+                        "success",
+                        _("All conflict entries were deleted")
+                    );
+                    this.setState({
+                        showConfirmDeleteAllConflicts: false,
+                        modalSpinning: false,
+                    });
+                })
+                .fail(err => {
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Failed to delete all conflict entries: $0 - $1"),
+                                       this.props.suffix, err)
+                    );
+                    this.setState({
+                        showConfirmDeleteAllConflicts: false,
+                        modalSpinning: false,
+                    });
                 });
     }
 
@@ -221,6 +251,14 @@ export class ReplMonConflict extends React.Component {
                 });
     }
 
+    closeConfirmDeleteAllConflicts () {
+        this.setState({
+            showConfirmDeleteAllConflicts: false,
+            modalChecked: false,
+            modalSpinning: false,
+        });
+    }
+
     confirmConvertGlue (dn) {
         this.setState({
             showConfirmConvertGlue: true,
@@ -246,7 +284,7 @@ export class ReplMonConflict extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.props.reloadConflicts();
+                    this.props.reloadConflicts(this.props.suffix);
                     this.props.addNotification(
                         "success",
                         _("Replication glue entry was converted")
@@ -272,6 +310,14 @@ export class ReplMonConflict extends React.Component {
         });
     }
 
+    confirmDeleteAllConflicts () {
+        this.setState({
+            showConfirmDeleteAllConflicts: true,
+            modalChecked: false,
+            modalSpinning: false,
+        });
+    }
+
     deleteGlue () {
         const cmd = ["dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "repl-conflict", "delete-glue", this.state.glueEntry];
@@ -279,7 +325,7 @@ export class ReplMonConflict extends React.Component {
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
-                    this.props.reloadConflicts();
+                    this.props.reloadConflicts(this.props.suffix);
                     this.props.addNotification(
                         "success",
                         _("Replication glue entry was deleted")
@@ -389,6 +435,7 @@ export class ReplMonConflict extends React.Component {
     render () {
         const conflictEntries = this.props.data?.conflicts || [];
         const glueEntries = this.props.data?.glues || [];
+        const deleteBtnName = this.state.modalSpinning ? "Deleting All Conflict Entries ..." : "Delete All Conflict Entries";
 
         return (
             <div>
@@ -423,6 +470,20 @@ export class ReplMonConflict extends React.Component {
                                 resolveConflict={this.resolveConflict}
                                 key={conflictEntries}
                             />
+                            {conflictEntries.length > 0 &&
+                                <Button
+                                    variant="secondary"
+                                    ouiaId="DangerSecondary"
+                                    isDanger
+                                    aria-label={"Delete all conflict entries"}
+                                    className="ds-margin-top-lg"
+                                    onClick={this.confirmDeleteAllConflicts}
+                                    isDisabled={this.state.modalSpinning}
+                                    isLoading={this.state.modalSpinning}
+                                >
+                                    {deleteBtnName}
+                                </Button>
+                            }
                         </div>
                     </Tab>
                     <Tab eventKey={1} title={<TabTitleText>{_("Glue Entries ")}<font size="2">({glueEntries.length})</font></TabTitleText>}>
@@ -461,7 +522,7 @@ export class ReplMonConflict extends React.Component {
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmDeleteGlue}
                     closeHandler={this.closeConfirmDeleteGlue}
-                    handleChange={this.onFieldChange}
+                    handleChange={this.onChange}
                     actionHandler={this.deleteGlue}
                     spinning={this.state.modalSpinning}
                     item={this.state.glueEntry}
@@ -474,7 +535,7 @@ export class ReplMonConflict extends React.Component {
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmConvertGlue}
                     closeHandler={this.closeConfirmConvertGlue}
-                    handleChange={this.onFieldChange}
+                    handleChange={this.onChange}
                     actionHandler={this.convertGlue}
                     spinning={this.state.modalSpinning}
                     item={this.state.glueEntry}
@@ -487,7 +548,7 @@ export class ReplMonConflict extends React.Component {
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmConvertConflict}
                     closeHandler={this.closeConfirmConvertConflict}
-                    handleChange={this.onFieldChange}
+                    handleChange={this.onChange}
                     actionHandler={this.convertConflict}
                     spinning={this.state.modalSpinning}
                     item={this.state.conflictEntry}
@@ -500,7 +561,7 @@ export class ReplMonConflict extends React.Component {
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmSwapConflict}
                     closeHandler={this.closeConfirmSwapConflict}
-                    handleChange={this.onFieldChange}
+                    handleChange={this.onChange}
                     actionHandler={this.swapConflict}
                     spinning={this.state.modalSpinning}
                     item={this.state.conflictEntry}
@@ -513,7 +574,7 @@ export class ReplMonConflict extends React.Component {
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmDeleteConflict}
                     closeHandler={this.closeConfirmDeleteConflict}
-                    handleChange={this.onFieldChange}
+                    handleChange={this.onChange}
                     actionHandler={this.deleteConflict}
                     spinning={this.state.modalSpinning}
                     item={this.state.conflictEntry}
@@ -522,6 +583,19 @@ export class ReplMonConflict extends React.Component {
                     mMsg={_("Are you really sure you want to delete this conflict entry?")}
                     mSpinningMsg={_("Deleting Conflict Entry ...")}
                     mBtnName={_("Delete Conflict")}
+                />
+                <DoubleConfirmModal
+                    showModal={this.state.showConfirmDeleteAllConflicts}
+                    closeHandler={this.closeConfirmDeleteAllConflicts}
+                    handleChange={this.onChange}
+                    actionHandler={this.deleteAllConflicts}
+                    spinning={this.state.modalSpinning}
+                    item={conflictEntries.length + " conflict entries"}
+                    checked={this.state.modalChecked}
+                    mTitle={_("Delete All Conflict Entries")}
+                    mMsg={_("Are you really sure you want to delete all conflict entries?")}
+                    mSpinningMsg={_("Deleting All Conflict Entries ...")}
+                    mBtnName={_("Delete All Conflict Entries")}
                 />
             </div>
         );

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -1214,7 +1214,7 @@ export class Monitor extends React.Component {
                         <div className="ds-margin-top-xlg ds-center">
                             <TextContent>
                                 <Text component={TextVariants.h3}>
-                                    cockpit.format(_("Loading Chaining Monitor Information For <b>$0 ...</b>"), this.state.node_text)
+                                    cockpit.format(_("Loading Chaining Monitor Information for $0 ..."), this.state.node_text)
                                 </Text>
                             </TextContent>
                             <Spinner className="ds-margin-top-lg" size="xl" />

--- a/src/lib389/lib389/cli_conf/conflicts.py
+++ b/src/lib389/lib389/cli_conf/conflicts.py
@@ -49,6 +49,25 @@ def del_conflict(inst, basedn, log, args):
     conflict.delete()
 
 
+def del_all_conflicts(inst, basedn, log, args):
+    count = 0
+    failed = 0
+    conflicts = ConflictEntries(inst, args.suffix).list()
+    for conflict in conflicts:
+        try:
+            log.info(f"Deleting conflict entry: {conflict.dn}")
+            conflict.delete()
+            count += 1
+        except Exception as e:
+            log.error(f"Failed to delete conflict entry {conflict.dn}: {str(e)}")
+            failed += 1
+
+    if failed > 0:
+        log.warning(f"Deleted {count} conflict entries, {failed} failed.")
+    else:
+        log.info(f"Deleted {count} conflict entries.")
+
+
 def swap_conflict(inst, basedn, log, args):
     conflict = ConflictEntry(inst, args.DN)
     conflict.swap()
@@ -100,6 +119,10 @@ def create_parser(subparsers):
     del_parser = subcommands.add_parser('delete', help="Delete a conflict entry", formatter_class=CustomHelpFormatter)
     del_parser.add_argument('DN', help='The DN of the conflict entry')
     del_parser.set_defaults(func=del_conflict)
+
+    del_all_parser = subcommands.add_parser('delete-all', help="Delete all conflict entries", formatter_class=CustomHelpFormatter)
+    del_all_parser.add_argument('suffix', help='Sets the backend name, or suffix, to remove all conflict entries from')
+    del_all_parser.set_defaults(func=del_all_conflicts)
 
     replace_parser = subcommands.add_parser('swap', help="Replace the valid entry with the conflict entry", formatter_class=CustomHelpFormatter)
     replace_parser.add_argument('DN', help='The DN of the conflict entry')


### PR DESCRIPTION
Description:

Add CLI option for deleting all conflict entries. Also added this option to the UI. Parts of the UI for conflicts was not updated for PF5 so some updates were needed there for handling modal updates.

Relates: https://github.com/389ds/389-ds-base/issues/7039

## Summary by Sourcery

Add bulk deletion support for replication conflict entries across the dsconf CLI and Cockpit UI, update UI components for PF5 compatibility and suffix-based reloading, fix monitor text, and add comprehensive tests for repl-conflict functionality.

New Features:
- Add `delete-all` subcommand to the dsconf CLI for bulk deletion of replication conflict entries
- Add "Delete All Conflict Entries" button and confirmation modal to the Cockpit UI

Enhancements:
- Update event handlers and modals in the UI for PatternFly 5 compatibility
- Include backend suffix when reloading conflict entries after operations
- Correct the loading text in the monitor view

Tests:
- Introduce an end-to-end pytest suite exercising all dsconf repl-conflict commands including the new delete-all feature