### PR TITLE
Issue 6951 - Dynamic Certificate refresh phase 2 - Add/Modify/Delete support

### DIFF
--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -204,7 +204,7 @@ class ECDSA_Certificate:
         self.fixNamingAttribute(NameOID.COUNTRY_NAME, 'US')
         self.fixNamingAttribute(NameOID.ORGANIZATION_NAME, 'Example Organization')
 
-    def generateCA(self, namingAttributes, validity_days=3650):
+    def generateCA(self, nickname, namingAttributes={}, validity_days=3650):
         """Generate an intermediary CA certificate using elliptic curve"""
         ca = ECDSA_Certificate()
         ca.namingAttrs = namingAttributes

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -6,17 +6,38 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import os
+import sys
+import copy
+import datetime
+import ipaddress
+import ldap
+import ldapurl
 import logging
 import pytest
-import os
+import secrets
+import shutil
+import socket
 import subprocess
-from lib389.utils import ds_is_older
+import textwrap
+import time
+from contextlib import contextmanager, suppress
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography import x509
+from cryptography.x509.oid import NameOID, ExtensionOID
+from lib389.cli_base import FakeArgs
 from lib389._constants import DN_DM, PW_DM
+from lib389.dseldif import DSEldif
 from lib389.topologies import topology_st as topo
-from tempfile import TemporaryDirectory
+from lib389.utils import ds_is_older, ensure_str
+from tempfile import NamedTemporaryFile
 
 pytestmark = pytest.mark.tier1
 
+DYNCERT_SUFFIX = "cn=dynamiccertificates"
 DEBUGGING = os.getenv("DEBUGGING", default=False)
 if DEBUGGING:
     logging.getLogger(__name__).setLevel(logging.DEBUG)
@@ -24,187 +45,603 @@ else:
     logging.getLogger(__name__).setLevel(logging.INFO)
 log = logging.getLogger(__name__)
 
