### PR TITLE
Issue 6951 - Dynamic Certificate refresh phase 3 - Certificates switch

### DIFF
--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -8,8 +8,6 @@
 #
 import os
 import sys
-<<<<<<< HEAD
-<<<<<<< HEAD
 import copy
 import datetime
 import ipaddress
@@ -19,30 +17,10 @@ import logging
 import pytest
 import secrets
 import shutil
-=======
-import pytest
-=======
-import datetime
-import ipaddress
->>>>>>> 1236487850 (Phase 3 - suite)
-import ldap
-import ldapurl
-import logging
-import pytest
-import secrets
-<<<<<<< HEAD
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
-=======
-import shutil
->>>>>>> 1236487850 (Phase 3 - suite)
 import socket
 import subprocess
 import textwrap
 import time
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 1236487850 (Phase 3 - suite)
 from contextlib import contextmanager, suppress
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -50,32 +28,12 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography import x509
 from cryptography.x509.oid import NameOID, ExtensionOID
-<<<<<<< HEAD
-from lib389.cli_base import FakeArgs
-=======
-from contextlib import contextmanager
-from lib389.cli_base import FakeArgs
-from lib389.cli_ctl.tls import import_key_cert_pair
-from lib389.dseldif import DSEldif
-from lib389.utils import ds_is_older, ensure_str
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
-from lib389._constants import DN_DM, PW_DM
-from lib389.dseldif import DSEldif
-from lib389.topologies import topology_st as topo
-<<<<<<< HEAD
-from lib389.utils import ds_is_older, ensure_str
-from tempfile import NamedTemporaryFile
-=======
-from tempfile import TemporaryDirectory, NamedTemporaryFile
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
-=======
 from lib389.cli_base import FakeArgs
 from lib389._constants import DN_DM, PW_DM
 from lib389.dseldif import DSEldif
 from lib389.topologies import topology_st as topo
 from lib389.utils import ds_is_older, ensure_str
 from tempfile import NamedTemporaryFile
->>>>>>> 1236487850 (Phase 3 - suite)
 
 pytestmark = pytest.mark.tier1
 
@@ -123,7 +81,6 @@ def traced_ldap_connection(url, msg):
             yield l
         finally:
             l.unbind()
-<<<<<<< HEAD
 
 @contextmanager
 def ldapi(inst):
@@ -132,24 +89,17 @@ def ldapi(inst):
         yield l
     finally:
         l.unbind()
-=======
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
-@contextmanager
-def ldapi(inst):
-    l = open_ldapi_conn(inst)
-    try:
-        yield l
-    finally:
-        l.unbind()
+
+def utcdate():
+    return datetime.datetime.utcnow() # Python 3.8
+    # return datetime.datetime.now(datetime.UTC) # Python 3.11
 
 
 ################################
 ###### GENERATE CA CERT ########
 ################################
 class ECDSA_Certificate:
-<<<<<<< HEAD
-<<<<<<< HEAD
     """Elliptic Curve Certificate Generator"""
 
     PKCS12_PASSWORD = "a+password"
@@ -186,8 +136,8 @@ class ECDSA_Certificate:
             .issuer_name(ca.issuer)
             .public_key(ca.pkey.public_key())
             .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            .not_valid_before(utcdate())
+            .not_valid_after(utcdate() + datetime.timedelta(days=validity_days))
             # CA certificate extensions
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=0),
@@ -280,8 +230,8 @@ class ECDSA_Certificate:
             .issuer_name(ca.issuer)
             .public_key(ca.pkey.public_key())
             .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            .not_valid_before(utcdate())
+            .not_valid_after(utcdate() + datetime.timedelta(days=validity_days))
             # CA certificate extensions
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=0),
@@ -344,8 +294,8 @@ class ECDSA_Certificate:
             .issuer_name(cert.issuer)
             .public_key(cert.pkey.public_key())
             .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            .not_valid_before(utcdate())
+            .not_valid_after(utcdate() + datetime.timedelta(days=validity_days))
             # Server certificate extensions
             .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
@@ -540,385 +490,6 @@ class ECDSA_Certificate:
 ###### Work around to debug libldap/liblber CERT ########
 #########################################################
 
-=======
-    # Generate ecdsa certificate
-=======
-    """Elliptic Curve Certificate Generator"""
->>>>>>> 1236487850 (Phase 3 - suite)
-
-    PKCS12_PASSWORD = "a+password"
-
-    def __init__(self):
-        self.nickname = None
-        self.trust = None
-        self.namingAttrs = {}
-        self.subject = None
-        self.validity_days = 365
-        self.isCA = False
-        self.isRoot = False
-        self.caChain = None
-
-    @staticmethod
-    def generateRootCA(nickname, namingAttributes={}, validity_days=3650):
-        """Generate a self-signed Root CA certificate using elliptic curve"""
-        ca = ECDSA_Certificate()
-        ca.namingAttrs = namingAttributes
-        ca.validity_days = validity_days
-        ca.isCA = True
-        ca.isRoot = True
-        ca.nickname = nickname
-        ca.fixNamingAttributes()
-        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
-        ca.issuer = ca.subject
-        ca.trust = 'CT,,'
-
-        # Generate prime256v1 private key 
-        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
-        ca.cert = (
-            x509.CertificateBuilder()
-            .subject_name(ca.subject)
-            .issuer_name(ca.issuer)
-            .public_key(ca.pkey.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
-            # CA certificate extensions
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=0),
-                critical=True,
-            )
-            .add_extension(
-                x509.KeyUsage(
-                    digital_signature=False,
-                    key_cert_sign=True,
-                    crl_sign=False,
-                    key_encipherment=False,
-                    content_commitment=False,
-                    data_encipherment=False,
-                    key_agreement=False,
-                    encipher_only=False,
-                    decipher_only=False,
-                ),
-                critical=True,
-            )
-            .add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
-                critical=False,
-            )
-            .sign(ca.pkey, hashes.SHA256(), default_backend())
-        )
-        return ca
-
-    @staticmethod
-    def save_pem_file(filename, *items):
-        """Save PEM formatted items to file"""
-        with open(filename, "wb") as f:
-            for item in items:
-                if isinstance(item, ec.EllipticCurvePrivateKey):
-                    pem = item.private_bytes(
-                        encoding=serialization.Encoding.PEM,
-                        format=serialization.PrivateFormat.TraditionalOpenSSL,
-                        encryption_algorithm=serialization.NoEncryption()
-                    )
-                elif isinstance(item, x509.Certificate):
-                    pem = item.public_bytes(serialization.Encoding.PEM)
-                else:
-                    raise ValueError(f"Unknown item type: {type(item)}")
-                f.write(pem)
-
-    @staticmethod
-    def save_der_file(filename, item):
-        """Save DER formatted item to file"""
-        with open(filename, "wb") as f:
-            if isinstance(item, ec.EllipticCurvePrivateKey):
-                der = item.private_bytes(
-                    encoding=serialization.Encoding.DER,
-                    format=serialization.PrivateFormat.PKCS8, #format=serialization.PrivateFormat.TraditionalOpenSSL,
-                    encryption_algorithm=serialization.NoEncryption()
-                )
-            elif isinstance(item, x509.Certificate):
-                der = item.public_bytes(serialization.Encoding.DER)
-            else:
-                raise ValueError(f"Unknown item type: {type(item)}")
-            f.write(der)
-
-    def fixNamingAttribute(self, name, vdef):
-        """Set value for naming attribute if it is missing"""
-        if name not in self.namingAttrs:
-            self.namingAttrs[name] = vdef
-    
-    def fixNamingAttributes(self):
-        """Set default value for mandatory naming attributes"""
-        self.fixNamingAttribute(NameOID.COMMON_NAME, self.nickname)
-        self.fixNamingAttribute(NameOID.COUNTRY_NAME, 'US')
-        self.fixNamingAttribute(NameOID.ORGANIZATION_NAME, 'Example Organization')
-
-    def generateCA(self, namingAttributes, validity_days=3650):
-        """Generate an intermediary CA certificate using elliptic curve"""
-        ca = ECDSA_Certificate()
-        ca.namingAttrs = namingAttributes
-        ca.validity_days = validity_days
-        ca.isCA = True
-        ca.isRoot = False
-        ca.nickname = nickname
-        ca.fixNamingAttributes()
-        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
-        ca.issuer = self.subject
-        ca.trust = 'CT,,'
-
-        # Generate prime256v1 private key 
-        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
-        ca.cert = (
-            x509.CertificateBuilder()
-            .subject_name(ca.subject)
-            .issuer_name(ca.issuer)
-            .public_key(ca.pkey.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
-            # CA certificate extensions
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=0),
-                critical=True,
-            )
-            .add_extension(
-                x509.KeyUsage(
-                    digital_signature=False,
-                    key_cert_sign=True,
-                    crl_sign=False,
-                    key_encipherment=False,
-                    content_commitment=False,
-                    data_encipherment=False,
-                    key_agreement=False,
-                    encipher_only=False,
-                    decipher_only=False,
-                ),
-                critical=True,
-            )
-            .add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
-                critical=False,
-            )
-            .add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
-                critical=False,
-            )
-            .sign(self.pkey, hashes.SHA256(), default_backend())
-        )
-        return ca
-
-    def generateCertificate(self, nickname, namingAttributes={}, hostname=None, validity_days=3650):
-        """Generate an user certificate using elliptic curve"""
-        cert = ECDSA_Certificate()
-        cert.namingAttrs = namingAttributes
-        cert.validity_days = validity_days
-        cert.isCA = False
-        cert.isRoot = False
-        cert.nickname = nickname
-        cert.fixNamingAttributes()
-        cert.subject = x509.Name([x509.NameAttribute(k,v) for k,v in cert.namingAttrs.items()])
-        cert.issuer = self.subject
-        cert.trust = 'u,u,u'
-        cert.caChain = self
-
-        if hostname is None:
-            hostname = socket.gethostname()
-
-        san_list = [x509.DNSName(hostname),]
-        if hostname != 'localhost':
-            san_list.append(x509.DNSName(hostname))
-        san_list.append(x509.IPAddress(ipaddress.ip_address("127.0.0.1")))
-        san_list.append(x509.IPAddress(ipaddress.ip_address("::1")))
-
-        # Generate prime256v1 private key 
-        cert.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
-        cert.cert = (
-            x509.CertificateBuilder()
-            .subject_name(cert.subject)
-            .issuer_name(cert.issuer)
-            .public_key(cert.pkey.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.now(datetime.UTC))
-            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
-            # Server certificate extensions
-            .add_extension(
-                x509.BasicConstraints(ca=False, path_length=None),
-                critical=True,
-            )
-            .add_extension(
-                x509.KeyUsage(
-                    digital_signature=True,
-                    key_encipherment=True,
-                    key_cert_sign=False,
-                    crl_sign=False,
-                    content_commitment=False,
-                    data_encipherment=False,
-                    key_agreement=False,
-                    encipher_only=False,
-                    decipher_only=False,
-                ),
-                critical=True,
-            )
-            .add_extension(
-                x509.ExtendedKeyUsage([
-                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
-                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
-                ]),
-                critical=True,
-            )
-            .add_extension(
-                x509.SubjectAlternativeName(san_list),
-                critical=False,
-            )
-            .add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(cert.pkey.public_key()),
-                critical=False,
-            )
-            .add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
-                critical=False,
-            )
-            .sign(self.pkey, hashes.SHA256(), default_backend())
-        )
-        return cert
-
-    def write_pkcs12_file(self, filename, pw=PKCS12_PASSWORD):
-        """Save PKCS12 formatede certificate and private key"""
-        if isinstance(pw, str):
-            pw = pw.encode()
-        if pw is None or pw == b"":
-            enc = serialization.NoEncryption()
-        else:
-            enc = serialization.BestAvailableEncryption(pw)
-        with open(filename, "wb") as f:
-            f.write(pkcs12.serialize_key_and_certificates(
-                self.nickname.encode(),
-                self.pkey,
-                self.cert,
-                [],
-                enc
-            ))
-
-    def save(self, dirname, pk12pw=PKCS12_PASSWORD):
-        print(f'Writing files for {self.nickname}')
-        if self.isCA:
-            name = f'{dirname}/{self.nickname}-ca'
-        else:
-            name = f'{dirname}/{self.nickname}-cert'
-        self.pem = f"{name}-cert.pem"
-        self.der = f"{name}-cert.der"
-        self.key = f"{name}-key.pem"
-        self.kder = f"{name}-key.der"
-        self.p12 = f"{name}.p12"
-        ECDSA_Certificate.save_pem_file(self.pem, self.cert)
-        ECDSA_Certificate.save_der_file(self.der, self.cert)
-        ECDSA_Certificate.save_pem_file(self.key, self.pkey)
-        ECDSA_Certificate.save_der_file(self.kder, self.pkey)
-        self.write_pkcs12_file(self.p12, pk12pw)
-
-    def run(self, cmd):
-        log.info(f'Running: {" ".join(cmd)}')
-        res = subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
-        assert res
-        log.info(f'Stdout+Stderr:{res.stdout}')
-        res.check_returncode()
-
-    def __repr__(self):
-        return self.nickname
-
-    @staticmethod
-    def nss_db_paths(inst):
-        prefix = os.environ.get('PREFIX', "/")
-        certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
-        pwfile = f'{certdbdir}/pwdfile.txt'
-        return ( prefix, certdbdir, pwfile )
-
-    def clear_nss_db(self, inst):
-        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
-        inst.stop()
-        for f in ('cert9.db', 'key4.db'):
-            try:
-                os.remove(f'{certdbdir}/{f}')
-            except OSError:
-                pass
-        self.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile, '-@', pwfile))
-
-    def offline_install(self, inst):
-        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
-        if self.isCA:
-            self.run(('certutil', '-A', '-n', self.nickname, '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', self.pem))
-        else:
-            self.run(('pk12util', '-v', '-i', self.p12, '-d', certdbdir, '-k', pwfile, '-W', ECDSA_Certificate.PKCS12_PASSWORD))
-
-    def show(self, inst):
-        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
-        self.run(('certutil', '-L', '-n', self.nickname,  '-d', certdbdir))
-
-    def showAll(self, inst):
-        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
-        self.run(('certutil', '-L', '-d', certdbdir))
-
-    def read_cert(self, inst):
-        with ldapi(inst) as ldc:
-            with suppress(ldap.NO_SUCH_OBJECT):
-                dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
-                res = ldc.search_s(dn, ldap.SCOPE_BASE)
-                return res
-        return None
-
-    def online_install(self, inst):
-        old_cert = self.read_cert(inst)
-        log.info(f'Before online_install: cert={old_cert}')
-        dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
-        if self.isCA:
-            # Read DER file
-            with open(self.der, "rb") as f:
-                dercert = f.read()
-                derpkey = None
-        else:
-            # Read PKCS12 file
-            with open(self.p12, "rb") as f:
-                p12_data = f.read()
-                p12pw = ECDSA_Certificate.PKCS12_PASSWORD.encode()
-            privkey, cert, cas = pkcs12.load_key_and_certificates(p12_data, p12pw)
-            dercert = cert.public_bytes(serialization.Encoding.DER)
-            derpkey = privkey.private_bytes(encoding=serialization.Encoding.DER,
-                                            format=serialization.PrivateFormat.PKCS8,
-                                            encryption_algorithm=serialization.NoEncryption())
-        with ldapi(inst) as ldc:
-            if old_cert:
-                log.info(f'+++ Trying to replace {dn} +++')
-                mods = [(ldap.MOD_REPLACE, 'nsDynamicCertificateDER', [ dercert, ]),]
-                if derpkey:
-                    mods.append((ldap.MOD_REPLACE, 'nsDynamicCertificatePrivateKeyDER', [ derpkey, ]))
-                ldc.modify_s(dn, mods)
-                self.show(inst)
-            else:
-                log.info(f'+++ Trying to add {dn} +++')
-                e = [
-                     ('cn', [ self.nickname.encode(encoding="utf-8"), ] ),
-                     ('objectclass', [ b'top', b'extensibleobject' ] ),
-                     ('nsDynamicCertificateDER', [ dercert, ] ),
-                    ]
-                if derpkey:
-                    e.append(('nsDynamicCertificatePrivateKeyDER', [derpkey,]))
-                ldc.add_s(dn, e)
-        new_cert = self.read_cert(inst)
-        log.info(f'After online_install: cert={new_cert}')
-        assert new_cert != old_cert
-
-    def setSslPersonality(self, inst):
-        ldc = open_ldapi_conn(inst)
-        dn='cn=RSA,cn=encryption,cn=config'
-        mods = [ (ldap.MOD_REPLACE, 'nsSSLPersonalitySSL', [ self.nickname.encode(), ]), ]
-        ldc.modify_s(dn, mods)
-
-
-#########################################################
-###### Work around to debug libldap/liblber CERT ########
-#########################################################
-
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 def open_ldap(url, logfile):
     if logfile is not None:
         lutil_debug_file(logfile)
