### PR TITLE
Issue 7042 - Enable global_backend_lock when memberofallbackend is enabled

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -320,6 +320,66 @@ def test_healthcheck_MO_plugin_substring_index(topology_st):
     standalone.restart()
 
 
+def test_healthcheck_MO_plugin_global_lock(topology_st):
+    """Verify HealthCheck returns DSMOLE0003 when memberOfAllBackends=on
+    and nsslapd-global-backend-lock=off
+
+    :id: 2a93f824-4bb7-4958-adcb-4e8ba17bfcc0
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Configure the instance with MO Plugin
+        3. Set memberOfAllBackends and nsslapd-global-backend-lock to off
+        4. Use HealthCheck without --json option
+        5. Use HealthCheck with --json option
+        6. Set memberOfAllBackends to on and nsslapd-global-backend-lock to off
+        7. Use HealthCheck without --json option
+        8. Use HealthCheck with --json option
+
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Healthcheck reports no issue found
+        5. Healthcheck reports no issue found
+        6. Success
+        7. Healthcheck reports DSMOLE0003 code and related details
+        8. Healthcheck reports DSMOLE0003 code and related details
+    """
+
+    RET_CODE = 'DSMOLE0003'
+
+    standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
+
+    log.info('Enable MO plugin')
+    plugin = MemberOfPlugin(standalone)
+    plugin.disable()
+    plugin.enable()
+
+    log.info('Verify no return code')
+    standalone.config.set('nsslapd-global-backend-lock', "off")
+    plugin.replace('memberOfAllBackends', 'off')
+    standalone.restart()
+    assert plugin.get_attr_val_utf8('memberOfAllBackends') == "off"
+    assert standalone.config.get_attr_val_utf8('nsslapd-global-backend-lock') == 'off'
+
+    run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+
+    log.info('Verify return code')
+    plugin.replace('memberOfAllBackends', 'on')
+    standalone.restart()
+    assert plugin.get_attr_val_utf8('memberOfAllBackends') == "on"
+    assert standalone.config.get_attr_val_utf8('nsslapd-global-backend-lock') == 'off'
+
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+
+    # Restart the instance after changing the plugin to avoid breaking the other tests
+    standalone.restart()
+
+
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
 def test_healthcheck_virtual_attr_incorrectly_indexed(topology_st):
     """Check if HealthCheck returns DSVIRTLE0001 code

--- a/ldap/servers/plugins/memberof/memberof_config.c
+++ b/ldap/servers/plugins/memberof/memberof_config.c
@@ -17,6 +17,7 @@
 #include "plhash.h"
 #include <plstr.h>
 #include "memberof.h"
+#include "slap.h"
 
 #define MEMBEROF_CONFIG_FILTER "(objectclass=*)"
 #define MEMBEROF_HASHTABLE_SIZE 1000
@@ -208,6 +209,7 @@ memberof_validate_config(Slapi_PBlock *pb,
     char *config_dn = NULL;
     const char *skip_nested = NULL;
     const char *auto_add_oc = NULL;
+    const char *all_backends = NULL;
     char **entry_scopes = NULL;
     char **entry_exclude_scopes = NULL;
     char **specific_group_filter = NULL;
@@ -495,6 +497,47 @@ memberof_validate_config(Slapi_PBlock *pb,
                 x++;
             }
             i++;
+        }
+    }
+
+    /*
+     * If the memberof plugin is configured to monitor all backends, verify
+     * that the global backend lock is enabled. If it is not, log a warning
+     * since this config may lead to deadlocks during cross backend updates.
+     */
+    all_backends = slapi_entry_attr_get_ref(e, MEMBEROF_BACKEND_ATTR);
+    if (all_backends && (strcasecmp(all_backends, "on") == 0)) {
+        const char *config_base = "cn=config";
+        const char *filter = "(objectclass=*)";
+        char *attrs[] = { CONFIG_GLOBAL_BACKEND_LOCK, NULL };
+        Slapi_PBlock *pb = NULL;
+        Slapi_Entry **entries = NULL;
+        char *global_lock = NULL;
+
+        pb = slapi_pblock_new();
+        if (pb) {
+            slapi_search_internal_set_pb(pb, config_base, LDAP_SCOPE_BASE, filter,
+                                        attrs, 0, NULL, NULL,
+                                        memberof_get_plugin_id(), 0);
+
+            if (slapi_search_internal_pb(pb) == LDAP_SUCCESS) {
+                slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+                if (entries && entries[0]) {
+                    global_lock = slapi_entry_attr_get_charptr(entries[0], CONFIG_GLOBAL_BACKEND_LOCK);
+                }
+            }
+            if (global_lock && strcasecmp(global_lock, "off") == 0) {
+                slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
+                              "Warning: %s is set to \"off\" while %s is \"on\". "
+                              "This configuration may lead to potential deadlocks during "
+                              "cross backend updates. It is recommended to enable %s.\n",
+                              CONFIG_GLOBAL_BACKEND_LOCK, MEMBEROF_BACKEND_ATTR,
+                              CONFIG_GLOBAL_BACKEND_LOCK);
+           }
+
+            slapi_free_search_results_internal(pb);
+            slapi_pblock_destroy(pb);
+            slapi_ch_free_string(&global_lock);
         }
     }
 

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -314,6 +314,25 @@ from the large group can be slow.
 """
 }
 
