### PR TITLE
Issue 7265 - changelog maxage validation is not strict enough

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -100,7 +100,7 @@ def set_changelog_trimming(instance):
         cl = Changelog(instance, DEFAULT_SUFFIX)
     else:
         cl = Changelog5(instance)
-    cl.replace('nsslapd-changelogmaxage', '30')
+    cl.replace('nsslapd-changelogmaxage', '30d')
 
 
 def test_healthcheck_disabled_suffix(topology_st):

--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -570,8 +570,10 @@ def test_changelog_maxage(topo, changelog_init):
             '/var/lib/dirsrv/slapd-supplier1/changelog' and
             set cn=Retro Changelog Plugin,cn=plugins,cn=config to 'on'
     :steps:
-        1. Set nsslapd-changelogmaxage in cn=changelog5,cn=config to values - '12345','10s','30M','12h','2D','4w'
-        2. Set nsslapd-changelogmaxage in cn=changelog5,cn=config to values - '-123','xyz'
+        1. Set nsslapd-changelogmaxage in cn=changelog5,cn=config to values:
+           '100s','100S','30m','30M','12h','12H','2d','2D','4w','4W'
+        2. Set nsslapd-changelogmaxage in cn=changelog5,cn=config to values:
+           '12345', 'd', '-123', '-123d', '345345xyz', '0d', 'xyz'
 
     :expectedresults:
         1. Operation should be successful
@@ -583,13 +585,22 @@ def test_changelog_maxage(topo, changelog_init):
     topo.ms["supplier1"].log.info("Bind as %s" % DN_DM)
     topo.ms["supplier1"].simple_bind_s(DN_DM, PASSWORD)
 
-    add_and_check(topo, CHANGELOG, MAXAGE, '12345', True)
-    add_and_check(topo, CHANGELOG, MAXAGE, '10s', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '100s', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '100S', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '30m', True)
     add_and_check(topo, CHANGELOG, MAXAGE, '30M', True)
     add_and_check(topo, CHANGELOG, MAXAGE, '12h', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '12H', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '2d', True)
     add_and_check(topo, CHANGELOG, MAXAGE, '2D', True)
     add_and_check(topo, CHANGELOG, MAXAGE, '4w', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '4W', True)
+    add_and_check(topo, CHANGELOG, MAXAGE, '12345', False)
+    add_and_check(topo, CHANGELOG, MAXAGE, 'd', False)
     add_and_check(topo, CHANGELOG, MAXAGE, '-123', False)
+    add_and_check(topo, CHANGELOG, MAXAGE, '-123d', False)
+    add_and_check(topo, CHANGELOG, MAXAGE, '345345xyz', False)
+    add_and_check(topo, CHANGELOG, MAXAGE, '0d', False)
     add_and_check(topo, CHANGELOG, MAXAGE, 'xyz', False)
 
 
@@ -668,9 +679,9 @@ def test_retrochangelog_maxage(topo, changelog_init):
             set cn=Retro Changelog Plugin,cn=plugins,cn=config to 'on'
     :steps:
         1. Set nsslapd-changelogmaxage in cn=Retro Changelog Plugin,cn=plugins,cn=config to values -
-           '12345','10s','30M','12h','2D','4w'
+           '100s','100S','30m','30M','12h','12H','2d','2D','4w','4W'
         2. Set nsslapd-changelogmaxage in cn=Retro Changelog Plugin,cn=plugins,cn=config to values -
-           '-123','xyz'
+           '12345', 'd', '-123', '-123d', '345345xyz', '0d', 'xyz'
 
     :expectedresults:
         1. Operation should be successful
@@ -682,13 +693,22 @@ def test_retrochangelog_maxage(topo, changelog_init):
     topo.ms["supplier1"].log.info("Bind as %s" % DN_DM)
     topo.ms["supplier1"].simple_bind_s(DN_DM, PASSWORD)
 
