### PR TITLE
Issue 7166 - db_config_set asserts because of dynamic list

### DIFF
--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -544,7 +544,7 @@ def db_config_set(inst, basedn, log, args):
     did_something = False
     replace_list = []
 
-    if args.enable_dynamic_lists and args.disable_dynamic_lists:
+    if getattr(args,'enable_dynamic_lists', None) and getattr(args, 'disable_dynamic_lists', None):
         raise ValueError("You can not enable and disable dynamic lists at the same time")
 
     for attr, value in list(attrs.items()):


### PR DESCRIPTION
Avoid assertion in db_config_set when args does not contains dynamic list attributes

Issue: #7166 

Reviewed by: @tbordaz (Thanks!)

## Summary by Sourcery

Bug Fixes:
- Prevent db_config_set from asserting when dynamic list enable/disable options are not provided by treating them as optional arguments.