### PR TITLE
Issue 7089 - Fix dsconf certificate list

### DIFF
--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -460,7 +460,7 @@ only.
             if line == 'Database needs user init':
                 # There are no certs, abort...
                 return []
-            cert_values.append(re.match(r'^(.+[^\s])[\s]+([^\s]+)$', line.rstrip()).groups())
+            cert_values.append(re.match(r'^(.*[^\s])[\s]+([^\s]+)$', line.rstrip()).groups())
         return cert_values
 
     def _openssl_get_csr_subject(self, csr_dir, csr_name):


### PR DESCRIPTION
Description:
Fixing regex matching for listing certificates to also match a single character certificate name instead of failing the 'dsconf security certificate list' command

Relates: #7089
Author: Lenka Doudova
Reviewer: ???

## Summary by Sourcery

Bug Fixes:
- Allow single-character certificate names in dsconf security certificate list by adjusting the regex