### PR TITLE
Issue 7047 - MemberOf plugin logs null attribute name on fixup task completion

### DIFF
--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -975,9 +975,9 @@ perform_needed_fixup(void)
     slapi_ch_free_string(&cookie);
     slapi_ch_free_string(&td.bind_dn);
     slapi_ch_free_string(&td.filter_str);
-    memberof_free_config(&config);
     slapi_log_err(SLAPI_LOG_INFO, MEMBEROF_PLUGIN_SUBSYSTEM,
                   "Memberof plugin finished the global fixup task for attribute %s\n", config.memberof_attr);
+    memberof_free_config(&config);
     return rc;
 }
 


### PR DESCRIPTION
Description: The MemberOf plugin logged "(null)" instead of the attribute name when the global fixup task completed. This occurred because the config structure containing the attribute name was freed before the completion log message was written.

This fix moves the memberof_free_config() call to after the log statement, ensuring the attribute name is available for logging.

Additionally, the test_shutdown_on_deferred_memberof test has been improved to properly verify the fixup task behavior by checking that both the "started" and "finished" log messages contain the correct attribute name.

Fixes: https://github.com/389ds/389-ds-base/issues/7047

Reviewed by: ?

## Summary by Sourcery

Prevent null attribute names in MemberOf plugin fixup logs by deferring configuration free until after logging and update tests to validate correct log messages

Bug Fixes:
- Move memberof_free_config() to after the completion log to ensure the attribute name is available for logging

Tests:
- Enhance test_shutdown_on_deferred_memberof to assert both start and finish fixup logs include the correct attribute name and exclude '(null)'