### PR TITLE
Issue 1793 - RFE - Implement dynamic lists

### DIFF
--- a/dirsrvtests/tests/suites/dynamic_lists/dynamic_lists_test.py
+++ b/dirsrvtests/tests/suites/dynamic_lists/dynamic_lists_test.py
@@ -1,0 +1,312 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import ldap
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.topologies import topology_st as topo
+from lib389.idm.user import UserAccounts
+from lib389.idm.group import Groups
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.config import LDBMConfig
+
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def dynamic_lists_setup(topo, request):
+    log.info("Creating test users")
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    user_dns = []
+    num_users = 5
+
+    for i in range(1, num_users + 1):
+        user = users.create(properties={
+            'uid': f'testuser{i}',
+            'cn': f'testuser{i}',
+            'sn': f'User{i}',
+            'uidNumber': f'{1000 + i}',
+            'gidNumber': f'{1000 + i}',
+            'homeDirectory': f'/home/testuser{i}',
+        })
+        user_dns.append(user.dn)
+        log.info(f"Created user: {user.dn}")
+
+    def fin():
+        for user in users.list():
+            user.delete()
+    request.addfinalizer(fin)
+
+    return user_dns
+
+
+def test_dynamic_lists_memberurl_all_users(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list all users
+
+    :id: 6913fc98-fb22-4f21-817d-4cc19be1f1cd
+    :setup: Standalone Instance
+    :steps:
+        1. Configure dynamic lists with objectclass, url_attr, and list_attr
+        2. Create a group with memberURL attribute containing LDAP URL with filter (uid=testuser*)
+        3. Search for the group and verify all users are listed as members
+        4. Search using member as a filter and see if the group is returned
+    :expectedresults:
+        1. Success
+        2. Group should be created with memberURL successfully
+        3. All users should be listed as members of the group
+        4. Group should be returned when searching using member as a filter
+    """
+
+    inst = topo.standalone
+
+    user_dns = dynamic_lists_setup
+
+    # Step 1: Configure dynamic lists with objectclass, url_attr, and list_attr
+    ldbmconfig = LDBMConfig(inst)
+    ldbmconfig.replace('nsslapd-dynamic-lists-enabled', b'on')
+    ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'member')
+    ldbmconfig.replace('nsslapd-dynamic-lists-oc', b'groupOfUrls')
+    ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'memberURL')
+
+    # Step 2: Create a group with memberURL attribute
+    log.info("Creating group with memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    group = groups.create(properties={
+        'cn': 'test_dynamic_group',
+        'objectClass': ['groupOfUrls','groupOfNames'],
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)',
+    })
+    group_dn = group.dn
+    log.info(f"Created group: {group_dn} with memberURL: ldap:///{DEFAULT_SUFFIX}??sub?(uid=*)")
+
+    # Step 3: Search for the group to trigger the plugin and verify all users
+    # are listed as members. The plugin processes memberURL during search
+    # operations and dynamically adds member attributes
+    log.info("Searching for group to trigger dynamic lists plugin")
+    members = group.list_members()
+    log.info(f"Found {len(members)} members in group")
+    log.info(f"Members: {members}")
+
+    # Verify all users are members
+    assert len(members) == 5, f"Expected {5} members, got {len(members)}. Members: {members}"
+    for user_dn in user_dns:
+        assert user_dn in members, f"User {user_dn} should be a member of the group. Members: {members}"
+
+    # Step 4: Now search using member as a filter and see if the group is returned
+    results = groups.filter(f'(member={members[2]})')
+    assert len(results) == 1, f"Expected 1 group, got {len(results)}. Results: {results}"
+    assert results[0].dn == group_dn, (f"Group {results[0].dn} should be returned when searching "
+                                       "using member as a filter. Results: {results}")
+
+    log.info("Test completed successfully - all users are listed as members "
+             "and the group is returned when searching using member as a filter")
+
+
+def test_dynamic_lists_non_dn_attribute(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list
+    all users homeDirectory attribute
+
+    :id: c44ebc24-4fd5-45f7-9699-b481527821f0
+    :setup: Standalone Instance
+    :steps:
+        1. Configure dynamic lists with objectclass, url_attr, and list_attr
+        2. Create a group with memberURL attribute containing LDAP URL with
+           filter (uid=testuser*) and requested attribute (homeDirectory)
+        3. Search for the group and verify all users homeDirectory attribute
+           are listed in the entry
+    :expectedresults:
+        1. Success
+        2. Group should be created with memberURL successfully
+        3. All users homeDirectory attribute should be listed in the entry
+    """
+
+    inst = topo.standalone
+
+    # Step 1: Configure dynamic lists with objectclass, url_attr, and list_attr
+    ldbmconfig = LDBMConfig(inst)
+    ldbmconfig.replace('nsslapd-dynamic-lists-enabled', b'on')
+    ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'member')
+    ldbmconfig.replace('nsslapd-dynamic-lists-oc', b'groupOfUrls')
+    ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'memberURL')
+
+    # Step 2: Create a group with memberURL attribute
+    log.info("Creating group with memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    group = groups.create(properties={
+        'cn': 'test_dynamic_group_2',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}?homeDirectory?sub?(uid=testuser*)',
+    })
+    group_dn = group.dn
+    log.info(f"Created group: {group_dn} with memberURL: ldap:///{DEFAULT_SUFFIX}?"
+             "homeDirectory?sub?(uid=testuser*)")
+
+    # Step 3: Search for the group to trigger the plugin and verify all
+    # homeDirectories are listed in the entry
+    values = group.get_attr_vals_utf8_l('homeDirectory')
+    assert len(values) == 5, f"Expected {5} values, got {len(values)}. Values: {values}"
+    for value in ['/home/testuser1', '/home/testuser2', '/home/testuser3',
+                  '/home/testuser4', '/home/testuser5']:
+        assert value in values, f"Value {value} should be listed in the group. Values: {values}"
+
+
+def test_dynamic_lists_invalid_values(topo):
+    """Test dynamic lists plugin with memberURL filter (uid=testuser*) to list
+    all users homeDirectory attribute
+
+    :id: bbe98cdc-2255-45af-a40d-442d3995a388
+    :setup: Standalone Instance
+    :steps:
+        1. Configure dynamic lists with objectclass, url_attr, and list_attr
+        2. Configure dynamic lists with non-existing objectclass
+        3. Configure dynamic lists with non-existing url_attr
+        4. Configure dynamic lists with non-existing list_attr
+        5. Configure dynamic lists with non-dn syntax attribute for list-attr
+    :expectedresults:
+        1. Plugin should be enabled successfully
+        2. Plugin should not be configured successfully
+        3. Plugin should not be configured successfully
+        4. Plugin should not be configured successfully
+        5. Plugin should not be configured successfully
+        6. Plugin should not be configured successfully
+    """
+
+    inst = topo.standalone
+
+    # Step 1: Configure dynamic lists with objectclass, url_attr, and list_attr
+    ldbmconfig = LDBMConfig(inst)
+    ldbmconfig.replace('nsslapd-dynamic-lists-enabled', b'on')
+    ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'member')
+    ldbmconfig.replace('nsslapd-dynamic-lists-oc', b'groupOfUrls')
+    ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'memberURL')
+
+    # Step 2: Configure dynamic lists with non-existing objectclass
+    log.info("Configuring dynamic lists plugin")
+    with pytest.raises(ldap.LDAPError) as e:
+        ldbmconfig.replace('nsslapd-dynamic-lists-oc', b'doesNotExist')
+
+    # Step 3: Configure dynamic lists with non-existing url_attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'doesNotExist')
+
+    # Step 4: Configure dynamic lists with non-existing list_attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+       ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'doesNotExist')
+
+    # Step 5: Configure dynamic lists with non-dn syntax attribute for list-attr
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'cn')
+
+    # Step 6: Configure dynamic lists with where url_attr and list_attr are the same
+    ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'uniquemember')
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'uniquemember')
+
+
+def test_dynamic_lists_multiple_memberurl(topo, dynamic_lists_setup):
+    """Test dynamic lists plugin with multiple memberURL attributes pointing to
+    different organizational units
+
+    :id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    :setup: Standalone Instance
+    :steps:
+        1. Configure dynamic lists with objectclass, url_attr, and list_attr
+        2. Create a new organizational unit with one entry under it
+        3. Create a group (demo_group) with memberURL attribute pointing to DEFAULT_SUFFIX
+        4. Add an additional memberURL attribute to demo_group pointing to the new OU
+           with the same filter as the first memberURL
+        5. Search for the group and verify all users from both locations are listed as members
+    :expectedresults:
+        1. Success
+        2. Organizational unit and entry should be created successfully
+        3. Group should be created with first memberURL successfully
+        4. Second memberURL should be added successfully
+        5. All users from both locations should be listed as members of the group
+    """
+
+    inst = topo.standalone
+    user_dns = dynamic_lists_setup
+
+    # Step 1: Configure dynamic lists with objectclass, url_attr, and list_attr
+    ldbmconfig = LDBMConfig(inst)
+    ldbmconfig.replace('nsslapd-dynamic-lists-enabled', b'on')
+    ldbmconfig.replace('nsslapd-dynamic-lists-attr', b'member')
+    ldbmconfig.replace('nsslapd-dynamic-lists-oc', b'groupOfUrls')
+    ldbmconfig.replace('nsslapd-dynamic-lists-url-attr', b'memberURL')
+
+    # Step 2: Create a new organizational unit with one entry under it
+    log.info("Creating new organizational unit")
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    test_ou = ous.create(properties={
+        'ou': 'TestOU',
+        'description': 'Test Organizational Unit for dynamic lists',
+    })
+    ou_dn = test_ou.dn
+    log.info(f"Created organizational unit: {ou_dn}")
+
+    # Create a user entry under the new OU
+    log.info("Creating user entry under the new OU")
+    ou_users = UserAccounts(inst, DEFAULT_SUFFIX, rdn="ou=TestOU")
+    ou_user = ou_users.create(properties={
+        'uid': 'testuser6',
+        'cn': 'testuser6',
+        'sn': 'User6',
+        'uidNumber': '1006',
+        'gidNumber': '1006',
+        'homeDirectory': '/home/testuser6',
+    })
+    ou_user_dn = ou_user.dn
+    log.info(f"Created user under OU: {ou_user_dn}")
+
+    # Step 3: Create a group (demo_group) with memberURL attribute pointing to DEFAULT_SUFFIX
+    log.info("Creating demo_group with first memberURL")
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    demo_group = groups.create(properties={
+        'cn': 'demo_group_multiple',
+        'objectClass': 'groupOfUrls',
+        'memberURL': f'ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)',
+    })
+    log.info(f"Created demo_group: {demo_group.dn} with memberURL: ldap:///{DEFAULT_SUFFIX}??sub?(uid=testuser*)")
+
+    # Step 4: Add an additional memberURL attribute to demo_group pointing to the new OU
+    # with the same filter as the first memberURL
+    log.info("Adding second memberURL to demo_group pointing to new OU")
+    second_memberurl = f'ldap:///{ou_dn}??sub?(uid=testuser*)'
+    demo_group.add('memberURL', second_memberurl)
+    log.info(f"Added second memberURL: {second_memberurl}")
+
+    # Step 5: Search for the group to trigger the plugin and verify all users
+    # from both locations are listed as members
+    log.info("Searching for group to trigger dynamic lists plugin")
+    members = demo_group.list_members()
+    log.info(f"Found {len(members)} members in group")
+    log.info(f"Members: {members}")
+
+    # Verify all users from DEFAULT_SUFFIX are members
+    assert len(members) == 7, f"Expected {7} members, got {len(members)}. Members: {members}"
+
+    # Verify all users from DEFAULT_SUFFIX are members
+    for user_dn in user_dns:
+        assert user_dn in members, f"User {user_dn} should be a member of the group. Members: {members}"
+
+    # Verify the user from the new OU is a member
+    assert ou_user_dn in members, f"User {ou_user_dn} should be a member of the group. Members: {members}"
+
+    log.info("Test completed successfully - all users from both locations are listed as members")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -345,6 +345,8 @@ struct backentry
     void *ep_uuid_link;             /*     looking up entries */
     PRMonitor *ep_mutexp;           /* protection for mods; make it reentrant */
     uint64_t ep_weight;             /* for cache eviction */