-    add_and_check(topo, RETROCHANGELOG, MAXAGE, '12345', True)
-    add_and_check(topo, RETROCHANGELOG, MAXAGE, '10s', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '100s', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '100S', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '30m', True)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, '30M', True)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, '12h', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '12H', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '2d', True)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, '2D', True)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, '4w', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '4W', True)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '12345', False)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, 'd', False)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, '-123', False)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '-123d', False)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '345345xyz', False)
+    add_and_check(topo, RETROCHANGELOG, MAXAGE, '0d', False)
     add_and_check(topo, RETROCHANGELOG, MAXAGE, 'xyz', False)
 
     topo.ms["supplier1"].log.info("ticket47669 was successfully verified.")

--- a/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_trimming_test.py
@@ -77,11 +77,11 @@ def setup_max_age(topo, request):
     supplier.config.loglevel((ErrorLog.REPLICA,), 'error')
 
     if ds_supports_new_changelog():
-        set_value(supplier, MAXAGE, '5')
+        set_value(supplier, MAXAGE, '5s')
         set_value(supplier, TRIMINTERVAL, '300')
     else:
         cl = Changelog5(supplier)
-        cl.set_max_age('5')
+        cl.set_max_age('5s')
         cl.set_trim_interval('300')
 
 def test_max_age(topo, setup_max_age):
@@ -253,11 +253,11 @@ def test_cl_trim_ignore_empty_ruv_element(topology_m1c1):
     # - Step 8 - set Triming interval to 2sec to have frequent trimming
     # and max-age to 8sec to not wait too long
     if ds_supports_new_changelog():
-        set_value(s1, MAXAGE, '8')
+        set_value(s1, MAXAGE, '8s')
         set_value(s1, TRIMINTERVAL, '2')
     else:
         cl = Changelog5(s1)
-        cl.set_max_age('8')
+        cl.set_max_age('8s')
         cl.set_trim_interval('2')
 
     # - Step 9 - Wait for the trimming to occur

--- a/dirsrvtests/tests/suites/replication/regression_m2c1_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2c1_test.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.tier1
 
 CHANGELOG = 'cn=changelog,{}'.format(DN_USERROOT_LDBM)
 MAXAGE_ATTR = 'nsslapd-changelogmaxage'
-MAXAGE_VALUE = '5'
+MAXAGE_VALUE = '5s'
 TRIMINTERVAL = 'nsslapd-changelogtrim-interval'
 TRIMINTERVAL_VALUE = '15'
 MAX_USERS = 10
@@ -94,7 +94,7 @@ def test_changelog_trimming(topo_m2c1):
     log.info("Create updates on S1 and S2")
     users_s1 = UserAccounts(S1, DEFAULT_SUFFIX)
     users_s2 = UserAccounts(S2, DEFAULT_SUFFIX)
-    
+
     for idx in range(1, MAX_USERS):
         user_properties = TEST_USER_PROPERTIES.copy()
         user_properties.update({'uid': f'user_{idx}'})
@@ -107,7 +107,7 @@ def test_changelog_trimming(topo_m2c1):
         user.replace('description', 'value from S2')
 
     log.info("Wait for maxage")
-    time.sleep(int(MAXAGE_VALUE))
+    time.sleep(int(MAXAGE_VALUE[:-1]))
 
     log.info("Pause replica agreement S1->S2")
     agreement_s1_s2 = S1.agreement.list(suffix=DEFAULT_SUFFIX, consumer_host=S2.host, consumer_port=S2.port)[0]

--- a/dirsrvtests/tests/suites/replication/regression_m3_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m3_test.py
@@ -28,7 +28,7 @@ NEW_SUFFIX = 'o={}'.format(NEW_SUFFIX_NAME)
 NEW_BACKEND = 'repl_base'
 CHANGELOG = 'cn=changelog,{}'.format(DN_USERROOT_LDBM)
 MAXAGE_ATTR = 'nsslapd-changelogmaxage'
-MAXAGE_STR = '30'
+MAXAGE_STR = '30s'
 TRIMINTERVAL_STR = '5'
 TRIMINTERVAL = 'nsslapd-changelogtrim-interval'
 

