### PR TITLE
Issue 6933 - (Cont) When deferred memberof update is enabled after th…

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/regression_test.py
@@ -1282,7 +1282,7 @@ def _kill_instance(inst, sig=signal.SIGTERM, delay=None):
         time.sleep(delay)
     os.kill(pid, signal.SIGKILL)
 
-def test_shutdown_on_deferred_memberof(topology_st):
+def test_shutdown_on_deferred_memberof(topology_st, request):
     """This test checks that shutdown is handled properly if memberof updayes are deferred.
 
     :id: c5629cae-15a0-11ee-8807-482ae39447e5


### PR DESCRIPTION
…e server crashed it should not launch memberof fixup task by default

Bug description:
	This is a continuation of the #6933
	The previous fix missed to add the request arugment in test_shutdown_on_deferred_memberof

Fix description:
	The fix adds the missing argument.

relates: #6933

## Summary by Sourcery

Tests:
- Update the deferred memberof shutdown test to accept the request fixture argument required by the test framework.