### PR TITLE
Issue 7223 - Use lexicographical order for ancestorid

### DIFF
--- a/ldap/servers/slapd/back-ldbm/instance.c
+++ b/ldap/servers/slapd/back-ldbm/instance.c
@@ -231,7 +231,7 @@ ldbm_instance_create_default_indexes(backend *be)
      * ancestorid is special, there is actually no such attr type
      * but we still want to use the attr index file APIs.
      */
-    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, "integerOrderingMatch");
+    e = ldbm_instance_init_config_entry(LDBM_ANCESTORID_STR, "eq", 0, 0, 0, 0);
     attr_index_config(be, "ldbm index init", 0, e, 1, 0, NULL);
     slapi_entry_free(e);
 


### PR DESCRIPTION
Description:
`ldbm_instance_create_default_indexes()` configured ancestorid with integerOrderingMatch in the in-memory attrinfo, but ancestorid on disk might be using lexicographic ordering (data before the upgrade or after ldif2db import).

Relates: https://github.com/389ds/389-ds-base/issues/7223

## Summary by Sourcery

Bug Fixes:
- Prevent mismatches between in-memory and on-disk ancestorid index ordering that could occur when ancestorid was configured with integerOrderingMatch in memory while stored lexicographically on disk.