### PR TITLE
Issue 7223 - Fix system index configuration issues (parentid/ancestorid)

### DIFF
--- a/dirsrvtests/tests/suites/config/config_test.py
+++ b/dirsrvtests/tests/suites/config/config_test.py
@@ -706,19 +706,17 @@ def test_ndn_cache_size_enforcement(topo, request):
 
     request.addfinalizer(fin)
 
-def test_require_index(topo, request):
+def test_require_index(topo):
     """Validate that unindexed searches are rejected
 
     :id: fb6e31f2-acc2-4e75-a195-5c356faeb803
     :setup: Standalone instance
     :steps:
         1. Set "nsslapd-require-index" to "on"
-        2. ancestorid/idlscanlimit to 100
-        3. Test an unindexed search is rejected
+        2. Test an unindexed search is rejected
     :expectedresults:
         1. Success
         2. Success
-        3. Success
     """
 
     # Set the config
@@ -729,10 +727,6 @@ def test_require_index(topo, request):
 
     db_cfg = DatabaseConfig(topo.standalone)
     db_cfg.set([('nsslapd-idlistscanlimit', '100')])
-    backend = Backends(topo.standalone).get_backend(DEFAULT_SUFFIX)
-    ancestorid_index = backend.get_index('ancestorid')
-    ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
-    topo.standalone.restart()
 
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     for i in range(101):
@@ -743,15 +737,10 @@ def test_require_index(topo, request):
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         raw_objects.filter("(description=test*)")
 
-    def fin():
-        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
-
-    request.addfinalizer(fin)
-
 
 
 @pytest.mark.skipif(ds_is_older('1.4.2'), reason="The config setting only exists in 1.4.2 and higher")
