### PR TITLE
Issue 7178 - Bundled jemalloc fails to build with GCC 15

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -143,6 +143,7 @@ srpmdistdir:
 rpmbuildprep:
 	cp dist/sources/$(TARBALL) $(RPMBUILD)/SOURCES/
 	cp rpm/$(PACKAGE)-* $(RPMBUILD)/SOURCES/
+	cp rpm/jemalloc-5.3.0_throw_bad_alloc.patch $(RPMBUILD)/SOURCES/
 	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
 		cp dist/sources/$(JEMALLOC_TARBALL) $(RPMBUILD)/SOURCES/ ; \
 	fi

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -152,8 +152,8 @@ BuildRequires:    python%{python3_pkgversion}-devel
 # For cockpit
 %if %{with cockpit}
 BuildRequires:    rsync
-BuildRequires:    npm
-BuildRequires:    nodejs
+BuildRequires:    /usr/bin/npm
+BuildRequires:    /usr/bin/node
 %endif
 
 # END BUILD REQUIRES
@@ -188,9 +188,7 @@ Requires:         %{name}-robdb-libs = %{version}-%{release}
 Requires:         libdb
 %endif
 %endif
-Requires:         lmdb
-# This picks up libperl.so as a Requires, so we add this versioned one
-Requires:         perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
+Requires:         lmdb-libs
 # Needed by logconv.pl
 %if %{without libbdb_ro}
 %if %{without bundle_libdb}
@@ -217,6 +215,7 @@ Source0:          %{name}-%{version}.tar.bz2
 Source2:          %{name}-devel.README
 %if %{with bundle_jemalloc}
 Source3:          https://github.com/jemalloc/%{jemalloc_name}/releases/download/%{jemalloc_ver}/%{jemalloc_name}-%{jemalloc_ver}.tar.bz2
+Source5:          jemalloc-5.3.0_throw_bad_alloc.patch
 %endif
 %if %{with bundle_libdb}
 Source4:          https://fedorapeople.org/groups/389ds/libdb-5.3.28-59.tar.bz2
@@ -434,6 +433,7 @@ COCKPIT_FLAGS="--disable-cockpit"
 
 # Build jemalloc
 pushd ../%{jemalloc_name}-%{jemalloc_ver}
+patch -p1 -F3 < %{SOURCE5}
 %configure \
         --libdir=%{_libdir}/%{pkgname}/lib \
         --bindir=%{_libdir}/%{pkgname}/bin \

--- a/rpm/jemalloc-5.3.0_throw_bad_alloc.patch
+++ b/rpm/jemalloc-5.3.0_throw_bad_alloc.patch
@@ -1,0 +1,12 @@
+diff --git a/src/jemalloc_cpp.cpp b/src/jemalloc_cpp.cpp
+index fffd6aee..5a682991 100644
+--- a/src/jemalloc_cpp.cpp
++++ b/src/jemalloc_cpp.cpp
+@@ -93,7 +93,7 @@ handleOOM(std::size_t size, bool nothrow) {
+        }
+
+        if (ptr == nullptr && !nothrow)
+-		std::__throw_bad_alloc();
++		throw std::bad_alloc();
+        return ptr;
+ }


### PR DESCRIPTION
Description:
Update spec file to fix build failures on Fedora Rawhide

Fixes: https://github.com/389ds/389-ds-base/issues/7178

## Summary by Sourcery

Build:
- Copy the jemalloc-5.3.0_throw_bad_alloc.patch into the RPM build SOURCES directory during SRPM generation.