### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/VERSION.sh
+++ b/VERSION.sh
@@ -9,8 +9,8 @@ vendor="389 Project"
 
 # PACKAGE_VERSION is constructed from these
 VERSION_MAJOR=3
-VERSION_MINOR=1
-VERSION_MAINT=3
+VERSION_MINOR=2
+VERSION_MAINT=0
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=
 VERSION_DATE=$(date -u +%Y%m%d%H%M)

--- a/src/lib389/pyproject.toml
+++ b/src/lib389/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lib389"
-version = "3.1.3"  # Should match the main 389-ds-base version
+version = "3.2.0"  # Should match the main 389-ds-base version
 description = "A library for accessing, testing, and configuring the 389 Directory Server"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the package version from 3.1.3 to 3.2.0 in VERSION.sh.