### PR TITLE
Issue 7243 - UI - add support for hot certificates

### DIFF
--- a/src/cockpit/389-console/src/lib/security/securityTables.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityTables.jsx
@@ -4,7 +4,6 @@ import {
     Grid,
     GridItem,
     Pagination,
-    PaginationVariant,
     SearchInput,
     Tooltip,
 } from '@patternfly/react-core';
@@ -94,10 +93,10 @@ class KeyTable extends React.Component {
     ];
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
-        
+
         this.setState({
             sortBy: {
                 index,
@@ -127,7 +126,7 @@ class KeyTable extends React.Component {
                 >
                     <a className="ds-font-size-sm">{_("What is an orphan key?")}</a>
                 </Tooltip>
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="orph key table"
                     variant="compact"
@@ -135,7 +134,7 @@ class KeyTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -163,7 +162,7 @@ class KeyTable extends React.Component {
                                 )}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -224,7 +223,7 @@ class CSRTable extends React.Component {
     }
 
     handleSort(_event, index, direction) {
-        const sortedRows = [...this.state.rows].sort((a, b) => 
+        const sortedRows = [...this.state.rows].sort((a, b) =>
             (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0)
         );
         this.setState({
@@ -316,7 +315,7 @@ class CSRTable extends React.Component {
                         onClear={(evt) => this.handleSearchChange(evt, '')}
                     />
                 }
-                <Table 
+                <Table
                     className="ds-margin-top"
                     aria-label="csr table"
                     variant="compact"
@@ -324,7 +323,7 @@ class CSRTable extends React.Component {
                     <Thead>
                         <Tr>
                             {columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy,
@@ -352,7 +351,7 @@ class CSRTable extends React.Component {
                                 )}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -418,41 +417,11 @@ class CertTable extends React.Component {
     }
 
     handleSort(_event, columnIndex, direction) {
-        const sorted_rows = [];
-        const rows = [];
-        let count = 0;
+        const rows = [...this.state.rows];
 
-        // Convert the rows pairings into a sortable array
-        for (let idx = 0; idx < this.state.rows.length; idx += 2) {
-            sorted_rows.push({
-                expandedRow: this.state.rows[idx + 1],
-                1: this.state.rows[idx].cells[0].content,
-                2: this.state.rows[idx].cells[1].content,
-                3: this.state.rows[idx].cells[2].content,
-                issuer: this.state.rows[idx].issuer,
-                flags: this.state.rows[idx].flags
-            });
-        }
-
-        sorted_rows.sort((a, b) => (a[columnIndex + 1] > b[columnIndex + 1]) ? 1 : -1);
+        rows.sort((a, b) => (a.cells[columnIndex].content > b.cells[columnIndex].content) ? 1 : -1);
         if (direction !== SortByDirection.asc) {
-            sorted_rows.reverse();
-        }
-
-        for (const srow of sorted_rows) {
-            rows.push({
-                isOpen: false,
-                cells: [
-                    { content: srow[1] },
-                    { content: srow[2] },
-                    { content: srow[3] }
-                ],
-                issuer: srow.issuer,
-                flags: srow.flags,
-            });
-            srow.expandedRow.parent = count;
-            rows.push(srow.expandedRow);
-            count += 2;
+            rows.reverse();
         }
 
         this.setState({
@@ -534,18 +503,16 @@ class CertTable extends React.Component {
             rows.push(
                 {
                     isOpen: false,
-                    cells: [cert.attrs.nickname, cert.attrs.subject, cert.attrs.expires],
+                    cells: [
+                        { content: cert.attrs.nickname },
+                        { content: cert.attrs.subject },
+                        { content: cert.attrs.expires }
+                    ],
                     issuer: cert.attrs.issuer,
                     flags: cert.attrs.flags,
-
-                },
-                {
-                    parent: count,
-                    fullWidth: true,
-                    cells: [{ title: this.getExpandedRow(cert.attrs.issuer, cert.attrs.flags) }]
-                },
+                }
             );
-            count += 2;
+            count += 1;
         }
 
         this.setState({
@@ -587,7 +554,7 @@ class CertTable extends React.Component {
                         onChange={this.handleSearchChange}
                         onClear={(evt) => this.handleSearchChange(evt, '')}
                     />}
-                <Table 
+                <Table
                     aria-label="cert table"
                     variant='compact'
                 >
@@ -626,7 +593,7 @@ class CertTable extends React.Component {
                                         </Td>
                                     ))}
                                     <Td isActionCell>
-                                        <ActionsColumn 
+                                        <ActionsColumn
                                             items={this.getActionsForRow(row)}
                                         />
                                     </Td>
@@ -646,7 +613,7 @@ class CertTable extends React.Component {
                 </Table>
                 {hasRows &&
                     <Pagination
-                        itemCount={this.state.rows.length / 2}
+                        itemCount={this.state.rows.length}
                         widgetId="pagination-options-menu-bottom"
                         perPage={perPage}
                         page={page}
@@ -728,7 +695,7 @@ class CRLTable extends React.Component {
         if (direction !== SortByDirection.asc) {
             sorted_rows.reverse();
         }
-        
+
         for (const srow of sorted_rows) {
             rows.push({
                 isOpen: false,
@@ -806,14 +773,14 @@ class CRLTable extends React.Component {
                     onChange={this.handleSearchChange}
                     onClear={(evt) => this.handleSearchChange(evt, '')}
                 />
-                <Table 
+                <Table
                     aria-label="CRL Table"
                     variant="compact"
                 >
                     <Thead>
                         <Tr>
                             {this.state.columns.map((column, idx) => (
-                                <Th 
+                                <Th
                                     key={idx}
                                     sort={column.sortable ? {
                                         sortBy: this.state.sortBy,
@@ -836,7 +803,7 @@ class CRLTable extends React.Component {
                                     ))}
                                     {this.state.hasRows && (
                                         <Td isActionCell>
-                                            <ActionsColumn 
+                                            <ActionsColumn
                                                 items={this.getActionsForRow(row)}
                                             />
                                         </Td>

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -60,6 +60,8 @@ export class Security extends React.Component {
             primaryCertName: '',
             serverCertNames: [],
             serverCerts: [],
+            CACerts: [],
+            CACertNames: [],
             isMinSSLOpen: false,
             isMaxSSLOpen: false,
             isClientAuthOpen: false,
@@ -330,9 +332,14 @@ export class Security extends React.Component {
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
                     const certs = JSON.parse(content);
+                    const certNames = [];
+                    for (const cert of certs) {
+                        certNames.push(cert.attrs.nickname);
+                    }
                     this.setState(() => (
                         {
                             CACerts: certs,
+                            CACertNames: certNames,
                         }), this.loadCSRs
                     );
                 })
@@ -1226,6 +1233,9 @@ export class Security extends React.Component {
                                     ServerKeys={this.state.serverOrphanKeys}
                                     addNotification={this.props.addNotification}
                                     certDir={this.props.certDir}
+                                    certNicknames={this.state.serverCertNames}
+                                    CACertNicknames={this.state.CACertNames}
+                                    reloadCerts={this.loadCerts}
                                 />
                             </Tab>
                             <Tab eventKey={2} title={<TabTitleText>{_("Cipher Preferences")}</TabTitleText>}>

--- a/src/lib389/lib389/cli_conf/security.py
+++ b/src/lib389/lib389/cli_conf/security.py
@@ -86,9 +86,9 @@ def _security_generic_get(inst, basedn, log, args, attrs_map):
             val = ""
         result[props.attr.lower()] = val
     if args.json:
-        print(json.dumps({'type': 'list', 'items': result}, indent=4))
+        log.info(json.dumps({'type': 'list', 'items': result}, indent=4))
     else:
-        print('\n'.join([f'{attr}: {value or ""}' for attr, value in result.items()]))
+        log.info('\n'.join([f'{attr}: {value or ""}' for attr, value in result.items()]))
 
 
 def _security_generic_set(inst, basedn, log, args, attrs_map):
@@ -228,10 +228,10 @@ def security_ciphers_set(inst, basedn, log, args):
 def security_ciphers_get(inst, basedn, log, args):
     enc = Encryption(inst)
     if args.json:
-        print({'type': 'list', 'items': enc.ciphers})
+        log.info({'type': 'list', 'items': enc.ciphers})
     else:
         val = ','.join(enc.ciphers)
-        print(val if val != '' else '<undefined>')
+        log.info(val if val != '' else '<undefined>')
 
 
 def security_ciphers_list(inst, basedn, log, args):
@@ -247,12 +247,13 @@ def security_ciphers_list(inst, basedn, log, args):
         lst = enc.ciphers
 
     if args.json:
-        print(json.dumps({'type': 'list', 'items': lst}, indent=4))
+        log.info(json.dumps({'type': 'list', 'items': lst}, indent=4))
     else:
         if lst == []:
             log.getChild('security').warn('List of ciphers is empty')
         else:
-            print(*lst, sep='\n')
+            for item in lst:
+                log.info(item)
 
 
 def security_disable_plaintext_port(inst, basedn, log, args, warn=True):
@@ -312,7 +313,10 @@ def cert_list(inst, basedn, log, args):
     certmgr = CertManager(instance=inst)
     certs = certmgr.list_certs()
     if not certs:
-        log.info("No certificates found.")
+        if args.json:
+            log.info(json.dumps([], indent=4))
+        else:
+            log.info("No certificates found.")
         return
 
     if args.json:
@@ -328,7 +332,10 @@ def cacert_list(inst, basedn, log, args):
     certmgr = CertManager(instance=inst)
     ca_certs = certmgr.list_ca_certs()
     if not ca_certs:
-        log.info("No CA certificates found.")
+        if args.json:
+            log.info(json.dumps([], indent=4))
+        else:
+            log.info("No CA certificates found.")
         return
 
     if args.json:


### PR DESCRIPTION
Description:

In the "Add Server Certificate" modal add password options for pkcs#12 certificates. Also improved validation for certificate names and fixed the table sorting

relates: https://github.com/389ds/389-ds-base/issues/7243

## Summary by Sourcery

Add PKCS#12 password handling and nickname validation to certificate management UI and refactor CA certificate addition into a dedicated modal.

New Features:
- Introduce PKCS#12 password options (none, stdin, file, or direct text) and a skip‑verification flag when adding server certificates.
- Add a dedicated Certificate Authority add modal, separating CA certificate creation from server certificate creation.

Bug Fixes:
- Fix certificate table sorting so it operates directly on visible rows and updates pagination correctly.
- Correct handling of empty certificate lists when selecting server-side certificates in the add certificate modals.
- Improve error handling when adding certificates with PKCS#12 passwords provided via stdin.

Enhancements:
- Prevent reuse of existing certificate nicknames across server and CA certificates when adding new certificates.
- Refine the Add Server Certificate UI with tabbed layout separating certificate details from PKCS#12 password options.
- Improve certificate and CA certificate loading to track and expose nickname lists for validation and reuse.
- Simplify certificate table sorting and row structure while keeping pagination in sync with visible rows.
- Tighten validation of password file paths for PKCS#12 options.