### PR TITLE
Issue 7041 - CLI/UI - memberOf - no way to add/remove specific group …

### DIFF
--- a/src/cockpit/389-console/po/ja.po
+++ b/src/cockpit/389-console/po/ja.po
@@ -3714,7 +3714,7 @@ msgstr ""
 "ネストされたグループをスキップするかどうかを指定します (memberOfSkipNested)"
 
 #: src/lib/plugins/memberOf.jsx:1417 src/lib/plugins/memberOf.jsx:1587
-msgid "Skip Nested"
+msgid "Skip Nested Groups"
 msgstr "ネストをスキップ"
 
 #: src/lib/plugins/memberOf.jsx:1421 src/lib/plugins/memberOf.jsx:1619

--- a/src/cockpit/389-console/src/dsBasicComponents.jsx
+++ b/src/cockpit/389-console/src/dsBasicComponents.jsx
@@ -421,6 +421,7 @@ const TypeaheadSelect = ({
                                         ev.stopPropagation();
                                         handleSelect(selection);
                                     }}
+                                    textMaxWidth="32ch"
                                 >
                                     {getChildren(selection)}
                                 </Label>

--- a/src/cockpit/389-console/src/lib/plugins/memberOfModals.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOfModals.jsx
@@ -1,0 +1,590 @@
+import cockpit from "cockpit";
+import React from "react";
+import {
+    Button,
+    Checkbox,
+    Form,
+    Grid,
+    GridItem,
+    HelperText,
+    HelperTextItem,
+    Modal,
+    ModalVariant,
+    Text,
+    TextContent,
+    TextVariants,
+    FormHelperText,
+    ValidatedOptions,
+    TextInput,
+    FormSelect,
+    FormSelectOption,
+    Tabs,
+    Tab,
+    TabTitleText,
+} from "@patternfly/react-core";
+import PropTypes from "prop-types";
+import { valid_dn } from "../tools.jsx";
+import TypeaheadSelect from "../../dsBasicComponents.jsx";
+import { MemberOfTable } from "./pluginTables.jsx";
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+
+
+const _ = cockpit.gettext;
+
+export class MemberOfFixupTaskModal extends React.Component {
+    render() {
+        const {
+            fixupModalShow,
+            handleToggleFixupModal,
+            handleRunFixup,
+            fixupDN,
+            fixupFilter,
+            handleFieldChange,
+        } = this.props;
+
+        return (
+            <Modal
+                variant={ModalVariant.small}
+                aria-labelledby="ds-modal"
+                title={_("MemberOf Plugin FixupTask")}
+                isOpen={fixupModalShow}
+                onClose={handleToggleFixupModal}
+                actions={[
+                <Button
+                    key="confirm"
+                        variant="primary"
+                        onClick={handleRunFixup}
+                        isDisabled={!valid_dn(fixupDN)}
+                    >
+                        {_("Run")}
+                    </Button>,
+                    <Button key="cancel" variant="link" onClick={handleToggleFixupModal}>
+                        {_("Cancel")}
+                    </Button>
+                ]}
+            >
+                <Grid>
+                    <GridItem span={12}>
+                        <Form isHorizontal autoComplete="off">
+                            <TextContent>
+                                <Text className="ds-margin-top" component={TextVariants.h4}>
+                                    {_("This task only needs to be run after enabling the plugin for the first time, or if the plugin configuration has changed in a way that will impact the group memberships.")}
+                                </Text>
+                            </TextContent>
+                            <Grid className="ds-margin-top" title={_("Base DN that contains entries to fix up.")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Subtree DN")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TextInput
+                                        value={fixupDN}
+                                        type="text"
+                                        id="fixupDN"
+                                        aria-describedby="horizontal-form-name-helper"
+                                        name="fixupDN"
+                                        onChange={(e, str) => { handleFieldChange(e) }}
+                                        validated={!valid_dn(fixupDN) ? ValidatedOptions.error : ValidatedOptions.default}
+                                    />
+                                    <FormHelperText>
+                                        {_("Value must be a valid DN")}
+                                    </FormHelperText>
+                                </GridItem>
+                            </Grid>
+                            <Grid className="ds-margin-bottom" title={_("Optional. Filter for finding entries to fix up. For example:  (uid=*).  If omitted, all entries with objectclass 'inetuser', 'inetadmin', or 'nsmemberof' under the specified subtree DN will have their memberOf attribute regenerated.")}>
+                                <GridItem span={3} className="ds-label">
+                                    {_("Search Filter")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TextInput
+                                        value={fixupFilter}
+                                        type="text"
+                                        id="fixupFilter"
+                                        aria-describedby="horizontal-form-name-helper"
+                                        name="fixupFilter"
+                                        onChange={(e, str) => { handleFieldChange(e) }}
+                                    />
+                                </GridItem>
+                            </Grid>
+                        </Form>
+                    </GridItem>
+                </Grid>
+            </Modal>
+        );
+    }
+}
+
+export class MemberOfConfigEntryModal extends React.Component {
+    render() {
+        const {
+            configEntryModalShow,
+            activeTabModalKey,
+            handleModalChange,
+            objectClasses,
+            newEntry,
+            settings,
+            errorModal,
+            handlers,
+            openers,
+            saveBtnDisabledModal,
+            savingModal,
+            extraPrimaryProps,
+            validateModalFilterCreate,
+            openSpecificExcludeGroupAddModal,
+        } = this.props;
+
+        let modalButtons = [];
+        if (!newEntry) {
+            modalButtons = [
+                <Button key="del" variant="primary" onClick={this.handleShowConfirmDelete}>
+                    {_("Delete Config")}
+                </Button>,
+                <Button
+                    key="save"
+                    variant="primary"
+                    onClick={handlers.handleEditConfig}
+                    isDisabled={saveBtnDisabledModal || savingModal}
+                    isLoading={savingModal}
+                    spinnerAriaValueText={savingModal ? _("Saving") : undefined}
+                    {...extraPrimaryProps}
+                >
+                    {savingModal ? _("Saving ...") : _("Save Config")}
+                </Button>,
+                <Button key="cancel" variant="link" onClick={handlers.handleCloseModal}>
+                    {_("Cancel")}
+                </Button>
+            ];
+        } else {
+            modalButtons = [
+                <Button
+                    key="add"
+                    variant="primary"
+                    onClick={handlers.handleAddConfig}
+                    isDisabled={saveBtnDisabledModal || savingModal}
+                    isLoading={savingModal}
+                    spinnerAriaValueText={savingModal ? _("Saving") : undefined}
+                    {...extraPrimaryProps}
+                >
+                    {savingModal ? _("Adding ...") : _("Add Config")}
+                </Button>,
+                <Button key="cancel" variant="link" onClick={handlers.handleCloseModal}>
+                    {_("Cancel")}
+                </Button>
+            ];
+        }
+
+        return (
+            <Modal
+                variant={ModalVariant.medium}
+                aria-labelledby="ds-modal"
+                title={_("Manage MemberOf Plugin Shared Config Entry")}
+                isOpen={configEntryModalShow}
+                onClose={handlers.handleCloseModal}
+                actions={modalButtons}
+            >
+                <Tabs isFilled activeKey={activeTabModalKey} onSelect={handlers.handleNavSelectModal}>
+                    <Tab eventKey={0} title={<TabTitleText>{_("Plugin Settings")}</TabTitleText>}>
+                        <Form isHorizontal autoComplete="off">
+                            <Grid className="ds-margin-top-lg" title={_("The config entry full DN")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Config DN")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TextInput
+                                        value={settings.configDN}
+                                        type="text"
+                                        id="configDN"
+                                        aria-describedby="horizontal-form-name-helper"
+                                        name="configDN"
+                                        onChange={(e, str) => { handlers.handleModalChange(e) }}
+                                        validated={errorModal.configDN ? ValidatedOptions.error : ValidatedOptions.default}
+                                        isDisabled={!newEntry}
+                                    />
+                                    {newEntry &&
+                                        <FormHelperText>
+                                            {_("Value must be a valid DN")}
+                                        </FormHelperText>
+                                    }
+                                </GridItem>
+                            </Grid>
+                            <Grid title={_("Specifies the attribute in the user entry for the Directory Server to manage to reflect group membership (memberOfAttr)")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Membership Attribute")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        selected={settings.configAttr}
+                                        onSelect={handlers.handleConfigAttrSelect}
+                                        onClear={handlers.handleConfigAttrClear}
+                                        options={["memberOf"]}
+                                        placeholder={_("Type a member attribute...")}
+                                        noResultsText={_("There are no matching entries")}
+                                        validated={errorModal.configAttr ? "error" : "default"}
+                                        ariaLabel="Type a member attribute"
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid className="ds-margin-top" title={_("Specifies the attribute in the group entry to use to identify the DNs of group members (memberOfGroupAttr)")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Group Attribute")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        isMulti
+                                        hasCheckbox
+                                        selected={settings.configGroupAttr}
+                                        onSelect={handlers.handleConfigGroupAttrSelect}
+                                        onClear={handlers.handleConfigGroupAttrClear}
+                                        options={["member", "memberCertificate", "uniqueMember"]}
+                                        placeholder={_("Type a member group attribute...")}
+                                        noResultsText={_("There are no matching entries")}
+                                        validated={errorModal.configGroupAttr ? "error" : "default"}
+                                        ariaLabel="Type a member group attribute"
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title={_("If an entry does not have an object class that allows the memberOf attribute then the memberOf plugin will automatically add the object class listed in the memberOfAutoAddOC parameter")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Auto Add OC")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <FormSelect
+                                        id="configAutoAddOC"
+                                        value={settings.configAutoAddOC}
+                                        onChange={(event, value) => {
+                                            handlers.handleModalChange(event);
+                                        }}
+                                        aria-label="FormSelect Input"
+                                    >
+                                        <FormSelectOption key="no_setting2" value="" label="-" />
+                                        {objectClasses.map((attr, index) => (
+                                            <FormSelectOption key={attr} value={attr} label={attr} />
+                                        ))}
+                                    </FormSelect>
+                                </GridItem>
+                            </Grid>
+                            <Grid>
+                                <GridItem className="ds-left-margin" span={3}>
+                                    <Checkbox
+                                        id="configSkipNested"
+                                        isChecked={settings.configSkipNested}
+                                        onChange={(e, checked) => { handleModalChange(e) }}
+                                        title={_("Specifies wherher to skip nested groups or not (memberOfSkipNested)")}
+                                        label={_("Skip Nested")}
+                                    />
+                                </GridItem>
+                            </Grid>
+                            <Grid title={_("Specifies whether to search the local suffix for user entries on all available suffixes (memberOfAllBackends)")}>
+                                <GridItem className="ds-left-margin" span={3}>
+                                    <Checkbox
+                                        id="configAllBackends"
+                                        isChecked={settings.configAllBackends}
+                                        onChange={(e, checked) => { handlers.handleModalChange(e) }}
+                                        label={_("All Backends")}
+                                    />
+                                </GridItem>
+                            </Grid>
+                        </Form>
+                    </Tab>
+                    <Tab eventKey={1} title={<TabTitleText>{_("Subtree Scopes")}</TabTitleText>}>
+                        <Form isHorizontal autoComplete="off">
+                            <Grid className="ds-margin-top" title={_("Specifies backends or multiple-nested suffixes for the MemberOf plug-in to work on (memberOfEntryScope)")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Subtree Scope")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        isMulti
+                                        selected={settings.configEntryScope}
+                                        onSelect={handlers.handleConfigScopeSelect}
+                                        onClear={handlers.handleConfigScopeClear}
+                                        options={settings.configEntryScopeOptions}
+                                        isCreatable
+                                        onCreateOption={handlers.handleConfigCreateOption}
+                                        validateCreate={(value) => valid_dn(value)}
+                                        placeholder={_("Type a subtree DN...")}
+                                        noResultsText={_("There are no matching entries")}
+                                        validated={errorModal.configEntryScope ? "error" : "default"}
+                                        onToggle={handlers.handleConfigScopeToggle}
+                                        isOpen={openers.isConfigSubtreeScopeOpen}
+                                        ariaLabel="Type a subtree DN"
+                                    />
+                                    <FormHelperText>
+                                        {_("Values must be valid DN's")}
+                                    </FormHelperText>
+                                </GridItem>
+                            </Grid>
+                            <Grid title={_("Specifies backends or multiple-nested suffixes for the MemberOf plug-in to exclude (memberOfEntryScopeExcludeSubtree)")}>
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Exclude Subtree")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        isMulti
+                                        selected={settings.configEntryScopeExcludeSubtreeScope}
+                                        onSelect={handlers.handleConfigExcludeScopeSelect}
+                                        onClear={handlers.handleConfigExcludeScopeClear}
+                                        options={settings.configEntryScopeExcludeOptions}
+                                        isCreatable
+                                        onCreateOption={handlers.handleConfigExcludeCreateOption}
+                                        validateCreate={(value) => valid_dn(value)}
+                                        placeholder={_("Type a subtree DN...")}
+                                        noResultsText={_("There are no matching entries")}
+                                        validated={errorModal.configEntryScopeExcludeSubtreeScope ? "error" : "default"}
+                                        ariaLabel="Type a subtree DN"
+                                        onToggle={handlers.handleConfigExcludeScopeToggle}
+                                        isOpen={openers.isConfigExcludeScopeOpen}
+                                    />
+                                    <FormHelperText>
+                                        {_("Values must be valid DN's")}
+                                    </FormHelperText>
+                                </GridItem>
+                            </Grid>
+                        </Form>
+                    </Tab>
+
+                    {!newEntry && (
+                        <Tab eventKey={2} title={<TabTitleText>{_("Group Scopes")}</TabTitleText>}>
+                            <MemberOfTable
+                                title={"Specific Group Filters"}
+                                rows={settings.configSpecificGroup}
+                                addAttr={handlers.openSpecificGroupAddModal}
+                                deleteAttr={handlers.openDeleteFilterConfirmation}
+                            />
+                            <Button
+                                id="specific-group-filter"
+                                className="ds-margin-top"
+                                key="specific-group-filter"
+                                variant="secondary"
+                                onClick={handlers.openSpecificGroupAddModal}
+                            >
+                                Add filter
+                            </Button>
+                            <MemberOfTable
+                                title={"Specific Group Exclude Filters"}
+                                rows={settings.configExcludeSpecificGroup}
+                                addAttr={handlers.openSpecificExcludeGroupAddModal}
+                                deleteAttr={handlers.openDeleteExcludeFilterConfirmation}
+                            />
+                            <Button
+                                id="specific-group-exclude-filter"
+                                className="ds-margin-top"
+                                key="specific-group-exclude-filter"
+                                variant="secondary"
+                                onClick={openSpecificExcludeGroupAddModal}
+                            >
+                                Add exclude filter
+                            </Button>
+                            <Grid
+                                className="ds-margin-top-lg"
+                                title={_("Specifies the objectclasses for the specific groups to include/exclude (memberOfSpecificGroupOC)")}
+                            >
+                                <GridItem className="ds-label" span={3}>
+                                    {_("Specific Group OC")}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        isMulti
+                                        selected={settings.configSpecificGroupOC}
+                                        onSelect={handlers.handleConfigSpecificGroupOCSelect}
+                                        onClear={handlers.handleConfigSpecificGroupOCClear}
+                                        options={objectClasses}
+                                        placeholder={_("Type a objectclass...")}
+                                        noResultsText="There are no matching objectclasses"
+                                        ariaLabel="Type a objectclass"
+                                        onToggle={handlers.handleConfigSpecificGroupOCToggle}
+                                        isOpen={openers.isConfigSpecificGroupOCOpen}
+                                    />
+                                </GridItem>
+                            </Grid>
+                        </Tab>
+                    )}
+                    {newEntry && (
+                            <Tab eventKey={2} title={<TabTitleText>{_("Specific Group Filters")}</TabTitleText>}>
+                                <Grid
+                                    className="ds-margin-top-lg"
+                                    title={"Specifies a filter for specific groups to include, example: (cn=group). (memberOfSpecificGroupFilter)"}
+                                >
+                                    <GridItem className="ds-label" span={3}>
+                                        {"Specific Group Filter"}
+                                    </GridItem>
+                                    <GridItem span={9}>
+                                        <TypeaheadSelect
+                                            isMulti
+                                            selected={settings.configSpecificGroup}
+                                            onSelect={handlers.handleConfigSpecificGroupSelect}
+                                            onClear={handlers.handleConfigSpecificGroupClear}
+                                            options={settings.configSpecificGroupOptions}
+                                            isCreatable
+                                            onCreateOption={handlers.handleConfigSpecificGroupCreateOption}
+                                            validateCreate={(value) => validateModalFilterCreate(value, 'configSpecificGroup')}
+                                            placeholder={_("Type a search filter...")}
+                                            validated={errorModal.configSpecificGroup ? "error" : "default"}
+                                            ariaLabel="Type a search filter"
+                                            onToggle={handlers.handleConfigSpecificGroupToggle}
+                                            isOpen={openers.isConfigSpecificGroupOpen}
+                                        />
+                                        <FormHelperText>
+                                            {_("Values must be valid search filters")}
+                                        </FormHelperText>
+                                    </GridItem>
+                                </Grid>
+                                <Grid
+                                    className="ds-margin-top-lg"
+                                    title={"Specifies a filter for specific groups to exclude, example: (cn=group). (memberOfExcludeSpecificGroupFilter)"}
+                                >
+                                <GridItem className="ds-label" span={3}>
+                                    {"Exclude Specific Group Filter"}
+                                </GridItem>
+                                <GridItem span={9}>
+                                    <TypeaheadSelect
+                                        isMulti
+                                        selected={settings.configExcludeSpecificGroup}
+                                        onSelect={handlers.handleConfigExcludeSpecificGroupSelect}
+                                        onClear={handlers.handleConfigExcludeSpecificGroupClear}
+                                        options={settings.configExcludeSpecificGroupOptions}
+                                        isCreatable
+                                        onCreateOption={handlers.handleConfigExcludeSpecificGroupCreateOption}
+                                        validateCreate={(value) => validateModalFilterCreate(value, 'configExcludeSpecificGroup')}
+                                        placeholder={_("Type a search filter...")}
+                                        validated={errorModal.configExcludeSpecificGroup ? "error" : "default"}
+                                        ariaLabel="Type a search filter"
+                                        onToggle={handlers.handleConfigExcludeSpecificGroupToggle}
+                                        isOpen={openers.isConfigExcludeSpecificGroupOpen}
+                                    />
+                                        <FormHelperText>
+                                            {"Values must be valid search filters"}
+                                        </FormHelperText>
+                                    </GridItem>
+                                </Grid>
+                                <Grid
+                                    title={_("Specifies the objectclasses for the specific groups to include/exclude (memberOfSpecificGroupOC)")}
+                                    className="ds-margin-top-lg"
+                                >
+                                    <GridItem className="ds-label" span={3}>
+                                        {_("Specific Group OC")}
+                                    </GridItem>
+                                    <GridItem span={9}>
+                                        <TypeaheadSelect
+                                            isMulti
+                                            selected={settings.configSpecificGroupOC}
+                                            onSelect={handlers.handleConfigSpecificGroupOCSelect}
+                                            onClear={handlers.handleConfigSpecificGroupOCClear}
+                                            options={objectClasses}
+                                            placeholder={_("Type a objectclass...")}
+                                            noResultsText="There are no matching objectclasses"
+                                            ariaLabel="Type a objectclass"
+                                            onToggle={handlers.handleConfigSpecificGroupOCToggle}
+                                            isOpen={openers.isConfigSpecificGroupOCOpen}
+                                        />
+                                        <FormHelperText>
+                                            {_("Values must be valid objectclasses")}
+                                        </FormHelperText>
+                                    </GridItem>
+                                </Grid>
+                            </Tab>
+                        )}
+                </Tabs>
+            </Modal>
+        );
+    }
+}
+
+MemberOfConfigEntryModal.propTypes = {
+    handlers: PropTypes.object,
+    openers: PropTypes.object,
+    settings: PropTypes.object,
+    errorModal: PropTypes.object,
+    activeTabModalKey: PropTypes.number,
+    objectClasses: PropTypes.array,
+    newEntry: PropTypes.bool,
+    configEntryModalShow: PropTypes.bool,
+    saveBtnDisabledModal: PropTypes.bool,
+    savingModal: PropTypes.bool,
+    extraPrimaryProps: PropTypes.object,
+    validateModalFilterCreate: PropTypes.func,
+};
+
+MemberOfConfigEntryModal.defaultProps = {
+    handlers: {},
+    openers: {},
+    settings: {},
+    errorModal: {},
+    activeTabModalKey: 0,
+    objectClasses: [],
+    newEntry: false,
+    configEntryModalShow: false,
+    saveBtnDisabledModal: false,
+    savingModal: false,
+    extraPrimaryProps: {},
+    validateModalFilterCreate: () => {},
+};
+
+export class MemberOfSpecificGroupFilterModal extends React.Component {
+    render() {
+        const {
+            isSpecificGroupModalOpen,
+            closeSpecificGroupAddModal,
+            handleAddDelSpecificGroupFilter,
+            groupFilter,
+            groupFilterType,
+            handleFieldChange,
+            modalSpinning,
+            validFilterChange,
+        } = this.props;
+
+        return (
+            <Modal
+                variant={ModalVariant.small}
+                aria-labelledby="ds-modal"
+                title={groupFilterType === "include" ? _("Add Specific Group Filter") : _("Add Specific Group Exclude Filter")}
+                isOpen={isSpecificGroupModalOpen}
+                onClose={closeSpecificGroupAddModal}
+                actions={[
+                    <Button
+                        key="confirm"
+                        variant="primary"
+                        onClick={() => handleAddDelSpecificGroupFilter("add", groupFilter)}
+                        isDisabled={!validFilterChange(groupFilter)}
+                    >
+                        {modalSpinning ? _("Adding ...") : _("Add Filter")}
+                    </Button>,
+                    <Button key="cancel" variant="link" onClick={closeSpecificGroupAddModal}>
+                        {_("Cancel")}
+                    </Button>
+                ]}
+            >
+                <Form isHorizontal autoComplete="off">
+                    <TextContent>
+                        <Text className="ds-margin-top" component={TextVariants.h4}>
+                            {_("Enter an LDAP search filter, example: (cn=group)")}
+                        </Text>
+                    </TextContent>
+                    <Grid className="ds-margin-top">
+                        <GridItem className="ds-label" span={3}>
+                            {_(groupFilterType === "include" ? "Specific Group Filter" : "Specific Group Exclude Filter")}
+                        </GridItem>
+                        <GridItem span={9}>
+                            <TextInput
+                                value={groupFilter}
+                                type="text"
+                                id="groupFilter"
+                                aria-describedby="horizontal-form-name-helper"
+                                name="groupFilter"
+                                onChange={(e, str) => { handleFieldChange(e) }}
+                                validated={groupFilter !== "" && !validFilterChange(groupFilter) ? ValidatedOptions.error : ValidatedOptions.default}
+                                isDisabled={modalSpinning}
+                            />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant={groupFilter !== "" && !validFilterChange(groupFilter) ? 'error' : 'default'} {...(groupFilter !== "" && !validFilterChange(groupFilter) && { icon: <ExclamationCircleIcon /> })}>
+                                        {_("Value must be a valid LDAP filter, and it must be unique.")}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
+                        </GridItem>
+                    </Grid>
+                </Form>
+            </Modal>
+        );
+    }
+}

--- a/src/cockpit/389-console/src/lib/plugins/pluginTables.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pluginTables.jsx
@@ -1,6 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import {
+    Button,
     Grid,
     GridItem,
     Pagination,
@@ -66,7 +67,7 @@ class PluginTable extends React.Component {
 
     handleSort(_event, columnIndex, direction) {
         const rows = [...this.state.rows];
-        
+
         rows.sort((a, b) => (a.cells[columnIndex].content > b.cells[columnIndex].content) ? 1 : -1);
         if (direction !== SortByDirection.asc) {
             rows.reverse();
@@ -327,10 +328,10 @@ class AttrUniqConfigTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -343,7 +344,7 @@ class AttrUniqConfigTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn[0],
@@ -387,7 +388,7 @@ class AttrUniqConfigTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="attribute uniqueness config table"
                     variant="compact"
@@ -395,7 +396,7 @@ class AttrUniqConfigTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -423,7 +424,7 @@ class AttrUniqConfigTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -515,10 +516,10 @@ class LinkedAttributesTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -531,7 +532,7 @@ class LinkedAttributesTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn?.[0] || "",
@@ -575,7 +576,7 @@ class LinkedAttributesTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="linked attributes table"
                     variant="compact"
@@ -583,7 +584,7 @@ class LinkedAttributesTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -611,7 +612,7 @@ class LinkedAttributesTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -702,10 +703,10 @@ class DNATable extends React.Component {
     ];
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -718,7 +719,7 @@ class DNATable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn?.[0] || "",
@@ -762,7 +763,7 @@ class DNATable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="dna table"
                     variant="compact"
@@ -770,7 +771,7 @@ class DNATable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -798,7 +799,7 @@ class DNATable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -873,10 +874,10 @@ class DNASharedTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -889,7 +890,7 @@ class DNASharedTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.dnahostname[0],
@@ -946,7 +947,7 @@ class DNASharedTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="dna shared table"
                     variant="compact"
@@ -954,7 +955,7 @@ class DNASharedTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -982,7 +983,7 @@ class DNASharedTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1059,7 +1060,7 @@ class AutoMembershipDefinitionTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
         this.setState({
@@ -1074,7 +1075,7 @@ class AutoMembershipDefinitionTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn[0],
@@ -1133,7 +1134,7 @@ class AutoMembershipDefinitionTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="automember def table"
                     variant="compact"
@@ -1141,7 +1142,7 @@ class AutoMembershipDefinitionTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -1169,7 +1170,7 @@ class AutoMembershipDefinitionTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1246,10 +1247,10 @@ class AutoMembershipRegexTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -1276,7 +1277,7 @@ class AutoMembershipRegexTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn[0],
@@ -1321,7 +1322,7 @@ class AutoMembershipRegexTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="automember regex table"
                     variant="compact"
@@ -1329,7 +1330,7 @@ class AutoMembershipRegexTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -1357,7 +1358,7 @@ class AutoMembershipRegexTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1435,10 +1436,10 @@ class ManagedDefinitionTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -1451,7 +1452,7 @@ class ManagedDefinitionTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn[0],
@@ -1510,7 +1511,7 @@ class ManagedDefinitionTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="managed def table"
                     variant="compact"
@@ -1518,7 +1519,7 @@ class ManagedDefinitionTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -1546,7 +1547,7 @@ class ManagedDefinitionTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1615,7 +1616,7 @@ class ManagedTemplateTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
         this.setState({
@@ -1630,7 +1631,7 @@ class ManagedTemplateTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [row.entrydn[0]]);
         } else {
@@ -1684,7 +1685,7 @@ class ManagedTemplateTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="managed template table"
                     variant="compact"
@@ -1692,7 +1693,7 @@ class ManagedTemplateTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -1720,7 +1721,7 @@ class ManagedTemplateTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1789,10 +1790,10 @@ class PassthroughAuthURLsTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -1805,7 +1806,7 @@ class PassthroughAuthURLsTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [row.url]);
         } else {
@@ -1859,7 +1860,7 @@ class PassthroughAuthURLsTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="passthru url table"
                     variant="compact"
@@ -1867,7 +1868,7 @@ class PassthroughAuthURLsTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -1895,7 +1896,7 @@ class PassthroughAuthURLsTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -1972,10 +1973,10 @@ class PassthroughAuthConfigsTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -1988,7 +1989,7 @@ class PassthroughAuthConfigsTable extends React.Component {
     handleSearchChange(event, value) {
         let rows = [];
         const val = value.toLowerCase();
-        
+
         if (val === "") {
             rows = this.props.rows.map(row => [
                 row.cn[0],
@@ -2047,7 +2048,7 @@ class PassthroughAuthConfigsTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="pass config table"
                     variant="compact"
@@ -2055,7 +2056,7 @@ class PassthroughAuthConfigsTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -2083,7 +2084,7 @@ class PassthroughAuthConfigsTable extends React.Component {
                                 )}
                                 {has_rows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -2116,6 +2117,153 @@ PassthroughAuthConfigsTable.defaultProps = {
     rows: [],
 };
 
+
+class MemberOfTable extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            page: 1,
+            perPage: 10,
+            value: '',
+            sortBy: {},
+            rows: this.props.rows,
+            columns: [
+                { title: _(this.props.title), sortable: true },
+            ],
+        };
+
+        this.handleSetPage = (_event, pageNumber) => {
+            this.setState({
+                page: pageNumber
+            });
+        };
+
+        this.handlePerPageSelect = (_event, perPage) => {
+            this.setState({
+                perPage
+            });
+        };
+
+        this.handleSort = this.handleSort.bind(this);
+    }
+
+    componentDidMount() {
+        this.setState({ rows: this.props.rows });
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.rows !== this.props.rows) {
+            this.setState({ rows: this.props.rows });
+        }
+    }
+
+    handleSort(_event, index, direction) {
+        const sortedRows = [...this.state.rows].sort((a, b) =>
+            (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
+        );
+
+        this.setState({
+            sortBy: {
+                index,
+                direction
+            },
+            rows: direction === SortByDirection.asc ? sortedRows : sortedRows.reverse()
+        });
+    }
+
+    getActionsForRow = (rowData) => [
+        {
+            title: _("Delete"),
+            onClick: () => this.props.deleteConfig(rowData[0])
+        }
+    ];
+
+    render() {
+        const rows = JSON.parse(JSON.stringify(this.state.rows));
+        let columns = this.state.columns;
+        let has_rows = true;
+        let tableRows;
+
+        if (rows.length === 0) {
+            has_rows = false;
+            columns = [{ title: this.props.title}];
+            tableRows = [_("No items")];
+        } else {
+            const startIdx = (this.state.perPage * this.state.page) - this.state.perPage;
+            tableRows = rows.splice(startIdx, this.state.perPage);
+        }
+
+        return (
+            <div>
+                <Table
+                    className="ds-margin-top-xlg"
+                    aria-label="memberof table"
+                    variant="compact"
+                >
+                    <Thead>
+                        <Tr>
+                            {columns.map((column, idx) => (
+                                <Th
+                                    key={idx}
+                                    sort={column.sortable ? {
+                                        sortBy: this.state.sortBy,
+                                        onSort: this.handleSort,
+                                        columnIndex: idx
+                                    } : undefined}
+                                    width={80}
+                                >
+                                    {column.title}
+                                </Th>
+                            ))}
+                            {has_rows && <Th screenReaderText="Actions" />}
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {tableRows.map((row, rowIndex) => (
+                            <Tr key={rowIndex}>
+                                <Td key={rowIndex}>{row}</Td>
+                                {has_rows && (
+                                    <Td>
+                                        <Button
+                                            key={row}
+                                            variant="secondary"
+                                            onClick={() => this.props.deleteAttr(row)}
+                                        >
+                                            Delete
+                                        </Button>
+                                    </Td>
+                                )}
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+                <Pagination
+                    itemCount={this.props.rows.length}
+                    widgetId="pagination-options-menu-bottom"
+                    perPage={this.state.perPage}
+                    page={this.state.page}
+                    variant="bottom"
+                    onSetPage={this.handleSetPage}
+                    onPerPageSelect={this.handlePerPageSelect}
+                    isCompact
+                />
+            </div>
+        );
+    }
+}
+
+MemberOfTable.propTypes = {
+    title: PropTypes.string,
+    rows: PropTypes.array,
+    deleteAttr: PropTypes.func
+};
+
+MemberOfTable.defaultProps = {
+    rows: [],
+    title: "",
+    deleteAttr: () => {},
+};
+
 export {
     PluginTable,
     AttrUniqConfigTable,
@@ -2127,5 +2275,6 @@ export {
     ManagedDefinitionTable,
     ManagedTemplateTable,
     PassthroughAuthURLsTable,
-    PassthroughAuthConfigsTable
+    PassthroughAuthConfigsTable,
+    MemberOfTable
 };

--- a/src/lib389/lib389/cli_conf/plugins/memberof.py
+++ b/src/lib389/lib389/cli_conf/plugins/memberof.py
@@ -10,7 +10,13 @@
 import ldap
 from lib389.plugins import MemberOfPlugin, MemberOfSharedConfig, MemberOfFixupTasks
 from lib389.utils import get_task_status
-from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add
+from lib389.cli_conf import (
+    add_generic_plugin_parsers,
+    generic_object_edit,
+    generic_object_add,
+    generic_object_add_attr,
+    generic_object_del_attr,
+)
 from lib389.cli_base import CustomHelpFormatter
 
 arg_to_attr = {
@@ -35,6 +41,32 @@ def memberof_edit(inst, basedn, log, args):
     log = log.getChild('memberof_edit')
     plugin = MemberOfPlugin(inst)
     generic_object_edit(plugin, log, args, arg_to_attr)
+
+
+def memberof_add_attr(inst, basedn, log, args):
+    log = log.getChild('memberof_add_attr')
+    plugin = MemberOfPlugin(inst)
+    generic_object_add_attr(plugin, log, args, arg_to_attr)
+
+
+def memberof_del_attr(inst, basedn, log, args):
+    log = log.getChild('memberof_del_attr')
+    plugin = MemberOfPlugin(inst)
+    generic_object_del_attr(plugin, log, args, arg_to_attr)
+
+
+def memberof_add_attr_config(inst, basedn, log, args):
+    log = log.getChild('memberof_add_attr_config')
+    config = MemberOfSharedConfig(inst, args.DN)
+    del args.DN
+    generic_object_add_attr(config, log, args, arg_to_attr)
+
+
+def memberof_del_attr_config(inst, basedn, log, args):
+    log = log.getChild('memberof_del_attr_config')
+    config = MemberOfSharedConfig(inst, args.DN)
+    del args.DN
+    generic_object_del_attr(config, log, args, arg_to_attr)
 
 
 def memberof_add_config(inst, basedn, log, args):
@@ -106,7 +138,7 @@ def do_fixup_status(inst, basedn, log, args):
                     watch=args.watch, use_json=args.json)
 
 
-def _add_parser_args(parser):
+def _set_attr_parser_args(parser):
     parser.add_argument('--attr',
                         help='Specifies the attribute in the user entry for the Directory Server '
                              'to manage to reflect group membership (memberOfAttr)')
@@ -122,12 +154,6 @@ def _add_parser_args(parser):
                                                    'for the MemberOf plug-in to work on (memberOfEntryScope)')
     parser.add_argument('--exclude', nargs='+', help='Specifies backends or multiple-nested suffixes '
                                                      'for the MemberOf plug-in to exclude (memberOfEntryScopeExcludeSubtree)')
-    parser.add_argument('--specific-group-filter', nargs='+',
-                        help='Specifies a filter for groups to include. Otherwise all other groups will be excluded (memberOfSpecificGroup)')
-    parser.add_argument('--exclude-specific-group-filter', nargs='+',
-                        help='Specifies a filter for groups to exclude. Otherwise all other groups will be included (memberOfExcludeSpecificGroup)')
-    parser.add_argument('--specific-group-oc', nargs='+',
-                        help='Specifies the objectclasses for the specific groups to include/exclude. Otherwise all other groups will be excluded (memberOfSpecificGroupOC)')
     parser.add_argument('--autoaddoc', type=str.lower,
                         help='If an entry does not have an object class that allows the memberOf attribute '
                              'then the memberOf plugin will automatically add the object class listed '
@@ -139,7 +165,27 @@ def _add_parser_args(parser):
     parser.add_argument('--launchfixup', choices=['on', 'off'], type=str.lower,
                         help='Specify that if the server disorderly shutdown (crash, kill,..) then '
                              'at restart the memberof fixup task is launched automatically')
+    parser.add_argument('--specific-group-oc', nargs='+',
+                        help='Set objectclasses for the specific groups to include/exclude. '
+                              'Otherwise all other groups will be excluded. Note, this replaces '
+                              'all existing values. To add a new value, use the "add-attr" command. '
+                              '(memberOfSpecificGroupOC)')
+    parser.add_argument('--specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to include. Otherwise all other groups will be excluded (memberOfSpecificGroupFilter)')
+    parser.add_argument('--exclude-specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to exclude. Otherwise all other groups will be included. (memberOfExcludeSpecificGroupFilter)')
 
+def _add_attr_parser_args(parser):
+    parser.add_argument('--specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to include. This adds to the existing values. Otherwise all other groups will be excluded (memberOfSpecificGroupFilter)')
+    parser.add_argument('--exclude-specific-group-filter', nargs='+',
+                        help='Specifies a filter for groups to exclude. This adds to the existing values. Otherwise all other groups will be included (memberOfExcludeSpecificGroupFilter)')
+
+def _del_attr_parser_args(parser):
+    parser.add_argument('--specific-group-filter', nargs='+',
+                        help='Removes a filter for groups to include. This removes the value from the existing values. (memberOfSpecificGroupFilter)')
+    parser.add_argument('--exclude-specific-group-filter', nargs='+',
+                        help="Removes a filter for groups to exclude. This removes the value from the existing values. (memberOfExcludeSpecificGroupFilter)")
 
 def create_parser(subparsers):
     memberof = subparsers.add_parser('memberof', help='Manage and configure MemberOf plugin', formatter_class=CustomHelpFormatter)
@@ -148,21 +194,44 @@ def create_parser(subparsers):
 
     add_generic_plugin_parsers(subcommands, MemberOfPlugin)
 
+    # Core plugin
     edit = subcommands.add_parser('set', help='Edit the plugin settings', formatter_class=CustomHelpFormatter)
     edit.set_defaults(func=memberof_edit)
-    _add_parser_args(edit)
+    _set_attr_parser_args(edit)
     edit.add_argument('--config-entry', help='The value to set as nsslapd-pluginConfigArea')
 
+    add_attr = subcommands.add_parser('add-attr', help='Add attributes to the plugin', formatter_class=CustomHelpFormatter)
+    add_attr.set_defaults(func=memberof_add_attr)
+    _add_attr_parser_args(add_attr)
+
+    del_attr = subcommands.add_parser('del-attr', help='Delete attributes from the plugin', formatter_class=CustomHelpFormatter)
+    del_attr.set_defaults(func=memberof_del_attr)
+    _del_attr_parser_args(del_attr)
+
+    # Shared config entry
     config = subcommands.add_parser('config-entry', help='Manage the config entry', formatter_class=CustomHelpFormatter)
     config_subcommands = config.add_subparsers(help='action')
     add_config = config_subcommands.add_parser('add', help='Add the config entry', formatter_class=CustomHelpFormatter)
     add_config.set_defaults(func=memberof_add_config)
     add_config.add_argument('DN', help='The config entry full DN')
-    _add_parser_args(add_config)
+    _set_attr_parser_args(add_config)
     edit_config = config_subcommands.add_parser('set', help='Edit the config entry', formatter_class=CustomHelpFormatter)
     edit_config.set_defaults(func=memberof_edit_config)
     edit_config.add_argument('DN', help='The config entry full DN')
-    _add_parser_args(edit_config)
+    _set_attr_parser_args(edit_config)
+
+    add_attr_config = config_subcommands.add_parser('add-attr', help='Add attributes to the config entry',
+                                                    formatter_class=CustomHelpFormatter)
+    add_attr_config.set_defaults(func=memberof_add_attr_config)
+    add_attr_config.add_argument('DN', help='The config entry full DN')
+    _add_attr_parser_args(add_attr_config)
+
+    del_attr_config = config_subcommands.add_parser('del-attr', help='Delete attributes from the config entry',
+                                                    formatter_class=CustomHelpFormatter)
+    del_attr_config.set_defaults(func=memberof_del_attr_config)
+    del_attr_config.add_argument('DN', help='The config entry full DN')
+    _del_attr_parser_args(del_attr_config)
+
     show_config = config_subcommands.add_parser('show', help='Display the config entry', formatter_class=CustomHelpFormatter)
     show_config.set_defaults(func=memberof_show_config)
     show_config.add_argument('DN', help='The config entry full DN')
@@ -172,6 +241,7 @@ def create_parser(subparsers):
     del_config_.set_defaults(func=memberof_del_config)
     del_config_.add_argument('DN', help='The config entry full DN')
 
+    # Tasks
     fixup = subcommands.add_parser('fixup', help='Run the fix-up task for memberOf plugin', formatter_class=CustomHelpFormatter)
     fixup.set_defaults(func=do_fixup)
     fixup.add_argument('DN', help="Base DN that contains entries to fix up")


### PR DESCRIPTION
…filters

Description:

All of the memberof CLI set options do a full replace of the attribute, but in the case of specific fitlers would could be many values and it would be difficult to have to replace all the values when you just want to add or remove a filter.

Added new types of arguments to add and remove values:  "add-attr" and "del-attr".

The UI also needed a lot of work to include these new arguments as the original form was doing full replcaes, so for hte specifc filter I added tables to control the individual values so that the current Save button enabling still worked correctly.  Also found other bugs in the existing memberOf UI page that needed to be fixed.

Relates: https://github.com/389ds/389-ds-base/issues/7041
