### PR TITLE
Issue 7049 - RetroCL plugin generates invalid LDIF

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl_po.c
+++ b/ldap/servers/plugins/retrocl/retrocl_po.c
@@ -99,6 +99,9 @@ make_changes_string(LDAPMod **ldm, const char **includeattrs)
             addlenstr(l, ldm[i]->mod_type);
             addlenstr(l, "\n");
             break;
+        default:
+            /* LDAP_MOD_IGNORE or unknown - skip this mod entirely */
+            continue;
         }
         for (j = 0; ldm[i]->mod_bvalues != NULL &&
                     ldm[i]->mod_bvalues[j] != NULL;

--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -828,8 +828,8 @@ write_audit_file(
                         slapi_ch_free((void **)&buf);
                     }
                 }
+                addlenstr(l, "-\n");
             }
-            addlenstr(l, "-\n");
         }
         break;
 


### PR DESCRIPTION
Bug Description:
When a replicated modification marked with LDAP_MOD_IGNORE is logged,
`changes` attribute contains invalid LDIF:

```
replace: modifiersName
modifiersName: cn=MemberOf Plugin,cn=plugins,cn=config
-
modifyTimestamp: 20250903092211Z
-
```
Line `replace: modifyTimestamp` is missing.

A similar issue is present in audit log:
```
time: 20251031064114
dn: ou=tuser,dc=example,dc=com
result: 0
changetype: modify
add: objectClass
objectClass: nsMemberOf
-
replace: modifiersName
modifiersName: cn=MemberOf Plugin,cn=plugins,cn=config
-
-
```
Dash separator is logged, while the operation is not.
This issue is not present wheh JSON format is used.

Fix Description:
* retrocl_po.c: add a default case to skip the entire modification if it
  has LDAP_MOD_IGNORE flag.
* auditlog.c: write the dash separator only if operation type is not
  LDAP_MOD_IGNORE

Fixes: https://github.com/389ds/389-ds-base/issues/7049

## Summary by Sourcery

Bug Fixes:
- Mask LDAP_MOD_IGNORE flag in mod_op evaluation alongside LDAP_MOD_BVALUES to ensure correct operation detection and valid LDIF output