### PR TITLE
Issue 7118 - Revise paged result search locking

### DIFF
--- a/ldap/servers/slapd/abandon.c
+++ b/ldap/servers/slapd/abandon.c
@@ -179,7 +179,7 @@ do_abandon(Slapi_PBlock *pb)
     logpb.tv_sec = -1;
     logpb.tv_nsec = -1;
 
-    if (0 == pagedresults_free_one_msgid(pb_conn, id, pageresult_lock_get_addr(pb_conn))) {
+    if (0 == pagedresults_free_one_msgid(pb_conn, id, PR_NOT_LOCKED)) {
         if (log_format != LOG_FORMAT_DEFAULT) {
             /* JSON logging */
             logpb.target_op = "Simple Paged Results";

--- a/ldap/servers/slapd/opshared.c
+++ b/ldap/servers/slapd/opshared.c
@@ -572,8 +572,8 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                         be = be_list[index];
                     }
                 }
-                pr_search_result = pagedresults_get_search_result(pb_conn, operation, 0 /*not locked*/, pr_idx);
-                estimate = pagedresults_get_search_result_set_size_estimate(pb_conn, operation, pr_idx);
+                pr_search_result = pagedresults_get_search_result(pb_conn, operation, PR_NOT_LOCKED, pr_idx);
+                estimate = pagedresults_get_search_result_set_size_estimate(pb_conn, operation, PR_NOT_LOCKED, pr_idx);
                 /* Set operation note flags as required. */
                 if (pagedresults_get_unindexed(pb_conn, operation, pr_idx)) {
                     slapi_pblock_set_flag_operation_notes(pb, SLAPI_OP_NOTE_UNINDEXED);
@@ -619,14 +619,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
             int32_t tlimit;
             slapi_pblock_get(pb, SLAPI_SEARCH_TIMELIMIT, &tlimit);
             pagedresults_set_timelimit(pb_conn, operation, (time_t)tlimit, pr_idx);
-            /* When using this mutex in conjunction with the main paged
-             * result lock, you must do so in this order:
-             *
-             * --> pagedresults_lock()
-             *    --> pagedresults_mutex
-             *    <-- pagedresults_mutex
-             * <-- pagedresults_unlock()
-             */
+            /* IMPORTANT: Never acquire pagedresults_mutex when holding c_mutex. */
             pagedresults_mutex = pageresult_lock_get_addr(pb_conn);
         }
 
@@ -743,17 +736,15 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
         if (op_is_pagedresults(operation) && pr_search_result) {
             void *sr = NULL;
             /* PAGED RESULTS and already have the search results from the prev op */
-            pagedresults_lock(pb_conn, pr_idx);
             /*
              * In async paged result case, the search result might be released
              * by other theads.  We need to double check it in the locked region.
              */
             pthread_mutex_lock(pagedresults_mutex);
-            pr_search_result = pagedresults_get_search_result(pb_conn, operation, 1 /*locked*/, pr_idx);
+            pr_search_result = pagedresults_get_search_result(pb_conn, operation, PR_LOCKED, pr_idx);
             if (pr_search_result) {
-                if (pagedresults_is_abandoned_or_notavailable(pb_conn, 1 /*locked*/, pr_idx)) {
+                if (pagedresults_is_abandoned_or_notavailable(pb_conn, PR_LOCKED, pr_idx)) {
                     pthread_mutex_unlock(pagedresults_mutex);
-                    pagedresults_unlock(pb_conn, pr_idx);
                     /* Previous operation was abandoned and the simplepaged object is not in use. */
                     send_ldap_result(pb, 0, NULL, "Simple Paged Results Search abandoned", 0, NULL);
                     rc = LDAP_SUCCESS;
@@ -764,14 +755,13 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
 
                     /* search result could be reset in the backend/dse */
                     slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_SET, &sr);
-                    pagedresults_set_search_result(pb_conn, operation, sr, 1 /*locked*/, pr_idx);
+                    pagedresults_set_search_result(pb_conn, operation, sr, PR_LOCKED, pr_idx);
                 }
             } else {
                 pr_stat = PAGEDRESULTS_SEARCH_END;
                 rc = LDAP_SUCCESS;
             }
             pthread_mutex_unlock(pagedresults_mutex);
-            pagedresults_unlock(pb_conn, pr_idx);
 
             if ((PAGEDRESULTS_SEARCH_END == pr_stat) || (0 == pnentries)) {
                 /* no more entries to send in the backend */
@@ -789,22 +779,22 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
             }
             pagedresults_set_response_control(pb, 0, estimate,
                                               curr_search_count, pr_idx);
-            if (pagedresults_get_with_sort(pb_conn, operation, pr_idx)) {
+            if (pagedresults_get_with_sort(pb_conn, operation, PR_NOT_LOCKED, pr_idx)) {
                 sort_make_sort_response_control(pb, CONN_GET_SORT_RESULT_CODE, NULL);
             }
             pagedresults_set_search_result_set_size_estimate(pb_conn,
                                                              operation,
-                                                             estimate, pr_idx);
+                                                             estimate, PR_NOT_LOCKED, pr_idx);
             if (PAGEDRESULTS_SEARCH_END == pr_stat) {
-                pagedresults_lock(pb_conn, pr_idx);
+                pthread_mutex_lock(pagedresults_mutex);
                 slapi_pblock_set(pb, SLAPI_SEARCH_RESULT_SET, NULL);
-                if (!pagedresults_is_abandoned_or_notavailable(pb_conn, 0 /*not locked*/, pr_idx)) {
-                    pagedresults_free_one(pb_conn, operation, pr_idx);
+                if (!pagedresults_is_abandoned_or_notavailable(pb_conn, PR_LOCKED, pr_idx)) {
+                    pagedresults_free_one(pb_conn, operation, PR_LOCKED, pr_idx);
                 }
-                pagedresults_unlock(pb_conn, pr_idx);
+                pthread_mutex_unlock(pagedresults_mutex);
                 if (next_be) {
                     /* no more entries, but at least another backend */
-                    if (pagedresults_set_current_be(pb_conn, next_be, pr_idx, 0) < 0) {
+                    if (pagedresults_set_current_be(pb_conn, next_be, pr_idx, PR_NOT_LOCKED) < 0) {
                         goto free_and_return;
                     }
                 }
@@ -915,7 +905,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                         }
                     }
                     pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
-                    rc = pagedresults_set_current_be(pb_conn, NULL, pr_idx, 1);
+                    rc = pagedresults_set_current_be(pb_conn, NULL, pr_idx, PR_LOCKED);
                     pthread_mutex_unlock(pagedresults_mutex);
 #pragma GCC diagnostic pop
                 }
@@ -954,7 +944,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                         pthread_mutex_lock(pagedresults_mutex);
                         pagedresults_set_search_result(pb_conn, operation, NULL, 1, pr_idx);
                         be->be_search_results_release(&sr);
-                        rc = pagedresults_set_current_be(pb_conn, next_be, pr_idx, 1);
+                        rc = pagedresults_set_current_be(pb_conn, next_be, pr_idx, PR_LOCKED);
                         pthread_mutex_unlock(pagedresults_mutex);
                         pr_stat = PAGEDRESULTS_SEARCH_END; /* make sure stat is SEARCH_END */
                         if (NULL == next_be) {
@@ -967,23 +957,23 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                     } else {
                         curr_search_count = pnentries;
                         slapi_pblock_get(pb, SLAPI_SEARCH_RESULT_SET_SIZE_ESTIMATE, &estimate);
-                        pagedresults_lock(pb_conn, pr_idx);
-                        if ((pagedresults_set_current_be(pb_conn, be, pr_idx, 0) < 0) ||
-                            (pagedresults_set_search_result(pb_conn, operation, sr, 0, pr_idx) < 0) ||
-                            (pagedresults_set_search_result_count(pb_conn, operation, curr_search_count, pr_idx) < 0) ||
-                            (pagedresults_set_search_result_set_size_estimate(pb_conn, operation, estimate, pr_idx) < 0) ||
-                            (pagedresults_set_with_sort(pb_conn, operation, with_sort, pr_idx) < 0)) {
-                            pagedresults_unlock(pb_conn, pr_idx);
+                        pthread_mutex_lock(pagedresults_mutex);
+                        if ((pagedresults_set_current_be(pb_conn, be, pr_idx, PR_LOCKED) < 0) ||
+                            (pagedresults_set_search_result(pb_conn, operation, sr, PR_LOCKED, pr_idx) < 0) ||
+                            (pagedresults_set_search_result_count(pb_conn, operation, curr_search_count, PR_LOCKED, pr_idx) < 0) ||
+                            (pagedresults_set_search_result_set_size_estimate(pb_conn, operation, estimate, PR_LOCKED, pr_idx) < 0) ||
+                            (pagedresults_set_with_sort(pb_conn, operation, with_sort, PR_LOCKED, pr_idx) < 0)) {
+                            pthread_mutex_unlock(pagedresults_mutex);
                             cache_return_target_entry(pb, be, operation);
                             goto free_and_return;
                         }
-                        pagedresults_unlock(pb_conn, pr_idx);
+                        pthread_mutex_unlock(pagedresults_mutex);
                     }
                     slapi_pblock_set(pb, SLAPI_SEARCH_RESULT_SET, NULL);
                     next_be = NULL; /* to break the loop */
                     if (operation->o_status & SLAPI_OP_STATUS_ABANDONED) {
                         /* It turned out this search was abandoned. */
-                        pagedresults_free_one_msgid(pb_conn, operation->o_msgid, pagedresults_mutex);
+                        pagedresults_free_one_msgid(pb_conn, operation->o_msgid, PR_NOT_LOCKED);
                         /* paged-results-request was abandoned; making an empty cookie. */
                         pagedresults_set_response_control(pb, 0, estimate, -1, pr_idx);
                         send_ldap_result(pb, 0, NULL, "Simple Paged Results Search abandoned", 0, NULL);
@@ -993,7 +983,7 @@ op_shared_search(Slapi_PBlock *pb, int send_result)
                     }
                     pagedresults_set_response_control(pb, 0, estimate, curr_search_count, pr_idx);
                     if (curr_search_count == -1) {
-                        pagedresults_free_one(pb_conn, operation, pr_idx);
+                        pagedresults_free_one(pb_conn, operation, PR_NOT_LOCKED, pr_idx);
                     }
                 }
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1614,20 +1614,22 @@ pthread_mutex_t *pageresult_lock_get_addr(Connection *conn);
 int pagedresults_parse_control_value(Slapi_PBlock *pb, struct berval *psbvp, ber_int_t *pagesize, int *index, Slapi_Backend *be);
 void pagedresults_set_response_control(Slapi_PBlock *pb, int iscritical, ber_int_t estimate, int curr_search_count, int index);
 Slapi_Backend *pagedresults_get_current_be(Connection *conn, int index);
-int pagedresults_set_current_be(Connection *conn, Slapi_Backend *be, int index, int nolock);
-void *pagedresults_get_search_result(Connection *conn, Operation *op, int locked, int index);
-int pagedresults_set_search_result(Connection *conn, Operation *op, void *sr, int locked, int index);
-int pagedresults_get_search_result_count(Connection *conn, Operation *op, int index);
-int pagedresults_set_search_result_count(Connection *conn, Operation *op, int cnt, int index);
+int pagedresults_set_current_be(Connection *conn, Slapi_Backend *be, int index, bool locked);
+void *pagedresults_get_search_result(Connection *conn, Operation *op, bool locked, int index);
+int pagedresults_set_search_result(Connection *conn, Operation *op, void *sr, bool locked, int index);
+int pagedresults_get_search_result_count(Connection *conn, Operation *op, bool locked, int index);
+int pagedresults_set_search_result_count(Connection *conn, Operation *op, int cnt, bool locked, int index);
 int pagedresults_get_search_result_set_size_estimate(Connection *conn,
                                                      Operation *op,
+                                                     bool locked,
                                                      int index);
 int pagedresults_set_search_result_set_size_estimate(Connection *conn,
                                                      Operation *op,
                                                      int cnt,
+                                                     bool locked,
                                                      int index);
-int pagedresults_get_with_sort(Connection *conn, Operation *op, int index);
-int pagedresults_set_with_sort(Connection *conn, Operation *op, int flags, int index);
+int pagedresults_get_with_sort(Connection *conn, Operation *op, bool locked, int index);
+int pagedresults_set_with_sort(Connection *conn, Operation *op, int flags, bool locked, int index);
 int pagedresults_get_unindexed(Connection *conn, Operation *op, int index);
 int pagedresults_set_unindexed(Connection *conn, Operation *op, int index);
 int pagedresults_get_sort_result_code(Connection *conn, Operation *op, int index);
@@ -1639,15 +1641,13 @@ int pagedresults_cleanup(Connection *conn, int needlock);
 int pagedresults_is_timedout_nolock(Connection *conn);
 int pagedresults_reset_timedout_nolock(Connection *conn);
 int pagedresults_in_use_nolock(Connection *conn);
-int pagedresults_free_one(Connection *conn, Operation *op, int index);
-int pagedresults_free_one_msgid(Connection *conn, ber_int_t msgid, pthread_mutex_t *mutex);
+int pagedresults_free_one(Connection *conn, Operation *op, bool locked, int index);
+int pagedresults_free_one_msgid(Connection *conn, ber_int_t msgid, bool locked);
 int op_is_pagedresults(Operation *op);
 int pagedresults_cleanup_all(Connection *conn, int needlock);
 void op_set_pagedresults(Operation *op);
-void pagedresults_lock(Connection *conn, int index);
-void pagedresults_unlock(Connection *conn, int index);
-int pagedresults_is_abandoned_or_notavailable(Connection *conn, int locked, int index);
-int pagedresults_set_search_result_pb(Slapi_PBlock *pb, void *sr, int locked);
+int pagedresults_is_abandoned_or_notavailable(Connection *conn, bool locked, int index);
+int pagedresults_set_search_result_pb(Slapi_PBlock *pb, void *sr, bool locked);
 
 /*
  * sort.c

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -89,6 +89,10 @@ static char ptokPBE[34] = "Internal (Software) Token        ";
 #include <stdbool.h>
 #include <time.h> /* For timespec definitions */
 
+/* Macros for paged results lock parameter */
+#define PR_LOCKED true
+#define PR_NOT_LOCKED false
+
 /* Provides our int types and platform specific requirements. */
 #include <slapi_pal.h>
 
@@ -1669,7 +1673,6 @@ typedef struct _paged_results
     struct timespec pr_timelimit_hr;        /* expiry time of this request rel to clock monotonic */
     int pr_flags;
     ber_int_t pr_msgid; /* msgid of the request; to abandon */
-    PRLock *pr_mutex;   /* protect each conn structure    */
 } PagedResults;
 
 /* array of simple paged structure stashed in connection */


### PR DESCRIPTION
Description:

Move to a single lock approach verses having two locks. This will impact concurrency when multiple async paged result searches are done on the same connection, but it simplifies the code and avoids race conditions and deadlocks.

Relates: https://github.com/389ds/389-ds-base/issues/7118

This was written using github spec-kit.  Later the actual "spec" could be merged if we decide we want to maintain this information for future reference.

## Summary by Sourcery

Unify paged results search locking to a single connection-based mutex and update related APIs and call sites to use a boolean lock-state parameter, simplifying concurrency control and reducing risk of deadlocks.

Enhancements:
- Replace per-paged-result PRLock usage with a single hash-based pthread mutex per connection for all paged results operations.
- Extend paged results helper APIs to accept a boolean indicating whether the caller already holds the main paged results lock, and adjust callers accordingly.
- Clarify and document lock ordering constraints with c_mutex and the paged results lock, and add macros to standardize locked/not-locked arguments.
- Remove now-unused per-entry paged results mutex field from the PagedResults structure and associated lock/unlock helpers.