@@ -938,15 +509,7 @@ def open_ldap(url, logfile):
 #########################
 
 def open_ldaps_conn(inst, ca):
-<<<<<<< HEAD
-<<<<<<< HEAD
     url = f'ldaps://localhost:{inst.sslport}'
-=======
-    url = inst.toLDAPURL()
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
-=======
-    url = f'ldaps://localhost:{inst.sslport}'
->>>>>>> 1236487850 (Phase 3 - suite)
     log.info(f'Attempt to connect to {url} using {ca.pem}')
     ld = ldap.initialize(url)
     #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
@@ -954,8 +517,6 @@ def open_ldaps_conn(inst, ca):
     ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
     ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
     return ld
-<<<<<<< HEAD
-=======
 
 
 def open_ldapi_conn(inst, logfile=None):
@@ -1000,55 +561,7 @@ def refresh_certs(inst, timeout=60):
             return
         time.sleep(1)
     raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
-<<<<<<< HEAD
-
-def open_ldapi_conn(inst, logfile=None):
-    dse = DSEldif(inst)
-    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
-    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
-    log.info(f'Attempt to connect to {url} using sasl external authentication')
-    ld = ldap.initialize(url)
-    # Perform autobind
-    sasl_auth = ldap.sasl.external()
-    ld.sasl_interactive_bind_s("", sasl_auth)
-    return ld
-
-
-def tls_search(inst, ca):
-    url = f'ldaps://localhost:{inst.sslport}'
-    log.info(f'Attempt to connect to {url} using {ca.pem}')
-    with traced_ldap_connection(url, f'ldaps bind using CA {ca}') as ld:
-        #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
-        ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
-        ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
-        ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
-        ld.simple_bind_s(DN_DM, PW_DM)
-        results = ld.search_s('', ldap.SCOPE_BASE)
-        assert len(results) == 1
-
-
-#
-#  Ideally There should be a dsctl/dsconf subcommand
-#
-def refresh_certs(inst, timeout=60):
-    ld = open_ldapi_conn(inst)
-    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
-    # Now lets wait until the config value is off again
-    for _ in range(timeout):
-        result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
-        log.info(f'cn=config result: {result}')
-        attrs = result[0][1]
-        vals = attrs['nsslapd-refresh-certificates']
-        if vals[0].decode("utf-8").lower() == "off":
-            ld.unbind()
-            return
-        time.sleep(1)
-    raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
-
-=======
->>>>>>> 1236487850 (Phase 3 - suite)
 # Generate Server Certifcate and Root CA and install them
 @pytest.fixture(scope="module")
 def ecdsa_certs(topo, request):
@@ -1061,7 +574,6 @@ def ecdsa_certs(topo, request):
     with suppress(FileNotFoundError):
         shutil.rmtree(dir)
     os.makedirs(dir, 0o700)
-<<<<<<< HEAD
     inst=topo.standalone
     global tls_enabled
     if not tls_enabled:
@@ -1089,7 +601,6 @@ def test_ecdsa(topo, ecdsa_certs):
     :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
     :setup: Standalone Instance with ecdsa certificates
     :steps:
-<<<<<<< HEAD
         1. Open ldaps connection with server CA certificate and search root entry
     :expectedresults:
         1. No error
@@ -1103,7 +614,7 @@ def test_ecdsa(topo, ecdsa_certs):
 def test_dynamic(topo, ecdsa_certs):
     """Check that certificates can be managed dynamically
 
-    :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
+    :id: 20615484-db69-11f0-aad9-c85309d5c3e3
     :setup: Standalone Instance with ecdsa certificates
     :steps:
         1. Create Test-DynCert-1 certificate
@@ -1136,60 +647,10 @@ def test_dynamic(topo, ecdsa_certs):
     assert cert2.read_cert(inst)
     cert2.delete(inst)
     assert not cert2.read_cert(inst)
-=======
-        1. Generate ECDSA CA and User Cert
-        2. Install the certificates
-        3. Restart the server
-        4. Open ldaps connection with server CA certificate and search root entry
-    :expectedresults:
-        1. No error
-        2. No error
-        3. No error
-        4. No error
-    """
-
-=======
->>>>>>> 1236487850 (Phase 3 - suite)
-    inst=topo.standalone
-    global tls_enabled
-    if not tls_enabled:
-        inst.enable_tls()
-        tls_enabled = True
-    ca = ECDSA_Certificate.generateRootCA("CA")
-    cert = ca.generateCertificate("Cert")
-    cert.setSslPersonality(inst)
-    ca.clear_nss_db(inst)
-    ca.showAll(inst)
-    ca.save(dir)
-    cert.save(dir)
-    cert.offline_install(inst)
-    cert.show(inst)
-    ca.offline_install(inst)
-    ca.show(inst)
-    ca.showAll(inst)
-    inst.restart(post_open=False)
-    return (cert, ca, dir)
-
-
-def test_ecdsa(topo, ecdsa_certs):
-    """Specify a test case purpose or name here
-
-    :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
-    :setup: Standalone Instance with ecdsa certificates
-    :steps:
-        1. Open ldaps connection with server CA certificate and search root entry
-    :expectedresults:
-        1. No error
-    """
-
-    inst=topo.standalone
-    cert, ca, dir = ecdsa_certs
-    tls_search(inst, ca)
 
 
 def test_refresh_ecdsa_1ca(topo, ecdsa_certs):
     """Test dynamic refresh of server certificate
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
     :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
     :setup: Standalone Instance with ecdsa certificates

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -690,7 +690,7 @@ def test_refresh_ecdsa_1ca(topo, ecdsa_certs):
 def test_refresh_ecdsa_2ca(topo, ecdsa_certs):
     """Test dynamic refresh of server certificate and CA
 
-    :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
+    :id: f77ae9b0-db70-11f0-a059-c85309d5c3e3
     :setup: Standalone Instance
     :steps:
         1. Open ldaps connection with server CA certificate and search root entry

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -9,6 +9,7 @@
 import os
 import sys
 <<<<<<< HEAD
+<<<<<<< HEAD
 import copy
 import datetime
 import ipaddress
@@ -20,16 +21,28 @@ import secrets
 import shutil
 =======
 import pytest
+=======
+import datetime
+import ipaddress
+>>>>>>> 1236487850 (Phase 3 - suite)
 import ldap
 import ldapurl
 import logging
+import pytest
 import secrets
+<<<<<<< HEAD
 >>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
+=======
+import shutil
+>>>>>>> 1236487850 (Phase 3 - suite)
 import socket
 import subprocess
 import textwrap
 import time
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 1236487850 (Phase 3 - suite)
 from contextlib import contextmanager, suppress
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -37,6 +50,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography import x509
 from cryptography.x509.oid import NameOID, ExtensionOID
+<<<<<<< HEAD
 from lib389.cli_base import FakeArgs
 =======
 from contextlib import contextmanager
@@ -54,6 +68,14 @@ from tempfile import NamedTemporaryFile
 =======
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 >>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
+=======
+from lib389.cli_base import FakeArgs
+from lib389._constants import DN_DM, PW_DM
+from lib389.dseldif import DSEldif
+from lib389.topologies import topology_st as topo
+from lib389.utils import ds_is_older, ensure_str
+from tempfile import NamedTemporaryFile
+>>>>>>> 1236487850 (Phase 3 - suite)
 
 pytestmark = pytest.mark.tier1
 
@@ -113,11 +135,20 @@ def ldapi(inst):
 =======
 >>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
