### PR TITLE
Backport issue 7012 to 389-ds-base-2.6.

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_verify.c
@@ -195,6 +195,8 @@ bdb_verify(Slapi_PBlock *pb)
                 }
                 rval_main |= bdb_dbverify_ext(inst, verbose);
             } else {
+                slapi_log_err(SLAPI_LOG_ERR, "bdb_verify",
+                              "Backend '%s' does not exist.\n", *inp);
                 rval_main |= 1; /* no such instance */
             }
         }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_verify.c
@@ -17,5 +17,6 @@
 int
 dbmdb_verify(Slapi_PBlock *pb)
 {
+    slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_verify", "With lmdb, db_verify feature is meaningless and is always successfull.\n");
     return 0;  /* Fonction useless with lmdb - as we can verify the db when doing a backup */
 }


### PR DESCRIPTION
* Issue 7012 - improve dscrl dbverify result when backend does not exists

Improve error message when running dsctl instance dbverify wrongBeName To tell explicitly that the backend does not exists in bdb case To tell explicitly that dbverify is useless and always successfull in lmdb case

(cherry picked from commit 2c4dc8ecb2652452edcd47ed2295e67220ba2629. patch applies cleanly)

## Summary by Sourcery

Backport improved dbverify behavior and messaging for non-existent backends and LMDB backends to the 2.6 branch.

Bug Fixes:
- Ensure dbverify exits with an error and logs a clear message when run against a non-existent BDB backend.
- Clarify that dbverify is a no-op that always succeeds when using LMDB backends and log this behavior.
- Prevent test log handler leakage by removing the file handler during test cleanup.

Tests:
- Add a regression test that validates dbverify output and return codes for non-existent backends under BDB and LMDB configurations.