### PR TITLE
Issue 7241 - Drop dateutil

### DIFF
--- a/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_warning_test.py
@@ -15,9 +15,8 @@ from lib389.topologies import topology_st
 from lib389.idm.user import UserAccounts
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389._constants import (DEFAULT_SUFFIX, DN_CONFIG, PASSWORD, DN_DM)
-from dateutil.parser import parse as dt_parse
 from lib389.config import Config
-import datetime
+import datetime as dt
 
 pytestmark = pytest.mark.tier1
 
@@ -351,7 +350,7 @@ def test_with_different_password_states(topology_st, global_policy, add_user):
     old_ts = user.get_attr_val_utf8('passwordExpirationTime')
     log.info("Old passwordExpirationTime: {}".format(old_ts))
 
-    new_ts = (dt_parse(old_ts) - datetime.timedelta(31)).strftime('%Y%m%d%H%M%SZ')
+    new_ts = (dt.datetime.strptime(old_ts, '%Y%m%d%H%M%SZ') - dt.timedelta(31)).strftime('%Y%m%d%H%M%SZ')
     log.info("New passwordExpirationTime: {}".format(new_ts))
     user.replace('passwordExpirationTime', new_ts)
 

--- a/src/lib389/lib389/tests/dirsrv_log_test.py
+++ b/src/lib389/lib389/tests/dirsrv_log_test.py
@@ -12,8 +12,7 @@ from lib389 import DirSrv, Entry
 import pytest
 import time
 import shutil
-import datetime
-from dateutil.tz import tzoffset
+import datetime as dt
 
 INSTANCE_PORT = 54321
 INSTANCE_SERVERID = 'standalone'
@@ -74,7 +73,7 @@ def test_access_log(topology):
         topology.standalone.ds_access_log.parse_line('[27/Apr/2016:12:49:49.726093186 +1000] conn=1 fd=64 slot=64 connection from ::1 to ::1') ==
         {
             'slot': '64', 'remote': '::1', 'action': 'CONNECT', 'timestamp': '[27/Apr/2016:12:49:49.726093186 +1000]', 'fd': '64', 'conn': '1', 'local': '::1',
-            'datetime': datetime.datetime(2016, 4, 27, 12, 0, 0, 726093, tzinfo=tzoffset(None, 36000))
+            'datetime': dt.datetime(2016, 4, 27, 12, 49, 49, 726093, tzinfo=dt.timezone(dt.timedelta(seconds=36000)))
         }
     )
     assert(
@@ -82,21 +81,21 @@ def test_access_log(topology):
         {
             'rem': 'base="cn=config" scope=0 filter="(objectClass=*)" attrs="nsslapd-instancedir nsslapd-errorlog nsslapd-accesslog nsslapd-auditlog nsslapd-certdir nsslapd-schemadir nsslapd-bakdir nsslapd-ldifdir"',  # noqa
             'action': 'SRCH', 'timestamp': '[27/Apr/2016:12:49:49.727235997 +1000]', 'conn': '1', 'op': '2',
-            'datetime': datetime.datetime(2016, 4, 27, 12, 0, 0, 727235, tzinfo=tzoffset(None, 36000))
+            'datetime': dt.datetime(2016, 4, 27, 12, 49, 49, 727235, tzinfo=dt.timezone(dt.timedelta(seconds=36000)))
         }
     )
     assert(
         topology.standalone.ds_access_log.parse_line('[27/Apr/2016:12:49:49.736297002 +1000] conn=1 op=4 fd=64 closed - U1') ==
         {
             'status': 'U1', 'fd': '64', 'action': 'DISCONNECT', 'timestamp': '[27/Apr/2016:12:49:49.736297002 +1000]', 'conn': '1', 'op': '4',
-            'datetime': datetime.datetime(2016, 4, 27, 12, 0, 0, 736297, tzinfo=tzoffset(None, 36000))
+            'datetime': dt.datetime(2016, 4, 27, 12, 49, 49, 736297, tzinfo=dt.timezone(dt.timedelta(seconds=36000)))
         }
     )
     assert(
         topology.standalone.ds_access_log.parse_line('[27/Apr/2016:12:49:49.736297002 -1000] conn=1 op=4 fd=64 closed - U1') ==
         {
             'status': 'U1', 'fd': '64', 'action': 'DISCONNECT', 'timestamp': '[27/Apr/2016:12:49:49.736297002 -1000]', 'conn': '1', 'op': '4',
-            'datetime': datetime.datetime(2016, 4, 27, 12, 0, 0, 736297, tzinfo=tzoffset(None, -36000))
+            'datetime': dt.datetime(2016, 4, 27, 12, 49, 49, 736297, tzinfo=dt.timezone(dt.timedelta(seconds=-36000)))
         }
     )
 
@@ -113,7 +112,7 @@ def test_error_log(topology):
         topology.standalone.ds_error_log.parse_line('[27/Apr/2016:13:46:35.775670167 +1000] slapd started.  Listening on All Interfaces port 54321 for LDAP requests') ==  # noqa
         {
             'timestamp': '[27/Apr/2016:13:46:35.775670167 +1000]', 'message': 'slapd started.  Listening on All Interfaces port 54321 for LDAP requests',
-            'datetime': datetime.datetime(2016, 4, 27, 13, 0, 0, 775670, tzinfo=tzoffset(None, 36000))
+            'datetime': dt.datetime(2016, 4, 27, 13, 46, 35, 775670, tzinfo=dt.timezone(dt.timedelta(seconds=36000)))
         }
     )
 

--- a/src/lib389/pyproject.toml
+++ b/src/lib389/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
     "argparse-manpage[setuptools]",
     "pyasn1",
     "pyasn1-modules",
-    "python-dateutil",
     "argcomplete",
     "python-ldap",
     "distro",
@@ -43,7 +42,6 @@ classifiers = [
 dependencies = [
     "pyasn1",
     "pyasn1-modules",
-    "python-dateutil",
     "argcomplete",
     "python-ldap",
     "distro",

--- a/src/lib389/requirements.txt
+++ b/src/lib389/requirements.txt
@@ -1,6 +1,5 @@
 pyasn1
 pyasn1-modules
-python-dateutil
 argcomplete
 argparse-manpage
 python-ldap


### PR DESCRIPTION
Bug Description:
python-dateutil is unmaintained upstream and is marked for deprecation.

Fix Description:
* Replace `dateutil.tz.tzoffset` with `datetime.timezone(datetime.timedelta())`.
* Replace `dateutil.parser.parse` with standard `datetime` calls.
* Import `datetime` as `dt` to avoid confusion between module and class.

Fixes: https://github.com/389ds/389-ds-base/issues/7241

## Summary by Sourcery

Replace use of python-dateutil with standard library datetime handling and remove the deprecated dependency.

Bug Fixes:
- Ensure log timestamp and password expiration time parsing uses robust standard library datetime APIs instead of the deprecated python-dateutil package.

Enhancements:
- Refine log timestamp parsing to explicitly handle month and timezone offset components using datetime.timezone and datetime.timedelta.
- Standardize datetime imports in tests and code by aliasing the module as dt to avoid ambiguity.

Build:
- Remove python-dateutil from pyproject dependency configuration and lib389 requirements.

Tests:
- Update log parsing and password policy tests to assert against datetime objects built with standard library timezone and parsing APIs instead of python-dateutil helpers.