+@contextmanager
+def ldapi(inst):
+    l = open_ldapi_conn(inst)
+    try:
+        yield l
+    finally:
+        l.unbind()
+
 
 ################################
 ###### GENERATE CA CERT ########
 ################################
 class ECDSA_Certificate:
+<<<<<<< HEAD
 <<<<<<< HEAD
     """Elliptic Curve Certificate Generator"""
 
@@ -511,136 +542,279 @@ class ECDSA_Certificate:
 
 =======
     # Generate ecdsa certificate
+=======
+    """Elliptic Curve Certificate Generator"""
+>>>>>>> 1236487850 (Phase 3 - suite)
 
-    PEM_PASSWORD_LEN = 15
+    PKCS12_PASSWORD = "a+password"
 
-    # For the CA policy
-    CONF_CA_HEADER = textwrap.dedent("""\
-        [ req ]
-        distinguished_name = req_distinguished_name
-        policy             = policy_match
-        x509_extensions     = v3_ca
+    def __init__(self):
+        self.nickname = None
+        self.trust = None
+        self.namingAttrs = {}
+        self.subject = None
+        self.validity_days = 365
+        self.isCA = False
+        self.isRoot = False
+        self.caChain = None
 
-        # For the CA policy""")
+    @staticmethod
+    def generateRootCA(nickname, namingAttributes={}, validity_days=3650):
+        """Generate a self-signed Root CA certificate using elliptic curve"""
+        ca = ECDSA_Certificate()
+        ca.namingAttrs = namingAttributes
+        ca.validity_days = validity_days
+        ca.isCA = True
+        ca.isRoot = True
+        ca.nickname = nickname
+        ca.fixNamingAttributes()
+        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
+        ca.issuer = ca.subject
+        ca.trust = 'CT,,'
 
-    CONF_CA_TRAILER = textwrap.dedent("""\
-        [ v3_ca ]
-        subjectKeyIdentifier = hash
-        authorityKeyIdentifier = keyid:always,issuer
-        basicConstraints = critical,CA:true
-        #nsComment = "OpenSSL Generated Certificate"
-        keyUsage=critical, keyCertSign
-        """)
+        # Generate prime256v1 private key 
+        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        ca.cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca.subject)
+            .issuer_name(ca.issuer)
+            .public_key(ca.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # CA certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    key_cert_sign=True,
+                    crl_sign=False,
+                    key_encipherment=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
+                critical=False,
+            )
+            .sign(ca.pkey, hashes.SHA256(), default_backend())
+        )
+        return ca
 
-    # For the other certificates policy
-    CONF_CERT_HEADER = textwrap.dedent("""\
-        distinguished_name = req_distinguished_name
-        policy             = policy_match
-        x509_extensions     = v3_cert
+    @staticmethod
+    def save_pem_file(filename, *items):
+        """Save PEM formatted items to file"""
+        with open(filename, "wb") as f:
+            for item in items:
+                if isinstance(item, ec.EllipticCurvePrivateKey):
+                    pem = item.private_bytes(
+                        encoding=serialization.Encoding.PEM,
+                        format=serialization.PrivateFormat.TraditionalOpenSSL,
+                        encryption_algorithm=serialization.NoEncryption()
+                    )
+                elif isinstance(item, x509.Certificate):
+                    pem = item.public_bytes(serialization.Encoding.PEM)
+                else:
+                    raise ValueError(f"Unknown item type: {type(item)}")
+                f.write(pem)
 
-        # For the cert policy""")
+    @staticmethod
+    def save_der_file(filename, item):
+        """Save DER formatted item to file"""
+        with open(filename, "wb") as f:
+            if isinstance(item, ec.EllipticCurvePrivateKey):
+                der = item.private_bytes(
+                    encoding=serialization.Encoding.DER,
+                    format=serialization.PrivateFormat.PKCS8, #format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption()
+                )
+            elif isinstance(item, x509.Certificate):
+                der = item.public_bytes(serialization.Encoding.DER)
+            else:
+                raise ValueError(f"Unknown item type: {type(item)}")
+            f.write(der)
 
-    CONF_CERT_TRAILER = textwrap.dedent("""\
-        [ v3_cert ]
-        basicConstraints = critical,CA:false
-        subjectAltName=DNS:progier-thinkpadt14gen5.rmtfr.csb
-        keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-        #nsComment = OpenSSL Generated Certificate
-        extendedKeyUsage=clientAuth, serverAuth
-        nsCertType=client, server
-        """)
+    def fixNamingAttribute(self, name, vdef):
+        """Set value for naming attribute if it is missing"""
+        if name not in self.namingAttrs:
+            self.namingAttrs[name] = vdef
+    
+    def fixNamingAttributes(self):
+        """Set default value for mandatory naming attributes"""
+        self.fixNamingAttribute(NameOID.COMMON_NAME, self.nickname)
+        self.fixNamingAttribute(NameOID.COUNTRY_NAME, 'US')
+        self.fixNamingAttribute(NameOID.ORGANIZATION_NAME, 'Example Organization')
 
-    # Shared by all certificates (CA included)
-    CONF_COMMOM = textwrap.dedent("""\
-        [ policy_match ]
-        countryName             = optional
-        stateOrProvinceName     = optional
-        organizationName        = optional
-        organizationalUnitName  = optional
-        commonName              = supplied
-        emailAddress            = optional
+    def generateCA(self, namingAttributes, validity_days=3650):
+        """Generate an intermediary CA certificate using elliptic curve"""
+        ca = ECDSA_Certificate()
+        ca.namingAttrs = namingAttributes
+        ca.validity_days = validity_days
+        ca.isCA = True
+        ca.isRoot = False
+        ca.nickname = nickname
+        ca.fixNamingAttributes()
+        ca.subject = x509.Name([x509.NameAttribute(k,v) for k,v in ca.namingAttrs.items()])
+        ca.issuer = self.subject
+        ca.trust = 'CT,,'
 
-        [ req_distinguished_name ]
-        countryName			= Country Name (2 letter code)
-        countryName_default		= FR
-        countryName_min			= 2
-        countryName_max			= 2
+        # Generate prime256v1 private key 
+        ca.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        ca.cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca.subject)
+            .issuer_name(ca.issuer)
+            .public_key(ca.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # CA certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    key_cert_sign=True,
+                    crl_sign=False,
+                    key_encipherment=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(ca.pkey.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
+                critical=False,
+            )
+            .sign(self.pkey, hashes.SHA256(), default_backend())
+        )
+        return ca
 
-        stateOrProvinceName		= State or Province Name (full name)
-        stateOrProvinceName_default	= test
+    def generateCertificate(self, nickname, namingAttributes={}, hostname=None, validity_days=3650):
+        """Generate an user certificate using elliptic curve"""
+        cert = ECDSA_Certificate()
+        cert.namingAttrs = namingAttributes
+        cert.validity_days = validity_days
+        cert.isCA = False
+        cert.isRoot = False
+        cert.nickname = nickname
+        cert.fixNamingAttributes()
+        cert.subject = x509.Name([x509.NameAttribute(k,v) for k,v in cert.namingAttrs.items()])
+        cert.issuer = self.subject
+        cert.trust = 'u,u,u'
+        cert.caChain = self
 
-        localityName			= Locality Name (eg, city)
+        if hostname is None:
+            hostname = socket.gethostname()
 
-        0.organizationName		= Organization Name (eg, company)
-        0.organizationName_default	= {organizationName}
+        san_list = [x509.DNSName(hostname),]
+        if hostname != 'localhost':
+            san_list.append(x509.DNSName(hostname))
+        san_list.append(x509.IPAddress(ipaddress.ip_address("127.0.0.1")))
+        san_list.append(x509.IPAddress(ipaddress.ip_address("::1")))
 
-        organizationalUnitName		= Organizational Unit Name (eg, section)
-        #organizationalUnitName_default	=
+        # Generate prime256v1 private key 
+        cert.pkey = ec.generate_private_key( ec.SECP256R1(), default_backend())
+        cert.cert = (
+            x509.CertificateBuilder()
+            .subject_name(cert.subject)
+            .issuer_name(cert.issuer)
+            .public_key(cert.pkey.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.UTC))
+            .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=validity_days))
+            # Server certificate extensions
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_encipherment=True,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+                ]),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectAlternativeName(san_list),
+                critical=False,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(cert.pkey.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(self.pkey.public_key()),
+                critical=False,
+            )
+            .sign(self.pkey, hashes.SHA256(), default_backend())
+        )
+        return cert
 
-        commonName			= Common Name (e.g. server FQDN or YOUR name)
-        commonName_max			= 64
-
-        """)
-
-
-    VDEF = {
-        "countryName": "FR",
-        "stateOrProvinceName": "test",
-        "organizationName": "test-ECDSA",
-        "organizationalUnitName": None,
-        "localityName": None,
-        "commonName": socket.gethostname(),
-        "maxAge": "3",
-    }
-
-
-    SUBJECT_ATTR = ( "commonName", "organizationName", "countryName" )
-    SUBJECT_MAP = {
-        "countryName": "C",
-        "commonName": "CN",
-        "organizationName": "O",
-    }
-
-
-    def __init__(self, prefix, outdir, **kwargs):
-        self.dir = outdir
-        self.prefix = prefix
-        self.args = { **ECDSA_Certificate.VDEF, **kwargs }
-        if 'organizationName' not in kwargs:
-            self.args['organizationName'] = f'{self.args["organizationName"]}-{prefix}'
-        self.args['subject'] = self.get_subject()
-        for name in ( 'conf', 'csr', 'key', 'p12', 'pem', 'pw1', 'pw2'):
-            setattr(self, name, f'{outdir}/{prefix}.{name}')
-        for path in ( self.pw1, self.pw2 ):
-            with open(path, 'wt') as fd:
-                fd.write(secrets.token_urlsafe(ECDSA_Certificate.PEM_PASSWORD_LEN))
-                fd.write('\n')
-
-
-    def get_subject(self, **kwargs):
-        args = { **self.args, **kwargs }
-        subject = ""
-        for arg in ECDSA_Certificate.SUBJECT_ATTR:
-            if arg in args and arg in ECDSA_Certificate.SUBJECT_MAP:
-                subject += f"/{ECDSA_Certificate.SUBJECT_MAP[arg]}={args[arg]}"
-        # return f"/CN={args['commonName']}/DC=example/DC=com"
-        return subject
-
-    def generate_conf(self, isCA):
-        if isCA:
-            confl = ( ECDSA_Certificate.CONF_CA_HEADER,
-                      ECDSA_Certificate.CONF_COMMOM,
-                      ECDSA_Certificate.CONF_CA_TRAILER )
+    def write_pkcs12_file(self, filename, pw=PKCS12_PASSWORD):
+        """Save PKCS12 formatede certificate and private key"""
+        if isinstance(pw, str):
+            pw = pw.encode()
+        if pw is None or pw == b"":
+            enc = serialization.NoEncryption()
         else:
-            confl = ( ECDSA_Certificate.CONF_CERT_HEADER,
-                      ECDSA_Certificate.CONF_COMMOM,
-                      ECDSA_Certificate.CONF_CERT_TRAILER )
-        conf_path = f'{self.dir}/{self.prefix}.conf'
-        conf_data = "\n".join(confl).format(dir=self.dir, prefix=self.prefix, **self.args)
-        with open(conf_path, "wt") as fd:
-            for line in conf_data.split('\n'):
-                sep = "#" if " = None" in line else ""
-                fd.write(f'{sep}{line}\n')
+            enc = serialization.BestAvailableEncryption(pw)
+        with open(filename, "wb") as f:
+            f.write(pkcs12.serialize_key_and_certificates(
+                self.nickname.encode(),
+                self.pkey,
+                self.cert,
+                [],
+                enc
+            ))
+
+    def save(self, dirname, pk12pw=PKCS12_PASSWORD):
+        print(f'Writing files for {self.nickname}')
+        if self.isCA:
+            name = f'{dirname}/{self.nickname}-ca'
+        else:
+            name = f'{dirname}/{self.nickname}-cert'
+        self.pem = f"{name}-cert.pem"
+        self.der = f"{name}-cert.der"
+        self.key = f"{name}-key.pem"
+        self.kder = f"{name}-key.der"
+        self.p12 = f"{name}.p12"
+        ECDSA_Certificate.save_pem_file(self.pem, self.cert)
+        ECDSA_Certificate.save_der_file(self.der, self.cert)
+        ECDSA_Certificate.save_pem_file(self.key, self.pkey)
+        ECDSA_Certificate.save_der_file(self.kder, self.pkey)
+        self.write_pkcs12_file(self.p12, pk12pw)
 
     def run(self, cmd):
         log.info(f'Running: {" ".join(cmd)}')
