### PR TITLE
Issue 7069 - Add Subnet/CIDR Support for HAProxy Trusted IPs

### DIFF
--- a/dirsrvtests/tests/suites/basic/haproxy_test.py
+++ b/dirsrvtests/tests/suites/basic/haproxy_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -96,3 +96,494 @@ def test_binds_with_haproxy_trust_ip_attribute(topo, setup_test):
     user_entry = UserAccount(user_conn, DN)
     home = user_entry.get_attr_val_utf8('homeDirectory')
     assert home == HOME_DIR
+
+
+def test_haproxy_trust_ip_subnet_ipv4(topo):
+    """Test nsslapd-haproxy-trusted-ip with IPv4 CIDR subnet notation
+
+    :id: 20023301-b7c7-4db5-8287-06f6bbb14786
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-haproxy-trusted-ip to an IPv4 subnet (192.168.0.0/24)
+        2. Check that the subnet is present
+        3. Delete the attribute
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    log.info("Set nsslapd-haproxy-trusted-ip to IPv4 subnet")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.0.0/24')
+
+    log.info("Check that nsslapd-haproxy-trusted-ip subnet is present")
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.0.0/24')
+
+    log.info("Delete nsslapd-haproxy-trusted-ip attribute")
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Check that nsslapd-haproxy-trusted-ip attribute is not present")
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.0.0/24')
+
+
+def test_haproxy_trust_ip_subnet_ipv6(topo):
+    """Test nsslapd-haproxy-trusted-ip with IPv6 CIDR subnet notation
+
+    :id: 711d134d-0e26-47e1-8144-8c8aa6c73757
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-haproxy-trusted-ip to an IPv6 subnet (2001:db8::/32)
+        2. Check that the subnet is present
+        3. Delete the attribute
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    log.info("Set nsslapd-haproxy-trusted-ip to IPv6 subnet")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '2001:db8::/32')
+
+    log.info("Check that nsslapd-haproxy-trusted-ip subnet is present")
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '2001:db8::/32')
+
+    log.info("Delete nsslapd-haproxy-trusted-ip attribute")
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Check that nsslapd-haproxy-trusted-ip attribute is not present")
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '2001:db8::/32')
+
+
+def test_haproxy_trust_ip_mixed_values(topo):
+    """Test nsslapd-haproxy-trusted-ip with mixed individual IPs and subnets
+
+    :id: 0a4e8826-7db1-4c3a-bfba-a2483d0f69d2
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-haproxy-trusted-ip to multiple values including IPs and subnets
+        2. Check that all values are present
+        3. Delete the attribute
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    log.info("Set nsslapd-haproxy-trusted-ip to mixed values")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', ['192.168.0.0/24', '10.0.0.1', '2001:db8::/64'])
+
+    log.info("Check that all values are present")
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.0.0/24')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '10.0.0.1')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '2001:db8::/64')
+
+    log.info("Delete nsslapd-haproxy-trusted-ip attribute")
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Check that nsslapd-haproxy-trusted-ip attribute is not present")
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.0.0/24')
+
+
+def test_haproxy_trust_ip_buffer_overflow_protection(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects oversized strings (buffer overflow protection)
+
+    :id: 96b63d88-3ec9-4b70-84f1-e48dfeadd293
+    :setup: Standalone instance
+    :steps:
+        1. Try to set nsslapd-haproxy-trusted-ip with a string longer than 256 characters
+        2. Verify the operation is rejected
+    :expectedresults:
+        1. Operation should fail with LDAP_OPERATIONS_ERROR
+        2. Attribute should not be set
+    """
+    log.info("Attempt to set oversized IP string (buffer overflow test)")
+    oversized_ip = "192.168.1." + "0" * 300  # 300+ character string
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', oversized_ip)
+
+    log.info("Verify attribute was not set")
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', oversized_ip)
+
+
+def test_haproxy_trust_ip_invalid_cidr_multiple_slashes(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects multiple slashes in CIDR notation
+
+    :id: 38a7eb6e-cec8-47c5-aba8-79bc9511127f
+    :setup: Standalone instance
+    :steps:
+        1. Try to set CIDR with multiple slashes (192.168.1.0/24/32)
+        2. Verify the operation is rejected
+    :expectedresults:
+        1. Operation should fail
+        2. Attribute should not be set
+    """
+    log.info("Attempt to set CIDR with multiple slashes")
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/24/32')
+
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.1.0/24/32')
+
+
+def test_haproxy_trust_ip_invalid_cidr_empty_prefix(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects empty CIDR prefix
+
+    :id: 75ed1fc1-a30a-4913-9d1f-fcf14745f876
+    :setup: Standalone instance
+    :steps:
+        1. Try to set CIDR with empty prefix (192.168.1.0/)
+        2. Verify the operation is rejected
+    :expectedresults:
+        1. Operation should fail
+        2. Attribute should not be set
+    """
+    log.info("Attempt to set CIDR with empty prefix")
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/')
+
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.1.0/')
+
+
+def test_haproxy_trust_ip_invalid_cidr_non_numeric_prefix(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects non-numeric CIDR prefix
+
+    :id: 7acdadb5-a809-4aae-a6b3-ea6fe8f37ff5
+    :setup: Standalone instance
+    :steps:
+        1. Try to set CIDR with non-numeric prefix (192.168.1.0/abc)
+        2. Try to set CIDR with special characters (192.168.1.0/24!)
+        3. Verify both operations are rejected
+    :expectedresults:
+        1. Operation should fail
+        2. Operation should fail
+        3. Attributes should not be set
+    """
+    log.info("Attempt to set CIDR with non-numeric prefix")
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/abc')
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/24!')
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/2 4')
+
+    assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.1.0/abc')
+
+
+def test_haproxy_trust_ip_invalid_cidr_prefix_out_of_range(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects out-of-range CIDR prefixes
+
+    :id: d60ebd80-9e2e-4c85-8d3b-076a24d2e063
+    :setup: Standalone instance
+    :steps:
+        1. Try to set IPv4 CIDR with prefix > 32
+        2. Try to set IPv6 CIDR with prefix > 128
+        3. Verify both operations are rejected
+    :expectedresults:
+        1. Operation should fail
+        2. Operation should fail
+        3. Attributes should not be set
+    """
+    log.info("Attempt to set IPv4 CIDR with prefix > 32")
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/33')
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.0/64')
+
+    log.info("Attempt to set IPv6 CIDR with prefix > 128")
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '2001:db8::/129')
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '2001:db8::/256')
+
+
+def test_haproxy_trust_ip_invalid_characters(topo):
+    """Test nsslapd-haproxy-trusted-ip rejects IPs with invalid characters
+
+    :id: 7eaf95f1-1477-477d-b743-7415801c395d
+    :setup: Standalone instance
+    :steps:
+        1. Try to set IP with invalid characters
+        2. Try to set CIDR with wildcards (not allowed in CIDR)
+        3. Verify operations are rejected
+    :expectedresults:
+        1. Operation should fail
+        2. Operation should fail
+        3. Attributes should not be set
+    """
+    log.info("Attempt to set IP with invalid characters")
+
+    # Invalid characters in regular IP
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.x')
+
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.1@')
+
+    # Wildcards not allowed in any format
+    log.info("Attempt to set CIDR with wildcards (should be rejected)")
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.*/24')
+
+    # Wildcards not allowed in individual IPs either
+    log.info("Attempt to set individual IP with wildcard (should be rejected)")
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.*')
+
+    # Invalid IPv6 characters
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '2001:db8::gggg')
+
+
+def test_haproxy_trust_ip_cidr_boundary_values(topo):
+    """Test nsslapd-haproxy-trusted-ip with boundary CIDR prefix values
+
+    :id: 7cbb711b-4366-4c23-8ec0-e64174081840
+    :setup: Standalone instance
+    :steps:
+        1. Test /0 prefix (matches everything)
+        2. Test /32 prefix for IPv4 (exact match)
+        3. Test /128 prefix for IPv6 (exact match)
+        4. Clean up
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+    log.info("Set IPv4 /0 (matches all)")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '0.0.0.0/0')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '0.0.0.0/0')
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Set IPv4 /32 (exact match)")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '192.168.1.1/32')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '192.168.1.1/32')
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Set IPv6 /0 (matches all)")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '::/0')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '::/0')
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Set IPv6 /128 (exact match)")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', '2001:db8::1/128')
+    assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', '2001:db8::1/128')
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+
+def test_haproxy_trust_ip_invalid_formats_comprehensive(topo):
+    """Test comprehensive validation of invalid IP formats
+
+    :id: 3b5b8082-de75-46b0-b53d-12d87da10f34
+    :setup: Standalone instance
+    :steps:
+        1. Test various malformed CIDR notations
+        2. Test invalid IP address formats
+        3. Test edge cases and attack vectors
+    :expectedresults:
+        1. All invalid formats should be rejected
+        2. No attributes should be set
+        3. Server should remain stable
+    """
+    log.info("Test malformed CIDR notations")
+
+    invalid_cidrs = [
+        '192.168.1.0/',           # Empty prefix
+        '192.168.1.0/24/32',      # Multiple slashes
+        '192.168.1.0/abc',        # Non-numeric prefix
+        '192.168.1.0/24!',        # Special chars in prefix
+        '192.168.1.0/ 24',        # Space in prefix
+        '192.168.1.0/-1',         # Negative prefix
+        '192.168.1.0/33',         # IPv4 prefix > 32
+        '192.168.1.0/999',        # Way out of range
+        '192.168.1.*/24',         # Wildcard in CIDR (rejected)
+        '2001:db8::/',            # IPv6 empty prefix
+        '2001:db8::/129',         # IPv6 prefix > 128
+        '2001:db8::/abc',         # IPv6 non-numeric prefix
+        '2001:db8::*/64',         # IPv6 wildcard in CIDR (rejected)
+    ]
+
+    for invalid_cidr in invalid_cidrs:
+        log.info(f"Testing invalid CIDR: {invalid_cidr}")
+        with pytest.raises(ldap.OPERATIONS_ERROR):
+            topo.standalone.config.set('nsslapd-haproxy-trusted-ip', invalid_cidr)
+        assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', invalid_cidr)
+
+    log.info("Test invalid IP address formats")
+
+    invalid_ips = [
+        '256.168.1.1',            # IPv4 octet > 255
+        '192.168.1',              # Incomplete IPv4
+        '192.168.1.1.1',          # Too many octets
+        '192.168.1.x',            # Invalid character
+        '192.168.1.1@',           # Special character
+        '192.168.1.1#comment',    # Comment-like
+        '192.168.1.*',            # Wildcard (rejected)
+        '192.168.*.*',            # Multiple wildcards (rejected)
+        '2001:db8::gggg',         # Invalid hex in IPv6
+        '2001:db8::1::2',         # Double :: in IPv6
+        '2001:db8::*',            # IPv6 wildcard (rejected)
+        'not.an.ip.address',      # Alphabetic
+    ]
+
+    for invalid_ip in invalid_ips:
+        log.info(f"Testing invalid IP: {invalid_ip}")
+        with pytest.raises(ldap.OPERATIONS_ERROR):
+            topo.standalone.config.set('nsslapd-haproxy-trusted-ip', invalid_ip)
+        assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', invalid_ip)
+
+
+def test_haproxy_trust_ip_security_attack_vectors(topo):
+    """Test nsslapd-haproxy-trusted-ip against potential security attack vectors
+
+    :id: 20890d58-ba62-41bf-8484-66144dc143d7
+    :setup: Standalone instance
+    :steps:
+        1. Test buffer overflow attempts
+        2. Test format string attacks
+        3. Test injection attempts
+    :expectedresults:
+        1. All attacks should be rejected safely
+        2. Server should not crash
+        3. No attributes should be set
+    """
+    log.info("Test potential attack vectors")
+
+    attack_vectors = [
+        'A' * 300,                           # Buffer overflow attempt
+        '192.168.1.0' + '/24' * 50,          # Repeated slashes
+        '192.168.1.0/24\x00/32',             # Null byte injection
+        '../../../etc/passwd',               # Path traversal attempt
+        '192.168.1.0/$(whoami)',             # Command injection attempt
+        '192.168.1.0/%s%s%s%s',              # Format string attempt
+        '192.168.1.0/24\r\n192.168.2.0/24',  # CRLF injection
+    ]
+
+    for attack in attack_vectors:
+        log.info(f"Testing attack vector: {attack[:50]}...")  # Log first 50 chars
+        with pytest.raises(ldap.OPERATIONS_ERROR):
+            topo.standalone.config.set('nsslapd-haproxy-trusted-ip', attack)
+
+    log.info("Server remained stable after attack attempts")
+
+
+def test_haproxy_trust_ip_additional_edge_cases(topo):
+    """Test nsslapd-haproxy-trusted-ip with additional validation edge cases
+
+    :id: c0ed7407-5bbd-4b08-86ae-d0174c59b92b
+    :setup: Standalone instance
+    :steps:
+        1. Test leading zeros in prefix (should be rejected or normalized)
+        2. Test integer overflow in prefix
+        3. Test whitespace handling
+        4. Test case sensitivity
+    :expectedresults:
+        1. All invalid formats should be rejected
+        2. Server should remain stable
+    """
+    log.info("Test additional edge cases for validation")
+
+    additional_invalid = [
+        '192.168.1.0/024',                  # Leading zeros in prefix
+        '192.168.1.0/99999999999999999',    # Integer overflow in prefix
+        ' 192.168.1.0/24',                  # Leading whitespace
+        '192.168.1.0/24 ',                  # Trailing whitespace
+        '192.168.1.0 /24',                  # Space before slash
+        '192.168. 1.0/24',                  # Space in IP
+        '2001:db8::/0x20',                  # Hex notation in prefix
+        '192.168.1.0/+24',                  # Plus sign in prefix
+    ]
+
+    for invalid in additional_invalid:
+        log.info(f"Testing additional invalid: {invalid}")
+        with pytest.raises(ldap.OPERATIONS_ERROR):
+            topo.standalone.config.set('nsslapd-haproxy-trusted-ip', invalid)
+        assert not topo.standalone.config.present('nsslapd-haproxy-trusted-ip', invalid)
+
+    log.info("Additional edge cases handled correctly")
+
+
+def test_haproxy_trust_ip_valid_edge_cases(topo):
+    """Test nsslapd-haproxy-trusted-ip with valid edge cases
+
+    :id: 82a14e70-475b-423d-9e6e-52a89b2f0506
+    :setup: Standalone instance
+    :steps:
+        1. Test various valid CIDR prefix lengths
+        2. Test localhost addresses
+        3. Test private network ranges
+        4. Clean up
+    :expectedresults:
+        1. All valid formats should be accepted
+        2. All values should be retrievable
+        3. Clean up successful
+    """
+    log.info("Test various valid CIDR prefix lengths")
+
+    valid_configs = [
+        '10.0.0.0/8',             # Class A network
+        '172.16.0.0/12',          # Private network
+        '192.168.0.0/16',         # Class C network
+        '192.0.2.0/24',           # TEST-NET-1
+        '198.51.100.0/24',        # TEST-NET-2
+        '203.0.113.0/24',         # TEST-NET-3
+        '127.0.0.1/32',           # Localhost exact
+        '::1/128',                # IPv6 localhost
+        'fe80::/10',              # IPv6 link-local
+        '2001:db8::/32',          # IPv6 documentation
+        'fc00::/7',               # IPv6 unique local
+    ]
+
+    for valid_config in valid_configs:
+        log.info(f"Testing valid config: {valid_config}")
+        topo.standalone.config.set('nsslapd-haproxy-trusted-ip', valid_config)
+        assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', valid_config)
+        topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("All valid edge cases handled correctly")
+
+
+def test_haproxy_trust_ip_performance_optimizations(topo):
+    """Test that performance optimizations don't break functionality
+
+    :id: e10cfdc4-8d5e-4240-a457-cab75a481ad1
+    :setup: Standalone instance
+    :steps:
+        1. Set multiple mixed IP/subnet values
+        2. Verify all values are stored correctly
+        3. Verify parsed binary format is created
+        4. Clean up
+    :expectedresults:
+        1. All values should be accepted
+        2. All values should be retrievable
+        3. Server should handle the configuration correctly
+    """
+    log.info("Test performance optimizations with mixed values")
+
+    mixed_values = [
+        '192.168.1.0/24',      # IPv4 subnet
+        '10.0.0.1',            # IPv4 single IP
+        '2001:db8::/32',       # IPv6 subnet
+        'fe80::1',             # IPv6 single IP
+        '172.16.0.0/12',       # Another IPv4 subnet
+        '::ffff:192.168.1.50', # IPv4-mapped IPv6
+    ]
+
+    log.info("Set mixed IP/subnet values")
+    topo.standalone.config.set('nsslapd-haproxy-trusted-ip', mixed_values)
+
+    log.info("Verify all values are present")
+    for value in mixed_values:
+        assert topo.standalone.config.present('nsslapd-haproxy-trusted-ip', value), \
+            f"Value {value} should be present"
+
+    log.info("Clean up")
+    topo.standalone.config.remove_all('nsslapd-haproxy-trusted-ip')
+
+    log.info("Performance optimization test passed")

--- a/dirsrvtests/tests/suites/clu/dsconf_config_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_config_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -19,7 +19,10 @@ log = logging.getLogger(__name__)
 
 HAPROXY_IPS = {
     'single': '192.168.1.1',
-    'multiple': ['10.0.0.1', '172.16.0.1', '192.168.2.1']
+    'multiple': ['10.0.0.1', '172.16.0.1', '192.168.2.1'],
+    'subnet_ipv4': '192.168.1.0/24',
+    'subnet_ipv6': '2001:db8::/32',
+    'mixed': ['192.168.1.0/24', '10.0.0.1', '2001:db8::/64']
 }
 
 REFERRALS = {
@@ -350,6 +353,169 @@ def test_multi_value_batch_persists_after_restart(topology_st, attr_name, values
         output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
         for value in values_dict['multiple']:
             assert value in output
+
+    finally:
+        execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])
+
+
+def test_haproxy_subnet_ipv4(topology_st):
+    """Test adding IPv4 subnet in CIDR notation to nsslapd-haproxy-trusted-ip
+
+    :id: 19456de2-06f6-4c6c-be00-b07f84ba1c18
+    :setup: Standalone DS instance
+    :steps:
+        1. Add an IPv4 subnet in CIDR notation
+        2. Verify the subnet was added correctly
+    :expectedresults:
+        1. Command should execute successfully
+        2. Subnet should be present in the configuration
+    """
+    dsconf_cmd = get_dsconf_base_cmd(topology_st)
+    attr_name = 'nsslapd-haproxy-trusted-ip'
+
+    try:
+        subnet = HAPROXY_IPS['subnet_ipv4']
+        test_attr = f"{attr_name}={subnet}"
+
+        # Add subnet
+        output, rc = execute_dsconf_command(dsconf_cmd, ['config', 'add', test_attr])
+        assert rc == 0
+
+        # Verify
+        output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
+        assert subnet in output
+
+    finally:
+        execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])
+
+
+def test_haproxy_subnet_ipv6(topology_st):
+    """Test adding IPv6 subnet in CIDR notation to nsslapd-haproxy-trusted-ip
+
+    :id: b0b8b546-979c-47a2-bc9a-a4c664be8eba
+    :setup: Standalone DS instance
+    :steps:
+        1. Add an IPv6 subnet in CIDR notation
+        2. Verify the subnet was added correctly
+    :expectedresults:
+        1. Command should execute successfully
+        2. Subnet should be present in the configuration
+    """
+    dsconf_cmd = get_dsconf_base_cmd(topology_st)
+    attr_name = 'nsslapd-haproxy-trusted-ip'
+
+    try:
+        subnet = HAPROXY_IPS['subnet_ipv6']
+        test_attr = f"{attr_name}={subnet}"
+
+        # Add subnet
+        output, rc = execute_dsconf_command(dsconf_cmd, ['config', 'add', test_attr])
+        assert rc == 0
+
+        # Verify
+        output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
+        assert subnet in output
+
+    finally:
+        execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])
+
+
+def test_haproxy_mixed_ips_and_subnets(topology_st):
+    """Test adding mixed individual IPs and subnets to nsslapd-haproxy-trusted-ip
+
+    :id: d4f70db4-8f32-4771-95c2-32e6c83838df
+    :setup: Standalone DS instance
+    :steps:
+        1. Add multiple values including both individual IPs and subnets
+        2. Verify all values were added correctly
+    :expectedresults:
+        1. Batch add command should execute successfully
+        2. All values should be present in the configuration
+    """
+    dsconf_cmd = get_dsconf_base_cmd(topology_st)
+    attr_name = 'nsslapd-haproxy-trusted-ip'
+
+    try:
+        # Add mixed values
+        attr_values = [f"{attr_name}={val}" for val in HAPROXY_IPS['mixed']]
+        output, rc = execute_dsconf_command(dsconf_cmd, ['config', 'add'] + attr_values)
+        assert rc == 0
+
+        # Verify all values
+        output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
+        for value in HAPROXY_IPS['mixed']:
+            assert value in output
+
+    finally:
+        execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])
+
+
+def test_haproxy_invalid_cidr_prefix(topology_st):
+    """Test that invalid CIDR prefix lengths are rejected
+
+    :id: cfcc9fcc-70e8-49a7-82ac-dcf5e1a0cca3
+    :setup: Standalone DS instance
+    :steps:
+        1. Try to add an IPv4 address with invalid prefix length (>32)
+        2. Try to add an IPv6 address with invalid prefix length (>128)
+    :expectedresults:
+        1. IPv4 command should fail
+        2. IPv6 command should fail
+    """
+    dsconf_cmd = get_dsconf_base_cmd(topology_st)
+    attr_name = 'nsslapd-haproxy-trusted-ip'
+
+    try:
+        # Test invalid IPv4 prefix
+        invalid_ipv4 = f"{attr_name}=192.168.1.0/33"
+        output, rc = execute_dsconf_command(dsconf_cmd, ['config', 'add', invalid_ipv4])
+        assert rc != 0  # Should fail
+
+        # Test invalid IPv6 prefix
+        invalid_ipv6 = f"{attr_name}=2001:db8::/129"
+        output, rc = execute_dsconf_command(dsconf_cmd, ['config', 'add', invalid_ipv6])
+        assert rc != 0  # Should fail
+
+    finally:
+        execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])
+
+
+def test_haproxy_subnet_persists_after_restart(topology_st):
+    """Test subnet configuration persists after server restart
+
+    :id: 7ea0d55c-5345-465e-a33b-46f2e41a90cf
+    :setup: Standalone DS instance
+    :steps:
+        1. Add subnet in CIDR notation
+        2. Verify the subnet is present
+        3. Restart the server
+        4. Verify the subnet persists after restart
+    :expectedresults:
+        1. Subnet should be added successfully
+        2. Subnet should be present before restart
+        3. Server should restart successfully
+        4. Subnet should still be present after restart
+    """
+    dsconf_cmd = get_dsconf_base_cmd(topology_st)
+    attr_name = 'nsslapd-haproxy-trusted-ip'
+
+    try:
+        # Add subnet
+        subnet = HAPROXY_IPS['subnet_ipv4']
+        output, rc = execute_dsconf_command(dsconf_cmd,
+                                          ['config', 'add', f"{attr_name}={subnet}"])
+        assert rc == 0
+
+        # Verify before restart
+        output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
+        assert subnet in output
+
+        # Restart the server
+        topology_st.standalone.restart(timeout=10)
+
+        # Verify after restart
+        output, _ = execute_dsconf_command(dsconf_cmd, ['config', 'get', attr_name])
+        assert subnet in output
 
     finally:
         execute_dsconf_command(dsconf_cmd, ['config', 'delete', attr_name])

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1366,9 +1366,9 @@ connection_read_operation(Connection *conn, Operation *op, ber_tag_t *tag, int *
                             /* Parsed entries should always be available after config load.
                              * If they're not, this indicates a configuration initialization failure. */
                             slapi_log_err(SLAPI_LOG_ERR, "connection_read_operation",
-                                         "HAProxy trusted IPs not properly initialized - disconnecting connection\n");
+                                          "HAProxy trusted IPs not properly initialized - disconnecting connection\n");
                             disconnect_server_nomutex(conn, conn->c_connid, -1,
-                                                     SLAPD_DISCONNECT_PROXY_UNKNOWN, EPROTO);
+                                                      SLAPD_DISCONNECT_PROXY_UNKNOWN, EPROTO);
                             ret = CONN_DONE;
                             goto done;
                         }

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2021 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1332,36 +1332,45 @@ connection_read_operation(Connection *conn, Operation *op, ber_tag_t *tag, int *
 
                     /* If bval is NULL and we don't have an error - we still want the proper log and update */
                     if ((haproxy_rc == HAPROXY_HEADER_PARSED) && (proxy_connection)) {
-                        /* Normalize IP addresses */
+                        /* Normalize IP addresses for logging */
                         normalize_IPv4(conn->cin_addr, buf_ip, sizeof(buf_ip), str_ip, sizeof(str_ip));
                         normalize_IPv4(&pr_netaddr_dest, buf_haproxy_destip, sizeof(buf_haproxy_destip),
                                        str_haproxy_destip, sizeof(str_haproxy_destip));
-                        size_t ip_len = strlen(buf_ip);
-                        size_t destip_len = strlen(buf_haproxy_destip);
 
-                        /* Now, reset RC and set it to 0 only if a match is found */
+                        /* Initialize match result - will be set to 0 if both IPs match */
                         haproxy_rc = -1;
 
                         /*
-                         * We need to allow a configuration where DS instance and HAProxy are on the same machine.
-                         * In this case, we need to check if
-                         * the HAProxy client IP (which will be a loopback address) matches one of the the trusted IP addresses,
-                         * while still checking that
-                         * the HAProxy header destination IP address matches one of the trusted IP addresses.
-                         * Additionally, this change will also allow configuration having
-                         * HAProxy listening on a different subnet than one used to forward the request.
+                         * Validate connection against trusted IPs/subnets.
+                         *
+                         * Both the HAProxy client IP and the destination IP from the HAProxy header
+                         * must match one of the configured trusted IP addresses or subnets.
+                         * This allows configurations where DS instance and HAProxy are on the same machine.
+                         *
+                         * Uses parsed binary entries for efficient matching during connection handling.
                          */
-                        for (size_t i = 0; bvals[i] != NULL; ++i) {
-                            size_t bval_len = strlen(bvals[i]->bv_val);
+                        haproxy_trusted_entry_t *parsed_entries = NULL;
+                        size_t parsed_count = 0;
 
-                            /* Check if the Client IP (HAProxy's machine IP) address matches the trusted IP address */
-                            if (!trusted_matches_ip_found) {
-                                trusted_matches_ip_found = (bval_len == ip_len) && (strncasecmp(bvals[i]->bv_val, buf_ip, ip_len) == 0);
-                            }
-                            /* Check if the HAProxy header destination IP address matches the trusted IP address */
-                            if (!trusted_matches_destip_found) {
-                                trusted_matches_destip_found = (bval_len == destip_len) && (strncasecmp(bvals[i]->bv_val, buf_haproxy_destip, destip_len) == 0);
-                            }
+                        parsed_entries = g_get_haproxy_trusted_ip_parsed(&parsed_count);
+
+                        if (parsed_entries && parsed_count > 0) {
+                            /* Use parsed binary entries for matching */
+                            trusted_matches_ip_found = haproxy_ip_matches_parsed(conn->cin_addr,
+                                                                                 parsed_entries,
+                                                                                 parsed_count);
+                            trusted_matches_destip_found = haproxy_ip_matches_parsed(&pr_netaddr_dest,
+                                                                                     parsed_entries,
+                                                                                     parsed_count);
+                        } else {
+                            /* Parsed entries should always be available after config load.
+                             * If they're not, this indicates a configuration initialization failure. */
+                            slapi_log_err(SLAPI_LOG_ERR, "connection_read_operation",
+                                         "HAProxy trusted IPs not properly initialized - disconnecting connection\n");
+                            disconnect_server_nomutex(conn, conn->c_connid, -1,
+                                                     SLAPD_DISCONNECT_PROXY_UNKNOWN, EPROTO);
+                            ret = CONN_DONE;
+                            goto done;
                         }
 
                         if (trusted_matches_ip_found && trusted_matches_destip_found) {
@@ -1380,8 +1389,8 @@ connection_read_operation(Connection *conn, Operation *op, ber_tag_t *tag, int *
                         /* Replace cin_addr and cin_destaddr in the Connection struct with received addresses */
                         slapi_ch_free((void**)&conn->cin_addr);
                         slapi_ch_free((void**)&conn->cin_destaddr);
-                        conn->cin_addr = (PRNetAddr*)malloc(sizeof(PRNetAddr));
-                        conn->cin_destaddr = (PRNetAddr*)malloc(sizeof(PRNetAddr));
+                        conn->cin_addr = (PRNetAddr*)slapi_ch_malloc(sizeof(PRNetAddr));
+                        conn->cin_destaddr = (PRNetAddr*)slapi_ch_malloc(sizeof(PRNetAddr));
                         memcpy(conn->cin_addr, &pr_netaddr_from, sizeof(PRNetAddr));
                         memcpy(conn->cin_destaddr, &pr_netaddr_dest, sizeof(PRNetAddr));
                         conn->c_ipaddr = slapi_ch_strdup(str_haproxy_ip);

--- a/ldap/servers/slapd/haproxy.c
+++ b/ldap/servers/slapd/haproxy.c
@@ -20,7 +20,8 @@
 #include "slap.h"
 
 /* Function to parse IPv4 addresses in version 2 */
-static int haproxy_parse_v2_addr_v4(uint32_t in_addr, unsigned in_port, PRNetAddr *pr_netaddr)
+static int
+haproxy_parse_v2_addr_v4(uint32_t in_addr, unsigned in_port, PRNetAddr *pr_netaddr)
 {
     char addr[INET_ADDRSTRLEN];
 
@@ -46,7 +47,8 @@ static int haproxy_parse_v2_addr_v4(uint32_t in_addr, unsigned in_port, PRNetAdd
 
 
 /* Function to parse IPv6 addresses in version 2 */
-static int haproxy_parse_v2_addr_v6(uint8_t *in6_addr, unsigned in6_port, PRNetAddr *pr_netaddr)
+static int
+haproxy_parse_v2_addr_v6(uint8_t *in6_addr, unsigned in6_port, PRNetAddr *pr_netaddr)
 {
     struct sockaddr_in6 sin6;
     char addr[INET6_ADDRSTRLEN];
@@ -76,7 +78,8 @@ static int haproxy_parse_v2_addr_v6(uint8_t *in6_addr, unsigned in6_port, PRNetA
 
 
 /* Function to parse the header in version 2 */
-int haproxy_parse_v2_hdr(const char *str, size_t *str_len, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
+int
+haproxy_parse_v2_hdr(const char *str, size_t *str_len, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
 {
     struct proxy_hdr_v2 *hdr_v2 = (struct proxy_hdr_v2 *) str;
     uint16_t hdr_v2_len = 0;
@@ -172,7 +175,8 @@ done:
 
 
 /* Function to parse the protocol in version 1 */
-static int haproxy_parse_v1_protocol(const char *str, const char *protocol)
+static int
+haproxy_parse_v1_protocol(const char *str, const char *protocol)
 {
     slapi_log_err(SLAPI_LOG_CONNS, "haproxy_parse_v1_protocol", "HAProxy protocol - %s\n", str ? str : "(null)");
     if ((str != 0) && (strcasecmp(str, protocol) == 0)) {
@@ -184,7 +188,8 @@ static int haproxy_parse_v1_protocol(const char *str, const char *protocol)
 
 
 /* Function to parse the family (i.e., IPv4 or IPv6) in version 1 */
-static int haproxy_parse_v1_fam(const char *str, int *addr_family)
+static int
+haproxy_parse_v1_fam(const char *str, int *addr_family)
 {
     slapi_log_err(SLAPI_LOG_CONNS, "haproxy_parse_fam", "Address family - %s\n", str ? str : "(null)");
     if (str == 0) {
@@ -206,7 +211,8 @@ static int haproxy_parse_v1_fam(const char *str, int *addr_family)
 
 
 /* Function to parse addresses in version 1 */
-static int haproxy_parse_v1_addr(const char *str, PRNetAddr *pr_netaddr, int addr_family)
+static int
+haproxy_parse_v1_addr(const char *str, PRNetAddr *pr_netaddr, int addr_family)
 {
     char addrbuf[256];
 
@@ -244,7 +250,8 @@ static int haproxy_parse_v1_addr(const char *str, PRNetAddr *pr_netaddr, int add
 
 
 /* Function to parse port numbers in version 1 */
-static int haproxy_parse_v1_port(const char *str, PRNetAddr *pr_netaddr)
+static int
+haproxy_parse_v1_port(const char *str, PRNetAddr *pr_netaddr)
 {
     char *endptr;
     long port;
@@ -275,7 +282,8 @@ static inline char *get_next_token(char **copied) {
 
 
 /* Function to parse the header in version 1 */
-int haproxy_parse_v1_hdr(const char *str, size_t *str_len, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
+int
+haproxy_parse_v1_hdr(const char *str, size_t *str_len, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
 {
     PRNetAddr parsed_addr_from = {{0}};
     PRNetAddr parsed_addr_dest = {{0}};
@@ -349,7 +357,8 @@ done:
  *
  * @return: Returns 0 on successful operation, -1 on error.
  */
-int haproxy_receive(int fd, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
+int
+haproxy_receive(int fd, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
 {
     /* Buffer to store the header received from the HAProxy server */
     char hdr[HAPROXY_HEADER_MAX_LEN + 1] = {0};
@@ -460,10 +469,10 @@ haproxy_ipv6_in_subnet(const struct in6_addr *ip, const struct in6_addr *subnet,
 {
     const uint32_t *ip_u32 = (const uint32_t *)ip->s6_addr;
     const uint32_t *subnet_u32 = (const uint32_t *)subnet->s6_addr;
-    int full_u32_words;
+    size_t full_u32_words;
+    size_t last_word_idx;
     int remaining_bits;
     uint32_t mask32;
-    int last_word_idx;
 
     /* Handle exact match case - compare as four 32-bit integers with early exit */
     if (prefix_len == 128) {
@@ -492,7 +501,7 @@ haproxy_ipv6_in_subnet(const struct in6_addr *ip, const struct in6_addr *subnet,
     remaining_bits = prefix_len & 31;  /* prefix_len % 32 - bits in partial word */
 
     /* Compare full 32-bit words with early exit on mismatch */
-    for (int i = 0; i < full_u32_words; i++) {
+    for (size_t i = 0; i < full_u32_words; i++) {
         if (ip_u32[i] != subnet_u32[i]) {
             return 0;
         }

--- a/ldap/servers/slapd/haproxy.c
+++ b/ldap/servers/slapd/haproxy.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include "slap.h"
 
 /* Function to parse IPv4 addresses in version 2 */
@@ -339,12 +341,12 @@ done:
 
 /**
  * Function to receive and parse HAProxy headers, supporting both v1 and v2 of the protocol.
- * 
+ *
  * @param fd: The file descriptor of the socket from which to read.
  * @param proxy_connection: A pointer to an integer to store the proxy connection status (0 or 1).
  * @param pr_netaddr_from: A pointer to a PRNetAddr structure to store the source address info.
  * @param pr_netaddr_dest: A pointer to a PRNetAddr structure to store the destination address info.
- * 
+ *
  * @return: Returns 0 on successful operation, -1 on error.
  */
 int haproxy_receive(int fd, int *proxy_connection, PRNetAddr *pr_netaddr_from, PRNetAddr *pr_netaddr_dest)
@@ -389,4 +391,484 @@ int haproxy_receive(int fd, int *proxy_connection, PRNetAddr *pr_netaddr_from, P
         }
     }
     return rc;
+}
+
+/**
+ * Check if an IPv4 address is within a subnet.
+ *
+ * *****************************************************************************
+ * NOTE: This function exists ONLY for unit testing purposes.
+ * Production code MUST use haproxy_ip_matches_parsed() for connection validation.
+ * *****************************************************************************
+ *
+ * Used by haproxy_ip_matches_cidr() for test convenience and by unit tests
+ * for granular testing of IPv4 subnet logic.
+ *
+ * @param ip: The IP address to check (network byte order)
+ * @param subnet: The subnet address (network byte order)
+ * @param prefix_len: The prefix length (e.g., 24 for /24)
+ *
+ * @return: 1 if IP is in subnet, 0 otherwise
+ */
+int
+haproxy_ipv4_in_subnet(uint32_t ip, uint32_t subnet, int prefix_len)
+{
+    uint32_t mask;
+
+    /* Handle exact match case */
+    if (prefix_len == 32) {
+        return ip == subnet;
+    }
+
+    /* Handle match-all case */
+    if (prefix_len == 0) {
+        return 1;
+    }
+
+    /* Validate prefix length */
+    if (prefix_len < 0 || prefix_len > 32) {
+        return 0;
+    }
+
+    /* Create subnet mask and compare network portions - safe bit shift */
+    mask = 0xFFFFFFFFu << (32 - prefix_len);
+    mask = htonl(mask);
+    return (ip & mask) == (subnet & mask);
+}
+
+/**
+ * Check if an IPv6 address is within a subnet.
+ *
+ * *****************************************************************************
+ * NOTE: This function exists ONLY for unit testing purposes.
+ * Production code MUST use haproxy_ip_matches_parsed() for connection validation.
+ * *****************************************************************************
+ *
+ * Used by haproxy_ip_matches_cidr() for test convenience and by unit tests
+ * for granular testing of IPv6 subnet logic.
+ *
+ * Optimized for efficiency using 32-bit word comparisons throughout.
+ *
+ * @param ip: The IPv6 address to check
+ * @param subnet: The subnet address
+ * @param prefix_len: The prefix length (e.g., 64 for /64)
+ *
+ * @return: 1 if IP is in subnet, 0 otherwise
+ */
+int
+haproxy_ipv6_in_subnet(const struct in6_addr *ip, const struct in6_addr *subnet, int prefix_len)
+{
+    const uint32_t *ip_u32 = (const uint32_t *)ip->s6_addr;
+    const uint32_t *subnet_u32 = (const uint32_t *)subnet->s6_addr;
+    int full_u32_words;
+    int remaining_bits;
+    uint32_t mask32;
+    int last_word_idx;
+
+    /* Handle exact match case - compare as four 32-bit integers with early exit */
+    if (prefix_len == 128) {
+        return (ip_u32[0] == subnet_u32[0] &&
+                ip_u32[1] == subnet_u32[1] &&
+                ip_u32[2] == subnet_u32[2] &&
+                ip_u32[3] == subnet_u32[3]);
+    }
+
+    /* Handle match-all case */
+    if (prefix_len == 0) {
+        return 1;
+    }
+
+    /* Validate prefix length */
+    if (prefix_len < 0 || prefix_len > 128) {
+        return 0;
+    }
+
+    /*
+     * Optimized comparison using 32-bit words throughout.
+     * This is consistent with haproxy_ip_matches_parsed and avoids
+     * switching between word and byte comparisons.
+     */
+    full_u32_words = prefix_len >> 5;  /* prefix_len / 32 - number of full 32-bit words */
+    remaining_bits = prefix_len & 31;  /* prefix_len % 32 - bits in partial word */
+
+    /* Compare full 32-bit words with early exit on mismatch */
+    for (int i = 0; i < full_u32_words; i++) {
+        if (ip_u32[i] != subnet_u32[i]) {
+            return 0;
+        }
+    }
+
+    /* Handle partial 32-bit word if prefix not on word boundary */
+    if (remaining_bits > 0) {
+        last_word_idx = full_u32_words;
+
+        /* Create mask for the partial word - safe bit shift (remaining_bits is 1-31) */
+        mask32 = 0xFFFFFFFFu << (32 - remaining_bits);
+        mask32 = htonl(mask32);
+
+        if ((ip_u32[last_word_idx] & mask32) != (subnet_u32[last_word_idx] & mask32)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/**
+ * Check if an IP address matches a CIDR notation or exact IP (string-based utility).
+ *
+ * *****************************************************************************
+ * NOTE: This function exists ONLY for unit testing purposes.
+ * Production code MUST use haproxy_ip_matches_parsed() for connection validation.
+ * *****************************************************************************
+ *
+ * This string-based function is convenient for writing readable tests but has
+ * significant overhead (string parsing, address conversion). It is NOT used
+ * anywhere in the production connection validation path.
+ *
+ * @param ip_str: The IP address to check (string format)
+ * @param cidr_str: The CIDR notation or exact IP (e.g., "192.168.1.0/24" or "192.168.1.1")
+ *
+ * @return: 1 if match, 0 otherwise
+ */
+int
+haproxy_ip_matches_cidr(const char *ip_str, const char *cidr_str)
+{
+    const char *slash_pos;
+    char cidr_copy[MAX_CIDR_STRING_LEN];
+    char *subnet_str;
+    int prefix_len;
+    PRNetAddr ip_addr;
+    PRNetAddr subnet_addr;
+    size_t cidr_len;
+
+    /* Check if the CIDR string contains a slash */
+    slash_pos = strchr(cidr_str, '/');
+    if (slash_pos == NULL) {
+        /* No CIDR notation - perform exact IP match */
+        return (strcasecmp(ip_str, cidr_str) == 0);
+    }
+
+    /* Process CIDR notation */
+    cidr_len = strlen(cidr_str);
+    if (cidr_len >= sizeof(cidr_copy)) {
+        slapi_log_err(SLAPI_LOG_ERR, "haproxy_ip_matches_cidr",
+                      "CIDR string exceeds maximum length (%zu bytes, max %d)\n",
+                      cidr_len, MAX_CIDR_STRING_LEN);
+        return 0;
+    }
+
+    /* Copy CIDR string for tokenization */
+    memcpy(cidr_copy, cidr_str, cidr_len);
+    cidr_copy[cidr_len] = '\0';
+
+    /* Split at slash to separate subnet address and prefix */
+    subnet_str = cidr_copy;
+    cidr_copy[slash_pos - cidr_str] = '\0';
+
+    /* Extract prefix length with validation */
+    {
+        char *endptr;
+        long prefix_long;
+        errno = 0;
+        prefix_long = strtol(slash_pos + 1, &endptr, 10);
+
+        if (errno != 0 || *endptr != '\0' || endptr == slash_pos + 1 ||
+            prefix_long < 0 || prefix_long > 128) {
+            return 0;
+        }
+        prefix_len = (int)prefix_long;
+    }
+
+    /* Parse both IP addresses */
+    if (PR_StringToNetAddr(ip_str, &ip_addr) != PR_SUCCESS) {
+        return 0;
+    }
+
+    if (PR_StringToNetAddr(subnet_str, &subnet_addr) != PR_SUCCESS) {
+        return 0;
+    }
+
+    /* Verify both addresses are the same family */
+    if (ip_addr.raw.family != subnet_addr.raw.family) {
+        return 0;
+    }
+
+    /* Perform subnet matching based on address family */
+    if (ip_addr.raw.family == PR_AF_INET) {
+        return haproxy_ipv4_in_subnet(ip_addr.inet.ip, subnet_addr.inet.ip, prefix_len);
+    } else if (ip_addr.raw.family == PR_AF_INET6) {
+        return haproxy_ipv6_in_subnet((const struct in6_addr *)&ip_addr.ipv6.ip,
+                                      (const struct in6_addr *)&subnet_addr.ipv6.ip,
+                                      prefix_len);
+    }
+
+    return 0;
+}
+
+/**
+ * Parse trusted IP addresses and subnets into binary format with pre-computed netmasks.
+ *
+ * Converts string representations (e.g., "192.168.1.0/24") into optimized binary
+ * structures containing network addresses and netmasks. This parsing is done once
+ * at configuration time to avoid repeated string operations during connection handling.
+ *
+ * @param ipaddress: Array of berval IP addresses/subnets from configuration
+ * @param count_out: Output parameter for number of parsed entries
+ * @param errorbuf: Buffer for error messages (validation done in libglobs.c)
+ *
+ * @return: Array of parsed entries, or NULL on error
+ */
+haproxy_trusted_entry_t *
+haproxy_parse_trusted_ips(struct berval **ipaddress, size_t *count_out, char *errorbuf)
+{
+    haproxy_trusted_entry_t *entries = NULL;
+    size_t count = 0;
+    size_t i;
+
+    if (!ipaddress) {
+        *count_out = 0;
+        return NULL;
+    }
+
+    /* Count entries */
+    for (count = 0; ipaddress[count] != NULL; count++)
+        ;
+
+    if (count == 0) {
+        *count_out = 0;
+        return NULL;
+    }
+
+    /* Allocate array for parsed entries */
+    entries = (haproxy_trusted_entry_t *)slapi_ch_calloc(count, sizeof(haproxy_trusted_entry_t));
+
+    /* Parse each entry into binary format (validation already done in libglobs.c) */
+    for (i = 0; i < count; i++) {
+        char *ip_val = ipaddress[i]->bv_val;
+        char *slash_pos = strchr(ip_val, '/');
+        char ip_part[MAX_CIDR_STRING_LEN];
+        int is_ipv6;
+
+        /* Store original for logging */
+        PL_strncpyz(entries[i].original, ip_val, sizeof(entries[i].original));
+
+        /* Check for CIDR notation */
+        if (slash_pos != NULL) {
+            size_t ip_len = slash_pos - ip_val;
+            char *endptr;
+            long prefix_long;
+
+            /* Validate IP portion length (need room for null terminator) */
+            if (ip_len >= sizeof(ip_part) - 1) {
+                slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                             "IP address portion too long in CIDR notation: %s\n", ip_val);
+                slapi_ch_free((void **)&entries);
+                *count_out = 0;
+                return NULL;
+            }
+
+            memcpy(ip_part, ip_val, ip_len);
+            ip_part[ip_len] = '\0';
+
+            /* Parse prefix length with strict validation */
+            errno = 0;
+            prefix_long = strtol(slash_pos + 1, &endptr, 10);
+
+            /* Validate: must be pure number, in valid range, no overflow */
+            if (errno != 0 || *endptr != '\0' || endptr == slash_pos + 1 ||
+                prefix_long < 0 || prefix_long > 128) {
+                slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                             "Invalid CIDR prefix length in: %s (must be 0-128 for IPv6, 0-32 for IPv4)\n", ip_val);
+                slapi_ch_free((void **)&entries);
+                *count_out = 0;
+                return NULL;
+            }
+
+            entries[i].prefix_len = (int)prefix_long;
+            entries[i].is_subnet = 1;
+
+            /* Parse network address */
+            if (PR_StringToNetAddr(ip_part, &entries[i].network) != PR_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                             "Failed to parse network address: %s\n", ip_part);
+                slapi_ch_free((void **)&entries);
+                *count_out = 0;
+                return NULL;
+            }
+
+            /* Create netmask based on address family and prefix */
+            if (entries[i].network.raw.family == PR_AF_INET) {
+                /* Validate IPv4 prefix range before bit operations */
+                if (entries[i].prefix_len > 32) {
+                    slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                                 "IPv4 CIDR prefix must be 0-32, got %d in: %s\n",
+                                 entries[i].prefix_len, ip_val);
+                    slapi_ch_free((void **)&entries);
+                    *count_out = 0;
+                    return NULL;
+                }
+
+                /* Calculate netmask safely - avoid undefined behavior */
+                uint32_t mask;
+                if (entries[i].prefix_len == 0) {
+                    mask = 0;
+                } else {
+                    /* Safe bit shift: prefix_len is validated to be 1-32 */
+                    mask = 0xFFFFFFFFu << (32 - entries[i].prefix_len);
+                }
+                entries[i].netmask.inet.family = PR_AF_INET;
+                entries[i].netmask.inet.ip = htonl(mask);
+                /* Pre-apply mask to network address for faster matching */
+                entries[i].network.inet.ip &= entries[i].netmask.inet.ip;
+            } else if (entries[i].network.raw.family == PR_AF_INET6) {
+                /* Validate IPv6 prefix range */
+                if (entries[i].prefix_len > 128) {
+                    slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                                 "IPv6 CIDR prefix must be 0-128, got %d in: %s\n",
+                                 entries[i].prefix_len, ip_val);
+                    slapi_ch_free((void **)&entries);
+                    *count_out = 0;
+                    return NULL;
+                }
+                /*
+                 * Build IPv6 netmask from CIDR prefix length.
+                 * For /48: first 6 bytes = 0xFF, remaining bytes = 0x00
+                 * For /33: first 4 bytes = 0xFF, 5th byte = 0x80, rest = 0x00
+                 */
+                int full_bytes = entries[i].prefix_len >> 3;      /* prefix_len / 8 */
+                int remaining_bits = entries[i].prefix_len & 7;   /* prefix_len % 8 */
+                int j;
+
+                entries[i].netmask.ipv6.family = PR_AF_INET6;
+                memset(&entries[i].netmask.ipv6.ip, 0, sizeof(entries[i].netmask.ipv6.ip));
+
+                /* Set full bytes to 0xFF */
+                for (j = 0; j < full_bytes; j++) {
+                    entries[i].netmask.ipv6.ip.pr_s6_addr[j] = 0xFF;
+                }
+
+                /* Set partial byte mask if prefix not on byte boundary */
+                if (remaining_bits > 0) {
+                    entries[i].netmask.ipv6.ip.pr_s6_addr[full_bytes] =
+                        (uint8_t)(0xFF << (8 - remaining_bits));
+                }
+                /* Remaining bytes are already 0x00 from memset */
+
+                /* Pre-apply mask to network address for faster matching */
+                uint32_t *net_u32 = (uint32_t *)entries[i].network.ipv6.ip.pr_s6_addr;
+                const uint32_t *mask_u32 = (const uint32_t *)entries[i].netmask.ipv6.ip.pr_s6_addr;
+                for (j = 0; j < 4; j++) {
+                    net_u32[j] &= mask_u32[j];
+                }
+            }
+        } else {
+            /* Single IP address (no CIDR) */
+            entries[i].is_subnet = 0;
+            entries[i].prefix_len = -1;
+
+            /* Parse as regular IP address */
+            if (PR_StringToNetAddr(ip_val, &entries[i].network) != PR_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_ERR, "haproxy_parse_trusted_ips",
+                             "Failed to parse IP address: %s\n", ip_val);
+                slapi_ch_free((void **)&entries);
+                *count_out = 0;
+                return NULL;
+            }
+        }
+    }
+
+    *count_out = count;
+    return entries;
+}
+
+/**
+ * Check if an IP address matches any trusted entry using parsed binary format.
+ *
+ * Compares the given IP address against an array of parsed trusted entries.
+ * Supports exact IP matching and CIDR subnet matching.
+ * Handles IPv4, IPv6, and IPv4-mapped IPv6 addresses.
+ *
+ * @param ip_addr: The IP address to check (from connection)
+ * @param entries: Array of parsed trusted entries (from config_get_haproxy_trusted_ip_parsed)
+ * @param entry_count: Number of entries in the array
+ *
+ * @return: 1 if IP matches any entry, 0 otherwise
+ */
+int
+haproxy_ip_matches_parsed(const PRNetAddr *ip_addr, const haproxy_trusted_entry_t *entries, size_t entry_count)
+{
+    size_t i;
+    PRNetAddr normalized_ip;
+    char ip_str[INET6_ADDRSTRLEN];
+
+    if (!entries || entry_count == 0 || !ip_addr) {
+        return 0;
+    }
+
+    /* Normalize IPv4-mapped IPv6 addresses for consistent matching */
+    if (PR_IsNetAddrType(ip_addr, PR_IpAddrV4Mapped)) {
+        normalized_ip.inet.family = PR_AF_INET;
+        normalized_ip.inet.ip = ip_addr->ipv6.ip.pr_s6_addr32[3];
+    } else {
+        memcpy(&normalized_ip, ip_addr, sizeof(PRNetAddr));
+    }
+
+    /* Check against each trusted entry */
+    for (i = 0; i < entry_count; i++) {
+        const haproxy_trusted_entry_t *entry = &entries[i];
+
+        /* Skip if address families don't match */
+        if (normalized_ip.raw.family != entry->network.raw.family) {
+            continue;
+        }
+
+        /* Exact IP matching (non-subnet) */
+        if (!entry->is_subnet) {
+            if (normalized_ip.raw.family == PR_AF_INET) {
+                if (normalized_ip.inet.ip == entry->network.inet.ip) {
+                    return 1;
+                }
+            } else if (normalized_ip.raw.family == PR_AF_INET6) {
+                /* Compare IPv6 as four 32-bit words with early exit on mismatch */
+                const uint32_t *ip_u32 = (const uint32_t *)normalized_ip.ipv6.ip.pr_s6_addr;
+                const uint32_t *net_u32 = (const uint32_t *)entry->network.ipv6.ip.pr_s6_addr;
+                if (ip_u32[0] != net_u32[0]) continue;
+                if (ip_u32[1] != net_u32[1]) continue;
+                if (ip_u32[2] != net_u32[2]) continue;
+                if (ip_u32[3] != net_u32[3]) continue;
+                return 1;
+            }
+        } else {
+            /* CIDR subnet matching using stored netmask */
+            if (normalized_ip.raw.family == PR_AF_INET) {
+                /*
+                 * IPv4 subnet check: apply netmask to incoming IP only.
+                 * Network address was already masked during parsing.
+                 */
+                uint32_t mask = entry->netmask.inet.ip;
+                if ((normalized_ip.inet.ip & mask) == entry->network.inet.ip) {
+                    return 1;
+                }
+            } else if (normalized_ip.raw.family == PR_AF_INET6) {
+                /*
+                 * IPv6 subnet check: apply netmask to incoming IP only.
+                 * Network address was already masked during parsing.
+                 * Compare as four 32-bit words with early exit for efficiency.
+                 */
+                const uint32_t *ip_u32 = (const uint32_t *)normalized_ip.ipv6.ip.pr_s6_addr;
+                const uint32_t *net_u32 = (const uint32_t *)entry->network.ipv6.ip.pr_s6_addr;
+                const uint32_t *mask_u32 = (const uint32_t *)entry->netmask.ipv6.ip.pr_s6_addr;
+
+                /* Check each 32-bit word with early exit on mismatch */
+                if ((ip_u32[0] & mask_u32[0]) != net_u32[0]) continue;
+                if ((ip_u32[1] & mask_u32[1]) != net_u32[1]) continue;
+                if ((ip_u32[2] & mask_u32[2]) != net_u32[2]) continue;
+                if ((ip_u32[3] & mask_u32[3]) != net_u32[3]) continue;
+                return 1;
+            }
+        }
+    }
+
+    return 0;
 }

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2021 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -2080,6 +2080,10 @@ FrontendConfig_init(void)
     cfg->tcp_fin_timeout = SLAPD_DEFAULT_TCP_FIN_TIMEOUT;
     cfg->tcp_keepalive_time = SLAPD_DEFAULT_TCP_KEEPALIVE_TIME;
 
+    /* Initialize parsed HAProxy trusted IP entries */
+    cfg->haproxy_trusted_ip_parsed = NULL;
+    cfg->haproxy_trusted_ip_parsed_count = 0;
+
     /* Done, unlock!  */
     CFG_UNLOCK_WRITE(cfg);
 
@@ -2883,26 +2887,236 @@ config_set_haproxy_trusted_ip(const char *attrname, struct berval **value, char 
     if (value && value[0] &&
         PL_strncasecmp((char *)value[0]->bv_val, HAPROXY_TRUSTED_IP_REMOVE_CMD, value[0]->bv_len) != 0) {
         for (size_t i = 0; value[i] != NULL; i++) {
-            end = strspn(value[i]->bv_val, "0123456789:ABCDEFabcdef.*");
-            /*
-            * If no valid characters are found, or if there are characters after the valid ones,
-            * then print an error message and exit with LDAP_OPERATIONS_ERROR.
-            */
-            if (!end || value[i]->bv_val[end] != '\0') {
-                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "IP address contains invalid characters (%s), skipping\n",
-                                value[i]->bv_val);
+            char *slash_pos = strchr(value[i]->bv_val, '/');
+            char ip_part[MAX_CIDR_STRING_LEN];
+            int prefix_len = -1;
+
+            /* Validate total input length before processing */
+            if (value[i]->bv_len >= MAX_CIDR_STRING_LEN) {
+                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                      "IP address/subnet string too long (max %d bytes): %s\n",
+                                      MAX_CIDR_STRING_LEN, value[i]->bv_val);
                 return LDAP_OPERATIONS_ERROR;
             }
-            if (strstr(value[i]->bv_val, ":") == 0) {
-                /* IPv4 - make sure it's just numbers, dots, and wildcard */
-                end = strspn(value[i]->bv_val, "0123456789.*");
-                if (!end || value[i]->bv_val[end] != '\0') {
-                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, "IPv4 address contains invalid characters (%s), skipping\n",
-                                    value[i]->bv_val);
+
+            /* Check for embedded null bytes */
+            if (strlen(value[i]->bv_val) != value[i]->bv_len) {
+                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                      "Null bytes not allowed in IP address/subnet (%s)\n",
+                                      value[i]->bv_val);
+                return LDAP_OPERATIONS_ERROR;
+            }
+
+            /* Reject leading or trailing whitespace - ambiguous and error-prone */
+            if (value[i]->bv_len > 0) {
+                const char *str = value[i]->bv_val;
+                if (isspace((unsigned char)str[0]) || isspace((unsigned char)str[value[i]->bv_len - 1])) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Leading or trailing whitespace not allowed in IP address/subnet (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+            }
+
+            /* Check for CIDR notation */
+            if (slash_pos != NULL) {
+                size_t ip_len = slash_pos - value[i]->bv_val;
+                if (ip_len >= sizeof(ip_part)) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "IP address part too long in CIDR notation (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Extract IP part */
+                memcpy(ip_part, value[i]->bv_val, ip_len);
+                ip_part[ip_len] = '\0';
+
+                /* Check for multiple slashes */
+                if (strchr(slash_pos + 1, '/') != NULL) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Multiple slashes not allowed in CIDR notation (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Validate the prefix part contains only digits */
+                const char *p = slash_pos + 1;
+                if (*p == '\0') {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Empty CIDR prefix length (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Reject leading zeros (e.g., "024", "007") - ambiguous and non-standard */
+                if (*p == '0' && *(p + 1) != '\0') {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Leading zeros not allowed in CIDR prefix (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                while (*p) {
+                    if (*p < '0' || *p > '9') {
+                        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                              "Invalid characters in CIDR prefix (must be numeric) (%s)\n",
+                                              value[i]->bv_val);
+                        return LDAP_OPERATIONS_ERROR;
+                    }
+                    p++;
+                }
+
+                /* Parse and validate prefix length */
+                char *endptr;
+                errno = 0;
+                long parsed_prefix = strtol(slash_pos + 1, &endptr, 10);
+                if (*endptr != '\0' || errno == ERANGE || parsed_prefix < 0) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Invalid CIDR prefix length in (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+                prefix_len = (int)parsed_prefix;
+
+                /* Validate prefix length based on IP type */
+                if (strstr(ip_part, ":") != NULL) {
+                    /* IPv6 */
+                    if (prefix_len > 128) {
+                        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                              "IPv6 CIDR prefix length must be 0-128 (%s)\n",
+                                              value[i]->bv_val);
+                        return LDAP_OPERATIONS_ERROR;
+                    }
+                } else {
+                    /* IPv4 */
+                    if (prefix_len > 32) {
+                        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                              "IPv4 CIDR prefix length must be 0-32 (%s)\n",
+                                              value[i]->bv_val);
+                        return LDAP_OPERATIONS_ERROR;
+                    }
+                }
+
+                /* Validate CIDR IP address */
+                int is_ipv6 = (strchr(ip_part, ':') != NULL);
+
+                /* Check for valid IP address characters based on protocol */
+                if (is_ipv6) {
+                    /* IPv6: hex digits, colons, dots */
+                    end = strspn(ip_part, "0123456789:ABCDEFabcdef.");
+                } else {
+                    /* IPv4: digits and dots */
+                    end = strspn(ip_part, "0123456789.");
+                }
+
+                if (!end || ip_part[end] != '\0') {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "CIDR IP address contains invalid characters (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Validate that the CIDR IP address is parseable */
+                /* For IPv4, ensure exactly 4 octets (3 dots) */
+                if (!is_ipv6) {
+                    int dot_count = 0;
+                    for (const char *p = ip_part; *p; p++) {
+                        if (*p == '.') dot_count++;
+                    }
+                    if (dot_count != 3) {
+                        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                              "IPv4 address in CIDR must have exactly 4 octets (%s)\n",
+                                              value[i]->bv_val);
+                        return LDAP_OPERATIONS_ERROR;
+                    }
+                }
+
+                PRNetAddr test_addr;
+                if (PR_StringToNetAddr(ip_part, &test_addr) != PR_SUCCESS) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Invalid IP address in CIDR notation (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+            } else {
+                /* Validate individual IP address */
+                PL_strncpyz(ip_part, value[i]->bv_val, sizeof(ip_part));
+
+                /* Determine IP protocol type */
+                int is_ipv6 = (strchr(ip_part, ':') != NULL);
+
+                /* Reject wildcards with helpful error message */
+                if (strchr(ip_part, '*') != NULL) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                         "Wildcard patterns are not supported (%s). "
+                                         "Use CIDR notation instead, for example:\n"
+                                         "  - For single IP: 192.168.1.50 (or 192.168.1.50/32)\n"
+                                         "  - For subnet: 192.168.1.0/24 (matches 192.168.1.0-255)\n"
+                                         "  - For IPv6: 2001:db8::/32\n",
+                                         value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Validate characters based on protocol type */
+                if (is_ipv6) {
+                    /* IPv6: hex digits, colons, dots */
+                    end = strspn(ip_part, "0123456789:ABCDEFabcdef.");
+                } else {
+                    /* IPv4: digits and dots */
+                    end = strspn(ip_part, "0123456789.");
+                }
+
+                if (!end || ip_part[end] != '\0') {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "IP address contains invalid characters (%s)\n",
+                                          value[i]->bv_val);
+                    return LDAP_OPERATIONS_ERROR;
+                }
+
+                /* Validate that the IP address is parseable */
+                /* For IPv4, ensure exactly 4 octets (3 dots) */
+                if (!is_ipv6) {
+                    int dot_count = 0;
+                    for (const char *p = ip_part; *p; p++) {
+                        if (*p == '.') dot_count++;
+                    }
+                    if (dot_count != 3) {
+                        slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                              "IPv4 address must have exactly 4 octets (%s)\n",
+                                              value[i]->bv_val);
+                        return LDAP_OPERATIONS_ERROR;
+                    }
+                }
+
+                PRNetAddr test_addr;
+                if (PR_StringToNetAddr(ip_part, &test_addr) != PR_SUCCESS) {
+                    slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                          "Invalid IP address format (%s)\n",
+                                          value[i]->bv_val);
                     return LDAP_OPERATIONS_ERROR;
                 }
             }
         }
+
+        /*
+         * Final validation: test that all values can be successfully parsed into binary format.
+         * This ensures the parsed entries will always be available at runtime
+         */
+        haproxy_trusted_entry_t *test_parsed = NULL;
+        size_t test_count = 0;
+        char parse_errorbuf[SLAPI_DSE_RETURNTEXT_SIZE];
+
+        test_parsed = haproxy_parse_trusted_ips(value, &test_count, parse_errorbuf);
+        if (test_parsed == NULL && test_count == 0) {
+            /* Parsing failed - this should not happen if validation above is correct */
+            slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                                  "Failed to parse trusted IPs into binary format: %s\n",
+                                  parse_errorbuf[0] ? parse_errorbuf : "unknown error");
+            return LDAP_OPERATIONS_ERROR;
+        }
+        /* Free the test parsed entries - they'll be re-parsed during apply */
+        slapi_ch_free((void **)&test_parsed);
     }
 
     if (apply) {

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2021-2024 Red Hat, Inc.
+ * Copyright (C) 2021-2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1102,6 +1102,7 @@ void g_set_default_referral(struct berval **ldap_url);
 struct berval **g_get_default_referral(void);
 void g_set_haproxy_trusted_ip(struct berval **ipaddress);
 struct berval **g_get_haproxy_trusted_ip(void);
+haproxy_trusted_entry_t *g_get_haproxy_trusted_ip_parsed(size_t *count_out);
 void disconnect_server(Connection *conn, PRUint64 opconnid, int opid, PRErrorCode reason, PRInt32 error);
 int send_ldap_search_entry(Slapi_PBlock *pb, Slapi_Entry *e, LDAPControl **ectrls, char **attrs, int attrsonly);
 void send_ldap_result(Slapi_PBlock *pb, int err, char *matched, char *text, int nentries, struct berval **urls);

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -223,7 +223,7 @@ g_set_haproxy_trusted_ip(struct berval **ipaddress)
                      "CRITICAL: Failed to parse trusted IPs into binary format. "
                      "This should have been caught during validation.\n");
         /* Free the temporary array and return without updating config */
-        for (int i = 0; haproxy_trusted_ip[i] != NULL; i++) {
+        for (size_t i = 0; haproxy_trusted_ip[i] != NULL; i++) {
             ber_bvfree(haproxy_trusted_ip[i]);
         }
         slapi_ch_free((void **)&haproxy_trusted_ip);

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -169,11 +169,19 @@ delete_haproxy_trusted_ip(struct berval **ipaddress)
     }
 }
 
+/*
+ * Set the haproxy trusted IP list.
+ *
+ * NOTE: This function must be called with CFG_LOCK_WRITE held by the caller.
+ * It directly modifies slapdFrontendConfig fields without acquiring locks.
+ */
 void
 g_set_haproxy_trusted_ip(struct berval **ipaddress)
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     struct berval **haproxy_trusted_ip = NULL;
+    haproxy_trusted_entry_t *parsed_entries = NULL;
+    size_t parsed_count = 0;
     int nTrustedIPs = 0;
 
     /* check to see if we want to delete all values */
@@ -181,6 +189,10 @@ g_set_haproxy_trusted_ip(struct berval **ipaddress)
         PL_strncasecmp((char *)ipaddress[0]->bv_val, HAPROXY_TRUSTED_IP_REMOVE_CMD, ipaddress[0]->bv_len) == 0) {
         delete_haproxy_trusted_ip(slapdFrontendConfig->haproxy_trusted_ip);
         slapdFrontendConfig->haproxy_trusted_ip = NULL;
+
+        /* Free parsed binary entries */
+        slapi_ch_free((void **)&slapdFrontendConfig->haproxy_trusted_ip_parsed);
+        slapdFrontendConfig->haproxy_trusted_ip_parsed_count = 0;
         return;
     }
 
@@ -199,15 +211,72 @@ g_set_haproxy_trusted_ip(struct berval **ipaddress)
         nTrustedIPs--;
     }
 
+    /* Parse IP addresses into binary format for runtime matching */
+    parsed_entries = haproxy_parse_trusted_ips(ipaddress, &parsed_count, NULL);
+
+    /*
+     * Parsing must succeed. If it fails, this indicates validation in config_set_haproxy_trusted_ip
+     * didn't catch an issue, or there's a logic error. This should never happen in production.
+     */
+    if (parsed_entries == NULL && parsed_count == 0 && ipaddress && ipaddress[0]) {
+        slapi_log_err(SLAPI_LOG_ERR, "g_set_haproxy_trusted_ip",
+                     "CRITICAL: Failed to parse trusted IPs into binary format. "
+                     "This should have been caught during validation.\n");
+        /* Free the temporary array and return without updating config */
+        for (int i = 0; haproxy_trusted_ip[i] != NULL; i++) {
+            ber_bvfree(haproxy_trusted_ip[i]);
+        }
+        slapi_ch_free((void **)&haproxy_trusted_ip);
+        return;
+    }
+
+    /* Free old parsed entries */
+    slapi_ch_free((void **)&slapdFrontendConfig->haproxy_trusted_ip_parsed);
+
+    /* Update configuration with new values */
     delete_haproxy_trusted_ip(slapdFrontendConfig->haproxy_trusted_ip);
     slapdFrontendConfig->haproxy_trusted_ip = haproxy_trusted_ip;
+    slapdFrontendConfig->haproxy_trusted_ip_parsed = parsed_entries;
+    slapdFrontendConfig->haproxy_trusted_ip_parsed_count = parsed_count;
 }
 
 struct berval **
 g_get_haproxy_trusted_ip()
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
-    return slapdFrontendConfig->haproxy_trusted_ip;
+    struct berval **retVal = NULL;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapdFrontendConfig->haproxy_trusted_ip;
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+/**
+ * Get parsed trusted IP entries in binary format.
+ *
+ * Returns the array of trusted IP entries that have been parsed from string
+ * format into binary network addresses and netmasks. These entries are used
+ * for efficient IP matching during connection validation.
+ *
+ * @param count_out: Optional output parameter for the number of entries
+ * @return: Array of parsed entries, or NULL if none configured
+ */
+haproxy_trusted_entry_t *
+g_get_haproxy_trusted_ip_parsed(size_t *count_out)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    haproxy_trusted_entry_t *retVal = NULL;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    if (count_out) {
+        *count_out = slapdFrontendConfig->haproxy_trusted_ip_parsed_count;
+    }
+    retVal = slapdFrontendConfig->haproxy_trusted_ip_parsed;
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
 }
 
 /*

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2529,7 +2529,9 @@ typedef struct _slapdFrontendConfig
     char *encryptionalias;
     char *errorlog;
     char *listenhost;
-    struct berval **haproxy_trusted_ip;
+    struct berval **haproxy_trusted_ip;                 /* LDAP config format (for dse.ldif/queries) */
+    haproxy_trusted_entry_t *haproxy_trusted_ip_parsed; /* Parsed binary format (for connection matching) */
+    size_t haproxy_trusted_ip_parsed_count;             /* Number of parsed entries */
     int snmp_index;
     char *localuser;
     char *localhost;

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn, isValidIpAddress, is_port_in_use } from "../tools.jsx";
+import { log_cmd, valid_dn, isValidIpAddress, isValidIpAddressOrCIDR, is_port_in_use } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -358,7 +358,7 @@ async validateSaveBtn(nav_tab, attr, value) {
             }
             if (attr === 'nsslapd-haproxy-trusted-ip') {
                 for (const ip of value) {
-                    if (value && !isValidIpAddress(ip)) {
+                    if (value && !isValidIpAddressOrCIDR(ip)) {
                         invalidIP = true;
                         disableSaveBtn = true;
                         break;
@@ -1644,10 +1644,10 @@ async validateSaveBtn(nav_tab, attr, value) {
                                         </GridItem>
                                     </Grid>
                                     <Grid
-                                        title="HAProxy header is only checked if this setting (nsslapd-haproxy-trusted-ip) is configured. It should have a list of trusted HAProxy server IPs"
+                                        title="HAProxy header is only checked if this setting (nsslapd-haproxy-trusted-ip) is configured. It should have a list of trusted HAProxy server IPs or subnets in CIDR notation (e.g., 192.168.1.0/24)"
                                     >
                                         <GridItem className="ds-label" span={3}>
-                                            Trusted HAProxy Server IPs
+                                            Trusted HAProxy Server IPs/Subnets
                                         </GridItem>
                                         <GridItem span={9}>
                             <TypeaheadSelect
@@ -1661,8 +1661,8 @@ async validateSaveBtn(nav_tab, attr, value) {
                                 options={[]}
                                 isOpen={this.state.isHaproxyIPsOpen}
                                 onToggle={this.handleOnHaproxyIPsToggle}
-                                placeholder="Type trusted HAProxy server IP address"
-                                ariaLabel="Type trusted HAProxy server IP address"
+                                placeholder="Type trusted HAProxy server IP or subnet (e.g., 192.168.1.0/24)"
+                                ariaLabel="Type trusted HAProxy server IP address or CIDR subnet"
                                 validated={this.state.invalidIP ? "error" : "default"}
                                 isMulti={true}
                                 isCreatable={true}
@@ -1670,7 +1670,7 @@ async validateSaveBtn(nav_tab, attr, value) {
                             />
                                             {(this.state.invalidIP) &&
                                                 <HelperText className="ds-left-margin">
-                                                    <HelperTextItem variant="error">Invalid format for IP address</HelperTextItem>
+                                                    <HelperTextItem variant="error">Invalid format for IP address or CIDR subnet</HelperTextItem>
                                                 </HelperText>}
                                         </GridItem>
                                     </Grid>

--- a/test/libslapd/haproxy/parse.c
+++ b/test/libslapd/haproxy/parse.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -127,7 +127,7 @@ void test_libslapd_haproxy_v1(void **state) {
 
         if (test_cases[i].expected_result == 0) {
             // slapi_log_error(SLAPI_LOG_ERR, "haproxy_parse_v1_hdr", "Expected pr_netaddr_from: ");
-            // slapi_log_prnetaddr(&test_cases[i].expected_pr_netaddr_from); 
+            // slapi_log_prnetaddr(&test_cases[i].expected_pr_netaddr_from);
             // slapi_log_error(SLAPI_LOG_ERR, "haproxy_parse_v1_hdr", "Actual pr_netaddr_from: ");
             // slapi_log_prnetaddr(&pr_netaddr_from);
 
@@ -209,7 +209,7 @@ void test_libslapd_haproxy_v2_invalid(void **state) {
         PRNetAddr pr_netaddr_from;
         PRNetAddr pr_netaddr_dest;
         char *str_to_test = tests[i].str ? tests[i].str : (char *) &tests[i].hdr_v2;
-        
+
         int result = haproxy_parse_v2_hdr(str_to_test, &tests[i].str_len, &proxy_connection, &pr_netaddr_from, &pr_netaddr_dest);
 
         assert_int_equal(result, tests[i].expected_result);
@@ -337,4 +337,355 @@ void test_libslapd_haproxy_v2_valid_local(void **state) {
 
     assert_int_equal(result, HAPROXY_HEADER_PARSED);
     assert_int_equal(proxy_connection, 0);
+}
+
+/* Test IPv4 subnet matching */
+void test_haproxy_ipv4_subnet_matching(void **state) {
+    PRNetAddr ip1, ip2, network;
+
+    (void)state; /* Unused */
+
+    /* Test /24 subnet */
+    PR_StringToNetAddr("192.168.1.50", &ip1);
+    PR_StringToNetAddr("192.168.1.0", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 24), 1);
+
+    /* Test IP outside /24 subnet */
+    PR_StringToNetAddr("192.168.2.50", &ip2);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip2.inet.ip, network.inet.ip, 24), 0);
+
+    /* Test /32 exact match */
+    PR_StringToNetAddr("192.168.1.0", &ip1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 32), 1);
+
+    /* Test /32 non-match */
+    PR_StringToNetAddr("192.168.1.1", &ip1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 32), 0);
+
+    /* Test /16 subnet */
+    PR_StringToNetAddr("192.168.0.0", &network);
+    PR_StringToNetAddr("192.168.255.255", &ip1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 16), 1);
+
+    /* Test /0 matches everything */
+    PR_StringToNetAddr("1.2.3.4", &ip1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 0), 1);
+}
+
+/* Test IPv6 subnet matching */
+void test_haproxy_ipv6_subnet_matching(void **state) {
+    PRNetAddr ip1, network;
+    struct in6_addr *ip_v6, *net_v6;
+
+    (void)state; /* Unused */
+
+    /* Test /64 subnet */
+    PR_StringToNetAddr("2001:db8::1234", &ip1);
+    PR_StringToNetAddr("2001:db8::", &network);
+    ip_v6 = (struct in6_addr *)&ip1.ipv6.ip;
+    net_v6 = (struct in6_addr *)&network.ipv6.ip;
+    assert_int_equal(haproxy_ipv6_in_subnet(ip_v6, net_v6, 64), 1);
+
+    /* Test IP outside /64 subnet */
+    PR_StringToNetAddr("2001:db9::1234", &ip1);
+    ip_v6 = (struct in6_addr *)&ip1.ipv6.ip;
+    assert_int_equal(haproxy_ipv6_in_subnet(ip_v6, net_v6, 64), 0);
+
+    /* Test /32 subnet */
+    PR_StringToNetAddr("2001:db8:abcd::1234", &ip1);
+    PR_StringToNetAddr("2001:db8::", &network);
+    ip_v6 = (struct in6_addr *)&ip1.ipv6.ip;
+    net_v6 = (struct in6_addr *)&network.ipv6.ip;
+    assert_int_equal(haproxy_ipv6_in_subnet(ip_v6, net_v6, 32), 1);
+
+    /* Test /128 exact match */
+    PR_StringToNetAddr("2001:db8::1", &ip1);
+    PR_StringToNetAddr("2001:db8::1", &network);
+    ip_v6 = (struct in6_addr *)&ip1.ipv6.ip;
+    net_v6 = (struct in6_addr *)&network.ipv6.ip;
+    assert_int_equal(haproxy_ipv6_in_subnet(ip_v6, net_v6, 128), 1);
+
+    /* Test /0 matches everything */
+    PR_StringToNetAddr("fe80::1", &ip1);
+    ip_v6 = (struct in6_addr *)&ip1.ipv6.ip;
+    assert_int_equal(haproxy_ipv6_in_subnet(ip_v6, net_v6, 0), 1);
+}
+
+/* Test trusted IP parsing and binary matching */
+void test_haproxy_trusted_ip_parsing(void **state) {
+    struct berval bv1 = {.bv_val = "192.168.1.0/24", .bv_len = 14};
+    struct berval bv2 = {.bv_val = "10.0.0.5", .bv_len = 8};
+    struct berval bv3 = {.bv_val = "2001:db8::/32", .bv_len = 13};
+    struct berval bv4 = {.bv_val = "fe80::1", .bv_len = 7};
+    struct berval *bvals[] = {&bv1, &bv2, &bv3, &bv4, NULL};
+    size_t count = 0;
+    char errorbuf[1024];
+    haproxy_trusted_entry_t *parsed;
+    PRNetAddr test_ip1, test_ip2, test_ip3, test_ip4, test_ip5, test_ip6, test_ip7;
+
+    (void)state; /* Unused */
+
+    /* Create test configuration with mixed IPs and subnets */
+
+    /* Parse into binary format */
+    parsed = haproxy_parse_trusted_ips(bvals, &count, errorbuf);
+
+    assert_non_null(parsed);
+    assert_int_equal(count, 4);
+
+    /* Verify parsed structure for IPv4 subnet */
+    assert_int_equal(parsed[0].is_subnet, 1);
+    assert_int_equal(parsed[0].prefix_len, 24);
+    assert_int_equal(parsed[0].network.raw.family, PR_AF_INET);
+
+    /* Verify parsed structure for IPv4 single IP */
+    assert_int_equal(parsed[1].is_subnet, 0);
+    assert_int_equal(parsed[1].prefix_len, -1);
+    assert_int_equal(parsed[1].network.raw.family, PR_AF_INET);
+
+    /* Verify parsed structure for IPv6 subnet */
+    assert_int_equal(parsed[2].is_subnet, 1);
+    assert_int_equal(parsed[2].prefix_len, 32);
+    assert_int_equal(parsed[2].network.raw.family, PR_AF_INET6);
+
+    /* Verify parsed structure for IPv6 single IP */
+    assert_int_equal(parsed[3].is_subnet, 0);
+    assert_int_equal(parsed[3].prefix_len, -1);
+    assert_int_equal(parsed[3].network.raw.family, PR_AF_INET6);
+
+    /* Test binary matching with parsed entries */
+
+    /* Test 1: IP in IPv4 subnet should match */
+    PR_StringToNetAddr("192.168.1.100", &test_ip1);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip1, parsed, count), 1);
+
+    /* Test 2: IP outside IPv4 subnet should not match */
+    PR_StringToNetAddr("192.168.2.100", &test_ip2);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip2, parsed, count), 0);
+
+    /* Test 3: Exact IPv4 match */
+    PR_StringToNetAddr("10.0.0.5", &test_ip3);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip3, parsed, count), 1);
+
+    /* Test 4: IP in IPv6 subnet should match */
+    PR_StringToNetAddr("2001:db8::1234", &test_ip4);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip4, parsed, count), 1);
+
+    /* Test 5: IP outside IPv6 subnet should not match */
+    PR_StringToNetAddr("2001:db9::1234", &test_ip5);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip5, parsed, count), 0);
+
+    /* Test 6: Exact IPv6 match */
+    PR_StringToNetAddr("fe80::1", &test_ip6);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip6, parsed, count), 1);
+
+    /* Test 7: IPv4-mapped IPv6 address normalization */
+    PR_StringToNetAddr("::ffff:192.168.1.50", &test_ip7);
+    /* Should match the 192.168.1.0/24 subnet after normalization */
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip7, parsed, count), 1);
+
+    /* Cleanup */
+    slapi_ch_free((void **)&parsed);
+}
+
+/* Test edge cases and error handling in parsing */
+void test_haproxy_parsing_edge_cases(void **state) {
+    size_t count = 0;
+    char errorbuf[1024];
+    haproxy_trusted_entry_t *parsed;
+    struct berval *empty[] = {NULL};
+    struct berval bv_8 = {.bv_val = "10.0.0.0/8", .bv_len = 10};
+    struct berval bv_16 = {.bv_val = "172.16.0.0/16", .bv_len = 13};
+    struct berval bv_32 = {.bv_val = "203.0.113.1/32", .bv_len = 14};
+    struct berval *prefixes[] = {&bv_8, &bv_16, &bv_32, NULL};
+    PRNetAddr test_ip;
+
+    (void)state; /* Unused */
+
+    /* Test NULL input */
+    parsed = haproxy_parse_trusted_ips(NULL, &count, errorbuf);
+    assert_null(parsed);
+    assert_int_equal(count, 0);
+
+    /* Test empty array */
+    parsed = haproxy_parse_trusted_ips(empty, &count, errorbuf);
+    assert_null(parsed);
+    assert_int_equal(count, 0);
+
+
+    /* Test various CIDR prefix lengths */
+    parsed = haproxy_parse_trusted_ips(prefixes, &count, errorbuf);
+    assert_non_null(parsed);
+    assert_int_equal(count, 3);
+
+    /* /8 should match wide range */
+    PR_StringToNetAddr("10.255.255.255", &test_ip);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip, parsed, count), 1);
+
+    /* /16 should match within range */
+    PR_StringToNetAddr("172.16.99.99", &test_ip);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip, parsed, count), 1);
+
+    /* Outside /16 */
+    PR_StringToNetAddr("172.17.0.1", &test_ip);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip, parsed, count), 0);
+
+    /* /32 exact match only */
+    PR_StringToNetAddr("203.0.113.1", &test_ip);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip, parsed, count), 1);
+
+    PR_StringToNetAddr("203.0.113.2", &test_ip);
+    assert_int_equal(haproxy_ip_matches_parsed(&test_ip, parsed, count), 0);
+
+    slapi_ch_free((void **)&parsed);
+}
+
+/* Test netmask precomputation during parsing */
+void test_haproxy_netmask_precomputation(void **state) {
+    struct berval bv1 = {.bv_val = "192.168.1.0/24", .bv_len = 14};
+    struct berval *bvals[] = {&bv1, NULL};
+    struct berval bv2 = {.bv_val = "2001:db8:abcd::/48", .bv_len = 18};
+    struct berval *bvals2[] = {&bv2, NULL};
+    struct berval bv3 = {.bv_val = "2001:db8::/33", .bv_len = 13};
+    struct berval *bvals3[] = {&bv3, NULL};
+    size_t count = 0;
+    char errorbuf[1024];
+    haproxy_trusted_entry_t *parsed;
+    uint32_t expected_mask;
+    int i;
+
+    (void)state; /* Unused */
+
+    /* IPv4 /24 netmask should be 0xFFFFFF00 (255.255.255.0) */
+    parsed = haproxy_parse_trusted_ips(bvals, &count, errorbuf);
+
+    assert_non_null(parsed);
+    assert_int_equal(count, 1);
+
+    /* Verify netmask was pre-computed */
+    expected_mask = htonl(0xFFFFFF00);
+    assert_int_equal(parsed[0].netmask.inet.ip, expected_mask);
+
+    slapi_ch_free((void **)&parsed);
+
+    /* IPv6 /48 netmask - first 6 bytes should be 0xFF, rest 0x00 */
+    parsed = haproxy_parse_trusted_ips(bvals2, &count, errorbuf);
+    assert_non_null(parsed);
+    assert_int_equal(count, 1);
+
+    /* Verify IPv6 netmask bytes */
+    for (i = 0; i < 6; i++) {
+        assert_int_equal(parsed[0].netmask.ipv6.ip.pr_s6_addr[i], 0xFF);
+    }
+    for (i = 6; i < 16; i++) {
+        assert_int_equal(parsed[0].netmask.ipv6.ip.pr_s6_addr[i], 0x00);
+    }
+
+    slapi_ch_free((void **)&parsed);
+
+    /* IPv6 /33 - partial byte mask (first 4 bytes + 1 bit) */
+    parsed = haproxy_parse_trusted_ips(bvals3, &count, errorbuf);
+    assert_non_null(parsed);
+
+    /* First 4 bytes should be 0xFF */
+    for (i = 0; i < 4; i++) {
+        assert_int_equal(parsed[0].netmask.ipv6.ip.pr_s6_addr[i], 0xFF);
+    }
+    /* 5th byte should be 0x80 (10000000 binary - 1 bit set) */
+    assert_int_equal(parsed[0].netmask.ipv6.ip.pr_s6_addr[4], 0x80);
+    /* Remaining bytes should be 0x00 */
+    for (i = 5; i < 16; i++) {
+        assert_int_equal(parsed[0].netmask.ipv6.ip.pr_s6_addr[i], 0x00);
+    }
+
+    slapi_ch_free((void **)&parsed);
+}
+
+/* Test CIDR string matching */
+void test_haproxy_ip_matches_cidr(void **state) {
+    (void)state; /* Unused */
+
+    /* IPv4 subnet matching */
+    assert_int_equal(haproxy_ip_matches_cidr("192.168.1.50", "192.168.1.0/24"), 1);
+    assert_int_equal(haproxy_ip_matches_cidr("192.168.2.50", "192.168.1.0/24"), 0);
+
+    /* IPv4 exact match (no CIDR) */
+    assert_int_equal(haproxy_ip_matches_cidr("10.0.0.1", "10.0.0.1"), 1);
+    assert_int_equal(haproxy_ip_matches_cidr("10.0.0.1", "10.0.0.2"), 0);
+
+    /* IPv6 subnet matching */
+    assert_int_equal(haproxy_ip_matches_cidr("2001:db8::1234", "2001:db8::/32"), 1);
+    assert_int_equal(haproxy_ip_matches_cidr("2001:db9::1234", "2001:db8::/32"), 0);
+
+    /* IPv6 exact match */
+    assert_int_equal(haproxy_ip_matches_cidr("fe80::1", "fe80::1"), 1);
+    assert_int_equal(haproxy_ip_matches_cidr("fe80::1", "fe80::2"), 0);
+
+    /* Case insensitivity for IPv6 */
+    assert_int_equal(haproxy_ip_matches_cidr("2001:DB8::1", "2001:db8::1"), 1);
+}
+
+/* Test IPv4 mask calculation edge cases and undefined behavior prevention */
+void test_haproxy_ipv4_mask_edge_cases(void **state) {
+    PRNetAddr ip1, ip2, network;
+
+    (void)state; /* Unused */
+
+    /* Test prefix_len = 0 (should match everything without undefined behavior) */
+    PR_StringToNetAddr("192.168.1.1", &ip1);
+    PR_StringToNetAddr("10.0.0.0", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 0), 1);
+
+    /* Test with completely different IPs - /0 should still match */
+    PR_StringToNetAddr("255.255.255.255", &ip1);
+    PR_StringToNetAddr("0.0.0.0", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 0), 1);
+
+    /* Test prefix_len = 32 (exact match only) */
+    PR_StringToNetAddr("192.168.1.1", &ip1);
+    PR_StringToNetAddr("192.168.1.1", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 32), 1);
+
+    /* Test prefix_len = 32 with different IPs */
+    PR_StringToNetAddr("192.168.1.2", &ip2);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip2.inet.ip, network.inet.ip, 32), 0);
+
+    /* Test prefix_len = 1 (half of all IPs) */
+    PR_StringToNetAddr("127.255.255.255", &ip1);
+    PR_StringToNetAddr("0.0.0.0", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 1), 1);
+
+    PR_StringToNetAddr("128.0.0.0", &ip2);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip2.inet.ip, network.inet.ip, 1), 0);
+
+    /* Test prefix_len = 31 (smallest non-trivial subnet) */
+    PR_StringToNetAddr("192.168.1.0", &network);
+    PR_StringToNetAddr("192.168.1.0", &ip1);
+    PR_StringToNetAddr("192.168.1.1", &ip2);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 31), 1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip2.inet.ip, network.inet.ip, 31), 1);
+
+    PR_StringToNetAddr("192.168.1.2", &ip1);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 31), 0);
+
+    /* Test invalid prefix lengths */
+    PR_StringToNetAddr("192.168.1.1", &ip1);
+    PR_StringToNetAddr("192.168.1.0", &network);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, -1), 0);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 33), 0);
+    assert_int_equal(haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, 255), 0);
+
+    /* Test various prefix lengths to ensure no undefined behavior */
+    PR_StringToNetAddr("10.0.0.0", &network);
+    for (int prefix = 0; prefix <= 32; prefix++) {
+        PR_StringToNetAddr("10.255.255.255", &ip1);
+        /* Should not crash or exhibit undefined behavior */
+        int result = haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, prefix);
+        /* For /8, 10.255.255.255 should match 10.0.0.0 */
+        if (prefix <= 8) {
+            assert_int_equal(result, 1);
+        } else if (prefix == 32) {
+            assert_int_equal(result, 0); /* Not exact match */
+        }
+    }
 }

--- a/test/libslapd/haproxy/parse.c
+++ b/test/libslapd/haproxy/parse.c
@@ -204,7 +204,7 @@ void test_libslapd_haproxy_v2_invalid(void **state) {
          0}
         };
 
-    for (int i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+    for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         int proxy_connection;
         PRNetAddr pr_netaddr_from;
         PRNetAddr pr_netaddr_dest;
@@ -680,7 +680,7 @@ void test_haproxy_ipv4_mask_edge_cases(void **state) {
     for (int prefix = 0; prefix <= 32; prefix++) {
         PR_StringToNetAddr("10.255.255.255", &ip1);
         /* Should not crash or exhibit undefined behavior */
-        int result = haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, prefix);
+        int result = haproxy_ipv4_in_subnet(ip1.inet.ip, network.inet.ip, (int)prefix);
         /* For /8, 10.255.255.255 should match 10.0.0.0 */
         if (prefix <= 8) {
             assert_int_equal(result, 1);

--- a/test/libslapd/test.c
+++ b/test/libslapd/test.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * Copyright (C) 2019 William Brown <william@blackhats.net.au>
  * All rights reserved.
  *
@@ -33,10 +33,19 @@ run_libslapd_tests(void)
         cmocka_unit_test(test_libslapd_filter_optimise),
         cmocka_unit_test(test_libslapd_pal_meminfo),
         cmocka_unit_test(test_libslapd_util_cachesane),
+        /* HAProxy header parsing tests */
         cmocka_unit_test(test_libslapd_haproxy_v1),
         cmocka_unit_test(test_libslapd_haproxy_v2_valid),
         cmocka_unit_test(test_libslapd_haproxy_v2_valid_local),
         cmocka_unit_test(test_libslapd_haproxy_v2_invalid),
+        /* HAProxy IP validation and subnet matching tests */
+        cmocka_unit_test(test_haproxy_ipv4_subnet_matching),
+        cmocka_unit_test(test_haproxy_ipv6_subnet_matching),
+        cmocka_unit_test(test_haproxy_trusted_ip_parsing),
+        cmocka_unit_test(test_haproxy_parsing_edge_cases),
+        cmocka_unit_test(test_haproxy_netmask_precomputation),
+        cmocka_unit_test(test_haproxy_ip_matches_cidr),
+        cmocka_unit_test(test_haproxy_ipv4_mask_edge_cases),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/test_slapd.h
+++ b/test/test_slapd.h
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  * Copyright (C) 2019 William Brown <william@blackhats.net.au>
  * All rights reserved.
  *
@@ -60,6 +60,13 @@ void test_libslapd_haproxy_v1(void **state);
 void test_libslapd_haproxy_v2_valid(void **state);
 void test_libslapd_haproxy_v2_valid_local(void **state);
 void test_libslapd_haproxy_v2_invalid(void **state);
+void test_haproxy_ipv4_subnet_matching(void **state);
+void test_haproxy_ipv6_subnet_matching(void **state);
+void test_haproxy_trusted_ip_parsing(void **state);
+void test_haproxy_parsing_edge_cases(void **state);
+void test_haproxy_netmask_precomputation(void **state);
+void test_haproxy_ip_matches_cidr(void **state);
+void test_haproxy_ipv4_mask_edge_cases(void **state);
 
 /* plugins */
 


### PR DESCRIPTION
Description: nsslapd-haproxy-trusted-ip now supports CIDR notation (192.168.0.0/24, 2001:db8::/32) instead of requiring individual IPs for each address in a subnet. This makes it practical to trust entire HAProxy network ranges without manually adding hundreds of entries.

The implementation includes CIDR parsing with validation, netmask precomputation for performance, and support for mixing individual IPs and subnets. Added comprehensive tests for subnet matching, edge cases, and malformed input validation. Updated Cockpit console UI accordingly.

Fixes: https://github.com/389ds/389-ds-base/issues/7069

Reviewed by: ?

## Summary by Sourcery

Add support for CIDR-based subnets to the HAProxy trusted IP feature, including parsing, validation, and optimized runtime matching; update configuration handling, UI, CLI, and tests to accommodate both individual IPs and subnets.

New Features:
- Allow nsslapd-haproxy-trusted-ip to accept CIDR notation for IPv4 and IPv6 subnets alongside individual IPs
- Expose binary parsed entries via g_get_haproxy_trusted_ip_parsed for efficient connection validation

Enhancements:
- Precompute and store network/netmask pairs for each trusted entry to speed up IP matching
- Switch runtime HAProxy header validation to use binary subnet matching instead of string comparisons
- Enforce stricter validation in config_set_haproxy_trusted_ip to reject malformed inputs (wildcards, extra slashes, whitespace, etc.)
- Refactor memory allocations to use slapi_ch_malloc and integrate parsed entries into frontend config

Documentation:
- Update Cockpit console validation and labels to accept and describe IP/subnet CIDR notation

Tests:
- Add cmocka unit tests for IPv4/IPv6 subnet logic, CIDR matching, netmask precomputation, and edge cases
- Add Python integration tests to cover valid and invalid CIDR configuration scenarios in server and dsconf CLI
- Update existing haproxy header parsing and CLI test suites to include subnet coverage

Chores:
- Bump copyright years across multiple source and test files to 2025