### PR TITLE
Issue 7246 - correct formatting of 'Gen as CSN' in dsctl get-nsstate …

### DIFF
--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -407,7 +407,7 @@ class DSEldif(DSLint):
             'endian': endian,
             'rid': str(rid),
             'gen_time': str(sampled_time),
-            'gencsn': "%08x%04d%04d0000" % (sampled_time, seq_num, rid),
+            'gencsn': "%08x%04x%04x0000" % (sampled_time, seq_num, rid),
             'gen_time_str': time.ctime(sampled_time),
             'local_offset': str(local_offset),
             'local_offset_str': print_nice_time(local_offset),


### PR DESCRIPTION
…output

Description: CSNs are formatted as hexadecimal, but the replica id and sequence number are displayed in decomal.

Fix: use correct format specifiers for hexadecimal output.

Fixes: https://github.com/389ds/389-ds-base/issues/7246

## Summary by Sourcery

Bug Fixes:
- Display the replica id and sequence number components of generated CSNs in hexadecimal to match the rest of the CSN format.