### PR TITLE
Issue 7135 - Not enough space for tests on GH runner

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -82,6 +82,21 @@ jobs:
         sudo systemctl unmask docker
         sudo systemctl start docker
 
+    - name: Free disk space
+      run: |
+        echo "Disk space before cleanup:"
+        df -h
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/lib/android/sdk/ndk
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo docker image prune --all --force
+        sudo apt-get clean
+        echo "Disk space after cleanup:"
+        df -h
+
     - name: Download RPMs
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -82,6 +82,21 @@ jobs:
         sudo systemctl unmask docker
         sudo systemctl start docker
 
+    - name: Free disk space
+      run: |
+        echo "Disk space before cleanup:"
+        df -h
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/lib/android/sdk/ndk
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo docker image prune --all --force
+        sudo apt-get clean
+        echo "Disk space after cleanup:"
+        df -h
+
     - name: Download RPMs
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Description:
Recently healthcheck tests started to fail with DSDSLE0001

> The disk partition used by the server (/), either for the database,
the configuration files, or the logs is over 90% full.

A fresh runner has 78% free space:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   57G   17G  78% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

There is preinstalled software that we don't use, like dotnet, GHC, CodeQL, docker images. We can remove them as part of the CI job to free up disk space.

Fixes: https://github.com/389ds/389-ds-base/issues/7135

## Summary by Sourcery

CI:
- Add a cleanup step in lmdbpytest and pytest GitHub workflows to remove unused preinstalled tools, prune Docker images, and clean apt caches to increase available disk space on runners.