### PR TITLE
Issue 7152 - ns-slapd fails to shutdown when deferred memberof update…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_add.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_add.c
@@ -1452,7 +1452,7 @@ common_return:
                 slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                 if (deferred) {
                     PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred) {
+                    while (deferred && !g_get_shutdown()) {
                         DS_Sleep(delay);
                         slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                     }

--- a/ldap/servers/slapd/back-ldbm/ldbm_delete.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_delete.c
@@ -1536,7 +1536,7 @@ diskfull_return:
                 slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                 if (deferred) {
                     PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred) {
+                    while (deferred && !g_get_shutdown()) {
                         DS_Sleep(delay);
                         slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                     }

--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -1179,7 +1179,7 @@ common_return:
                 slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                 if (deferred) {
                     PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred) {
+                    while (deferred && !g_get_shutdown()) {
                         DS_Sleep(delay);
                         slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                     }

--- a/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
@@ -1469,7 +1469,7 @@ common_return:
                 slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                 if (deferred) {
                     PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred) {
+                    while (deferred && !g_get_shutdown()) {
                         DS_Sleep(delay);
                         slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
                     }


### PR DESCRIPTION
… is in progress

Bug Description:
When a deferred memberof update is in progress during shutdown, the backend operations (add, modify, delete, modrdn) wait in a polling loop for the deferred task to complete. However, if the deferred thread exits before clearing the SLAPI_DEFERRED_MEMBEROF flag, the loop becomes infinite, causing the server to hang during shutdown.

Fix Description:
Add additional check to the polling loops so they exit immediately when the server is shutting down.

Fixes: https://github.com/389ds/389-ds-base/issues/7152

## Summary by Sourcery

Bug Fixes:
- Ensure add, modify, delete, and modrdn backend operations stop waiting on deferred memberOf processing once server shutdown begins to avoid infinite polling loops.