### PR TITLE
Issue 7230 - Regression in healtcheck NssCheck

### DIFF
--- a/src/lib389/lib389/cli_ctl/tls.py
+++ b/src/lib389/lib389/cli_ctl/tls.py
@@ -25,9 +25,9 @@ def list_client_cas(inst, log, args):
 
 def list_cas(inst, log, args):
     tls = NssSsl(dirsrv=inst)
-    # This turns an array of [('CA', 'C,,')]
+    # Returns a list of cert dicts, eg {'cn': 'nickname', etc}
     for c in tls.list_ca_certs():
-        log.info(c[0])
+        log.info(c['cn'])
 
 
 def show_cert(inst, log, args):

--- a/src/lib389/lib389/nss_ssl.py
+++ b/src/lib389/lib389/nss_ssl.py
@@ -91,13 +91,13 @@ class NssSsl(DSLint):
             if diff_date < timedelta(days=0):
                 # Expired
                 report = copy.deepcopy(DSCERTLE0002)
-                report['detail'] = report['detail'].replace('CERT', cert[0])
+                report['detail'] = report['detail'].replace('CERT', cert['cn'])
                 report['check'] = f'tls:certificate_expiration'
                 yield report
             elif diff_date < timedelta(days=30):
                 # Expiring within 30 days
                 report = copy.deepcopy(DSCERTLE0001)
-                report['detail'] = report['detail'].replace('CERT', cert[0])
+                report['detail'] = report['detail'].replace('CERT', cert['cn'])
                 report['check'] = f'tls:certificate_expiration'
                 yield report
 


### PR DESCRIPTION
Description:
Dynamic Certificate lib389 updadates modified get_cert_details() to return a dict instead of tuple format. _lint_certificate_expiration() still assumes tuple style access.

Fix:
Update _lint_certificate_expiration() to use dict key.

Fixes: https://github.com/389ds/389-ds-base/issues/7230

Co-authored-by: @flo-renaud

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Fix certificate expiration healthcheck regression caused by assuming tuple-based certificate details instead of the new dict format.