### PR TITLE
Issue 7056 - DSBLE0007 doesn't generate remediation steps for missing…

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -172,7 +172,8 @@ def test_missing_parentid(topology_st, log_buffering_enabled):
 
     log.info("Re-add the parentId index")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
+                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -260,7 +261,8 @@ def test_usn_plugin_missing_entryusn(topology_st, usn_plugin_enabled, log_buffer
 
     log.info("Re-add the entryusn index")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"])
+    backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"],
+                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -444,7 +446,8 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
 
     log.info("Re-add the missing system indexes")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
+                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
     backend.add_index("nsuniqueid", ["eq"])
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)


### PR DESCRIPTION
… indexes

Bug Description:
dsctl healthcheck doesn't generate remediation steps for missing indexes, instead it prints an error message:

```
- Unable to check index ancestorId: No object exists given the filter criteria: ancestorId (&(&(objectclass=nsIndex))(|(cn=ancestorId)))
```

Fix Description:
Catch `ldap.NO_SUCH_OBJECT` when index is missing and generate remediation instructions.

Fixes: https://github.com/389ds/389-ds-base/issues/7056

## Summary by Sourcery

Generate remediation commands for missing system indexes by catching ldap.NO_SUCH_OBJECT exceptions and conditionally including matching rules and scan limits

Bug Fixes:
- Catch ldap.NO_SUCH_OBJECT when system indexes are missing to avoid errors and generate remediation steps

Enhancements:
- Use optional dict get() for matching_rule and scanlimit to avoid KeyError