-script_content="""
-#!/bin/bash
-set -e  # Exit if a command fails
-set -x  # Log the commands
+tls_enabled = False
 
-cd {dir}
-inst={instname}
-url={url}
-rootdn="{rootdn}"
-rootpw="{rootpw}"
+
+@contextmanager
+def redirect_stdio(msg):
+    # Used to log stdin/stdout in pytest logs
+    with NamedTemporaryFile('w+t') as f:
+        oldstdout = os.dup(1)
+        oldstderr = os.dup(2)
+        os.dup2(f.fileno(), 1)
+        os.dup2(f.fileno(), 2)
+        try:
+            yield f
+        finally:
+            os.dup2(oldstdout, 1)
+            os.dup2(oldstderr, 2)
+            os.close(oldstdout)
+            os.close(oldstderr)
+            f.seek(0)
+            log.info(f'STDIO TRACE: start of {msg} traces')
+            for line in f:
+                log.info(f'STDIO TRACE: {line.rstrip()}')
+            log.info(f'STDIO TRACE: end of {msg} traces')
+
+
+@contextmanager
+def traced_ldap_connection(url, msg):
+    # Open ldap connection with traces
+    with redirect_stdio(msg) as f:
+        ldap.set_option(ldap.OPT_DEBUG_LEVEL, -1)
+        ldap.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+        l = ldap.initialize(url, trace_level=0, trace_file=f, trace_stack_limit=1)
+        try:
+            yield l
+        finally:
+            l.unbind()
+
+@contextmanager
+def ldapi(inst):
+    l = open_ldapi_conn(inst)
+    try:
+        yield l
+    finally:
+        l.unbind()
+
 
 ################################
 ###### GENERATE CA CERT ########
 ################################
+class ECDSA_Certificate:
+    """Elliptic Curve Certificate Generator"""
 
-echo "
-[ req ]
-distinguished_name = req_distinguished_name
-policy             = policy_match
-x509_extensions     = v3_ca
+    PKCS12_PASSWORD = "a+password"
 
-# For the CA policy
-[ policy_match ]
-countryName             = optional
-stateOrProvinceName     = optional
-organizationName        = optional
-organizationalUnitName  = optional
-commonName              = supplied
-emailAddress            = optional
+    def __init__(self):
+        self.nickname = None
+        self.trust = None
+        self.namingAttrs = {}
+        self.subject = None
+        self.validity_days = 365
+        self.isCA = False
+        self.isRoot = False
+        self.caChain = None
 
-[ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= FR
-countryName_min			= 2
-countryName_max			= 2
+    @staticmethod
+    def generateRootCA(nickname, namingAttributes={}, validity_days=3650):
+        """Generate a self-signed Root CA certificate using elliptic curve"""
+        ca = ECDSA_Certificate()
+        ca.namingAttrs = namingAttributes
+        ca.validity_days = validity_days
+        ca.isCA = True
+        ca.isRoot = True
+        ca.nickname = nickname
+        ca.fixNamingAttributes()
+        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
+        ca.issuer = ca.subject
+        ca.trust = 'CT,,'
 
-stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= test
+        # Generate prime256v1 private key
+        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        ca.cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca.subject)
+            .issuer_name(ca.issuer)
+            .public_key(ca.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # CA certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    key_cert_sign=True,
+                    crl_sign=False,
+                    key_encipherment=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
+                critical=False,
+            )
+            .sign(ca.pkey, hashes.SHA256(), default_backend())
+        )
+        return ca
 
-localityName			= Locality Name (eg, city)
+    @staticmethod
+    def save_pem_file(filename, *items):
+        """Save PEM formatted items to file"""
+        with open(filename, "wb") as f:
+            for item in items:
+                if isinstance(item, ec.EllipticCurvePrivateKey):
+                    pem = item.private_bytes(
+                        encoding=serialization.Encoding.PEM,
+                        format=serialization.PrivateFormat.TraditionalOpenSSL,
+                        encryption_algorithm=serialization.NoEncryption()
+                    )
+                elif isinstance(item, x509.Certificate):
+                    pem = item.public_bytes(serialization.Encoding.PEM)
+                else:
+                    raise ValueError(f"Unknown item type: {type(item)}")
+                f.write(pem)
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= test-ECDSA-CA
+    @staticmethod
+    def save_der_file(filename, item):
+        """Save DER formatted item to file"""
+        with open(filename, "wb") as f:
+            if isinstance(item, ec.EllipticCurvePrivateKey):
+                der = item.private_bytes(
+                    encoding=serialization.Encoding.DER,
+                    format=serialization.PrivateFormat.PKCS8, #format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption()
+                )
+            elif isinstance(item, x509.Certificate):
+                der = item.public_bytes(serialization.Encoding.DER)
+            else:
+                raise ValueError(f"Unknown item type: {type(item)}")
+            f.write(der)
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
+    def fixNamingAttribute(self, name, vdef):
+        """Set value for naming attribute if it is missing"""
+        if name not in self.namingAttrs:
+            self.namingAttrs[name] = vdef
 
-commonName			= Common Name (e.g. server FQDN or YOUR name)
-commonName_max			= 64
+    def fixNamingAttributes(self):
+        """Set default value for mandatory naming attributes"""
+        self.fixNamingAttribute(NameOID.COMMON_NAME, self.nickname)
+        self.fixNamingAttribute(NameOID.COUNTRY_NAME, 'US')
+        self.fixNamingAttribute(NameOID.ORGANIZATION_NAME, 'Example Organization')
+
+    def generateCA(self, namingAttributes, validity_days=3650):
+        """Generate an intermediary CA certificate using elliptic curve"""
+        ca = ECDSA_Certificate()
+        ca.namingAttrs = namingAttributes
+        ca.validity_days = validity_days
+        ca.isCA = True
+        ca.isRoot = False
+        ca.nickname = nickname
+        ca.fixNamingAttributes()
+        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
+        ca.issuer = self.subject
+        ca.trust = 'CT,,'
+
+        # Generate prime256v1 private key
+        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        ca.cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca.subject)
+            .issuer_name(ca.issuer)
+            .public_key(ca.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # CA certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    key_cert_sign=True,
+                    crl_sign=False,
+                    key_encipherment=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
+                critical=False,
+            )
+            .sign(self.pkey, hashes.SHA256(), default_backend())
+        )
+        return ca
+
+    def generateCertificate(self, nickname, namingAttributes={}, hostname=None, validity_days=3650):
+        """Generate an user certificate using elliptic curve"""
+        cert = ECDSA_Certificate()
+        cert.namingAttrs = namingAttributes
+        cert.validity_days = validity_days
+        cert.isCA = False
+        cert.isRoot = False
+        cert.nickname = nickname
+        cert.fixNamingAttributes()
+        cert.subject = x509.Name([x509.NameAttribute(k,v) for k,v in cert.namingAttrs.items()])
+        cert.issuer = self.subject
+        cert.trust = 'u,u,u'
+        cert.caChain = self
+
+        if hostname is None:
+            hostname = socket.gethostname()
+
+        san_list = [x509.DNSName(hostname),]
+        if hostname != 'localhost':
+            san_list.append(x509.DNSName(hostname))
+        san_list.append(x509.IPAddress(ipaddress.ip_address("127.0.0.1")))
+        san_list.append(x509.IPAddress(ipaddress.ip_address("::1")))
+
+        # Generate prime256v1 private key
+        cert.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        cert.cert = (
+            x509.CertificateBuilder()
+            .subject_name(cert.subject)
+            .issuer_name(cert.issuer)
+            .public_key(cert.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # Server certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_encipherment=True,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+                ]),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectAlternativeName(san_list),
+                critical=False,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(cert.pkey.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
+                critical=False,
+            )
+            .sign(self.pkey, hashes.SHA256(), default_backend())
+        )
+        return cert
+
+    def write_pkcs12_file(self, filename, pw=PKCS12_PASSWORD):
+        """Save PKCS12 formatede certificate and private key"""
+        if isinstance(pw, str):
+            pw = pw.encode()
+        if pw is None or pw == b"":
+            enc = serialization.NoEncryption()
+        else:
+            enc = serialization.BestAvailableEncryption(pw)
+        with open(filename, "wb") as f:
+            f.write(pkcs12.serialize_key_and_certificates(
+                self.nickname.encode(),
+                self.pkey,
+                self.cert,
+                [],
+                enc
+            ))
+
+    def save(self, dirname, pk12pw=PKCS12_PASSWORD):
+        print(f'Writing files for {self.nickname}')
+        if self.isCA:
+            name = f'{dirname}/{self.nickname}-ca'
+        else:
+            name = f'{dirname}/{self.nickname}-cert'
+        self.pem = f"{name}-cert.pem"
+        self.der = f"{name}-cert.der"
+        self.key = f"{name}-key.pem"
+        self.kder = f"{name}-key.der"
+        self.p12 = f"{name}.p12"
+        ECDSA_Certificate.save_pem_file(self.pem, self.cert)
+        ECDSA_Certificate.save_der_file(self.der, self.cert)
+        ECDSA_Certificate.save_pem_file(self.key, self.pkey)
+        ECDSA_Certificate.save_der_file(self.kder, self.pkey)
+        self.write_pkcs12_file(self.p12, pk12pw)
+
+    def run(self, cmd):
+        log.info(f'Running: {" ".join(cmd)}')
+        res = subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        assert res
+        log.info(f'Stdout+Stderr:{res.stdout}')
+        res.check_returncode()
+
+    def __repr__(self):
+        return self.nickname
+
+    @staticmethod
+    def nss_db_paths(inst):
+        prefix = os.environ.get('PREFIX', "/")
+        certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
+        pwfile = f'{certdbdir}/pwdfile.txt'
+        return ( prefix, certdbdir, pwfile )
+
+    def clear_nss_db(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)
+        inst.stop()
+        for f in ('cert9.db', 'key4.db'):
+            try:
+                os.remove(f'{certdbdir}/{f}')
+            except OSError:
+                pass
+        self.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile, '-@', pwfile))
+
+    def offline_install(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)
+        if self.isCA:
+            self.run(('certutil', '-A', '-n', self.nickname, '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', self.pem))
+        else:
+            self.run(('pk12util', '-v', '-i', self.p12, '-d', certdbdir, '-k', pwfile, '-W', ECDSA_Certificate.PKCS12_PASSWORD))
+
+    def show(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)
+        self.run(('certutil', '-L', '-n', self.nickname,  '-d', certdbdir))
+
+    def rename(self, inst, newname):
+        olddn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+        newdn = f'cn={newname}'
+        with ldapi(inst) as ldc:
+            ldc.modrdn_s(olddn, newdn)
+        newobj = copy.copy(self)
+        newobj.nickname = newname
+        return newobj
+
+    def delete(self, inst):
+        dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+        with ldapi(inst) as ldc:
+            ldc.delete_s(dn)
+
+    def showAll(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)
+        self.run(('certutil', '-L', '-d', certdbdir))
+
+    def read_cert(self, inst):
+        with ldapi(inst) as ldc:
+            with suppress(ldap.NO_SUCH_OBJECT):
+                dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+                res = ldc.search_s(dn, ldap.SCOPE_BASE)
+                log.info(f'Certificate {self.nickname} is {res}')
+                return res
+        log.info(f'Certificate {self.nickname} is not found')
+        return None
+
+    def online_install(self, inst):
+        old_cert = self.read_cert(inst)
+        log.info(f'Before online_install: cert={old_cert}')
+        dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+        if self.isCA:
+            # Read DER file
+            with open(self.der, "rb") as f:
+                dercert = f.read()
+                derpkey = None
+        else:
+            # Read PKCS12 file
+            with open(self.p12, "rb") as f:
+                p12_data = f.read()
+                p12pw = ECDSA_Certificate.PKCS12_PASSWORD.encode()
+            privkey, cert, cas = pkcs12.load_key_and_certificates(p12_data, p12pw)
+            dercert = cert.public_bytes(serialization.Encoding.DER)
+            derpkey = privkey.private_bytes(encoding=serialization.Encoding.DER,
+                                            format=serialization.PrivateFormat.PKCS8,
+                                            encryption_algorithm=serialization.NoEncryption())
+        with ldapi(inst) as ldc:
+            if old_cert:
+                log.info(f'+++ Trying to replace {dn} +++')
+                mods = [(ldap.MOD_REPLACE, 'nsDynamicCertificateDER', [ dercert, ]),]
+                if derpkey:
+                    mods.append((ldap.MOD_REPLACE, 'nsDynamicCertificatePrivateKeyDER', [ derpkey, ]))
+                ldc.modify_s(dn, mods)
+                self.show(inst)
+            else:
+                log.info(f'+++ Trying to add {dn} +++')
+                e = [
+                     ('cn', [ self.nickname.encode(encoding="utf-8"), ] ),
+                     ('objectclass', [ b'top', b'extensibleobject' ] ),
+                     ('dsDynamicCertificateDER', [ dercert, ] ),
+                    ]
+                if derpkey:
+                    e.append(('dsDynamicCertificatePrivateKeyDER', [derpkey,]))
+                ldc.add_s(dn, e)
+        new_cert = self.read_cert(inst)
+        log.info(f'After online_install: cert={new_cert}')
+        assert new_cert != old_cert
+
+    def setSslPersonality(self, inst):
+        ldc = open_ldapi_conn(inst)
+        dn='cn=RSA,cn=encryption,cn=config'
+        mods = [ (ldap.MOD_REPLACE, 'nsSSLPersonalitySSL', [ self.nickname.encode(), ]), ]
+        ldc.modify_s(dn, mods)
 
 
-[ v3_ca ]
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = critical,CA:true
-#nsComment = "OpenSSL Generated Certificate"
-keyUsage=critical, keyCertSign
-" >ca.conf
+#########################################################
+###### Work around to debug libldap/liblber CERT ########
+#########################################################
 
-
-openssl ecparam -genkey -name prime256v1 -out ca.key
-openssl req -x509 -new -sha256 -key ca.key -nodes -days 3650 -config ca.conf -subj "/CN=`hostname`/O=test-ECDSA-CA/C=FR"  -out ca.pem -keyout ca.key
-openssl x509 -outform der -in ca.pem -out ca.crt
-
-openssl x509 -text -in ca.pem
-
-####################################
-###### GENERATE SERVER CERT ########
-####################################
-
-echo "
-[ req ]
-distinguished_name = req_distinguished_name
-policy             = policy_match
-x509_extensions     = v3_cert
-
-# For the cert policy
-[ policy_match ]
-countryName             = optional
-stateOrProvinceName     = optional
-organizationName        = optional
-organizationalUnitName  = optional
-commonName              = supplied
-emailAddress            = optional
-
-[ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= FR
-countryName_min			= 2
-countryName_max			= 2
-
-stateOrProvinceName		= State or Province Name (full name)
-
-localityName			= Locality Name (eg, city)
-
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= test-ECDSA
-
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
-
-commonName			= Common Name (e.g. server FQDN or YOUR name)
-commonName_max			= 64
-
-
-[ v3_cert ]
-basicConstraints = critical,CA:false
-subjectAltName=DNS:`hostname`
-keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-#nsComment = "OpenSSL Generated Certificate"
-extendedKeyUsage=clientAuth, serverAuth
-nsCertType=client, server
-" >cert.conf
-
-openssl ecparam -genkey -name prime256v1 -out cert.key
-openssl req -new -sha256 -key cert.key -nodes  -config cert.conf -subj "/CN=`hostname`/O=test-ECDSA/C=FR" -out cert.csr 
-openssl x509 -req -sha256 -days 3650 -extensions v3_cert -extfile cert.conf -in cert.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out cert.pem 
-openssl pkcs12 -export -inkey cert.key -in cert.pem -name ecdsacert -out cert.p12 -passout pass:secret12
-
-openssl x509 -text -in cert.pem
-
-
-#############################
-###### INSTALL CERTS ########
-#############################
-
-certdbdir=$PREFIX/etc/dirsrv/slapd-$inst
-rm -f $certdbdir/cert9.db $certdbdir/key4.db
-certutil -N -d $certdbdir -f $certdbdir/pwdfile.txt 
-
-certutil -A -n Self-Signed-CA -t CT,, -f $certdbdir/pwdfile.txt -d $certdbdir -a -i ca.pem
-
-dsctl $inst tls import-server-key-cert cert.pem cert.key
-
-dsctl $inst restart
+def open_ldap(url, logfile):
+    if logfile is not None:
+        lutil_debug_file(logfile)
+        ldap.set_option(ldap.OPT_DEBUG_LEVEL, -1)
+        loglv = 3
+    else:
+        lutil_debug_file(logfile)
+        ldap.set_option(ldap.OPT_DEBUG_LEVEL, 0)
+        loglv = 0
+        logfile = sys.stderr
+    ldap.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+    return ldap.initialize(url, trace_level=loglv, trace_file=logfile)
 
 
 #########################
 ###### TEST CERT ########
 #########################
-LDAPTLS_CACERT=$PWD/ca.pem ldapsearch -x -H $url -D "$rootdn" -w "$rootpw" -b "" -s base
-"""
+
+def open_ldaps_conn(inst, ca):
+    url = f'ldaps://localhost:{inst.sslport}'
+    log.info(f'Attempt to connect to {url} using {ca.pem}')
+    ld = ldap.initialize(url)
+    #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+    ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
+    ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
+    ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+    return ld
 
 
-def test_ecdsa(topo):
-    """Specify a test case purpose or name here
+def open_ldapi_conn(inst, logfile=None):
+    dse = DSEldif(inst)
+    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
+    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
+    log.info(f'Attempt to connect to {url} using sasl external authentication')
+    ld = ldap.initialize(url)
+    # Perform autobind
+    sasl_auth = ldap.sasl.external()
+    ld.sasl_interactive_bind_s("", sasl_auth)
+    return ld
+
+
+def tls_search(inst, ca):
+    url = f'ldaps://localhost:{inst.sslport}'
+    log.info(f'Attempt to connect to {url} using {ca.pem}')
+    with traced_ldap_connection(url, f'ldaps bind using CA {ca}') as ld:
+        #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+        ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
+        ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
+        ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        ld.simple_bind_s(DN_DM, PW_DM)
+        results = ld.search_s('', ldap.SCOPE_BASE)
+        assert len(results) == 1
+
+
+#
+#  Ideally There should be a dsctl/dsconf subcommand
+#
+def refresh_certs(inst, timeout=60):
+    ld = open_ldapi_conn(inst)
+    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
+    # Now lets wait until the config value is off again
+    for _ in range(timeout):
+        result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
+        log.info(f'cn=config result: {result}')
+        attrs = result[0][1]
+        vals = attrs['nsslapd-refresh-certificates']
+        if vals[0].decode("utf-8").lower() == "off":
+            ld.unbind()
+            return
+        time.sleep(1)
+    raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
+
+# Generate Server Certifcate and Root CA and install them
+@pytest.fixture(scope="module")
+def ecdsa_certs(topo, request):
+    dir = '/tmp/ecdsa_certs'
+    def fin():
+        if not DEBUGGING:
+            with suppress(FileNotFoundError):
+                shutil.rmtree(dir)
+    request.addfinalizer(fin)
+    with suppress(FileNotFoundError):
+        shutil.rmtree(dir)
+    os.makedirs(dir, 0o700)
+    inst=topo.standalone
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
+    ca = ECDSA_Certificate.generateRootCA("CA")
+    cert = ca.generateCertificate("Cert")
+    cert.setSslPersonality(inst)
+    ca.clear_nss_db(inst)
+    ca.showAll(inst)
+    ca.save(dir)
+    cert.save(dir)
+    cert.offline_install(inst)
+    cert.show(inst)
+    ca.offline_install(inst)
+    ca.show(inst)
+    ca.showAll(inst)
+    inst.restart(post_open=False)
+    return (cert, ca, dir)
+
+
+def test_ecdsa(topo, ecdsa_certs):
+    """Setup instance with ecdsa certificates
 
     :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
