### PR TITLE
Issue 7014 - memberOf - ignored deferred updates with LMDB

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_lmdb_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_deferred_lmdb_test.py
@@ -1,4 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
+
 # Copyright (C) 2025 Red Hat, Inc.
 # All rights reserved.
 #
@@ -28,7 +29,7 @@ else:
     logging.getLogger(__name__).setLevel(logging.INFO)
 
 
-@pytest.mark.skipif(get_default_db_lib() != "mdb", reason="Not supported over mdb")
+@pytest.mark.skipif(get_default_db_lib() != "mdb", reason="Not supported over bdb")
 def test_memberof_deferred_update_lmdb_rejection(topo):
     """Test that memberOf plugin rejects deferred update configuration with LMDB backend
 


### PR DESCRIPTION
Description:
Fix typo in pytest marker reason.

Relates: #7014

Author: Lenka Doudova
Reviewed by: ???

## Summary by Sourcery

Tests:
- Update the pytest skip marker reason string for the LMDB memberOf deferred update test.