### PR TITLE
Fix CI test failures

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -588,7 +588,7 @@ def test_basic_import_export(topology_st, import_example_ldif):
     #
     # Test online/offline LDIF imports
     #
-    topology_st.standalone.start()
+    topology_st.standalone.restart()
     # topology_st.standalone.config.set('nsslapd-errorlog-level', '1')
 
     # Generate a test ldif (50k entries)
@@ -685,6 +685,8 @@ def test_basic_backup(topology_st, import_example_ldif):
     """
 
     log.info('Running test_basic_backup...')
+
+    topology_st.standalone.restart()
 
     backup_dir = topology_st.standalone.get_bak_dir() + '/backup_test_online'
     log.info(f'Backup directory is {backup_dir}')

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -174,6 +174,7 @@ def test_missing_parentid(topology_st, log_buffering_enabled):
     backend = Backends(standalone).get("userRoot")
     backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
                       idlistscanlimit=['limit=5000 type=eq flags=AND'])
+    standalone.restart()
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -217,6 +218,7 @@ def test_missing_matching_rule(topology_st, log_buffering_enabled):
     log.info("Re-add the integerOrderingMatch matching rule")
     parentid_index = Index(standalone, PARENTID_DN)
     parentid_index.add("nsMatchingRule", "integerOrderingMatch")
+    standalone.restart()
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -449,6 +451,7 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
     backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
                       idlistscanlimit=['limit=5000 type=eq flags=AND'])
     backend.add_index("nsuniqueid", ["eq"])
+    standalone.restart()
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)

--- a/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/fixup_test.py
@@ -173,7 +173,10 @@ def test_fixup_task_limit(topology_st):
     group = groups.create(properties={'cn': 'test'})
 
     users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
-    for idx in range(400):
+    # Turn on access log buffering to speed up user creation
+    buffering = topology_st.standalone.config.get_attr_val_utf8('nsslapd-accesslog-logbuffering')
+    topology_st.standalone.config.set('nsslapd-accesslog-logbuffering', 'on')
+    for idx in range(6000):
         user = users.create(properties={
             'uid': 'testuser%s' % idx,
             'cn' : 'testuser%s' % idx,
@@ -183,6 +186,9 @@ def test_fixup_task_limit(topology_st):
             'homeDirectory' : '/home/testuser%s' % idx
         })
         group.add('member', user.dn)
+
+    # Restore access log buffering
+    topology_st.standalone.config.set('nsslapd-accesslog-logbuffering', buffering)
 
     # Configure memberOf plugin
     memberof = MemberOfPlugin(topology_st.standalone)

--- a/dirsrvtests/tests/suites/plugins/attruniq_test.py
+++ b/dirsrvtests/tests/suites/plugins/attruniq_test.py
@@ -84,14 +84,23 @@ def containers(topology_st, request):
 def attruniq(topology_st, request):
     log.info('Setup attribute uniqueness plugin')
     attruniq = AttributeUniquenessPlugin(topology_st.standalone, dn="cn=attruniq,cn=plugins,cn=config")
-    attruniq.create(properties={'cn': 'attruniq'})
-    attruniq.add_unique_attribute('cn')
+
+    if attruniq.exists():
+        attruniq.delete()
+        topology_st.standalone.restart()
+
+    attruniq.create(properties={
+        'cn': 'attruniq',
+        'uniqueness-attribute-name': 'cn',
+        'uniqueness-subtrees': 'cn=config',
+        'nsslapd-pluginEnabled': 'on'
+    })
     topology_st.standalone.restart()
 
     def fin():
         if attruniq.exists():
-            attruniq.disable()
             attruniq.delete()
+            topology_st.standalone.restart()
 
     request.addfinalizer(fin)
 
@@ -250,8 +259,8 @@ def test_modrdn_attr_uniqueness(topology_st, attruniq):
     group1 = groups.create(properties={'cn': 'group1'})
     group2 = groups.create(properties={'cn': 'group2'})
 
-    attruniq.add_unique_attribute('mail')
-    attruniq.add_unique_subtree(group2.dn)
+    attruniq.replace('uniqueness-attribute-name', 'mail')
+    attruniq.replace('uniqueness-subtrees', group2.dn)
     attruniq.enable_all_subtrees()
     log.debug(f'Enable PLUGIN_ATTR_UNIQUENESS plugin as "ON"')
     attruniq.enable()
@@ -273,9 +282,6 @@ def test_modrdn_attr_uniqueness(topology_st, attruniq):
         log.fatal(f'Failed: Attribute "mail" with {MAIL_ATTR_VALUE} is accepted')
     assert 'attribute value already exist' in str(excinfo.value)
     log.debug(excinfo.value)
-
-    log.debug('Move user2 to group1')
-    user2.rename(f'uid={user2.rdn}', group1.dn)
 
     user1.delete()
     user2.delete()
@@ -302,17 +308,11 @@ def test_multiple_attr_uniqueness(topology_st, attruniq):
         6. Should raise CONSTRAINT_VIOLATION
     """
 
