### PR TITLE
Make nss include paths platform-agnostic

### DIFF
--- a/ldap/servers/slapd/dyncerts.c
+++ b/ldap/servers/slapd/dyncerts.c
@@ -18,8 +18,8 @@
 #include "slap.h"
 #include "fe.h"
 #include <nss.h>
-#include <nss3/pk11pub.h>
-#include <nss3/certdb.h>
+#include <pk11pub.h>
+#include <certdb.h>
 #include "svrcore.h"
 #include "dyncerts.h"
 


### PR DESCRIPTION
Bug Description:
The NSS headers can be packaged in different paths on different platforms.

Fix Description:
Rely on pkg-config to include correct platform paths.

Fixes: https://github.com/389ds/389-ds-base/issues/7158

## Summary by Sourcery

Enhancements:
- Update NSS header includes to avoid hardcoded nss3/ subpaths for better portability across platforms.