### PR TITLE
Issue 7091 - Duplicate local password policy entries listed

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -1522,8 +1522,8 @@ def test_get_pwpolicy_cn_with_quotes(topology_m1, policy_qoutes_setup):
     people.replace('passwordhistory', 'off')
     assert people.get_attr_val_utf8('passwordhistory') == 'off'
 
-def test_pwpolicy_list(topo):
-    """Verify duplicate local password polices are not listed when
+def test_pwpolicy_list(topo, request):
+    """Verify duplicate local password policies are not listed when
     all local password are listed
 
     :id: 480a3fae-8c0e-4033-806e-03bc572bf3df
@@ -1539,6 +1539,7 @@ def test_pwpolicy_list(topo):
         2. Success
         3. Success
         4. Success
+        5. Success
     """
     inst = topo.standalone
 
@@ -1590,6 +1591,15 @@ def test_pwpolicy_list(topo):
     # Verify there are no duplicates reported
     assert len(logged_output) == len(set(logged_output))
     topo.logcap.flush()
+
+    # Cleanup
+    def fin():
+        try:
+            backend_entry.delete()
+        except Exception:
+            pass
+
+    request.addfinalizer(fin)
 
 if __name__ == "__main__":
     CURRENT_FILE = os.path.realpath(__file__)

--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -13,7 +13,10 @@ This test script will test password policy.
 import os
 import pytest
 import time
+from lib389.backend import Backend
 from lib389.config import Config
+from lib389.cli_conf.pwpolicy import list_policies
+from lib389.cli_base import FakeArgs
 from lib389.topologies import topology_st as topo
 from lib389.topologies import topology_m1
 from lib389.idm.domain import Domain
@@ -1518,6 +1521,75 @@ def test_get_pwpolicy_cn_with_quotes(topology_m1, policy_qoutes_setup):
     people = policy_qoutes_setup.get_pwpolicy_entry(f'ou=people,{DEFAULT_SUFFIX}')
     people.replace('passwordhistory', 'off')
     assert people.get_attr_val_utf8('passwordhistory') == 'off'
+
+def test_pwpolicy_list(topo):
+    """Verify duplicate local password polices are not listed when
+    all local password are listed
+
+    :id: 480a3fae-8c0e-4033-806e-03bc572bf3df
+    :setup: Standalone
+    :steps:
+        1. Create a sub suffix
+        2. Verify sub suffix OU exists
+        3. Create pwp on sub suffix
+        4. List all local pwps
+        5. Verify no duplicates
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+    inst = topo.standalone
+
+    # Create a sub suffix
+    SUB_SUFFIX = 'dc=testSuffix,dc=example,dc=com'
+    props = {
+        'cn': 'testSuffix',
+        'nsslapd-suffix': SUB_SUFFIX,
+    }
+    be = Backend(topo.standalone)
+    backend_entry = be.create(properties=props)
+    backend_entry.create_sample_entries('001004002')
+
+    # Verify OU exists
+    ous = OrganizationalUnits(inst, SUB_SUFFIX)
+    people = ous.get("People")
+    assert people.exists()
+
+    # Create subtree pwp on sub suffix OU
+    policy_props = {
+        'passwordMustChange': 'off',
+        'passwordExp': 'off',
+        'passwordMinAge': '0',
+        'passwordChange': 'off',
+        'passwordStorageScheme': 'ssha',
+        'passwordminlength': '6'
+    }
+    pwp = PwPolicyManager(topo.standalone)
+    pwp.create_subtree_policy(people.dn, policy_props)
+    subtree_policy = pwp.get_pwpolicy_entry(people.dn)
+    assert subtree_policy.get_attr_val_utf8('passwordminlength') == '6'
+
+    # Capture policy listing
+    args = FakeArgs()
+    args.suffix = False
+    args.json = False
+    args.verbose = False
+    args.DN = None
+
+    topo.logcap.flush()
+    list_policies(inst, None, topo.logcap.log, args)
+    logged_output = []
+    for rec in topo.logcap.outputs:
+        msg = rec.getMessage()
+        for line in msg.splitlines():
+            if line.strip():
+                logged_output.append(line)
+
+    # Verify there are no duplicates reported
+    assert len(logged_output) == len(set(logged_output))
+    topo.logcap.flush()
 
 if __name__ == "__main__":
     CURRENT_FILE = os.path.realpath(__file__)

--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -91,6 +91,7 @@ def list_policies(inst, basedn, log, args):
     else:
         result = ""
 
+    seen_dns = set()
     for targetdn in targetdns:
         # Verify target dn exists before getting started
         user_entry = Account(inst, targetdn)
@@ -104,6 +105,11 @@ def list_policies(inst, basedn, log, args):
         attr_list = list(pwp_manager.arg_to_attr.values())
 
         for pwp_entry in pwp_entries.list():
+            # Filter duplicates because subtree search on parent suffix also returns
+            # policies from sub suffixes
+            if pwp_entry.dn in seen_dns:
+                continue
+            seen_dns.add(pwp_entry.dn)
             # Sometimes, the cn value includes quotes (for example, after migration from pre-CLI version).
             # We need to strip them as python-ldap doesn't expect them
             dn_comps_str = pwp_entry.get_attr_val_utf8_l('cn').strip("\'").strip("\"")


### PR DESCRIPTION
Bug description:
When listing local password policies, duplicate entries are shown if a subtree password policy exists under a sub suffix. The parent suffix search also returns the same policy, resulting in duplicates.

Fix description:
Add a check for duplicate policy entries when iterating over results from multiple suffixes.

Fixes: https://github.com/389ds/389-ds-base/issues/7091

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate local password policy entries by tracking seen DNs and skipping duplicates when listing policies across suffixes.