-def test_require_internal_index(topo, request):
+def test_require_internal_index(topo):
     """Ensure internal operations require indexed attributes
 
     :id: 22b94f30-59e3-4f27-89a1-c4f4be036f7f
@@ -782,10 +771,6 @@ def test_require_internal_index(topo, request):
     # Create a bunch of users
     db_cfg = DatabaseConfig(topo.standalone)
     db_cfg.set([('nsslapd-idlistscanlimit', '100')])
-    backend = Backends(topo.standalone).get_backend(DEFAULT_SUFFIX)
-    ancestorid_index = backend.get_index('ancestorid')
-    ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
-    topo.standalone.restart()
     users = UserAccounts(topo.standalone, DEFAULT_SUFFIX)
     for i in range(102, 202):
         users.create_test_user(uid=i)
@@ -809,12 +794,6 @@ def test_require_internal_index(topo, request):
     # Deletion of user should be rejected
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
         user.delete()
-
-    def fin():
-        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
-
-    request.addfinalizer(fin)
-
 
 
 def get_pstack(pid):

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -590,6 +590,599 @@ def test_upgrade_removes_ancestorid_index_config(topology_st):
         log.info(f"Idempotency verified - ancestorid still absent after second restart (got exception: {e})")
 
 
+def test_index_check_basic(topology_st):
+    """Check if dsctl index-check works correctly
+
+    :id: 8a4e5c2d-1f3b-4a7c-9e8d-2b6f0c4a5d3e
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Run dsctl index-check while server is running (should fail)
+        3. Stop the server
+        4. Run dsctl index-check (should pass)
+        5. Start the server
+    :expectedresults:
+        1. Success
+        2. index-check returns False and logs error
+        3. Success
+        4. index-check returns True (no mismatches)
+        5. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+    standalone = topology_st.standalone
+
+    log.info("Run index-check while server is running")
+    args = FakeArgs()
+    args.backend = None
+    args.fix = False
+
+    # Server should be running, index-check should fail
+    assert standalone.status()
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False
+    assert topology_st.logcap.contains("index-check requires the instance to be stopped")
+    topology_st.logcap.flush()
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Run index-check with server stopped")
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True
+    assert topology_st.logcap.contains("All checks passed")
+    topology_st.logcap.flush()
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_specific_backend(topology_st):
+    """Check if dsctl index-check works with a specific backend
+
+    :id: 407d8fcc-62e0-43dd-90fa-70e7090a5cfd
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Run dsctl index-check with specific backend (userRoot)
+        4. Run dsctl index-check with non-existent backend
+        5. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. index-check returns True for userRoot
+        4. index-check returns False for non-existent backend
+        5. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Run index-check for userRoot backend")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True
+    # Check for backend name in any case
+    assert topology_st.logcap.contains("Checking backend:")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check for non-existent backend")
+    args.backend = "nonExistentBackend"
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False
+    assert topology_st.logcap.contains("not found")
+    topology_st.logcap.flush()
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_mismatch_detection(topology_st):
+    """Check if dsctl index-check detects ordering mismatch
+
+    :id: 50d14520-b0bf-4243-9fe6-b097928d4351
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Run dsctl index-check (without --fix)
+        4. Verify output format
+        5. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. index-check returns True (no mismatch on fresh instance)
+        4. Log contains expected format
+        5. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Run index-check to verify detection logic")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    # On a fresh instance, there should be no mismatch
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    # Fresh instance should have matching config and disk ordering
+    assert result is True
+    # Check that the backend was checked (may skip indexes if ordering can't be determined)
+    assert topology_st.logcap.contains("Checking backend:")
+    topology_st.logcap.flush()
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_with_fix(topology_st):
+    """Check if dsctl index-check --fix triggers reindexing
+
+    :id: 38ae36e4-c861-4771-ae7d-354370376a2f
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Run dsctl index-check --fix (should pass since no mismatch)
+        4. Verify output indicates check passed
+        5. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. index-check returns True
+        4. Log contains "All checks passed"
+        5. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Run index-check with --fix option")
+    args = FakeArgs()
+    args.backend = None
+    args.fix = True
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    # On a fresh instance, there should be no mismatch, so no reindexing needed
+    assert result is True
+    assert topology_st.logcap.contains("All checks passed")
+    topology_st.logcap.flush()
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_fixes_scanlimit(topology_st):
+    """Check if dsctl index-check --fix removes nsIndexIDListScanLimit
+
+    :id: 4a9b2c7d-8e1f-4b3a-9c5d-6e7f8a0b1c2d
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Add nsIndexIDListScanLimit to parentid index using DSEldif
+        4. Run dsctl index-check (should detect issue)
+        5. Run dsctl index-check --fix
+        6. Verify nsIndexIDListScanLimit was removed
+        7. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. index-check returns False and detects scanlimit
+        5. index-check returns True after fix
+        6. nsIndexIDListScanLimit no longer present
+        7. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Add nsIndexIDListScanLimit to parentid index using DSEldif")
+    dse_ldif = DSEldif(standalone)
+    parentid_dn = "cn=parentid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+    dse_ldif.add(parentid_dn, "nsIndexIDListScanLimit", "4000")
+
+    # Verify it was added
+    scanlimit = dse_ldif.get(parentid_dn, "nsIndexIDListScanLimit", single=True)
+    assert scanlimit == "4000", f"Failed to add nsIndexIDListScanLimit, got: {scanlimit}"
+    log.info("Added nsIndexIDListScanLimit to parentid index")
+
+    log.info("Run index-check without --fix (should detect issue)")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False, "index-check should detect scanlimit issue"
+    assert topology_st.logcap.contains("nsIndexIDListScanLimit")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check with --fix")
+    args.fix = True
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check --fix should succeed"
+    assert topology_st.logcap.contains("Removed nsIndexIDListScanLimit")
+    topology_st.logcap.flush()
+
+    log.info("Verify nsIndexIDListScanLimit was removed")
+    dse_ldif = DSEldif(standalone)  # Reload to get fresh data
+    scanlimit = dse_ldif.get(parentid_dn, "nsIndexIDListScanLimit", single=True)
+    assert scanlimit is None, f"nsIndexIDListScanLimit should be removed, but got: {scanlimit}"
+    log.info("nsIndexIDListScanLimit successfully removed")
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_fixes_ancestorid_config(topology_st):
+    """Check if dsctl index-check --fix removes ancestorid config entries
+
+    :id: 5b0c3d8e-9f2a-4c4b-0d6e-7f8a9b1c2d3e
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Add ancestorid index config entry using DSEldif
+        4. Run dsctl index-check (should detect issue)
+        5. Run dsctl index-check --fix
+        6. Verify ancestorid config entry was removed
+        7. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. index-check returns False and detects ancestorid config
+        5. index-check returns True after fix
+        6. ancestorid config entry no longer present
+        7. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Add ancestorid index config entry using DSEldif")
+    dse_ldif = DSEldif(standalone)
+    ancestorid_entry = [
+        "dn: cn=ancestorid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config\n",
+        "objectClass: top\n",
+        "objectClass: nsIndex\n",
+        "cn: ancestorid\n",
+        "nsSystemIndex: true\n",
+        "nsIndexType: eq\n",
+    ]
+    dse_ldif.add_entry(ancestorid_entry)
+
+    # Verify it was added
+    ancestorid_dn = "cn=ancestorid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+    dse_ldif = DSEldif(standalone)  # Reload
+    cn_value = dse_ldif.get(ancestorid_dn, "cn", single=True)
+    assert cn_value is not None, "Failed to add ancestorid index config entry"
+    log.info(f"Added ancestorid index entry with cn: {cn_value}")
+
+    log.info("Run index-check without --fix (should detect issue)")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False, "index-check should detect ancestorid config issue"
+    assert topology_st.logcap.contains("ancestorid") and topology_st.logcap.contains("config entry exists")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check with --fix")
+    args.fix = True
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check --fix should succeed"
+    assert topology_st.logcap.contains("Removed ancestorid config entry")
+    topology_st.logcap.flush()
+
+    log.info("Verify ancestorid config entry was removed")
+    dse_ldif = DSEldif(standalone)  # Reload to get fresh data
+    cn_value = dse_ldif.get(ancestorid_dn, "cn", single=True)
+    assert cn_value is None, f"ancestorid config entry should be removed, but got: {cn_value}"
+    log.info("ancestorid config entry successfully removed")
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_fixes_missing_matching_rule(topology_st):
+    """Check if dsctl index-check --fix adds missing integerOrderingMatch
+
+    :id: 6c1d4e9f-0a3b-4d5c-1e7f-8a9b0c2d3e4f
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Remove integerOrderingMatch from parentid index using DSEldif
+        4. Run dsctl index-check (should detect issue)
+        5. Run dsctl index-check --fix
+        6. Verify integerOrderingMatch was added back
+        7. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. index-check returns False and detects missing matching rule
+        5. index-check returns True after fix
+        6. integerOrderingMatch is present
+        7. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Remove integerOrderingMatch from parentid index using DSEldif")
+    dse_ldif = DSEldif(standalone)
+    parentid_dn = "cn=parentid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+
+    # Check current matching rules
+    matching_rules = dse_ldif.get(parentid_dn, "nsMatchingRule")
+    log.info(f"Current matching rules: {matching_rules}")
+
+    # Remove integerOrderingMatch if present
+    if matching_rules:
+        for mr in matching_rules:
+            if "integerorderingmatch" in mr.lower():
+                dse_ldif.delete(parentid_dn, "nsMatchingRule", mr)
+                log.info(f"Removed matching rule: {mr}")
+
+    # Verify it was removed
+    dse_ldif = DSEldif(standalone)  # Reload
+    matching_rules = dse_ldif.get(parentid_dn, "nsMatchingRule")
+    if matching_rules:
+        for mr in matching_rules:
+            assert "integerorderingmatch" not in mr.lower(), \
+                f"integerOrderingMatch should be removed, but found: {mr}"
+    log.info("integerOrderingMatch removed from parentid index")
+
+    log.info("Run index-check without --fix (should detect issue)")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False, "index-check should detect missing matching rule"
+    assert topology_st.logcap.contains("missing integerOrderingMatch")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check with --fix")
+    args.fix = True
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check --fix should succeed"
+    assert topology_st.logcap.contains("integerOrderingMatch")
+    topology_st.logcap.flush()
+
+    log.info("Verify integerOrderingMatch was added back")
+    dse_ldif = DSEldif(standalone)  # Reload to get fresh data
+    matching_rules = dse_ldif.get(parentid_dn, "nsMatchingRule")
+    assert matching_rules is not None, "nsMatchingRule should be present"
+    found_int_order = False
+    for mr in matching_rules:
+        if "integerorderingmatch" in mr.lower():
+            found_int_order = True
+            break
+    assert found_int_order, f"integerOrderingMatch should be present, got: {matching_rules}"
+    log.info("integerOrderingMatch successfully added back")
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_fixes_default_ancestorid(topology_st):
+    """Check if dsctl index-check --fix removes ancestorid from default indexes
+
+    :id: 7d2e5f0a-1b4c-4e6d-2f8a-9b0c1d3e4f5a
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Add ancestorid to cn=default indexes using DSEldif
+        4. Run dsctl index-check (should detect issue)
+        5. Run dsctl index-check --fix
+        6. Verify ancestorid was removed from default indexes
+        7. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. index-check returns False and detects ancestorid in default indexes
+        5. index-check returns True after fix
+        6. ancestorid no longer in default indexes
+        7. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Add ancestorid to cn=default indexes using DSEldif")
+    dse_ldif = DSEldif(standalone)
+    ancestorid_default_entry = [
+        "dn: cn=ancestorid,cn=default indexes,cn=config,cn=ldbm database,cn=plugins,cn=config\n",
+        "objectClass: top\n",
+        "objectClass: nsIndex\n",
+        "cn: ancestorid\n",
+        "nsSystemIndex: true\n",
+        "nsIndexType: eq\n",
+    ]
+    dse_ldif.add_entry(ancestorid_default_entry)
+
+    # Verify it was added
+    ancestorid_default_dn = "cn=ancestorid,cn=default indexes,cn=config,cn=ldbm database,cn=plugins,cn=config"
+    dse_ldif = DSEldif(standalone)  # Reload
+    cn_value = dse_ldif.get(ancestorid_default_dn, "cn", single=True)
+    assert cn_value is not None, "Failed to add ancestorid to default indexes"
+    log.info(f"Added ancestorid to default indexes with cn: {cn_value}")
+
+    log.info("Run index-check without --fix (should detect issue)")
+    args = FakeArgs()
+    args.backend = None  # Check all backends including default indexes
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False, "index-check should detect ancestorid in default indexes"
+    assert topology_st.logcap.contains("ancestorid found in cn=default indexes")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check with --fix")
+    args.fix = True
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check --fix should succeed"
+    assert topology_st.logcap.contains("Removed ancestorid from default indexes")
+    topology_st.logcap.flush()
+
+    log.info("Verify ancestorid was removed from default indexes")
+    dse_ldif = DSEldif(standalone)  # Reload to get fresh data
+    cn_value = dse_ldif.get(ancestorid_default_dn, "cn", single=True)
+    assert cn_value is None, f"ancestorid should be removed from default indexes, but got: {cn_value}"
+    log.info("ancestorid successfully removed from default indexes")
+
+    log.info("Start the server")
+    standalone.start()
+
+
+def test_index_check_fixes_multiple_issues(topology_st):
+    """Check if dsctl index-check --fix handles multiple issues at once
+
+    :id: 8e3f6a1b-2c5d-4f7e-3a9b-0c1d2e4f5a6b
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Add multiple issues: scanlimit, ancestorid config, missing matching rule
+        4. Run dsctl index-check (should detect all issues)
+        5. Run dsctl index-check --fix
+        6. Verify all issues were fixed
+        7. Run dsctl index-check again (should pass)
+        8. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. index-check returns False and detects all issues
+        5. index-check returns True after fix
+        6. All issues resolved
+        7. index-check returns True (no issues)
+        8. Success
+    """
+    from lib389.cli_ctl.dbtasks import dbtasks_index_check
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    dse_ldif = DSEldif(standalone)
+    parentid_dn = "cn=parentid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+    ancestorid_dn = "cn=ancestorid,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+
+    log.info("Add issue 1: nsIndexIDListScanLimit to parentid")
+    dse_ldif.add(parentid_dn, "nsIndexIDListScanLimit", "4000")
+
+    log.info("Add issue 2: ancestorid index config entry")
+    ancestorid_entry = [
+        f"dn: {ancestorid_dn}\n",
+        "objectClass: top\n",
+        "objectClass: nsIndex\n",
+        "cn: ancestorid\n",
+        "nsSystemIndex: true\n",
+        "nsIndexType: eq\n",
+    ]
+    dse_ldif.add_entry(ancestorid_entry)
+
+    log.info("Add issue 3: Remove integerOrderingMatch from parentid")
+    dse_ldif = DSEldif(standalone)  # Reload
+    matching_rules = dse_ldif.get(parentid_dn, "nsMatchingRule")
+    if matching_rules:
+        for mr in matching_rules:
+            if "integerorderingmatch" in mr.lower():
+                dse_ldif.delete(parentid_dn, "nsMatchingRule", mr)
+
+    log.info("Run index-check without --fix (should detect all issues)")
+    args = FakeArgs()
+    args.backend = "userRoot"
+    args.fix = False
+
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is False, "index-check should detect multiple issues"
+    # Check that multiple issues were detected
+    assert topology_st.logcap.contains("nsIndexIDListScanLimit")
+    assert topology_st.logcap.contains("ancestorid")
+    topology_st.logcap.flush()
+
+    log.info("Run index-check with --fix")
+    args.fix = True
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check --fix should succeed"
+    assert topology_st.logcap.contains("All issues fixed")
+    topology_st.logcap.flush()
+
+    log.info("Verify all issues were fixed")
+    dse_ldif = DSEldif(standalone)  # Reload
+
+    # Check scanlimit removed
+    scanlimit = dse_ldif.get(parentid_dn, "nsIndexIDListScanLimit", single=True)
+    assert scanlimit is None, f"nsIndexIDListScanLimit should be removed, got: {scanlimit}"
+
+    # Check ancestorid config removed
+    cn_value = dse_ldif.get(ancestorid_dn, "cn", single=True)
+    assert cn_value is None, f"ancestorid config should be removed, got: {cn_value}"
+
+    # Check matching rule added back
+    matching_rules = dse_ldif.get(parentid_dn, "nsMatchingRule")
+    found_int_order = False
+    if matching_rules:
+        for mr in matching_rules:
+            if "integerorderingmatch" in mr.lower():
+                found_int_order = True
+                break
+    assert found_int_order, f"integerOrderingMatch should be present, got: {matching_rules}"
+
+    log.info("All issues verified as fixed")
+
+    log.info("Run index-check again to confirm all clear")
+    args.fix = False
+    result = dbtasks_index_check(standalone, topology_st.logcap.log, args)
+    assert result is True, "index-check should pass after fix"
+    assert topology_st.logcap.contains("All checks passed")
+    topology_st.logcap.flush()
+
+    log.info("Start the server")
+    standalone.start()
+
+
 if __name__ == "__main__":
     # Run isolated
     # -s for DEBUG mode

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -453,6 +453,58 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
 
+def test_upgrade_removes_parentid_scanlimit(topology_st):
+    """Check if upgrade function removes nsIndexIDListScanLimit from parentid index
+
+    :id: 2808886e-c1c1-441d-b3a3-299c4ef1ab4a
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Use DSEldif to add nsIndexIDListScanLimit to parentid index
+        4. Start the server (triggers upgrade)
+        5. Verify nsIndexIDListScanLimit is removed from parentid index
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. nsIndexIDListScanLimit is no longer present
+    """
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+    SCANLIMIT_VALUE = "limit=5000 type=eq flags=AND"
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Add nsIndexIDListScanLimit to parentid index using DSEldif")
+    dse_ldif = DSEldif(standalone)
+    dse_ldif.add(PARENTID_DN, "nsIndexIDListScanLimit", SCANLIMIT_VALUE)
+
+    # Verify it was added
+    scanlimit = dse_ldif.get(PARENTID_DN, "nsIndexIDListScanLimit")
+    assert scanlimit is not None, "Failed to add nsIndexIDListScanLimit"
+    log.info(f"Added nsIndexIDListScanLimit: {scanlimit}")
+
+    log.info("Start the server (triggers upgrade)")
+    standalone.start()
+
+    log.info("Verify nsIndexIDListScanLimit was removed by upgrade")
+    # Check via LDAP - the upgrade should have removed it
+    parentid_index = Index(standalone, PARENTID_DN)
+    scanlimit_after = parentid_index.get_attr_vals_utf8("nsIndexIDListScanLimit")
+    log.info(f"nsIndexIDListScanLimit after upgrade: {scanlimit_after}")
+
+    # The upgrade function should have removed nsIndexIDListScanLimit
+    assert not scanlimit_after, \
+        f"nsIndexIDListScanLimit should have been removed but found: {scanlimit_after}"
+
+    log.info("Upgrade successfully removed nsIndexIDListScanLimit from parentid index")
+
+
 if __name__ == "__main__":
     # Run isolated
     # -s for DEBUG mode

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -504,6 +504,91 @@ def test_upgrade_removes_parentid_scanlimit(topology_st):
 
     log.info("Upgrade successfully removed nsIndexIDListScanLimit from parentid index")
 
+    # Verify idempotency - restart again and ensure no errors
+    log.info("Restart server again to verify idempotency (no errors on second run)")
+    standalone.restart()
+    # Verify the attribute is still absent
+    scanlimit_after_second = parentid_index.get_attr_vals_utf8("nsIndexIDListScanLimit")
+    assert not scanlimit_after_second, \
+        f"nsIndexIDListScanLimit should still be absent after second restart but found: {scanlimit_after_second}"
+    log.info("Idempotency verified - no issues on second restart")
+
+
+def test_upgrade_removes_ancestorid_index_config(topology_st):
+    """Check if upgrade function removes ancestorid index config entry
+
+    :id: 3f3d6e9b-75ac-4f0d-b2ce-7204e6eacd0a
+    :setup: Standalone instance
+    :steps:
+        1. Create DS instance
+        2. Stop the server
+        3. Use DSEldif to add an ancestorid index config entry
+        4. Start the server (triggers upgrade)
+        5. Verify ancestorid index config entry is removed
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. ancestorid index config entry is no longer present
+    """
+    from lib389.dseldif import DSEldif
+
+    standalone = topology_st.standalone
+    ANCESTORID_DN = "cn=ancestorid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
+
+    log.info("Stop the server")
+    standalone.stop()
+
+    log.info("Add ancestorid index config entry using DSEldif")
+    dse_ldif = DSEldif(standalone)
+
+    # Create a fake ancestorid index entry
+    ancestorid_entry = [
+        "dn: {}\n".format(ANCESTORID_DN),
+        "objectClass: top\n",
+        "objectClass: nsIndex\n",
+        "cn: ancestorid\n",
+        "nsSystemIndex: true\n",
+        "nsIndexType: eq\n",
+        "nsMatchingRule: integerOrderingMatch\n",
+        "\n"
+    ]
+    dse_ldif.add_entry(ancestorid_entry)
+
+    # Verify it was added by re-reading dse.ldif
+    dse_ldif2 = DSEldif(standalone)
+    cn_value = dse_ldif2.get(ANCESTORID_DN, "cn")
+    assert cn_value is not None, "Failed to add ancestorid index config entry"
+    log.info(f"Added ancestorid index entry with cn: {cn_value}")
+
+    log.info("Start the server (triggers upgrade)")
+    standalone.start()
+
+    log.info("Verify ancestorid index config entry was removed by upgrade")
+    # Check via LDAP - the upgrade should have removed the entry
+    try:
+        ancestorid_index = Index(standalone, ANCESTORID_DN)
+        # If we can get the entry, it wasn't removed - this is a failure
+        cn_after = ancestorid_index.get_attr_vals_utf8("cn")
+        assert False, f"ancestorid index config entry should have been removed but still exists: {cn_after}"
+    except Exception as e:
+        # Entry should not exist - this is expected
+        log.info(f"ancestorid index config entry correctly removed (got exception: {e})")
+
+    log.info("Upgrade successfully removed ancestorid index config entry")
+
+    # Verify idempotency - restart again and ensure no errors
+    log.info("Restart server again to verify idempotency (no errors on second run)")
+    standalone.restart()
+    # Verify the entry is still absent
+    try:
+        ancestorid_index = Index(standalone, ANCESTORID_DN)
+        cn_after_second = ancestorid_index.get_attr_vals_utf8("cn")
+        assert False, f"ancestorid index config entry should still be absent after second restart but found: {cn_after_second}"
+    except Exception as e:
+        log.info(f"Idempotency verified - ancestorid still absent after second restart (got exception: {e})")
+
 
 if __name__ == "__main__":
     # Run isolated

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -172,9 +172,7 @@ def test_missing_parentid(topology_st, log_buffering_enabled):
 
     log.info("Re-add the parentId index")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
-                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
-    standalone.restart()
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -263,8 +261,7 @@ def test_usn_plugin_missing_entryusn(topology_st, usn_plugin_enabled, log_buffer
 
     log.info("Re-add the entryusn index")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"],
-                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
+    backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"])
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -408,132 +405,6 @@ def test_retrocl_plugin_missing_matching_rule(topology_st, retrocl_plugin_enable
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
 
-def test_missing_scanlimit(topology_st, log_buffering_enabled):
-    """Check if healthcheck returns DSBLE0007 code when parentId index is missing scanlimit
-
-    :id: 40e1bf6a-2397-459b-bdf3-f787ca118b86
-    :setup: Standalone instance
-    :steps:
-        1. Create DS instance
-        2. Remove nsIndexIDListScanLimit from parentId index
-        3. Use healthcheck without --json option
-        4. Use healthcheck with --json option
-        5. Verify the remediation command has properly quoted scanlimit
-        6. Re-add the scanlimit
-        7. Use healthcheck without --json option
-        8. Use healthcheck with --json option
-    :expectedresults:
-        1. Success
-        2. Success
-        3. healthcheck reports DSBLE0007 code and related details
-        4. healthcheck reports DSBLE0007 code and related details
-        5. The scanlimit value is quoted in the remediation command
-        6. Success
-        7. healthcheck reports no issues found
-        8. healthcheck reports no issues found
-    """
-
-    RET_CODE = "DSBLE0007"
-    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
-    SCANLIMIT_VALUE = "limit=5000 type=eq flags=AND"
-
-    standalone = topology_st.standalone
-
-    log.info("Remove nsIndexIDListScanLimit from parentId index")
-    parentid_index = Index(standalone, PARENTID_DN)
-    parentid_index.remove("nsIndexIDListScanLimit", SCANLIMIT_VALUE)
-
-    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
-
-    # Verify the remediation command has properly quoted scanlimit
-    args = FakeArgs()
-    args.instance = standalone.serverid
-    args.verbose = standalone.verbose
-    args.list_errors = False
-    args.list_checks = False
-    args.exclude_check = []
-    args.check = ["backends"]
-    args.dry_run = False
-    args.json = False
-    health_check_run(standalone, topology_st.logcap.log, args)
-    # Check that the scanlimit is quoted in the output
-    assert topology_st.logcap.contains('--add-scanlimit "limit=5000 type=eq flags=AND"')
-    log.info("Verified scanlimit is properly quoted in remediation command")
-    topology_st.logcap.flush()
-
-    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
-
-    log.info("Re-add the nsIndexIDListScanLimit")
-    parentid_index = Index(standalone, PARENTID_DN)
-    parentid_index.add("nsIndexIDListScanLimit", SCANLIMIT_VALUE)
-
-    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
-    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
-
-
-def test_missing_matching_rule_and_scanlimit(topology_st, log_buffering_enabled):
-    """Check if healthcheck generates a single combined command when both matching rule and scanlimit are missing
-
-    :id: af8214ad-5e4c-422a-8f74-3e99227551df
-    :setup: Standalone instance
-    :steps:
-        1. Create DS instance
-        2. Remove both integerOrderingMatch and nsIndexIDListScanLimit from parentId index
-        3. Use healthcheck and verify a single combined command is generated
-        4. Re-add the matching rule and scanlimit
-        5. Use healthcheck without --json option
-        6. Use healthcheck with --json option
-    :expectedresults:
-        1. Success
-        2. Success
-        3. healthcheck reports DSBLE0007 and generates a single command with both --add-mr and --add-scanlimit
-        4. Success
-        5. healthcheck reports no issues found
-        6. healthcheck reports no issues found
-    """
-
-    RET_CODE = "DSBLE0007"
-    PARENTID_DN = "cn=parentid,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config"
-    SCANLIMIT_VALUE = "limit=5000 type=eq flags=AND"
-
-    standalone = topology_st.standalone
-
-    log.info("Remove both integerOrderingMatch and nsIndexIDListScanLimit from parentId index")
-    parentid_index = Index(standalone, PARENTID_DN)
-    parentid_index.remove("nsMatchingRule", "integerOrderingMatch")
-    parentid_index.remove("nsIndexIDListScanLimit", SCANLIMIT_VALUE)
-
-    # Run healthcheck and verify combined command
-    args = FakeArgs()
-    args.instance = standalone.serverid
-    args.verbose = standalone.verbose
-    args.list_errors = False
-    args.list_checks = False
-    args.exclude_check = []
-    args.check = ["backends"]
-    args.dry_run = False
-    args.json = False
-    health_check_run(standalone, topology_st.logcap.log, args)
-
-    # Verify DSBLE0007 is reported
-    assert topology_st.logcap.contains(RET_CODE)
-    log.info("healthcheck returned code: %s" % RET_CODE)
-
-    # Verify a single combined command is generated with both --add-mr and --add-scanlimit
-    assert topology_st.logcap.contains('--add-mr integerOrderingMatch --add-scanlimit "limit=5000 type=eq flags=AND"')
-    log.info("Verified combined command with both --add-mr and --add-scanlimit")
-
-    topology_st.logcap.flush()
-
-    log.info("Re-add the integerOrderingMatch matching rule and scanlimit")
-    parentid_index = Index(standalone, PARENTID_DN)
-    parentid_index.add("nsMatchingRule", "integerOrderingMatch")
-    parentid_index.add("nsIndexIDListScanLimit", SCANLIMIT_VALUE)
-
-    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
-    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
-
-
 def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
     """Check if healthcheck returns DSBLE0007 code when multiple system indexes are missing
 
