### PR TITLE
Issue 7044 - RFE - index sudoHost by default

### DIFF
--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -1076,12 +1076,13 @@ cn: memberOf
 nssystemindex: false
 nsindextype: eq
 
-dn: cn=memberuid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+dn: cn=memberUid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsIndex
 cn: memberuid
 nssystemindex: false
 nsindextype: eq
+nsindextype: pres
 
 dn: cn=nsUniqueId,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
@@ -1141,6 +1142,14 @@ nssystemindex: false
 nsindextype: pres
 nsindextype: eq
 nsindextype: sub
+
+dn: cn=sudoHost,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
+objectclass: top
+objectclass: nsIndex
+cn: sudoHost
+nssystemindex: false
+nsindextype: eq
+nsindextype: pres
 
 dn: cn=telephoneNumber,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top


### PR DESCRIPTION
Bug Description: SSSD by default will emit a complex query for sudoHost during logins. As this attribute is unindexed by default and there are no other significant attributes or indexes related, this can force ALLIDS searches during logins.

Fix Description: Index sudoHost by default to improve SSSD login performance.

fixes: https://github.com/389ds/389-ds-base/issues/7044

Author: William Brown <william@blackhats.net.au>

Review by: ???

## Summary by Sourcery

Enhancements:
- Add default equality and presence index entries for the sudoHost attribute in template-dse.ldif.in