### PR TITLE
Issue 7155 - build_candidate_list - Database error 11 with range search

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1553,6 +1553,8 @@ subtree_candidates(
             idl_free(&tmp);
             idl_free(&descendants);
         }
+    } else if (candidates != NULL) {
+        *err = LDAP_SUCCESS;
     }
 
     return (candidates);


### PR DESCRIPTION
Range search behavior discrepancy when hitting  nsslapd-rangelookthroughlimit whether filter_candidates_ext returns a short or long list of candidates:
  Search is successful if the candidate list is long but fail if it is short
 Error should be ignored in both case 
 
 Issue: #7155 
 
 Reviewed by: @tbordaz  (Thanks!)

## Summary by Sourcery

Handle range search candidate list errors consistently and validate correct behavior with a new regression test.

Bug Fixes:
- Avoid returning spurious database error codes from subtree candidate searches when a non-empty candidate list is available.

Tests:
- Add a regression test and supporting LDAP objects/fixtures to verify range search behavior when nsslapd-rangelookthroughlimit is hit.