@@ -574,8 +445,7 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
 
     log.info("Re-add the missing system indexes")
     backend = Backends(standalone).get("userRoot")
-    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"],
-                      idlistscanlimit=['limit=5000 type=eq flags=AND'])
+    backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
     backend.add_index("nsuniqueid", ["eq"])
     standalone.restart()
 

--- a/dirsrvtests/tests/suites/paged_results/paged_results_test.py
+++ b/dirsrvtests/tests/suites/paged_results/paged_results_test.py
@@ -306,19 +306,19 @@ def test_search_success(topology_st, create_user, page_size, users_num):
     del_users(users_list)
 
 
-@pytest.mark.parametrize("page_size,users_num,suffix,attr_name,attr_value,expected_err, restart", [
+@pytest.mark.parametrize("page_size,users_num,suffix,attr_name,attr_value,expected_err", [
     (50, 200, 'cn=config,%s' % DN_LDBM, 'nsslapd-idlistscanlimit', '100',
-     ldap.UNWILLING_TO_PERFORM, True),
+     ldap.UNWILLING_TO_PERFORM),
     (5, 15, DN_CONFIG, 'nsslapd-timelimit', '20',
-     ldap.UNAVAILABLE_CRITICAL_EXTENSION, False),
+     ldap.UNAVAILABLE_CRITICAL_EXTENSION),
     (21, 50, DN_CONFIG, 'nsslapd-sizelimit', '20',
-     ldap.SIZELIMIT_EXCEEDED, False),
+     ldap.SIZELIMIT_EXCEEDED),
     (21, 50, DN_CONFIG, 'nsslapd-pagedsizelimit', '5',
-     ldap.SIZELIMIT_EXCEEDED, False),
+     ldap.SIZELIMIT_EXCEEDED),
     (5, 50, 'cn=config,%s' % DN_LDBM, 'nsslapd-lookthroughlimit', '20',
-     ldap.ADMINLIMIT_EXCEEDED, False)])
+     ldap.ADMINLIMIT_EXCEEDED)])
 def test_search_limits_fail(topology_st, create_user, page_size, users_num,
-                            suffix, attr_name, attr_value, expected_err, restart):
+                            suffix, attr_name, attr_value, expected_err):
     """Verify that search with a simple paged results control
     throws expected exceptoins when corresponding limits are
     exceeded.
@@ -341,15 +341,6 @@ def test_search_limits_fail(topology_st, create_user, page_size, users_num,
 
     users_list = add_users(topology_st, users_num, DEFAULT_SUFFIX)
     attr_value_bck = change_conf_attr(topology_st, suffix, attr_name, attr_value)
-    ancestorid_index = None
-    if attr_name == 'nsslapd-idlistscanlimit':
-        backend = Backends(topology_st.standalone).get_backend(DEFAULT_SUFFIX)
-        ancestorid_index = backend.get_index('ancestorid')
-        ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=100 type=eq flags=AND"))
-
-    if (restart):
-        log.info('Instance restarted')
-        topology_st.standalone.restart()
     conf_param_dict = {attr_name: attr_value}
     search_flt = r'(uid=test*)'
     searchreq_attrlist = ['dn', 'sn']
@@ -402,8 +393,6 @@ def test_search_limits_fail(topology_st, create_user, page_size, users_num,
             else:
                 break
     finally:
-        if ancestorid_index:
-            ancestorid_index.replace("nsIndexIDListScanLimit", ensure_bytes("limit=5000 type=eq flags=AND"))
         del_users(users_list)
         change_conf_attr(topology_st, suffix, attr_name, attr_value_bck)
 

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -998,14 +998,6 @@ cn: aci
 nssystemindex: true
 nsindextype: pres
 
-dn: cn=ancestorid,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
-objectclass: top
-objectclass: nsIndex
-cn: ancestorid
-nssystemindex: true
-nsindextype: eq
-nsmatchingrule: integerOrderingMatch
-
 dn: cn=cn,cn=default indexes, cn=config,cn=ldbm database,cn=plugins,cn=config
 objectclass: top
 objectclass: nsIndex

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -583,7 +583,6 @@ struct ldbminfo
     int li_mode;
     int li_lookthroughlimit;
     int li_allidsthreshold;
-    int li_system_allidsthreshold;
     char *li_directory;
     int li_reslimit_lookthrough_handle;
     uint64_t li_dbcachesize;

--- a/ldap/servers/slapd/back-ldbm/index.c
+++ b/ldap/servers/slapd/back-ldbm/index.c
@@ -997,8 +997,6 @@ index_read_ext_allids(
     }
     if (pb) {
         slapi_pblock_get(pb, SLAPI_SEARCH_IS_AND, &is_and);
-    } else if (strcasecmp(type, LDBM_ANCESTORID_STR) == 0) {
-        is_and = 1;
     }
     ai_flags = is_and ? INDEX_ALLIDS_FLAG_AND : 0;
     /* the caller can pass in a value of 0 - just ignore those - but if the index

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -239,6 +239,266 @@ ldbm_instance_create_default_indexes(backend *be)
 }
 
 
+/*
+ * Check if an index has integerOrderingMatch configured in DSE.
+ *
+ * This function performs an internal LDAP search to check if the index
+ * configuration entry has nsMatchingRule: integerOrderingMatch.
+ *
+ * Parameters:
+ *   inst_name - backend instance name (e.g., "userRoot")
+ *   index_name - name of the index to check (e.g., "parentid", "ancestorid")
+ *
+ * Returns:
+ *   PR_TRUE if integerOrderingMatch is configured
+ *   PR_FALSE if not configured or index entry doesn't exist
+ */
+static PRBool
+ldbm_instance_index_has_int_order_in_dse(const char *inst_name, const char *index_name)
+{
+    Slapi_PBlock *pb = NULL;
+    Slapi_Entry **entries = NULL;
+    char *idx_dn = NULL;
+    PRBool has_int_order = PR_FALSE;
+
+    idx_dn = slapi_create_dn_string("cn=%s,cn=index,cn=%s,cn=ldbm database,cn=plugins,cn=config",
+                                     index_name, inst_name);
+    if (idx_dn == NULL) {
+        return PR_FALSE;
+    }
+
+    pb = slapi_pblock_new();
+    slapi_search_internal_set_pb(pb, idx_dn, LDAP_SCOPE_BASE,
+                                  "(objectclass=nsIndex)", NULL, 0, NULL, NULL,
+                                  plugin_get_default_component_id(), 0);
+    slapi_search_internal_pb(pb);
+    slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &entries);
+
+    if (entries && entries[0]) {
+        Slapi_Attr *mr_attr = NULL;
+        if (slapi_entry_attr_find(entries[0], "nsMatchingRule", &mr_attr) == 0) {
+            Slapi_Value *sval = NULL;
+            int idx;
+            for (idx = slapi_attr_first_value(mr_attr, &sval);
+                 idx != -1;
+                 idx = slapi_attr_next_value(mr_attr, idx, &sval)) {
+                const struct berval *bval = slapi_value_get_berval(sval);
+                if (bval && bval->bv_val &&
+                    strcasecmp(bval->bv_val, "integerOrderingMatch") == 0) {
+                    has_int_order = PR_TRUE;
+                    break;
+                }
+            }
+        }
+    }
+
+    slapi_ch_free_string(&idx_dn);
+    slapi_free_search_results_internal(pb);
+    slapi_pblock_destroy(pb);
+
+    return has_int_order;
+}
+
+/*
+ * Check a system index for ordering mismatch between config and on-disk data.
+ *
+ * This function compares what's configured in DSE (nsMatchingRule) with
+ * what's actually on disk. A mismatch can occur in two scenarios:
+ * 1. Ordering rule is configured but disk has lexicographic order
+ *    (rule was added after index was created)
+ * 2. No ordering rule configured but disk has integer order
+ *    (rule was removed after index was created with it)
+ *
+ * This function reads the first keys from the specified index and checks
+ * if they are stored in lexicographic order (string: "1" < "10" < "2") or
+ * integer order (numeric: "1" < "2" < "10").
+ *
+ * Parameters:
+ *   be - backend
+ *   index_name - name of the index to check (e.g., "parentid", "ancestorid")
+ *
+ */
+static void
+ldbm_instance_check_index_config(backend *be, const char *index_name)
+{
+    ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
+    struct attrinfo *ai = NULL;
+    dbi_db_t *db = NULL;
+    dbi_cursor_t dbc = {0};
+    dbi_val_t key = {0};
+    dbi_val_t data = {0};
+    int ret = 0;
+    PRBool config_has_int_order = PR_FALSE;
+    PRBool disk_has_int_order = PR_TRUE;  /* Assume integer order until proven otherwise */
+    ID prev_id = 0;
+    int key_count = 0;
+    PRBool first_key = PR_TRUE;
+    PRBool found_ordering_evidence = PR_FALSE;
+
+    slapi_log_err(SLAPI_LOG_DEBUG, "ldbm_instance_check_index_config",
+            "Backend '%s': checking %s index ordering...\n",
+            inst->inst_name, index_name);
+
+    /* Check if integerOrderingMatch is configured in DSE */
+    config_has_int_order = ldbm_instance_index_has_int_order_in_dse(inst->inst_name, index_name);
+
+    /* Get attrinfo for the index */
+    ainfo_get(be, (char *)index_name, &ai);
+    if (ai == NULL || strcmp(ai->ai_type, index_name) != 0) {
+        /* No index config found */
+        slapi_log_err(SLAPI_LOG_DEBUG, "ldbm_instance_check_index_config",
+                "Backend '%s': no %s attrinfo found, skipping check\n",
+                inst->inst_name, index_name);
+        return;
+    }
+
+    /* Open the index file */
+    ret = dblayer_get_index_file(be, ai, &db, 0);
+    if (ret != 0 || db == NULL) {
+        /* Index file doesn't exist or can't be opened - this is fine for new instances */
+        slapi_log_err(SLAPI_LOG_DEBUG, "ldbm_instance_check_index_config",
+                "Backend '%s': could not open %s index file (ret=%d), skipping order check\n",
+                inst->inst_name, index_name, ret);
+        return;
+    }
+
+    /* Create a cursor to read keys */
+    ret = dblayer_new_cursor(be, db, NULL, &dbc);
+    if (ret != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "ldbm_instance_check_index_config",
+                "Backend '%s': could not create cursor on %s index (ret=%d)\n",
+                inst->inst_name, index_name, ret);
+        dblayer_release_index_file(be, ai, db);
+        return;
+    }
+
+    dblayer_value_init(be, &key);
+    dblayer_value_init(be, &data);
+
+    /*
+     * Read up to 100 unique keys and check their ordering.
+     * With lexicographic ordering: "1" < "10" < "100" < "2" < "20" < "3"
+     * With integer ordering: "1" < "2" < "3" < "10" < "20" < "100"
+     *
+     * If we find a case where prev_id > current_id (numerically), but the
+     * keys are still in order (lexicographically), then the index uses
+     * lexicographic ordering.
+     */
+    while (key_count < 100) {
+        ID current_id;
+
+        ret = dblayer_cursor_op(&dbc, first_key ? DBI_OP_MOVE_TO_FIRST : DBI_OP_NEXT_KEY, &key, &data);
+        first_key = PR_FALSE;  /* Always advance cursor on next iteration */
+        if (ret != 0) {
+            break;  /* No more keys or error */
+        }
+
+        /* Skip non-equality keys */
+        if (key.size < 2 || *(char *)key.data != EQ_PREFIX) {
+            continue;
+        }
+
+        /* Parse the ID from the key (format: "=<id>") */
+        current_id = (ID)strtoul((char *)key.data + 1, NULL, 10);
+        if (current_id == 0) {
+            continue;  /* Invalid ID, skip */
+        }
+
+        key_count++;
+
+        if (prev_id != 0) {
+            /*
+             * Check ordering: if prev_id > current_id numerically,
+             * but we got this key after prev in DB order, then
+             * the index is using lexicographic ordering.
+             *
+             * Example: if we see "10" followed by "2", that's lexicographic
+             * because "10" < "2" as strings, but 10 > 2 as integers.
+             */
+            if (prev_id > current_id) {
+                /* Found evidence of lexicographic ordering */
+                disk_has_int_order = PR_FALSE;
+                found_ordering_evidence = PR_TRUE;
+                break;
+            } else if (prev_id < current_id) {
+                /*
+                 * This is consistent with integer ordering, but we need
+                 * to find a case that proves lexicographic ordering.
+                 * For example, seeing "1" followed by "2" is ambiguous,
+                 * but seeing "1" followed by "10" (not "2") proves lexicographic.
+                 *
+                 * A definitive test: if we see an ID followed by a smaller
+                 * ID, that's lexicographic. If all IDs are strictly increasing,
+                 * it could be either (or the index only has sequential IDs).
+                 */
+                found_ordering_evidence = PR_TRUE;
+            }
+        }
+        prev_id = current_id;
+    }
+
+    /* Close the cursor and free values */
+    dblayer_cursor_op(&dbc, DBI_OP_CLOSE, NULL, NULL);
+    dblayer_value_free(be, &key);
+    dblayer_value_free(be, &data);
+
+    /* Release the index file */
+    dblayer_release_index_file(be, ai, db);
+
+    /*
+     * Report findings and check for config/disk mismatch.
+     * Log an error if there's a discrepancy between what's configured
+     * in DSE and what's actually on disk.
+     */
+    if (!found_ordering_evidence) {
+        slapi_log_err(SLAPI_LOG_DEBUG, "ldbm_instance_check_index_config",
+                "Backend '%s': %s index ordering check - "
+                "could not determine on-disk ordering (index may be empty or have sequential IDs only). "
+                "Config has integerOrderingMatch: %s\n",
+                inst->inst_name, index_name, config_has_int_order ? "yes" : "no");
+    } else if (config_has_int_order && !disk_has_int_order) {
+        /* Config expects integer ordering, but disk has lexicographic - MISMATCH */
+        slapi_log_err(SLAPI_LOG_ERR, "ldbm_instance_check_index_config",
+                "Backend '%s': MISMATCH - %s index has integerOrderingMatch configured, "
+                "but on-disk data uses lexicographic ordering. "
+                "This will cause searches to return incorrect or incomplete results. "
+                "Please reindex the %s attribute: "
+                "dsconf <instance> backend index reindex --attr %s %s\n",
+                inst->inst_name, index_name, index_name, index_name, inst->inst_name);
+    } else if (!config_has_int_order && disk_has_int_order) {
+        /* Config expects lexicographic ordering, but disk has integer - MISMATCH */
+        slapi_log_err(SLAPI_LOG_ERR, "ldbm_instance_check_index_config",
+                "Backend '%s': MISMATCH - %s index does not have integerOrderingMatch configured, "
+                "but on-disk data uses integer ordering. "
+                "This will cause searches to return incorrect or incomplete results. "
+                "Please reindex the %s attribute: "
+                "dsconf <instance> backend index reindex --attr %s %s\n",
+                inst->inst_name, index_name, index_name, index_name, inst->inst_name);
+    } else {
+        /* Config and disk ordering match - no action needed */
+        slapi_log_err(SLAPI_LOG_DEBUG, "ldbm_instance_check_index_config",
+                "Backend '%s': %s index ordering check passed - "
+                "config has integerOrderingMatch: %s, on-disk data matches.\n",
+                inst->inst_name, index_name, config_has_int_order ? "yes" : "no");
+    }
+}
+
+/*
+ * Check system indexes for ordering mismatches.
+ * If a mismatch is detected, log an error advising the administrator
+ * to reindex the affected attribute.
+ *
+ * Note: We only check parentid here. The ancestorid index is a special
+ * system index that has no DSE config entry - its ordering is hardcoded
+ * in ldbm_instance_init_config_entry() and cannot be changed by users.
+ */
+static void
+ldbm_instance_check_indexes(backend *be)
+{
+    /* Check parentid index */
+    ldbm_instance_check_index_config(be, LDBM_PARENTID_STR);
+}
+
 /* Starts a backend instance */
 int
 ldbm_instance_start(backend *be)
@@ -308,6 +568,8 @@ ldbm_instance_startall(struct ldbminfo *li)
             ldbm_instance_register_modify_callback(inst);
             vlv_init(inst);
             slapi_mtn_be_started(inst->inst_be);
+            /* Check index configuration for potential issues */
+            ldbm_instance_check_indexes(inst->inst_be);
         }
         if (slapi_exist_referral(inst->inst_be)) {
             slapi_be_set_flag(inst->inst_be, SLAPI_BE_FLAG_CONTAINS_REFERRAL);

--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -16,7 +16,7 @@
 
 /* Forward declarations */
 static void ldbm_instance_destructor(void **arg);
-Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4, char *mr, char *scanlimit);
+Slapi_Entry *ldbm_instance_init_config_entry(char *cn_val, char *v1, char *v2, char *v3, char *v4, char *mr);
 
 
 /* Creates and initializes a new ldbm_instance structure.
@@ -126,7 +126,7 @@ done:
  * Take a bunch of strings, and create a index config entry
  */
 Slapi_Entry *
-ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4, char *mr, char *scanlimit)
+ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3, char *val4, char *mr)
 {
     Slapi_Entry *e = slapi_entry_alloc();
     struct berval *vals[2];
@@ -167,11 +167,6 @@ ldbm_instance_init_config_entry(char *cn_val, char *val1, char *val2, char *val3
         slapi_entry_add_values(e, "nsMatchingRule", vals);
     }
 
-    if (scanlimit) {
-        val.bv_val = scanlimit;
-        val.bv_len = strlen(scanlimit);
-        slapi_entry_add_values(e, "nsIndexIDListScanLimit", vals);
-    }
     return e;
 }
 
@@ -184,60 +179,8 @@ ldbm_instance_create_default_indexes(backend *be)
 {
     Slapi_Entry *e;
     ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
-    struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
     /* write the dse file only on the final index */
     int flags = LDBM_INSTANCE_CONFIG_DONT_WRITE;
-    char *ancestorid_indexes_limit = NULL;
-    char *parentid_indexes_limit = NULL;
-    struct attrinfo *ai = NULL;
-    int index_already_configured = 0;
-    struct index_idlistsizeinfo *iter;
-    int cookie;
-    int limit;
-
-    ainfo_get(be, (char *)LDBM_ANCESTORID_STR, &ai);
-    if (ai && ai->ai_idlistinfo) {
-        iter = (struct index_idlistsizeinfo *)dl_get_first(ai->ai_idlistinfo, &cookie);
-        if (iter) {
-            limit = iter->ai_idlistsizelimit;
-            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set ancestorid limit to %d from attribute index\n",
-                      limit);
-        } else {
-            limit = li->li_system_allidsthreshold;
-            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set ancestorid limit to %d from default (fail to read limit)\n",
-                      limit);
-        }
-        ancestorid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", limit);
-    } else {
-        ancestorid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", li->li_system_allidsthreshold);
-        slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set ancestorid limit to %d from default (no attribute or limit)\n",
-                      li->li_system_allidsthreshold);
-    }
-
-    ainfo_get(be, (char *)LDBM_PARENTID_STR, &ai);
-    if (ai && ai->ai_idlistinfo) {
-        iter = (struct index_idlistsizeinfo *)dl_get_first(ai->ai_idlistinfo, &cookie);
-        if (iter) {
-            limit = iter->ai_idlistsizelimit;
-            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set parentid limit to %d from attribute index\n",
-                      limit);
-        } else {
-            limit = li->li_system_allidsthreshold;
-            slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set parentid limit to %d from default (fail to read limit)\n",
-                      limit);
-        }
-        parentid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", limit);
-    } else {
-        parentid_indexes_limit = slapi_ch_smprintf("limit=%d type=eq flags=AND", li->li_system_allidsthreshold);
-        slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_instance_create_default_indexes",
-                      "set parentid limit to %d from default (no attribute or limit)\n",
-                      li->li_system_allidsthreshold);
-    }
 
     /*
      * Always index (entrydn or entryrdn), parentid, objectclass,
@@ -245,48 +188,42 @@ ldbm_instance_create_default_indexes(backend *be)
      * since they are used by some searches, replication and the
      * ACL routines.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_ENTRYRDN_STR, "subtree", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    ainfo_get(be, (char *)LDBM_PARENTID_STR, &ai);
-    /* Check if the attrinfo is actually for parentid, not a fallback to .default */
-    index_already_configured = (ai != NULL && strcmp(ai->ai_type, LDBM_PARENTID_STR) == 0);
-    if (!index_already_configured) {
-        e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0, "integerOrderingMatch", parentid_indexes_limit);
-        ldbm_instance_config_add_index_entry(inst, e, flags);
-        attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
-        slapi_entry_free(e);
-    }
-
-    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_PARENTID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry("objectclass", "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry("aci", "pres", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_NUMSUBORDINATES_STR, "pres", 0, 0, 0, 0);
+    ldbm_instance_config_add_index_entry(inst, e, flags);
+    slapi_entry_free(e);
+
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_UNIQUEID, "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* For MMR, we need this attribute (to replace use of dncomp in delete). */
-    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(ATTR_NSDS5_REPLCONFLICT, "eq", "pres", 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* write the dse file only on the final index */
-    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(SLAPI_ATTR_NSCP_ENTRYDN, "eq", 0, 0, 0, 0);
     ldbm_instance_config_add_index_entry(inst, e, flags);
     slapi_entry_free(e);
 
     /* ldbm_instance_config_add_index_entry(inst, 2, argv); */
-    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0, 0, 0);
+    e = ldbm_instance_init_config_entry(LDBM_PSEUDO_ATTR_DEFAULT, "none", 0, 0, 0, 0);
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 
@@ -294,18 +231,9 @@ ldbm_instance_create_default_indexes(backend *be)
      * ancestorid is special, there is actually no such attr type
      * but we still want to use the attr index file APIs.
      */
-    ainfo_get(be, (char *)LDBM_ANCESTORID_STR, &ai);
-    /* Check if the attrinfo is actually for ancestorid, not a fallback to .default */
-    index_already_configured = (ai != NULL && strcmp(ai->ai_type, LDBM_ANCESTORID_STR) == 0);
-    if (!index_already_configured) {
-        e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch", ancestorid_indexes_limit);
-        ldbm_instance_config_add_index_entry(inst, e, flags);
-        attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
-        slapi_entry_free(e);
-    }
-
-    slapi_ch_free_string(&ancestorid_indexes_limit);
-    slapi_ch_free_string(&parentid_indexes_limit);
+    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
+    attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
+    slapi_entry_free(e);
 
     return 0;
 }

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.c
@@ -386,35 +386,6 @@ ldbm_config_allidsthreshold_set(void *arg, void *value, char *errorbuf __attribu
 }
 
 static void *
-ldbm_config_system_allidsthreshold_get(void *arg)
-{
-    struct ldbminfo *li = (struct ldbminfo *)arg;
-
-    return (void *)((uintptr_t)(li->li_system_allidsthreshold));
-}
-
-static int
-ldbm_config_system_allidsthreshold_set(void *arg, void *value, char *errorbuf __attribute__((unused)), int phase __attribute__((unused)), int apply)
-{
-    struct ldbminfo *li = (struct ldbminfo *)arg;
-    int retval = LDAP_SUCCESS;
-    int val = (int)((uintptr_t)value);
-
-    /* Do whatever we can to make sure the data is ok. */
-
-    /* Catch attempts to configure a stupidly low ancestorid allidsthreshold */
-    if ((val > -1) && (val < 5000)) {
-        val = 5000;
-    }
-
-    if (apply) {
-        li->li_system_allidsthreshold = val;
-    }
-
-    return retval;
-}
-
-static void *
 ldbm_config_pagedallidsthreshold_get(void *arg)
 {
     struct ldbminfo *li = (struct ldbminfo *)arg;
@@ -1094,7 +1065,6 @@ static config_info ldbm_config[] = {
     {CONFIG_LOOKTHROUGHLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_lookthroughlimit_get, &ldbm_config_lookthroughlimit_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_MODE, CONFIG_TYPE_INT_OCTAL, "0600", &ldbm_config_mode_get, &ldbm_config_mode_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_IDLISTSCANLIMIT, CONFIG_TYPE_INT, "2147483646", &ldbm_config_allidsthreshold_get, &ldbm_config_allidsthreshold_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
-    {CONFIG_SYSTEMIDLISTSCANLIMIT, CONFIG_TYPE_INT, "5000", &ldbm_config_system_allidsthreshold_get, &ldbm_config_system_allidsthreshold_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_DIRECTORY, CONFIG_TYPE_STRING, "", &ldbm_config_directory_get, &ldbm_config_directory_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE | CONFIG_FLAG_SKIP_DEFAULT_SETTING},
     {CONFIG_MAXPASSBEFOREMERGE, CONFIG_TYPE_INT, "100", &ldbm_config_maxpassbeforemerge_get, &ldbm_config_maxpassbeforemerge_set, 0},
 

--- a/ldap/servers/slapd/back-ldbm/ldbm_config.h
+++ b/ldap/servers/slapd/back-ldbm/ldbm_config.h
@@ -60,7 +60,6 @@ struct config_info
 #define CONFIG_RANGELOOKTHROUGHLIMIT "nsslapd-rangelookthroughlimit"
 #define CONFIG_PAGEDLOOKTHROUGHLIMIT "nsslapd-pagedlookthroughlimit"
 #define CONFIG_IDLISTSCANLIMIT "nsslapd-idlistscanlimit"
-#define CONFIG_SYSTEMIDLISTSCANLIMIT "nsslapd-systemidlistscanlimit"
 #define CONFIG_PAGEDIDLISTSCANLIMIT "nsslapd-pagedidlistscanlimit"
 #define CONFIG_DIRECTORY "nsslapd-directory"
 #define CONFIG_MODE "nsslapd-mode"

--- a/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
@@ -384,14 +384,6 @@ ldbm_instance_config_add_index_entry(
         }
     }
 
-    /* get nsIndexIDListScanLimit and its values, and add them */
-    if (0 == slapi_entry_attr_find(e, "nsIndexIDListScanLimit", &attr)) {
-        for (j = slapi_attr_first_value(attr, &sval); j != -1; j = slapi_attr_next_value(attr, j, &sval)) {
-            attrValue = slapi_value_get_berval(sval);
-            eBuf = PR_sprintf_append(eBuf, "nsIndexIDListScanLimit: %s\n", attrValue->bv_val);
-        }
-    }
-
     ldbm_config_add_dse_entry(li, eBuf, flags);
     if (eBuf) {
         PR_smprintf_free(eBuf);

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -331,6 +331,107 @@ upgrade_remove_subtree_rename(void)
 }
 
 /*
+ * Remove nsIndexIDListScanLimit from parentid index configuration.
+ *
+ * This attribute was incorrectly added by a previous version and can
+ * cause issues with index configuration. Remove it if present.
+ */
+static upgrade_status
+upgrade_remove_index_scanlimit(void)
+{
+    struct slapi_pblock *pb = slapi_pblock_new();
+    Slapi_Entry **backends = NULL;
+    const char *be_base_dn = "cn=ldbm database,cn=plugins,cn=config";
+    const char *be_filter = "(objectclass=nsBackendInstance)";
+    const char *attrs_to_check[] = {"parentid", NULL};
+    upgrade_status uresult = UPGRADE_SUCCESS;
+
+    /* Search for all backend instances */
+    slapi_search_internal_set_pb(
+            pb, be_base_dn,
+            LDAP_SCOPE_ONELEVEL,
+            be_filter, NULL, 0, NULL, NULL,
+            plugin_get_default_component_id(), 0);
+    slapi_search_internal_pb(pb);
+    slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &backends);
+
+    if (backends) {
+        for (size_t be_idx = 0; backends[be_idx] != NULL; be_idx++) {
+            const char *be_dn = slapi_entry_get_dn_const(backends[be_idx]);
+            const char *be_name = slapi_entry_attr_get_ref(backends[be_idx], "cn");
+            if (!be_dn || !be_name) {
+                continue;
+            }
+
+            for (size_t attr_idx = 0; attrs_to_check[attr_idx] != NULL; attr_idx++) {
+                const char *attr_name = attrs_to_check[attr_idx];
+                struct slapi_pblock *idx_pb = slapi_pblock_new();
+                Slapi_Entry **idx_entries = NULL;
+                char *idx_dn = slapi_create_dn_string("cn=%s,cn=index,%s",
+                                                       attr_name, be_dn);
+                char *idx_filter = "(objectclass=nsIndex)";
+
+                if (!idx_dn) {
+                    slapi_pblock_destroy(idx_pb);
+                    continue;
+                }
+
+                slapi_search_internal_set_pb(
+                        idx_pb, idx_dn,
+                        LDAP_SCOPE_BASE,
+                        idx_filter, NULL, 0, NULL, NULL,
+                        plugin_get_default_component_id(), 0);
+                slapi_search_internal_pb(idx_pb);
+                slapi_pblock_get(idx_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &idx_entries);
+
+                if (idx_entries && idx_entries[0]) {
+                    /* Check if nsIndexIDListScanLimit is present */
+                    if (slapi_entry_attr_get_ref(idx_entries[0], "nsIndexIDListScanLimit") != NULL) {
+                        /* Remove nsIndexIDListScanLimit */
+                        Slapi_PBlock *mod_pb = slapi_pblock_new();
+                        Slapi_Mods smods;
+                        int rc;
+
+                        slapi_mods_init(&smods, 1);
+                        slapi_mods_add(&smods, LDAP_MOD_DELETE, "nsIndexIDListScanLimit", 0, NULL);
+
+                        slapi_modify_internal_set_pb(
+                                mod_pb, idx_dn,
+                                slapi_mods_get_ldapmods_byref(&smods),
+                                NULL, NULL,
+                                plugin_get_default_component_id(), 0);
+                        slapi_modify_internal_pb(mod_pb);
+                        slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+                        if (rc == LDAP_SUCCESS) {
+                            slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_remove_index_scanlimit",
+                                    "Removed 'nsIndexIDListScanLimit' from index '%s' in backend '%s'\n",
+                                    attr_name, be_name);
+                        } else if (rc != LDAP_NO_SUCH_ATTRIBUTE) {
+                            slapi_log_err(SLAPI_LOG_ERR, "upgrade_remove_index_scanlimit",
+                                    "Failed to remove 'nsIndexIDListScanLimit' from index '%s' in backend '%s': error %d\n",
+                                    attr_name, be_name, rc);
+                        }
+
+                        slapi_mods_done(&smods);
+                        slapi_pblock_destroy(mod_pb);
+                    }
+                }
+
+                slapi_ch_free_string(&idx_dn);
+                slapi_free_search_results_internal(idx_pb);
+                slapi_pblock_destroy(idx_pb);
+            }
+        }
+    }
+
+    slapi_free_search_results_internal(pb);
+    slapi_pblock_destroy(pb);
+
+    return uresult;
+}
+
+/*
  * Check if parentid/ancestorid indexes are missing the integerOrderingMatch
  * matching rule.
  *
@@ -646,6 +747,10 @@ upgrade_server(void)
     }
 
     if (upgrade_pam_pta_default_config() != UPGRADE_SUCCESS) {
+        return UPGRADE_FAILURE;
+    }
+
+    if (upgrade_remove_index_scanlimit() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
 

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -432,6 +432,126 @@ upgrade_remove_index_scanlimit(void)
 }
 
 /*
+ * Remove ancestorid index configuration entry if present.
+ *
+ * The ancestorid index is special - it has no corresponding attribute type
+ * and should not have a DSE config entry. If an entry exists, remove it.
+ *
+ * This function removes:
+ * 1. The ancestorid entry from cn=default indexes (to prevent re-creation on startup)
+ * 2. The ancestorid entry from each backend's cn=index (if it exists)
+ */
+static upgrade_status
+upgrade_remove_ancestorid_index_config(void)
+{
+    struct slapi_pblock *pb = slapi_pblock_new();
+    Slapi_Entry **backends = NULL;
+    const char *be_base_dn = "cn=ldbm database,cn=plugins,cn=config";
+    const char *be_filter = "(objectclass=nsBackendInstance)";
+    upgrade_status uresult = UPGRADE_SUCCESS;
+    int rc;
+
+    /*
+     * First, remove ancestorid from cn=default indexes to prevent
+     * ldbm_instance_create_default_user_indexes() from re-creating it.
+     */
+    {
+        Slapi_PBlock *def_pb = slapi_pblock_new();
+        char *def_idx_dn = slapi_create_dn_string(
+                "cn=ancestorid,cn=default indexes,cn=config,%s", be_base_dn);
+
+        if (def_idx_dn) {
+            slapi_delete_internal_set_pb(
+                    def_pb, def_idx_dn, NULL, NULL,
+                    plugin_get_default_component_id(), 0);
+            slapi_delete_internal_pb(def_pb);
+            slapi_pblock_get(def_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+            if (rc == LDAP_SUCCESS) {
+                slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_remove_ancestorid_index_config",
+                        "Removed 'ancestorid' from default indexes.\n");
+            } else if (rc != LDAP_NO_SUCH_OBJECT) {
+                slapi_log_err(SLAPI_LOG_ERR, "upgrade_remove_ancestorid_index_config",
+                        "Failed to remove 'ancestorid' from default indexes: error %d\n", rc);
+            }
+
+            slapi_ch_free_string(&def_idx_dn);
+        }
+        slapi_pblock_destroy(def_pb);
+    }
+
+    /* Search for all backend instances */
+    slapi_search_internal_set_pb(
+            pb, be_base_dn,
+            LDAP_SCOPE_ONELEVEL,
+            be_filter, NULL, 0, NULL, NULL,
+            plugin_get_default_component_id(), 0);
+    slapi_search_internal_pb(pb);
+    slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &backends);
+
+    if (backends) {
+        for (size_t be_idx = 0; backends[be_idx] != NULL; be_idx++) {
+            const char *be_dn = slapi_entry_get_dn_const(backends[be_idx]);
+            const char *be_name = slapi_entry_attr_get_ref(backends[be_idx], "cn");
+            if (!be_dn || !be_name) {
+                continue;
+            }
+
+            struct slapi_pblock *idx_pb = slapi_pblock_new();
+            Slapi_Entry **idx_entries = NULL;
+            char *idx_dn = slapi_create_dn_string("cn=ancestorid,cn=index,%s",
+                                                   be_dn);
+            char *idx_filter = "(objectclass=nsIndex)";
+
+            if (!idx_dn) {
+                slapi_pblock_destroy(idx_pb);
+                continue;
+            }
+
+            slapi_search_internal_set_pb(
+                    idx_pb, idx_dn,
+                    LDAP_SCOPE_BASE,
+                    idx_filter, NULL, 0, NULL, NULL,
+                    plugin_get_default_component_id(), 0);
+            slapi_search_internal_pb(idx_pb);
+            slapi_pblock_get(idx_pb, SLAPI_PLUGIN_INTOP_SEARCH_ENTRIES, &idx_entries);
+
+            if (idx_entries && idx_entries[0]) {
+                /* ancestorid index entry exists - delete it */
+                Slapi_PBlock *del_pb = slapi_pblock_new();
+
+                slapi_delete_internal_set_pb(
+                        del_pb, idx_dn, NULL, NULL,
+                        plugin_get_default_component_id(), 0);
+                slapi_delete_internal_pb(del_pb);
+                slapi_pblock_get(del_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+                if (rc == LDAP_SUCCESS) {
+                    slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_remove_ancestorid_index_config",
+                            "Removed 'ancestorid' index config entry in backend '%s'.\n",
+                            be_name);
+                } else if (rc != LDAP_NO_SUCH_OBJECT) {
+                    slapi_log_err(SLAPI_LOG_ERR, "upgrade_remove_ancestorid_index_config",
+                            "Failed to remove 'ancestorid' index config entry in backend '%s': error %d\n",
+                            be_name, rc);
+                }
+
+                slapi_pblock_destroy(del_pb);
+            }
+
+            slapi_ch_free_string(&idx_dn);
+            slapi_free_search_results_internal(idx_pb);
+            slapi_pblock_destroy(idx_pb);
+        }
+    }
+
+    slapi_free_search_results_internal(pb);
+    slapi_pblock_destroy(pb);
+
+    return uresult;
+}
+
+/*
  * Check if parentid/ancestorid indexes are missing the integerOrderingMatch
  * matching rule.
  *
@@ -445,7 +565,7 @@ upgrade_check_id_index_matching_rule(void)
     Slapi_Entry **backends = NULL;
     const char *be_base_dn = "cn=ldbm database,cn=plugins,cn=config";
     const char *be_filter = "(objectclass=nsBackendInstance)";
-    const char *attrs_to_check[] = {"parentid", "ancestorid", NULL};
+    const char *attrs_to_check[] = {"parentid", NULL};
     upgrade_status uresult = UPGRADE_SUCCESS;
 
     /* Search for all backend instances */
@@ -459,8 +579,9 @@ upgrade_check_id_index_matching_rule(void)
 
     if (backends) {
         for (size_t be_idx = 0; backends[be_idx] != NULL; be_idx++) {
+            const char *be_dn = slapi_entry_get_dn_const(backends[be_idx]);
             const char *be_name = slapi_entry_attr_get_ref(backends[be_idx], "cn");
-            if (!be_name) {
+            if (!be_dn || !be_name) {
                 continue;
             }
 
@@ -469,8 +590,8 @@ upgrade_check_id_index_matching_rule(void)
                 const char *attr_name = attrs_to_check[attr_idx];
                 struct slapi_pblock *idx_pb = slapi_pblock_new();
                 Slapi_Entry **idx_entries = NULL;
-                char *idx_dn = slapi_create_dn_string("cn=%s,cn=index,cn=%s,%s",
-                                                       attr_name, be_name, be_base_dn);
+                char *idx_dn = slapi_create_dn_string("cn=%s,cn=index,%s",
+                                                       attr_name, be_dn);
                 char *idx_filter = "(objectclass=nsIndex)";
                 PRBool has_matching_rule = PR_FALSE;
 
@@ -751,6 +872,10 @@ upgrade_server(void)
     }
 
     if (upgrade_remove_index_scanlimit() != UPGRADE_SUCCESS) {
+        return UPGRADE_FAILURE;
+    }
+
+    if (upgrade_remove_ancestorid_index_config() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
 

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -628,41 +628,44 @@ if ! getent passwd $USERNAME >/dev/null ; then
 fi
 
 # Reload our sysctl before we restart (if we can)
-sysctl --system &> $output; true
+sysctl --system &> "$output"; true
 
-# Gather the running instances so we can restart them
+# Gather running instances, stop them, run index-check, then restart
 instbase="%{_sysconfdir}/%{pkgname}"
+instances=""
 ninst=0
-for dir in $instbase/slapd-* ; do
-    echo dir = $dir >> $output 2>&1 || :
+
+for dir in "$instbase"/slapd-* ; do
+    echo "dir = $dir" >> "$output" 2>&1 || :
     if [ ! -d "$dir" ] ; then continue ; fi
     case "$dir" in *.removed) continue ;; esac
-    basename=`basename $dir`
-    inst="%{pkgname}@`echo $basename | sed -e 's/slapd-//g'`"
-    echo found instance $inst - getting status  >> $output 2>&1 || :
-    if /bin/systemctl -q is-active $inst ; then
-       echo instance $inst is running >> $output 2>&1 || :
+    basename=$(basename "$dir")
+    inst="%{pkgname}@${basename#slapd-}"
+    inst_name="${basename#slapd-}"
+    echo "found instance $inst - getting status" >> "$output" 2>&1 || :
+    if /bin/systemctl -q is-active "$inst" ; then
+       echo "instance $inst is running - stopping for upgrade" >> "$output" 2>&1 || :
        instances="$instances $inst"
+       /bin/systemctl stop "$inst" >> "$output" 2>&1 || :
     else
-       echo instance $inst is not running >> $output 2>&1 || :
+       echo "instance $inst is not running" >> "$output" 2>&1 || :
     fi
-    ninst=`expr $ninst + 1`
+    # Run index-check on all instances (running or not)
+    # This fixes index ordering mismatches from older versions
+    dsctl "$inst_name" index-check --fix >> "$output2" 2>&1 || :
+    ninst=$((ninst + 1))
 done
+
 if [ $ninst -eq 0 ] ; then
-    echo no instances to upgrade >> $output 2>&1 || :
-    exit 0 # have no instances to upgrade - just skip the rest
-else
-    # restart running instances
-    echo shutting down all instances . . . >> $output 2>&1 || :
-    for inst in $instances ; do
-        echo stopping instance $inst >> $output 2>&1 || :
-        /bin/systemctl stop $inst >> $output 2>&1 || :
-    done
-    for inst in $instances ; do
-        echo starting instance $inst >> $output 2>&1 || :
-        /bin/systemctl start $inst >> $output 2>&1 || :
-    done
+    echo "no instances to upgrade" >> "$output" 2>&1 || :
+    exit 0
 fi
+
+# Restart previously running instances
+for inst in $instances ; do
+    echo "starting instance $inst" >> "$output" 2>&1 || :
+    /bin/systemctl start "$inst" >> "$output" 2>&1 || :
+done
 
 
 %preun

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -39,7 +39,6 @@ arg_to_attr = {
         'mode': 'nsslapd-mode',
         'state': 'nsslapd-state',
         'idlistscanlimit': 'nsslapd-idlistscanlimit',
-        'systemidlistscanlimit': 'nsslapd-systemidlistscanlimit',
         'directory': 'nsslapd-directory',
         'dbcachesize': 'nsslapd-dbcachesize',
         'logdirectory': 'nsslapd-db-logdirectory',
@@ -626,21 +625,6 @@ def backend_set_index(inst, basedn, log, args):
             except ldap.NO_SUCH_ATTRIBUTE:
                 raise ValueError('Can not delete matching rule type because it does not exist')
 
-    if args.replace_scanlimit is not None:
-        for replace_scanlimit in args.replace_scanlimit:
-            index.replace('nsIndexIDListScanLimit', replace_scanlimit)
-
-    if args.add_scanlimit is not None:
-        for add_scanlimit in args.add_scanlimit:
-            index.add('nsIndexIDListScanLimit', add_scanlimit)
-
-    if args.del_scanlimit is not None:
-        for del_scanlimit in args.del_scanlimit:
-            try:
-                index.remove('nsIndexIDListScanLimit', del_scanlimit)
-            except ldap.NO_SUCH_ATTRIBUTE:
-                raise ValueError('Can not delete a fine grain limit definition because it does not exist')
-
     if args.reindex:
         be.reindex(attrs=[args.attr])
     log.info("Index successfully updated")
@@ -963,9 +947,6 @@ def create_parser(subparsers):
     edit_index_parser.add_argument('--del-type', action='append', help='Removes an index type from the index: (eq, sub, pres, or approx)')
     edit_index_parser.add_argument('--add-mr', action='append', help='Adds a matching-rule to the index')
     edit_index_parser.add_argument('--del-mr', action='append', help='Removes a matching-rule from the index')
-    edit_index_parser.add_argument('--add-scanlimit', action='append', help='Adds a fine grain limit definiton to the index')
-    edit_index_parser.add_argument('--replace-scanlimit', action='append', help='Replaces a fine grain limit definiton to the index')
-    edit_index_parser.add_argument('--del-scanlimit', action='append', help='Removes a fine grain limit definiton to the index')
     edit_index_parser.add_argument('--reindex', action='store_true', help='Re-indexes the database after editing the index')
     edit_index_parser.add_argument('be_name', help='The backend name or suffix')
 
@@ -1092,7 +1073,6 @@ def create_parser(subparsers):
                                                                  'will check when examining candidate entries in response to a search request')
     set_db_config_parser.add_argument('--mode', help='Specifies the permissions used for newly created index files')
     set_db_config_parser.add_argument('--idlistscanlimit', help='Specifies the number of entry IDs that are searched during a search operation')
-    set_db_config_parser.add_argument('--systemidlistscanlimit', help='Specifies the number of entry IDs that are fetch from ancestorid/parentid indexes')
     set_db_config_parser.add_argument('--directory', help='Specifies absolute path to database instance')
     set_db_config_parser.add_argument('--dbcachesize', help='Specifies the database index cache size in bytes')
     set_db_config_parser.add_argument('--logdirectory', help='Specifies the path to the directory that contains the database transaction logs')

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -125,11 +125,14 @@ class DSEldif(DSLint):
             self._contents[i] = self._contents[i].replace(strfrom, strto)
         self._update()
 
-    def _find_attr(self, entry_dn, attr):
+    def _find_attr(self, entry_dn, attr, lower=False):
         """Find all attribute values and indexes under a given entry
 
         Returns entry dn index and attribute data dict:
         relative attribute indexes and the attribute value
