### PR TITLE
Issue 7248 - CLI - attribute uniqueness - fix usage for exclude subtee option

### DIFF
--- a/src/lib389/lib389/cli_conf/plugins/attruniq.py
+++ b/src/lib389/lib389/cli_conf/plugins/attruniq.py
@@ -127,7 +127,7 @@ def _add_parser_args(parser):
                         help='Sets the DN under which the plug-in checks for uniqueness of '
                              'the attributes value. This attribute is multi-valued (uniqueness-subtrees)')
     parser.add_argument('--exclude-subtree', nargs='+',
-                        help='Sets subtrees that should not excludedfrom attribute uniqueness. '
+                        help='Sets subtrees that should be excluded from attribute uniqueness checks. '
                              'This attribute is multi-valued (uniqueness-exclude-subtrees)')
     parser.add_argument('--across-all-subtrees', choices=['on', 'off'], type=str.lower,
                         help='If enabled (on), the plug-in checks that the attribute is unique across all subtrees '


### PR DESCRIPTION
Description:

Fix typo in usage message for the exclude subtree option

relates: https://github.com/389ds/389-ds-base/issues/7248

## Summary by Sourcery

Bug Fixes:
- Fix incorrect wording in the --exclude-subtree help message for the attribute uniqueness plugin CLI.