### PR TITLE
Issue 7093 - A password policy can be created when an identical policy already exists

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -1569,7 +1569,7 @@ def test_duplicate_policies(topo):
         'passwordminlength': '6'
     }
 
-    log.info(f'Creating subtree pwp')
+    log.info('Creating subtree pwp')
     pwp = PwPolicyManager(topo.standalone)
     pwp.create_subtree_policy(people.dn, policy_props)
     subtree_policy = pwp.get_pwpolicy_entry(people.dn)
@@ -1583,6 +1583,7 @@ def test_duplicate_policies(topo):
     modified_props = policy_props.copy()
     modified_props['passwordminlength'] = '8'
     pwp.create_subtree_policy(people.dn, modified_props)
+    subtree_policy = pwp.get_pwpolicy_entry(people.dn)
     assert subtree_policy.get_attr_val_utf8('passwordminlength') == '8'
 
     log.info('Creating test user')
@@ -1601,6 +1602,7 @@ def test_duplicate_policies(topo):
     modified_props = policy_props.copy()
     modified_props['passwordMinAge'] = '1'
     pwp.create_user_policy(user.dn, modified_props)
+    subtree_policy = pwp.get_pwpolicy_entry(people.dn)
     assert user_policy.get_attr_val_utf8('passwordMinAge') == '1'
 
 

--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -159,19 +159,41 @@ def create_subtree_policy(inst, basedn, log, args):
     # Gather the attributes
     pwp_manager = PwPolicyManager(inst)
     attrs = _args_to_attrs(args, pwp_manager.arg_to_attr)
-    pwp_manager.create_subtree_policy(args.DN[0], attrs)
+    try:
+        pwp_manager.create_subtree_policy(args.DN[0], attrs)
+        log.info('Successfully created subtree password policy')
 
-    log.info('Successfully created subtree password policy')
+    except ldap.ALREADY_EXISTS as ae:
+        raise ValueError(f"Subtree password policy already exists")
 
+    except ValueError as ve:
+        raise ValueError(f"Failed to create subtree password policy: {ve}")
+
+    except ldap.LDAPError as le:
+        raise ValueError(f"LDAP error while creating subtree policy: {le}")
+
+    except Exception as e:
+        raise ValueError(f"Unexpected error: {e}")
 
 def create_user_policy(inst, basedn, log, args):
     log = log.getChild('create_user_policy')
     pwp_manager = PwPolicyManager(inst)
     attrs = _args_to_attrs(args, pwp_manager.arg_to_attr)
-    pwp_manager.create_user_policy(args.DN[0], attrs)
+    try:
+        pwp_manager.create_user_policy(args.DN[0], attrs)
+        log.info('Successfully created user password policy')
 
-    log.info('Successfully created user password policy')
+    except ldap.ALREADY_EXISTS:
+        raise ValueError(f"User password policy already exists")
 
+    except ValueError as ve:
+        raise ValueError(f"Failed to create user password policy: {ve}")
+
+    except ldap.LDAPError:
+        raise ValueError(f"LDAP error while creating user policy")
+
+    except Exception as e:
+        raise ValueError(f"Unexpected error: {e}")
 
 def set_global_policy(inst, basedn, log, args):
     log = log.getChild('set_global_policy')

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -118,7 +118,12 @@ class PwPolicyManager(object):
             val_norm = _normalise_val(v)
             new_norm[key_norm] = val_norm
 
-        # Compare policies
+        # If the new props introduce a new key, its not a duplicate
+        for key in new_norm.keys():
+            if key not in existing_norm:
+                return False
+
+        # Overlapping values must match
         for key, new_vals in new_norm.items():
             old_vals = existing_norm.get(key, [])
             if sorted(old_vals) != sorted(new_vals):


### PR DESCRIPTION
Bug description: Currently, during password policy creation, if an existing policy entry is found, a MOD_REPLACE operation is silently performed instead of alerting the user. This behaviour makes the operation appear successful but hides the fact that the policy already exists.

Fix description: PwPolicyManager has been updated to compare an existing policy with the new policy being created. The following scenarions are supported:

- If an identical policy exists, an ldap.ALREADY_EXISTS exception is raised.
- If no policy exists, the normal create() path is used.
- If a policy exists but its properties differ, ensure_state() is called to update it.

Fixes: https://github.com/389ds/389-ds-base/issues/7093

Reviewed by:

## Summary by Sourcery

Enforce uniqueness for password policy creation by comparing new and existing policies, raising ALREADY_EXISTS for identical entries, updating differing ones, and improving CLI error handling.

New Features:
- Detect identical subtree and user password policies and raise ALREADY_EXISTS instead of silently updating.
- Support three creation paths in PwPolicyManager: create new, update differing, or error on duplicates.

Bug Fixes:
- Prevent silent MOD_REPLACE on duplicate policy creation by raising an exception.

Enhancements:
- Introduce _is_duplicate_policy helper for normalizing and comparing policy properties.
- Improve CLI commands to catch and translate ldap exceptions into user-friendly errors.
- Refactor test helper and enable configurable logging level for password policy tests.

Tests:
- Add test_duplicate_policies to verify creation, duplicate rejection, and update flows for subtree and user policies.