### PR TITLE
Issue 7213 - (2nd) MDB_BAD_VALSIZE error while handling VLV

### DIFF
--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -1175,6 +1175,7 @@ def test_vlv_with_mr(vlv_setup_with_uid_mr):
 
 
 
+@pytest.mark.skipif(get_default_db_lib() == "bdb", reason="Hangs on BDB")
 def test_vlv_long_attribute_value(topology_st, request):
     """
     Test VLV with an entry containing a very long attribute value (2K).


### PR DESCRIPTION
Decription:
Disable test_vlv_long_attribute_value on BDB as it hangs sometimes in CI, blocking other pipelines.

Relates: https://github.com/389ds/389-ds-base/issues/7213

## Summary by Sourcery

Tests:
- Mark the VLV long attribute value test as skipped on BDB backends due to lack of support and intermittent hangs in CI.