--- a/ldap/servers/plugins/replication/cl5_config.c
+++ b/ldap/servers/plugins/replication/cl5_config.c
@@ -176,7 +176,7 @@ changelog5_config_add(Slapi_PBlock *pb __attribute__((unused)),
     slapi_log_err(SLAPI_LOG_NOTICE, repl_plugin_name_cl,
                   "changelog5_config_add - Separate changelog no longer supported; "
                   "use cn=changelog,<backend> instead\n");
- 
+
     if (returntext) {
         PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE, "Changelog configuration is part of the backend configuration");
     }
@@ -198,7 +198,7 @@ changelog5_config_modify(Slapi_PBlock *pb,
     slapi_log_err(SLAPI_LOG_NOTICE, repl_plugin_name_cl,
                   "changelog5_config_modify - Separate changelog no longer supported; "
                   "request ignored\n");
- 
+
     *returncode = LDAP_SUCCESS;
     return SLAPI_DSE_CALLBACK_OK;
 }
@@ -217,7 +217,7 @@ changelog5_config_delete(Slapi_PBlock *pb __attribute__((unused)),
     slapi_log_err(SLAPI_LOG_NOTICE, repl_plugin_name_cl,
                   "changelog5_config_delete - Separate changelog no longer supported; "
                   "request ignored\n");
- 
+
     *returncode = LDAP_SUCCESS;
     return SLAPI_DSE_CALLBACK_OK;
 }
