### PR TITLE
Issue 7231 - Sync repl tests fail in FIPS mode due to non FIPS compliant crypto

### DIFF
--- a/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
+++ b/dirsrvtests/tests/suites/syncrepl_plugin/basic_test.py
@@ -217,7 +217,10 @@ class Sync_persist(threading.Thread, ReconnectLDAPObject, SyncreplConsumer):
         ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, os.path.join(self.inst.get_config_dir(), "ca.crt"))
         ldap_connection = TestSyncer(self.inst.toLDAPURL())
         ldap_connection.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
-        ldap_connection.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        # Use FIPS approved TLS versions, ciphers
+        ldap_connection.set_option(ldap.OPT_X_TLS_CIPHER_SUITE, "AES256-GCM-SHA384:AES128-GCM-SHA256")
+        ldap_connection.set_option(ldap.OPT_X_TLS_PROTOCOL_MIN, ldap.OPT_X_TLS_PROTOCOL_TLS1_2)
+
         ldap_connection.simple_bind_s('cn=directory manager', 'password')
         ldap_search = ldap_connection.syncrepl_search(
             "dc=example,dc=com",


### PR DESCRIPTION
Description:
Several sync_repl tests fail when running on a FIPS enabled system. The failures are caused by the sync repl client (Sync_persist), using TLS options and ciphers that are not FIPS compatible.

Fix:
Update the sync repl client to use FIPS approved TLS protocols and ciphers.

Fixes: https://github.com/389ds/389-ds-base/issues/7231

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Adjust sync repl client TLS protocol and cipher configuration in tests to be compatible with FIPS-enabled systems.