### PR TITLE
Issue 7061 - CLI/UI - Improve error messages for dsconf localpwp list

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseTables.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseTables.jsx
@@ -1079,6 +1079,7 @@ class PwpTable extends React.Component {
                                 {hasRows && (
                                     <Td isActionCell>
                                         <ActionsColumn
+                                            isDisabled={row[1] === "Unknown policy type"}
                                             items={this.getActions(row)}
                                         />
                                     </Td>

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -1130,6 +1130,8 @@ export class LocalPwPolicy extends React.Component {
             },
         };
 
+        this.unknownPolicyType = "Unknown policy type";
+
         // Check User Attributes Create
         this.handleUserAttrsCreateToggle = (_event, isUserAttrsCreateOpen) => {
             this.setState({
@@ -1847,7 +1849,11 @@ export class LocalPwPolicy extends React.Component {
                     const policy_obj = JSON.parse(content);
                     const pwpRows = [];
                     for (const row of policy_obj.items) {
-                        pwpRows.push([row.targetdn, row.pwp_type, row.basedn]);
+                        let {basedn} = row;
+                        if (row.pwp_type === this.unknownPolicyType) {
+                            basedn = row.dn;
+                        }
+                        pwpRows.push([row.targetdn, row.pwp_type, basedn]);
                     }
                     this.setState({
                         localActiveTabKey: 0,

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -248,12 +248,16 @@ class PwPolicyManager(object):
             # Sometimes, the cn value includes quotes (for example, after migration from pre-CLI version).
             # We need to strip them as python-ldap doesn't expect them
             dn_comps_str = policy.get_attr_val_utf8_l('cn').strip("\'").strip("\"")
-            dn_comps = ldap.dn.explode_dn(dn_comps_str)
-            dn_comps.pop(0)
-            pwp_dn = ",".join(dn_comps)
-            if pwp_dn == dn.lower():
-                # This DN does have a policy associated with it
-                return policy
+            try:
+                dn_comps = ldap.dn.explode_dn(dn_comps_str)
+                dn_comps.pop(0)
+                pwp_dn = ",".join(dn_comps)
+                if pwp_dn == dn.lower():
+                    # This DN does have a policy associated with it
+                    return policy
+            except ldap.DECODING_ERROR:
+                # This is some kind of custom password policy
+                continue
 
         # Did not find a policy for this entry
         raise ValueError("No password policy was found for this entry")


### PR DESCRIPTION
Description:

If local password policies are created outside of dsconf and they do not use a DN as part of the "cn" value then "dsconf localpwd list" will produce a python traceback.

We can still list the policy, but hte tool can not modify it. Also improved the UI handling of these policies

Relates: https://github.com/389ds/389-ds-base/issues/7061

## Summary by Sourcery

Improve handling of custom local password policies in CLI and UI by catching LDAP decoding errors, labeling unknown policies, and preventing tracebacks

Bug Fixes:
- Prevent python traceback in dsconf localpwd list and lookup when 'cn' is not a valid DN by catching ldap.DECODING_ERROR

Enhancements:
- Label policies with non-DN 'cn' values as "Unknown policy type" and set target to "Unknown target"
- Skip or format unknown policies differently for JSON and text output in the CLI
- Update React UI to use the DN as the basedn for unknown policies and disable actions on them