@@ -649,44 +823,95 @@ class ECDSA_Certificate:
         log.info(f'Stdout+Stderr:{res.stdout}')
         res.check_returncode()
 
-    def generate_CA(self):
-        self.generate_conf(True)
-        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
-        self.run(("openssl", "req", "-x509", "-new", "-sha256", "-key", self.key, "-days", self.args['maxAge'], "-config", self.conf, "-subj", self.get_subject(), "-out", self.pem, "-keyout", self.key, "-passout", f"file:{self.pw1}"))
-        self.run(("openssl", "x509", "-text", "-in", self.pem))
-        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
-
-    def generate_cert(self, ca):
-        self.generate_conf(False)
-        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
-        self.run(("openssl", "req", "-new", "-sha256", "-key", self.key, "-config", self.conf, "-subj", self.get_subject(), "-out", self.csr))
-        self.run(("openssl", "x509", "-req", "-sha256", "-days", self.args['maxAge'], "-extensions", "v3_cert", "-extfile", self.conf, "-in", self.csr, "-CA", ca.pem, "-CAkey", ca.key, "-CAcreateserial", "-out", self.pem,  "-passin", f"file:{ca.pw1}"))
-        self.run(("openssl", "x509", "-text", "-in", self.pem))
-        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
-
     def __repr__(self):
-        return self.prefix
+        return self.nickname
 
+    @staticmethod
+    def nss_db_paths(inst):
+        prefix = os.environ.get('PREFIX', "/")
+        certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
+        pwfile = f'{certdbdir}/pwdfile.txt'
+        return ( prefix, certdbdir, pwfile )
 
-#############################
-###### INSTALL CERTS ########
-#############################
-def install_certs(ca, cert, inst):
-    prefix = os.environ.get('PREFIX', "/")
-    certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
-    pwfile = f'{certdbdir}/pwdfile.txt'
-    for f in ('cert9.db', 'key4.db'):
-        try:
-            os.remove(f'{certdbdir}/{f}')
-        except OSError:
-            pass
+    def clear_nss_db(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
+        inst.stop()
+        for f in ('cert9.db', 'key4.db'):
+            try:
+                os.remove(f'{certdbdir}/{f}')
+            except OSError:
+                pass
+        self.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile, '-@', pwfile))
 
