### PR TITLE
Issue 7138 - test_cleanallruv_repl does not restart supplier3

### DIFF
--- a/dirsrvtests/tests/suites/replication/regression_m3_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m3_test.py
@@ -166,6 +166,7 @@ def test_cleanallruv_repl(topo_m3):
 
     assert set(expected_m1_users).issubset(current_m1_users)
     assert set(expected_m2_users).issubset(current_m2_users)
+    M3.start()
 
 
 def get_agmt(inst_from, inst_to):


### PR DESCRIPTION
Fix CI by ensuring that all suppliers are started when completing the test

Issue: #7138

Reviewed by: @droideck  (Thanks!)

## Summary by Sourcery

Tests:
- Update the cleanallruv replication regression test to start the third supplier instance before completion.