### PR TITLE
Issue 7121 - LeakSanitizer: various leaks during replication

### DIFF
--- a/ldap/servers/plugins/replication/repl5_connection.c
+++ b/ldap/servers/plugins/replication/repl5_connection.c
@@ -504,6 +504,7 @@ conn_read_result_ex(Repl_Connection *conn, char **retoidp, struct berval **retda
         {
             if (NULL != returned_controls) {
                 *returned_controls = loc_returned_controls;
+                loc_returned_controls = NULL; /* ownership transferred */
             }
             if (LDAP_SUCCESS != rc) {
                 conn->last_ldap_error = rc;
@@ -517,6 +518,9 @@ conn_read_result_ex(Repl_Connection *conn, char **retoidp, struct berval **retda
         slapi_ch_free_string(&errmsg);
         slapi_ch_free_string(&matched);
         charray_free(referrals);
+        if (loc_returned_controls) {
+            ldap_controls_free(loc_returned_controls);
+        }
     }
     if (res)
         ldap_msgfree(res);

--- a/ldap/servers/plugins/replication/repl5_inc_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_inc_protocol.c
@@ -371,6 +371,10 @@ repl5_inc_result_threadmain(void *param)
         if (op) {
             repl5_inc_op_free(op);
         }
+        if (returned_controls) {
+            ldap_controls_free(returned_controls);
+            returned_controls = NULL;
+        }
     }
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "repl5_inc_result_threadmain exiting\n");
 }

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -4288,6 +4288,9 @@ replica_add_session_abort_control(Slapi_PBlock *pb)
     bvp->bv_val = NULL;
     ber_bvfree(bvp);
     slapi_pblock_set(pb, SLAPI_ADD_RESCONTROL, &ctrl);
+    /* Free the control since slapi_pblock_set duplicates it */
+    slapi_ch_free_string(&ctrl.ldctl_oid);
+    slapi_ch_free_string(&ctrl.ldctl_value.bv_val);
 
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                   "add_session_abort_control - abort control successfully added to result\n");

--- a/ldap/servers/slapd/entrywsi.c
+++ b/ldap/servers/slapd/entrywsi.c
@@ -1185,8 +1185,8 @@ resolve_attribute_state_deleted_to_present(Slapi_Entry *e, Slapi_Attr *a, Slapi_
             if ((csn_compare(vucsn, deletedcsn) >= 0) ||
                 value_distinguished_at_csn(e, a, valuestoupdate[i], deletedcsn)) {
                 entry_deleted_value_to_present_value(a, valuestoupdate[i]);
+                csnset_free(&valuestoupdate[i]->v_csnset);
             }
-            csnset_free(&valuestoupdate[i]->v_csnset);
         }
     }
 }

--- a/ldap/servers/slapd/entrywsi.c
+++ b/ldap/servers/slapd/entrywsi.c
@@ -1186,7 +1186,7 @@ resolve_attribute_state_deleted_to_present(Slapi_Entry *e, Slapi_Attr *a, Slapi_
                 value_distinguished_at_csn(e, a, valuestoupdate[i], deletedcsn)) {
                 entry_deleted_value_to_present_value(a, valuestoupdate[i]);
             }
-            valuestoupdate[i]->v_csnset = NULL;
+            csnset_free(&valuestoupdate[i]->v_csnset);
         }
     }
 }

--- a/ldap/servers/slapd/valueset.c
+++ b/ldap/servers/slapd/valueset.c
@@ -1335,6 +1335,7 @@ valueset_remove_valuearray(Slapi_ValueSet *vs, const Slapi_Attr *a, Slapi_Value 
                     }
                 } else {
                     if (flags & SLAPI_VALUE_FLAG_PRESERVECSNSET) {
+                        csnset_free(&valuestodelete[i]->v_csnset);
                         valuestodelete[i]->v_csnset = found->v_csnset;
                         found->v_csnset = NULL;
                     }

--- a/ldap/servers/slapd/valueset.c
+++ b/ldap/servers/slapd/valueset.c
@@ -1324,6 +1324,7 @@ valueset_remove_valuearray(Slapi_ValueSet *vs, const Slapi_Attr *a, Slapi_Value 
                     if (found->v_csnset &&
                         (flags & (SLAPI_VALUE_FLAG_PRESERVECSNSET |
                                   SLAPI_VALUE_FLAG_USENEWVALUE))) {
+                        csnset_free(&valuestodelete[i]->v_csnset);
                         valuestodelete[i]->v_csnset = csnset_dup(found->v_csnset);
                     }
                     if (flags & SLAPI_VALUE_FLAG_USENEWVALUE) {


### PR DESCRIPTION
1. CSN Leaks

In `resolve_attribute_state_deleted_to_present()` we set CSN set pointer to NULL without freeing the allocated memory.
In `valueset_remove_valuearray()` we overwrite `csnset` pointer without freeing the existing `csnset`.

2. Leak in `replica_add_session_abort_control()`

Control's OID and value are allocated but never freed after `slapi_pblock_set`, which duplicates the control. Added cleanup to free `ctrl.ldctl_oid` and `ctrl.ldctl_value.bv_val` after `slapi_pblock_set`.

3. LDAP controls leak

`ldap_parse_result` allocates controls that are not being freed when not transferred to caller or on error paths.  Free `loc_returned_controls` in cleanup section and NULL the pointer after the transfer.

`returned_controls` allocated in `conn_read_result_ex` are used to check for abort session control, but never freed before the next loop iteration.

Fixes: https://github.com/389ds/389-ds-base/issues/7121

## Summary by Sourcery

Fix memory leaks in replication CSN handling and LDAP control processing.

Bug Fixes:
- Free CSN sets instead of nulling or overwriting their pointers when resolving deleted-to-present attribute state and when removing values from value sets.
- Ensure LDAP controls returned from result processing threads are freed after use, including local and transferred control arrays.
- Release the OID and value memory for the session abort control after adding it to the operation pblock, since the control is duplicated there.