### PR TITLE
Issue 7105 - ns-slapd crashes when binding with user with SSHA hashed password

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -280,12 +280,16 @@ entry_get_rdn_mods(Slapi_PBlock *pb, Slapi_Entry *entry, CSN *csn, int repl_op, 
 
         /* Check if the RDN value exists */
         if ((slapi_entry_attr_find(entry, type, &attr) != 0) ||
-            (slapi_attr_value_find(attr, &bv))) {
+            (attr && slapi_attr_value_find(attr, &bv))) {
             const CSN *csn_rdn_add;
-            const CSN *adcsn = attr_get_deletion_csn(attr);
+            const CSN *adcsn = NULL;
+
+            if (attr) {
+                adcsn = attr_get_deletion_csn(attr);
+            }
 
             /* It is missing => adds it */
-            if (slapi_attr_flag_is_set(attr, SLAPI_ATTR_FLAG_SINGLE)) {
+            if (attr && slapi_attr_flag_is_set(attr, SLAPI_ATTR_FLAG_SINGLE)) {
                 if (csn_compare(adcsn, csn) >= 0) {
                     /* this is a single valued attribute and the current value
                      * (that is different from RDN value) is more recent than
@@ -313,8 +317,10 @@ entry_get_rdn_mods(Slapi_PBlock *pb, Slapi_Entry *entry, CSN *csn, int repl_op, 
                 return -1;
             }
             /* Make the RDN value a distinguished value */
-            attr_value_find_wsi(attr, &bv, &value);
-            value_update_csn(value, CSN_TYPE_VALUE_DISTINGUISHED, csn_rdn_add);
+            if (attr) {
+                attr_value_find_wsi(attr, &bv, &value);
+                value_update_csn(value, CSN_TYPE_VALUE_DISTINGUISHED, csn_rdn_add);
+            }
         }
     }
     slapi_ldap_value_free(rdns);


### PR DESCRIPTION
Bug Description:
A NULL pointer dereference occurs in `entry_get_rdn_mods()` when processing entries where the RDN attribute name does not match any attribute in the entry, for example:
```
dn: userid=test,dc=example,dc=com
uid: test
```

When `slapi_entry_attr_find()` fails to find the attribute, it sets `attr` to NULL and returns -1. The code then enters the conditional block and attempts to dereference `attr` by calling `attr_get_deletion_csn(attr)`, causing a crash. This can occur during bind operations with password encoding updates or any operation that calls `entry_get_rdn_mods()`.

Fix Description:
Add NULL pointer checks before dereferencing `attr` in `entry_get_rdn_mods()`.

Fixes: https://github.com/389ds/389-ds-base/issues/7105

## Summary by Sourcery

Bug Fixes:
- Add checks to ensure attr is non-NULL before calling slapi_attr_value_find, attr_get_deletion_csn, slapi_attr_flag_is_set, attr_value_find_wsi, and value_update_csn in entry_get_rdn_mods