### PR TITLE
Issue: 7147 - entrycache_eviction_test is failing

### DIFF
--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -1061,7 +1061,12 @@ static bool
 debug_pattern_matches(struct cache *cache, const char *dn)
 {
     if (cache->c_inst->cache_debug_re && dn) {
-        if (slapi_re_exec_nt(cache->c_inst->cache_debug_re, dn)) {
+        static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+        int rc = 0;
+        pthread_mutex_lock(&mutex);
+        rc = slapi_re_exec_nt(cache->c_inst->cache_debug_re, dn);
+        pthread_mutex_unlock(&mutex);
+        if (rc) {
             return true;
         }
     }


### PR DESCRIPTION
Several reason explain the test failure:

- log buffereing is not disabled
- a race condition causing double free in slapi_re_exec_nt when several thread uses the same compiled regex
- The searched done during the test were silently unindexed so some entries were unexpectedly added  to the entry cache

Issue: #7147

Reviewed by: @tbordaz, @droideck (Thanks!)

## Summary by Sourcery

Stabilise entry cache eviction behaviour and debug logging by tightening test searches and making regex-based cache debugging thread-safe.

Bug Fixes:
- Prevent concurrent use of the shared cache debug regex from causing race conditions by serialising calls to slapi_re_exec_nt with a mutex.

Enhancements:
- Ensure cache debugging output is consistently captured by disabling error log buffering for the test.
- Avoid interference from the automember plugin during entry cache eviction testing by disabling it for the test instance.

Tests:
- Update entry cache eviction tests to search only for relevant group and person object classes so entries remain indexed and eviction behaviour is deterministic.