### PR TITLE
Issue 7196 - DynamicCertificates returns empty DER

### DIFF
--- a/ldap/servers/slapd/dyncerts.c
+++ b/ldap/servers/slapd/dyncerts.c
@@ -786,8 +786,8 @@ dyncerts_cert2entry(CERTCertificate *cert)
     COND_STR(e, DYCATTR_TYPE, "OBJECT SIGNING CA", cert->nsCertType & NS_CERT_TYPE_OBJECT_SIGNING_CA);
     slapi_entry_add_string(e, DYCATTR_TOKEN, PK11_GetTokenName(cert->slot));
     secitemv(&cert->derCert, &tmpv);
-    value_done(&tmpv);
     slapi_entry_add_value(e, DYCATTR_CERTDER, &tmpv);
+    value_done(&tmpv);
     tmpstr = secitem2hex(&cert->serialNumber);
     slapi_entry_add_string(e, DYCATTR_SN, tmpstr);
     slapi_ch_free_string(&tmpstr);


### PR DESCRIPTION
Fixing a mistake done while fixing memory leaks.
 Value was freed before being added in the entry rather than after ...

Issue: #7196 

Reviewed by: @jchapma (thanks!)

## Summary by Sourcery

Bug Fixes:
- Fix dynamic certificate handling so the DER value is not freed before being added to the entry.