+
+        :param lower: Use case-insensitive matching for attribute name
+        :type lower: boolean
         """
 
         entry_dn_i = self._contents.index("dn: {}\n".format(entry_dn.lower()))
@@ -146,7 +149,11 @@ class DSEldif(DSLint):
 
         # Find the attribute
         for line in entry_slice:
-            if line.startswith("{}:".format(attr)):
+            if lower:
+                match = line.lower().startswith("{}:".format(attr.lower()))
+            else:
+                match = line.startswith("{}:".format(attr))
+            if match:
                 attr_value = line.split(" ", 1)[1][:-1]
                 attr_data.update({entry_slice.index(line): attr_value})
 
@@ -155,7 +162,7 @@ class DSEldif(DSLint):
 
         return entry_dn_i, attr_data
 
-    def get(self, entry_dn, attr, single=False):
+    def get(self, entry_dn, attr, single=False, lower=False):
         """Return attribute values under a given entry
 
         :param entry_dn: a DN of entry we want to get attribute from
@@ -163,11 +170,13 @@ class DSEldif(DSLint):
         :param attr: an attribute name
         :type attr: str
         :param single: Return a single value instead of a list
-        :type sigle: boolean
+        :type single: boolean
+        :param lower: Use case-insensitive matching for attribute name
+        :type lower: boolean
         """
 
         try:
-            _, attr_data = self._find_attr(entry_dn, attr)
+            _, attr_data = self._find_attr(entry_dn, attr, lower=lower)
         except ValueError:
             return None
 
@@ -190,6 +199,38 @@ class DSEldif(DSLint):
 
         return indexes
 
+    def get_backends(self):
+        """Return a list of backend names from DSE.
+
+        Returns backend names preserving their original case, as the
+        database directory names on disk use the original case.
+
+        Note: DSEldif lowercases DN lines, so we read the 'cn' attribute
+        from each entry to get the original case.
+
+        :returns: List of backend names
+        """
+        backends = []
+        excluded = ("config", "monitor", "index", "encrypted attributes")
+
+        for entry in self._contents:
+            if (entry.startswith("dn: cn=") and
+                    ",cn=ldbm database,cn=plugins,cn=config" in entry):
+                parts = entry.split(",")
+                if len(parts) > 1:
+                    cn_lower = parts[0].replace("dn: cn=", "")
+                    if cn_lower not in excluded:
+                        dn = entry.strip()[4:].strip()
+                        try:
+                            suffix = self.get(dn, "nsslapd-suffix")
+                            if suffix:
+                                cn_values = self.get(dn, "cn")
+                                if cn_values:
+                                    backends.append(cn_values[0])
+                        except (ValueError, IndexError):
+                            pass
+
+        return list(set(backends))
 
     def add_entry(self, entry):
         """Add a new entry