-    ca.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile))
-    ca.run(('certutil', '-A', '-n', 'Self-Signed-CA', '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', ca.pem))
-    args = FakeArgs()
-    for k,v in { 'key_path': cert.key, 'cert_path': cert.pem }.items():
-        setattr(args, k, v)
-    import_key_cert_pair(inst, log, args)
+    def offline_install(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
+        if self.isCA:
+            self.run(('certutil', '-A', '-n', self.nickname, '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', self.pem))
+        else:
+            self.run(('pk12util', '-v', '-i', self.p12, '-d', certdbdir, '-k', pwfile, '-W', ECDSA_Certificate.PKCS12_PASSWORD))
+
+    def show(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
+        self.run(('certutil', '-L', '-n', self.nickname,  '-d', certdbdir))
+
+    def showAll(self, inst):
+        prefix, certdbdir, pwfile = ECDSA_Certificate.nss_db_paths(inst)        
+        self.run(('certutil', '-L', '-d', certdbdir))
+
+    def read_cert(self, inst):
+        with ldapi(inst) as ldc:
+            with suppress(ldap.NO_SUCH_OBJECT):
+                dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+                res = ldc.search_s(dn, ldap.SCOPE_BASE)
+                return res
+        return None
+
+    def online_install(self, inst):
+        old_cert = self.read_cert(inst)
+        log.info(f'Before online_install: cert={old_cert}')
+        dn = f'cn={self.nickname},{DYNCERT_SUFFIX}'
+        if self.isCA:
+            # Read DER file
+            with open(self.der, "rb") as f:
+                dercert = f.read()
+                derpkey = None
+        else:
+            # Read PKCS12 file
+            with open(self.p12, "rb") as f:
+                p12_data = f.read()
+                p12pw = ECDSA_Certificate.PKCS12_PASSWORD.encode()
+            privkey, cert, cas = pkcs12.load_key_and_certificates(p12_data, p12pw)
+            dercert = cert.public_bytes(serialization.Encoding.DER)
+            derpkey = privkey.private_bytes(encoding=serialization.Encoding.DER,
+                                            format=serialization.PrivateFormat.PKCS8,
+                                            encryption_algorithm=serialization.NoEncryption())
+        with ldapi(inst) as ldc:
+            if old_cert:
+                log.info(f'+++ Trying to replace {dn} +++')
+                mods = [(ldap.MOD_REPLACE, 'nsDynamicCertificateDER', [ dercert, ]),]
+                if derpkey:
+                    mods.append((ldap.MOD_REPLACE, 'nsDynamicCertificatePrivateKeyDER', [ derpkey, ]))
+                ldc.modify_s(dn, mods)
+                self.show(inst)
+            else:
+                log.info(f'+++ Trying to add {dn} +++')
+                e = [
+                     ('cn', [ self.nickname.encode(encoding="utf-8"), ] ),
+                     ('objectclass', [ b'top', b'extensibleobject' ] ),
+                     ('nsDynamicCertificateDER', [ dercert, ] ),
+                    ]
+                if derpkey:
+                    e.append(('nsDynamicCertificatePrivateKeyDER', [derpkey,]))
+                ldc.add_s(dn, e)
+        new_cert = self.read_cert(inst)
+        log.info(f'After online_install: cert={new_cert}')
+        assert new_cert != old_cert
+
+    def setSslPersonality(self, inst):
+        ldc = open_ldapi_conn(inst)
+        dn='cn=RSA,cn=encryption,cn=config'
+        mods = [ (ldap.MOD_REPLACE, 'nsSSLPersonalitySSL', [ self.nickname.encode(), ]), ]
+        ldc.modify_s(dn, mods)
 
 
 #########################################################
@@ -714,10 +939,14 @@ def open_ldap(url, logfile):
 
 def open_ldaps_conn(inst, ca):
 <<<<<<< HEAD
+<<<<<<< HEAD
     url = f'ldaps://localhost:{inst.sslport}'
 =======
     url = inst.toLDAPURL()
 >>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
+=======
+    url = f'ldaps://localhost:{inst.sslport}'
+>>>>>>> 1236487850 (Phase 3 - suite)
     log.info(f'Attempt to connect to {url} using {ca.pem}')
     ld = ldap.initialize(url)
     #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
@@ -727,46 +956,6 @@ def open_ldaps_conn(inst, ca):
     return ld
 <<<<<<< HEAD
 =======
-
-
-def open_ldapi_conn(inst, logfile=None):
-    dse = DSEldif(inst)
-    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
-    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
-    ld = ldap.initialize(url)
-    # Perform autobind
-    sasl_auth = ldap.sasl.external()
-    ld.sasl_interactive_bind_s("", sasl_auth)
-    return ld
-
-
-def tls_search(inst, ca):
-    with traced_ldap_connection(inst.toLDAPURL(), f'ldaps bind using CA {ca}') as ld:
-        #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
-        ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
-        ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
-        ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
-        ld.simple_bind_s(DN_DM, PW_DM)
-
-
-#
-#  Ideally There should be a dsctl/dsconf subcommand
-#
-def refresh_certs(inst, timeout=60):
-    ld = open_ldapi_conn(inst)
-    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
-    # Now lets wait until the config value is off again
-    for _ in range(timeout):
-        result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
-        log.info(f'cn=config result: {result}')
-        attrs = result[0][1]
-        vals = attrs['nsslapd-refresh-certificates']
-        if vals[0].decode("utf-8").lower() == "off":
-            ld.unbind()
-            return
-        time.sleep(1)
-    raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
->>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
 
 def open_ldapi_conn(inst, logfile=None):
@@ -811,7 +1000,55 @@ def refresh_certs(inst, timeout=60):
             return
         time.sleep(1)
     raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
+<<<<<<< HEAD
+
+def open_ldapi_conn(inst, logfile=None):
+    dse = DSEldif(inst)
+    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
+    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
+    log.info(f'Attempt to connect to {url} using sasl external authentication')
+    ld = ldap.initialize(url)
+    # Perform autobind
+    sasl_auth = ldap.sasl.external()
+    ld.sasl_interactive_bind_s("", sasl_auth)
+    return ld
+
+
+def tls_search(inst, ca):
+    url = f'ldaps://localhost:{inst.sslport}'
+    log.info(f'Attempt to connect to {url} using {ca.pem}')
+    with traced_ldap_connection(url, f'ldaps bind using CA {ca}') as ld:
+        #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+        ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
+        ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
+        ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        ld.simple_bind_s(DN_DM, PW_DM)
+        results = ld.search_s('', ldap.SCOPE_BASE)
+        assert len(results) == 1
+
+
+#
+#  Ideally There should be a dsctl/dsconf subcommand
+#
+def refresh_certs(inst, timeout=60):
+    ld = open_ldapi_conn(inst)
+    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
+    # Now lets wait until the config value is off again
+    for _ in range(timeout):
+        result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
+        log.info(f'cn=config result: {result}')
+        attrs = result[0][1]
+        vals = attrs['nsslapd-refresh-certificates']
+        if vals[0].decode("utf-8").lower() == "off":
+            ld.unbind()
+            return
+        time.sleep(1)
+    raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
+
+=======
+>>>>>>> 1236487850 (Phase 3 - suite)
 # Generate Server Certifcate and Root CA and install them
 @pytest.fixture(scope="module")
 def ecdsa_certs(topo, request):
@@ -824,6 +1061,7 @@ def ecdsa_certs(topo, request):
     with suppress(FileNotFoundError):
         shutil.rmtree(dir)
     os.makedirs(dir, 0o700)
+<<<<<<< HEAD
     inst=topo.standalone
     global tls_enabled
     if not tls_enabled:
@@ -910,41 +1148,59 @@ def test_dynamic(topo, ecdsa_certs):
         4. No error
     """
 
+=======
+>>>>>>> 1236487850 (Phase 3 - suite)
     inst=topo.standalone
     global tls_enabled
     if not tls_enabled:
         inst.enable_tls()
         tls_enabled = True
-    with TemporaryDirectory() as dir:
-        ca = ECDSA_Certificate("CA", dir)
-        ca.generate_CA()
-        cert = ECDSA_Certificate("Cert", dir)
-        cert.generate_cert(ca)
-        install_certs(ca, cert, inst)
-        inst.restart(post_open=False)
-        tls_search(inst, ca)
+    ca = ECDSA_Certificate.generateRootCA("CA")
+    cert = ca.generateCertificate("Cert")
+    cert.setSslPersonality(inst)
+    ca.clear_nss_db(inst)
+    ca.showAll(inst)
+    ca.save(dir)
+    cert.save(dir)
+    cert.offline_install(inst)
+    cert.show(inst)
+    ca.offline_install(inst)
+    ca.show(inst)
+    ca.showAll(inst)
+    inst.restart(post_open=False)
+    return (cert, ca, dir)
 
 
-def test_refresh_ecdsa_1ca(topo):
+def test_ecdsa(topo, ecdsa_certs):
+    """Specify a test case purpose or name here
+
+    :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
+    :setup: Standalone Instance with ecdsa certificates
+    :steps:
+        1. Open ldaps connection with server CA certificate and search root entry
+    :expectedresults:
+        1. No error
+    """
+
+    inst=topo.standalone
+    cert, ca, dir = ecdsa_certs
+    tls_search(inst, ca)
+
+
+def test_refresh_ecdsa_1ca(topo, ecdsa_certs):
     """Test dynamic refresh of server certificate
 >>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
     :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
-    :setup: Standalone Instance
+    :setup: Standalone Instance with ecdsa certificates
     :steps:
-        1. Generate ECDSA CA and User Cert
-        2. Generate a second ECDSA CA and User Cert pair
-        3. Install the first set of certificates
-        4. Restart the server
-        5. Open ldaps connection with server CA certificate and search root entry
-        6. Open a second ldaps connection with server CA certificate and keep it open
-        7. Open a third ldaps connection with server CA2 certificate and keep it open
-        8. Install the second set of certificates
-        9. Set the certificate refresh attribute to true (using ldapi)
-        10. Wait a bit until certificates get replaced
-        11. Open ldaps connection with new server CA certificate and search root entry
-        12. Perform a search on the second open connection
-        13. Perform a search on the third open connection
+        1. Open ldaps connection with server CA certificate and search root entry
+        2. Open a second ldaps connection with server CA certificate and keep it open
+        3. Generate a new server certificate (signed by original CA)
+        4. Change nsSSLPersonalitySSL to the new certificate nickname
+        5. Add the new server cert (using add operation on dynamic certificates)
+        6. Open ldaps connection with server CA certificate and search root entry
+        7. Perform a search on the second open ldaps connection
     :expectedresults:
         1. No error
         2. No error
@@ -953,77 +1209,38 @@ def test_refresh_ecdsa_1ca(topo):
         5. No error
         6. No error
         7. No error
-        8. No error
-        9. No error
-        10. No error
-        11. No error
-        12. ldap.SERVER_DOWN because the old CA does not match the server one
-        13. No error
     """
 
     inst=topo.standalone
-    global tls_enabled
-    if not tls_enabled:
-        inst.enable_tls()
-        tls_enabled = True
-    with TemporaryDirectory() as dir:
-        ca = ECDSA_Certificate("CA", dir)
-        ca.generate_CA()
-        cert = ECDSA_Certificate("Cert", dir)
-        cert.generate_cert(ca)
-        ca2 = ca
-        cert2 = ECDSA_Certificate("Cert2", dir)
-        cert2.generate_cert(ca2)
+    cert, ca, dir = ecdsa_certs
+    tls_search(inst, ca)
+    ld = open_ldaps_conn(inst, ca)
+    cert2 = ca.generateCertificate("New-Cert-1CA")
+    cert2.save(dir)
+    cert2.setSslPersonality(inst)
+    cert2.online_install(inst)
+    tls_search(inst, ca)
+    with redirect_stdio(f"Search using already open connection with CA: {ca}"):
+        results = ld.search_s('', ldap.SCOPE_BASE)
+        assert len(results) == 1
+        ld.unbind()
 
-        install_certs(ca, cert, inst)
-        inst.restart(post_open=False)
-        tls_search(inst, ca)
-        ld = open_ldaps_conn(inst, ca)
-        ld2 = open_ldaps_conn(inst, ca2)
 
-        install_certs(ca2, cert2, inst)
-        refresh_certs(inst)
-        time.sleep(1)
-
-        # if we restart the next tls_search is OK and ld.search_s fails as expected
-        # if we dont the tls_search fails ==> something is down
-        tls_search(inst, ca2)
-        # When trying to use an already open connection with the old CA.
-        # the server renegotiate the SSL after server certificate change
-        # So the ldap operation fails
-        with redirect_stdio("Search using already open connection with CA 'CA'"):
-            # Although connection is open, the certificate change triggers a renegotiation
-            # That must be done with the new certificate
-            results = ld.search_s('', ldap.SCOPE_BASE)
-            assert len(results) == 1
-            ld.unbind()
-
-        with redirect_stdio("Search using already open connection with CA 'CA2'"):
-            # Although connection is open, the certificate change triggers a renegotiation
-            # That must be done with the new certificate
-            results = ld2.search_s('', ldap.SCOPE_BASE)
-            assert len(results) == 1
-            ld2.unbind()
-
-def test_refresh_ecdsa_2ca(topo):
+def test_refresh_ecdsa_2ca(topo, ecdsa_certs):
     """Test dynamic refresh of server certificate and CA
 
     :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
     :setup: Standalone Instance
     :steps:
-        1. Generate ECDSA CA and User Cert
-        2. Generate a second User Cert pair
-        3. Install the first set of certificates
-        4. Restart the server
-        5. Open ldaps connection with server CA certificate and search root entry
-        6. Open a second ldaps connection with server CA certificate and keep it open
-        7. Open a third ldaps connection with server CA2 certificate and keep it open
-        8. Install the second set of certificates
-        9. Set the certificate refresh attribute to true (using ldapi)
-        10. Wait a bit until certificates get replaced
-        11. Open ldaps connection with new server CA certificate and search root entry
-        12. Perform a search on the second open connection
-        13. Perform a search on the third open connection
+        1. Open ldaps connection with server CA certificate and search root entry
+        2. Open a second ldaps connection with server CA certificate and keep it open
+        3. Generate a new Self Signed CA
+        4. Generate a new server certificate (signed by the new CA)
+        5. Add the new CA (using add operation on dynamic certificates)
+        6. Add the new server cert (using add operation on dynamic certificates)
+        7. Open ldaps connection with old server CA certificate and search root entry
+        8. Open ldaps connection with new server CA certificate and search root entry
+        9. Perform a search on the second open ldaps connection
     :expectedresults:
         1. No error
         2. No error
@@ -1031,60 +1248,31 @@ def test_refresh_ecdsa_2ca(topo):
         4. No error
         5. No error
         6. No error
-        7. No error
+        7. ldap.SERVER_DOWN because the old CA does not match the server one
         8. No error
-        9. No error
-        10. No error
-        11. No error
-        12. ldap.SERVER_DOWN because the old CA does not match the server one
-        13. No error
+        9. ldap.SERVER_DOWN because the old CA does not match the server one
     """
 
     inst=topo.standalone
-    global tls_enabled
-    if not tls_enabled:
-        inst.enable_tls()
-        tls_enabled = True
-    with TemporaryDirectory() as dir:
-        ca = ECDSA_Certificate("CA", dir)
-        ca.generate_CA()
-        cert = ECDSA_Certificate("Cert", dir)
-        cert.generate_cert(ca)
-        ca2 = ECDSA_Certificate("CA2", dir)
-        ca2.generate_CA()
-        cert2 = ECDSA_Certificate("Cert2", dir)
-        cert2.generate_cert(ca2)
-
-        install_certs(ca, cert, inst)
-        inst.restart(post_open=False)
+    cert, ca, dir = ecdsa_certs
+    tls_search(inst, ca)
+    ld = open_ldaps_conn(inst, ca)
+    ca2 = ECDSA_Certificate.generateRootCA("New-CA-2CA")
+    cert2 = ca2.generateCertificate("New-Cert-2CA")
+    ca2.save(dir)
+    cert2.save(dir)
+    cert2.setSslPersonality(inst)
+    ca2.online_install(inst)
+    cert2.online_install(inst)
+    with pytest.raises(ldap.SERVER_DOWN):
         tls_search(inst, ca)
-        ld = open_ldaps_conn(inst, ca)
-        ld2 = open_ldaps_conn(inst, ca2)
-
-        install_certs(ca2, cert2, inst)
-        refresh_certs(inst)
-        time.sleep(1)
-
-        # if we restart the next tls_search is OK and ld.search_s fails as expected
-        # if we dont the tls_search fails ==> something is down
-        tls_search(inst, ca2)
-        # When trying to use an already open connection with the old CA.
-        # the server renegotiate the SSL after server certificate change
-        # So the ldap operation fails
+    tls_search(inst, ca2)
+    with redirect_stdio(f"Search using already open connection with CA: {ca}"):
         with pytest.raises(ldap.SERVER_DOWN):
-            with redirect_stdio("Search using already open connection with CA 'CA'"):
-                # Although connection is open, the certificate change triggers a renegotiation
-                # That must be done with the new certificate
-                results = ld.search_s('', ldap.SCOPE_BASE)
-                assert len(results) == 1
-                ld.unbind()
-
-        with redirect_stdio("Search using already open connection with CA 'CA2'"):
-            # Although connection is open, the certificate change triggers a renegotiation
-            # That must be done with the new certificate
-            results = ld2.search_s('', ldap.SCOPE_BASE)
+            results = ld.search_s('', ldap.SCOPE_BASE)
             assert len(results) == 1
-            ld2.unbind()
+        ld.unbind()
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/dirsrvtests/tests/suites/tls/ecdsa_test.py
+++ b/dirsrvtests/tests/suites/tls/ecdsa_test.py
@@ -8,6 +8,7 @@
 #
 import os
 import sys
+<<<<<<< HEAD
 import copy
 import datetime
 import ipaddress
@@ -17,10 +18,18 @@ import logging
 import pytest
 import secrets
 import shutil
+=======
+import pytest
+import ldap
+import ldapurl
+import logging
+import secrets
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 import socket
 import subprocess
 import textwrap
 import time
+<<<<<<< HEAD
 from contextlib import contextmanager, suppress
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -29,11 +38,22 @@ from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography import x509
 from cryptography.x509.oid import NameOID, ExtensionOID
 from lib389.cli_base import FakeArgs
+=======
+from contextlib import contextmanager
+from lib389.cli_base import FakeArgs
+from lib389.cli_ctl.tls import import_key_cert_pair
+from lib389.dseldif import DSEldif
+from lib389.utils import ds_is_older, ensure_str
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 from lib389._constants import DN_DM, PW_DM
 from lib389.dseldif import DSEldif
 from lib389.topologies import topology_st as topo
+<<<<<<< HEAD
 from lib389.utils import ds_is_older, ensure_str
 from tempfile import NamedTemporaryFile
+=======
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
 pytestmark = pytest.mark.tier1
 
@@ -81,6 +101,7 @@ def traced_ldap_connection(url, msg):
             yield l
         finally:
             l.unbind()
+<<<<<<< HEAD
 
 @contextmanager
 def ldapi(inst):
@@ -89,12 +110,15 @@ def ldapi(inst):
         yield l
     finally:
         l.unbind()
+=======
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
 
 ################################
 ###### GENERATE CA CERT ########
 ################################
 class ECDSA_Certificate:
+<<<<<<< HEAD
     """Elliptic Curve Certificate Generator"""
 
     PKCS12_PASSWORD = "a+password"
@@ -485,6 +509,191 @@ class ECDSA_Certificate:
 ###### Work around to debug libldap/liblber CERT ########
 #########################################################
 
+=======
+    # Generate ecdsa certificate
+
+    PEM_PASSWORD_LEN = 15
+
+    # For the CA policy
+    CONF_CA_HEADER = textwrap.dedent("""\
+        [ req ]
+        distinguished_name = req_distinguished_name
+        policy             = policy_match
+        x509_extensions     = v3_ca
+
+        # For the CA policy""")
+
+    CONF_CA_TRAILER = textwrap.dedent("""\
+        [ v3_ca ]
+        subjectKeyIdentifier = hash
+        authorityKeyIdentifier = keyid:always,issuer
+        basicConstraints = critical,CA:true
+        #nsComment = "OpenSSL Generated Certificate"
+        keyUsage=critical, keyCertSign
+        """)
+
+    # For the other certificates policy
+    CONF_CERT_HEADER = textwrap.dedent("""\
+        distinguished_name = req_distinguished_name
+        policy             = policy_match
+        x509_extensions     = v3_cert
+
+        # For the cert policy""")
+
+    CONF_CERT_TRAILER = textwrap.dedent("""\
+        [ v3_cert ]
+        basicConstraints = critical,CA:false
+        subjectAltName=DNS:progier-thinkpadt14gen5.rmtfr.csb
+        keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+        #nsComment = OpenSSL Generated Certificate
+        extendedKeyUsage=clientAuth, serverAuth
+        nsCertType=client, server
+        """)
+
+    # Shared by all certificates (CA included)
+    CONF_COMMOM = textwrap.dedent("""\
+        [ policy_match ]
+        countryName             = optional
+        stateOrProvinceName     = optional
+        organizationName        = optional
+        organizationalUnitName  = optional
+        commonName              = supplied
+        emailAddress            = optional
+
+        [ req_distinguished_name ]
+        countryName			= Country Name (2 letter code)
+        countryName_default		= FR
+        countryName_min			= 2
+        countryName_max			= 2
+
+        stateOrProvinceName		= State or Province Name (full name)
+        stateOrProvinceName_default	= test
+
+        localityName			= Locality Name (eg, city)
+
+        0.organizationName		= Organization Name (eg, company)
+        0.organizationName_default	= {organizationName}
+
+        organizationalUnitName		= Organizational Unit Name (eg, section)
+        #organizationalUnitName_default	=
+
+        commonName			= Common Name (e.g. server FQDN or YOUR name)
+        commonName_max			= 64
+
+        """)
+
+
+    VDEF = {
+        "countryName": "FR",
+        "stateOrProvinceName": "test",
+        "organizationName": "test-ECDSA",
+        "organizationalUnitName": None,
+        "localityName": None,
+        "commonName": socket.gethostname(),
+        "maxAge": "3",
+    }
+
+
+    SUBJECT_ATTR = ( "commonName", "organizationName", "countryName" )
+    SUBJECT_MAP = {
+        "countryName": "C",
+        "commonName": "CN",
+        "organizationName": "O",
+    }
+
+
+    def __init__(self, prefix, outdir, **kwargs):
+        self.dir = outdir
+        self.prefix = prefix
+        self.args = { **ECDSA_Certificate.VDEF, **kwargs }
+        if 'organizationName' not in kwargs:
+            self.args['organizationName'] = f'{self.args["organizationName"]}-{prefix}'
+        self.args['subject'] = self.get_subject()
+        for name in ( 'conf', 'csr', 'key', 'p12', 'pem', 'pw1', 'pw2'):
+            setattr(self, name, f'{outdir}/{prefix}.{name}')
+        for path in ( self.pw1, self.pw2 ):
+            with open(path, 'wt') as fd:
+                fd.write(secrets.token_urlsafe(ECDSA_Certificate.PEM_PASSWORD_LEN))
+                fd.write('\n')
+
+
+    def get_subject(self, **kwargs):
+        args = { **self.args, **kwargs }
+        subject = ""
+        for arg in ECDSA_Certificate.SUBJECT_ATTR:
+            if arg in args and arg in ECDSA_Certificate.SUBJECT_MAP:
+                subject += f"/{ECDSA_Certificate.SUBJECT_MAP[arg]}={args[arg]}"
+        # return f"/CN={args['commonName']}/DC=example/DC=com"
+        return subject
+
+    def generate_conf(self, isCA):
+        if isCA:
+            confl = ( ECDSA_Certificate.CONF_CA_HEADER,
+                      ECDSA_Certificate.CONF_COMMOM,
+                      ECDSA_Certificate.CONF_CA_TRAILER )
+        else:
+            confl = ( ECDSA_Certificate.CONF_CERT_HEADER,
+                      ECDSA_Certificate.CONF_COMMOM,
+                      ECDSA_Certificate.CONF_CERT_TRAILER )
+        conf_path = f'{self.dir}/{self.prefix}.conf'
+        conf_data = "\n".join(confl).format(dir=self.dir, prefix=self.prefix, **self.args)
+        with open(conf_path, "wt") as fd:
+            for line in conf_data.split('\n'):
+                sep = "#" if " = None" in line else ""
+                fd.write(f'{sep}{line}\n')
+
+    def run(self, cmd):
+        log.info(f'Running: {" ".join(cmd)}')
+        res = subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        assert res
+        log.info(f'Stdout+Stderr:{res.stdout}')
+        res.check_returncode()
+
+    def generate_CA(self):
+        self.generate_conf(True)
+        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
+        self.run(("openssl", "req", "-x509", "-new", "-sha256", "-key", self.key, "-days", self.args['maxAge'], "-config", self.conf, "-subj", self.get_subject(), "-out", self.pem, "-keyout", self.key, "-passout", f"file:{self.pw1}"))
+        self.run(("openssl", "x509", "-text", "-in", self.pem))
+        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
+
+    def generate_cert(self, ca):
+        self.generate_conf(False)
+        self.run(("openssl", "ecparam", "-genkey", "-name", "secp256r1", "-out", self.key))
+        self.run(("openssl", "req", "-new", "-sha256", "-key", self.key, "-config", self.conf, "-subj", self.get_subject(), "-out", self.csr))
+        self.run(("openssl", "x509", "-req", "-sha256", "-days", self.args['maxAge'], "-extensions", "v3_cert", "-extfile", self.conf, "-in", self.csr, "-CA", ca.pem, "-CAkey", ca.key, "-CAcreateserial", "-out", self.pem,  "-passin", f"file:{ca.pw1}"))
+        self.run(("openssl", "x509", "-text", "-in", self.pem))
+        self.run(("openssl", "pkcs12", "-export", "-inkey", self.key, "-in", self.pem, "-name", f"ecdsaw-{self.prefix}", "-out", self.p12, "-passin", f"file:{self.pw1}", "-passout", f"file:{self.pw2}"))
+
+    def __repr__(self):
+        return self.prefix
+
+
+#############################
+###### INSTALL CERTS ########
+#############################
+def install_certs(ca, cert, inst):
+    prefix = os.environ.get('PREFIX', "/")
+    certdbdir = f"{prefix}/etc/dirsrv/slapd-{inst.serverid}"
+    pwfile = f'{certdbdir}/pwdfile.txt'
+    for f in ('cert9.db', 'key4.db'):
+        try:
+            os.remove(f'{certdbdir}/{f}')
+        except OSError:
+            pass
+
+    ca.run(('certutil', '-N', '-d', certdbdir, '-f', pwfile))
+    ca.run(('certutil', '-A', '-n', 'Self-Signed-CA', '-t', 'CT,,', '-f', pwfile, '-d', certdbdir, '-a', '-i', ca.pem))
+    args = FakeArgs()
+    for k,v in { 'key_path': cert.key, 'cert_path': cert.pem }.items():
+        setattr(args, k, v)
+    import_key_cert_pair(inst, log, args)
+
+
+#########################################################
+###### Work around to debug libldap/liblber CERT ########
+#########################################################
+
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 def open_ldap(url, logfile):
     if logfile is not None:
         lutil_debug_file(logfile)
@@ -504,7 +713,11 @@ def open_ldap(url, logfile):
 #########################
 
 def open_ldaps_conn(inst, ca):
+<<<<<<< HEAD
     url = f'ldaps://localhost:{inst.sslport}'
+=======
+    url = inst.toLDAPURL()
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
     log.info(f'Attempt to connect to {url} using {ca.pem}')
     ld = ldap.initialize(url)
     #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
@@ -512,6 +725,48 @@ def open_ldaps_conn(inst, ca):
     ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
     ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
     return ld
+<<<<<<< HEAD
+=======
+
+
+def open_ldapi_conn(inst, logfile=None):
+    dse = DSEldif(inst)
+    ldapi_socket = dse.get('cn=config', 'nsslapd-ldapifilepath', single=True)
+    url = f"ldapi://{ldapurl.ldapUrlEscape(ensure_str(ldapi_socket))}"
+    ld = ldap.initialize(url)
+    # Perform autobind
+    sasl_auth = ldap.sasl.external()
+    ld.sasl_interactive_bind_s("", sasl_auth)
+    return ld
+
+
+def tls_search(inst, ca):
+    with traced_ldap_connection(inst.toLDAPURL(), f'ldaps bind using CA {ca}') as ld:
+        #ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+        ld.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
+        ld.set_option(ldap.OPT_X_TLS_CACERTFILE, f'{ca.pem}')
+        ld.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        ld.simple_bind_s(DN_DM, PW_DM)
+
+
+#
+#  Ideally There should be a dsctl/dsconf subcommand
+#
+def refresh_certs(inst, timeout=60):
+    ld = open_ldapi_conn(inst)
+    ld.modify_s('cn=config', [(ldap.MOD_REPLACE, 'nsslapd-refresh-certificates', b'on')])
+    # Now lets wait until the config value is off again
+    for _ in range(timeout):
+        result = ld.search_s('cn=config', ldap.SCOPE_BASE, attrlist=['nsslapd-refresh-certificates',])
+        log.info(f'cn=config result: {result}')
+        attrs = result[0][1]
+        vals = attrs['nsslapd-refresh-certificates']
+        if vals[0].decode("utf-8").lower() == "off":
+            ld.unbind()
+            return
+        time.sleep(1)
+    raise TimeoutError(f"Certificate not changed after {timeout} secopnds")
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
 
 
 def open_ldapi_conn(inst, logfile=None):
@@ -596,6 +851,7 @@ def test_ecdsa(topo, ecdsa_certs):
     :id: 7902f37c-01d3-11ed-b65c-482ae39447e5
     :setup: Standalone Instance with ecdsa certificates
     :steps:
+<<<<<<< HEAD
         1. Open ldaps connection with server CA certificate and search root entry
     :expectedresults:
         1. No error
@@ -642,7 +898,193 @@ def test_dynamic(topo, ecdsa_certs):
     assert cert2.read_cert(inst)
     cert2.delete(inst)
     assert not cert2.read_cert(inst)
+=======
+        1. Generate ECDSA CA and User Cert
+        2. Install the certificates
+        3. Restart the server
+        4. Open ldaps connection with server CA certificate and search root entry
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error
+    """
 
+    inst=topo.standalone
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
+    with TemporaryDirectory() as dir:
+        ca = ECDSA_Certificate("CA", dir)
+        ca.generate_CA()
+        cert = ECDSA_Certificate("Cert", dir)
+        cert.generate_cert(ca)
+        install_certs(ca, cert, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca)
+
+
+def test_refresh_ecdsa_1ca(topo):
+    """Test dynamic refresh of server certificate
+>>>>>>> 87c7465ad8 (Dynamic Certificate - phase 3 - switching tls cert)
+
+    :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
+    :setup: Standalone Instance
+    :steps:
+        1. Generate ECDSA CA and User Cert
+        2. Generate a second ECDSA CA and User Cert pair
+        3. Install the first set of certificates
+        4. Restart the server
+        5. Open ldaps connection with server CA certificate and search root entry
+        6. Open a second ldaps connection with server CA certificate and keep it open
+        7. Open a third ldaps connection with server CA2 certificate and keep it open
+        8. Install the second set of certificates
+        9. Set the certificate refresh attribute to true (using ldapi)
+        10. Wait a bit until certificates get replaced
+        11. Open ldaps connection with new server CA certificate and search root entry
+        12. Perform a search on the second open connection
+        13. Perform a search on the third open connection
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error
+        5. No error
+        6. No error
+        7. No error
+        8. No error
+        9. No error
+        10. No error
+        11. No error
+        12. ldap.SERVER_DOWN because the old CA does not match the server one
+        13. No error
+    """
+
+    inst=topo.standalone
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
+    with TemporaryDirectory() as dir:
+        ca = ECDSA_Certificate("CA", dir)
+        ca.generate_CA()
+        cert = ECDSA_Certificate("Cert", dir)
+        cert.generate_cert(ca)
+        ca2 = ca
+        cert2 = ECDSA_Certificate("Cert2", dir)
+        cert2.generate_cert(ca2)
+
+        install_certs(ca, cert, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca)
+        ld = open_ldaps_conn(inst, ca)
+        ld2 = open_ldaps_conn(inst, ca2)
+
+        install_certs(ca2, cert2, inst)
+        refresh_certs(inst)
+        time.sleep(1)
+
+        # if we restart the next tls_search is OK and ld.search_s fails as expected
+        # if we dont the tls_search fails ==> something is down
+        tls_search(inst, ca2)
+        # When trying to use an already open connection with the old CA.
+        # the server renegotiate the SSL after server certificate change
+        # So the ldap operation fails
+        with redirect_stdio("Search using already open connection with CA 'CA'"):
+            # Although connection is open, the certificate change triggers a renegotiation
+            # That must be done with the new certificate
+            results = ld.search_s('', ldap.SCOPE_BASE)
+            assert len(results) == 1
+            ld.unbind()
+
+        with redirect_stdio("Search using already open connection with CA 'CA2'"):
+            # Although connection is open, the certificate change triggers a renegotiation
+            # That must be done with the new certificate
+            results = ld2.search_s('', ldap.SCOPE_BASE)
+            assert len(results) == 1
+            ld2.unbind()
+
+def test_refresh_ecdsa_2ca(topo):
+    """Test dynamic refresh of server certificate and CA
+
+    :id: 96039bce-5370-11f0-9de5-c85309d5c3e3
+    :setup: Standalone Instance
+    :steps:
+        1. Generate ECDSA CA and User Cert
+        2. Generate a second User Cert pair
+        3. Install the first set of certificates
+        4. Restart the server
+        5. Open ldaps connection with server CA certificate and search root entry
+        6. Open a second ldaps connection with server CA certificate and keep it open
+        7. Open a third ldaps connection with server CA2 certificate and keep it open
+        8. Install the second set of certificates
+        9. Set the certificate refresh attribute to true (using ldapi)
+        10. Wait a bit until certificates get replaced
+        11. Open ldaps connection with new server CA certificate and search root entry
+        12. Perform a search on the second open connection
+        13. Perform a search on the third open connection
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error
+        5. No error
+        6. No error
+        7. No error
+        8. No error
+        9. No error
+        10. No error
+        11. No error
+        12. ldap.SERVER_DOWN because the old CA does not match the server one
+        13. No error
+    """
+
+    inst=topo.standalone
+    global tls_enabled
+    if not tls_enabled:
+        inst.enable_tls()
+        tls_enabled = True
+    with TemporaryDirectory() as dir:
+        ca = ECDSA_Certificate("CA", dir)
+        ca.generate_CA()
+        cert = ECDSA_Certificate("Cert", dir)
+        cert.generate_cert(ca)
+        ca2 = ECDSA_Certificate("CA2", dir)
+        ca2.generate_CA()
+        cert2 = ECDSA_Certificate("Cert2", dir)
+        cert2.generate_cert(ca2)
+
+        install_certs(ca, cert, inst)
+        inst.restart(post_open=False)
+        tls_search(inst, ca)
+        ld = open_ldaps_conn(inst, ca)
+        ld2 = open_ldaps_conn(inst, ca2)
+
+        install_certs(ca2, cert2, inst)
+        refresh_certs(inst)
+        time.sleep(1)
+
+        # if we restart the next tls_search is OK and ld.search_s fails as expected
+        # if we dont the tls_search fails ==> something is down
+        tls_search(inst, ca2)
+        # When trying to use an already open connection with the old CA.
+        # the server renegotiate the SSL after server certificate change
+        # So the ldap operation fails
+        with pytest.raises(ldap.SERVER_DOWN):
+            with redirect_stdio("Search using already open connection with CA 'CA'"):
+                # Although connection is open, the certificate change triggers a renegotiation
+                # That must be done with the new certificate
+                results = ld.search_s('', ldap.SCOPE_BASE)
+                assert len(results) == 1
+                ld.unbind()
+
+        with redirect_stdio("Search using already open connection with CA 'CA2'"):
+            # Although connection is open, the certificate change triggers a renegotiation
+            # That must be done with the new certificate
+            results = ld2.search_s('', ldap.SCOPE_BASE)
+            assert len(results) == 1
+            ld2.unbind()
 
 if __name__ == '__main__':
     # Run isolated

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -31,9 +31,6 @@ objectClass: nsEncryptionConfig
 cn: encryption
 nsSSLSessionTimeout: 0
 nsSSLClientAuth: allowed
-aci: (target ="ldap:///*cn=dynamiccertificates")(targetattr="
- *")(version 3.0; acl "dynamic certificates"; deny( all ) us
- erdn = "ldap:///all";)
 
 dn: cn=RSA,cn=encryption,cn=config
 objectClass: top

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -31,6 +31,9 @@ objectClass: nsEncryptionConfig
 cn: encryption
 nsSSLSessionTimeout: 0
 nsSSLClientAuth: allowed
+aci: (target ="ldap:///*cn=dynamiccertificates")(targetattr="
+ *")(version 3.0; acl "dynamic certificates"; deny( all ) us
+ erdn = "ldap:///all";)
 
 dn: cn=RSA,cn=encryption,cn=config
 objectClass: top

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -120,6 +120,15 @@ static PRFileDesc *tls_listener = NULL; /* Stashed tls listener for get_ssl_list
 
 #define SLAPD_POLL_LISTEN_READY(xxflagsxx) (xxflagsxx & PR_POLL_READ)
 
+static int cert_refresh_nbthreads = -1;
+static int32_t cert_refresh_asked = 0;
+static int32_t refresh_cert_count = 1;
+static pthread_mutex_t cert_refresh_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cert_refresh_cv = PTHREAD_COND_INITIALIZER;
+
+static void init_cert_refresh(int nbthreads);
+static void wait4certs_refresh(daemon_ports_t *ports);
+
 static int get_connection_table_size(void);
 #ifdef RESOLVER_NEEDS_LOW_FILE_DESCRIPTORS
 static void get_loopback_by_addr(void);
@@ -996,13 +1005,13 @@ accept_thread(void *vports)
     PRFileDesc **n_tcps = NULL;
     PRFileDesc **s_tcps = NULL;
     PRFileDesc **i_unix = NULL;
+    int32_t last_refresh_cert_count = 0;
+    int32_t cur_refresh_cert_count = 0;
     n_tcps = ports->n_socket;
     s_tcps = ports->s_socket;
 #if defined(ENABLE_LDAPI)
     i_unix = ports->i_socket;
 #endif /* ENABLE_LDAPI */
-
-    num_poll = setup_pr_accept_pds(n_tcps, s_tcps, i_unix, &fds);
 
     while (!g_get_shutdown()) {
         /* Do we need to accept new connections, account for ct->size including list heads. */
@@ -1024,6 +1033,17 @@ accept_thread(void *vports)
             }
         }
 
+        wait4certs_refresh(ports);
+        cur_refresh_cert_count = slapi_atomic_load_32(&refresh_cert_count, __ATOMIC_RELAXED);
+        if (cur_refresh_cert_count != last_refresh_cert_count) {
+            last_refresh_cert_count = cur_refresh_cert_count;
+            /*
+             * refresh_cert() has been called so the PR_FileDesc may
+             * have changed ==> Lets recompute the poll list
+             */
+            slapi_ch_free((void **)&fds);
+            num_poll = setup_pr_accept_pds(n_tcps, s_tcps, i_unix, &fds);
+        }
         select_return = POLL_FN(fds, num_poll, pr_timeout);
         switch (select_return) {
         case 0: /* Timeout */
@@ -1534,6 +1554,8 @@ ct_list_thread(uint64_t threadnum)
          PRIntn num_poll = 0;
          PRIntervalTime pr_timeout = PR_MillisecondsToInterval(slapd_ct_thread_wakeup_timer);
          PRErrorCode prerr;
+
+         wait4certs_refresh(NULL);
 #ifdef ENABLE_EPOLL
             struct epoll_event events[the_connection_table->list_size];
             select_return = epoll_wait(the_connection_table->epoll_fd[threadid], events, the_connection_table->list_size, pr_timeout);
@@ -1570,6 +1592,10 @@ init_ct_list_threads(void)
 {
     int ctlists = the_connection_table->list_num;
 
+    /* Provides the thread number for the certificate refresh api:
+     *  listening threads + accept thread
+     */
+    init_cert_refresh(ctlists+1);
     /* start the connection table threads, one thread per CT list */
     for (uint64_t i = 0; i < ctlists; i++) {
         if(PR_CreateThread(PR_SYSTEM_THREAD,
@@ -3128,4 +3154,59 @@ disk_monitoring_stop(void)
         pthread_cond_signal(&diskmon_cvar);
         pthread_mutex_unlock(&diskmon_mutex);
     }
+}
+
+static void
+init_cert_refresh(int nbthreads)
+{
+    cert_refresh_nbthreads = nbthreads;
+}
+
+void
+set_cert_refresh_asked(bool val)
+{
+    slapi_atomic_store_32(&cert_refresh_asked, (val ? 1 : 0), __ATOMIC_RELAXED);
+}
+
+static inline bool __attribute__((always_inline))
+get_cert_refresh_asked(void)
+{
+    return slapi_atomic_load_32(&cert_refresh_asked, __ATOMIC_RELAXED) != 0;
+}
+
+void
+wait4certs_refresh(daemon_ports_t *ports)
+{
+    static int refcnt = 0;
+    bool need_refresh = get_cert_refresh_asked();
+    if (!need_refresh) {
+        /* Avoid taking a mutex in the usual case */
+        return;
+    }
+    pthread_mutex_lock(&cert_refresh_mutex);
+    refcnt ++;
+    /* accept thread may be waiting, so lets wake it up */
+    pthread_cond_broadcast(&cert_refresh_cv);
+    /* Break the condition loop once refresh is done */
+    need_refresh = get_cert_refresh_asked();
+    for (; need_refresh; need_refresh = get_cert_refresh_asked()) {
+        /* Lets block the listening threads and
+         *  also block accept thread until all listening threads are
+         *  blocked
+         */
+        if (ports == NULL || refcnt < cert_refresh_nbthreads) {
+            pthread_cond_wait(&cert_refresh_cv, &cert_refresh_mutex);
+            continue;
+        }
+        if (need_refresh) {
+            /* This is the accept thread and all listening threads are blocked.
+             * ==> time to updatye the certificates */
+            refresh_certs(ports);
+            slapi_atomic_incr_32(&refresh_cert_count, __ATOMIC_RELAXED),
+            set_cert_refresh_asked(false);
+            pthread_cond_broadcast(&cert_refresh_cv);
+       }
+    }
+    refcnt--;
+    pthread_mutex_unlock(&cert_refresh_mutex);
 }

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -127,7 +127,7 @@ static pthread_mutex_t cert_refresh_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t cert_refresh_cv = PTHREAD_COND_INITIALIZER;
 
 static void init_cert_refresh(int nbthreads);
-static void wait4certs_refresh(daemon_ports_t *ports);
+void wait4certs_refresh(daemon_ports_t *ports);
 
 static int get_connection_table_size(void);
 #ifdef RESOLVER_NEEDS_LOW_FILE_DESCRIPTORS
@@ -3202,7 +3202,7 @@ wait4certs_refresh(daemon_ports_t *ports)
             /* This is the accept thread and all listening threads are blocked.
              * ==> time to updatye the certificates */
             refresh_certs(ports);
-            slapi_atomic_incr_32(&refresh_cert_count, __ATOMIC_RELAXED),
+            slapi_atomic_incr_32(&refresh_cert_count, __ATOMIC_RELAXED);
             set_cert_refresh_asked(false);
             pthread_cond_broadcast(&cert_refresh_cv);
        }

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -3177,6 +3177,13 @@ get_cert_refresh_asked(void)
 void
 wait4certs_refresh(daemon_ports_t *ports)
 {
+    /*
+     * Block listening and accept threads until 
+     *  certificates refresh is complete
+     * Note:
+     *  Listening threads have a NULL ports
+     *  Accept threads have non NULL ports
+     */
     static int refcnt = 0;
     bool need_refresh = get_cert_refresh_asked();
     if (!need_refresh) {
@@ -3200,7 +3207,7 @@ wait4certs_refresh(daemon_ports_t *ports)
         }
         if (need_refresh) {
             /* This is the accept thread and all listening threads are blocked.
-             * ==> time to updatye the certificates */
+             * ==> time to update the certificates */
             refresh_certs(ports);
             slapi_atomic_incr_32(&refresh_cert_count, __ATOMIC_RELAXED);
             set_cert_refresh_asked(false);

--- a/ldap/servers/slapd/dyncerts.c
+++ b/ldap/servers/slapd/dyncerts.c
@@ -996,7 +996,11 @@ done2:
 static void
 dyncert_refresh_certs()
 {
-    /* TBD in  phase3 */
+        caddr_t cb = NULL;
+        get_entry_point(ENTRY_POINT_SLAPD_CERT_REFRESH_ASKED, &cb);
+        if (cb) {
+            ((slapd_ssl_set_cert_refresh_asked_ptr)cb)(true);
+        }
 }
 
 /* Import the certificate and the key */

--- a/ldap/servers/slapd/globals.c
+++ b/ldap/servers/slapd/globals.c
@@ -68,6 +68,7 @@ set_entry_points()
     sep->sep_disconnect_server = (caddr_t)disconnect_server;
     sep->sep_slapd_ssl_init = (caddr_t)slapd_ssl_init;
     sep->sep_slapd_ssl_init2 = (caddr_t)slapd_ssl_init2;
+    sep->sep_slapd_ssl_refresh_certs = (caddr_t)set_cert_refresh_asked;
     set_dll_entry_points(sep);
 
     /* To apply the nsslapd-counters config value properly,

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -2261,6 +2261,9 @@ get_entry_point(int ep_name, caddr_t *ep_addr)
         case ENTRY_POINT_SLAPD_SSL_INIT2:
             *ep_addr = sep->sep_slapd_ssl_init2;
             break;
+        case ENTRY_POINT_SLAPD_CERT_REFRESH_ASKED:
+            *ep_addr = sep->sep_slapd_ssl_refresh_certs;
+            break;
         default:
             rc = -1;
         }

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -685,6 +685,8 @@ void slapi_parse_control(LDAPControl *ctrl, char **oid, char **value, bool *isCr
  * daemon.c
  */
 int validate_num_config_reservedescriptors(void) ;
+void set_cert_refresh_asked(bool val);
+
 
 /*
  * delete.c
@@ -1181,6 +1183,7 @@ int slapd_security_library_is_initialized(void);
 int slapd_ssl_listener_is_initialized(void);
 int slapd_SSL_client_auth(LDAP *ld);
 SECKEYPrivateKey *slapd_get_unlocked_key_for_cert(CERTCertificate *cert, void *pin_arg);
+void refresh_certs(daemon_ports_t *ports);
 
 /*
  * security_wrappers.c

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2084,6 +2084,7 @@ struct snmp_vars_t
 #define ENTRY_POINT_SLAPD_SSL_CLIENT_INIT 108
 #define ENTRY_POINT_SLAPD_SSL_INIT 109
 #define ENTRY_POINT_SLAPD_SSL_INIT2 110
+#define ENTRY_POINT_SLAPD_CERT_REFRESH_ASKED 111
 
 typedef void (*ps_wakeup_all_fn_ptr)(void);
 typedef void (*ps_service_fn_ptr)(Slapi_Entry *, Slapi_Entry *, int, int);
@@ -2092,6 +2093,7 @@ typedef void (*get_disconnect_server_fn_ptr)(Connection *conn, PRUint64 opconnid
 typedef int (*modify_config_dse_fn_ptr)(Slapi_PBlock *pb);
 typedef int (*slapd_ssl_init_fn_ptr)(void);
 typedef int (*slapd_ssl_init_fn_ptr2)(PRFileDesc **s, int StartTLS);
+typedef void (*slapd_ssl_set_cert_refresh_asked_ptr)(bool val);
 
 /*
  * A structure of entry points in the NT exe which need
@@ -2104,6 +2106,7 @@ typedef struct _slapdEntryPoints
     caddr_t sep_disconnect_server;
     caddr_t sep_slapd_ssl_init;
     caddr_t sep_slapd_ssl_init2;
+    caddr_t sep_slapd_ssl_refresh_certs;
 } slapdEntryPoints;
 
 #define DLL_IMPORT_DATA

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -2353,21 +2353,25 @@ slapd_get_unlocked_key_for_cert(CERTCertificate *cert, void *pin_arg)
         PK11SlotInfo *slot = sle->slot;
         const char *slotname = (slot && PK11_GetSlotName(slot)) ? PK11_GetSlotName(slot) : "unknown slot";
         const char *tokenname = (slot && PK11_GetTokenName(slot)) ? PK11_GetTokenName(slot) : "unknown token";
+slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG: Looking at slot %s on token %s\n", slotname, tokenname);
         if (!slot) {
             slapi_log_err(SLAPI_LOG_TRACE, "slapd_get_unlocked_key_for_cert",
                           "Missing slot for slot list element for certificate [%s]\n",
                           certsubject);
+slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE\n", __LINE__);
         } else if (!PK11_NeedLogin(slot) || PK11_IsLoggedIn(slot, pin_arg)) {
             key = PK11_FindKeyByDERCert(slot, cert, pin_arg);
             slapi_log_err(SLAPI_LOG_TRACE, "slapd_get_unlocked_key_for_cert",
                           "Found unlocked slot [%s] token [%s] for certificate [%s]\n",
                           slotname, tokenname, certsubject);
+slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE (key=%p)\n", __LINE__, key);
             break;
         } else {
             PRErrorCode errcode = PR_GetError();
             slapi_log_err(SLAPI_LOG_NOTICE, "slapd_get_unlocked_key_for_cert",
                           "Skipping locked slot [%s] token [%s] for certificate [%s] (%d - %s)\n",
                           slotname, tokenname, certsubject, errcode, slapd_pr_strerror(errcode));
+slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE token is locked\n", __LINE__);
         }
     }
 

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3059,3 +3059,59 @@ slapi_set_cacertfile(char *certfile)
     slapi_ch_free_string(&CACertPemFile);
     CACertPemFile = certfile;
 }
+
+/*
+ * Function handling on line certificat refresh
+ */
+
+static void
+pop_ssl_layer(PRFileDesc *fd)
+{
+    /*
+     * Remove ssl layer from listening fd stack to stop using the old
+     * certificate
+     */
+    PRFileDesc *oldsock = PR_PopIOLayer(fd, PR_TOP_IO_LAYER);
+    if (oldsock != NULL) {
+        PRDescIdentity id = PR_GetLayersIdentity(oldsock);
+        const char *name = PR_GetNameForIdentity(id);
+        slapi_log_err(SLAPI_LOG_DEBUG, "pop_ssl_layer", "Poping %s layer\n", name);
+        if (oldsock->dtor) {
+            oldsock->dtor(oldsock); /* Call nspr layer destructor */
+        }
+    }
+}
+
+void
+refresh_certs(daemon_ports_t *ports)
+{
+    /*
+     * replace the server certificate(s)
+     */
+    PRFileDesc **sock = NULL;
+
+    slapi_log_err(SLAPI_LOG_WARNING, "Security certificates refresh",
+                  "Refresh in progress.\n");
+
+    /* Perform some cleanup */
+    _security_library_initialized = 0;
+    for (sock = ports->s_socket; sock && *sock; sock++) {
+        pop_ssl_layer(*sock);
+    }
+    SSL_ClearSessionCache();
+
+    slapd_ssl_init();
+    if (_security_library_initialized == 0) {
+        slapi_log_err(SLAPI_LOG_CRIT, "Security certificates refresh",
+            "Failed to reinitialize the security module. Stopping the server.");
+    }
+
+    for (sock = ports->s_socket; sock && *sock; sock++) {
+        if (slapd_ssl_init2(sock, 0)) {
+            slapi_log_err(SLAPI_LOG_CRIT, "Security certificates refresh",
+                "Failed to update the new certificates. Stopping the server.");
+        }
+    }
+    slapi_log_err(SLAPI_LOG_WARNING, "Security certificates refresh",
+                  "Refresh completed propgress.\n");
+}

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -2353,25 +2353,21 @@ slapd_get_unlocked_key_for_cert(CERTCertificate *cert, void *pin_arg)
         PK11SlotInfo *slot = sle->slot;
         const char *slotname = (slot && PK11_GetSlotName(slot)) ? PK11_GetSlotName(slot) : "unknown slot";
         const char *tokenname = (slot && PK11_GetTokenName(slot)) ? PK11_GetTokenName(slot) : "unknown token";
-slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG: Looking at slot %s on token %s\n", slotname, tokenname);
         if (!slot) {
             slapi_log_err(SLAPI_LOG_TRACE, "slapd_get_unlocked_key_for_cert",
                           "Missing slot for slot list element for certificate [%s]\n",
                           certsubject);
-slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE\n", __LINE__);
         } else if (!PK11_NeedLogin(slot) || PK11_IsLoggedIn(slot, pin_arg)) {
             key = PK11_FindKeyByDERCert(slot, cert, pin_arg);
             slapi_log_err(SLAPI_LOG_TRACE, "slapd_get_unlocked_key_for_cert",
                           "Found unlocked slot [%s] token [%s] for certificate [%s]\n",
                           slotname, tokenname, certsubject);
-slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE (key=%p)\n", __LINE__, key);
             break;
         } else {
             PRErrorCode errcode = PR_GetError();
             slapi_log_err(SLAPI_LOG_NOTICE, "slapd_get_unlocked_key_for_cert",
                           "Skipping locked slot [%s] token [%s] for certificate [%s] (%d - %s)\n",
                           slotname, tokenname, certsubject, errcode, slapd_pr_strerror(errcode));
-slapi_log_err(SLAPI_LOG_INFO, "slapd_get_unlocked_key_for_cert", "MYDBG[%d] HERE token is locked\n", __LINE__);
         }
     }
 

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -3089,9 +3089,10 @@ refresh_certs(daemon_ports_t *ports)
      * replace the server certificate(s)
      */
     PRFileDesc **sock = NULL;
+    bool stop = false;
 
     slapi_log_err(SLAPI_LOG_WARNING, "Security certificates refresh",
-                  "Refresh in progress.\n");
+                  "Certificate refresh started.\n");
 
     /* Perform some cleanup */
     _security_library_initialized = 0;
@@ -3104,14 +3105,20 @@ refresh_certs(daemon_ports_t *ports)
     if (_security_library_initialized == 0) {
         slapi_log_err(SLAPI_LOG_CRIT, "Security certificates refresh",
             "Failed to reinitialize the security module. Stopping the server.");
+        stop = true;
     }
 
     for (sock = ports->s_socket; sock && *sock; sock++) {
         if (slapd_ssl_init2(sock, 0)) {
             slapi_log_err(SLAPI_LOG_CRIT, "Security certificates refresh",
                 "Failed to update the new certificates. Stopping the server.");
+            stop = true;
         }
     }
+    if (stop) {
+        g_set_shutdown(SLAPI_SHUTDOWN_EXIT);
+    }
+
     slapi_log_err(SLAPI_LOG_WARNING, "Security certificates refresh",
-                  "Refresh completed propgress.\n");
+                  "Certificate refresh completed.\n");
 }

--- a/src/svrcore/src/systemd-ask-pass.c
+++ b/src/svrcore/src/systemd-ask-pass.c
@@ -45,10 +45,10 @@ struct SVRCORESystemdPinObj
     uint64_t timeout;
 };
 
+#ifdef WITH_SYSTEMD
 static void destroyObject(SVRCOREPinObj *obj);
 static char *getPin(SVRCOREPinObj *obj, const char *tokenName, PRBool retry);
 
-#ifdef WITH_SYSTEMD
 static const SVRCOREPinMethods vtable = { 0, 0, destroyObject, getPin };
 #endif // WITH_SYSTEMD
 


### PR DESCRIPTION
Third phase of [Dynamic Certificate Refresh](https://www.port389.org/docs/389ds/design/online-certificate-refresh.html)

cn=dynamiccertificates backend now supports the following operations:

server certificate is switched when modified. This is done by:
  - Block listening and accept threads (to ensure that they are not in a middle of an I/O
  - Removing SSL layer from listening FileDescriptor
  - Switch Certificate in NSS layers
  - Add back SSl layer with new certificates in  listening FileDescriptor
  - Unblock all the threads

Allowing to store and modify dynamically the nss database

issue: #6951 

Reviewed by:  @tbordaz, @jchapma (Thanks!)

## Summary by Sourcery

Implement dynamic online TLS certificate refresh in the server and extend tests to cover certificate and CA switching without restarting.

New Features:
- Support online refresh of server certificates by coordinating listener and accept threads to reload NSS state and rewrap listening sockets.
- Expose an entry point from the dynamic certificates backend to trigger certificate refresh in the main server process.

Enhancements:
- Refine daemon threading to allow safe blocking and synchronization around certificate reload events using atomic flags and condition variables.
- Log certificate refresh lifecycle events to aid observability of online certificate rotation.

Tests:
- Extend ECDSA TLS tests to cover dynamic server certificate refresh with unchanged CA and with a new CA, including behavior of existing and new LDAPS connections.
- Adjust certificate generation helpers to use a UTC-compatible timestamp function for broader Python version compatibility.