### PR TITLE
Issue 7096 - (2nd) During replication online total init the function …

### DIFF
--- a/ldap/servers/slapd/back-ldbm/idl_new.c
+++ b/ldap/servers/slapd/back-ldbm/idl_new.c
@@ -701,9 +701,9 @@ error:
                 }
             }
         }
-        slapi_ch_free((void **)&leftover);
-        idrange_free(&idrange_list);
     }
+    slapi_ch_free((void **)&leftover);
+    idrange_free(&idrange_list);
     slapi_log_err(SLAPI_LOG_FILTER, "idl_new_range_fetch",
                   "Found %d candidates; error code is: %d\n",
                   idl ? idl->b_nids : 0, *flag_err);
@@ -885,6 +885,7 @@ idl_lmdb_range_fetch(
     idl_range_ctx.lastid = 0;
     idl_range_ctx.count = 0;
     idl_range_ctx.index_id = index_id;
+    idl_range_ctx.idrange_list = NULL;
     if (operator & SLAPI_OP_RANGE_NO_IDL_SORT) {
             struct _back_info_index_key bck_info;
             /* We are doing a bulk import
@@ -969,9 +970,9 @@ error:
                 }
             }
         }
-        slapi_ch_free((void **)&idl_range_ctx.leftover);
-        idrange_free(&idl_range_ctx.idrange_list);
     }
+    slapi_ch_free((void **)&idl_range_ctx.leftover);
+    idrange_free(&idl_range_ctx.idrange_list);
     *flag_err = idl_range_ctx.flag_err;
     slapi_log_err(SLAPI_LOG_FILTER, "idl_lmdb_range_fetch",
                   "Found %d candidates; error code is: %d\n",


### PR DESCRIPTION
…idl_id_is_in_idlist is not scaling with large database

Bug Description:
The fix for #7096 optimized the BDB backend's `idl_new_range_fetch()` function to use ID ranges instead of checking the full ID list during online total initialization. However, the LMDB backend's `idl_lmdb_range_fetch()` function and its callback `idl_range_add_id_cb()` were not updated and still use the non-scaling `idl_id_is_in_idlist()` function.

Fix Description:
Apply the same optimization to the LMDB backend.

Fixes: https://github.com/389ds/389-ds-base/issues/7096

## Summary by Sourcery

Optimize LMDB ID range fetching to scale with large databases by aligning it with the range-based approach used in the BDB backend.

Bug Fixes:
- Avoid non-scaling parent-ID lookups during LMDB online total initialization by replacing full ID list scans with range-based membership checks.

Enhancements:
- Track ID ranges alongside ID lists during LMDB range fetch operations and clean up associated range state after processing leftovers.