### PR TITLE
Issue 7078 - audit json logging does not encode binary values

### DIFF
--- a/dirsrvtests/tests/suites/logging/audit_json_logging_test.py
+++ b/dirsrvtests/tests/suites/logging/audit_json_logging_test.py
@@ -1,11 +1,12 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import base64
 import logging
 import pytest
 import os
@@ -14,6 +15,7 @@ import re
 import time
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.topologies import topology_st as topo
+from lib389.idm.group import Groups, Group
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.dirsrv_log import DirsrvAuditJSONLog
 
@@ -164,6 +166,62 @@ def test_audit_json_logging(topo, setup_test):
     assert re.match(
         r'[0-9]{4}\-[0-9]{2}\-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
         event['local_time'])
+
+
+def test_audit_json_logging_with_binary_value(topo, setup_test):
+    """Test audit json logging is working with binary values
+
+    :id: 79870a11-907d-490c-8d9d-3ca242902966
+    :setup: Standalone Instance
+    :steps:
+        1. Get audit log event
+        2. Check nsState attribute is present
+        3. Check modifiersname attribute is present
+        4. Check nsState value is base64 encoded
+        5. Check modifiersname value is not base64 encoded
+        6. Add large binary value is correctly encoded
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+    inst = topo.standalone
+
+    event = get_log_event(inst, "cn=uniqueid generator,cn=config", "modify")
+    assert event['result'] == 0
+    assert event['modify'][0]['op'] == "replace"
+    assert event['modify'][0]['attr'] == "nsState"
+    assert event['modify'][1]['attr'] == "modifiersname"
+
+    # Decoding nsState should not raise an error
+    nsState_value = event['modify'][0]['values_encoded'][0]
+    assert base64.b64decode(nsState_value, validate=True)
+
+    # Decoding modifiersname should raise an error
+    modifersname_value = event['modify'][1]['values'][0]
+    with pytest.raises(base64.binascii.Error):
+        base64.b64decode(modifersname_value, validate=True)
+
+    # Add large binary value and mixed value
+    groups = Groups(inst, DEFAULT_SUFFIX, rdn=None)
+    group_properties = {
+        'cn': 'binary_group',
+        'description': 'testgroup for binary value',
+        'objectclass': ['nsValueItem', 'top', 'groupOfNames']}
+    test_group = groups.create(properties=group_properties)
+
+    # Add large binary value
+    bin_value_large = bytes([(i % 256) for i in range(2 * 512 * 512)])
+    test_group.add('nsValueBin', bin_value_large)
+    event = get_log_event(inst, test_group.dn, "modify")
+    assert event['result'] == 0
+    assert event['modify'][0]['op'] == "add"
+    assert event['modify'][0]['attr'] == "nsValueBin"
+    bin_value = event['modify'][0]['values_encoded'][0]
+    assert base64.b64decode(bin_value, validate=True)
 
 
 if __name__ == '__main__':

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -1082,6 +1082,7 @@ export class SearchDatabase extends React.Component {
                                         />
                                     </GridItem>
                                 </Grid>
+                                <hr />
                             </div>
                         </div>
                     </ExpandableSection>
@@ -1095,7 +1096,7 @@ export class SearchDatabase extends React.Component {
                         </TextContent>
                         <Spinner className="ds-margin-top-lg" size="xl" />
                     </div>
-                    <div className={searching ? "ds-hidden" : ""}>
+                    <div className={searching ? "ds-hidden" : "ds-margin-top"}>
                         <center>
                             <p><b>{_("Results:")}</b> {total}</p>
                         </center>

--- a/src/cockpit/389-console/src/lib/monitor/accesslog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/accesslog.jsx
@@ -80,7 +80,7 @@ export class AccessLogMonitor extends React.Component {
         this.setState({
             accessReloading: true
         });
-        
+
         // Use different command when "no-limit" is selected
         let cmd;
         if (this.state.accessLines === "no-limit") {
@@ -88,7 +88,7 @@ export class AccessLogMonitor extends React.Component {
         } else {
             cmd = ["tail", "-" + this.state.accessLines, this.props.logLocation];
         }
-        
+
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
@@ -97,8 +97,8 @@ export class AccessLogMonitor extends React.Component {
                         accessReloading: false
                     }));
                 })
-                .fail(() => {
-                    // Notification of failure (could only be server down)
+                .fail((err_msg) => {
+                    cockpit.error(err_msg);
                     this.setState({
                         accessReloading: false,
                     });
@@ -173,7 +173,7 @@ export class AccessLogMonitor extends React.Component {
                 <TextContent>
                     <Text component={TextVariants.h3}>
                         {_("Access Log")}
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh access log")}
                             onClick={this.handleRefreshAccessLog}

--- a/src/cockpit/389-console/src/lib/monitor/auditfaillog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/auditfaillog.jsx
@@ -51,7 +51,7 @@ export class AuditFailLogMonitor extends React.Component {
         this.setState({
             auditfailReloading: true
         });
-        
+
         // Use different command when "no-limit" is selected
         let cmd;
         if (this.state.auditfailLines === "no-limit") {
@@ -59,7 +59,7 @@ export class AuditFailLogMonitor extends React.Component {
         } else {
             cmd = ["tail", "-" + this.state.auditfailLines, this.props.logLocation];
         }
-        
+
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
@@ -67,6 +67,10 @@ export class AuditFailLogMonitor extends React.Component {
                         auditfaillogData: content,
                         auditfailReloading: false
                     }));
+                })
+                .fail((err_msg) => {
+                    cockpit.error(err_msg);
+                    this.setState({ auditfailReloading: false });
                 });
     }
 
@@ -167,7 +171,7 @@ export class AuditFailLogMonitor extends React.Component {
                 <TextContent>
                     <Text component={TextVariants.h3}>
                         {_("Audit Failure Log")}
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh audit failure log")}
                             onClick={this.handleRefreshAuditFailLog}

--- a/src/cockpit/389-console/src/lib/monitor/auditlog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/auditlog.jsx
@@ -50,7 +50,7 @@ export class AuditLogMonitor extends React.Component {
         this.setState({
             auditReloading: true
         });
-        
+
         // Use different command when "no-limit" is selected
         let cmd;
         if (this.state.auditLines === "no-limit") {
@@ -58,7 +58,7 @@ export class AuditLogMonitor extends React.Component {
         } else {
             cmd = ["tail", "-" + this.state.auditLines, this.props.logLocation];
         }
-        
+
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
@@ -66,6 +66,10 @@ export class AuditLogMonitor extends React.Component {
                         auditlogData: content,
                         auditReloading: false
                     }));
+                })
+                .fail((err_msg) => {
+                    cockpit.error(err_msg);
+                    this.setState({ auditReloading: false });
                 });
     }
 
@@ -166,7 +170,7 @@ export class AuditLogMonitor extends React.Component {
                 <TextContent>
                     <Text component={TextVariants.h3}>
                         {_("Audit Log")}
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh audit log")}
                             onClick={this.handleRefreshAuditLog}

--- a/src/cockpit/389-console/src/lib/monitor/errorlog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/errorlog.jsx
@@ -83,7 +83,7 @@ export class ErrorLogMonitor extends React.Component {
         } else {
             cmd = ["tail", "-" + this.state.errorLines, this.props.logLocation];
         }
-        
+
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(data => {
@@ -118,6 +118,10 @@ export class ErrorLogMonitor extends React.Component {
                         errorlogData: data,
                         errorReloading: false
                     }));
+                })
+                .fail((err_msg) => {
+                    cockpit.error(err_msg);
+                    this.setState({ errorReloading: false });
                 });
     }
 
@@ -254,7 +258,7 @@ export class ErrorLogMonitor extends React.Component {
                 <TextContent>
                     <Text component={TextVariants.h3}>
                         {_("Errors Log")}
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh error log")}
                             onClick={this.handleRefreshErrorLog}

--- a/src/cockpit/389-console/src/lib/monitor/securitylog.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/securitylog.jsx
@@ -80,7 +80,7 @@ export class SecurityLogMonitor extends React.Component {
         this.setState({
             securityReloading: true
         });
-        
+
         // Use different command when "no-limit" is selected
         let cmd;
         if (this.state.securityLines === "no-limit") {
@@ -88,7 +88,7 @@ export class SecurityLogMonitor extends React.Component {
         } else {
             cmd = ["tail", "-" + this.state.securityLines, this.props.logLocation];
         }
-        
+
         cockpit
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
@@ -97,8 +97,8 @@ export class SecurityLogMonitor extends React.Component {
                         securityReloading: false
                     }));
                 })
-                .fail(() => {
-                    // Notification of failure (could only be server down)
+                .fail((err_msg) => {
+                    cockpit.error(err_msg);
                     this.setState({
                         securityReloading: false,
                     });
@@ -173,7 +173,7 @@ export class SecurityLogMonitor extends React.Component {
                 <TextContent>
                     <Text component={TextVariants.h3}>
                         {_("Security Log")}
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh security log")}
                             onClick={this.handleRefreshSecurityLog}


### PR DESCRIPTION
Description:

Audit log does encode binary values, and this breaks the UI when it tries displaying the log contents. When the value is not "printable" base64 encode it.

Relates: https://github.com/389ds/389-ds-base/issues/7078

## Summary by Sourcery

Enable Base64 encoding of non-printable binary values in JSON audit logs, add a test for this behavior, and enhance console UI log viewers with error handling and formatting cleanup.

New Features:
- JSON audit logging now Base64 encodes non-printable binary attribute values
- Add test verifying binary values are Base64 encoded and printable values remain unchanged

Enhancements:
- Improve error handling in 389-console log monitor components by displaying cockpit.error on log retrieval failures
- Clean up trailing whitespace and standardize button JSX formatting in multiple log viewer components

Tests:
- Add audit_json_logging_with_binary_value test to validate proper encoding of binary values in audit logs