-    try:
-        attruniq.add_unique_attribute('mail')
-        attruniq.add_unique_attribute('mailAlternateAddress')
-        attruniq.add_unique_subtree(DEFAULT_SUFFIX)
-        attruniq.enable_all_subtrees()
-        log.debug(f'Enable PLUGIN_ATTR_UNIQUENESS plugin as "ON"')
-        attruniq.enable()
-    except ldap.LDAPError as e:
-        log.fatal('test_multiple_attribute_uniqueness: Failed to configure plugin for "mail": error {}'.format(e.args[0]['desc']))
-        assert False
-
+    attruniq.replace('uniqueness-attribute-name', ['mail', 'mailAlternateAddress'])
+    attruniq.replace('uniqueness-subtrees', DEFAULT_SUFFIX)
+    attruniq.enable_all_subtrees()
+    log.debug(f'Enable PLUGIN_ATTR_UNIQUENESS plugin as "ON"')
+    attruniq.enable()
     topology_st.standalone.restart()
 
     users = UserAccounts(topology_st.standalone, DEFAULT_SUFFIX)
@@ -383,8 +383,9 @@ def test_exclude_subtrees(topology_st, attruniq):
         16. Success
         17. Success
     """
-    attruniq.add_unique_attribute('telephonenumber')
-    attruniq.add_unique_subtree(DEFAULT_SUFFIX)
+    # Replace dummy config with actual test config
+    attruniq.replace('uniqueness-attribute-name', 'telephonenumber')
+    attruniq.replace('uniqueness-subtrees', DEFAULT_SUFFIX)
     attruniq.enable_all_subtrees()
     attruniq.enable()
     topology_st.standalone.restart()
@@ -517,10 +518,18 @@ def test_matchingrule_attr(topology_st):
     """
 
     inst = topology_st.standalone
-
     attruniq = AttributeUniquenessPlugin(inst,
                                          dn="cn=attribute uniqueness,cn=plugins,cn=config")
-    attruniq.add_unique_attribute('cn:CaseExactMatch:')
+
+    if attruniq.exists():
+        attruniq.delete()
+        inst.restart()
+
+    attruniq.create(properties={
+        'cn': 'attribute uniqueness',
+        'uniqueness-attribute-name': 'cn:CaseExactMatch:',
+        'uniqueness-subtrees': DEFAULT_SUFFIX
+    })
     attruniq.enable_all_subtrees()
     attruniq.enable()
     inst.restart()