+DSMOLE0003 = {
+    'dsle': 'DSMOLE0003',
+    'severity': 'MEDIUM',
+    'description': 'Global backend lock is disabled while memberOf monitors all backends',
+    'items': ['cn=memberof plugin,cn=plugins,cn=config',],
+    'detail': """The memberOf plugin is configured to monitor all backends and the
+global backend lock is disabled, this may lead to potential deadlocks
+during cross backend updates. The server will log a warning, but no
+automatic fix is applied.""",
+    'fix': """To prevent potential deadlocks, enable the global backend lock:
+
+    # dsconf slapd-YOUR_INSTANCE config replace ATTR=on
+
+Alternatively, if monitoring all backends is not required, you can disable it:
+
+    # dsconf slapd-YOUR_INSTANCE plugin memberof set --allbackends off
+"""
+}
+
 # Disk Space check.  Note - PARTITION is replaced by the calling function
 DSDSLE0001 = {
     'dsle': 'DSDSLE0001',

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -12,7 +12,7 @@ import copy
 import os.path
 from lib389 import tasks
 from lib389._mapped_object import DSLdapObjects, DSLdapObject
-from lib389.lint import DSRILE0001, DSRILE0002, DSMOLE0001, DSMOLE0002
+from lib389.lint import DSRILE0001, DSRILE0002, DSMOLE0001, DSMOLE0002, DSMOLE0003
 from lib389.utils import ensure_str, ensure_list_bytes
 from lib389.schema import Schema
 from lib389._constants import (
@@ -871,6 +871,26 @@ class MemberOfPlugin(Plugin):
                             yield report
                     except KeyError:
                         continue
+
+    def _lint_member_globalbackend_lock(self):
+        """
+        Verify that when the memberOf plugin monitors all backends,
+        the global backend lock is enabled. Warn if disabled.
+        """
+        if self.status():
+            from lib389.config import Config
+            allbackends = self.get_attr_val_utf8_l("memberofallbackends")
+            config = Config(self._instance)
+            if allbackends == "on":
+                GLOBAL_BE_LOCK = "nsslapd-global-backend-lock"
+                global_be_lock = config.get_attr_val_utf8(GLOBAL_BE_LOCK)
+                if global_be_lock == "off":
+                    report = copy.deepcopy(DSMOLE0003)
+                    report['check'] = f'attr:{GLOBAL_BE_LOCK}'
+                    report['items'].append(config.dn)
+                    report['fix'] = report['fix'].replace(f'ATTR', GLOBAL_BE_LOCK)
+                    report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                    yield report
 
     def get_attr(self):
         """Get memberofattr attribute"""


### PR DESCRIPTION
Description: When the memberOf plugin is configured with memberOfAllBackends=on option, concurrent updates to group memberships across multiple backends can lead to deadlock.

Fix: The plugin now automatically updates the nsslapd-global-backend-lock config to match the state of memberOfAllBackends, ensuring global backend locking.

Fixes: https://github.com/389ds/389-ds-base/issues/7042

Reviewed by:

## Summary by Sourcery

Automatically align nsslapd-global-backend-lock with the memberOfAllBackends setting to prevent cross-backend deadlocks and add a concurrency test to verify deadlock-free behavior.

New Features:
- Automatically enable or disable the global backend lock when memberOfAllBackends is toggled

Tests:
- Add a multi-backend concurrency test with worker and watchdog threads to validate no deadlocks under memberOfAllBackends=on