@@ -280,13 +280,16 @@ cldb_config_modify(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *entryAfter, in
                         config.maxEntries = 0;
                     }
                 } else if (strcasecmp(config_attr, CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE) == 0) {
-                    if (slapi_is_duration_valid(config_attr_value)) {
+                    if (config_attr_value &&
+                        (strcmp(config_attr_value, CL5_STR_IGNORE) == 0 ||
+                         slapi_is_duration_valid_strict(config_attr_value)))
+                    {
                         slapi_ch_free_string(&config.maxAge);
                         config.maxAge = slapi_ch_strdup(config_attr_value);
                     } else {
                         if (returntext) {
                             PR_snprintf(returntext, SLAPI_DSE_RETURNTEXT_SIZE,
-                                        "%s: invalid value \"%s\", %s must range from 0 to %lld or digit[sSmMhHdDwW]",
+                                        "%s: invalid value \"%s\", %s must be \"-1\" or a range from 1 to %lld and end with a duration unit[sSmMhHdDwW]",
                                         CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, config_attr_value ? config_attr_value : "null",
                                         CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE,
                                         (long long int)LONG_MAX);
@@ -428,15 +431,22 @@ changelog5_extract_config(Slapi_Entry *entry, changelog5Config *config)
     }
 
     max_age = slapi_entry_attr_get_charptr(entry, CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE);
-    if (max_age) {
-        if (slapi_is_duration_valid(max_age)) {
+    if (max_age && strcmp(max_age, CL5_STR_IGNORE) != 0) {
+        if (slapi_is_duration_valid_strict(max_age)) {
             config->maxAge = max_age;
         } else {
-            slapi_ch_free_string(&max_age);
-            slapi_log_err(SLAPI_LOG_NOTICE, repl_plugin_name_cl,
-                          "changelog5_extract_config - %s: invalid value \"%s\", ignoring the change.\n",
-                          CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, max_age);
-            config->maxAge = slapi_ch_strdup(CL5_STR_IGNORE);
+            if (slapi_is_duration_valid(max_age)) {
+                slapi_log_err(SLAPI_LOG_NOTICE, repl_plugin_name_cl,
+                    "changelog5_extract_config - %s: missing duration unit - assuming seconds (%ss)\n",
+                    CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, max_age);
+                config->maxAge = max_age;
+            } else {
+                slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name_cl,
+                    "changelog5_extract_config - %s: invalid value \"%s\", trimming will not be done based on age.\n",
+                    CONFIG_CHANGELOG_MAXAGE_ATTRIBUTE, max_age);
+                config->maxAge = slapi_ch_strdup(CL5_STR_IGNORE);
+                slapi_ch_free_string(&max_age);
+            }
         }
     } else {
         config->maxAge = slapi_ch_strdup(CL5_STR_IGNORE);

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1461,6 +1461,7 @@ char *slapi_getSSLVersion_str(PRUint16 vnum, char *buf, size_t bufsize);
 time_t slapi_parse_duration(const char *value);
 long long slapi_parse_duration_longlong(const char *value) __attribute__((deprecated));
 int slapi_is_duration_valid(const char *value);
+int slapi_is_duration_valid_strict(const char *value);
 
 /**
  * Possible results of a cachesize check

--- a/ldap/servers/slapd/time.c
+++ b/ldap/servers/slapd/time.c
@@ -748,6 +748,44 @@ slapi_is_duration_valid(const char *value)
     } else {
         rc = 0;
     }
+
+bail:
+    return rc;
+}
+
+/*
+ * The duration MUST contain a "unit" as the last character,
+ * and the first digit can not be a zero
+ */
+int
+slapi_is_duration_valid_strict(const char *value)
+{
+    int rc = 1; /* valid */
+    const char *p = value;
+    const char *last = NULL;
+
+    if (!(p && *p && isdigit(*p)) || *p == '0') {
+        rc = 0;
+        goto bail;
+    }
+
+    while (*p) {
+        last = p;
+        p++;
+    }
+
+    if (last == value || !is_valid_duration_unit(*last)) {
+        rc = 0;
+        goto bail;
+    }
+
+    for (p = value; p < last; p++) {
+        if (!isdigit(*p)) {
+            rc = 0;
+            goto bail;
+        }
+    }
+
 bail:
     return rc;
 }

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -720,7 +720,18 @@ export class Replication extends React.Component {
                                         clMaxEntries = val;
                                     }
                                     if (attr === "nsslapd-changelogmaxage") {
-                                        clMaxAge = val;
+                                        // Add duration value if missing
+                                        if (val !== "-1") {
+                                            const unit = val[val.length - 1];
+                                            if (unit >= '0' && unit <= '9') {
+                                                // Missing duration unit, assume seconds
+                                                clMaxAge = val + "s";
+                                            } else {
+                                                clMaxAge = val;
+                                            }
+                                        } else {
+                                            clMaxAge = val;
+                                        }
                                     }
                                     if (attr === "nsslapd-changelogtrim-interval") {
                                         clTrimInt = val;

--- a/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
+++ b/src/lib389/lib389/cli_conf/plugins/retrochangelog.py
@@ -8,6 +8,8 @@
 from lib389.plugins import RetroChangelogPlugin
 from lib389.cli_conf import add_generic_plugin_parsers, generic_object_edit, generic_object_add_attr, generic_object_del_attr
 from lib389.cli_base import CustomHelpFormatter
+from lib389.utils import validate_max_age
+
 
 arg_to_attr = {
     'is_replicated': 'isReplicated',
@@ -21,12 +23,16 @@ arg_to_attr = {
 
 def retrochangelog_edit(inst, basedn, log, args):
     log = log.getChild('retrochangelog_edit')
+    if args.max_age:
+        validate_max_age(args.max_age, ignore_value="0")
     plugin = RetroChangelogPlugin(inst)
     generic_object_edit(plugin, log, args, arg_to_attr)
 
 
 def retrochangelog_add(inst, basedn, log, args):
     log = log.getChild('retrochangelog_add')
+    if args.max_age:
+        validate_max_age(args.max_age, ignore_value="0")
     plugin = RetroChangelogPlugin(inst)
     generic_object_add_attr(plugin, log, args, arg_to_attr)
 
@@ -46,16 +52,17 @@ def _add_parser_args(parser):
                         help='Specifies the name of the directory in which the changelog database '
                              'is created the first time the plug-in is run')
     parser.add_argument('--max-age',
-                        help='Specifies the maximum age of any entry in the changelog.  Used to trim the '
-                            'changelog (nsslapd-changelogmaxage)')
+                        help='Specifies the maximum age of any entry in the changelog. '
+                             'The value must be a number followed by a duration unit [sSmMhHdDwW]. '
+                             'Used to trim the changelog (nsslapd-changelogmaxage)')
     parser.add_argument('--trim-interval',
                         help='. nsslapd-changelog-trim-interval)')
     parser.add_argument('--exclude-suffix', nargs='*',
                         help='Specifies the suffix which will be excluded from the scope of the plugin '
-                            '(nsslapd-exclude-suffix)')
+                             '(nsslapd-exclude-suffix)')
     parser.add_argument('--exclude-attrs', nargs='*',
                         help='Specifies the attributes which will be excluded from the scope of the plugin '
-                            '(nsslapd-exclude-attrs)')
+                             '(nsslapd-exclude-attrs)')
 
 
 def create_parser(subparsers):

--- a/src/lib389/lib389/cli_conf/replication.py
+++ b/src/lib389/lib389/cli_conf/replication.py
@@ -17,7 +17,9 @@ from getpass import getpass
 from lib389._constants import ReplicaRole, DSRC_HOME
 from lib389.cli_base.dsrc import dsrc_to_repl_monitor
 from lib389.cli_base import _get_arg, CustomHelpFormatter
-from lib389.utils import is_a_dn, copy_with_permissions, ds_supports_new_changelog, get_passwd_from_file
+from lib389.utils import (
+    is_a_dn, copy_with_permissions, ds_supports_new_changelog,
+    get_passwd_from_file, validate_max_age)
 from lib389.repltools import ReplicationLogAnalyzer
 from lib389.replica import Replicas, ReplicationMonitor, BootstrapReplicationManager, Changelog5, ChangelogLDIF, Changelog
 from lib389.tasks import CleanAllRUVTask, AbortCleanAllRUVTask
@@ -717,6 +719,9 @@ def set_per_backend_cl(inst, basedn, log, args):
         del args.disable_encrypt
         did_something = True
         log.info("You must restart the server for this to take effect")
+
+    if args.max_age:
+        validate_max_age(args.max_age, ignore_value="-1")
 
     for attr, value in attrs.items():
         if value == "":
@@ -1525,7 +1530,9 @@ def create_parser(subparsers):
     repl_set_per_backend_cl.set_defaults(func=set_per_backend_cl)
     repl_set_per_backend_cl.add_argument('--suffix', required=True, help='Sets the suffix that uses the changelog')
     repl_set_per_backend_cl.add_argument('--max-entries', help="Sets the maximum number of entries to get in the replication changelog")
-    repl_set_per_backend_cl.add_argument('--max-age', help="Set the maximum age of a replication changelog entry")
+    repl_set_per_backend_cl.add_argument('--max-age',
+                                         help='Specifies the maximum age of any entry in the changelog. '
+                                              'The value must be a number followed by a duration unit [sSmMhHdDwW].')
     repl_set_per_backend_cl.add_argument('--trim-interval', help="Sets the interval to check if the replication changelog can be trimmed")
     repl_set_per_backend_cl.add_argument('--encrypt', action='store_true',
                                          help="Sets the replication changelog to use encryption. You must export and "

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -2151,3 +2151,14 @@ def rpm_is_older(pkg, version):
                     return False
     return False
 
+
+# Validate the max-age settings for changelogs.
+# The value must be a number followed by a duration unit [sSmMhHdDwW].
+# The first digit can not be a zero.
+def validate_max_age(value, ignore_value=None):
+    if ignore_value is not None and value == ignore_value:
+        return
+
+    # check value using digits except for the last character which must be a duration unit
+    if not re.match(r'^\d+[sSmMhHdDwW]$', value) or value[0] == '0':
+        raise ValueError(f"Invalid max age value: {value}")


### PR DESCRIPTION
Description:

We need to enforce a duration unit is set and the first digit is not zero when setting maxage for the replication and retro changelogs.

relates: https://github.com/389ds/389-ds-base/issues/7265

## Summary by Sourcery

Enforce stricter validation of changelog maxage values for replication and retro changelog configuration and adjust tests accordingly.

Bug Fixes:
- Reject changelog maxage values without a duration unit, with non-digit characters in the numeric portion, or starting with zero for replication and retro changelog configuration.

Enhancements:
- Introduce a strict duration validation helper used by changelog and retro changelog maxage handling.
- Clarify the changelog maxage configuration error message to describe the valid range and required duration unit.

Tests:
- Expand replication and retro changelog tests to cover accepted and rejected maxage formats, including unit presence, case handling, and leading-zero and invalid-unit cases.