### PR TITLE
Issue 7073 - Add NDN cache size configuration and enforcement tests

### DIFF
--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -10,9 +10,11 @@
 import logging
 import pytest
 import os
+import ldap
 from lib389 import DirSrv, pid_from_file
 from lib389.dseldif import DSEldif
 from lib389.tasks import *
+from lib389.dbgen import dbgen_users
 from lib389.topologies import topology_m2, topology_st as topo
 from lib389.utils import *
 from lib389._constants import DN_CONFIG, DEFAULT_SUFFIX, DEFAULT_BENAME
@@ -502,6 +504,207 @@ def test_ndn_cache_enabled(topo):
     with pytest.raises(ldap.OPERATIONS_ERROR):
         topo.standalone.config.set('nsslapd-ndn-cache-max-size', 'invalid_value')
 
+def test_ndn_cache_max_size(topo):
+    """Test that nsslapd-ndn-cache-max-size correctly sets the cache size
+
+    :id: 1618cf36-5979-4826-9995-be0019d64818
+    :setup: Standalone instance
+    :steps:
+         1. Set cache to 10MB
+         2. Verify reported size accounts for entry-based rounding
+         3. Populate cache with searches
+         4. Verify size doesn't exceed limit
+         5. Change to 50MB
+         6. Verify new limit is respected
+         7. Test minimum value enforcement (1MB)
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+         6. This should be successful
+         7. This should be successful
+    """
+    inst = topo.standalone
+    config = inst.config
+    monitor = MonitorLDBM(inst)
+
+    NDN_ENTRY_AVG_SIZE = 168
+
+    log.info("Saving original cache config and enabling cache")
+    original_size = config.get_attr_val_utf8('nsslapd-ndn-cache-max-size')
+    config.set('nsslapd-ndn-cache-enabled', 'on')
+
+    log.info("Setting cache to 10MB")
+    config.set('nsslapd-ndn-cache-max-size', '10485760')
+    inst.restart()
+
+    max_size = int(monitor.get_attr_val_utf8('maxNormalizedDnCacheSize'))
+    expected = (10485760 // NDN_ENTRY_AVG_SIZE) * NDN_ENTRY_AVG_SIZE
+    log.info(f"Cache max size: {max_size} bytes (expected {expected})")
+    assert max_size == expected
+
+    log.info("Creating test users and performing searches")
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    test_users = [users.create_test_user(uid=1000 + i) for i in range(20)]
+    for user in test_users:
+        try:
+            user.get_attr_val_utf8('uid')
+        except:
+            pass
+
+    if monitor.present('currentNormalizedDnCacheSize'):
+        current = int(monitor.get_attr_val_utf8('currentNormalizedDnCacheSize'))
+        log.info(f"Current cache size: {current} bytes (max: {max_size})")
+        assert current <= max_size
+
+    log.info("Setting cache to 50MB")
+    config.set('nsslapd-ndn-cache-max-size', '52428800')
+    inst.restart()
+    max_size = int(monitor.get_attr_val_utf8('maxNormalizedDnCacheSize'))
+    expected = (52428800 // NDN_ENTRY_AVG_SIZE) * NDN_ENTRY_AVG_SIZE
+    log.info(f"New cache max size: {max_size} bytes (expected {expected})")
+    assert max_size == expected
+
+    log.info("Testing minimum value enforcement (setting to 500KB)")
+    config.set('nsslapd-ndn-cache-max-size', '500000')
+    inst.restart()
+    adjusted = int(monitor.get_attr_val_utf8('maxNormalizedDnCacheSize'))
+    min_expected = (1048576 // NDN_ENTRY_AVG_SIZE) * NDN_ENTRY_AVG_SIZE
+    log.info(f"Adjusted cache size: {adjusted} bytes (min expected: {min_expected})")
+    assert adjusted >= min_expected
+
+    log.info("Restoring original cache config")
+    config.set('nsslapd-ndn-cache-max-size', original_size)
+    inst.restart()
+    for user in test_users:
+        try:
+            user.delete()
+        except:
+            pass
+
+def test_ndn_cache_size_enforcement(topo, request):
+    """Test that nsslapd-ndn-cache-max-size actually enforces the cache size
+
+    :id: 08cdcce2-82e2-4f32-b083-e18bbddd06e2
+    :setup: Standalone instance
+    :steps:
+         1. Set small cache (2MB)
+         2. Import many entries
+         3. Verify evictions occur
+         4. Increase to large cache (200MB)
+         5. Verify more entries fit
+    :expectedresults:
+         1. This should be successful
+         2. This should be successful
+         3. This should be successful
+         4. This should be successful
+         5. This should be successful
+    """
+    inst = topo.standalone
+    config = inst.config
+    monitor = MonitorLDBM(inst)
+
+    NDN_ENTRY_AVG_SIZE = 168
+    TEST_CACHE_SIZE = 2097152  # 2MB
+
+    log.info("Setting up small cache (2MB)")
+    original_size = config.get_attr_val_utf8('nsslapd-ndn-cache-max-size')
+    config.set('nsslapd-ndn-cache-enabled', 'on')
+    config.set('nsslapd-ndn-cache-max-size', str(TEST_CACHE_SIZE))
+    inst.restart()
+
+    max_size = int(monitor.get_attr_val_utf8('maxNormalizedDnCacheSize'))
+    entry_capacity = max_size // NDN_ENTRY_AVG_SIZE
+    expected = (TEST_CACHE_SIZE // NDN_ENTRY_AVG_SIZE) * NDN_ENTRY_AVG_SIZE
+    log.info(f"Cache capacity: {entry_capacity} entries ({max_size} bytes)")
+    assert max_size == expected
+
+    # Generate and import entries (capacity + 1000)
+    num_users = entry_capacity + 1000
+    log.info(f"Generating {num_users} test users (cache capacity + 1000)")
+    ldif_dir = inst.get_ldif_dir()
+    import_ldif = os.path.join(ldif_dir, 'ndn_cache_test.ldif')
+    RDN = "ndnTestUser"
+    PARENT = f"ou=people,{DEFAULT_SUFFIX}"
+
+    dbgen_users(inst, num_users, import_ldif, DEFAULT_SUFFIX, entry_name=RDN, generic=True, parent=PARENT)
+
+    log.info("Importing LDIF")
+    import_task = ImportTask(inst)
+    import_task.import_suffix_from_ldif(ldiffile=import_ldif, suffix=DEFAULT_SUFFIX)
+    import_task.wait(timeout=400)
+    assert import_task.get_exit_code() == 0
+    inst.restart()
+
+    log.info("Performing searches to fill cache")
+    entries = inst.search_s(PARENT, ldap.SCOPE_SUBTREE, f"(uid={RDN}*)")
+    log.info(f"Found {len(entries)} entries, performing individual DN searches")
+
+    for i in range(1, min(num_users, entry_capacity * 2) + 1):
+        dn = f"uid={RDN}{str(i).zfill(len(str(num_users)))},{PARENT}"
+        try:
+            inst.search_s(dn, ldap.SCOPE_BASE, '(objectclass=*)', ['uid'])
+        except ldap.NO_SUCH_OBJECT:
+            pass
+
+    time.sleep(2)
+
+    current_count = int(monitor.get_attr_val_utf8('currentNormalizedDnCacheCount'))
+    current_size = int(monitor.get_attr_val_utf8('currentNormalizedDnCacheSize'))
+    evictions = int(monitor.get_attr_val_utf8('normalizedDnCacheEvictions')) if monitor.present('normalizedDnCacheEvictions') else 0
+
+    log.info(f"Small cache stats: {current_count}/{entry_capacity} entries, {evictions} evictions")
+    assert current_count <= entry_capacity
+    assert current_size <= max_size
+    assert current_size == current_count * NDN_ENTRY_AVG_SIZE
+    assert evictions > 0, "Cache should have evicted entries"
+
+    small_cache_count = current_count
+
+    log.info("Increasing cache to 200MB")
+    LARGE_CACHE_SIZE = TEST_CACHE_SIZE * 100
+    config.set('nsslapd-ndn-cache-max-size', str(LARGE_CACHE_SIZE))
+    inst.restart()
+
+    large_max_size = int(monitor.get_attr_val_utf8('maxNormalizedDnCacheSize'))
+    large_capacity = large_max_size // NDN_ENTRY_AVG_SIZE
+    log.info(f"Large cache capacity: {large_capacity} entries")
+    assert large_capacity > entry_capacity
+
+    log.info("Searching all entries with large cache")
+    for i in range(1, num_users + 1):
+        dn = f"uid={RDN}{str(i).zfill(len(str(num_users)))},{PARENT}"
+        try:
+            inst.search_s(dn, ldap.SCOPE_BASE, '(objectclass=*)', ['uid'])
+        except ldap.NO_SUCH_OBJECT:
+            pass
+
+    time.sleep(2)
+
+    large_count = int(monitor.get_attr_val_utf8('currentNormalizedDnCacheCount'))
+    large_size = int(monitor.get_attr_val_utf8('currentNormalizedDnCacheSize'))
+    log.info(f"Large cache stats: {large_count}/{large_capacity} entries (small cache had {small_cache_count})")
+
+    assert large_count <= large_capacity
+    assert large_size <= large_max_size
+    assert large_count >= small_cache_count
+
+    log.info("Restoring original cache config")
+    config.set('nsslapd-ndn-cache-max-size', original_size)
+    inst.restart()
+
+    def fin():
+        try:
+            config.set('nsslapd-ndn-cache-max-size', original_size)
+            inst.restart()
+        except:
+            pass
+        if os.path.exists(import_ldif):
+            os.remove(import_ldif)
+
+    request.addfinalizer(fin)
 
 def test_require_index(topo, request):
     """Validate that unindexed searches are rejected


### PR DESCRIPTION
Description: Adds two new tests for nsslapd-ndn-cache-max-size behavior:

test_ndn_cache_max_size verifies the cache size is correctly set and adjusts based on entry-based rounding;

test_ndn_cache_size_enforcement validates that the cache limit is actually enforced with evictions occurring when the cache fills. The enforcement test populates the cache with (capacity + 1000) entries to trigger evictions, then verifies behavior with a larger cache size. Tests cover size adjustments, minimum value enforcement, and eviction statistics monitoring.

Fixes: https://github.com/389ds/389-ds-base/issues/7073

Reviewed by: ?

## Summary by Sourcery

Add tests to validate nsslapd-ndn-cache-max-size configuration, rounding, minimum value enforcement, and eviction behavior under different cache sizes.

Tests:
- Add test_ndn_cache_max_size to verify cache size setting, entry-based rounding, dynamic limit adjustments, and minimum value enforcement.
- Add test_ndn_cache_size_enforcement to validate cache eviction behavior when filled under small and increased cache size scenarios.