### PR TITLE
Issue - CLI - dsctl db2index needs some hardening with MBD

### DIFF
--- a/dirsrvtests/tests/suites/import/import_test.py
+++ b/dirsrvtests/tests/suites/import/import_test.py
@@ -514,7 +514,7 @@ def test_entry_with_escaped_characters_fails_to_import_and_index(topo, _import_c
             count += 1
     # Now re-index the database
     topo.standalone.stop()
-    topo.standalone.db2index()
+    topo.standalone.db2index(bename="userroot")
     topo.standalone.start()
     # Should not return error.
     assert not topo.standalone.searchErrorsLog('error')

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -2953,7 +2953,7 @@ class DirSrv(SimpleLDAPObject, object):
 
         return True
 
-    def db2index(self, bename=None, suffixes=None, attrs=None, vlvTag=None):
+    def db2index(self, bename, suffixes=None, attrs=None, vlvTag=None):
         """
         @param bename - The backend name to reindex
         @param suffixes - List/tuple of suffixes to reindex, currently unused
@@ -2966,34 +2966,18 @@ class DirSrv(SimpleLDAPObject, object):
         if self.status():
             self.log.error("db2index: Can not operate while directory server is running")
             return False
-        cmd = [prog, ]
-        # No backend specified, do an upgrade on all backends
-        # Backend and no attrs specified, reindex with all backend indexes
-        # Backend and attr/s specified, reindex backend with attr/s
-        if bename:
-            cmd.append('db2index')
-            cmd.append('-n')
-            cmd.append(bename)
-            if attrs:
-                 for attr in attrs:
-                        cmd.append('-t')
-                        cmd.append(attr)
-            else:
-                dse_ldif = DSEldif(self)
-                indexes = dse_ldif.get_indexes(bename)
-                if indexes:
-                    for idx in indexes:
-                        cmd.append('-t')
-                        cmd.append(idx)
+        cmd = [prog, 'db2index', '-n', bename, '-D', self.get_config_dir()]
+        if attrs:
+            for attr in attrs:
+                cmd.append('-t')
+                cmd.append(attr)
         else:
-            cmd.append('upgradedb')
-            cmd.append('-a')
-            now = datetime.now().isoformat()
-            cmd.append(os.path.join(self.get_bak_dir(), 'reindex_%s' % now))
-            cmd.append('-f')
-
-        cmd.append('-D')
-        cmd.append(self.get_config_dir())
+            dse_ldif = DSEldif(self)
+            indexes = dse_ldif.get_indexes(bename)
+            if indexes:
+                for idx in indexes:
+                    cmd.append('-t')
+                    cmd.append(idx)
 
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -26,32 +26,18 @@ class IndexOrdering(Enum):
 
 
 def dbtasks_db2index(inst, log, args):
-    rtn = False
-    if not args.backend:
-        if not inst.db2index():
-            rtn = False
-        else:
-            rtn = True
-    elif args.backend and not args.attr:
-        if not inst.db2index(bename=args.backend):
-            rtn = False
-        else:
-            rtn = True
-    else:
-        if not inst.db2index(bename=args.backend, attrs=args.attr):
-            rtn = False
-        else:
-            rtn = True
-    if rtn:
-        log.info("db2index successful")
-        return rtn
-    else:
+    inst.log = log
+    if not inst.db2index(bename=args.backend, attrs=args.attr):
         log.fatal("db2index failed")
-        return rtn
+        return False
+    else:
+        log.info("db2index successful")
+        return True
 
 
 def dbtasks_db2bak(inst, log, args):
     # Needs an output name?
+    inst.log = log
     if not inst.db2bak(args.archive):
         log.fatal("db2bak failed")
         return False
@@ -61,6 +47,7 @@ def dbtasks_db2bak(inst, log, args):
 
 def dbtasks_bak2db(inst, log, args):
     # Needs the archive to restore.
+    inst.log = log
     if not inst.bak2db(args.archive):
         log.fatal("bak2db failed")
         return False
@@ -70,6 +57,7 @@ def dbtasks_bak2db(inst, log, args):
 
 def dbtasks_db2ldif(inst, log, args):
     # If export filename is provided, check if file path exists
+    inst.log = log
     if args.ldif:
         path = Path(args.ldif)
         parent = path.parent.absolute()
@@ -88,6 +76,7 @@ def dbtasks_db2ldif(inst, log, args):
 
 def dbtasks_ldif2db(inst, log, args):
     # Check if ldif file exists
+    inst.log = log
     if not os.path.exists(args.ldif):
         raise ValueError("The LDIF file does not exist: " + args.ldif)
 
@@ -103,6 +92,7 @@ def dbtasks_ldif2db(inst, log, args):
 
 
 def dbtasks_backups(inst, log, args):
+    inst.log = log
     if args.delete:
         # Delete backup
         inst.del_backup(args.delete[0])
@@ -117,6 +107,7 @@ def dbtasks_backups(inst, log, args):
 
 
 def dbtasks_ldifs(inst, log, args):
+    inst.log = log
     if args.delete:
         # Delete LDIF file
         inst.del_ldif(args.delete[0])
@@ -131,6 +122,7 @@ def dbtasks_ldifs(inst, log, args):
 
 
 def dbtasks_verify(inst, log, args):
+    inst.log = log
     if not inst.dbverify(bename=args.backend):
         log.fatal("dbverify failed")
         return False
@@ -521,9 +513,8 @@ def dbtasks_index_check(inst, log, args):
 
 def create_parser(subcommands):
     db2index_parser = subcommands.add_parser('db2index', help="Initialise a reindex of the server database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)
-    # db2index_parser.add_argument('suffix', help="The suffix to reindex. IE dc=example,dc=com.")
-    db2index_parser.add_argument('backend', nargs="?", help="The backend to reindex. IE userRoot", default=False)
-    db2index_parser.add_argument('--attr', nargs="*", help="The attribute's to reindex. IE --attr aci cn givenname", default=False)
+    db2index_parser.add_argument('backend', help="The backend to reindex. IE userRoot")
+    db2index_parser.add_argument('--attr', action='append', help="An attribute to reindex. IE: --attr member --attr cn ...")
     db2index_parser.set_defaults(func=dbtasks_db2index)
 
     db2bak_parser = subcommands.add_parser('db2bak', help="Initialise a BDB backup of the database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)


### PR DESCRIPTION
Description:

The usage for dsctl db2index was confusing. The way the attr options and backend name were displayed it looks like the backend name could come after the attributes, but instead the backend name was treated as an attribute.

Instead make the backend name required, and change the attribute naming to require individual options instead of a list of values.

Relates: https://github.com/389ds/389-ds-base/issues/7250

## Summary by Sourcery

Require an explicit backend when running db2index and simplify db task logging integration.

New Features:
- Make the db2index CLI require a backend argument and accept repeated attribute options instead of a positional list.

Bug Fixes:
- Ensure db2index treats the backend name as a backend rather than as an attribute and harden its invocation semantics.

Enhancements:
- Propagate the CLI logger into db task instance methods for db2index, backups, LDIF operations, and verification to centralize logging.
- Clarify db2index help text to describe the new attribute flag usage and backend requirement.
- Document that the db2index upgradedb path only works with BDB backends.

Tests:
- Update the import test to call db2index with an explicit backend to match the new CLI requirements.