### PR TITLE
Issue 7233 - test_produce_division_by_zero fails with IsADirectoryErr…

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -126,6 +126,8 @@ def pytest_runtest_makereport(item, call):
                     text = asan_report.read()
                     extra.append(pytest_html.extras.text(text, name=os.path.basename(f)))
             for f in glob.glob(f'{p.log_dir.split("/slapd",1)[0]}/*/*'):
+                if not os.path.isfile(f):
+                    continue
                 if f.endswith('gz'):
                     with gzip.open(f, 'rb') as dirsrv_log:
                         text = dirsrv_log.read()

--- a/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
+++ b/dirsrvtests/tests/suites/disk_monitoring/disk_monitoring_divide_test.py
@@ -31,15 +31,16 @@ def create_dummy_mount(topology_st, request):
     log.info('Create dummy mount')
     for cmd in cmds:
         log.info('Command used : %s' % cmd)
-        subprocess.Popen(cmd, shell=True)
+        subprocess.run(cmd, shell=True)
 
     def fin():
         cmds = ['umount /var/log/dirsrv/slapd-{}/tmp'.format(topology_st.standalone.serverid),
+                'rmdir /var/log/dirsrv/slapd-{}/tmp'.format(topology_st.standalone.serverid),
                 'setenforce 1']
 
         for cmd in cmds:
-            log.info('Command used : %s' % cmds)
-            subprocess.Popen(cmd, shell=True)
+            log.info('Command used : %s' % cmd)
+            subprocess.run(cmd, shell=True)
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
…or in conftest.py

Description: glob('/*/*') matches directories causing open() to fail.

Fixes: #7233

Reviewed by: ???

## Summary by Sourcery

Guard test log collection and cleanup to prevent directory-related errors during disk monitoring tests.

Bug Fixes:
- Skip non-regular files when iterating over log glob matches to avoid IsADirectoryError when opening paths.
- Ensure dummy mount temporary directory is removed after unmounting to avoid leftover directories interfering with tests.