### PR TITLE
Issue 6758 - Fix Enable Replication dropdown not opening

### DIFF
--- a/src/cockpit/389-console/src/lib/replication/replModals.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replModals.jsx
@@ -1757,8 +1757,6 @@ export class EnableReplModal extends React.Component {
                                     handleChange(syntheticEvent);
                                 }}
                                 options={[_("Supplier"), _("Hub"), _("Consumer")]}
-                                isOpen={false}
-                                onToggle={() => {}}
                                 placeholder={_("Select role...")}
                                 ariaLabel="Replication role selection"
                                 isMulti={false}


### PR DESCRIPTION
Removed hardcoded isOpen={false} and empty onToggle handler that prevented dropdown from opening. Let component manage its own state.

Relates: #6758

Reviewed by: ???

## Summary by Sourcery

Bug Fixes:
- Allow the replication role dropdown in the EnableReplModal to open by removing hardcoded closed state and no-op toggle handler.