### PR TITLE
Issue 6660 - CLI, UI - Improve replication log analyzer usability

### DIFF
--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -1248,6 +1248,17 @@ class ScatterLineChart extends React.Component {
             }
         }
 
+        // Helper function to format time values
+        const formatTimeValue = (seconds) => {
+            if (seconds >= 3600) {
+                return `${(seconds / 3600).toFixed(3)}h`;
+            } else if (seconds >= 60) {
+                return `${(seconds / 60).toFixed(3)}m`;
+            } else {
+                return `${seconds.toFixed(3)}s`;
+            }
+        };
+
         // Process tooltip HTML tags
         const formatTooltip = (datum) => {
             if (datum.childName && datum.childName.includes('line-')) {
@@ -1256,7 +1267,7 @@ class ScatterLineChart extends React.Component {
                     // Split the hoverInfo by <br> tags and join with newlines
                     return datum.hoverInfo.split(/<br\s*\/?>/i).join('\n');
                 }
-                return `${datum.name}: ${datum.y.toFixed(3)}s`;
+                return `${datum.name}: ${formatTimeValue(datum.y)}`;
             }
             return null;
         };
@@ -1338,7 +1349,21 @@ class ScatterLineChart extends React.Component {
                             dependentAxis
                             showGrid
                             label={yAxisLabel || "Value"}
-                            tickFormat={(t) => `${t.toFixed(2)}s`}
+                            tickFormat={(t) => {
+                                // Format large values as hours/minutes for better readability
+                                if (t >= 3600) {
+                                    // Show as hours
+                                    const hours = (t / 3600).toFixed(2);
+                                    return `${hours}h`;
+                                } else if (t >= 60) {
+                                    // Show as minutes
+                                    const minutes = (t / 60).toFixed(2);
+                                    return `${minutes}m`;
+                                } else {
+                                    // Show as seconds
+                                    return `${t.toFixed(2)}s`;
+                                }
+                            }}
                             style={{
                                 axisLabel: {
                                     fontSize: 14,

--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -1353,15 +1353,15 @@ class ScatterLineChart extends React.Component {
                                 // Format large values as hours/minutes for better readability
                                 if (t >= 3600) {
                                     // Show as hours
-                                    const hours = (t / 3600).toFixed(2);
+                                    const hours = (t / 3600).toFixed(1);
                                     return `${hours}h`;
                                 } else if (t >= 60) {
                                     // Show as minutes
-                                    const minutes = (t / 60).toFixed(2);
+                                    const minutes = (t / 60).toFixed(1);
                                     return `${minutes}m`;
                                 } else {
                                     // Show as seconds
-                                    return `${t.toFixed(2)}s`;
+                                    return `${t.toFixed(1)}s`;
                                 }
                             }}
                             style={{

--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -2564,6 +2564,7 @@ class ChooseLagReportModal extends React.Component {
                                     <ExistingLagReportsTable
                                         reports={reports}
                                         onSelectReport={this.handleSelectReport}
+                                        addNotification={this.props.addNotification}
                                     />
                                 )}
                             </CardBody>
@@ -2732,13 +2733,15 @@ LagReportModal.defaultProps = {
 ChooseLagReportModal.propTypes = {
     showing: PropTypes.bool,
     onClose: PropTypes.func,
-    reportDirectory: PropTypes.string
+    reportDirectory: PropTypes.string,
+    addNotification: PropTypes.func
 };
 
 ChooseLagReportModal.defaultProps = {
     showing: false,
     onClose: () => {},
-    reportDirectory: '/tmp'
+    reportDirectory: '/tmp',
+    addNotification: () => {}
 };
 
 export {

--- a/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/monitorModals.jsx
@@ -1293,8 +1293,8 @@ class ScatterLineChart extends React.Component {
                         maxDomain={{ y: calculatedMaxY }}
                         minDomain={{ y: calculatedMinY }}
                         padding={{
-                            bottom: 100,
-                            left: 80,
+                            bottom: 75,
+                            left: 90,
                             right: 50,
                             top: 50
                         }}
@@ -1342,7 +1342,7 @@ class ScatterLineChart extends React.Component {
                             style={{
                                 axisLabel: {
                                     fontSize: 14,
-                                    padding: 55,
+                                    padding: 70,
                                     fill: "var(--pf-v5-chart-global--label--Fill, currentColor)"
                                 },
                                 tickLabels: {
@@ -1397,7 +1397,7 @@ class ScatterLineChart extends React.Component {
                         </ChartGroup>
                     </Chart>
                 </div>
-                <div className="ds-margin-top-sm" style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '8px' }}>
                     <Button
                         variant="link"
                         isSmall
@@ -1409,7 +1409,7 @@ class ScatterLineChart extends React.Component {
                     </Button>
                 </div>
                 {this.state.showLegend && (
-                    <div className="ds-margin-top-sm">
+                    <div style={{ marginTop: '4px' }}>
                         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--pf-v5-global--spacer--md)' }}>
                             {series.map((s, idx) => (
                                 <button
@@ -1852,9 +1852,9 @@ class LagReportModal extends React.Component {
                             <div className="ds-margin-top">
                                 <Button
                                     variant="secondary"
+                                    icon={<DownloadIcon />}
                                     onClick={() => this.downloadFile(reportUrls.summary, "replication_analysis_summary.json")}
                                 >
-                                    <DownloadIcon className="ds-right-margin-sm" />
                                     {_("Download Summary JSON")}
                                 </Button>
                             </div>
@@ -1909,9 +1909,9 @@ class LagReportModal extends React.Component {
                     </EmptyStateBody>
                     <Button
                         variant="secondary"
+                        icon={<DownloadIcon />}
                         onClick={() => this.downloadFile(reportUrls.json, "replication_analysis.json")}
                     >
-                        <DownloadIcon className="ds-right-margin-sm" />
                         {_("Download JSON Data")}
                     </Button>
                 </EmptyState>
@@ -1956,9 +1956,9 @@ class LagReportModal extends React.Component {
                                 <div className="ds-margin-top">
                                     <Button
                                         variant="secondary"
+                                        icon={<DownloadIcon />}
                                         onClick={() => this.downloadFile(reportUrls.json, "replication_analysis.json")}
                                     >
-                                        <DownloadIcon className="ds-right-margin-sm" />
                                         {_("Download JSON Data")}
                                     </Button>
                                 </div>
@@ -2005,9 +2005,9 @@ class LagReportModal extends React.Component {
                     </EmptyStateBody>
                     <Button
                         variant="primary"
+                        icon={<DownloadIcon />}
                         onClick={() => this.downloadFile(reportUrls.png, "replication_analysis.png")}
                     >
-                        <DownloadIcon className="ds-right-margin-sm" />
                         {_("Download PNG")}
                     </Button>
                 </EmptyState>
@@ -2038,9 +2038,9 @@ class LagReportModal extends React.Component {
                                 <div className="ds-margin-top ds-text-center">
                                     <Button
                                         variant="primary"
+                                        icon={<DownloadIcon />}
                                         onClick={() => this.downloadFile(reportUrls.png, "replication_analysis.png")}
                                     >
-                                        <DownloadIcon className="ds-right-margin-sm" />
                                         {_("Download PNG")}
                                     </Button>
                                 </div>
@@ -2103,9 +2103,9 @@ class LagReportModal extends React.Component {
                                 <div className="ds-margin-top ds-text-center">
                                     <Button
                                         variant="primary"
+                                        icon={<DownloadIcon />}
                                         onClick={() => this.downloadFile(reportUrls.csv, "replication_analysis.csv")}
                                     >
-                                        <DownloadIcon className="ds-right-margin-sm" />
                                         {_("Download CSV")}
                                     </Button>
                                 </div>
@@ -2370,8 +2370,19 @@ class ChooseLagReportModal extends React.Component {
 
                 const promises = directories.map(dir => {
                     // Check which report files exist in this directory
-                    return cockpit.spawn(["ls", "-la", dir], { superuser: true, err: "ignore" })
-                        .then(files => {
+                    return cockpit.spawn(["ls", "-1A", dir], { superuser: true, err: "ignore" })
+                        .then(output => {
+                            const files = output.trim().split('\n').filter(f => f);
+
+                            // List of valid report file names
+                            const validReportFiles = [
+                                'replication_analysis.json',
+                                'replication_analysis_summary.json',
+                                'replication_analysis.html',
+                                'replication_analysis.csv',
+                                'replication_analysis.png'
+                            ];
+
                             // Check if this directory contains any report files
                             const hasJson = files.includes('replication_analysis.json');
                             const hasHtml = files.includes('replication_analysis.html');
@@ -2381,6 +2392,13 @@ class ChooseLagReportModal extends React.Component {
 
                             // Skip directories that don't have any report files
                             if (!hasJson && !hasHtml && !hasCsv && !hasPng && !hasSummary) {
+                                return null;
+                            }
+
+                            // Validate that all files in the directory are expected report files
+                            const hasUnexpectedFiles = files.some(file => !validReportFiles.includes(file));
+                            if (hasUnexpectedFiles) {
+                                console.warn(`Directory ${dir} contains unexpected files, skipping:`, files);
                                 return null;
                             }
 
@@ -2515,7 +2533,7 @@ class ChooseLagReportModal extends React.Component {
             <>
                 <Modal
                     variant="large"
-                    title={_("Choose Existing Report")}
+                    title={_("View Existing Report")}
                     isOpen={showing}
                     onClose={onClose}
                     actions={[

--- a/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
@@ -2184,6 +2184,7 @@ export class ReplLogAnalysis extends React.Component {
                         showing={this.state.showChooseLagReportModal}
                         onClose={this.closeChooseLagReportModal}
                         reportDirectory={this.state.customOutputDir ? this.state.customOutputDir : '/tmp'}
+                        addNotification={this.props.addNotification}
                     />
                 )}
             </>

--- a/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
@@ -51,10 +51,8 @@ import {
     Chip,
     ChipGroup,
     yyyyMMddFormat,
-    ActionGroup
 } from "@patternfly/react-core";
 import {
-    SyncAltIcon,
     InfoCircleIcon,
     ExclamationCircleIcon,
     FolderIcon,
@@ -1424,7 +1422,7 @@ export class ReplLogAnalysis extends React.Component {
                                                                 <InfoCircleIcon />
                                                             </Tooltip>
                                                         }
-                                                        className="pf-v5-u-mb-xl"
+                                                        className="ds-margin-top pf-v5-u-mb-xl"
                                                     >
                                                         <HelperText>
                                                             <HelperTextItem>
@@ -1433,7 +1431,7 @@ export class ReplLogAnalysis extends React.Component {
                                                         </HelperText>
 
                                                         {suffixesList.length > 0 && (
-                                                            <div className="pf-v5-u-mt-sm pf-v5-u-mb-md">
+                                                            <div className="ds-margin-top ds-margin-bottom">
                                                                 <ChipGroup categoryName={_("Selected Suffixes")}>
                                                                     {suffixesList.map((suffix, index) => (
                                                                         <Chip
@@ -1902,7 +1900,7 @@ export class ReplLogAnalysis extends React.Component {
                                                     <FormGroup
                                                         label={_("Output Location")}
                                                         fieldId="output-location"
-                                                        className="ds-margin-top"
+                                                        className="ds-margin-top-lg"
                                                     >
                                                         <Checkbox
                                                             id="use-custom-output"
@@ -1952,7 +1950,7 @@ export class ReplLogAnalysis extends React.Component {
                                                     <FormGroup
                                                         label={_("Report Name")}
                                                         fieldId="report-name"
-                                                        className="ds-margin-top"
+                                                        className="ds-margin-top-lg"
                                                     >
                                                         <TextInput
                                                             id="report-name"

--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -597,6 +597,18 @@ def generate_lag_report(inst, basedn, log, args):
 
         repl_analyzer.parse_logs()
 
+        # Check if we have any data after parsing and filtering
+        if not repl_analyzer.csns:
+            error_msg = "No replication data found matching the specified criteria."
+            if args.lag_time_lowest is not None or args.etime_lowest is not None:
+                error_msg += "\n  - The threshold filters (lag time or etime) may be too restrictive."
+            if args.only_fully_replicated or args.only_not_replicated:
+                error_msg += "\n  - The replication status filter may have excluded all entries."
+            if time_range:
+                error_msg += "\n  - The time range may not contain any replication events."
+            error_msg += "\nTry adjusting the filters or expanding the time range."
+            raise ValueError(error_msg)
+
         # Generate reports
         if not json_output_only:
             log.info("Generating analysis reports...")

--- a/src/lib389/lib389/repltools.py
+++ b/src/lib389/lib389/repltools.py
@@ -1031,7 +1031,14 @@ class ReplicationLogAnalyzer:
                 raise OSError(f"Could not create directory {output_dir}: {e}")
 
         if not self.csns:
-            raise ValueError("No CSN data available for reporting. Did you call parse_logs()?")
+            # Provide a more user-friendly error message
+            error_msg = "No replication data found matching the specified criteria."
+            if self.lag_time_lowest is not None or self.etime_lowest is not None:
+                error_msg += " The threshold filters (lag time or etime) may be too restrictive."
+            if self.only_fully_replicated or self.only_not_replicated:
+                error_msg += " The replication status filter may have excluded all entries."
+            error_msg += " Try adjusting the filters or expanding the time range."
+            raise ValueError(error_msg)
 
         results = self.build_result()
         generated_files = {}


### PR DESCRIPTION
Description: Fixed chart spacing and layout issues, improved directory validation with existence checking, and enhanced error messages to provide actionable guidance when no replication data matches filter criteria.

Fixes: https://github.com/389ds/389-ds-base/issues/6660

Reviewed by: ?

## Summary by Sourcery

Add report deletion capability with confirmation in the UI, refine error messages and directory validation across the UI and CLI, and adjust UI layout and labels for improved usability of replication log analysis

New Features:
- Provide report deletion functionality with a confirmation modal and path validation in the Existing Lag Reports table

Enhancements:
- Enhance CLI and UI error messages for no replication data or parse failures with actionable guidance
- Validate custom output directory existence and skip directories containing unexpected files when listing reports
- Update suffix input helper and error display in the log analysis form for clearer guidance
- Rename "Choose Existing Report" to "View Existing Report" for consistency
- Adjust chart component padding and margins and add download icons to report modal buttons for improved layout