### PR DESCRIPTION
## Summary by Sourcery

Adjust system index configuration and introduce tooling and upgrade paths to correct parentid/ancestorid index ordering and scanlimit issues.

New Features:
- Add a dsctl dbtasks index-check command to detect and optionally fix parentid and ancestorid index ordering and configuration issues across backends.

Bug Fixes:
- Ensure upgrade removes nsIndexIDListScanLimit from parentid indexes and deletes obsolete ancestorid index configuration entries, preventing misconfigured system indexes.
- Stop generating and managing nsIndexIDListScanLimit for system indexes in both server-side defaults and lib389 helpers, avoiding inconsistent scan limit behavior.
- Fix system index linting and healthcheck tests to reflect that only parentId is externally configurable and that ancestorid is an internal index.

Enhancements:
- Add server-side runtime checks at backend startup to validate parentid and ancestorid index ordering against configuration and log reindex guidance when mismatches are detected.
- Extend DSEldif utilities and backend discovery helpers to support case-insensitive attribute access and enumerating backends for index validation.
- Simplify default index creation by always configuring parentid and ancestorid with integerOrderingMatch without per-attribute scanlimit tuning.

Tests:
- Replace and extend healthcheck and configuration tests to cover missing system indexes, removal of scanlimit, upgrade-time cleanup of parentid/ancestorid configuration, and the new index-check CLI behavior including fix scenarios.
- Update config and paged results tests to no longer depend on ancestorid nsIndexIDListScanLimit tuning while preserving coverage of idlistscanlimit-related limits.

Fixes: https://github.com/389ds/389-ds-base/issues/7223