### PR TITLE
Issue 7096 - During replication online total init the function

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -282,6 +282,18 @@ typedef struct _idlist_set
 #define INDIRECT_BLOCK(idl) ((idl)->b_nids == INDBLOCK)
 #define IDL_NIDS(idl)       (idl ? (idl)->b_nids : (NIDS)0)
 
+/*
+ * used by the supplier during online total init
+ * it stores the ranges of ID that are already present
+ * in the candidate list ('parentid>=1')
+ */
+typedef struct IdRange {
+    ID first;
+    ID last;
+    struct IdRange *next;
+} IdRange_t;
+
+
 typedef size_t idl_iterator;
 
 /* small hashtable implementation used in the entry cache -- the table

--- a/ldap/servers/slapd/back-ldbm/idl_new.c
+++ b/ldap/servers/slapd/back-ldbm/idl_new.c
@@ -417,7 +417,6 @@ idl_new_range_fetch(
 {
     int ret = 0;
     int ret2 = 0;
-    int idl_rc = 0;
     dbi_cursor_t cursor = {0};
     IDList *idl = NULL;
     dbi_val_t cur_key = {0};
@@ -436,6 +435,7 @@ idl_new_range_fetch(
     size_t leftoverlen = 32;
     size_t leftovercnt = 0;
     char *index_id = get_index_name(be, db, ai);
+    IdRange_t *idrange_list = NULL;
 
 
     if (NULL == flag_err) {
@@ -578,10 +578,12 @@ idl_new_range_fetch(
                      * found entry is the one from the suffix
                      */
                     suffix = key;
-                    idl_rc = idl_append_extend(&idl, id);
-                } else if ((key == suffix) || idl_id_is_in_idlist(idl, key)) {
+                    idl_append_extend(&idl, id);
+                    idrange_add_id(&idrange_list, id);
+                } else if ((key == suffix) || idl_id_is_in_idlist_ranges(idl, idrange_list, key)) {
                     /* the parent is the suffix or already in idl. */
-                    idl_rc = idl_append_extend(&idl, id);
+                    idl_append_extend(&idl, id);
+                    idrange_add_id(&idrange_list, id);
                 } else {
                     /* Otherwise, keep the {key,id} in leftover array */
                     if (!leftover) {
@@ -596,13 +598,7 @@ idl_new_range_fetch(
                     leftovercnt++;
                 }
             } else {
-                idl_rc = idl_append_extend(&idl, id);
-            }
-            if (idl_rc) {
-                slapi_log_err(SLAPI_LOG_ERR, "idl_new_range_fetch",
-                              "Unable to extend id list (err=%d)\n", idl_rc);
-                idl_free(&idl);
-                goto error;
+                idl_append_extend(&idl, id);
             }
 
             count++;
@@ -695,21 +691,17 @@ error:
 
         while(remaining > 0) {
             for (size_t i = 0; i < leftovercnt; i++) {
-                if (leftover[i].key > 0 && idl_id_is_in_idlist(idl, leftover[i].key) != 0) {
+                if (leftover[i].key > 0 && idl_id_is_in_idlist_ranges(idl, idrange_list, leftover[i].key) != 0) {
                     /* if the leftover key has its parent in the idl */
-                    idl_rc = idl_append_extend(&idl, leftover[i].id);
-                    if (idl_rc) {
-                        slapi_log_err(SLAPI_LOG_ERR, "idl_new_range_fetch",
-                                      "Unable to extend id list (err=%d)\n", idl_rc);
-                        idl_free(&idl);
-                        return NULL;
-                    }
+                    idl_append_extend(&idl, leftover[i].id);
+                    idrange_add_id(&idrange_list, leftover[i].id);
                     leftover[i].key = 0;
                     remaining--;
                 }
             }
         }
         slapi_ch_free((void **)&leftover);
+        idrange_free(&idrange_list);
     }
     slapi_log_err(SLAPI_LOG_FILTER, "idl_new_range_fetch",
                   "Found %d candidates; error code is: %d\n",

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -217,6 +217,9 @@ ID idl_firstid(IDList *idl);
 ID idl_nextid(IDList *idl, ID id);
 int idl_init_private(backend *be, struct attrinfo *a);
 int idl_release_private(struct attrinfo *a);
+IdRange_t *idrange_add_id(IdRange_t **head, ID id);
+void idrange_free(IdRange_t **head);
+int idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id);
 int idl_id_is_in_idlist(IDList *idl, ID id);
 
 idl_iterator idl_iterator_init(const IDList *idl);


### PR DESCRIPTION
idl_id_is_in_idlist is not scaling with large database

Bug description:
	During a online total initialization, the supplier sorts
	the candidate list of entries so that the parents are sent before
	children entries.
	With large DB the ID array used for the sorting is not
	scaling. It takes so long to build the candidate list that
	the connection gets closed

Fix description:
        Instead of using an ID array, uses a list of ID ranges

fixes: #7096

Reviewed by:

## Summary by Sourcery

Optimize replication candidate list handling during online total initialization by tracking included entry IDs as ranges instead of individual IDs to improve scalability on large databases.

Bug Fixes:
- Prevent timeouts during online total initialization by replacing per-ID membership checks with range-based tracking of candidate entry IDs.

Enhancements:
- Introduce an ID range data structure and helper routines to manage and query ID membership efficiently, and integrate them into range-based IDL fetching logic.