### PR TITLE
Issue 7128 - memory corruption in alias entry plugin

### DIFF
--- a/ldap/servers/plugins/alias_entries/alias-entries.c
+++ b/ldap/servers/plugins/alias_entries/alias-entries.c
@@ -139,7 +139,7 @@ alias_entry_srch(Slapi_PBlock *pb)
     /* If we hit MAXALIASCHAIN, free last node if not search_target */
     if (dn2 != NULL && dn1 != search_target) {
         slapi_sdn_free(&dn1);
-        slapi_sdn_free(&dn2)
+        slapi_sdn_free(&dn2);
         return 0;
     }
 

--- a/ldap/servers/plugins/alias_entries/alias-entries.c
+++ b/ldap/servers/plugins/alias_entries/alias-entries.c
@@ -123,7 +123,6 @@ alias_entry_srch(Slapi_PBlock *pb)
             if (tmp != search_target) {
                 slapi_sdn_free(&tmp);
             }
-            slapi_sdn_free(&tmp);
             slapi_send_ldap_result(pb, rc, NULL, errorbuf, 0, NULL);
             slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &rc);
             return SLAPI_PLUGIN_FAILURE;
@@ -140,6 +139,7 @@ alias_entry_srch(Slapi_PBlock *pb)
     /* If we hit MAXALIASCHAIN, free last node if not search_target */
     if (dn2 != NULL && dn1 != search_target) {
         slapi_sdn_free(&dn1);
+        slapi_sdn_free(&dn2)
         return 0;
     }
 


### PR DESCRIPTION
Description:
The plugin was freeing the original search base sdn, leading to memory corruption during operation teardown.

Fix:
Track ownership of sdn values in the alias dereference loop, only free temp alias sdn's created by the plugin.

Fixes: https://github.com/389ds/389-ds-base/issues/7128

Reviewed by:

## Summary by Sourcery

Fix memory corruption in the alias entries plugin by correcting DN ownership handling during alias dereference and search teardown.

Bug Fixes:
- Prevent freeing the original search base DN by only releasing temporary alias DNs created during alias dereference.
- Ensure alias chain traversal respects the maximum chain depth while safely cleaning up intermediate DNs.