### PR TITLE
Issue 1793 - RFE - Implement dynamic lists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -365,7 +365,7 @@ serverplugin_LTLIBRARIES = libacl-plugin.la \
 	libattr-unique-plugin.la \
 	libautomember-plugin.la $(DB_IMPL) libchainingdb-plugin.la \
 	libcollation-plugin.la libcos-plugin.la libderef-plugin.la \
-	libpbe-plugin.la libdistrib-plugin.la \
+	libdynamic-lists-plugin.la libpbe-plugin.la libdistrib-plugin.la \
 	liblinkedattrs-plugin.la libmanagedentries-plugin.la \
 	libmemberof-plugin.la libpassthru-plugin.la libpwdstorage-plugin.la \
 	libcontentsync-plugin.la \
@@ -444,6 +444,7 @@ dist_noinst_HEADERS = \
 	ldap/servers/plugins/collation/orfilter.h \
 	ldap/servers/plugins/chainingdb/cb.h \
 	ldap/servers/plugins/deref/deref.h \
+	ldap/servers/plugins/dynamic_lists/dynamic_lists.h \
 	ldap/servers/plugins/acctpolicy/acctpolicy.h \
 	ldap/servers/plugins/posix-winsync/posix-wsp-ident.h \
 	ldap/servers/plugins/posix-winsync/posix-group-func.h \
@@ -1521,6 +1522,17 @@ libderef_plugin_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS)
 libderef_plugin_la_LIBADD = libslapd.la $(LDAPSDK_LINK) $(NSPR_LINK)
 libderef_plugin_la_DEPENDENCIES = libslapd.la
 libderef_plugin_la_LDFLAGS = -avoid-version
+
+#------------------------
+# libdynamic-lists-plugin
+#-----------------------
+libdynamic_lists_plugin_la_SOURCES = ldap/servers/plugins/dynamic_lists/dynamic_lists.c \
+    ldap/servers/plugins/dynamic_lists/dynamic_lists_config.c
+
+libdynamic_lists_plugin_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS)
+libdynamic_lists_plugin_la_LIBADD = libslapd.la
+libdynamic_lists_plugin_la_DEPENDENCIES = libslapd.la
+libdynamic_lists_plugin_la_LDFLAGS = -avoid-version
 
 #------------------------
 # libentryuuid-syntax-plugin

--- a/dirsrvtests/tests/suites/clu/dsconf_dynamic_lists_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_dynamic_lists_test.py
@@ -1,0 +1,423 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+"""Test dsconf CLI with Dynamic Lists plugin configuration"""
+
+import json
+import os
+import subprocess
+import logging
+import pytest
+from lib389._constants import DN_DM
+from lib389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+# Dynamic Lists plugin configuration options to test
+DYNAMIC_LISTS_SETTINGS = [
+    ('objectclass', 'GroupOfUrls'),
+    ('url-attr', 'MemberUrl'),
+    ('list-attr', 'uniquemember'),
+]
+
+
+def execute_dsconf_command(dsconf_cmd, subcommands):
+    """Execute dsconf command and return output and return code"""
+
+    cmdline = dsconf_cmd + subcommands
+    proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+
+    if proc.returncode != 0 and err:
+        log.error(f"Command failed: {' '.join(cmdline)}")
+        log.error(f"Stderr: {err.decode('utf-8')}")
+
+    return out.decode('utf-8'), proc.returncode
+
+
+def get_dsconf_base_cmd(topo):
+    """Return base dsconf command list"""
+    return ['/usr/sbin/dsconf', topo.standalone.serverid,
+            '-j', '-D', DN_DM, '-w', 'password', 'plugin', 'dynamic-lists']
+
+
+def test_dynamic_lists_plugin_status(topo):
+    """Test dynamic lists plugin status and basic operations
+
+    :id: 50be4d7a-3267-4d86-91e6-b6945dac54fa
+    :setup: Standalone DS instance
+    :steps:
+        1. Check plugin status
+        2. Enable plugin if needed
+        3. Verify plugin is enabled
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Check plugin status
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    log.info(f"Plugin status: {output}")
+
+    # Enable plugin if not already enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['enable'])
+    assert rc == 0
+    log.info(f"Plugin enable result: {output}")
+
+    # Verify plugin is enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'enabled'
+
+
+def test_dynamic_lists_plugin_get(topo):
+    """Test dynamic lists plugin get command
+
+    :id: 8bf18caf-ecca-41d0-a1c9-09f66febf540
+    :setup: Standalone DS instance
+    :steps:
+        1. Get plugin configuration
+    :expectedresults:
+        1. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    output, rc = execute_dsconf_command(dsconf_cmd, ['show'])
+    assert rc == 0
+    log.info(f"Plugin configuration: {output}")
+
+    # Parse JSON output to verify structure
+    json_result = json.loads(output)
+    assert json_result.get('type') == 'entry'
+
+
+@pytest.mark.parametrize("attr,value", DYNAMIC_LISTS_SETTINGS)
+def test_dynamic_lists_plugin_set(topo, attr, value):
+    """Test dynamic lists plugin set command with various configuration options
+
+    :id: 8e9fd0d8-bc96-43f0-8119-e18286a325e5
+    :setup: Standalone DS instance
+    :steps:
+        1. Set various dynamic lists plugin configuration options
+        2. Verify the setting was applied
+        3. Reset to default values
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Build the set command
+    set_cmd = ['set', f'--{attr}', value]
+
+    # Set the configuration
+    output, rc = execute_dsconf_command(dsconf_cmd, set_cmd)
+    assert rc == 0, f"Failed to set {attr}={value}: {output}"
+    log.info(f"Set {attr}={value} successfully")
+
+    # Verify the setting was applied by getting the configuration
+    output, rc = execute_dsconf_command(dsconf_cmd, ['show'])
+    assert rc == 0
+    json_result = json.loads(output)
+
+    # Check if the attribute was set correctly
+    # Map CLI argument names to LDAP attribute names
+    attr_map = {
+        'objectclass': 'dynamiclistobjectclass',
+        'url_attr': 'dynamiclisturlattr',
+        'list_attr': 'dynamiclistattr'
+    }
+    ldap_attr = attr_map.get(attr)
+    if ldap_attr and 'attrs' in json_result:
+        config_value = json_result['attrs'].get(ldap_attr)
+        if config_value:
+            if isinstance(config_value, list):
+                assert value in config_value or config_value[0] == value, \
+                    f"Expected {value} in {config_value}"
+            else:
+                assert config_value == value, f"Expected {value}, got {config_value}"
+
+    # Reset to default values (delete the attribute)
+    reset_cmd = ['set', f'--{attr}', 'delete']
+
+    output, rc = execute_dsconf_command(dsconf_cmd, reset_cmd)
+    # Some attributes might not be deletable, so we don't assert on return code
+    log.info(f"Reset {attr}: {output}")
+
+
+def test_dynamic_lists_config_entry_operations(topo):
+    """Test dynamic lists config-entry operations
+
+    :id: 4b13d427-3ec1-4991-aaf0-19274a970003
+    :setup: Standalone DS instance
+    :steps:
+        1. Add a config entry
+        2. Show the config entry
+        3. Edit the config entry
+        4. Delete the config entry
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    config_dn = 'cn=test-config,cn=dynamic lists,cn=plugins,cn=config'
+
+    # Add config entry
+    add_cmd = ['config-entry', 'add', config_dn,
+               '--objectclass', 'dynamicList',
+               '--url-attr', 'dynamicListURL',
+               '--list-attr', 'member']
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    assert rc == 0, f"Failed to add config entry: {output}"
+    log.info(f"Added config entry: {output}")
+
+    # Show config entry
+    show_cmd = ['config-entry', 'show', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show config entry: {output}"
+    log.info(f"Config entry details: {output}")
+
+    # Parse JSON to verify it was created correctly
+    json_result = json.loads(output)
+    assert json_result.get('type') == 'entry'
+    assert 'dynamiclistobjectclass' in json_result.get('attrs', {})
+    assert 'dynamiclisturlattr' in json_result.get('attrs', {})
+    assert 'dynamiclistattr' in json_result.get('attrs', {})
+
+    # Edit config entry
+    edit_cmd = ['config-entry', 'set', config_dn,
+                '--objectclass', 'GroupOfUrls',
+                '--url-attr', 'MemberUrl',
+                '--list-attr', 'uniqueMember']
+    output, rc = execute_dsconf_command(dsconf_cmd, edit_cmd)
+    assert rc == 0, f"Failed to edit config entry: {output}"
+    log.info(f"Edited config entry: {output}")
+
+    # Show config entry again to verify changes
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show updated config entry: {output}"
+    json_result = json.loads(output)
+    assert json_result['attrs']['dynamiclistobjectclass'][0] == 'GroupOfUrls'
+    assert json_result['attrs']['dynamiclisturlattr'][0] == 'MemberUrl'
+    assert json_result['attrs']['dynamiclistattr'][0] == 'uniqueMember'
+
+    # Delete config entry
+    delete_cmd = ['config-entry', 'delete', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, delete_cmd)
+    assert rc == 0, f"Failed to delete config entry: {output}"
+    log.info(f"Deleted config entry: {output}")
+
+
+@pytest.mark.parametrize("attr,value", DYNAMIC_LISTS_SETTINGS)
+def test_dynamic_lists_config_entry_set(topo, attr, value):
+    """Test dynamic lists config-entry set command with various configuration options
+
+    :id: 2dbcd6c5-1eb1-4d9a-964b-8dd471505ffa
+    :setup: Standalone DS instance
+    :steps:
+        1. Add a config entry with specific settings
+        2. Verify the settings were applied
+        3. Delete the config entry
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    config_dn = f'cn=test-config-{attr},cn=dynamic lists,cn=plugins,cn=config'
+
+    # Build the add command with all required attributes
+    add_cmd = ['config-entry', 'add', config_dn]
+    # Add all three attributes with default values if not the one being tested
+    if attr != 'objectclass':
+        add_cmd.extend(['--objectclass', 'GroupOfUrls'])
+    if attr != 'url_attr':
+        add_cmd.extend(['--url-attr', 'MemberUrl'])
+    if attr != 'list_attr':
+        add_cmd.extend(['--list-attr', 'uniqueMember'])
+    # Add the attribute being tested
+    add_cmd.extend([f'--{attr}', value])
+
+    # Add config entry
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    assert rc == 0, f"Failed to add config entry with {attr}={value}: {output}"
+    log.info(f"Added config entry with {attr}={value}")
+
+    # Show config entry to verify it worked
+    show_cmd = ['config-entry', 'show', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, show_cmd)
+    assert rc == 0, f"Failed to show config entry: {output}"
+    json_result = json.loads(output)
+
+    # Verify the setting was applied
+    attr_map = {
+        'objectclass': 'dynamiclistobjectclass',
+        'url_attr': 'dynamiclisturlattr',
+        'list_attr': 'dynamiclistattr'
+    }
+    config_attr = attr_map.get(attr)
+    if config_attr:
+        config_value = json_result['attrs'].get(config_attr)
+        if config_value:
+            if isinstance(config_value, list):
+                assert value in config_value or config_value[0] == value, \
+                    f"Expected {value} in {config_value}"
+            else:
+                assert config_value == value, f"Expected {value}, got {config_value}"
+
+    # Finally delete the config entry
+    delete_cmd = ['config-entry', 'delete', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, delete_cmd)
+    assert rc == 0, f"Failed to delete config entry: {output}"
+    log.info(f"Deleted config entry: {output}")
+
+
+def test_dynamic_lists_plugin_set_config_entry(topo):
+    """Test dynamic lists plugin set command with config-entry option
+
+    :id: e0b73edf-1c92-4152-a114-f6a40bd1507c
+    :setup: Standalone DS instance
+    :steps:
+        1. Add a config entry
+        2. Set the plugin's config-entry attribute to point to it
+        3. Verify the setting was applied
+        4. Clean up
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+    config_dn = 'cn=test-config-entry,cn=dynamic lists,cn=plugins,cn=config'
+
+    # Add config entry first
+    add_cmd = ['config-entry', 'add', config_dn,
+               '--objectclass', 'GroupOfUrls',
+               '--url-attr', 'MemberUrl',
+               '--list-attr', 'member']
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    assert rc == 0, f"Failed to add config entry: {output}"
+    log.info(f"Added config entry: {output}")
+
+    # Verify the setting was applied
+    output, rc = execute_dsconf_command(dsconf_cmd, ['show'])
+    assert rc == 0
+    json_result = json.loads(output)
+    if 'attrs' in json_result and 'nsslapd-pluginConfigArea' in json_result['attrs']:
+        config_area = json_result['attrs']['nsslapd-pluginConfigArea']
+        if isinstance(config_area, list):
+            assert config_dn in config_area, f"Expected {config_dn} in {config_area}"
+        else:
+            assert config_area == config_dn, f"Expected {config_dn}, got {config_area}"
+
+    # Clean up - delete config entry (this should also remove the reference)
+    delete_cmd = ['config-entry', 'delete', config_dn]
+    output, rc = execute_dsconf_command(dsconf_cmd, delete_cmd)
+    assert rc == 0, f"Failed to delete config entry: {output}"
+    log.info(f"Deleted config entry: {output}")
+
+
+def test_dynamic_lists_invalid_configurations(topo):
+    """Test dynamic lists plugin with invalid configurations
+
+    :id: 5e161ebe-490c-4d7e-8008-9fbb239c0b54
+    :setup: Standalone DS instance
+    :steps:
+        1. Test with invalid DN values
+        2. Test with missing required parameters
+    :expectedresults:
+        1. Should fail gracefully
+        2. Should fail gracefully
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Test with invalid DN in config entry
+    invalid_dn = 'invalid-dn-format'
+    add_cmd = ['config-entry', 'add', invalid_dn,
+               '--objectclass', 'GroupOfUrls',
+               '--url-attr', 'MemberUrl',
+               '--list-attr', 'uniqueMember']
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    # This should fail
+    assert rc != 0, f"Expected failure for invalid DN, but got success: {output}"
+    log.info(f"Invalid DN test failed as expected: {output}")
+
+    # Test with missing required parameters in config entry
+    config_dn = 'cn=test-invalid,cn=dynamic lists,cn=plugins,cn=config'
+    add_cmd = ['config-entry', 'add', config_dn]  # Missing required attributes
+    output, rc = execute_dsconf_command(dsconf_cmd, add_cmd)
+    # This should fail
+    assert rc != 0, f"Expected failure for missing required parameters, but got success: {output}"
+    log.info(f"Missing parameters test failed as expected: {output}")
+
+
+def test_dynamic_lists_plugin_disable_enable(topo):
+    """Test dynamic lists plugin disable and enable operations
+
+    :id: efebe757-d9ee-4658-a06b-cdb45dc1ce36
+    :setup: Standalone DS instance
+    :steps:
+        1. Disable the plugin
+        2. Verify plugin is disabled
+        3. Enable the plugin
+        4. Verify plugin is enabled
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+
+    dsconf_cmd = get_dsconf_base_cmd(topo)
+
+    # Disable plugin
+    output, rc = execute_dsconf_command(dsconf_cmd, ['disable'])
+    assert rc == 0, f"Failed to disable plugin: {output}"
+    log.info(f"Disabled plugin: {output}")
+
+    # Verify plugin is disabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'disabled'
+
+    # Enable plugin
+    output, rc = execute_dsconf_command(dsconf_cmd, ['enable'])
+    assert rc == 0, f"Failed to enable plugin: {output}"
+    log.info(f"Enabled plugin: {output}")
+
+    # Verify plugin is enabled
+    output, rc = execute_dsconf_command(dsconf_cmd, ['status'])
+    assert rc == 0
+    json_result = json.loads(output)
+    assert json_result.get('msg') == 'enabled'
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])
+

