### PR TITLE
Issue 6810 - Fix PAM PTA test

### DIFF
--- a/dirsrvtests/tests/suites/plugins/pam_pta_test.py
+++ b/dirsrvtests/tests/suites/plugins/pam_pta_test.py
@@ -104,6 +104,8 @@ def pam_service_ldapserver(migrated_child_config):
                 f.write(line + "\n")
         os.chmod(pam_file, 0o644)
 
+        yield
+
     except Exception as e:
         if os.path.exists(backup_file):
             # Restore backup on error


### PR DESCRIPTION
Description: Fix the PAM PTA test by add missing yield in fixture.

Relates: #6810

Reviewed by: @jchapma

## Summary by Sourcery

Fix the PAM PTA test fixture so its setup and teardown execute correctly.

Bug Fixes:
- Ensure the PAM PTA pytest fixture yields control so tests run and cleanup logic is executed.

Tests:
- Restore correct fixture behavior for the PAM PTA test suite to prevent fixture-related test failures.