### PR TITLE
Issue 7132 - Keep alive entry updated too soon after an offline import

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m3_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m3_test.py
@@ -11,12 +11,15 @@ import time
 import logging
 import ldap
 import pytest
-from lib389.idm.user import TEST_USER_PROPERTIES, UserAccounts
+from lib389.idm.user import TEST_USER_PROPERTIES, UserAccounts, UserAccount
 from lib389.utils import *
 from lib389._constants import *
 from lib389.replica import Changelog5
 from lib389.dseldif import *
 from lib389.topologies import topology_m3 as topo_m3
+from lib389.agreement import Agreements
+from lib389.replica import ReplicationManager, Replicas
+from lib389.cli_ctl.dblib import DbscanHelper
 
 
 pytestmark = pytest.mark.tier1
@@ -37,6 +40,7 @@ else:
     logging.getLogger(__name__).setLevel(logging.INFO)
 log = logging.getLogger(__name__)
 
+count = 0
 
 def test_cleanallruv_repl(topo_m3):
     """Test that cleanallruv could not break replication if anchor csn in ruv originated
@@ -163,6 +167,119 @@ def test_cleanallruv_repl(topo_m3):
 
     assert set(expected_m1_users).issubset(current_m1_users)
     assert set(expected_m2_users).issubset(current_m2_users)
+
+
+def get_agmt(inst, cn):
+    for agmt in Agreements(inst).list():
+        if agmt.get_attr_val_utf8("cn") == cn:
+            return agmt
+    return None
+
+
+def wait_for_val(user, val, timeout=60):
+    val = val.encode()
+    for _ in range(timeout):
+        time.sleep(1)
+        vals = user.get_attr_vals('description')
+        if val in vals:
+            return
+    assert False, f"Value {val} not found in {repr(user)} after {timeout} seconds"
+
+
+def perform_updates(inst, replicas):
+    global count
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    dn = 'uid=demo_user,ou=people,dc=example,dc=com'
+    user = UserAccount(inst, dn)
+    for i in range(4):
+        val = f'Test {count}'
+        user.add('description', val)
+        count += 1
+    for r in replicas:
+        user = UserAccount(r, dn)
+        wait_for_val(user, val)
+
+
+def check_updates(inst):
+    global count
+    dn = 'uid=demo_user,ou=people,dc=example,dc=com'
+    user = UserAccount(inst, dn)
+    vals = user.get_attr_vals('description')
+    for i in range(count):
+        assert f'Test {i}'.encode() in vals
+
+
+def test_offline_import(topo_m3):
+    """Test that keep alive is not updated too soon after an offline import
+
+    :id: 493a4810-cc5b-11f0-8c70-c85309d5c3e3
+    :setup: 3 Suppliers
+    :steps:
+        1. Configure Topology in single loop S1 --> S2 --> S3 --> S1
+        2. Set keep alive interrval to 60 seconds
+        3. Perform some updates on S1
+        4. Wait until changes are replicated to S2 and S3
+        5. Stop S3
+        6. Export S3 to ldif with replication metadata
+        7. Perform some updates on S1
+        8. Wait until changes are replicated to S2
+        9. Stop S2
+        10. Perform bulk import S3->S1
+        11. Start S3
+        12. Wait 40s
+        13. Start S2
+        14. Perform some updates on S2
+        15. Wait until changes are replicated to S3 and S1
+        16. Check that all changes are present on S1
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error
+        5. No error
+        6. No error
+        7. No error
+        8. No error
+        9. No error
+        10. No error
+        11. No error
+        12. No error
+        13. No error
+        14. No error
+        15. No error
+        16. No error if RHEL-129675 is fixed
+    """
+
+    S1 = topo_m3.ms["supplier1"]
+    S2 = topo_m3.ms["supplier2"]
+    S3 = topo_m3.ms["supplier3"]
+
+    r1 = Replicas(S1).get(DEFAULT_SUFFIX)
+    # 60 is the smallest accepted value for the interval time
+    r1.replace('nsds5ReplicaKeepAliveUpdateInterval', '60')
+    # Need to restart to reset repeated timer
+    S1.restart()
+
+    get_agmt(S1, "003").delete()
+    get_agmt(S2, "001").delete()
+    get_agmt(S3, "002").delete()
+    perform_updates(S1, (S2, S3))
+    S3.stop()
+    ldif_file = '%s/supplier3.ldif' % S3.get_ldif_dir()
+    S3.db2ldif(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX],
+               excludeSuffixes=None, repl_data=True,
+               outputfile=ldif_file, encrypt=False)
+    perform_updates(S1, (S2,))
+    S2.stop()
+    S1.stop()
+    S3.start()
+    S1.ldif2db(DEFAULT_BENAME, None, None, None, ldif_file)
+    S1.start()
+    # wait more than 30s to update keep alive
+    time.sleep(40)
+    S2.start()
+    perform_updates(S2, (S3,S1))
+    check_updates(S1)
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/replication/regression_m3_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m3_test.py
@@ -168,9 +168,9 @@ def test_cleanallruv_repl(topo_m3):
     assert set(expected_m2_users).issubset(current_m2_users)
 
 
-def get_agmt(inst, cn):
-    for agmt in Agreements(inst).list():
-        if agmt.get_attr_val_utf8("cn") == cn:
+def get_agmt(inst_from, inst_to):
+    for agmt in Agreements(inst_from).list():
+        if agmt.get_attr_val_utf8("nsDS5ReplicaPort") == str(inst_to.port):
             return agmt
     return None
 
@@ -254,9 +254,9 @@ def test_offline_import(topo_m3, request):
     S3 = topo_m3.ms["supplier3"]
 
     def fin():
-        get_agmt(S1, "003").resume()
-        get_agmt(S2, "001").resume()
-        get_agmt(S3, "002").resume()
+        get_agmt(S1, S3).resume()
+        get_agmt(S2, S1).resume()
+        get_agmt(S3, S2).resume()
 
     request.addfinalizer(fin)
     r1 = Replicas(S1).get(DEFAULT_SUFFIX)
@@ -265,9 +265,9 @@ def test_offline_import(topo_m3, request):
     # Need to restart to reset repeated timer
     S1.restart()
 
-    get_agmt(S1, "003").pause()
-    get_agmt(S2, "001").pause()
-    get_agmt(S3, "002").pause()
+    get_agmt(S1, S3).pause()
+    get_agmt(S2, S1).pause()
+    get_agmt(S3, S2).pause()
     perform_updates(S1, (S2, S3))
     S3.stop()
     ldif_file = '%s/supplier3.ldif' % S3.get_ldif_dir()

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -689,6 +689,7 @@ typedef int (*FNEnumReplica)(Replica *r, void *arg);
    from the data already in the DIT */
 Replica *replica_new(const Slapi_DN *root);
 Replica *windows_replica_new(const Slapi_DN *root);
+void reset_keepalive_timer(Replica *r);
 /* this function should be called to construct the replica object
    during addition of the replica over LDAP */
 int replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation, Replica **r);

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -689,7 +689,6 @@ typedef int (*FNEnumReplica)(Replica *r, void *arg);
    from the data already in the DIT */
 Replica *replica_new(const Slapi_DN *root);
 Replica *windows_replica_new(const Slapi_DN *root);
-void reset_keepalive_timer(Replica *r);
 /* this function should be called to construct the replica object
    during addition of the replica over LDAP */
 int replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation, Replica **r);

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -146,7 +146,7 @@ replica_new(const Slapi_DN *root)
     return r;
 }
 
-void
+static void
 reset_keepalive_timer(Replica *r)
 {
     if (r->repl_eqcxt_ka_update != NULL) {

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -146,6 +146,28 @@ replica_new(const Slapi_DN *root)
     return r;
 }
 
+void
+reset_keepalive_timer(Replica *r)
+{
+    if (r->repl_eqcxt_ka_update != NULL) {
+        slapi_eq_cancel_rel(r->repl_eqcxt_ka_update);
+        r->repl_eqcxt_ka_update = NULL;
+    }
+    if (replica_get_type(r) == REPLICA_TYPE_UPDATABLE) {
+        int64_t interval = replica_get_keepalive_update_interval(r);
+        int64_t bomax = slapi_counter_get_value(r->backoff_max);
+        if (interval <= bomax) {
+            slapi_log_err(SLAPI_LOG_WARNING, repl_plugin_name, "Replica %s "
+                          "should have a keep alive interval greater than the "
+                          "maximum backoff timeout\n", r->repl_name);
+        }
+        r->repl_eqcxt_ka_update = slapi_eq_repeat_rel(replica_subentry_update, r,
+                                                      slapi_current_rel_time_t() + interval,
+                                                      1000 * interval);
+    }
+}
+
+
 /* constructs the replica object from the newly added entry */
 int
 replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation, Replica **rp)
@@ -250,11 +272,7 @@ replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation,
                                            RUV_SAVE_INTERVAL);
 
     /* create supplier update event */
-    if (r->repl_eqcxt_ka_update == NULL && replica_get_type(r) == REPLICA_TYPE_UPDATABLE) {
-        r->repl_eqcxt_ka_update = slapi_eq_repeat_rel(replica_subentry_update, r,
-                                                      slapi_current_rel_time_t() + 30,
-                                                      1000 * replica_get_keepalive_update_interval(r));
-    }
+    reset_keepalive_timer(r);
 
     if (r->tombstone_reap_interval > 0) {
         /*
@@ -1562,12 +1580,7 @@ replica_set_enabled(Replica *r, PRBool enable)
 
         }
         /* create supplier update event */
-        if (r->repl_eqcxt_ka_update == NULL && replica_get_type(r) == REPLICA_TYPE_UPDATABLE) {
-            /* Should not create local update before the replica get a chance to resync after a restore/import */
-            r->repl_eqcxt_ka_update = slapi_eq_repeat_rel(replica_subentry_update, r,
-                                                       slapi_current_rel_time_t() + 2*PROTOCOL_BACKOFF_MAXIMUM,
-                                                       1000 * replica_get_keepalive_update_interval(r));
-        }
+        reset_keepalive_timer(r);
     } else /* disable */
     {
         if (r->repl_eqcxt_rs) /* event is still registerd */
@@ -3743,6 +3756,7 @@ replica_set_keepalive_update_interval(Replica *r, int64_t interval)
 {
     replica_lock(r->repl_lock);
     r->keepalive_update_interval = interval;
+    reset_keepalive_timer(r);
     replica_unlock(r->repl_lock);
 }
 


### PR DESCRIPTION
Problem: first keep alive update is done 30 seconds after restarting the server which may be before the other replica have the time to replicate local changes after a re-initialization.
Solution:  unify the timer management so that it starts after the keep alive interval (which is configurable)  in the 3 following cases:
 - server starts 
 - replica is enabled (i.e after bulk import)
 - keep alive interval is changed (to avoid having to restart the server after configuration change)
 
 Also logs a warning if the keep alive interval is smaller than the maximum backoff  timer value

Issue: #7132 

Reviewed by: @tbordaz , @droideck  (Thanks!)

## Summary by Sourcery

Adjust replication keep-alive scheduling to avoid premature updates after offline imports and ensure timers honor the configured interval across key lifecycle events.

New Features:
- Add a regression test covering offline import scenarios to verify keep-alive updates do not occur before replicas have time to resynchronize.

Bug Fixes:
- Ensure replica keep-alive updates are scheduled based on the configured interval rather than a hard-coded delay, and are correctly reset when replicas are created, enabled, or reconfigured.
- Prevent premature keep-alive updates after bulk imports or restores that could interfere with replica resynchronization.

Enhancements:
- Centralize keep-alive timer management into a shared helper for consistent behavior across replica lifecycle operations.
- Log a warning when the configured keep-alive interval is smaller than the maximum replication backoff timeout to highlight unsafe configurations.

Tests:
- Extend the replication regression test suite with a multi-supplier scenario that validates correct behavior of keep-alive updates following offline export/import and topology changes.