--- a/dirsrvtests/tests/suites/plugins/dynamic_lists_test.py
+++ b/dirsrvtests/tests/suites/plugins/dynamic_lists_test.py
@@ -1,0 +1,422 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import ldap
+from lib389._constants import *
+from lib389.topologies import topology_st as topo
+from lib389.plugins import DynamicListsPlugin
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups, Group
+from lib389.idm.organizationalunit import OrganizationalUnits
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def dynamic_lists_setup(topo, request):
+    log.info("Creating test users")
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    user_dns = []
+    num_users = 5
+
+    for i in range(1, num_users + 1):
+        user = users.create(properties={
+            'uid': f'testuser{i}',
+            'cn': f'testuser{i}',
+            'sn': f'User{i}',
+            'uidNumber': f'{1000 + i}',
+            'gidNumber': f'{1000 + i}',
+            'homeDirectory': f'/home/testuser{i}',
+        })
+        user_dns.append(user.dn)
+        log.info(f"Created user: {user.dn}")
+
+    def fin():
+        for user in users.list():
+            user.delete()
+    request.addfinalizer(fin)
+
+    return user_dns
+
+
+def test_dynamic_lists_memberurl_all_users(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list all users
+
+    :id: 6913fc98-fb22-4f21-817d-4cc19be1f1cd
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the dynamic lists plugin
+        2. Configure the plugin with objectclass, url_attr, and list_attr
+        3. Create a group with memberURL attribute containing LDAP URL with filter (uid=testuser*)
+        4. Search for the group and verify all users are listed as members
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should be configured successfully
+        3. Group should be created with memberURL successfully
+        4. All users should be listed as members of the group
+    """
+
+    inst = topo.standalone
+
+    user_dns = dynamic_lists_setup
+
+    # Step 1: Enable the dynamic lists plugin
+    log.info("Enabling dynamic lists plugin")
+    plugin = DynamicListsPlugin(inst)
+    plugin.enable()
+
+    # Step 2: Configure the plugin
+    log.info("Configuring dynamic lists plugin")
+    plugin.set_dynamiclistobjectclass('groupOfUrls')
+    plugin.set_dynamiclisturlattr('memberURL')
+    plugin.set_dynamiclistattr('member')
+
+    # Restart the server to apply plugin configuration
+    topo.standalone.restart()
+    assert plugin.status(), "Plugin should be enabled"
+
+    # Step 3: Create a group with memberURL attribute
+    log.info("Creating group with memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    group = groups.create(properties={
+        'cn': 'test_dynamic_group',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)',
+    })
+    group_dn = group.dn
+    log.info(f"Created group: {group_dn} with memberURL: ldap:///{DEFAULT_SUFFIX}??sub?(uid=*)")
+
+    print("MARK attached gdb")
+    import time
+    time.sleep(25)
+    # Step 4: Search for the group to trigger the plugin and verify all users
+    # are listed as members. The plugin processes memberURL during search
+    # operations and dynamically adds member attributes
+    log.info("Searching for group to trigger dynamic lists plugin")
+    members = group.list_members()
+    log.info(f"Found {len(members)} members in group")
+    log.info(f"Members: {members}")
+
+    # Verify all users are members
+    assert len(members) == 5, f"Expected {5} members, got {len(members)}. Members: {members}"
+    for user_dn in user_dns:
+        assert user_dn in members, f"User {user_dn} should be a member of the group. Members: {members}"
+
+    log.info("Test completed successfully - all users are listed as members")
+
+
+def test_dynamic_lists_non_dn_attribute(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list
+    all users homeDirectory attribute
+
+    :id: c44ebc24-4fd5-45f7-9699-b481527821f0
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the dynamic lists plugin
+        2. Configure the plugin with objectclass, url_attr, and list_attr
+        3. Create a group with memberURL attribute containing LDAP URL with
+           filter (uid=testuser*) and requested attribute (homeDirectory)
+        4. Search for the group and verify all users homeDirectory attribute
+           are listed in the entry
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should be configured successfully
+        3. Group should be created with memberURL successfully
+        4. All users homeDirectory attribute should be listed in the entry
+    """
+
+    inst = topo.standalone
+
+    # Step 1: Enable the dynamic lists plugin
+    log.info("Enabling dynamic lists plugin")
+    plugin = DynamicListsPlugin(inst)
+    plugin.enable()
+
+    # Step 2: Configure the plugin
+    log.info("Configuring dynamic lists plugin")
+    plugin.set_dynamiclistobjectclass('groupOfUrls')
+    plugin.set_dynamiclisturlattr('memberURL')
+    plugin.set_dynamiclistattr('member')
+
+    # Restart the server to apply plugin configuration
+    topo.standalone.restart()
+    assert plugin.status(), "Plugin should be enabled"
+
+    # Step 3: Create a group with memberURL attribute
+    log.info("Creating group with memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    group = groups.create(properties={
+        'cn': 'test_dynamic_group_2',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}?homeDirectory?sub?(uid=testuser*)',
+    })
+    group_dn = group.dn
+    log.info(f"Created group: {group_dn} with memberURL: ldap:///{DEFAULT_SUFFIX}?"
+             "homeDirectory?sub?(uid=testuser*)")
+
+    # Step 4: Search for the group to trigger the plugin and verify all
+    # homeDirectories are listed in the entry
+    values = group.get_attr_vals_utf8_l('homeDirectory')
+    assert len(values) == 5, f"Expected {5} values, got {len(values)}. Values: {values}"
+    for value in ['/home/testuser1', '/home/testuser2', '/home/testuser3',
+                  '/home/testuser4', '/home/testuser5']:
+        assert value in values, f"Value {value} should be listed in the group. Values: {values}"
+
+
+def test_dynamic_lists_shared_config_entry(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with shared config entry
+
+    :id: f3a6f01b-a25c-4435-a85c-394acd2c489e
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the dynamic lists plugin
+        2. Configure the plugin with shared config entry with different settings
+           than the plugin configuration
+        3. Create a group with memberURL attribute containing LDAP URL with filter (uid=testuser*)
+        4. Search for the group and verify all users are listed as members
+        5. Unconfigure the shared config entry
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should be configured successfully
+        3. Group should be created with memberURL successfully
+        4. All users should be listed as members of the group
+        5. Plugin should be configured with the plugin configuration
+    """
+
+    inst = topo.standalone
+    user_dns = dynamic_lists_setup
+
+    # Step 1: Enable the dynamic lists plugin
+    log.info("Enabling dynamic lists plugin")
+    plugin = DynamicListsPlugin(inst)
+    # Set values that should be ignored since we are going to use a shared
+    # config entry
+    plugin.set_dynamiclistobjectclass('applicationProcess')
+    plugin.set_dynamiclisturlattr('cn')
+    plugin.set_dynamiclistattr('targetDN')
+    plugin.enable()
+
+    # Step 2: Configure the plugin with shared config entry
+    log.info("Create shared config entry with the proper values")
+    groups = Groups(inst, DEFAULT_SUFFIX)
+    groups.create(properties={
+        'cn': 'dynamic_lists',
+        'objectClass': 'extensibleObject',
+        'cn': 'dynamic_lists',
+        'dynamicListObjectclass': 'groupOfUrls',
+        'dynamicListUrlAttr': 'memberUrl',
+        'dynamicListAttr': 'member',
+    })
+
+    log.info("Configuring dynamic lists plugin to use the shared config entry")
+    plugin.set_configarea('cn=dynamic_lists,ou=groups,' + DEFAULT_SUFFIX)
+
+    # Restart the server to apply plugin configuration
+    inst.restart()
+    assert plugin.status(), "Plugin should be enabled"
+
+    # Step 3: Create a group with memberURL attribute
+    log.info("Creating group with memberURL")
+
+    group = groups.create(properties={
+        'cn': 'test_dynamic_group_3',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)',
+    })
+    group_dn = group.dn
+    log.info(f"Created group: {group_dn} with memberURL: ldap:///{DEFAULT_SUFFIX}??sub?(uid=*)")
+
+    # Step 4: Search for the group to trigger the plugin and verify all users
+    # are listed as members. The plugin processes memberURL during search
+    # operations and dynamically adds member attributes
+    log.info("Searching for group to trigger dynamic lists plugin")
+    members = group.list_members()
+    log.info(f"Found {len(members)} members in group")
+    log.info(f"Members: {members}")
+
+    # Verify all users are members
+    assert len(members) == 5, f"Expected {5} members, got {len(members)}. Members: {members}"
+    for user_dn in user_dns:
+        assert user_dn in members, f"User {user_dn} should be a member of the group. Members: {members}"
+
+    # Unconfigure the shared config entry
+    log.info("Unconfiguring dynamic lists plugin to use the shared config entry")
+    plugin.remove_all('nsslapd-pluginConfigArea')
+    inst.restart()
+    assert plugin.status(), "Plugin should be enabled"
+
+    log.info("Test completed successfully - all users are listed as members")
+
+
+def test_dynamic_lists_invalid_values(topo):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list
+    all users homeDirectory attribute
+
+    :id: bbe98cdc-2255-45af-a40d-442d3995a388
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the dynamic lists plugin
+        2. Configure the plugin with non-existing objectclass
+        3. Configure the plugin with non-existing url_attr
+        4. Configure the plugin with non-existing list_attr
+        5. Configure the plugin with non-dn syntax attribute for list-attr
+        6. Configure the plugin with where url_attr and list_attr are the same
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should not be configured successfully
+        3. Plugin should not be configured successfully
+        4. Plugin should not be configured successfully
+        5. Plugin should not be configured successfully
+        6. Plugin should not be configured successfully
+    """
+
+    inst = topo.standalone
+
+    # Step 1: Enable the dynamic lists plugin
+    log.info("Enabling dynamic lists plugin")
+    plugin = DynamicListsPlugin(inst)
+    plugin.enable()
+    inst.restart()
+
+    # Step 2: Configure the plugin
+    log.info("Configuring dynamic lists plugin")
+    with pytest.raises(ldap.LDAPError) as e:
+        plugin.set_dynamiclistobjectclass('doesNotExist')
+
+    # Step 3: Configure the plugin with non-existing url_attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        plugin.set_dynamiclisturlattr('doesNotExist')
+
+    # Step 4: Configure the plugin with non-existing list_attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        plugin.set_dynamiclistattr('doesNotExist')
+
+    # Step 5: Configure the plugin with non-dn syntax attribute for list-attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        plugin.set_dynamiclistattr('cn')
+
+    # Step 6: Configure the plugin with where url_attr and list_attr are the same
+    plugin.set_dynamiclisturlattr('uniquemember')
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        plugin.set_dynamiclistattr('uniquemember')
+
+
+def test_dynamic_lists_multiple_memberurl(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with multiple memberURL attributes pointing to
+    different organizational units
+
+    :id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the dynamic lists plugin
+        2. Configure the plugin with objectclass, url_attr, and list_attr
+        3. Create a new organizational unit with one entry under it
+        4. Create a group (demo_group) with memberURL attribute pointing to DEFAULT_SUFFIX
+        5. Add an additional memberURL attribute to demo_group pointing to the new OU
+           with the same filter as the first memberURL
+        6. Search for the group and verify all users from both locations are listed as members
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should be configured successfully
+        3. Organizational unit and entry should be created successfully
+        4. Group should be created with first memberURL successfully
+        5. Second memberURL should be added successfully
+        6. All users from both locations should be listed as members of the group
+    """
+
+    inst = topo.standalone
+    user_dns = dynamic_lists_setup
+
+    # Step 1: Enable the dynamic lists plugin
+    log.info("Enabling dynamic lists plugin")
+    plugin = DynamicListsPlugin(inst)
+    plugin.enable()
+
+    # Step 2: Configure the plugin
+    log.info("Configuring dynamic lists plugin")
+    plugin.set_dynamiclistobjectclass('groupOfUrls')
+    plugin.set_dynamiclisturlattr('memberURL')
+    plugin.set_dynamiclistattr('member')
+
+    # Restart the server to apply plugin configuration
+    topo.standalone.restart()
+    assert plugin.status(), "Plugin should be enabled"
+
+    # Step 3: Create a new organizational unit with one entry under it
+    log.info("Creating new organizational unit")
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    test_ou = ous.create(properties={
+        'ou': 'TestOU',
+        'description': 'Test Organizational Unit for dynamic lists',
+    })
+    ou_dn = test_ou.dn
+    log.info(f"Created organizational unit: {ou_dn}")
+
+    # Create a user entry under the new OU
+    log.info("Creating user entry under the new OU")
+    ou_users = UserAccounts(inst, DEFAULT_SUFFIX, rdn="ou=TestOU")
+    ou_user = ou_users.create(properties={
+        'uid': 'testuser6',
+        'cn': 'testuser6',
+        'sn': 'User6',
+        'uidNumber': '1006',
+        'gidNumber': '1006',
+        'homeDirectory': '/home/testuser6',
+    })
+    ou_user_dn = ou_user.dn
+    log.info(f"Created user under OU: {ou_user_dn}")
+
+    # Step 4: Create a group (demo_group) with memberURL attribute pointing to DEFAULT_SUFFIX
+    log.info("Creating demo_group with first memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    demo_group = groups.create(properties={
+        'cn': 'demo_group_multiple',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)',
+    })
+    log.info(f"Created demo_group: {demo_group.dn} with memberURL: ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)")
+
+    # Step 5: Add an additional memberURL attribute to demo_group pointing to the new OU
+    # with the same filter as the first memberURL
+    log.info("Adding second memberURL to demo_group pointing to new OU")
+    second_memberurl = f'ldap:///{ou_dn}??sub?(uid=testuser*)'
+    demo_group.add('memberURL', second_memberurl)
+    log.info(f"Added second memberURL: {second_memberurl}")
+
+    # Step 6: Search for the group to trigger the plugin and verify all users
+    # from both locations are listed as members
+    log.info("Searching for group to trigger dynamic lists plugin")
+    members = demo_group.list_members()
+    log.info(f"Found {len(members)} members in group")
+    log.info(f"Members: {members}")
+
+    # Verify all users from DEFAULT_SUFFIX are members (5 users)
+    # Plus the one user from the new OU (1 user)
+    # Total should be 6 members
+    assert len(members) == 7, f"Expected {7} members, got {len(members)}. Members: {members}"
+
+    # Verify all users from DEFAULT_SUFFIX are members
+    for user_dn in user_dns:
+        assert user_dn in members, f"User {user_dn} should be a member of the group. Members: {members}"
+
+    # Verify the user from the new OU is a member
+    assert ou_user_dn in members, f"User {ou_user_dn} should be a member of the group. Members: {members}"
+
+    log.info("Test completed successfully - all users from both locations are listed as members")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -608,6 +608,21 @@ nsslapd-pluginVendor: anilech
 nsslapd-pluginVersion: 0.1
 nsslapd-pluginId: alias-entries
 
+dn: cn=Dynamic Lists,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+objectclass: extensibleObject
+cn: Dynamic Lists
+nsslapd-pluginpath: libdynamic-lists-plugin
+nsslapd-plugininitfunc: dynamic_lists_init
+nsslapd-plugintype: preoperation
+nsslapd-pluginenabled: off
+nsslapd-pluginDescription: dynamic lists plugin
+nsslapd-pluginId: dynamic-lists
+dynamicListObjectclass: groupOfUrls
+dynamicListUrlAttr: memberUrl
+dynamicListAttr: member
+
 dn: cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -1315,3 +1315,18 @@ nsslapd-pluginDescription: alias entries plugin [base search only]
 nsslapd-pluginVendor: anilech
 nsslapd-pluginVersion: 0.1
 nsslapd-pluginId: alias-entries
+
+dn: cn=Dynamic Lists,cn=plugins,cn=config
+objectclass: top
+objectclass: nsSlapdPlugin
+objectclass: extensibleObject
+cn: Dynamic Lists
+nsslapd-pluginpath: libdynamic-lists-plugin
+nsslapd-plugininitfunc: dynamic_lists_init
+nsslapd-plugintype: preoperation
+nsslapd-pluginenabled: off
+nsslapd-pluginDescription: dynamic lists plugin
+nsslapd-pluginId: dynamic-lists
+dynamicListObjectclass: groupOfUrls
+dynamicListUrlAttr: memberUrl
+dynamicListAttr: member

--- a/ldap/servers/plugins/dynamic_lists/dynamic_lists.c
+++ b/ldap/servers/plugins/dynamic_lists/dynamic_lists.c
@@ -1,0 +1,302 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2025 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+/*
+ * Dynamic Lists plug-in
+ */
+#include "dynamic_lists.h"
+
+/*
+ * Plug-in globals
+ */
+static void *_PluginID = NULL;
+static DynamicListsConfig listConfig = {0};
+static Slapi_PluginDesc pdesc = { DYNAMIC_LISTS_FEATURE_DESC,
+                                  VENDOR,
+                                  DS_PACKAGE_VERSION,
+                                  DYNAMIC_LISTS_PLUGIN_DESC };
+
+/*
+ * Plug-in management functions
+ */
+int dynamic_lists_init(Slapi_PBlock *pb);
+static int dynamic_lists_start(Slapi_PBlock *pb);
+static int dynamic_lists_close(Slapi_PBlock *pb);
+static int dynamic_lists_pre_entry(Slapi_PBlock *pb);
+
+/*
+ * Plugin identity functions
+ */
+void
+dynamic_lists_set_plugin_id(void *pluginID)
+{
+    _PluginID = pluginID;
+}
+
+void *
+dynamic_lists_get_plugin_id(void)
+{
+    return _PluginID;
+}
+
+/*
+ * Plug-in initialization functions
+ */
+int
+dynamic_lists_init(Slapi_PBlock *pb)
+{
+    int status = 0;
+    char *plugin_identity = NULL;
+
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "--> dynamic_lists_init\n");
+
+    /* Store the plugin identity for later use.
+     * Used for internal operations. */
+    slapi_pblock_get(pb, SLAPI_PLUGIN_IDENTITY, &plugin_identity);
+    PR_ASSERT(plugin_identity);
+    dynamic_lists_set_plugin_id(plugin_identity);
+
+    /* Register callbacks */
+    if (slapi_pblock_set(pb, SLAPI_PLUGIN_VERSION,
+                         SLAPI_PLUGIN_VERSION_01) != 0 ||
+        slapi_pblock_set(pb, SLAPI_PLUGIN_START_FN,
+                         (void *)dynamic_lists_start) != 0 ||
+        slapi_pblock_set(pb, SLAPI_PLUGIN_CLOSE_FN,
+                         (void *)dynamic_lists_close) != 0 ||
+        slapi_pblock_set(pb, SLAPI_PLUGIN_DESCRIPTION,
+                         (void *)&pdesc) != 0 ||
+        slapi_pblock_set(pb, SLAPI_PLUGIN_PRE_ENTRY_FN,
+                         (void *)dynamic_lists_pre_entry) != 0)
+    {
+        slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                      "dynamic_lists_init - Failed to register plugin\n");
+        status = -1;
+    }
+
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "<-- dynamic_lists_init\n");
+    return status;
+}
+
+
+/*
+ * dynamic_lists_start()
+ *
+ * Creates config lock and loads config cache.
+ */
+static int
+dynamic_lists_start(Slapi_PBlock *pb)
+{
+    int rc = 0;
+
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "--> dynamic_lists_start\n");
+
+    /* Load the config - config only reloaded at startup */
+    rc = dynamic_lists_load_config(pb, &listConfig);
+
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "<-- dynamic_lists_start (rc %d)\n", rc);
+
+    return rc;
+}
+
+/*
+ * dynamic_lists_close()
+ *
+ */
+static int
+dynamic_lists_close(Slapi_PBlock *pb __attribute__((unused)))
+{
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "--> dynamic_lists_close\n");
+
+    /* Free the config values */
+    slapi_ch_free_string(&listConfig.oc);
+    slapi_ch_free_string(&listConfig.URLAttr);
+    slapi_ch_free_string(&listConfig.attr);
+
+    slapi_log_err(SLAPI_LOG_TRACE, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                  "<-- dynamic_lists_close\n");
+
+    return 0;
+}
+
+/*
+  See if the client has the requested rights over the entry and the specified
+  attributes.  Each attribute in attrs will be tested.  The retattrs array will
+  hold the attributes that could be read.  If NULL, this means the entry is
+  not allowed, or none of the requested attributes are allowed.  If non-NULL, this
+  array can be passed to a subsequent search operation.
+*/
+static bool
+dynamic_lists_check_access(Slapi_PBlock *pb, Slapi_Entry *entry, const char *attr)
+{
+    if (slapi_access_allowed(pb, entry, (char *)attr, NULL, SLAPI_ACL_READ) != LDAP_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_PLUGIN, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                      "dynamic_lists_check_access - "
+                      "The client does not have permission to read attribute %s in entry %s\n",
+                      attr, slapi_entry_get_dn_const(entry));
+        return false;
+    }
+
+    return true;
+}
+
+
+/*
+ * dynamic_lists_pre_entry()
+ *
+ */
+static int
+dynamic_lists_pre_entry(Slapi_PBlock *pb)
+{
+    Slapi_PBlock *search_pb = NULL;
+    LDAPURLDesc *ludp = NULL;
+    Slapi_Value *oc_value = NULL;
+    const Slapi_Value **urls = NULL;
+    Slapi_Entry *list_entry = NULL;
+    Slapi_Entry **entries = NULL;
+    Slapi_Entry *dup_entry = NULL;
+    const char *url = NULL;
+    char *list_attr = NULL;
+    int secure = 0;
+    int rc = 0;
+
+    slapi_pblock_get(pb, SLAPI_SEARCH_ENTRY_ORIG, &list_entry);
+    slapi_pblock_get(pb, SLAPI_SEARCH_ENTRY_COPY, &dup_entry);
+
+    if (slapi_op_internal(pb)) {
+        /* We do not build dynamic content for internal operations*/
+        return rc;
+    }
+
+    /*
+     * Check if the entry has the configured dynamic list objectclass
+     */
+    oc_value = slapi_value_new_string(listConfig.oc);
+    if (slapi_entry_attr_has_syntax_value(list_entry, "objectclass", oc_value) == 0) {
+        /* Entry does not have the groupOfUrls objectclass */
+        slapi_value_free(&oc_value);
+        return rc;
+    }
+    slapi_value_free(&oc_value);
+
+
+    /* The entry could have multiple urls, so we need to loop here */
+    urls = slapi_entry_attr_get_valuearray(list_entry, listConfig.URLAttr);
+    for (size_t i = 0; urls && urls[i]; i++) {
+        Slapi_ValueSet *list_set = NULL;
+        url = slapi_value_get_string(urls[i]);
+        /*
+        * Parse the LDAP URL and validate it
+        */
+        if ((rc = slapi_ldap_url_parse(url, &ludp, 0, &secure)) != 0) {
+            /* Failed to parse the memberUrl attribute */
+            slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                          "dynamic_lists_pre_entry - %s - failed to parse the LDAP url: %s\n",
+                          slapi_entry_get_dn_const(list_entry), url);
+            goto cont;
+        }
+
+        if (ludp->lud_filter == NULL) {
+            slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                          "dynamic_lists_pre_entry - %s - Missing filter in LDAP URL %s\n",
+                          slapi_entry_get_dn_const(list_entry), url);
+            goto cont;
+        }
+
+        if (ludp->lud_dn == NULL) {
+            slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                          "dynamic_lists_pre_entry - %s - Missing base dn in LDAP URL %s\n",
+                          slapi_entry_get_dn_const(list_entry), url);
+            goto cont;
+        }
+
+        if (ludp->lud_attrs != NULL && ludp->lud_attrs[0] != NULL) {
+            /* If an attribute is specified use it */
+            list_attr = ludp->lud_attrs[0];
+        }
+
+        /*
+        * Check if the client has permission to read the list attribute
+        */
+        if (dynamic_lists_check_access(pb, list_entry,
+                                       list_attr ? list_attr : listConfig.attr) == false)
+        {
+            /* Access denied, so we can't proceed */
+            goto cont;
+        }
+
+        slapi_log_err(SLAPI_LOG_PLUGIN, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                      "dynamic_lists_pre_entry - %s (url: %s) - Performing internal search\n",
+                      slapi_entry_get_dn_const(list_entry), url);
+
+        /*
+        * Get our DN's groupOfUrls attribute
+        */
+        search_pb = slapi_pblock_new();
+        slapi_search_internal_set_pb(search_pb, ludp->lud_dn, ludp->lud_scope, ludp->lud_filter,
+                                     NULL, 0, NULL, NULL, dynamic_lists_get_plugin_id(), 0);
+        slapi_search_internal_pb(search_pb);
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+        if (LDAP_SUCCESS != rc) {
+            /* log an error and use the plugin entry for the config */
+            slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                          "dynamic_lists_pre_entry - "
+                          "%s - Internal search based on LDAP url (%s) failed: err=%d\n",
+                          slapi_entry_get_dn_const(list_entry), url, rc);
+            goto cont;
+        } else {
+            list_set = slapi_valueset_new();
+            slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+            for (size_t i = 0; entries && entries[i]; i++) {
+                if (list_attr == NULL) {
+                    /* No list attribute, so use the DN of the entry */
+                    const char *dn = slapi_entry_get_dn_const(entries[i]);
+                    slapi_valueset_add_value_ext(list_set, slapi_value_new_string(dn),
+                                                 SLAPI_VALUE_FLAG_PASSIN);
+                } else {
+                    /* Use an attribute/value from within the entry */
+                    const char *entry_list_attr = slapi_entry_attr_get_ref(entries[i],
+                                                                           list_attr);
+                    if (entry_list_attr) {
+                        slapi_valueset_add_value_ext(list_set,
+                                                     slapi_value_new_string(entry_list_attr),
+                                                     SLAPI_VALUE_FLAG_PASSIN);
+                    }
+                }
+            }
+        }
+        if (slapi_valueset_isempty(list_set) == 0) {
+            if (dup_entry == NULL) {
+                dup_entry = slapi_entry_dup(list_entry);
+            }
+            slapi_entry_add_valueset(dup_entry,
+                                     list_attr ? list_attr : listConfig.attr,
+                                     list_set);
+        }
+
+cont:
+        slapi_valueset_free(list_set);
+        slapi_free_search_results_internal(search_pb);
+        slapi_pblock_destroy(search_pb);
+        if (ludp != NULL) {
+            ldap_free_urldesc(ludp);
+        }
+    } /* end of URL loop */
+
+    slapi_pblock_set(pb, SLAPI_SEARCH_ENTRY_COPY, dup_entry);
+
+    return 0;
+}

--- a/ldap/servers/plugins/dynamic_lists/dynamic_lists.h
+++ b/ldap/servers/plugins/dynamic_lists/dynamic_lists.h
@@ -1,0 +1,51 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2025 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+/*
+ * Dynamic Lists plug-in header files
+ */
+#include "slapi-plugin.h"
+#include "slapi-private.h"
+
+/*
+ * Plug-in defines
+ */
+#define DYNAMIC_LISTS_OBJECTCLASS "groupOfUrls"
+#define DYNAMIC_LISTS_URL_ATTR "memberUrl"
+#define DYNAMIC_LISTS_LIST_ATTR "member"
+
+#define DYNAMIC_LISTS_PLUGIN_SUBSYSTEM "dynamic-lists-plugin"
+#define DYNAMIC_LISTS_FEATURE_DESC "Dynamic Lists"
+#define DYNAMIC_LISTS_PLUGIN_DESC "Dynamic Lists plugin"
+#define DYNAMIC_LISTS_INT_PREOP_DESC "Dynamic Lists internal preop plugin"
+#define DYNAMIC_LISTS_PREOP_DESC "Dynamic Lists preop plugin"
+
+/*
+ * Config settings
+ */
+ #define DYNAMIC_LIST_CONFIG_OC "dynamicListObjectclass"
+ #define DYNAMIC_LIST_CONFIG_URL_ATTR "dynamicListUrlAttr"
+ #define DYNAMIC_LIST_CONFIG_LIST_ATTR "dynamicListAttr"
+
+/* Dynamic config struct */
+typedef struct dynamic_lists_config
+{
+    char *oc;      /* objectclass to identify entry that has a dynamic list */
+    char *URLAttr; /* attribute that contains the URL of the dynamic list */
+    char *attr;    /* attribute used to store the values of the dynamic list */
+} DynamicListsConfig;
+
+/*
+ * function prototypes
+ */
+int dynamic_lists_load_config(Slapi_PBlock *pb, DynamicListsConfig *config);
+void * dynamic_lists_get_plugin_id(void);

--- a/ldap/servers/plugins/dynamic_lists/dynamic_lists_config.c
+++ b/ldap/servers/plugins/dynamic_lists/dynamic_lists_config.c
@@ -1,0 +1,192 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2025 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif
+
+ /*
+  * Dynamic Lists plug-in
+  */
+ #include "dynamic_lists.h"
+
+/*
+ * dynamic_lists_validate_config()
+ *
+ * Validates the configuration of the dynamic lists plugin.
+ */
+static int
+dynamic_lists_validate_config(Slapi_PBlock *pb, Slapi_Entry *entryBefore, Slapi_Entry *e,
+                              int *returncode, char *returntext, void *arg)
+{
+    const char *setting = NULL;
+    char *value = NULL;
+
+    setting = slapi_entry_attr_get_ref(e, DYNAMIC_LIST_CONFIG_OC);
+    if (setting) {
+        /* Check if this is a real objectclass */
+        if ((value = slapi_schema_get_superior_name(setting)) == NULL) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must be set "
+                        "to an existing objectclass (unknown: %s)",
+                        DYNAMIC_LIST_CONFIG_OC, setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        } else {
+            slapi_ch_free_string(&value);
+        }
+    }
+
+    setting = slapi_entry_attr_get_ref(e, DYNAMIC_LIST_CONFIG_URL_ATTR);
+    if (setting) {
+        /* Check if this is a real attribute */
+        if (!slapi_attr_syntax_exists(setting)) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must be set "
+                        "to an existing attribute (unknown: %s)",
+                        DYNAMIC_LIST_CONFIG_URL_ATTR, setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        }
+
+        /* Now make sure we are not using this attribute for the list attr */
+        const char *other_setting = slapi_entry_attr_get_ref(e, DYNAMIC_LIST_CONFIG_LIST_ATTR);
+        if (other_setting && strcasecmp(other_setting, setting) == 0) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must not be set "
+                        "to the same attribute as the %s configuration attribute (same: %s)",
+                        DYNAMIC_LIST_CONFIG_URL_ATTR, DYNAMIC_LIST_CONFIG_LIST_ATTR, other_setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        }
+    }
+
+    setting = slapi_entry_attr_get_ref(e, DYNAMIC_LIST_CONFIG_LIST_ATTR);
+    if (setting) {
+        /* Check if this is a real attribute with DN syntax */
+        if (!slapi_attr_syntax_exists(setting)) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must be set "
+                        "to an existing attribute with DN syntax (unknown %s)",
+                        DYNAMIC_LIST_CONFIG_LIST_ATTR, setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        }
+
+        /* Now check if it has DN syntax */
+        if (!slapi_attr_is_dn_syntax_type((char *)setting)) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must be set "
+                        "to an attribute with DN syntax (incorrect syntax: %s)",
+                        DYNAMIC_LIST_CONFIG_LIST_ATTR, setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        }
+
+        /* Now make sure we are not using this attribute for the URL attr */
+        const char *other_setting = slapi_entry_attr_get_ref(e, DYNAMIC_LIST_CONFIG_URL_ATTR);
+        if (other_setting && strcasecmp(other_setting, setting) == 0) {
+            PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "The %s configuration attribute must not be set "
+                        "to the same attribute as the %s configuration attribute (same: %s)",
+                        DYNAMIC_LIST_CONFIG_LIST_ATTR, DYNAMIC_LIST_CONFIG_URL_ATTR, other_setting);
+            *returncode = LDAP_UNWILLING_TO_PERFORM;
+            return SLAPI_DSE_CALLBACK_ERROR;
+        }
+    }
+
+    return SLAPI_DSE_CALLBACK_OK;
+}
+
+static void
+dynamic_lists_set_config(DynamicListsConfig *config, Slapi_Entry *config_entry)
+{
+    /* Future proof memory leaks for dynamic plugins */
+    slapi_ch_free_string(&config->oc);
+    slapi_ch_free_string(&config->URLAttr);
+    slapi_ch_free_string(&config->attr);
+
+    config->oc = slapi_entry_attr_get_charptr(config_entry, DYNAMIC_LIST_CONFIG_OC);
+    if (config->oc == NULL) {
+        config->oc = slapi_ch_strdup(DYNAMIC_LISTS_OBJECTCLASS);
+    }
+
+    config->URLAttr = slapi_entry_attr_get_charptr(config_entry, DYNAMIC_LIST_CONFIG_URL_ATTR);
+    if (config->URLAttr == NULL) {
+        config->URLAttr = slapi_ch_strdup(DYNAMIC_LISTS_URL_ATTR);
+    }
+
+    config->attr = slapi_entry_attr_get_charptr(config_entry, DYNAMIC_LIST_CONFIG_LIST_ATTR);
+    if (config->attr == NULL) {
+        config->attr = slapi_ch_strdup(DYNAMIC_LISTS_LIST_ATTR);
+    }
+}
+
+int
+dynamic_lists_load_config(Slapi_PBlock *pb, DynamicListsConfig *config)
+{
+    int rc = 0;
+    int result;
+    Slapi_PBlock *search_pb = NULL;
+    Slapi_Entry **entries = NULL;
+    Slapi_Entry *config_e = NULL;
+    const char *config_area = NULL;
+    const char *config_dn = NULL;
+
+    /* Set the alternate config area if one is defined. */
+    slapi_pblock_get(pb, SLAPI_PLUGIN_CONFIG_AREA, &config_area);
+    if (config_area) {
+        search_pb = slapi_pblock_new();
+        slapi_search_internal_set_pb(search_pb, config_area, LDAP_SCOPE_BASE, "objectclass=*",
+                                     NULL, 0, NULL, NULL, dynamic_lists_get_plugin_id(), 0);
+        slapi_search_internal_pb(search_pb);
+        slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_RESULT, &result);
+        if (LDAP_SUCCESS != result) {
+            if (result == LDAP_NO_SUCH_OBJECT) {
+                /* log an error and use the plugin entry for the config */
+                slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                              "dynamic_lists_load_config - Config entry \"%s\" does "
+                              "not exist.\n",
+                              config_area);
+                rc = -1;
+                goto bail;
+            }
+        } else {
+            slapi_pblock_get(search_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+            if (entries && entries[0]) {
+                config_e = entries[0];
+            } else {
+                slapi_log_err(SLAPI_LOG_ERR, DYNAMIC_LISTS_PLUGIN_SUBSYSTEM,
+                              "dynamic_lists_load_config - Config entry \"%s\" was "
+                              "not located.\n",
+                              config_area);
+                rc = -1;
+                goto bail;
+            }
+        }
+    } else {
+        /* The plugin entry itself contains the config */
+        if (slapi_pblock_get(pb, SLAPI_ADD_ENTRY, &config_e) != 0) {
+            rc = -1;
+            goto bail;
+        }
+    }
+
+    /* Register callbacks to validate config changes*/
+    config_dn = slapi_entry_get_dn_const(config_e);
+    slapi_config_register_callback_plugin(SLAPI_OPERATION_MODIFY, DSE_FLAG_PREOP | DSE_FLAG_PLUGIN,
+                                          config_dn, LDAP_SCOPE_BASE, "(objectclass=*)",
+                                          dynamic_lists_validate_config, NULL, pb);
+    dynamic_lists_set_config(config, config_e);
+
+bail:
+    slapi_free_search_results_internal(search_pb);
+    slapi_pblock_destroy(search_pb);
+
+    return rc;
+}

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -2889,16 +2889,16 @@ slapi_entry_attr_get_bool(const Slapi_Entry *e, const char *type)
     return slapi_entry_attr_get_bool_ext(e, type, PR_FALSE);
 }
 
-const struct slapi_value **
-slapi_entry_attr_get_valuearray(const Slapi_Entry *e, const char *attrname)
+const Slapi_Value **
+slapi_entry_attr_get_valuearray(const Slapi_Entry *e, const char *type)
 {
     Slapi_Attr *attr;
 
-    if (slapi_entry_attr_find(e, attrname, &attr) != 0) {
+    if (slapi_entry_attr_find(e, type, &attr) != 0) {
         return NULL;
     }
 
-    return (const struct slapi_value **)attr->a_present_values.va;
+    return (const Slapi_Value **)attr->a_present_values.va;
 }
 
 /*

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -1848,6 +1848,15 @@ PRBool slapi_entry_attr_get_bool(const Slapi_Entry *e, const char *type);
 PRBool slapi_entry_attr_get_bool_ext(const Slapi_Entry *e, const char *type, PRBool default_value);
 
 /**
+ * Gets a set of value of a given attribute of a given entry
+ *
+ * \param e Entry from which you want to get the values.
+ * \param type Attribute type from which you want to get the values.
+ * \return \c an array of Slapi_Value pointers
+ */
+const Slapi_Value **slapi_entry_attr_get_valuearray(const Slapi_Entry *e, const char *type);
+
+/**
  * Replaces the value or values of an attribute in an entry with a specified string
  * value.
  *

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -512,6 +512,33 @@ upgrade_pam_pta_default_config(void)
     return UPGRADE_SUCCESS;
 }
 
+static upgrade_status
+upgrade_dynamic_lists_plugin(void)
+{
+    char *entry = "dn: cn=Dynamic Lists,cn=plugins,cn=config\n"
+                  "objectclass: top\n"
+                  "objectclass: nsSlapdPlugin\n"
+                  "objectclass: extensibleObject\n"
+                  "cn: Dynamic Lists\n"
+                  "nsslapd-pluginpath: libdynamic-lists-plugin\n"
+                  "nsslapd-plugininitfunc: dynamic_lists_init\n"
+                  "nsslapd-plugintype: preoperation\n"
+                  "nsslapd-pluginenabled: off\n"
+                  "nsslapd-pluginId: dynamic-lists\n"
+                  "nsslapd-pluginVersion: none\n"
+                  "nsslapd-pluginVendor: 389 Project\n"
+                  "nsslapd-pluginDescription: dynamic lists plugin\n"
+                  "dynamicListObjectclass: groupOfUrls\n"
+                  "dynamicListUrlAttr: memberUrl\n"
+                  "dynamicListAttr: member\n";
+
+    return upgrade_entry_exists_or_create(
+        "upgrade_dynamic_lists_plugin",
+        "(cn=dynamic lists)",
+        "cn=dynamic lists,cn=plugins,cn=config",
+        entry
+    );
+}
 
 upgrade_status
 upgrade_server(void)
@@ -547,7 +574,11 @@ upgrade_server(void)
     if (upgrade_pam_pta_default_config() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
-    
+
+    if (upgrade_dynamic_lists_plugin() != UPGRADE_SUCCESS) {
+        return UPGRADE_FAILURE;
+    }
+
     return UPGRADE_SUCCESS;
 }
 

--- a/src/cockpit/389-console/src/lib/plugins/dynamicLists.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/dynamicLists.jsx
@@ -1,0 +1,780 @@
+import cockpit from "cockpit";
+import React, { useState, useEffect } from 'react';
+import {
+	Button,
+	Form,
+	FormHelperText,
+    FormSelect,
+    FormSelectOption,
+	Grid,
+	GridItem,
+	Modal,
+	ModalVariant,
+	TextInput,
+	ValidatedOptions
+} from '@patternfly/react-core';
+import PluginBasicConfig from "./pluginBasicConfig.jsx";
+import { log_cmd, valid_dn } from "../tools.jsx";
+import { DoubleConfirmModal } from "../notifications.jsx";
+
+const _ = cockpit.gettext;
+
+const DynamicLists = ({
+    rows = [],
+    serverId = "",
+    savePluginHandler,
+    pluginListHandler,
+    addNotification,
+    toggleLoadingHandler,
+    attributes = [],
+    objectClasses = [],
+}) => {
+    // Main plugin settings
+    const [settings, setSettings] = React.useState({
+        'objectclass': 'groupofurls',
+        'URLAttr': 'memberurl',
+        'listAttr': 'member',
+        'sharedConfigEntry': ''});
+    const [_settings, setOriginalSettings] = React.useState({
+        'objectclass': 'groupofurls',
+        'URLAttr': 'memberurl',
+        'listAttr': 'member',
+        'sharedConfigEntry': ''});
+    const [newEntry, setNewEntry] = React.useState(false);
+    // Main plugin state settings
+    const [saveBtnDisabled, setSaveBtnDisabled] = React.useState(true);
+    const [saving, setSaving] = React.useState(false);
+    const [dnAttrs, setDnAttrs] = React.useState([]);
+    const [urlAttrs, setUrlAttrs] = React.useState([]);
+    // Shared config settings
+    const [configSettings, setConfigSettings] = React.useState({
+        'objectclass': 'groupofurls',
+        'URLAttr': 'memberurl',
+        'listAttr': 'member'});
+    const [_configSettings, setOriginalConfigSettings] = React.useState({
+        'objectclass': 'groupofurls',
+        'URLAttr': 'memberurl',
+        'listAttr': 'member'});
+    const [configDN, setConfigDN] = React.useState('');
+    const [_configDN, setOriginalConfigDN] = React.useState('');
+    // Modal state settings
+    const [configEntryModalShow, setConfigEntryModalShow] = React.useState(false);
+    const [saveBtnDisabledModal, setSaveBtnDisabledModal] = React.useState(true);
+    const [modalSpinning, setModalSpinning] = React.useState(false);
+    const [modalChecked, setModalChecked] = React.useState(false);
+    const [showConfirmDelete, setShowConfirmDelete] = React.useState(false);
+    const [addSpinning, setAddSpinning] = React.useState(false);
+    const [dnAttrsConfig, setDnAttrsConfig] = React.useState([]);
+    const [urlAttrsConfig, setUrlAttrsConfig] = React.useState([]);
+
+    const dn_syntax_oids = ["1.3.6.1.4.1.1466.115.121.1.34", "1.3.6.1.4.1.1466.115.121.1.12"];
+
+    useEffect(() => {
+        updateFields();
+    }, [rows, serverId, attributes, objectClasses]);
+
+    useEffect(() => {
+        validateModal();
+    }, [configSettings.objectclass, configSettings.URLAttr,
+        configSettings.listAttr, configDN, _configDN]);
+
+    useEffect(() => {
+        validateConfig();
+    }, [settings.objectclass, settings.URLAttr,
+        settings.listAttr, settings.sharedConfigEntry]);
+
+    const setSetting = (key, value) => {
+        setSettings(prevSettings => ({
+            ...prevSettings,
+            [key]: value
+        }));
+
+    };
+    const setOriginalSetting = (key, value) => {
+        setOriginalSettings(prevSettings => ({
+            ...prevSettings,
+            [key]: value
+        }));
+    };
+
+    const setConfigSetting = (key, value) => {
+        setConfigSettings(prevConfigSettings => ({
+            ...prevConfigSettings,
+            [key]: value
+        }));
+    };
+
+    const setOriginalConfigSetting = (key, value) => {
+        setOriginalConfigSettings(prevConfigSettings => ({
+            ...prevConfigSettings,
+            [key]: value
+        }));
+    };
+
+    const handleShowConfirmDelete = () => {
+        setShowConfirmDelete(true);
+        setModalChecked(false);
+        setModalSpinning(false);
+    };
+
+    const closeConfirmDelete = () => {
+        setShowConfirmDelete(false);
+        setModalChecked(false);
+        setModalSpinning(false);
+    };
+
+    const validateConfig = () => {
+        let all_good = false;
+
+        // Check for value differences to see if the save btn should be enabled
+        const attrs = [
+            'objectclass', 'URLAttr', 'listAttr', 'nsslapd-pluginConfigArea'
+        ];
+        for (const check_attr of attrs) {
+            if (settings[check_attr] !== _settings[check_attr]) {
+                all_good = true;
+                break;
+            }
+        }
+
+        setSaveBtnDisabled(!all_good);
+
+        // Update the available attributes and objectclasses
+        const dnAttrs = attributes.filter(attr =>
+            (attr.syntax[0] === dn_syntax_oids[0] || attr.syntax[0] === dn_syntax_oids[1]) &&
+            attr.name !== undefined &&
+            attr.name[0].toLowerCase() !== settings.URLAttr.toLowerCase());
+        const urlAttrs = attributes.filter(attr =>
+            attr.name !== undefined &&
+            attr.name[0].toLowerCase() !== settings.listAttr.toLowerCase());
+        setDnAttrs(dnAttrs);
+        setUrlAttrs(urlAttrs);
+    };
+
+    const validateModal = () => {
+        let all_good = false;
+
+        // Check for value differences to see if the save btn should be enabled
+        const attrs = [
+            'objectclass', 'URLAttr', 'listAttr',
+        ];
+        for (const check_attr of attrs) {
+            if (configSettings[check_attr] !== _configSettings[check_attr]) {
+                all_good = true;
+                break;
+            }
+        }
+        if (configDN !== _configDN) {
+            all_good = true;
+        }
+
+        setSaveBtnDisabledModal(!all_good);
+
+        // Update the available attributes and objectclasses
+        const dnAttrsConfig = attributes.filter(attr =>
+            (attr.syntax[0] === dn_syntax_oids[0] || attr.syntax[0] === dn_syntax_oids[1]) &&
+            attr.name !== undefined &&
+            attr.name[0].toLowerCase() !== configSettings.URLAttr.toLowerCase());
+        const urlAttrsConfig = attributes.filter(attr =>
+            attr.name !== undefined &&
+            attr.name[0].toLowerCase() !== configSettings.listAttr.toLowerCase());
+        setDnAttrsConfig(dnAttrsConfig);
+        setUrlAttrsConfig(urlAttrsConfig);
+    };
+
+    const onChange = (e) => {
+        // Generic handler for things that don't need validating
+        const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+        setModalChecked(value);
+    };
+
+    const handleSaveConfig = () => {
+        let cmd = [
+            "dsconf",
+            "-j",
+            "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "plugin",
+            "dynamic-lists",
+            "set",
+            "--objectclass",
+            settings.objectclass || "delete",
+            "--url-attr",
+            settings.URLAttr || "delete",
+            "--list-attr",
+            settings.listAttr || "delete",
+            "--config-entry",
+            settings.sharedConfigEntry || "delete"
+        ];
+
+        setSaving(true);
+
+        log_cmd(
+            "handleSaveConfig",
+            `Save Dynamic Lists Plugin`,
+            cmd
+        );
+        cockpit
+                .spawn(cmd, {
+                    superuser: true,
+                    err: "message"
+                })
+                .done(content => {
+                    console.info("dynamicListsOperation", "Result", content);
+                    addNotification(
+                        "success",
+                        _("Successfully updated Dynamic Lists Plugin")
+                    );
+                    setSaving(false);
+                    setSaveBtnDisabled(true);
+                    pluginListHandler();
+                })
+                .fail(err => {
+                    let errMsg = JSON.parse(err);
+                    if ('info' in errMsg) {
+                        errMsg = errMsg.desc + " " + errMsg.info;
+                    } else {
+                        errMsg = errMsg.desc;
+                    }
+                    addNotification(
+                        "error", cockpit.format(_("Error during update - $0"), errMsg)
+                    );
+                    setSaving(false);
+                    setSaveBtnDisabled(true);
+                    pluginListHandler();
+                });
+    };
+
+    const handleOpenModal = () => {
+        if (!settings.sharedConfigEntry) {
+            setNewEntry(true);
+            setConfigEntryModalShow(true);
+            setSaveBtnDisabledModal(true);
+        } else {
+            const cmd = [
+                "dsconf",
+                "-j",
+                "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+                "plugin",
+                "dynamic-lists",
+                "config-entry",
+                "show",
+                settings.sharedConfigEntry
+            ];
+
+            log_cmd("handleOpenModal", "Fetch the shared config entry", cmd);
+            cockpit
+                    .spawn(cmd, {
+                        superuser: true,
+                        err: "message"
+                    })
+                    .done(content => {
+                        const pluginRow = JSON.parse(content).attrs;
+                        setConfigEntryModalShow(true);
+                        setSaveBtnDisabledModal(true);
+                        setNewEntry(false);
+                        setConfigDN(settings.sharedConfigEntry);
+                        setOriginalConfigDN(settings.sharedConfigEntry);
+                        setConfigSetting('configObjectclass',
+                            pluginRow["dynamiclistobjectclass"] === undefined
+                                ? "GroupOfUrls"
+                                : pluginRow["dynamiclistobjectclass"][0]
+                        );
+                        setOriginalConfigSetting('configObjectclass',
+                            pluginRow["dynamiclistobjectclass"] === undefined
+                                ? "GroupOfUrls"
+                                : pluginRow["dynamiclistobjectclass"][0]
+                        );
+                        setConfigSetting('configURLAttr',
+                            pluginRow["dynamiclisturlattr"] === undefined
+                                ? "MemberUrl"
+                                : pluginRow["dynamiclisturlattr"][0]
+                        );
+                        setOriginalConfigSetting('configURLAttr',
+                            pluginRow["dynamiclisturlattr"] === undefined
+                                ? "MemberUrl"
+                                : pluginRow["dynamiclisturlattr"][0]
+                        );
+                        setConfigSetting('configListAttr',
+                            pluginRow["dynamiclistattr"] === undefined
+                                ? "member"
+                                : pluginRow["dynamiclistattr"][0]
+                        );
+                        setOriginalConfigSetting('configListAttr',
+                            pluginRow["dynamiclistattr"] === undefined
+                                ? "member"
+                                : pluginRow["dynamiclistattr"][0]
+                        );
+
+                    })
+                    .fail(_ => {
+                        setConfigEntryModalShow(false);
+                        setNewEntry(true);
+                        setConfigDN("");
+                        setOriginalConfigDN("");
+                        setConfigSetting('configObjectclass', "GroupOfUrls");
+                        setOriginalConfigSetting('configObjectclass', "GroupOfUrls");
+                        setConfigSetting('configURLAttr', "MemberUrl");
+                        setOriginalConfigSetting('configURLAttr', "MemberUrl");
+                        setConfigSetting('configListAttr', "member");
+                        setOriginalConfigSetting('configListAttr', "member");
+                    });
+        }
+    };
+
+    const handleCloseModal = () => {
+        setConfigEntryModalShow(false);
+        setAddSpinning(false);
+        setModalSpinning(false);
+        setConfigDN("");
+        setOriginalConfigDN("");
+        setConfigSetting('configObjectclass', "GroupOfUrls");
+        setOriginalConfigSetting('configObjectclass', "GroupOfUrls");
+        setConfigSetting('configURLAttr', "MemberUrl");
+        setOriginalConfigSetting('configURLAttr', "MemberUrl");
+        setConfigSetting('configListAttr', "member");
+        setOriginalConfigSetting('configListAttr', "member");
+    };
+
+    const cmdConfigOperation = (action) => {
+        let cmd = [
+            "dsconf",
+            "-j",
+            "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "plugin",
+            "dynamic-lists",
+            "config-entry",
+            action,
+            configDN,
+            "--objectclass",
+            configSettings.objectclass || "delete",
+            "--url-attr",
+            configSettings.URLAttr || "delete",
+            "--list-attr",
+            configSettings.listAttr || "delete",
+        ];
+
+        setModalSpinning(true);
+
+        log_cmd(
+            "dynamicListsOperation",
+            `Do the ${action} operation on the Dynamic Lists Plugin`,
+            cmd
+        );
+        cockpit
+                .spawn(cmd, {
+                    superuser: true,
+                    err: "message"
+                })
+                .done(content => {
+                    console.info("dynamicListsOperation", "Result", content);
+                    addNotification(
+                        "success",
+                        cockpit.format(_("Config entry $0 was successfully $1"),
+                                       configDN, action + "ed")
+                    );
+                    pluginListHandler();
+                    handleCloseModal();
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    addNotification(
+                        "error",
+                        cockpit.format(_("Error during the config entry $0 operation $1: $2"),
+                                       configDN, action , errMsg.desc)
+                    );
+                    pluginListHandler();
+                    handleCloseModal();
+                });
+    };
+
+    const deleteConfig = () => {
+        const cmd = [
+            "dsconf",
+            "-j",
+            "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "plugin",
+            "dynamic-lists",
+            "config-entry",
+            "delete",
+            settings.sharedConfigEntry
+        ];
+        setModalSpinning(true);
+        log_cmd("deleteConfig", "Delete the Dynamic Lists Plugin config entry", cmd);
+        cockpit
+                .spawn(cmd, {
+                    superuser: true,
+                    err: "message"
+                })
+                .done(content => {
+                    console.info("deleteConfig", "Result", content);
+                    addNotification(
+                        "success",
+                        cockpit.format(_("Config entry $0 was successfully deleted"),
+                                       settings.sharedConfigEntry)
+                    );
+                    pluginListHandler();
+                    closeConfirmDelete();
+                    handleCloseModal();
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    addNotification(
+                        "error",
+                        cockpit.format(_("Error during the config entry removal operation - $0"),
+                                       settings.sharedConfigEntry, errMsg.desc)
+                    );
+                    pluginListHandler();
+                    closeConfirmDelete();
+                    handleCloseModal();
+                });
+    };
+
+    const handleAddConfig = () => {
+        cmdConfigOperation("add");
+    };
+
+    const handleEditConfig = () => {
+        cmdConfigOperation("set");
+    };
+
+    const updateFields = () => {
+        if (rows.length > 0) {
+            const pluginRow = rows.find(
+                row => row.cn[0].toLowerCase() === "dynamic lists"
+            );
+            if (pluginRow === undefined) {
+                // This shouln't happen, but if it does reset the fields
+                setDnAttrs([]);
+                setUrlAttrs([]);
+                setDnAttrsConfig([]);
+                setUrlAttrsConfig([]);
+                setConfigDN("");
+                setOriginalConfigDN("");
+                setConfigSetting('configObjectclass', "GroupOfUrls");
+                setOriginalConfigSetting('configObjectclass', "GroupOfUrls");
+                setConfigSetting('configURLAttr', "MemberUrl");
+                setOriginalConfigSetting('configURLAttr', "MemberUrl");
+                setConfigSetting('configListAttr', "member");
+                setOriginalConfigSetting('configListAttr', "member");
+                return;
+            }
+
+            setSetting('objectclass',
+                pluginRow["dynamiclistobjectclass"] === undefined
+                    ? "GroupOfUrls"
+                    : pluginRow["dynamiclistobjectclass"][0]
+            );
+            setOriginalSetting('objectclass', pluginRow["dynamiclistobjectclass"] === undefined
+                ? "GroupOfUrls"
+                : pluginRow["dynamiclistobjectclass"][0]);
+
+            setSetting('URLAttr', pluginRow["dynamiclisturlattr"] === undefined
+                ? "MemberUrl"
+                : pluginRow["dynamiclisturlattr"][0]);
+            setOriginalSetting('URLAttr', pluginRow["dynamiclisturlattr"] === undefined
+                ? "MemberUrl"
+                : pluginRow["dynamiclisturlattr"][0]);
+
+            setSetting('listAttr', pluginRow["dynamiclistattr"] === undefined
+                ? "member"
+                : pluginRow["dynamiclistattr"][0]);
+            setOriginalSetting('listAttr', pluginRow["dynamiclistattr"] === undefined
+                ? "member"
+                : pluginRow["dynamiclistattr"][0]);
+
+            setSetting('sharedConfigEntry', pluginRow["nsslapd-pluginConfigArea"] === undefined
+                ? ""
+                : pluginRow["nsslapd-pluginConfigArea"][0]);
+            setOriginalSetting('sharedConfigEntry', pluginRow["nsslapd-pluginConfigArea"] === undefined
+                ? ""
+                : pluginRow["nsslapd-pluginConfigArea"][0]);
+
+            const dnAttrs = attributes.filter(attr =>
+                (attr.syntax[0] === dn_syntax_oids[0] || attr.syntax[0] === dn_syntax_oids[1]) &&
+                attr.name !== undefined &&
+                attr.name[0].toLowerCase() !== settings.URLAttr.toLowerCase());
+            const urlAttrs = attributes.filter(attr =>
+                attr.name !== undefined &&
+                attr.name[0].toLowerCase() !== settings.listAttr.toLowerCase());
+            setDnAttrs(dnAttrs);
+            setUrlAttrs(urlAttrs);
+        }
+    };
+
+    return (
+        <div className={saving || addSpinning || modalSpinning ? "ds-disabled" : ""}>
+            <Modal
+                variant={ModalVariant.medium}
+                title={_("Manage Dynamic Lists Plugin Shared Config Entry")}
+                isOpen={configEntryModalShow}
+                aria-labelledby="ds-modal"
+                onClose={handleCloseModal}
+                actions={
+                    !newEntry ? [
+                        <Button
+                            key="del"
+                            variant="primary"
+                            onClick={handleShowConfirmDelete}
+                        >
+                            {_("Delete Config")}
+                        </Button>,
+                        <Button
+                            key="save"
+                            variant="primary"
+                            onClick={handleEditConfig}
+                            isDisabled={saveBtnDisabledModal ||
+                                        modalSpinning ||
+                                        !valid_dn(configDN)}
+                            isLoading={modalSpinning}
+                            spinnerAriaValueText={modalSpinning ? _("Saving") : undefined}
+                        >
+                            {modalSpinning ? _("Saving ...") : _("Save Config")}
+                        </Button>,
+                        <Button key="cancel" variant="link" onClick={handleCloseModal}>
+                            {_("Cancel")}
+                        </Button>
+                    ] : [
+                        <Button
+                            key="add"
+                            variant="primary"
+                            onClick={handleAddConfig}
+                            isDisabled={saveBtnDisabledModal ||
+                                        modalSpinning ||
+                                        !valid_dn(configDN)}
+                            isLoading={modalSpinning}
+                            spinnerAriaValueText={modalSpinning ? _("Adding") : undefined}
+                        >
+                            {modalSpinning ? _("Adding ...") : _("Add Config")}
+                        </Button>,
+                        <Button key="cancel" variant="link" onClick={handleCloseModal}>
+                            {_("Cancel")}
+                        </Button>
+                    ]
+                }
+            >
+                <Form isHorizontal autoComplete="off">
+                    <Grid className="ds-margin-top" title={_("The config entry full DN")}>
+                        <GridItem span={3} className="ds-label">
+                            {_("Config DN")}
+                        </GridItem>
+                        <GridItem span={9}>
+                            <TextInput
+                                value={configDN}
+                                type="text"
+                                id="sharedConfigEntry"
+                                aria-describedby="horizontal-form-name-helper"
+                                name="sharedConfigEntry"
+                                onChange={(e, str) => { setConfigDN(str) }}
+                                validated={valid_dn(configDN) ?
+                                           ValidatedOptions.default :
+                                           ValidatedOptions.error}
+                                isDisabled={!newEntry}
+                            />
+                            {newEntry &&
+                                <FormHelperText>
+                                    {_("Value must be a valid DN")}
+                                </FormHelperText>
+                            }
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Specifies the objectclass that will trigger the dynamic list plugin (dynamicListObjectclass)")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("ObjectClass")}
+                        </GridItem>
+                        <GridItem span={9}>
+                            <FormSelect
+                                value={configSettings.objectclass.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setConfigSetting('objectclass', selection);
+                                }}
+                                aria-label="Dynamic List ObjectClass"
+                                ouiaId="DynamicListObjectClassSelect"
+                            >
+                                {objectClasses.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.toLowerCase()} label={option} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Specifies the attribute in the entry for the LDAP URL of the dynamic list (dynamicListUrlAttr)")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("URL Attribute")}
+                        </GridItem>
+                        <GridItem span={9}>
+                            <FormSelect
+                                value={configSettings.URLAttr.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setConfigSetting('URLAttr', selection);
+                                }}
+                                aria-label="Dynamic List URL Attribute"
+                                ouiaId="DynamicListURLAttributeSelect"
+                            >
+                                {urlAttrsConfig.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Specifies attributes to check for and update (referint-membership-attr)")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("List Attribute")}
+                        </GridItem>
+                        <GridItem span={9}>
+                            <FormSelect
+                                value={configSettings.listAttr.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setConfigSetting('listAttr', selection);
+                                }}
+                                aria-label="Dynamic List Attribute"
+                                ouiaId="DynamicListAttributeSelect"
+                            >
+                                {dnAttrsConfig.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                </Form>
+            </Modal>
+
+            <PluginBasicConfig
+                rows={rows}
+                serverId={serverId}
+                cn="dynamic lists"
+                pluginName="Dynamic Lists"
+                cmdName="dynamic-lists"
+                savePluginHandler={savePluginHandler}
+                pluginListHandler={pluginListHandler}
+                addNotification={addNotification}
+                toggleLoadingHandler={toggleLoadingHandler}
+                saveBtnDisabled={saveBtnDisabled}
+            >
+                <Form isHorizontal autoComplete="off">
+                    <Grid title={_("Specifies objectclass that indicates a dynamic group (dynamicListObjectclass).")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("Objectclass")}
+                        </GridItem>
+                        <GridItem span={8}>
+                            <FormSelect
+                                value={settings.objectclass.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setSetting('objectclass', selection);
+                                }}
+                                aria-label="Dynamic List Objectclass"
+                                ouiaId="DynamicListAttributeSelect"
+                            >
+                                {objectClasses.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.toLowerCase()} label={option} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Specifies attribute that contains the URL of the dynamic list (dynamicListUrlAttr).")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("URL Attribute")}
+                        </GridItem>
+                        <GridItem span={8}>
+                            <FormSelect
+                                value={settings.URLAttr.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setSetting('URLAttr', selection);
+                                }}
+                                aria-label="Dynamic List URL Attribute"
+                                ouiaId="DynamicListAttributeSelect"
+                            >
+                                {urlAttrs.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Specifies attribute used to store the values of the dynamic list (dynamicListAttr).")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("List Attribute")}
+                        </GridItem>
+                        <GridItem span={8}>
+                            <FormSelect
+                                value={settings.listAttr.toLowerCase()}
+                                onChange={(event, selection) => {
+                                    setSetting('listAttr', selection);
+                                }}
+                                aria-label="Dynamic List Attribute"
+                                ouiaId="DynamicListAttributeSelect"
+                            >
+                                {dnAttrs.map((option, index) => (
+                                    <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+
+                    <Grid title={_("The value to set as shared config entry (nsslapd-pluginConfigArea)")}>
+                        <GridItem className="ds-label" span={3}>
+                            {_("Shared Config Entry")}
+                        </GridItem>
+                        <GridItem className="ds-right-margin" span={9}>
+                            {settings.sharedConfigEntry !== "" && (
+                                <TextInput
+                                    value={settings.sharedConfigEntry}
+                                    type="text"
+                                    id="memberOfConfigEntry"
+                                    aria-describedby="horizontal-form-name-helper"
+                                    name="memberOfConfigEntry"
+                                    readOnlyVariant={'plain'}
+                                />
+                            )}
+                            {settings.sharedConfigEntry === "" && (
+                                <Button
+                                    variant="primary"
+                                    onClick={handleOpenModal}
+                                    size="sm"
+                                >
+                                    {_("Create Config")}
+                                </Button>
+                            )}
+                        </GridItem>
+                    </Grid>
+                    {settings.sharedConfigEntry !== "" && (
+                        <Grid>
+                            <GridItem offset={3} span={3}>
+                                <Button
+                                    variant="primary"
+                                    onClick={handleOpenModal}
+                                    size="sm"
+                                >
+                                    {_("Manage Config")}
+                                </Button>
+                            </GridItem>
+                        </Grid>
+                    )}
+                </Form>
+                <Button
+                    className="ds-margin-top-lg"
+                    key="at"
+                    isLoading={saving}
+                    spinnerAriaValueText={saving ? _("Loading") : undefined}
+                    variant="primary"
+                    onClick={handleSaveConfig}
+                    isDisabled={saveBtnDisabled || saving}
+                >
+                    {saving ? _("Saving ...") : _("Save")}
+                </Button>
+            </PluginBasicConfig>
+            <DoubleConfirmModal
+                showModal={showConfirmDelete}
+                closeHandler={closeConfirmDelete}
+                handleChange={onChange}
+                actionHandler={deleteConfig}
+                spinning={modalSpinning}
+                item={settings.sharedConfigEntry}
+                checked={modalChecked}
+                mTitle={_("Delete Dynamic Lists Plugin Shared Config Entry")}
+                mMsg={_("Are you sure you want to delete this config entry?")}
+                mSpinningMsg={_("Deleting ...")}
+                mBtnName={_("Delete")}
+            />
+        </div>
+    );
+}
+
+export default DynamicLists;

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -1776,7 +1776,7 @@ class MemberOf extends React.Component {
                                                 variant="primary"
                                                 onClick={this.handleOpenModal}
                                             >
-                                                {memberOfConfigEntry === "" ? _("Create Config") : _("Manage Config")}
+                                                {_("Manage Config")}
                                             </Button>
                                         </GridItem>
                                     </Grid>

--- a/src/cockpit/389-console/src/lib/plugins/pluginBasicConfig.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pluginBasicConfig.jsx
@@ -176,7 +176,9 @@ class PluginBasicConfig extends React.Component {
 
     updateSwitch() {
         if (this.props.rows.length > 0) {
-            const pluginRow = this.props.rows.find(row => row.cn[0] === this.props.cn);
+            const pluginRow = this.props.rows.find(row =>
+                row.cn[0].toLowerCase() === this.props.cn.toLowerCase());
+
             if (pluginRow) {
                 let pluginEnabled = false;
                 if (pluginRow["nsslapd-pluginEnabled"][0] === "on") {

--- a/src/cockpit/389-console/src/plugins.jsx
+++ b/src/cockpit/389-console/src/plugins.jsx
@@ -26,6 +26,7 @@ import AccountPolicy from "./lib/plugins/accountPolicy.jsx";
 import AttributeUniqueness from "./lib/plugins/attributeUniqueness.jsx";
 import AutoMembership from "./lib/plugins/autoMembership.jsx";
 import DNAPlugin from "./lib/plugins/dna.jsx";
+import DynamicLists from "./lib/plugins/dynamicLists.jsx";
 import LinkedAttributes from "./lib/plugins/linkedAttributes.jsx";
 import ManagedEntries from "./lib/plugins/managedEntries.jsx";
 import MemberOf from "./lib/plugins/memberOf.jsx";
@@ -74,8 +75,8 @@ export class Plugins extends React.Component {
             rows: [],
             pluginTableKey: 0,
             attributes: [],
-            objectclasses: [],
-
+            objectClasses: [],
+            attributesFullData: [],
             // Plugin attributes
             currentPluginName: "",
             currentPluginType: "",
@@ -148,6 +149,7 @@ export class Plugins extends React.Component {
                                 this.setState({
                                     objectClasses: ocs,
                                     attributes: attrs,
+                                    attributesFullData: attrContent.items
                                 });
                             })
                             .fail(err => {
@@ -493,6 +495,24 @@ export class Plugins extends React.Component {
                         toggleLoadingHandler={this.toggleLoading}
                         wasActiveList={this.props.wasActiveList}
                         attributes={this.state.attributes}
+                        key={this.props.wasActiveList}
+                    />
+                )
+            },
+            dynamicLists: {
+                name: "Dynamic Lists",
+                icon: this.getIconAndName("Dynamic Lists", "Dynamic Lists"),
+                component: (
+                    <DynamicLists
+                        rows={this.state.rows}
+                        serverId={this.props.serverId}
+                        savePluginHandler={this.savePlugin}
+                        pluginListHandler={this.pluginList}
+                        addNotification={this.props.addNotification}
+                        toggleLoadingHandler={this.toggleLoading}
+                        wasActiveList={this.props.wasActiveList}
+                        attributes={this.state.attributesFullData}
+                        objectClasses={this.state.objectClasses}
                         key={this.props.wasActiveList}
                     />
                 )

--- a/src/lib389/lib389/cli_conf/plugin.py
+++ b/src/lib389/lib389/cli_conf/plugin.py
@@ -22,6 +22,7 @@ from lib389.cli_conf.plugins import referint as cli_referint
 from lib389.cli_conf.plugins import accountpolicy as cli_accountpolicy
 from lib389.cli_conf.plugins import attruniq as cli_attruniq
 from lib389.cli_conf.plugins import dna as cli_dna
+from lib389.cli_conf.plugins import dynamic_lists as cli_dynamic_lists
 from lib389.cli_conf.plugins import linkedattr as cli_linkedattr
 from lib389.cli_conf.plugins import managedentries as cli_managedentries
 from lib389.cli_conf.plugins import pampassthrough as cli_pampassthrough
@@ -122,6 +123,7 @@ def create_parser(subparsers):
     cli_contentsync.create_parser(subcommands)
     cli_entryuuid.create_parser(subcommands)
     cli_pwstorage.create_parser(subcommands)
+    cli_dynamic_lists.create_parser(subcommands)
 
     list_parser = subcommands.add_parser('list', help="List current configured (enabled and disabled) plugins", formatter_class=CustomHelpFormatter)
     list_parser.set_defaults(func=plugin_list)

--- a/src/lib389/lib389/cli_conf/plugins/dynamic_lists.py
+++ b/src/lib389/lib389/cli_conf/plugins/dynamic_lists.py
@@ -1,0 +1,109 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import ldap
+from lib389.plugins import DynamicListsPlugin, DynamicListsConfig
+from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add
+from lib389.cli_base import CustomHelpFormatter
+
+arg_to_attr = {
+    'objectclass': 'dynamicListObjectclass',
+    'url_attr': 'dynamicListUrlAttr',
+    'list_attr': 'dynamicListAttr'
+}
+
+
+def dynamic_lists_edit(inst, basedn, log, args):
+    log = log.getChild('dynamic_lists_edit')
+    plugin = DynamicListsPlugin(inst)
+    generic_object_edit(plugin, log, args, arg_to_attr)
+
+
+def dynamic_lists_add_config(inst, basedn, log, args):
+    log = log.getChild('dynamic_lists_add_config')
+    targetdn = args.DN
+    config = generic_object_add(DynamicListsConfig, inst, log, args, arg_to_attr, dn=targetdn)
+    plugin = DynamicListsPlugin(inst)
+    plugin.replace('nsslapd-pluginConfigArea', config.dn)
+    log.info('Dynamic Lists attribute nsslapd-pluginConfigArea (config-entry) '
+             'was set in the main plugin config')
+
+
+def dynamic_lists_edit_config(inst, basedn, log, args):
+    log = log.getChild('dynamic_lists_edit_config')
+    targetdn = args.DN
+    config = DynamicListsConfig(inst, targetdn)
+    generic_object_edit(config, log, args, arg_to_attr)
+
+
+def dynamic_lists_show_config(inst, basedn, log, args):
+    log = log.getChild('dynamic_lists_show_config')
+    targetdn = args.DN
+    config = DynamicListsConfig(inst, targetdn)
+
+    if not config.exists():
+        raise ldap.NO_SUCH_OBJECT("Entry %s doesn't exists" % targetdn)
+    if args and args.json:
+        o_str = config.get_all_attrs_json()
+        log.info(o_str)
+    else:
+        log.info(config.display())
+
+
+def dynamic_lists_del_config(inst, basedn, log, args):
+    log = log.getChild('dynamic_lists_del_config')
+    targetdn = args.DN
+    config = DynamicListsConfig(inst, targetdn)
+    config.delete()
+    # Now remove the attribute from the plugin
+    plugin = DynamicListsPlugin(inst)
+    plugin.remove_all('nsslapd-pluginConfigArea')
+    log.info("Successfully deleted the %s", targetdn)
+
+
+def _add_parser_args(parser):
+    parser.add_argument('--objectclass',
+                        help='Specifies the objectclass to identify entry that has a dynamic list (dynamicListObjectclass)')
+    parser.add_argument('--url-attr',
+                        help='Specifies the attribute that contains the URL of the dynamic list (dynamicListUrlAttr)')
+    parser.add_argument('--list-attr',
+                        help='Specifies the attribute used to store the values of the dynamic list. '
+                             'The attribute must have a DN syntax (dynamicListAttr)')
+
+
+def create_parser(subparsers):
+    dynamic_lists = subparsers.add_parser('dynamic-lists',
+                                      help='Manage and configure Dynamic Lists plugin')
+
+    subcommands = dynamic_lists.add_subparsers(help='action')
+
+    add_generic_plugin_parsers(subcommands, DynamicListsPlugin)
+
+    edit = subcommands.add_parser('set', help='Edit the plugin settings', formatter_class=CustomHelpFormatter)
+    edit.set_defaults(func=dynamic_lists_edit)
+    _add_parser_args(edit)
+    edit.add_argument('--config-entry', help='The value to set as nsslapd-pluginConfigArea')
+
+    config = subcommands.add_parser('config-entry', help='Manage the config entry', formatter_class=CustomHelpFormatter)
+    config_subcommands = config.add_subparsers(help='action')
+    add_config = config_subcommands.add_parser('add', help='Add the config entry', formatter_class=CustomHelpFormatter)
+    add_config.set_defaults(func=dynamic_lists_add_config)
+    add_config.add_argument('DN', help='The config entry full DN')
+    _add_parser_args(add_config)
+    edit_config = config_subcommands.add_parser('set', help='Edit the config entry', formatter_class=CustomHelpFormatter)
+    edit_config.set_defaults(func=dynamic_lists_edit_config)
+    edit_config.add_argument('DN', help='The config entry full DN')
+    _add_parser_args(edit_config)
+    show_config = config_subcommands.add_parser('show', help='Display the config entry', formatter_class=CustomHelpFormatter)
+    show_config.set_defaults(func=dynamic_lists_show_config)
+    show_config.add_argument('DN', help='The shared config entry full DN')
+    del_config_ = config_subcommands.add_parser('delete',
+                                                help='Delete the config entry and remove the reference in the plugin entry',
+                                                formatter_class=CustomHelpFormatter)
+    del_config_.set_defaults(func=dynamic_lists_del_config)
+    del_config_.add_argument('DN', help='The config entry full DN')

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -678,6 +678,107 @@ class ReferentialIntegrityConfig(DSLdapObject):
         self._exit_code = None
 
 
+class DynamicListsPlugin(Plugin):
+    """A collection of Dynamic Lists config entries
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param basedn: Base DN
+    :type basedn: str
+    """
+
+    _plugin_properties = {
+        'cn' : 'dynamic lists',
+        'nsslapd-pluginEnabled': 'off',
+        'nsslapd-pluginPath': 'libdynamic-lists-plugin',
+        'nsslapd-pluginInitfunc': 'dynamic_lists_init',
+        'nsslapd-pluginType': 'preoperation',
+        'nsslapd-pluginprecedence': '40',
+        'nsslapd-plugin-depends-on-type': 'database',
+        'nsslapd-pluginId' : 'dynamic-lists',
+        'nsslapd-pluginVendor' : '389 Project',
+        'nsslapd-pluginVersion' : '1.0.0.0',
+        'nsslapd-pluginDescription' : 'dynamic lists plugin',
+    }
+
+    def __init__(self, instance, dn="cn=Dynamic Lists,cn=plugins,cn=config"):
+        super(DynamicListsPlugin, self).__init__(instance, dn)
+        self._create_objectclasses = ['top', 'nsSlapdPlugin', 'extensibleObject']
+        self._must_attributes = ['cn',
+                                 'dynamicListObjectclass',
+                                 'dynamicListUrlAttr',
+                                 'dynamicListAttr']
+        self._protected = False
+        self._exit_code = None
+
+    def get_dynamiclistobjectclass(self):
+        """Get dynamicListObjectclass attribute"""
+
+        return self.get_attr_val_utf8_l('dynamicListObjectclass')
+
+    def set_dynamiclistobjectclass(self, attr):
+        """Set dynamicListObjectclass attribute"""
+
+        return self.set('dynamicListObjectclass', attr)
+
+    def get_dynamiclisturlattr(self):
+        """Get dynamicListUrlAttr attribute"""
+
+        return self.get_attr_val_utf8_l('dynamicListUrlAttr')
+
+    def set_dynamiclisturlattr(self, attr):
+        """Set dynamicListUrlAttr attribute"""
+
+        return self.set('dynamicListUrlAttr', attr)
+
+    def get_dynamiclistattr(self):
+        """Get dynamicListAttr attribute"""
+
+        return self.get_attr_val_utf8_l('dynamicListAttr')
+
+    def set_dynamiclistattr(self, attr):
+        """Set dynamicListAttr attribute"""
+
+        return self.set('dynamicListAttr', attr)
+
+    def get_configarea(self):
+        """Get nsslapd-pluginConfigArea attribute"""
+
+        return self.get_attr_val_utf8_l('nsslapd-pluginConfigArea')
+
+    def set_configarea(self, attr):
+        """Set nsslapd-pluginConfigArea attribute"""
+
+        return self.set('nsslapd-pluginConfigArea', attr)
+
+    def remove_configarea(self):
+        """Remove all nsslapd-pluginConfigArea attributes"""
+
+        return self.remove_all('nsslapd-pluginConfigArea')
+
+
+class DynamicListsConfig(DSLdapObject):
+    """An instance of Dynamic Lists config entry
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param dn: Entry DN
+    :type dn: str
+    """
+
+    def __init__(self, instance, dn):
+        super(DynamicListsConfig, self).__init__(instance, dn)
+        self._dn = dn
+        self._rdn_attribute = 'cn'
+        self._must_attributes = ['cn',
+                                 'dynamicListObjectclass',
+                                 'dynamicListUrlAttr',
+                                 'dynamicListAttr']
+        self._create_objectclasses = ['top', 'extensibleObject']
+        self._protected = False
+        self._exit_code = None
+
+
 class SyntaxValidationPlugin(Plugin):
     """An instance of Syntax Validation Task plugin entry
 


### PR DESCRIPTION
Description:

Implement a new preoperation plugin to build dynamic content based of LDAP URI's. Configuration includes an identifying objectclass to mark an entry as a dynamic content entry. Another setting for the attribute that contains the LDAP URI, and an attribute for storing the dynamic content. Attributes specified in the LDAP URI override the content attribute and instead write that attribute's value into the dynamic content entry.

Design doc: https://www.port389.org/docs/389ds/design/dynamic-lists-design.html

Relates: https://github.com/389ds/389-ds-base/issues/1793

ASAN tests pass

## Summary by Sourcery

Implement the Dynamic Lists feature by adding a new preoperation plugin that builds entry attributes from LDAP URLs, integrate it into the server upgrade path, CLI, and 389-console UI, and provide comprehensive build support and tests.

New Features:
- Introduce Dynamic Lists preoperation plugin to dynamically populate entry content from LDAP URLs
- Support CLI management of the Dynamic Lists plugin via new dsconf `dynamic-lists` and `dynamic-lists config-entry` commands
- Add dynamic lists configuration UI in 389-console for plugin settings and shared config entries

Enhancements:
- Extend lib389 with DynamicListsPlugin and DynamicListsConfig classes for automated plugin and config entry management
- Add server upgrade path to create the default Dynamic Lists plugin entry if missing
- Integrate the build rules for libdynamic-lists-plugin into Makefile.am

Build:
- Add libdynamic-lists-plugin to the serverplugin libraries in Makefile.am

Tests:
- Add dsconf_dynamic_lists_test suite for CLI operations (status, show, set, config-entry)
- Add functional integration tests under dirsrvtests to verify dynamic list population based on memberURL

Chores:
- Include `dynamic-lists` parser in lib389 CLI subcommands
- Adjust existing plugin JS code to support attribute normalization for dynamic lists