+    bool ep_is_dynamic;             /* is the entry a dynamic entry and must be
+                                     * removed from cache asap */
 };
 
 /* From ep_type through ep_create_time MUST be identical to backcommon */
@@ -659,6 +661,12 @@ struct ldbminfo
 #define BACKEND_OPT_MANAGE_ENTRY_BEFORE_DBLOCK 0x04
     int li_backend_opt_level;
     size_t li_max_key_len;
+
+    /* dynamic lists */
+    bool li_dynamic_lists_enabled;
+    char *li_dynamic_lists_attr;
+    char *li_dynamic_lists_oc;
+    char *li_dynamic_lists_url_attr;
 };
 
 

--- a/ldap/servers/slapd/back-ldbm/dblayer.c
+++ b/ldap/servers/slapd/back-ldbm/dblayer.c
@@ -178,7 +178,7 @@ not_exporting(void)
     slapi_ch_free_string(&export_lock);
     return res;
 }
-        
+
 /* Get the db implementation plugin path (either libback-ldbm.so or libback-bdb.so) */
 char *
 backend_implement_get_libpath(struct ldbminfo *li, const char *plgname)

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.c
@@ -948,6 +948,145 @@ ldbm_config_exclude_from_export_get(void *arg)
 }
 
 
+static int
+ldbm_config_dynamic_lists_enabled_set(void *arg, void *value, char *errorbuf __attribute__((unused)), int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    int val = (int)((uintptr_t)value);
+
+    if (apply) {
+        li->li_dynamic_lists_enabled = val;
+    }
+    return LDAP_SUCCESS;
+}
+
+static void *
+ldbm_config_dynamic_lists_enabled_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)((uintptr_t)li->li_dynamic_lists_enabled);
+}
+
+static int
+ldbm_config_dynamic_lists_attr_set(void *arg, void *value, char *errorbuf, int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    char *val = (char *)value;
+
+    if (!slapi_attr_syntax_exists(val)) {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must be set "
+                    "to an existing attribute with DN syntax (unknown %s)",
+                    CONFIG_DYNAMIC_LISTS_ATTR, val);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+
+    if (!slapi_attr_is_dn_syntax_type(val)) {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must be set "
+                    "to an attribute with DN syntax (incorrect syntax: %s)",
+                    CONFIG_DYNAMIC_LISTS_ATTR, val);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+    if (li->li_dynamic_lists_url_attr &&
+        strcasecmp(li->li_dynamic_lists_url_attr, val) == 0)
+    {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must not be set "
+                    "to the same attribute as the %s configuration attribute (same: %s)",
+                    CONFIG_DYNAMIC_LISTS_ATTR, CONFIG_DYNAMIC_LISTS_URL_ATTR,
+                    li->li_dynamic_lists_url_attr);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+
+
+    if (apply) {
+        slapi_ch_free_string(&(li->li_dynamic_lists_attr));
+        li->li_dynamic_lists_attr = slapi_ch_strdup(val);
+    }
+    return LDAP_SUCCESS;
+}
+
+static void *
+ldbm_config_dynamic_lists_attr_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)slapi_ch_strdup(li->li_dynamic_lists_attr);
+}
+
+static int
+ldbm_config_dynamic_lists_oc_set(void *arg, void *value, char *errorbuf, int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    char *val = (char *)value;
+    char *oc_value = NULL;
+
+    /* Check if this is a real objectclass */
+    if ((oc_value = slapi_schema_get_superior_name(val)) == NULL) {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must be set "
+                    "to an existing objectclass (unknown: %s)",
+                    CONFIG_DYNAMIC_LISTS_OC, val);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+    slapi_ch_free_string(&oc_value);
+
+    if (apply) {
+        slapi_ch_free_string(&(li->li_dynamic_lists_oc));
+        li->li_dynamic_lists_oc = slapi_ch_strdup(val);
+    }
+    return LDAP_SUCCESS;
+}
+
+static void *
+ldbm_config_dynamic_lists_oc_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)slapi_ch_strdup(li->li_dynamic_lists_oc);
+}
+
+static int
+ldbm_config_dynamic_lists_url_attr_set(void *arg, void *value, char *errorbuf, int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    char *val = (char *)value;
+
+    if (!slapi_attr_syntax_exists(val)) {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must be set "
+                    "to an existing attribute (unknown: %s)",
+                    CONFIG_DYNAMIC_LISTS_URL_ATTR, val);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+
+    /* Now make sure we are not using this attribute for the list attr */
+    if (li->li_dynamic_lists_attr && strcasecmp(li->li_dynamic_lists_attr, val) == 0) {
+        PR_snprintf(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
+                    "The %s configuration attribute must not be set "
+                    "to the same attribute as the %s configuration attribute (same: %s)",
+                    CONFIG_DYNAMIC_LISTS_URL_ATTR, CONFIG_DYNAMIC_LISTS_ATTR,
+                    li->li_dynamic_lists_attr);
+        return LDAP_UNWILLING_TO_PERFORM;
+    }
+
+    if (apply) {
+        slapi_ch_free_string(&(li->li_dynamic_lists_url_attr));
+        li->li_dynamic_lists_url_attr = slapi_ch_strdup(val);
+    }
+    return LDAP_SUCCESS;
+}
+
+static void *
+ldbm_config_dynamic_lists_url_attr_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)slapi_ch_strdup(li->li_dynamic_lists_url_attr);
+}
+
 /*------------------------------------------------------------------------
  * Configuration array for ldbm and dblayer variables
  *----------------------------------------------------------------------*/
