### PR TITLE
Issue 7206 - Should log whether TLS key is PQC or not

### DIFF
--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -274,6 +274,7 @@ def test_mldsa(topo):
     """
 
     inst = topo.standalone
+    inst.config.set('nsslapd-errorlog-level', str(16384 + 8))
     inst.enable_tls()
 
     cm = CertmapLegacy(inst)

--- a/dirsrvtests/tests/suites/tls/mldsa_test.py
+++ b/dirsrvtests/tests/suites/tls/mldsa_test.py
@@ -294,6 +294,9 @@ def test_mldsa(topo):
             'loginShell': '/bin/false',
             'description': cert_dn })
 
+    inst.config.set("nsslapd-accesslog-logbuffering", "off")
+    inst.config.set("nsslapd-errorlog-logbuffering", "off")
+
     tmpdir_kwargs = {}
     if sys.version_info >= (3, 12):
         tmpdir_kwargs['delete'] = not DEBUGGING
@@ -314,6 +317,9 @@ def test_mldsa(topo):
         res.check_returncode()
         # If ldapsearch is successful then defaultnamingcontext should be in res.stdout
         assert "defaultnamingcontext" in res.stdout
+    assert inst.ds_access_log.match('.*RESULT.*dn="uid=test_user,ou=people,dc=example,dc=com".*')
+    assert inst.ds_access_log.match('.*TLS.*[PQC].*')
+    assert inst.ds_error_log.match('.*check_pqc.*')
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/auth.c
+++ b/ldap/servers/slapd/auth.c
@@ -411,7 +411,7 @@ check_pqc(uint64_t connid, SSLChannelInfo *sci)
     slapi_log_err(SLAPI_LOG_CONNS, "check_pqc", "conn=%" PRIu64 " TLS keaType=%d keaGroup=%d\n",
                   connid, sci->keaType, sci->keaGroup);
 #ifdef MAX_ML_DSA_PRIVATE_KEY_LEN
-    /* NSS supports PQC (because of the ifdef). No let check if the connection use it */
+    /* NSS supports PQC (because of the ifdef). Now lets check if the connection uses it */
     /* Check that PQC KeaType is hybrid */
     switch (sci->keaType) {
         case ssl_kea_ecdh_hybrid:

--- a/ldap/servers/slapd/auth.c
+++ b/ldap/servers/slapd/auth.c
@@ -396,14 +396,14 @@ handle_bad_certificate(void *clientData, PRFileDesc *prfd)
 
 
 /*
- * Determine if the connection key exchange is Post Quantum Cryptology aware.
+ * Determine if the connection key exchange is Post Quantum Cryptography aware.
  * This function may need to evolve with NSS as more PQC methods get supported.
  */
 static bool
-check_pqc(int connid, SSLChannelInfo *sci)
+check_pqc(uint64_t connid, SSLChannelInfo *sci)
 {
     /*
-     * FYI: To interprets the values:
+     * FYI: To interpret the values:
      * KeaType and KeaGroup values are defined in
      * https://github.com/nss-dev/nss/blob/master/lib/ssl/sslt.h
      * Respectively in SSLKEAType and SSLNamedGroup enums
@@ -411,7 +411,8 @@ check_pqc(int connid, SSLChannelInfo *sci)
     slapi_log_err(SLAPI_LOG_CONNS, "check_pqc", "conn=%" PRIu64 " TLS keaType=%d keaGroup=%d\n",
                   connid, sci->keaType, sci->keaGroup);
 #ifdef MAX_ML_DSA_PRIVATE_KEY_LEN
-    /* PQC KeaType is hybrid */
+    /* NSS supports PQC (because of the ifdef). No let check if the connection use it */
+    /* Check that PQC KeaType is hybrid */
     switch (sci->keaType) {
         case ssl_kea_ecdh_hybrid:
         case ssl_kea_ecdh_hybrid_psk:
@@ -419,7 +420,7 @@ check_pqc(int connid, SSLChannelInfo *sci)
         default:
             return false;
     }
-    /* PQC keaGroup is KEM */
+    /* Check that PQC keaGroup is KEM */
     switch (sci->keaGroup) {
         case ssl_grp_kem_secp256r1mlkem768:
         case ssl_grp_kem_secp384r1mlkem1024:

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -748,7 +748,7 @@ SSLPLCY_Install(void)
     if (!slapd_pk11_isFIPS()) {
         /* Set explicitly PQC algorithm policy if it is not set by default */
         for (size_t i=0; s == SECSuccess && i < PR_ARRAY_SIZE(oids); i++) {
-            int oflags = 0;
+            PRUint32 oflags = 0;
             (void) NSS_GetAlgorithmPolicy(oids[i], &oflags);
             if ((oflags & flags) != flags) {
                 s = NSS_SetAlgorithmPolicy(oids[i], flags, 0);


### PR DESCRIPTION
Append [PQC] to the cipher name when logging SSL/TLS if the Key Exchange is one of the KEM group
If connection debug level is enabled, logs in error log the keaType and keaGroup (as integer) 

Issue: #7206 

Reviewed by:  @tbordaz, @droideck  (Thanks!)

## Summary by Sourcery

Log TLS key exchange PQC usage and tag PQC cipher suites in connection logging.

New Features:
- Append a [PQC] marker to the logged cipher name when the TLS key exchange uses a PQC KEM group.
- Log TLS key exchange keaType and keaGroup values at connection debug level for TLS handshakes.

Enhancements:
- Add helper to detect PQC-capable key exchanges based on NSS SSL channel info.
- Use the correct unsigned type for NSS algorithm policy flags when configuring PQC algorithm policy.

Tests:
- Extend the MLDSA TLS test to enable detailed error log debugging for PQC-related logging.