### PR TITLE
Sync lib389 version to 3.1.4

### DIFF
--- a/src/lib389/pyproject.toml
+++ b/src/lib389/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lib389"
-version = "3.1.3"  # Should match the main 389-ds-base version
+version = "3.1.4"  # Should match the main 389-ds-base version
 description = "A library for accessing, testing, and configuring the 389 Directory Server"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}


### PR DESCRIPTION
Prepared with:
```
$ python3 validate_version.py --update
ERROR: Version mismatch detected!
Main project version: 3.1.4
lib389 version:       3.1.3
SUCCESS: Updated lib389 version to 3.1.4 in pyproject.toml
```
Fixes: https://github.com/389ds/389-ds-base/issues/7160