### PR TITLE
Issue 7201 - Syscall overhead in LMDB import writer thread

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -477,6 +477,28 @@ dbmdb_ctx_t_db_durable_transactions_set(void *arg, void *value, char *errorbuf _
     return retval;
 }
 
+static void *
+dbmdb_ctx_t_db_import_stats_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)((uintptr_t)(MDB_CONFIG(li)->dsecfg.import_stats));
+}
+
+static int
+dbmdb_ctx_t_db_import_stats_set(void *arg, void *value, char *errorbuf __attribute__((unused)), int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    int retval = LDAP_SUCCESS;
+    int val = (int)((uintptr_t)value);
+
+    if (apply) {
+        MDB_CONFIG(li)->dsecfg.import_stats = val;
+    }
+
+    return retval;
+}
+
 static int
 dbmdb_ctx_t_set_bypass_filter_test(void *arg,
                                    void *value,
@@ -589,6 +611,7 @@ static config_info dbmdb_ctx_t_param[] = {
     {CONFIG_MDB_MAX_DBS, CONFIG_TYPE_INT, "512", &dbmdb_ctx_t_db_max_dbs_get, &dbmdb_ctx_t_db_max_dbs_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_MAXPASSBEFOREMERGE, CONFIG_TYPE_INT, "100", &dbmdb_ctx_t_maxpassbeforemerge_get, &dbmdb_ctx_t_maxpassbeforemerge_set, 0},
     {CONFIG_DB_DURABLE_TRANSACTIONS, CONFIG_TYPE_ONOFF, "on", &dbmdb_ctx_t_db_durable_transactions_get, &dbmdb_ctx_t_db_durable_transactions_set, CONFIG_FLAG_ALWAYS_SHOW},
+    {CONFIG_MDB_IMPORT_STATS, CONFIG_TYPE_ONOFF, "off", &dbmdb_ctx_t_db_import_stats_get, &dbmdb_ctx_t_db_import_stats_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_BYPASS_FILTER_TEST, CONFIG_TYPE_STRING, "on", &dbmdb_ctx_t_get_bypass_filter_test, &dbmdb_ctx_t_set_bypass_filter_test, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_SERIAL_LOCK, CONFIG_TYPE_ONOFF, "on", &dbmdb_ctx_t_serial_lock_get, &dbmdb_ctx_t_serial_lock_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_CACHE_AUTOSIZE, CONFIG_TYPE_INT, "25", &mdb_config_cache_autosize_get, &mdb_config_cache_autosize_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -41,6 +41,7 @@
 #define CONFIG_MDB_MAX_SIZE       "nsslapd-mdb-max-size"
 #define CONFIG_MDB_MAX_READERS    "nsslapd-mdb-max-readers"
 #define CONFIG_MDB_MAX_DBS        "nsslapd-mdb-max-dbs"
+#define CONFIG_MDB_IMPORT_STATS   "nsslapd-mdb-import-stats"
 
 #define DBMDB_DB_MINSIZE             ( 4LL * MEGABYTE )
 #define DBMDB_DISK_RESERVE(disksize) ((disksize)*2ULL/1000ULL)
@@ -76,6 +77,7 @@ typedef struct
     int max_readers;
     int max_dbs;
     uint64_t max_size;
+    int import_stats;
 } dbmdb_cfg_t;
 
 /* config parameters limits */


### PR DESCRIPTION
Bug Description:
ldif2db import is slower with LMDB than with BDB (~3500 vs ~4500 entries/s) due to 2 issues:
1. The MDB_STAT_STEP macro calls `clock_gettime()` to collect performance statistics. This was called on every single operation inside the writer loop, resulting in ~3 syscalls per write or ~6000 syscalls per transaction (with 2000 as the default batch size).

2. In `dbmdb_import_workerq_push()`, after copying work to a worker slot, the condition variable was never signaled. This caused workers to spend up to 100ms in `safe_cond_wait()` before checking for new work, severely limiting import throughput.

Fix Description:
1. Add a new config parameter `nsslapd-mdb-import-stats` (default: off) to control whether performance statistics collection is enabled.
3. Add `pthread_cond_broadcast()` immediately after copying data to wake the workers.

After applying these fixes ldif2db import rate is about ~10000 entries/s.

Fixes: https://github.com/389ds/389-ds-base/issues/7201

## Summary by Sourcery

Optimize LMDB import writer throughput by reducing per-operation stats collection and ensuring worker threads are promptly notified of new work.

Bug Fixes:
- Signal/broadcast the worker queue condition variable after enqueuing work items so worker threads wake immediately to process new tasks.
- Move LMDB import statistics accounting from each individual write operation to transaction boundaries to avoid excessive syscall overhead.