### PR TITLE
Issue 7236 - Fix GSSAPI tests

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -120,7 +120,7 @@ jobs:
         sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
         sudo docker exec $CID sh -c "mkdir -p /workspace/assets/cores && chmod 777 /workspace{,/assets{,/cores}}"
         sudo docker exec $CID sh -c "echo '/workspace/assets/cores/core.%e.%P' > /proc/sys/kernel/core_pattern"
-        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=mdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=mdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" -e GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
 
     - name: Make the results file readable by all
       if: always()

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -120,7 +120,7 @@ jobs:
         sudo docker exec $CID sh -c "systemctl enable --now cockpit.socket"
         sudo docker exec $CID sh -c "mkdir -p /workspace/assets/cores && chmod 777 /workspace{,/assets{,/cores}}"
         sudo docker exec $CID sh -c "echo '/workspace/assets/cores/core.%e.%P' > /proc/sys/kernel/core_pattern"
-        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=mdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+        sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=mdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
 
     - name: Make the results file readable by all
       if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,7 +125,7 @@ jobs:
             echo "Tests skipped because read-only Berkeley Database is installed." > pytest.html
             echo "<?xml version="1.0" encoding="utf-8"?>'Tests skipped because read-only Berkeley Database is installed.'" > pytest.xml
         else
-            sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=bdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+            sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=bdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" -e GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
         fi
 
     - name: Make the results file readable by all

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,7 +125,7 @@ jobs:
             echo "Tests skipped because read-only Berkeley Database is installed." > pytest.html
             echo "<?xml version="1.0" encoding="utf-8"?>'Tests skipped because read-only Berkeley Database is installed.'" > pytest.xml
         else
-            sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=bdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
+            sudo docker exec -e WEBUI=1 -e NSSLAPD_DB_LIB=bdb -e DEBUG=pw:api -e PASSWD="${PASSWD}" GSSAPI_ACK=1 $CID py.test  --suppress-no-test-exit-code  -m "not flaky" --junit-xml=pytest.xml --html=pytest.html --browser=firefox --browser=chromium -v dirsrvtests/tests/suites/${{ matrix.suite }}
         fi
 
     - name: Make the results file readable by all

--- a/dirsrvtests/tests/suites/gssapi/simple_gssapi_test.py
+++ b/dirsrvtests/tests/suites/gssapi/simple_gssapi_test.py
@@ -34,6 +34,8 @@ def testuser(topology_st_gssapi):
     })
     # Give them a krb princ
     user.create_keytab()
+    # Make krb5 config readable by everyone for the tests to work
+    os.chmod(user._instance.realm.krb5confrealm, 0o644)
     return user
 
 @gssapi_ack


### PR DESCRIPTION
Description:
Fix for failing GSSAPI tests

Relates: #7236
Author: Lenka Doudova
Reviewer: ???

## Summary by Sourcery

Configure a dedicated two-supplier GSSAPI-enabled replication topology and update GSSAPI replication tests to rely on it and correctly handle Kerberos configuration and principals.

Tests:
- Add a new two-supplier GSSAPI topology fixture that sets up Kerberos realm, principals, keytabs, SASL mappings, and hostnames for replication tests.
- Update the GSSAPI replication test to use the new GSSAPI-specific topology fixture and dedicated decorator instead of manual /etc/hosts checks and disabled skips.
- Adjust GSSAPI replication agreement names to use actual supplier host and port values and simplify agreement setup.
- Ensure simple GSSAPI test makes the generated krb5 configuration world-readable so test principals can be used.