### PR TITLE
Issue 7027 - (2nd) 389-ds-base OpenScanHub Leaks Detected

### DIFF
--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -206,8 +206,8 @@ compress_log_file(char *log_name, int32_t mode)
 
     if ((source = fopen(log_name, "r")) == NULL) {
         /* Failed to open log file */
-        /* coverity[leaked_storage] gzclose does close FD */
         gzclose(outfile);
+        /* coverity[leaked_handle] gzclose does close FD */
         return -1;
     }
 
@@ -217,17 +217,17 @@ compress_log_file(char *log_name, int32_t mode)
         if (bytes_written == 0)
         {
             fclose(source);
-            /* coverity[leaked_storage] gzclose does close FD */
             gzclose(outfile);
+            /* coverity[leaked_handle] gzclose does close FD */
             return -1;
         }
         bytes_read = fread(buf, 1, LOG_CHUNK, source);
     }
-    /* coverity[leaked_storage] gzclose does close FD */
     gzclose(outfile);
     fclose(source);
     PR_Delete(log_name); /* remove the old uncompressed log */
 
+    /* coverity[leaked_handle] gzclose does close FD */
     return 0;
 }
 


### PR DESCRIPTION
Fix Description:
Update coverity annotations.

Relates: https://github.com/389ds/389-ds-base/issues/7027

## Summary by Sourcery

Enhancements:
- Adjust Coverity annotations on gzclose usage in log compression to indicate leaked_handle instead of leaked_storage.