### PR TITLE
Issue 7170 - Support of PQC keys

### DIFF
--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -293,10 +293,10 @@ def test_mldsa(topo):
             'loginShell': '/bin/false',
             'description': cert_dn })
 
-    # with TemporaryDirectory(delete=not DEBUGGING) as dir:
-    # (This is useful for debbuging but requires python >= 3.12 
-    #  which trigger failure in github Verify test)
-    with TemporaryDirectory() as dir:
+    tmpdir_kwargs = {}
+    if sys.version_info >= (3, 12):
+        tmpdir_kwargs['delete'] = not DEBUGGING
+    with TemporaryDirectory(**tmpdir_kwargs) as dir:
         scriptname = f"{dir}/doit"
         d = {
             'dir': dir,

--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -285,7 +285,6 @@ def test_mldsa(topo):
 
     with TemporaryDirectory(delete=not DEBUGGING) as dir:
         scriptname = f"{dir}/doit"
-        scriptname = "/tmp/doit"
         d = {
             'dir': dir,
             'instname': inst.serverid,
@@ -301,8 +300,6 @@ def test_mldsa(topo):
         res.check_returncode()
         # If ldapsearch is successful then defaultnamingcontext should be in res.stdout
         assert "defaultnamingcontext" in res.stdout
-
-
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -1,0 +1,312 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2022 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import rpm
+import socket
+import subprocess
+from lib389.utils import ds_is_older
+from lib389._constants import DN_DM, PW_DM, DEFAULT_SUFFIX
+from lib389.config import Encryption, CertmapLegacy
+from lib389.idm.user import UserAccount
+from lib389.topologies import topology_st as topo
+from tempfile import TemporaryDirectory
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+def rpm_is_older(pkg, version):
+    ts = rpm.TransactionSet()
+    mi = ts.dbMatch('name', pkg)
+    for h in mi:
+        if h['version'] < version:
+            return True
+    return False
+
+
+script_content="""
+#!/bin/bash
+set -e  # Exit if a command fails
+set -x  # Log the commands
+
+cd {dir}
+inst={instname}
+url={url}
+rootdn="{rootdn}"
+rootpw="{rootpw}"
+
+################################
+###### GENERATE CA CERT ########
+################################
+
+echo "
+[ req ]
+distinguished_name = req_distinguished_name
+policy             = policy_match
+x509_extensions     = v3_ca
+
+# For the CA policy
+[ policy_match ]
+countryName             = optional
+stateOrProvinceName     = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= FR
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= test
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= test-ML-DSA-CA
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:true
+#nsComment = "OpenSSL Generated Certificate"
+keyUsage=critical, keyCertSign
+" >ca.conf
+
+
+openssl genpkey -algorithm ML-DSA-87 -out ca.key
+openssl req -x509 -new -sha256 -key ca.key -nodes -days 3650 -config ca.conf -subj "/CN=`hostname`/O=test-ML-DSA-CA/C=FR"  -out ca.pem -keyout ca.key
+openssl x509 -outform der -in ca.pem -out ca.crt
+
+openssl x509 -text -in ca.pem
+
+####################################
+###### GENERATE SERVER CERT ########
+####################################
+
+echo "
+[ req ]
+distinguished_name = req_distinguished_name
+policy             = policy_match
+x509_extensions     = v3_cert
+
+# For the cert policy
+[ policy_match ]
+countryName             = optional
+stateOrProvinceName     = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= FR
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= test-ML-DSA
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+
+[ v3_cert ]
+basicConstraints = critical,CA:false
+subjectAltName=DNS:`hostname`
+keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+#nsComment = "OpenSSL Generated Certificate"
+extendedKeyUsage=clientAuth, serverAuth
+nsCertType=client, server
+" >cert.conf
+
+openssl genpkey -algorithm ML-DSA-65 -out cert.key
+openssl req -new -sha256 -key cert.key -nodes  -config cert.conf -subj "/CN=`hostname`/O=test-ML-DSA/C=FR" -out cert.csr
+openssl x509 -req -sha256 -days 3650 -extensions v3_cert -extfile cert.conf -in cert.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out cert.pem
+openssl pkcs12 -export -inkey cert.key -in cert.pem -name mldsacert -out cert.p12 -passout pass:secret12
+
+openssl x509 -text -in cert.pem
+
+
+
+####################################
+###### GENERATE CLIENT CERT ########
+####################################
+
+echo "
+[ req ]
+distinguished_name = req_distinguished_name
+policy             = policy_match
+x509_extensions     = v3_cert
+
+# For the cert policy
+[ policy_match ]
+countryName             = optional
+stateOrProvinceName     = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= FR
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= test-ML-DSA
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+
+[ v3_cert ]
+basicConstraints = critical,CA:false
+subjectAltName=DNS:`hostname`
+keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+#nsComment = "OpenSSL Generated Certificate"
+extendedKeyUsage=clientAuth
+nsCertType=client, server
+" >client.conf
+
+openssl genpkey -algorithm ML-DSA-65 -out client.key
+openssl req -new -sha256 -key client.key -nodes  -config client.conf -subj "/CN=`hostname`/O=client-test-ML-DSA/C=FR" -out client.csr
+openssl x509 -req -sha256 -days 3650 -extensions v3_cert -extfile client.conf -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out client.pem
+openssl pkcs12 -export -inkey client.key -in client.pem -name mldsacert2 -out client.p12 -passout pass:secret12
+
+openssl x509 -text -in client.pem
+
+
+#############################
+###### INSTALL CERTS ########
+#############################
+
+certdbdir=$PREFIX/etc/dirsrv/slapd-$inst
+rm -f $certdbdir/cert9.db $certdbdir/key4.db
+certutil -N -d $certdbdir -f $certdbdir/pwdfile.txt
+
+certutil -A -n Self-Signed-CA -t CT,, -f $certdbdir/pwdfile.txt -d $certdbdir -a -i ca.pem
+certutil -A -n Client-Cert -t u,, -f $certdbdir/pwdfile.txt -d $certdbdir -a -i client.pem
+
+dsctl $inst tls import-server-key-cert cert.pem cert.key
+
+dsctl $inst restart
+
+
+#########################
+###### TEST CERT ########
+#########################
+export LDAPTLS_CACERT=$PWD/ca.pem
+export LDAPTLS_CERT=$PWD/client.pem
+export LDAPTLS_KEY=$PWD/client.key
+
+ldapsearch -x -H $url -D "$rootdn" -w "$rootpw" -b "" -s base
+ldapsearch -Y external -H $url -b "" -s base
+"""
+
+@pytest.mark.skipif(rpm_is_older("openssl", "3.5"), reason="OpenSSL too old to support PQC")
+def test_mldsa(topo):
+    """Test using ML-DSA Certificate - (PQC)
+
+    :id: 87fb19ef-672d-4fa7-934d-dfb4397f2312
+    :setup: Standalone Instance
+    :steps:
+        1. Configure the certmap
+        2. Create user mapped with theclient certificate
+        3. Generate the test script
+        4. Run the test script
+        5. Check that ldapsearch returned the namingcontext
+    :expectedresults:
+        1. No error
+        2. No error
+        3. No error
+        4. No error and exit code should be 0
+        5. namingcontext should be in the script output
+    """
+
+    inst = topo.standalone
+    inst.enable_tls()
+
+    cm = CertmapLegacy(inst)
+    certmaps = cm.list()
+    certmaps['default'].update({'DNComps': None, 'CmapLdapAttr': 'description'})
+    cm.set(certmaps)
+
+    cert_dn = f'C=FR,O=client-test-ML-DSA,CN={socket.gethostname()}'
+    dn = f'uid=test_user,ou=people,{DEFAULT_SUFFIX}'
+    UserAccount(inst, dn=dn).create( properties= {
+            'uid': 'test_user',
+            'cn': 'Test user',
+            'sn': 'Test user',
+            'uidNumber': '99998',
+            'gidNumber': '99998',
+            'homeDirectory': '/var/empty',
+            'loginShell': '/bin/false',
+            'description': cert_dn })
+
+    with TemporaryDirectory(delete=not DEBUGGING) as dir:
+        scriptname = f"{dir}/doit"
+        scriptname = "/tmp/doit"
+        d = {
+            'dir': dir,
+            'instname': inst.serverid,
+            'url': f"ldaps://localhost:{inst.sslport}",
+            'rootdn': DN_DM,
+            'rootpw': PW_DM,
+        }
+        with open(scriptname, 'w') as f:
+            f.write(script_content.format(**d))
+        res = subprocess.run(('/bin/bash', scriptname), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        assert res
+        log.info(res.stdout)
+        res.check_returncode()
+        # If ldapsearch is successful then defaultnamingcontext should be in res.stdout
+        assert "defaultnamingcontext" in res.stdout
+
+
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -283,7 +283,9 @@ def test_mldsa(topo):
             'loginShell': '/bin/false',
             'description': cert_dn })
 
-    with TemporaryDirectory(delete=not DEBUGGING) as dir:
+    # Usefull to debug by requires Python 3.12
+    # with TemporaryDirectory(delete=not DEBUGGING) as dir:
+    with TemporaryDirectory() as dir:
         scriptname = f"{dir}/doit"
         d = {
             'dir': dir,

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -745,7 +745,7 @@ SSLPLCY_Install(void)
     s = NSS_SetDomesticPolicy();
 
 #ifdef MAX_ML_DSA_PRIVATE_KEY_LEN
-    /* Set explicitly PQC algorythm policy if it is not set by default */
+    /* Set explicitly PQC algorithm policy if it is not set by default */
     for (size_t i=0; s == SECSuccess && i < PR_ARRAY_SIZE(oids); i++) {
         int oflags = 0;
         (void) NSS_GetAlgorithmPolicy(oids[i], &oflags);
@@ -2797,7 +2797,7 @@ extractKeysAndSubject(
             char sktnames[100] = "";
             get_supported_key_type_names(sktnames, sizeof sktnames);
             slapi_log_err(SLAPI_LOG_ERR, "extractKeysAndSubject",
-                          "Unexpected key algorythm in certificate: %s. Only %s are supported.\n", nickname, sktnames);
+                          "Unexpected key algorithm in certificate: %s. Only %s are supported.\n", nickname, sktnames);
             goto bail;
         }
     }

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -177,7 +177,6 @@ static const struct {
     { rsaKey, "RSA", "Rivest–Shamir–Adleman" },
     { ecKey, "EC", "Elliptic Curve" },
 #ifdef MAX_ML_DSA_PRIVATE_KEY_LEN
-    { kyberKey, "Kyber", "Kyber key - Post-quantum cryptography key encapsulation mechanism" },
     { mldsaKey, "ML-DSA", "Module-Lattice-Based Digital Signature Algorithm (post-quantum)" },
 #endif
     { 0 }
@@ -1674,7 +1673,7 @@ slapd_ssl_init2(PRFileDesc **fd, int startTLS)
     /*
      * Now, get the complete list of cipher families. Each family
      * has a token name and personality name which we'll use to find
-     * appropriate keys and certs, and call SSL_ConfigSecureServer
+     * appropriate keys and certs, and call SSL_ConfigServerCert
      * with.
      */
 
@@ -1809,7 +1808,7 @@ slapd_ssl_init2(PRFileDesc **fd, int startTLS)
                     rv = SSL_ConfigServerCert(*fd, cert, key, NULL, 0);
                     if (SECSuccess != rv) {
                         errorCode = PR_GetError();
-                        slapd_SSL_warn("ConfigServerCert: "
+                        slapd_SSL_warn("SSL_ConfigServerCert: "
                                        "Server key/certificate is "
                                        "bad for cert %s of family %s (" SLAPI_COMPONENT_NAME_NSPR " error %d - %s)",
                                        cert_name, *family, errorCode,

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -744,12 +744,15 @@ SSLPLCY_Install(void)
     s = NSS_SetDomesticPolicy();
 
 #ifdef MAX_ML_DSA_PRIVATE_KEY_LEN
-    /* Set explicitly PQC algorithm policy if it is not set by default */
-    for (size_t i=0; s == SECSuccess && i < PR_ARRAY_SIZE(oids); i++) {
-        int oflags = 0;
-        (void) NSS_GetAlgorithmPolicy(oids[i], &oflags);
-        if ((oflags & flags) != flags) {
-            s = NSS_SetAlgorithmPolicy(oids[i], flags, 0);
+    /* Should rely on the crypto module policy in FIPS mode */
+    if (!slapd_pk11_isFIPS()) {
+        /* Set explicitly PQC algorithm policy if it is not set by default */
+        for (size_t i=0; s == SECSuccess && i < PR_ARRAY_SIZE(oids); i++) {
+            int oflags = 0;
+            (void) NSS_GetAlgorithmPolicy(oids[i], &oflags);
+            if ((oflags & flags) != flags) {
+                s = NSS_SetAlgorithmPolicy(oids[i], flags, 0);
+            }
         }
     }
 #endif

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -2788,7 +2788,7 @@ extractKeysAndSubject(
     keytype = (*privkey)->keyType;
     for (size_t i=0; ;i++) {
         KeyType kt = supported_key_types[i].kt;
-        if (kt == keytype) {
+        if (kt == keytype && keytype != 0) {
             /* Stop looping if the key type is supported */
             break;
         }


### PR DESCRIPTION
Support of Post Quantum Cryptography Keys in certificates:
   Added support of a new key type:  ML_DSA 
   Enable the following policies (that are not enabled by defaut):  ML-DSA-44, ML-DSA-65- ML-DSA-87
   Replaced deprecated  function SSL_ConfigSecureServer by SSL_ConfigServerCert
   Added test case for ML-DSA certificate. That test case rely of openssl command because python cryptography module does not yet support ML-DSA keys
   
  Issue: #7170 

Reviewed by:  @tbordaz, @droideck  and @vashirov (Thanks!)

## Summary by Sourcery

Add support for post-quantum cryptography key types in TLS handling and validate them through automated testing.

New Features:
- Support additional certificate key types, including ML-DSA and Kyber, in server TLS key handling.

Enhancements:
- Enable and enforce NSS algorithm policies for ML-DSA signature suites when available.
- Improve certificate key-type validation and error messaging to cover all supported key algorithms.
- Update server TLS configuration to use the non-deprecated SSL_ConfigServerCert API.

Tests:
- Add an end-to-end TLS test that provisions ML-DSA-based CA, server, and client certificates using OpenSSL and verifies LDAP over TLS and SASL EXTERNAL bind behavior.