### PR TITLE
Issue 7109 - AddressSanitizer: SEGV ldap/servers/slapd/csnset.c:302 in csnset_dup

### DIFF
--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -496,17 +496,24 @@ extensible_candidates(
                     struct berval **keys = NULL;
                     /* keys = mrINDEX (*val), conceptually.  In detail: */
                     struct berval *bvec[2];
+                    Slapi_Value **svals = NULL;
                     bvec[0] = *val;
                     bvec[1] = NULL;
 
+                    /* Convert berval array to Slapi_Value array */
+                    valuearray_init_bervalarray(bvec, &svals);
+
                     /* coverity[var_deref_model] */
                     if (slapi_pblock_set(pb, SLAPI_PLUGIN_OBJECT, mrOBJECT) ||
-                        slapi_pblock_set(pb, SLAPI_PLUGIN_MR_VALUES, bvec) ||
+                        slapi_pblock_set(pb, SLAPI_PLUGIN_MR_VALUES, svals) ||
                         mrINDEX(pb) ||
                         slapi_pblock_get(pb, SLAPI_PLUGIN_MR_KEYS, &keys)) {
                         /* something went wrong.  bail. */
+                        valuearray_free(&svals);
                         break;
-                    } else if (f->f_flags & SLAPI_FILTER_INVALID_ATTR_WARN) {
+                    }
+                    valuearray_free(&svals);
+                    if (f->f_flags & SLAPI_FILTER_INVALID_ATTR_WARN) {
                         /*
                          * REMEMBER: this flag is only set on WARN levels. If the filter verify
                          * is on strict, we reject in search.c, if we ar off, the flag will NOT


### PR DESCRIPTION
Bug Description:
In `extensible_candidates` we pass a `berval` struct directly to the pblock instead of `Slapi_Value`, which have different memory layouts. Reproducible with
`dirsrvtests/tests/suites/filter/filter_index_match_test.py::test_do_extensible_search`.

Fix Description:
Convert the `berval` to `Slapi_Value` before passing to the pblock.

Fixes: https://github.com/389ds/389-ds-base/issues/7109

## Summary by Sourcery

Fix crashes in extensible filter candidate processing by correctly handling match rule values passed to plugins.

Bug Fixes:
- Convert berval values to Slapi_Value objects before passing them to the match rule plugin pblock to prevent memory layout mismatches and related crashes.
- Ensure temporary match rule values are freed after plugin processing to avoid leaks.