### PR TITLE
Issue 6947 - (Cont) Revise time skew check in healthcheck tool and add

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -42,6 +42,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.list_checks = False
     args.check = None
     args.dry_run = False
+    args.exclude_check = []
 
     if json:
         log.info('Use healthcheck with --json option')

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -90,6 +90,7 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.verbose = instance.verbose
     args.list_errors = False
     args.list_checks = False
+    args.exclude_check = []
     args.check = [
         "config",
         "refint",


### PR DESCRIPTION
option to exclude checks

Description:
The changes for the following two files were missing.
- dirsrvtests/tests/suites/healthcheck/health_repl_test.py
- dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py

The change for health_repl_test.py is not same as other versions, since test_healthcheck_non_replicated_suffixes function doesn't exist. Changed run_healthcheck_and_flush_log function instead of that.

## Summary by Sourcery

Tests:
- Initialize the healthcheck CLI argument exclude_check in replication and system index healthcheck test helpers to cover the new exclusion option.