-    :setup: Standalone Instance
+    :setup: Standalone Instance with ecdsa certificates
     :steps:
-        1. Generate the test script
-        2. Run the test script
-        3. Check that ldapsearch returned the namingcontext
+        1. Open ldaps connection with server CA certificate and search root entry
     :expectedresults:
         1. No error
-        2. No error and exit code should be 0
-        3. namingcontext should be in the script output
     """
 
     inst=topo.standalone
-    inst.enable_tls()
-    with TemporaryDirectory() as dir:
-        scriptname = f"{dir}/doit"
-        scriptname = "/tmp/doit"
-        d = {
-            'dir': dir,
-            'instname': inst.serverid,
-            'url': f"ldaps://localhost:{inst.sslport}",
-            'rootdn': DN_DM,
-            'rootpw': PW_DM,
-        }
-        with open(scriptname, 'w') as f:
-            f.write(script_content.format(**d))
-        res = subprocess.run(('/bin/bash', scriptname), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
-        assert res
-        log.info(res.stdout)
-        res.check_returncode()
-        # If ldapsearch is successful then defaultnamingcontext should be in res.stdout
-        assert "defaultnamingcontext" in res.stdout
+    cert, ca, dir = ecdsa_certs
+    tls_search(inst, ca)
 
 
+def test_dynamic(topo, ecdsa_certs):
+    """Check that certificates can be managed dynamically
+
+    :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
+    :setup: Standalone Instance with ecdsa certificates
+    :steps:
+        1. Create Test-DynCert-1 certificate
+        2. Add it dynamically
+        3. Search for Test-DynCert-1
+        4. Rename Test-DynCert-1 as Test-DynCert-2
+        5. Search for Test-DynCert-1
+        6. Search for Test-DynCert-2
+        7. Delete dynamically Test-DynCert-2
+        8. Search for Test-DynCert-2
+    :expectedresults:
+        1. No error
+        2. No error
+        3. Entry should exists
+        4. No error
+        5. Entry should not exists
+        6. Entry should exists
+        7. No error
+        8. Entry should not exists
+    """
+
+    inst=topo.standalone
+    cert, ca, dir = ecdsa_certs
+    cert1 = ca.generateCertificate("Test-DynCert-1")
+    cert1.save(dir)
+    cert1.online_install(inst)
+    assert cert1.read_cert(inst)
+    cert2 = cert1.rename(inst, "Test-DynCert-2")
+    assert not cert1.read_cert(inst)
+    assert cert2.read_cert(inst)
+    cert2.delete(inst)
+    assert not cert2.read_cert(inst)
 
 
 if __name__ == '__main__':

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -31,9 +31,6 @@ objectClass: nsEncryptionConfig
 cn: encryption
 nsSSLSessionTimeout: 0
 nsSSLClientAuth: allowed
-aci: (target ="ldap:///*cn=dynamiccertificates")(targetattr="
- *")(version 3.0; acl "dynamic certificates"; deny( all ) us
- erdn = "ldap:///all";)
 
 dn: cn=RSA,cn=encryption,cn=config
 objectClass: top

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -31,6 +31,9 @@ objectClass: nsEncryptionConfig
 cn: encryption
 nsSSLSessionTimeout: 0
 nsSSLClientAuth: allowed
+aci: (target ="ldap:///*cn=dynamiccertificates")(targetattr="
+ *")(version 3.0; acl "dynamic certificates"; deny( all ) us
+ erdn = "ldap:///all";)
 
 dn: cn=RSA,cn=encryption,cn=config
 objectClass: top

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -428,6 +428,16 @@ attrcrypt_fetch_private_key(SECKEYPrivateKey **private_key)
     return ret;
 }
 
+/* Free acs */
+static void
+acs_free(attrcrypt_cipher_state **acs)
+{
+    if (*acs) {
+        PR_DestroyLock((*acs)->cipher_lock);
+        slapi_ch_free((void**)acs);
+    }
+}
+
 /*
  CKM_AES_CBC_PAD
  CKM_DES3_CBC_PAD
@@ -538,7 +548,7 @@ attrcrypt_init(ldbm_instance *li)
                     attrcrypt_cipher_state *acs = (attrcrypt_cipher_state *)slapi_ch_calloc(sizeof(attrcrypt_cipher_state), 1);
                     ret = attrcrypt_cipher_init(li, ace, private_key, public_key, acs);
                     if (ret) {
-                        slapi_ch_free((void **)&acs);
+                        acs_free(&acs);
                         if (li->attrcrypt_configured) {
                             if ((ace + 1)->cipher_number) {
                                 /* this is not the last cipher */
@@ -1171,7 +1181,7 @@ back_crypt_init(Slapi_Backend *be, const char *dn, const char *encAlgorithm, voi
                           "Please choose other cipher or disable changelog "
                           "encryption.\n",
                           ace->cipher_display_name);
-            slapi_ch_free((void **)&acs);
+            acs_free(&acs);
         } else {
             /* Since we succeeded, set acs to state_priv */
             _back_crypt_acs_list_add(state_priv, acs);

--- a/ldap/servers/slapd/dyncerts.c
+++ b/ldap/servers/slapd/dyncerts.c
@@ -38,7 +38,7 @@ static struct dyncerts pdyncerts;
  * dsDynamicCertificateSwitchInProgress is always seen as FALSE
  * Because accept and listening thread are blocked
  * when it is switched to TRUE (so it cannot be queried)
- */ 
+ */
 static const char *dyncerts_baseentry_str =
     "dn: " DYNCERTS_SUFFIX "\n"
     "objectclass: top\n"
@@ -63,10 +63,11 @@ static const struct trust_flags_mask trust_flags[] = {
 /* Some forward definitions */
 static DCSS *get_entry_list(const Slapi_DN *basesn, int scope, char **attrs);
 int dyncerts_apply_cb(const char *nickname, dyc_action_cb_t cb, void *arg, char *errmsg);
+static void dyncert_nickname_free(Nickname_t *n);
 
 /* Alloc a search set */
 static DCSS *
-ss_new()
+ss_new(void)
 {
     return (DCSS *)slapi_ch_calloc(1, sizeof (DCSS));
 }
@@ -113,7 +114,7 @@ be_unwillingtoperform(Slapi_PBlock *pb)
 
 /* Get instance config data and store them in private data */
 static void
-read_config_info()
+read_config_info(void)
 {
     if (pdyncerts.config == NULL) {
         DCSS *ss = ss_new();
@@ -150,7 +151,7 @@ read_config_info()
 
 /* Free private data instance config data */
 static void
-free_config_info()
+free_config_info(void)
 {
     if (pdyncerts.config != NULL) {
         ss_destroy(&pdyncerts.config);
@@ -183,16 +184,14 @@ dyncerts_search_set_release(void **pss)
 static Slapi_Entry *
 dyncerts_find_entry(const Slapi_DN *basedn, int scope, char **attrs, DCSS **be_ss)
 {
-    Slapi_DN suffix = {0};
     Slapi_Entry *e = NULL;
     DCSS *ss = NULL;
 
-    slapi_sdn_init_dn_byref(&suffix, DYNCERTS_SUFFIX);
     read_config_info();
-    if (slapi_sdn_compare(basedn, &suffix) != 0) {
+    if (slapi_sdn_compare(basedn, &pdyncerts.suffix_sdn) != 0) {
         scope = LDAP_SCOPE_SUBTREE;
     }
-    ss =  get_entry_list(&suffix, scope, attrs);
+    ss =  get_entry_list(&pdyncerts.suffix_sdn, scope, attrs);
     for(size_t idx = 0; idx<ss->nb_entries; idx++) {
         e = ss->entries[idx];
         if (slapi_sdn_compare(basedn, slapi_entry_get_sdn_const(e)) == 0) {
@@ -201,7 +200,6 @@ dyncerts_find_entry(const Slapi_DN *basedn, int scope, char **attrs, DCSS **be_s
         e = NULL;
     }
     *be_ss = ss;
-    slapi_sdn_done(&suffix);
     return e;
 }
 
@@ -328,7 +326,7 @@ dyncerts_prev_search_results(void *vp)
     Slapi_PBlock *pb = (Slapi_PBlock *)vp;
     DCSS *ss = NULL;
     slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_SET, &ss);
-    if (ss->cur_entry > 0) {
+    if (ss && ss->cur_entry > 0) {
         ss->cur_entry--;
     }
 }
@@ -351,6 +349,7 @@ dyncerts_cleanup(Slapi_PBlock *pb)
         pdata = NULL;
     }
     slapi_pblock_set(pb, SLAPI_PLUGIN_PRIVATE, pdata);
+    slapi_sdn_done(&pdyncerts.suffix_sdn);
     pthread_mutex_unlock(&mutex);
     return 0;
 }
@@ -754,7 +753,7 @@ dyncerts_cert2entry(CERTCertificate *cert)
     char *nickname = get_cert_nickname(cert);
     char *dn = slapi_ch_smprintf("cn=%s,%s", nickname, DYNCERTS_SUFFIX);
     Slapi_Entry *e = slapi_entry_alloc();
-    char tmpbuff[32] = "";
+    char tmpbuff[TRUST_SIZE] = "";
     PRTime notBefore = 0;
     PRTime notAfter = 0;
     Slapi_Value tmpv = {0};
@@ -798,6 +797,785 @@ dyncerts_cert2entry(CERTCertificate *cert)
     return e;
 }
 
+/* Free data alloced by nss_add_cert_and_key within CertCtx_t*/
+static void
+dyncerts_free_nss_add_cert_and_key(CertCtx_t *ctx)
+{
+    if (ctx->cert) {
+        CERT_DestroyCertificate(ctx->cert);
+        ctx->cert = NULL;
+    }
+    if (ctx->privkey) {
+        if (ctx->ldaprc) {
+            PK11_DeleteTokenPrivateKey(ctx->privkey, PR_FALSE);
+        } else {
+            SECKEY_DestroyPrivateKey(ctx->privkey);
+        }
+        ctx->privkey = NULL;
+    }
+}
+
+
+/* Free data within CertCtx_t */
+void
+dyncerts_cert_ctx_done(CertCtx_t *ctx)
+{
+    if (ctx->dercert.data) {
+         slapi_ch_free((void**)&ctx->dercert.data);
+         ctx->dercert.data = NULL;
+    }
+    if (ctx->derpkey.data) {
+        slapi_ch_free((void**)&ctx->derpkey.data);
+        ctx->derpkey.data = NULL;
+    }
+    dyncert_nickname_free(&ctx->n);
+    slapi_ch_free_string(&ctx->trust);
+    ctx->force = false;
+    if (ctx->slot) {
+        PK11_FreeSlot(ctx->slot);
+        ctx->slot = NULL;
+    }
+    dyncerts_free_nss_add_cert_and_key(ctx);
+    ctx->ldaprc = 0;
+}
+
+/* Split nicklname into nickname + tokenname */
+int
+dyncert_resolve_token(CertCtx_t *ctx)
+{
+    char *del = NULL;
+    if (ctx->n.nickname == 0) {
+        ERRMSG(ctx, LDAP_OBJECT_CLASS_VIOLATION, "%s attribute is missing.", DYCATTR_NICKNAME);
+    }
+    ctx->internal_token = (ctx->n.token == NULL);
+    del = strchr(ctx->n.nickname, ':');
+    if (del) {
+        ERRMSG(ctx, LDAP_UNWILLING_TO_PERFORM, "%s attribute should not contain any : except for the token name.", DYCATTR_NICKNAME);
+    }
+    if (ctx->internal_token) {
+        ctx->slot = slapd_pk11_getInternalKeySlot();
+        ctx->n.token = PK11_GetTokenName(ctx->slot);
+    } else {
+        ctx->slot = PK11_FindSlotByName(ctx->n.token);
+        if (!ctx->slot) {
+            ERRMSG(ctx, LDAP_UNWILLING_TO_PERFORM, "Cannot find token %s", ctx->n.token);
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Add a certificate and optionnaly its private key in NSS db
+ *
+ * CertCtx_t input:
+ *    - nickname
+ *    - dercert
+ *    - derpkey (optionnal)
+ *    - trust (optionnal)
+ *    - force (ignore verification failure)
+ *    - errmsg
+ * CertCtx_t output:
+ *    - primary (Is the primary server certificate)
+ *    - trust
+ *    - cert
+ *    - ldaprc
+ *    - errmsg
+ */
+static SECStatus
+nss_add_cert_and_key(CertCtx_t *ctx, bool verifyOnly)
+{
+#define CHECK_ERR(msg)    if (rv != SECSuccess) { errmsg = msg; goto done; }
+    SECStatus rv = SECFailure;
+    CERTCertificate *cert = ctx->cert;
+    SECKEYPrivateKey *privkey = NULL;
+    SECKEYPublicKey *pubkey = NULL;
+    SECCertificateUsage returnedUsages = 0;
+    SECCertificateUsage usage = 0;
+    CERTCertTrust trust = {0};
+    const char *errmsg = NULL;
+    char *pw = NULL;
+
+    if (PK11_NeedLogin(ctx->slot)) {
+        rv = PK11_Authenticate(ctx->slot, PR_TRUE, _get_pw(ctx->n.token));
+        CHECK_ERR("Failed to authenticate to token")
+    }
+    cert = CERT_DecodeCertFromPackage((char *)ctx->dercert.data, ctx->dercert.len);
+    ctx->cert = cert;
+    if (cert == NULL) {
+        errmsg = "Failed to decode certificate";
+        goto done;
+    }
+    if (cert->isperm && !(verifyOnly && strcasecmp(ctx->n.nickname, cert->nickname) == 0)) {
+        /* Certificate already exists so NSS will not add it again
+         * and we are not doing a modify operation that replace the certificate
+         * by itself
+         */
+        rv = SECFailure;
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        PR_snprintf((ctx)->errmsg, SLAPI_DSE_RETURNTEXT_SIZE, "Confict with certificate %s",
+                    cert->nickname);
+        goto done2;
+    }
+    ctx->primary = is_servercert_int(ctx->n.token, ctx->n.nickname);
+    if (!ctx->trust) {
+        ctx->trust = ",,";
+        if (cert->nsCertType & NS_CERT_TYPE_SSL_CA) {
+            if (ctx->primary) {
+                ctx->trust = "CTu,u,u";
+            } else {
+                ctx->trust = "CT,,";
+            }
+        } else if (ctx->cert->nsCertType & (NS_CERT_TYPE_SSL_CLIENT|NS_CERT_TYPE_SSL_SERVER)) {
+            ctx->trust = "u,u,u";
+        }
+        ctx->trust = slapi_ch_strdup(ctx->trust);
+    }
+    rv = CERT_DecodeTrustString(&trust, ctx->trust);
+    CHECK_ERR("Failed to decode the trust string");
+    if (ctx->derpkey.data) {
+        /* Import the private key (PKCS#8 format) */
+        rv = PK11_ImportDERPrivateKeyInfoAndReturnKey(
+            ctx->slot,
+            &ctx->derpkey,
+            NULL,              /* nickname */
+            NULL,              /* publicValue */
+            PR_TRUE,           /* isPerm */
+            PR_TRUE,           /* isPrivate */
+            KU_ALL,            /* key usage */
+            &privkey,
+            NULL               /* wincx */
+        );
+        CHECK_ERR("Failed to import private key")
+    }
+    pubkey = CERT_ExtractPublicKey(cert);
+    if (!pubkey) {
+        rv = SECFailure;
+        CHECK_ERR("Failed to extract public key from certificate");
+    }
+    if (cert->nsCertType & NS_CERT_TYPE_SSL_CA) {
+        usage = certificateUsageAnyCA;
+    } else {
+        usage = certificateUsageSSLServer;
+    }
+    pw = _get_pw(ctx->n.token);
+    rv = CERT_VerifyCertificateNow(cert->dbhandle, cert, PR_TRUE,
+                                   usage, pw, &returnedUsages);
+    slapi_ch_free_string(&pw);
+    if (!ctx->force) {
+        CHECK_ERR("Failed to extract public key from certificate");
+    }
+    rv = SECSuccess;
+    if (!verifyOnly) {
+        rv = PK11_ImportCert(ctx->slot, cert, CK_INVALID_HANDLE, ctx->n.nickname, PR_FALSE);
+        CHECK_ERR("Failed to import certificate");
+        rv = CERT_ChangeCertTrust(CERT_GetDefaultCertDB(), cert, &trust);
+        CHECK_ERR("Failed to set certificate trust")
+    }
+    rv = SECSuccess;
+done:
+    if (rv) {
+        rv = PR_GetError();
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        if (ctx->errmsg) {
+            PR_snprintf((ctx)->errmsg, SLAPI_DSE_RETURNTEXT_SIZE, "%s: %d - %s",
+                        errmsg, rv, slapd_pr_strerror(rv));
+        }
+    }
+done2:
+    ctx->privkey = privkey;
+    if (pubkey) {
+        SECKEY_DestroyPublicKey(pubkey);
+    }
+    if (verifyOnly) {
+        dyncerts_free_nss_add_cert_and_key(ctx);
+    }
+    return rv;
+}
+
+/* Tell daemon and ssl layers that certificate must be refresh */
+static void
+dyncert_refresh_certs()
+{
+    /* TBD in  phase3 */
+}
+
+/* Import the certificate and the key */
+int
+dyncerts_import_cert_and_key(CertCtx_t *ctx, bool verifyOnly)
+{
+    Slapi_Entry *e = NULL;
+    SECStatus rv = 0;
+    DCSS *ss = NULL;
+
+    if (dyncert_resolve_token(ctx)) {
+        return ctx->ldaprc;
+    }
+    if (ctx->dercert.data == 0) {
+        ERRMSG(ctx, LDAP_OBJECT_CLASS_VIOLATION, "%s attribute is missing.", DYCATTR_CERTDER);
+    }
+    if (!ctx->slot) {
+        slapi_log_err(SLAPI_LOG_ERR, "dyncerts_decode_cert", "Failed to get NSS internal key slot.\n");
+        ERRMSG(ctx, LDAP_UNWILLING_TO_PERFORM, "Failed to get NSS internal key slot.");
+    }
+    rv = nss_add_cert_and_key(ctx, verifyOnly);
+    if (rv != SECSuccess) {
+        return ctx->ldaprc;
+    }
+    if (verifyOnly) {
+        return 0;
+    }
+    e = dyncerts_find_entry(ctx->sdn, LDAP_SCOPE_BASE, NULL, &ss);
+    ss_destroy(&ss);
+    if (!e) {
+        slapi_log_err(SLAPI_LOG_ERR, "dyncerts_add",
+                      "Failed to add certificate %s (entry not found after import).\n",
+                      ctx->n.fullnickname);
+        ERRMSG(ctx, LDAP_UNWILLING_TO_PERFORM,
+               "Failed to add certificate %s (entry not found after import).\n",
+               ctx->n.fullnickname);
+    }
+    if (ctx->primary) {
+        dyncert_refresh_certs();
+    }
+
+    return 0;
+}
+
+/* Tell if dn is the container entry */
+static bool
+dyncert_is_suffix(Slapi_DN *sdn)
+{
+    return slapi_sdn_compare(sdn, &pdyncerts.suffix_sdn) == 0;
+}
+
+/* Release nickname buffer */
+static void
+dyncert_nickname_free(Nickname_t *n)
+{
+    if (n->data != n->buf) {
+        slapi_ch_free_string(&n->data);
+    }
+    memset(n, 0, sizeof *n);
+}
+
+/* Fill nickname from token and nickname */
+static void
+dyncert_nickname_from_token_and_name(Nickname_t *n, const char *token, const char *nickname)
+{
+    size_t nlen = strlen(nickname);
+    size_t tlen = (token && !is_internal_slot(token)) ? strlen(token) : 0;
+    size_t len = tlen+nlen+1;
+    if (2*len+2 >= sizeof n->buf) {
+        n->data = slapi_ch_malloc(2*len+2);
+    } else {
+        n->data = n->buf;
+    }
+    if (tlen == 0) {
+        strcpy(n->data, nickname);
+        n->nickname = n->fullnickname = n->data;
+        n->token = NULL;
+    } else {
+        n->token = n->data;
+        n->nickname = n->token + tlen +1;
+        n->fullnickname = n->nickname + nlen + 1;
+        strcpy(n->token, token);
+        strcpy(n->nickname, nickname);
+        strcpy(n->fullnickname, token);
+        strcpy(n->fullnickname + tlen + 1, nickname);
+        n->fullnickname[tlen] = ':';
+    }
+}
+
+/* Fill nickname from full_nickname */
+static void
+dyncert_nickname_from_full_nickname(Nickname_t *n, const char *fullnickname)
+{
+    size_t len = strlen(fullnickname);
+    size_t len2 = strcspn(fullnickname, ":");
+    if (2*len+2 >= sizeof n->buf) {
+        n->data = slapi_ch_malloc(2*len+2);
+    } else {
+        n->data = n->buf;
+    }
+    strcpy(n->data, fullnickname);
+    strcpy(n->data+len+1, fullnickname);
+    n->fullnickname = n->data+len+1;
+    if (len2<len) {
+        n->token = n->data;
+        n->token[len2] = 0;
+        n->nickname = n->token + len2+1;
+        if (is_internal_slot(n->token)) {
+            n->token = NULL;
+        }
+    } else {
+        n->token = NULL;
+        n->nickname = n->data;
+    }
+}
+
+/* Extract the certificate nickname from the dn */
+static const char *
+dyncert_nickname_from_dn(Nickname_t *n, Slapi_DN *sdn)
+{
+    Slapi_DN parent = {0};
+    Slapi_RDN rdn = {0};
+    const char *pt = NULL;
+
+    n->nickname = NULL;
+    slapi_sdn_init(&parent);
+    slapi_sdn_get_parent(sdn, &parent);
+    slapi_sdn_get_rdn(sdn, &rdn);
+    pt = slapi_rdn_get_rdn(&rdn);
+    if (dyncert_is_suffix(&parent) &&
+        !slapi_rdn_is_multivalued(&rdn) &&
+        strncasecmp(pt, "cn=", 3) == 0) {
+        dyncert_nickname_from_full_nickname(n, pt+3);
+    }
+    slapi_sdn_done(&parent);
+    slapi_rdn_done(&rdn);
+    return n->nickname;
+}
+
+static SECItem
+slapi_entry_attr_get_secitem(const Slapi_Entry *e, const char *type)
+{
+    const struct berval *bv = NULL;
+    Slapi_Attr *attr = NULL;
+    Slapi_Value *v = NULL;
+    SECItem si = {0};
+
+    if (slapi_entry_attr_find(e, type, &attr) == 0) {
+        slapi_attr_first_value(attr, &v);
+        bv = slapi_value_get_berval(v);
+        si.data = (unsigned char *) slapi_ch_malloc(bv->bv_len);
+        memcpy(si.data, bv->bv_val, bv->bv_len);
+        si.len = bv->bv_len;
+    }
+    return si;
+}
+
+int
+dyncerts_check_entry(Slapi_PBlock *pb, Slapi_Entry *e, Nickname_t *n, char *errmsg, bool needcert)
+{
+    int rc = LDAP_SUCCESS;
+    Slapi_Attr *a = NULL;
+    char *allowedattrs[] = {
+        DYCATTR_NICKNAME,
+        DYCATTR_CERTDER,
+        DYCATTR_PKEYDER,
+        DYCATTR_TRUST,
+        DYCATTR_FORCE,
+        NULL };
+    char *skipped_attrs[] = {
+        SLAPI_ATTR_OBJECTCLASS,
+        SLAPI_ATTR_UNIQUEID,
+        "creatorsName",
+        "modifiersName",
+        "createTimestamp",
+        "modifyTimestamp",
+        NULL };
+
+    /* Check that dn has the expected format */
+    if (!n->nickname) {
+        PR_snprintf(errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Invalid DN for a Dynamic certificate entry."
+                    " DN should be like cn=nickname,%s", DYNCERTS_SUFFIX);
+        return LDAP_NAMING_VIOLATION;
+    }
+    /*
+     * Check to make sure the entry passes the schema check
+     */
+    if (slapi_entry_schema_check(pb, e) != 0) {
+        char *err;
+        slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &err);
+        if (err && err[0]) {
+            PL_strncpyz(errmsg, err, SLAPI_DSE_RETURNTEXT_SIZE);
+        }
+        return LDAP_OBJECT_CLASS_VIOLATION;
+    }
+    /* Check if the attribute values in the entry obey the syntaxes */
+    if (slapi_entry_syntax_check(pb, e, 0) != 0) {
+        char *err;
+        slapi_pblock_get(pb, SLAPI_PB_RESULT_TEXT, &err);
+        if (err && err[0]) {
+            PL_strncpyz(errmsg, err, SLAPI_DSE_RETURNTEXT_SIZE);
+        }
+        return LDAP_INVALID_SYNTAX;
+    }
+    /* Check that only expected attributes are present. */
+    slapi_entry_first_attr(e, &a);
+    for (; a != NULL; slapi_entry_next_attr(e, a, &a)) {
+        Slapi_Value *v = NULL;
+        int i = 0;
+        if (charray_inlist(skipped_attrs, a->a_type)) {
+            continue;
+        }
+        i = slapi_attr_first_value(a, &v);
+        if (i == -1 || slapi_attr_next_value(a, i, &v) != -1) {
+            PR_snprintf(errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "Attribute %s should be single valued", a->a_type);
+            return LDAP_UNWILLING_TO_PERFORM;
+        }
+        if (!charray_inlist(allowedattrs, a->a_type)) {
+            PR_snprintf(errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "Unexpected attribute: %s", a->a_type);
+            return LDAP_OBJECT_CLASS_VIOLATION;
+        }
+    }
+    /* Check that nsDynamicCertificateDER attribute is present */
+    if ((needcert || slapi_entry_attr_get_ref(e, DYCATTR_PKEYDER)) &&
+        !slapi_entry_attr_get_ref(e, DYCATTR_CERTDER)) {
+        PR_snprintf(errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Attribute %s should be present", DYCATTR_CERTDER);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+    return rc;
+}
+
+/* Store the entry in NSS db */
+int
+dyncerts_import_entry(Slapi_Entry *e, char *errmsg, bool verifyOnly)
+{
+    int rc = LDAP_SUCCESS;
+    CertCtx_t ctx = {0};
+
+    dyncert_nickname_from_full_nickname(&ctx.n, slapi_entry_attr_get_charptr(e, DYCATTR_NICKNAME));
+    ctx.dercert = slapi_entry_attr_get_secitem(e, DYCATTR_CERTDER);
+    ctx.derpkey = slapi_entry_attr_get_secitem(e, DYCATTR_PKEYDER);
+    ctx.trust = slapi_entry_attr_get_charptr(e, DYCATTR_TRUST);
+    ctx.force = (slapi_entry_attr_get_bool(e, DYCATTR_FORCE) == PR_TRUE);
+    ctx.errmsg = errmsg;
+    ctx.sdn = (Slapi_DN*) slapi_entry_get_sdn_const(e);
+    rc = dyncerts_import_cert_and_key(&ctx, verifyOnly);
+    dyncerts_cert_ctx_done(&ctx);
+    return rc;
+}
+
+/* Backend callback (add operation) */
+int
+dyncerts_add(Slapi_PBlock *pb)
+{
+    char returntext[SLAPI_DSE_RETURNTEXT_SIZE] = "";
+    struct dyncerts *pdcerts = NULL;
+    int error = LDAP_SUCCESS;
+    int rc = LDAP_SUCCESS;
+    Slapi_Entry *e = NULL;
+    const char *dn = "???";
+    Slapi_DN *sdn = NULL;
+    Nickname_t n = {0};
+    DCSS *ss = NULL;
+
+    /*
+     * Get the database, the dn and the entry to add
+     */
+    if (slapi_pblock_get(pb, SLAPI_PLUGIN_PRIVATE, &pdcerts) < 0 ||
+        slapi_pblock_get(pb, SLAPI_ADD_TARGET_SDN, &sdn) < 0 ||
+        slapi_pblock_get(pb, SLAPI_ADD_ENTRY, &e) < 0 || (NULL == pdcerts)) {
+        rc = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+    dn = slapi_sdn_get_dn(slapi_entry_get_sdn_const(e));
+
+    /* Check entry attributes */
+    (void) dyncert_nickname_from_dn(&n, sdn);
+    rc = dyncerts_check_entry(pb, e, &n, returntext, true);
+    if (rc) {
+        e = NULL; /* caller will free upon error */
+        goto done;
+    }
+    /* Check that entry does not exist */
+    if (dyncerts_find_entry(sdn, LDAP_SCOPE_BASE, NULL, &ss)) {
+        e = NULL; /* caller will free upon error */
+        rc = LDAP_ALREADY_EXISTS;
+        goto done;
+    }
+    rc = dyncerts_import_entry(e, returntext, false);
+    e = NULL; /* caller will free it */
+done:
+    if (e) {
+        slapi_pblock_set(pb, SLAPI_ENTRY_POST_OP, slapi_entry_dup(e));
+    }
+    /* make sure OPRETURN and RESULT_CODE are set */
+    slapi_pblock_get(pb, SLAPI_PLUGIN_OPRETURN, &error);
+    if (rc) {
+        if (!error) {
+            slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &rc);
+        }
+        slapi_log_err(SLAPI_LOG_DYC, "dyncerts_add",
+                      "Add operation of entry %s failed: rc=%d : %s\n",
+                      dn, rc, returntext);
+    }
+    ss_destroy(&ss);
+    free_config_info();
+    dyncert_nickname_free(&n);
+    slapi_send_ldap_result(pb, rc, NULL, returntext[0] ? returntext : NULL, 0, NULL);
+    return rc;
+}
+
+/* Create pseudo entry to add from modifiers */
+static int
+dyncerts_mods2entry(Slapi_PBlock *pb, Slapi_DN *sdn, LDAPMod **mods, Nickname_t *n, char *errmsg, Slapi_Entry **pte)
+{
+    Slapi_Entry *e = *pte = slapi_entry_alloc();
+    const char *nickname = dyncert_nickname_from_dn(n, sdn);
+    const char *val = NULL;
+    char *dn = slapi_ch_strdup(slapi_sdn_get_dn(sdn));
+    int rc = LDAP_SUCCESS;
+
+    if (!nickname) {
+        /* Should not happen (unless heap corruption) because we already
+         * tested that the modified entry exists
+         */
+        rc = LDAP_NAMING_VIOLATION;
+        goto done;
+    }
+    slapi_entry_init(e, dn, NULL);
+    slapi_entry_add_string(e, "objectclass", "top");
+    slapi_entry_add_string(e, "objectclass", "extensibleobject");
+    slapi_entry_add_string(e, DYCATTR_NICKNAME, nickname);
+    rc = slapi_entry_apply_mods(e, mods);
+    if (rc) {
+        goto done;
+    }
+    val = slapi_entry_attr_get_charptr(e, DYCATTR_NICKNAME);
+    if (strcasecmp(val, nickname)) {
+        /* cn attribute was changed ! */
+        rc = LDAP_NAMING_VIOLATION;
+        goto done;
+    }
+    rc = dyncerts_check_entry(pb, e, n, errmsg, false);
+done:
+    dyncert_nickname_free(n);
+    return rc;
+}
+
+/* dyncerts_apply_cb callback to change trust flags */
+void
+dyncert_set_trust_cb(CertCtx_t *ctx)
+{
+    Slapi_Entry *e = ctx->arg;
+    CERTCertTrust trust = {0};
+    int rv = 0;
+
+    ctx->trust = slapi_entry_attr_get_charptr(e, DYCATTR_TRUST);
+    rv = CERT_DecodeTrustString(&trust, ctx->trust);
+    rv = CERT_ChangeCertTrust(ctx->cert->dbhandle, ctx->cert, &trust);
+    if (rv != SECSuccess) {
+        rv = PR_GetError();
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        PR_snprintf(ctx->errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Failed to change trust for certificate %s. Error is %d - %s.\n",
+                    ctx->n.fullnickname, rv, slapd_pr_strerror(rv));
+    }
+}
+
+/* dyncerts_apply_cb callback to delete a certificate */
+void
+dyncert_delete_cb(CertCtx_t *ctx)
+{
+    int rc = SEC_DeletePermCertificate(ctx->cert);
+    if (rc == SECFailure) {
+        rc = PR_GetError();
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        PR_snprintf(ctx->errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Failed to delete certificate %s. Error is %d - %s.\n",
+                    ctx->n.fullnickname, rc, slapd_pr_strerror(rc));
+    }
+}
+
+/* modify a certificate entry */
+int
+dyncerts_modify_cert(Slapi_PBlock *pb, Slapi_Entry *e, LDAPMod **mods, DCSS *ss, char *errmsg)
+{
+    Slapi_DN *sdn = (Slapi_DN *) slapi_entry_get_sdn_const(e);
+    Slapi_Entry *newe = NULL;
+    Nickname_t n = {0};
+    int rc = dyncerts_mods2entry(pb, sdn, mods, &n, errmsg, &newe);
+    const char *nickname = n.nickname;
+    PR_ASSERT(n.nickname);
+    if (slapi_entry_attr_get_charptr(newe, DYCATTR_CERTDER)) {
+        /* need to change the certificate ==> import the entry */
+        rc = dyncerts_import_entry(newe, errmsg, true);
+        if (rc == LDAP_SUCCESS) {
+            /* Remove current certificate */
+            rc = dyncerts_apply_cb(nickname, dyncert_delete_cb, NULL, errmsg);
+            /* Then add new one */
+            rc = dyncerts_import_entry(newe, errmsg, false);
+        }
+    } else {
+        /* Just change the trust */
+        if (!nickname) {
+            /* Should not happen (unless heap corruption) because we already
+             * tested that the modified entry exists
+             */
+            rc = LDAP_NAMING_VIOLATION;
+            goto done;
+        }
+        rc = dyncerts_apply_cb(nickname, dyncert_set_trust_cb, newe, errmsg);
+    }
+done:
+    slapi_entry_free(newe);
+    dyncert_nickname_free(&n);
+    return rc;
+}
+
+/* modify the container entry */
+int
+dyncerts_modify_cont(Slapi_Entry *e, LDAPMod **mods, DCSS *ss, char *errmsg)
+{
+    Slapi_PBlock *mod_pb = NULL;
+    Slapi_DN sdn = {0};
+    int rc = LDAP_SUCCESS;
+    bool has_aci = false;
+    char *allowed_attrs[] = {
+        DYCATTR_SWITCH,
+        "modifiersName",
+        "modifyTimestamp",
+        NULL
+    };
+
+    rc = slapi_entry_apply_mods(e, mods);
+    if (rc) {
+        return rc;
+    }
+
+    for (size_t i=0; mods[i]; i++) {
+        char *attr = mods[i]->mod_type;
+        if (strcasecmp(attr, "aci") == 0) {
+            has_aci = true;
+            continue;
+        }
+        if (!charray_inlist(allowed_attrs, attr)) {
+            PR_snprintf(errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "Attribute %s cannot be changed on %s entry", attr, DYNCERTS_SUFFIX);
+            return LDAP_UNWILLING_TO_PERFORM;
+        }
+    }
+    if (has_aci) {
+        /* Lets replace the aci(s) on cn=encryption,cn=config */
+        const Slapi_Value **va = slapi_entry_attr_get_valuearray(e, "aci");
+        LDAPMod acimod = { 0 };
+        LDAPMod *acimods[2] = { &acimod, NULL };
+
+        slapi_sdn_init_dn_byref(&sdn, CONFIG_DN2);
+        valuearray_get_bervalarray((Slapi_Value **)va, &acimod.mod_vals.modv_bvals);
+        acimod.mod_op = LDAP_MOD_REPLACE | LDAP_MOD_BVALUES;
+        acimod.mod_type = "aci";
+        mod_pb = slapi_pblock_new();
+        slapi_modify_internal_set_pb_ext(mod_pb, &sdn, acimods, NULL, NULL, plugin_get_default_component_id(), 0);
+        slapi_modify_internal_pb(mod_pb);
+        slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+        if (rc != LDAP_SUCCESS) {
+            char *err;
+            slapi_pblock_get(mod_pb, SLAPI_PB_RESULT_TEXT, &err);
+            if (err && err[0]) {
+                PL_strncpyz(errmsg, err, SLAPI_DSE_RETURNTEXT_SIZE);
+            }
+        }
+        ber_bvecfree(acimod.mod_vals.modv_bvals);
+    }
+    if (slapi_entry_attr_get_bool(e, DYCATTR_SWITCH)) {
+        dyncert_refresh_certs();
+    }
+    slapi_pblock_destroy(mod_pb);
+    slapi_sdn_done(&sdn);
+    return rc;
+}
+
+/* Backend callback (modify operation) */
+int
+dyncerts_modify(Slapi_PBlock *pb)
+{
+    char returntext[SLAPI_DSE_RETURNTEXT_SIZE] = "";
+    struct dyncerts *pdcerts = NULL;
+    int rc = LDAP_SUCCESS;
+    Slapi_Entry *e = NULL;
+    LDAPMod **mods = NULL;
+    const char *dn = NULL;
+    Slapi_DN *sdn = NULL;
+    DCSS *ss = NULL;
+
+    /*
+     * Get the database, the dn and the modifiers
+     */
+    PR_ASSERT(pb);
+    if (slapi_pblock_get(pb, SLAPI_PLUGIN_PRIVATE, &pdcerts) < 0 ||
+        slapi_pblock_get(pb, SLAPI_MODIFY_TARGET_SDN, &sdn) < 0 ||
+        slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &mods) < 0 || (NULL == pdcerts)) {
+        rc = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+
+    dn = slapi_sdn_get_dn(sdn);
+    e = dyncerts_find_entry(sdn, LDAP_SCOPE_BASE, NULL, &ss);
+    if (!e) {
+        rc = LDAP_NO_SUCH_OBJECT;
+        goto done;
+    }
+    if (e == ss->entries[0]) {
+        rc =  dyncerts_modify_cont(e, mods, ss, returntext);
+    } else {
+        rc =  dyncerts_modify_cert(pb, e, mods, ss, returntext);
+    }
+done:
+    if (rc) {
+        slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &rc);
+        slapi_log_err(SLAPI_LOG_DYC, "dyncerts_modify",
+                      "Modify operation of entry %s failed: rc=%d : %s\n",
+                      dn, rc, returntext);
+    }
+    ss_destroy(&ss);
+    free_config_info();
+    slapi_send_ldap_result(pb, rc, NULL, returntext[0] ? returntext : NULL, 0, NULL);
+
+    return rc;
+}
+
+/* dyncerts_apply_cb/PK11_TraverseSlotCerts callback */
+static SECStatus
+dyncert_find_cert_cb(CERTCertificate *cert, SECItem *sitem, void *arg)
+{
+    CertCtx_t *ctx = arg;
+    ctx->cert = cert;
+    const char *slotname = PK11_GetTokenName(cert->slot);
+    if (ctx->internal_token != is_internal_slot(slotname)) {
+        /* Wrong slot ! */
+        return SECSuccess;
+    }
+    if (!ctx->internal_token && strcasecmp(ctx->n.token, slotname)) {
+        /* Still wrong slot ! */
+        return SECSuccess;
+    }
+    if (strcasecmp(cert->nickname, ctx->n.nickname)==0) {
+        ctx->ldaprc = LDAP_SUCCESS;
+        ctx->action_cb(ctx);
+    }
+    return (ctx->ldaprc == LDAP_NO_SUCH_OBJECT) ? SECSuccess: SECFailure;
+}
+
+/* Apply a callback on the certificate with the nickname */
+int
+dyncerts_apply_cb(const char *nickname, dyc_action_cb_t cb, void *arg, char *errmsg)
+{
+    CertCtx_t ctx = {0};
+    int rc = LDAP_SUCCESS;
+
+    dyncert_nickname_from_full_nickname(&ctx.n, nickname);
+    ctx.errmsg = errmsg;
+    ctx.arg = arg;
+    ctx.action_cb = cb;
+    ctx.ldaprc = LDAP_NO_SUCH_OBJECT;
+    rc = dyncert_resolve_token(&ctx);
+    /* Could probably avoid to look in all slots but PK11_TraverseCertsInSlot is private */
+    if (rc == 0) {
+        (void) PK11_TraverseSlotCerts(dyncert_find_cert_cb, &ctx, NULL);
+    }
+    rc = ctx.ldaprc;
+    dyncerts_cert_ctx_done(&ctx);
+    return rc;
+}
+
 /* Backend callback (unbind operation) */
 int
 dyncerts_unbind(Slapi_PBlock *pb __attribute__((unused)))
@@ -839,9 +1617,7 @@ get_entry_list(const Slapi_DN *basesn, int scope, char **attrs)
     if (LDAP_SCOPE_BASE == scope) {
         /* Bypass getting cert list if only looking for the container */
         Slapi_DN sdn = {0};
-        slapi_sdn_init_dn_byref(&sdn, DYNCERTS_SUFFIX);
-        if (slapi_sdn_compare(&sdn, slapi_entry_get_sdn_const(e)) == 0) {
-            slapi_sdn_done(&sdn);
+        if (slapi_sdn_compare(&pdyncerts.suffix_sdn, slapi_entry_get_sdn_const(e)) == 0) {
             return ss;
         }
         slapi_sdn_done(&sdn);
@@ -853,6 +1629,235 @@ get_entry_list(const Slapi_DN *basesn, int scope, char **attrs)
     return ss;
 }
 
+/* Backend callback (delete operation) */
+int
+dyncerts_delete(Slapi_PBlock *pb)
+{
+    char returntext[SLAPI_DSE_RETURNTEXT_SIZE] = "";
+    struct dyncerts *pdcerts = NULL;
+    const char *nickname = NULL;
+    int rc = LDAP_SUCCESS;
+    Slapi_Entry *e = NULL;
+    const char *dn = "???";
+    Slapi_DN *sdn = NULL;
+    Nickname_t n = {0};
+    DCSS *ss = NULL;
+
+    /*
+     * Get the backend context and the dn
+     */
+    if (slapi_pblock_get(pb, SLAPI_PLUGIN_PRIVATE, &pdcerts) < 0 ||
+        slapi_pblock_get(pb, SLAPI_DELETE_TARGET_SDN, &sdn) < 0 ||
+        (pdcerts == NULL)) {
+        rc = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+    /* Check that the entry exists */
+    dn = slapi_sdn_get_dn(sdn);
+    e = dyncerts_find_entry(sdn, LDAP_SCOPE_BASE, NULL, &ss);
+    if (e==NULL) {
+        rc = LDAP_NO_SUCH_OBJECT;
+        goto done;
+    }
+    nickname = dyncert_nickname_from_dn(&n, sdn);
+    if (!nickname) {
+        /* Attempt to delete the container entry */
+        rc = LDAP_UNWILLING_TO_PERFORM;
+        goto done;
+    }
+    rc = dyncerts_apply_cb(nickname, dyncert_delete_cb, NULL, returntext);
+
+done:
+    if (rc) {
+        slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &rc);
+        slapi_log_err(SLAPI_LOG_DYC, "dyncerts_delete",
+                      "Delete operation of entry %s failed: rc=%d : %s\n",
+                      dn, rc, returntext);
+    }
+    ss_destroy(&ss);
+    free_config_info();
+    slapi_send_ldap_result(pb, rc, NULL, returntext[0] ? returntext : NULL, 0, NULL);
+    dyncert_nickname_free(&n);
+
+    return rc;
+}
+
+/* Duplicate SECItem content */
+static void
+copy_secitem(SECItem *to, const SECItem *from)
+{
+    if (from && from->len>0) {
+        to->len = from->len;
+        to->data = (unsigned char *) slapi_ch_malloc(from->len);
+        memcpy(to->data, from->data, from->len);
+    } else {
+        to->len = 0;
+        to->data = NULL;
+    }
+}
+
+
+/* dyncerts_apply_cb callback to modrdn a certificate */
+void
+dyncert_rename_cb(CertCtx_t *ctx)
+{
+    const char *new_dn = ctx->arg;
+    CertCtx_t new_ctx = {0};
+    Slapi_DN sdn_new = {0};
+    int rc = 0;
+
+    slapi_sdn_init_dn_byref(&sdn_new, new_dn);
+
+    (void) dyncert_nickname_from_dn(&new_ctx.n, &sdn_new);
+    new_ctx.errmsg = ctx->errmsg;
+    rc = dyncert_resolve_token(&new_ctx);
+    /* Could probably avoid to look in all slots but PK11_TraverseCertsInSlot is private */
+    if (rc != 0) {
+        ctx->ldaprc = rc;
+    }
+    if (ctx->internal_token != new_ctx.internal_token) {
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        PR_snprintf(ctx->errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Cannot use modrdn operation to change the token name");
+        goto done;
+    }
+    if (rc == 0 && !ctx->internal_token &&
+        strcasecmp(ctx->n.token, new_ctx.n.token) != 0) {
+        ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+        PR_snprintf(ctx->errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "Cannot use modrdn operation to change the token name");
+        goto done;
+    }
+    if (rc == 0) {
+        /* __PK11_SetCertificateNickname used by certutil cannot be used because
+         * it deos not update NSS in memory data.
+         * Furthermore adding an already existing certificate leads to increase
+         * reference count toward that certificate. So we cannot add the new name
+         * before having deleted the old one:
+         * ==> There is a risk of loosing the certificate in case of error
+         *     after the deletion
+         */
+        CERTCertificate *cert = ctx->cert;
+        SECKEYPrivateKeyInfo *pkeyinfo = PK11_ExportPrivateKeyInfo(cert, NULL);
+        int rc = 0;
+
+        if (pkeyinfo) {
+            copy_secitem(&new_ctx.derpkey, &pkeyinfo->privateKey);
+            SECKEY_DestroyPrivateKeyInfo(pkeyinfo, PR_TRUE);
+            pkeyinfo = NULL;
+        }
+        copy_secitem(&new_ctx.dercert, &cert->derCert);
+        new_ctx.trust = slapi_ch_malloc(TRUST_SIZE);
+        trustv(cert, new_ctx.trust, TRUST_SIZE);
+
+        rc = SEC_DeletePermCertificate(ctx->cert);
+        if (rc == SECFailure) {
+            rc = PR_GetError();
+            ctx->ldaprc = LDAP_UNWILLING_TO_PERFORM;
+            PR_snprintf(ctx->errmsg, SLAPI_DSE_RETURNTEXT_SIZE,
+                        "Failed to delete certificate %s. Error is %d - %s.\n",
+                        ctx->n.fullnickname, rc, slapd_pr_strerror(rc));
+            goto done;
+        } else {
+            rc = nss_add_cert_and_key(&new_ctx, false);
+        }
+    }
+done:
+    dyncerts_cert_ctx_done(&new_ctx);
+    slapi_sdn_done(&sdn_new);
+}
+
+/* Backend callback (modrdn operation) */
+int
+dyncerts_rename(Slapi_PBlock *pb)
+{
+    char returntext[SLAPI_DSE_RETURNTEXT_SIZE] = "";
+    struct dyncerts *pdcerts = NULL;
+    const char *old_nickname = NULL;
+    const char *new_nickname = NULL;
+    int rc = LDAP_SUCCESS;
+    Slapi_Entry *e = NULL;
+    const char *old_dn = "???";
+    Slapi_DN *sdn = NULL;
+    Slapi_DN *sdn_newsup = NULL;
+    Slapi_DN sdn_new = {0};
+    DCSS *ss = NULL;
+    char *new_rdn = NULL;
+    Nickname_t n_old = {0};
+    Nickname_t n_new = {0};
+    const char *new_sup = NULL;
+    const char *new_dn = NULL;
+
+    slapi_pblock_get(pb, SLAPI_MODRDN_TARGET_SDN, &sdn);
+    /*
+     * Get the backend context and the dn
+     */
+    if (slapi_pblock_get(pb, SLAPI_PLUGIN_PRIVATE, &pdcerts) < 0 ||
+        slapi_pblock_get(pb, SLAPI_MODRDN_TARGET_SDN, &sdn) < 0 ||
+        (pdcerts == NULL)) {
+        rc = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+    old_dn = slapi_sdn_get_dn(sdn);
+    slapi_pblock_get(pb, SLAPI_MODRDN_NEWRDN, &new_rdn);
+    if (new_rdn == NULL) {
+        rc = LDAP_OPERATIONS_ERROR;
+        goto done;
+    }
+    slapi_pblock_get(pb, SLAPI_MODRDN_NEWSUPERIOR_SDN, &sdn_newsup);
+    new_sup = slapi_sdn_get_dn(sdn_newsup);
+    if (new_sup) {
+        new_dn = slapi_ch_smprintf("%s,%s", new_rdn, new_sup);
+    } else {
+        new_dn = slapi_ch_smprintf("%s,%s", new_rdn, slapi_dn_find_parent(old_dn));
+    }
+    slapi_sdn_init_dn_passin(&sdn_new, new_dn);
+    if (slapi_sdn_compare(&sdn_new, sdn) == 0) {
+        /* NOOP */
+        rc = LDAP_SUCCESS;
+        goto done;
+    }
+    e = dyncerts_find_entry(sdn, LDAP_SCOPE_BASE, NULL, &ss);
+    ss_destroy(&ss);
+    if (e == NULL) {
+        rc = LDAP_NO_SUCH_OBJECT;
+        goto done;
+    }
+    old_nickname = dyncert_nickname_from_dn(&n_old, sdn);
+    if (!old_nickname) {
+        /* Attempt to delete the container entry */
+        rc = LDAP_UNWILLING_TO_PERFORM;
+        goto done;
+    }
+    e = dyncerts_find_entry(&sdn_new, LDAP_SCOPE_BASE, NULL, &ss);
+    ss_destroy(&ss);
+    if (e != NULL) {
+        rc = LDAP_ALREADY_EXISTS;
+        goto done;
+    }
+    new_nickname = dyncert_nickname_from_dn(&n_new, &sdn_new);
+    if (!new_nickname) {
+        rc = LDAP_UNWILLING_TO_PERFORM;
+        goto done;
+    }
+    rc = dyncerts_apply_cb(old_nickname, dyncert_rename_cb, (void*) new_dn, returntext);
+
+done:
+    if (rc) {
+        slapi_pblock_set(pb, SLAPI_PLUGIN_OPRETURN, &rc);
+        slapi_log_err(SLAPI_LOG_DYC, "dyncerts_delete",
+                      "Modrdn operation of entry %s failed: rc=%d : %s\n",
+                      old_dn, rc, returntext);
+    }
+    slapi_sdn_done(&sdn_new);
+    free_config_info();
+    slapi_send_ldap_result(pb, rc, NULL, returntext[0] ? returntext : NULL, 0, NULL);
+    dyncert_nickname_free(&n_old);
+    dyncert_nickname_free(&n_new);
+
+    return rc;
+}
+
 /* Create the dynamic certificate backend */
 Slapi_Backend *
 dyncert_init_be()
@@ -860,7 +1865,6 @@ dyncert_init_be()
     pthread_mutex_lock(&mutex);
     if (!pdyncerts.be) {
         Slapi_Backend *be = slapi_be_new(DYNCERTS_BETYPE, DYNCERTS_BENAME, 1 /* Private */, 0 /* Do Not Log Changes */);
-        Slapi_DN dn = {0};
         pdyncerts.be = be;
 
         be->be_database = &dyncerts_plugin;
@@ -872,19 +1876,16 @@ dyncert_init_be()
         be->be_database->plg_search_results_release = &dyncerts_search_set_release;
         be->be_database->plg_prev_search_results = &dyncerts_prev_search_results;
         be->be_database->plg_compare = &be_unwillingtoperform;
-/*
-        be->be_database->plg_modify = &dyncerts_modify;
-        be->be_database->plg_modrdn = &be_unwillingtoperform;
         be->be_database->plg_add = &dyncerts_add;
+        be->be_database->plg_modify = &dyncerts_modify;
+        be->be_database->plg_modrdn = &dyncerts_rename;
         be->be_database->plg_delete = &dyncerts_delete;
-*/
         be->be_database->plg_abandon = &be_unwillingtoperform;
         be->be_database->plg_cleanup = &dyncerts_cleanup;
         /* All the other function pointers default to NULL */
 
-        slapi_sdn_init_ndn_byref(&dn, DYNCERTS_SUFFIX);
-        be_addsuffix(be, &dn);
-        slapi_sdn_done(&dn);
+        slapi_sdn_init_dn_byref(&pdyncerts.suffix_sdn, DYNCERTS_SUFFIX);
+        be_addsuffix(be, &pdyncerts.suffix_sdn);
     }
     pthread_mutex_unlock(&mutex);
     return pdyncerts.be;

--- a/ldap/servers/slapd/dyncerts.h
+++ b/ldap/servers/slapd/dyncerts.h
@@ -74,10 +74,10 @@ typedef enum {
 /* Storage for nickname */
 typedef struct {
     char buf[TRUST_SIZE*2];
-    char *data;
-    char *fullnickname;
-    char *nickname;
-    char *token;
+    char *data;            /* Should be freed if != buf */
+    char *fullnickname;    /* Should not be freed: Point within buf or data */
+    char *nickname;        /* Should not be freed: Point within buf or data */
+    char *token;           /* Should not be freed: Point within buf or data */
 } Nickname_t;
 
 struct certctx_str;

--- a/ldap/servers/slapd/dyncerts.h
+++ b/ldap/servers/slapd/dyncerts.h
@@ -53,6 +53,8 @@
 #define INTERNAL_SLOTNAME1    "Internal (Software)"
 #define INTERNAL_SLOTNAME2    "Internal (Software) Token"
 
+#define TRUST_SIZE 32  /* Large enough to hold trust string */
+
 #define ERRMSG(ctx, rc, ...) { \
             (ctx)->ldaprc = (rc); \
             if ((ctx)->errmsg) { \
@@ -69,6 +71,15 @@ typedef enum {
     DYC_BOTH
 } dyc_et_t;
 
+/* Storage for nickname */
+typedef struct {
+    char buf[TRUST_SIZE*2];
+    char *data;
+    char *fullnickname;
+    char *nickname;
+    char *token;
+} Nickname_t;
+
 struct certctx_str;
 typedef void (*dyc_action_cb_t)(struct certctx_str *ctx);
 
@@ -76,9 +87,7 @@ typedef void (*dyc_action_cb_t)(struct certctx_str *ctx);
 typedef struct certctx_str {
     SECItem dercert;
     SECItem derpkey;
-    char *fullnickname;
-    char *nickname;
-    char *token;
+    Nickname_t n;
     char *trust;
     bool force;
     bool primary;
@@ -150,6 +159,7 @@ struct dyncerts {
     Slapi_Backend *be;
     DCSS *config;
     struct sock_elem *sockets;  /* Secure sockets (needed to get the pin) */
+    Slapi_DN suffix_sdn;
 };
 
 /* Alternate Name Decoder Callback */

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1089,7 +1089,7 @@ slapd_nss_init(int init_ssl __attribute__((unused)), int config_available __attr
 
     nssFlags &= (~NSS_INIT_READONLY);
     slapd_pk11_configurePKCS11(NULL, NULL, tokPBE, ptokPBE, NULL, NULL, NULL, NULL, 0, 0);
-   secStatus = NSS_InitReadWrite(certdir);
+    secStatus = NSS_InitReadWrite(certdir);
 
     dongle_file_name = slapi_ch_smprintf("%s/pin.txt", certdir);
 


### PR DESCRIPTION
Second phase of [Dynamic Certificate Refresh](https://www.port389.org/docs/389ds/design/online-certificate-refresh.html)

 cn=dynamiccertificates backend now supports the following operations:
-   add
- modify
- modrdn
- delete

Allowing to store and modify dynamically the nss database

issue: https://github.com/389ds/389-ds-base/issues/6951

Reviewed by:  @tbordaz  (Thanks!)

## Summary by Sourcery

Implement dynamic certificate management operations in the dynamic certificates backend and add ECDSA-based TLS tests.

New Features:
- Support adding, modifying, renaming, and deleting certificates through the dynamic certificates backend using LDAP operations.
- Add ECDSA certificate generation and management utilities for tests, including online and offline certificate installation and nickname handling.
- Introduce dynamic certificate-based TLS search and certificate lifecycle tests, including dynamic add/rename/delete flows.

Enhancements:
- Refine dynamic certificates backend DN handling by caching the suffix DN and improving nickname parsing and validation.
- Improve certificate import and trust management logic, including verification, trust decoding, and NSS database interactions.

Tests:
- Replace the shell-based ECDSA TLS test with a Python-based test suite that generates ECDSA certificates programmatically and validates TLS connectivity.
- Add tests that verify dynamic certificate add/modify/rename/delete operations via the cn=dynamiccertificates backend.