### PR TITLE
Issue 7084 - UI - schema - sorting attributes breaks expanded row

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseTables.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseTables.jsx
@@ -1215,6 +1215,7 @@ class VLVTable extends React.Component {
                             id={row.attrs.cn[0]}
                             icon={<TrashAltIcon />}
                             variant="link"
+                            size="sm"
                         >
                             {_("Delete")}
                         </Button>
@@ -1251,13 +1252,14 @@ class VLVTable extends React.Component {
                 </div>
                 <GridItem className="ds-label" span={1}>
                     <Button
-                        className="ds-margin-top"
+                        className="ds-indent ds-margin-bottom"
                         onClick={() => {
                             this.props.addSortFunc(row.attrs.cn[0]);
                         }}
-                        variant="primary"
+                        variant="secondary"
+                        size="sm"
                     >
-                        {_("Create Sort Index")}
+                        {_("Add Sort Index")}
                     </Button>
                 </GridItem>
             </Grid>

--- a/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
@@ -526,6 +526,7 @@ class AddVLVIndexModal extends React.Component {
     onTypeaheadChange(e, selection) {
         this.setState({
             sortValue: Array.isArray(selection) ? selection : [],
+            isVLVSortOpen: false,
         });
     }
 
@@ -535,6 +536,7 @@ class AddVLVIndexModal extends React.Component {
             handleChange,
             attrs,
             saving,
+            saveHandler,
         } = this.props;
         let saveBtnName = _("Create Sort Index");
         const extraPrimaryProps = {};
@@ -556,7 +558,7 @@ class AddVLVIndexModal extends React.Component {
                         key="confirm"
                         variant="primary"
                         onClick={() => {
-                            this.props.handleSave(this.state.sortValue);
+                            saveHandler(this.state.sortValue);
                         }}
                         isLoading={saving}
                         spinnerAriaValueText={saving ? _("Saving") : undefined}
@@ -575,19 +577,20 @@ class AddVLVIndexModal extends React.Component {
                         <GridItem className="ds-label" span={12}>
                             {_("Build a list of attributes to form the \"Sort\" index")}
                         </GridItem>
-                        <TypeaheadSelect
-                            selected={this.state.sortValue}
-                            onSelect={this.onTypeaheadChange}
-                            onClear={this.handleVLVSortClear}
-                            options={attrs}
-                            isOpen={this.state.isVLVSortOpen}
-                            onToggle={this.handleVLVSortToggle}
-                            placeholder={_("Type an attribute name ...")}
-                            noResultsText={_("There are no matching entries")}
-                            ariaLabel={_("Type an attribute names to create a sort index")}
-                            isMulti={true}
-                            className="ds-margin-top-lg"
-                        />
+                        <GridItem className="ds-margin-top" span={12}>
+                            <TypeaheadSelect
+                                selected={this.state.sortValue}
+                                onSelect={this.onTypeaheadChange}
+                                onClear={this.handleVLVSortClear}
+                                options={attrs}
+                                isOpen={this.state.isVLVSortOpen}
+                                onToggle={this.handleVLVSortToggle}
+                                placeholder={_("Type an attribute name ...")}
+                                noResultsText={_("There are no matching entries")}
+                                ariaLabel={_("Type an attribute names to create a sort index")}
+                                isMulti={true}
+                            />
+                        </GridItem>
                         <GridItem className="ds-margin-top-xlg" span={12}>
                             <Checkbox
                                 id="reindexVLV"

--- a/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
+++ b/src/cockpit/389-console/src/lib/schema/schemaTables.jsx
@@ -358,7 +358,8 @@ class AttributesTable extends React.Component {
                 1: this.state.rows[idx].cells[0].content,
                 2: this.state.rows[idx].cells[1].content,
                 3: this.state.rows[idx].cells[2].content,
-                not_user_defined: this.state.rows[idx].disableActions
+                not_user_defined: this.state.rows[idx].disableActions,
+                originalData: this.state.rows[idx].originalData
             });
         }
 
@@ -375,7 +376,8 @@ class AttributesTable extends React.Component {
                     { content: srow[2] },
                     { content: srow[3] }
                 ],
-                disableActions: srow.not_user_defined
+                disableActions: srow.not_user_defined,
+                originalData: srow.originalData
             });
             srow.expandedRow.parent = count;
             rows.push(srow.expandedRow);


### PR DESCRIPTION
Description:

When sorting attributes the expanded row is not properly set and it crashes the browser when trying to see it. The problem is that during sorting we are not transfering the "attribute data" to the new sorted row.

Relates: https://github.com/389ds/389-ds-base/issues/7084

Reviewed by: ?

## Summary by Sourcery

Bug Fixes:
- Transfer originalData to sorted rows and their expanded rows to avoid missing attribute data after sorting