### PR TITLE
Issue 7066/7052 - allow password history to be set to zero and remove history

### DIFF
--- a/dirsrvtests/tests/suites/password/pwp_history_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_history_test.py
@@ -189,9 +189,9 @@ def test_history_is_not_overwritten(topology_st, user):
 
 
 @pytest.mark.parametrize('policy',
-                          [(pytest.param('global', marks=pytest.mark.xfail(reason="DS7052"))),
-                           (pytest.param('subtree', marks=pytest.mark.xfail(reason="DS7066, DS7052"))),
-                           (pytest.param('user', marks=pytest.mark.xfail(reason="DS7066, DS7052")))])
+                          [(pytest.param('global')),
+                           (pytest.param('subtree')),
+                           (pytest.param('user'))])
 def test_basic(topology_st, user, policy):
     """Test basic password policy history feature functionality with dynamic count reduction
 
@@ -282,6 +282,7 @@ def test_basic(topology_st, user, policy):
     # Password history [password3, password4], current password is "password1"
 
     # Reset password by Directory Manager(admin reset)
+    dm = DirectoryManager(topology_st.standalone)
     dm.rebind()
     time.sleep(.5)
     change_password(user, 'password-reset', success=True)

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -87,7 +87,7 @@ static struct attr_value_check
     {CONFIG_PW_WARNING_ATTRIBUTE, check_pw_duration_value, 0, -1},
     {CONFIG_PW_MINLENGTH_ATTRIBUTE, attr_check_minmax, 2, 512},
     {CONFIG_PW_MAXFAILURE_ATTRIBUTE, attr_check_minmax, 1, 32767},
-    {CONFIG_PW_INHISTORY_ATTRIBUTE, attr_check_minmax, 1, 24},
+    {CONFIG_PW_INHISTORY_ATTRIBUTE, attr_check_minmax, 0, 24},
     {CONFIG_PW_LOCKDURATION_ATTRIBUTE, check_pw_duration_value, -1, -1},
     {CONFIG_PW_RESETFAILURECOUNT_ATTRIBUTE, check_pw_resetfailurecount_value, -1, -1},
     {CONFIG_PW_GRACELIMIT_ATTRIBUTE, attr_check_minmax, 0, -1},

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -1535,7 +1535,18 @@ update_pw_history(Slapi_PBlock *pb, const Slapi_DN *sdn, char *old_pw)
     pwpolicy = new_passwdPolicy(pb, dn);
 
     if (pwpolicy->pw_inhistory == 0){
-        /* We are only enforcing the current password, just return */
+        /* We are only enforcing the current password, just return but first
+         * cleanup any old passwords in the history */
+        attribute.mod_type = "passwordHistory";
+        attribute.mod_op = LDAP_MOD_REPLACE;
+        attribute.mod_values = NULL;
+        list_of_mods[0] = &attribute;
+        list_of_mods[1] = NULL;
+        mod_pb = slapi_pblock_new();
+        slapi_modify_internal_set_pb_ext(mod_pb, sdn, list_of_mods, NULL, NULL, pw_get_componentID(), 0);
+        slapi_modify_internal_pb(mod_pb);
+        slapi_pblock_destroy(mod_pb);
+
         return res;
     }
 


### PR DESCRIPTION
Description:

For local password policies the server was incorrectly rejecting updates that set the value to zero.  When password history is set to zero the old passwords in the entry history are not cleaned as expected.

relates: https://github.com/389ds/389-ds-base/issues/7052
relates: https://github.com/389ds/389-ds-base/issues/7066

## Summary by Sourcery

Allow password history policies to accept a value of zero and ensure existing history entries are cleared when history is disabled.

Bug Fixes:
- Fix rejection of password policy updates that set pw_inhistory to zero.
- Clear stored passwordHistory values when password history enforcement is disabled for an entry.

Enhancements:
- Enable zero as a valid value for pw_inhistory in password policy configuration validation.

Tests:
- Unskip and adjust password policy history tests to cover zero-history behavior and admin password resets.