@@ -976,6 +1115,11 @@ static config_info ldbm_config[] = {
     {CONFIG_RANGELOOKTHROUGHLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_rangelookthroughlimit_get, &ldbm_config_rangelookthroughlimit_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_BACKEND_OPT_LEVEL, CONFIG_TYPE_INT, "1", &ldbm_config_backend_opt_level_get, &ldbm_config_backend_opt_level_set, CONFIG_FLAG_ALWAYS_SHOW},
     {CONFIG_BACKEND_IMPLEMENT, CONFIG_TYPE_STRING, "bdb", &ldbm_config_backend_implement_get, &ldbm_config_backend_implement_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    /* dynamic lists */
+    {CONFIG_DYNAMIC_LISTS_ENABLED, CONFIG_TYPE_ONOFF, "off", &ldbm_config_dynamic_lists_enabled_get, &ldbm_config_dynamic_lists_enabled_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_DYNAMIC_LISTS_ATTR, CONFIG_TYPE_STRING, "member", &ldbm_config_dynamic_lists_attr_get, &ldbm_config_dynamic_lists_attr_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_DYNAMIC_LISTS_OC, CONFIG_TYPE_STRING, "groupOfUrls", &ldbm_config_dynamic_lists_oc_get, &ldbm_config_dynamic_lists_oc_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_DYNAMIC_LISTS_URL_ATTR, CONFIG_TYPE_STRING, "memberURL", &ldbm_config_dynamic_lists_url_attr_get, &ldbm_config_dynamic_lists_url_attr_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {NULL, 0, NULL, NULL, NULL, 0}};
 
 void
@@ -1189,7 +1333,6 @@ bail:
     slapi_ch_free_string(&dn);
     return rval;
 }
-
 
 /* Utility function used in creating config entries.  Using the
  * config_info, this function gets info and formats in the correct
@@ -1765,9 +1908,9 @@ ldbm_config_destroy(struct ldbminfo *li)
     if (li->li_attrs_to_exclude_from_export != NULL) {
         charray_free(li->li_attrs_to_exclude_from_export);
     }
-    slapi_ch_free((void **)&(li->li_new_directory));
-    slapi_ch_free((void **)&(li->li_directory));
-    slapi_ch_free((void **)&(li->li_backend_implement));
+    slapi_ch_free_string(&(li->li_new_directory));
+    slapi_ch_free_string(&(li->li_directory));
+    slapi_ch_free_string(&(li->li_backend_implement));
     /* Destroy the mutexes and cond var */
     if (li->li_shutdown_mutex) {
         PR_DestroyLock(li->li_shutdown_mutex);
@@ -1775,6 +1918,11 @@ ldbm_config_destroy(struct ldbminfo *li)
     if (li->li_config_mutex) {
         PR_DestroyLock(li->li_config_mutex);
     }
+
+    /* dynamic lists */
+    slapi_ch_free_string(&(li->li_dynamic_lists_attr));
+    slapi_ch_free_string(&(li->li_dynamic_lists_oc));
+    slapi_ch_free_string(&(li->li_dynamic_lists_url_attr));
 
     /* Finally free the ldbminfo */
     slapi_ch_free((void **)&li);

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -147,6 +147,11 @@ struct config_info
 
 #define CONFIG_LDBM_DN "cn=config,cn=ldbm database,cn=plugins,cn=config"
 
+#define CONFIG_DYNAMIC_LISTS_ENABLED "nsslapd-dynamic-lists-enabled"
+#define CONFIG_DYNAMIC_LISTS_ATTR "nsslapd-dynamic-lists-attr"
+#define CONFIG_DYNAMIC_LISTS_OC "nsslapd-dynamic-lists-oc"
+#define CONFIG_DYNAMIC_LISTS_URL_ATTR "nsslapd-dynamic-lists-url-attr"
+
 #define LDBM_INSTANCE_CONFIG_DONT_WRITE 1
 
 /* Some fuctions in ldbm_config.c used by ldbm_instance_config.c */


### PR DESCRIPTION
Implement a backend feature to build dynamic content based of LDAP URI's. Configuration includes an identifying objectclass to mark an entry as a dynamic content entry. Another setting for the attribute that contains the LDAP URI, and an attribute for storing the dynamic content. Attributes specified in the LDAP URI override the content attribute and instead write that attribute's value into the dynamic content entry.

Design doc: https://www.port389.org/docs/389ds/design/dynamic-lists-design.html

Relates: https://github.com/389ds/389-ds-base/issues/1793

## Summary by Sourcery

Add backend support for dynamic LDAP list entries that are materialized on search using LDAP URLs and are never cached persistently.

New Features:
- Introduce dynamic list handling in the ldbm backend, populating dynamic attributes based on LDAP URL searches and marking such entries as transient.
- Add configurable backend settings to enable dynamic lists and define the marker object class, URL attribute, and target list attribute.

Enhancements:
- Ensure dynamic entries are excluded from the entry cache so that their content is rebuilt on each access, and integrate dynamic list evaluation into candidate list building for relevant searches.

Tests:
- Add an automated test suite for dynamic lists covering basic member URL expansion, non-DN attribute population, invalid configuration handling, and multiple URL aggregation behavior.