### PR TITLE
Issue 7007 - Improve paged result search locking

### DIFF
--- a/ldap/servers/slapd/pagedresults.c
+++ b/ldap/servers/slapd/pagedresults.c
@@ -804,6 +804,7 @@ pagedresults_cleanup(Connection *conn, int needlock)
         prp->pr_current_be = NULL;
         if (prp->pr_mutex) {
             PR_DestroyLock(prp->pr_mutex);
+            prp->pr_mutex = NULL;
         }
         memset(prp, '\0', sizeof(PagedResults));
     }
@@ -841,6 +842,7 @@ pagedresults_cleanup_all(Connection *conn, int needlock)
         prp = conn->c_pagedresults.prl_list + i;
         if (prp->pr_mutex) {
             PR_DestroyLock(prp->pr_mutex);
+            prp->pr_mutex = NULL;
         }
         if (prp->pr_current_be && prp->pr_search_result_set &&
             prp->pr_current_be->be_search_results_release) {
@@ -1022,11 +1024,10 @@ pagedresults_lock(Connection *conn, int index)
     }
     pthread_mutex_lock(pageresult_lock_get_addr(conn));
     prp = conn->c_pagedresults.prl_list + index;
-    pthread_mutex_unlock(pageresult_lock_get_addr(conn));
     if (prp->pr_mutex) {
         PR_Lock(prp->pr_mutex);
     }
-    return;
+    pthread_mutex_unlock(pageresult_lock_get_addr(conn));
 }
 
 void
@@ -1038,11 +1039,10 @@ pagedresults_unlock(Connection *conn, int index)
     }
     pthread_mutex_lock(pageresult_lock_get_addr(conn));
     prp = conn->c_pagedresults.prl_list + index;
-    pthread_mutex_unlock(pageresult_lock_get_addr(conn));
     if (prp->pr_mutex) {
         PR_Unlock(prp->pr_mutex);
     }
-    return;
+    pthread_mutex_unlock(pageresult_lock_get_addr(conn));
 }
 
 int


### PR DESCRIPTION
Description:

Hold the paged result connection hash mutex while acquiring the global connection paged result lock. Otherwise there is a window where the mutex could be removed and lead to a crash

Relates: https://github.com/389ds/389-ds-base/issues/7007