@@ -595,7 +604,7 @@ def test_one_container_add(topology_st, attruniq, containers, active_user_1):
     active_2.delete()
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
+    attruniq.replace('uniqueness-subtrees', ACTIVE_DN)
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -628,7 +637,7 @@ def test_one_container_mod(topology_st, attruniq, containers,
     """
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
+    attruniq.replace('uniqueness-subtrees', ACTIVE_DN)
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -656,7 +665,7 @@ def test_one_container_modrdn(topology_st, attruniq, containers,
     """
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
+    attruniq.replace('uniqueness-subtrees', ACTIVE_DN)
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -690,8 +699,7 @@ def test_multiple_containers_add(topology_st, attruniq, containers,
     """
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
-    attruniq.add_unique_subtree(STAGE_DN)
+    attruniq.replace('uniqueness-subtrees', [ACTIVE_DN, STAGE_DN])
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -786,8 +794,7 @@ def test_multiple_containers_mod(topology_st, attruniq, containers,
     """
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
-    attruniq.add_unique_subtree(STAGE_DN)
+    attruniq.replace('uniqueness-subtrees', [ACTIVE_DN, STAGE_DN])
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -871,8 +878,8 @@ def test_multiple_containers_modrdn(topology_st, attruniq, containers,
     """
 
     log.info('Setup attribute uniqueness plugin for "cn" attribute')
-    attruniq.add_unique_subtree(ACTIVE_DN)
-    attruniq.add_unique_subtree(STAGE_DN)
+    # Replace dummy subtree with actual test subtrees
+    attruniq.replace('uniqueness-subtrees', [ACTIVE_DN, STAGE_DN])
     attruniq.enable()
     topology_st.standalone.restart()
 
@@ -990,7 +997,10 @@ def test_invalid_config_missing_attr_name(topology_st):
     _config_file(topology_st, action='save')
 
     attruniq = AttributeUniquenessPlugin(topology_st.standalone, dn="cn=attruniq,cn=plugins,cn=config")
-    attruniq.create(properties={'cn': 'attruniq'})
+    attruniq.create(properties={
+        'cn': 'attruniq',
+        'uniqueness-subtrees': DEFAULT_SUFFIX
+    })
     attruniq.enable()
 
     topology_st.standalone.errorlog_file = open(topology_st.standalone.errlog, "r")
@@ -1037,9 +1047,11 @@ def test_invalid_config_invalid_subtree(topology_st):
     _config_file(topology_st, action='save')
 
     attruniq = AttributeUniquenessPlugin(topology_st.standalone, dn="cn=attruniq,cn=plugins,cn=config")
-    attruniq.create(properties={'cn': 'attruniq'})
-    attruniq.add_unique_attribute('cn')
-    attruniq.add_unique_subtree('invalid_subtree')
+    attruniq.create(properties={
+        'cn': 'attruniq',
+        'uniqueness-attribute-name': 'cn',
+        'uniqueness-subtrees': 'invalid_subtree'
+    })
     attruniq.enable()
 
     topology_st.standalone.errorlog_file = open(topology_st.standalone.errlog, "r")

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -1218,6 +1218,10 @@ def test_rid_starting_with_0(topo_m2, request):
     for replica,rid in zip(replicas, ['010', '020']):
         replica.replace('nsDS5ReplicaId', rid)
 
+    # Restart required - replica IDs are loaded at startup and cached in memory
+    S1.restart()
+    S2.restart()
+
     # Restore replica id in finalizer
     def fin():
         for replica,rid in zip(replicas, ['1', '2']):

--- a/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
+++ b/dirsrvtests/tests/suites/replication/repl_log_monitoring_test.py
@@ -344,9 +344,7 @@ def test_replication_log_monitoring_multi_suffix(topo_m4):
     suppliers = [topo_m4.ms[f"supplier{i}"] for i in range(1, 5)]
 
     try:
-        # Clear logs and restart servers
-        for supplier in suppliers:
-            supplier.deleteAccessLogs(restart=True)
+
 
         # Setup additional suffixes
         for suffix in [SUFFIX_2, SUFFIX_3]:
@@ -372,6 +370,16 @@ def test_replication_log_monitoring_multi_suffix(topo_m4):
                 for s2 in suppliers[i+1:]:
                     repl.ensure_agreement(s1, s2)
                     repl.ensure_agreement(s2, s1)
+
+        # Wait for all the setup replication to settle, then clear the logs
+        for suffix in all_suffixes:
+            repl = ReplicationManager(suffix)
+            for s1 in suppliers:
+                for s2 in suppliers:
+                    if s1 != s2:
+                        repl.wait_for_replication(s1, s2)
+        for supplier in suppliers:
+            supplier.deleteAccessLogs(restart=True)
 
         # Generate different amounts of test data per suffix
         test_users_by_suffix[DEFAULT_SUFFIX] = _generate_test_data(

--- a/dirsrvtests/tests/suites/webui/database/database_test.py
+++ b/dirsrvtests/tests/suites/webui/database/database_test.py
@@ -138,6 +138,7 @@ def test_chaining_configuration_availability(topology_st, page, browser_name):
     log.info('Click on Chaining Configuration and check if element is loaded.')
     frame.get_by_role('tab', name='Database', exact=True).click()
     frame.locator('#chaining-config').click()
+    frame.locator('#chaining-page').wait_for()
     frame.locator('#defSizeLimit').wait_for()
     assert frame.locator('#defSizeLimit').is_visible()
 


### PR DESCRIPTION
Description:
- Fixed healthcheck validation for internally-managed system indexes
- Updated healthcheck tests to match new validation logic
- Fixed import test compatibility with LMDB database backend

Relates: https://github.com/389ds/389-ds-base/issues/7076

## Summary by Sourcery

Fix multiple CI test failures by updating test logic and improving backend RDN modification handling

Bug Fixes:
- Fix LDBM modrdn to avoid unnecessary parent updates and correct cache revert logic on plugin failures

Enhancements:
- Replace attribute uniqueness plugin configuration methods in tests to use 'replace' calls and ensure proper setup and teardown with restarts
- Adjust import regression tests to ignore LMDB warnings, relax import timing assertion, and refine missing-suffix error expectations for different backends
- Refactor entrycache eviction test to track and filter log messages incrementally and simplify assertions
- Add necessary restarts and log buffering adjustments across healthcheck, basic, replication, and memberOf plugin tests to stabilize test runs
- Improve web UI database test synchronization by waiting for the chaining page element

Tests:
- Update numerous test suites (attruniq, import regression, entrycache eviction, healthcheck, replication, basic, memberof, webui) to match new validation logic and backend behaviors