### PR TITLE
Issue 7174 - Add spec-kit constitution file

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -1,0 +1,110 @@
+<!--
+Sync Impact Report:
+Version change: N/A → 1.0.0 (initial constitution)
+Modified principles: N/A (all new)
+Added sections: Reliability, Performance & Scalability, Standards Compliance, Enterprise Features, Development Workflow
+Removed sections: N/A
+Templates requiring updates:
+  ✅ plan-template.md (Constitution Check section exists, no changes needed)
+  ✅ spec-template.md (no constitution-specific references)
+  ✅ tasks-template.md (no constitution-specific references)
+  ✅ All command files (no constitution-specific references found)
+Follow-up TODOs: None
+-->
+
+# 389 Directory Server Constitution
+
+## Core Principles
+
+### I. Reliability (NON-NEGOTIABLE)
+The 389 Directory Server MUST be an open source, real-world, hardened directory service. All code MUST be extensively tested with sanitization tools before integration. The server MUST provide a rich feature set of fail-over and backup technologies to give administrators confidence their accounts are safe. Reliability is critical for enterprise deployments handling identity and organizational data.
+
+### II. Performance & Scalability (NON-NEGOTIABLE)
+The server MUST be a high-performance LDAP server capable of handling thousands of operations per second and supporting hundreds of thousands of accounts. Database size MUST only be restricted by disk space. The server MUST support high throughput performance and multi-supplier replication for horizontal scaling to meet the needs of the most demanding environments - from small business to cloud deployments.
+
+### III. Standards Compliance
+The server MUST maintain LDAPv3 compliance and support the extensive list of RFCs that define LDAP functionality. All implementations MUST adhere to relevant RFC specifications including but not limited to: RFC 2251 (LDAPv3), RFC 2252 (Attribute Syntax), RFC 2253 (DN Representation), RFC 2254 (Search Filters), RFC 2255 (LDAP URLs), RFC 2256 (User Schema), RFC 2830 (TLS), RFC 2829 (Authentication), and other applicable RFCs. Standards compliance ensures interoperability and compatibility with LDAP clients and tools.
+
+### IV. Enterprise Features
+The server MUST support enterprise-grade features including: online, zero-downtime, LDAP-based updates of schema, configuration, and management including Access Control Information (ACIs); asynchronous multi-supplier replication for fault tolerance and high write performance; secure authentication and transport (TLS and SASL); and comprehensive documentation. These features are essential for production deployments in enterprise environments.
+
+### V. Testing & Quality Assurance
+All code MUST be extensively tested with sanitization tools (ASAN, static analysis, fuzzing where applicable) before integration. Test coverage MUST be maintained or improved with each change. Integration tests MUST verify replication, fail-over, and backup scenarios for affected features. The codebase has been deployed continuously for more than a decade by sites around the world, demonstrating proven reliability through real-world use.
+
+## Performance & Scalability Standards
+
+All features affecting core server operations MUST meet or exceed existing performance benchmarks. Performance testing MUST include:
+- Throughput measurements (operations per second) - must support thousands of operations per second
+- Latency measurements (p50, p95, p99)
+- Resource utilization (CPU, memory, disk I/O)
+- Scalability testing with increasing data volumes and concurrent connections - must support hundreds of thousands of accounts
+- Multi-supplier replication performance and horizontal scaling capabilities
+
+Performance regressions identified during development MUST be resolved before feature completion.
+
+## Security & Reliability Requirements
+
+Security requirements MUST be addressed at design time, not as an afterthought. All code MUST:
+- Follow secure coding practices
+- Pass sanitization tool checks (ASAN, static analysis, fuzzing where applicable)
+- Handle errors gracefully without exposing sensitive information
+- Validate all inputs and sanitize outputs
+- Maintain audit logging for security-relevant operations
+- Support secure authentication and transport (TLS and SASL)
+
+Reliability features (fail-over, backup, replication) MUST be tested under failure scenarios and documented for operators. The server MUST provide administrators confidence that accounts are safe through comprehensive fail-over and backup technologies.
+
+## Standards Compliance Requirements
+
+All LDAP protocol implementations MUST comply with relevant RFC specifications. The server MUST support:
+- Core LDAPv3 protocols (RFC 2251, RFC 3377)
+- Attribute syntax and schema definitions (RFC 2252, RFC 2256, RFC 1274)
+- Distinguished name representations (RFC 2253, RFC 1779, RFC 2247)
+- Search filters and LDAP URLs (RFC 2254, RFC 2255, RFC 1558)
+- Authentication and security (RFC 2829, RFC 2830, RFC 2222)
+- LDIF format (RFC 2849)
+- Operational attributes and controls (RFC 3673, RFC 4527)
+- Network Information Service (RFC 2307)
+- Other applicable RFCs as specified
+
+Standards compliance MUST be verified through testing and interoperability validation.
+
+## Development Workflow
+
+### Code Review Requirements
+All changes MUST be reviewed by at least one maintainer. Reviews MUST verify:
+- Constitution compliance (reliability, performance, scalability, standards)
+- Code quality and maintainability
+- Test coverage adequacy
+- Documentation completeness
+- Backward compatibility (when applicable)
+- Sanitization tool check results
+
+### Testing Gates
+Before merge, code MUST:
+- Pass all unit tests
+- Pass all integration tests
+- Pass sanitization tool checks (ASAN, static analysis)
+- Maintain or improve test coverage
+- Pass performance benchmarks (for performance-affecting changes)
+- Verify standards compliance for protocol changes
+
+### Documentation Requirements
+New features MUST include:
+- User-facing documentation
+- Configuration documentation
+- API documentation (for plugins/APIs)
+- Migration guides (for breaking changes)
+- Standards compliance documentation (for protocol features)
+
+## Governance
+
+This constitution supersedes all other development practices and guidelines. All pull requests and code reviews MUST verify compliance with these principles. Amendments to this constitution require:
+- Documentation of the rationale
+- Approval from project maintainers
+- Update to dependent templates and documentation
+- Version increment following semantic versioning (MAJOR.MINOR.PATCH)
+
+Complexity and deviations from these principles MUST be justified with clear rationale and documented exceptions. When in doubt, prioritize reliability, performance, scalability, and standards compliance over convenience or expediency.
+
+**Version**: 1.0.0 | **Ratified**: 2026-01-27 | **Last Amended**: 2026-01-27


### PR DESCRIPTION
Description:

Using a constitution file is the foundation of using spec-driven development. For now just add this file so the entire team and can use it if they deceide they want to use a spec-kit for development.

relates: https://github.com/389ds/389-ds-base/issues/7174

## Summary by Sourcery

Documentation:
- Add a versioned constitution document outlining reliability, performance, security, standards compliance, and development workflow requirements for the project.