### PR TITLE
Issue 7267 - MDB_BAD_VALSIZE error when updating index

### DIFF
--- a/ldap/servers/slapd/back-ldbm/attrcrypt.h
+++ b/ldap/servers/slapd/back-ldbm/attrcrypt.h
@@ -10,7 +10,7 @@
 #include <config.h>
 #endif
 
-/* Private tructures and #defines used in the attribute encryption code. */
+/* Private structures and #defines used in the attribute encryption code. */
 
 #ifndef _ATTRCRYPT_H_
 #define _ATTRCRYPT_H_

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -104,6 +104,8 @@ typedef unsigned short u_int16_t;
  */
 #define BE_CHANGELOG_FILE     "replication_changelog"
 
+#define INDEX_KEY_LENGHT(lenval,lenprefix)  (lenval+lenprefix+2)
+
 #define BDB_IMPL              "bdb"
 #define BDB_BACKEND           "libback-ldbm" /* This backend plugin */
 #define BDB_NEWIDL            "newidl"       /* new idl format */

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -104,7 +104,7 @@ typedef unsigned short u_int16_t;
  */
 #define BE_CHANGELOG_FILE     "replication_changelog"
 
-#define INDEX_KEY_LENGHT(lenval,lenprefix)  (lenval+lenprefix+2)
+#define INDEX_KEY_LENGTH(lenval,lenprefix)  (lenval+lenprefix+2)
 
 #define BDB_IMPL              "bdb"
 #define BDB_BACKEND           "libback-ldbm" /* This backend plugin */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -75,9 +75,9 @@ static IDList *bdb_idl_union_allids(backend *be, struct attrinfo *ai, IDList *a,
 #define DEBUG_SUBCOUNT_MSG(msg, ...) { debug_subcount(__FUNCTION__, __LINE__, (msg), __VA_ARGS__); }
 #define DUMP_SUBCOUNT_KEY(msg, key, ret) { debug_subcount(__FUNCTION__, __LINE__, "ret=%d size=%u ulen=%u doff=%u dlen=%u", \
                                                ret, (key).size, (key).ulen, (key).doff, (key).dlen); \
-                                           if (ret == 0) hexadump(msg, (key).data, 0, (key).size); \
+                                           if (ret == 0) slapi_log_hexadump(SLAPI_LOG_INFO, msg, (key).data, (key).size); \
                                            else if (ret == DB_BUFFER_SMALL) \
-                                                hexadump(msg, (key).data, 0, (key).ulen); }
+                                                slapi_log_hexadump(SLAPI_LOG_INFO, msg, (key).data, (key).ulen); }
 
 static void
 debug_subcount(const char *funcname, int line, char *msg, ...)
@@ -90,41 +90,6 @@ debug_subcount(const char *funcname, int line, char *msg, ...)
     slapi_log_err(SLAPI_LOG_INFO, (char*)funcname, "DEBUG SUBCOUNT [%d] %s\n", line, buff);
 }
 
-/*
- * Dump a memory buffer in hexa and ascii in error log
- *
- * addr - The memory buffer address.
- * len - The memory buffer lenght.
- */
-static void
-hexadump(char *msg, const void *addr, size_t offset, size_t len)
-{
-#define  HEXADUMP_TAB 4
-/* 4 characters per bytes:  2 hexa digits, 1 space and the ascii  */
-#define  HEXADUMP_BUF_SIZE (4*16+HEXADUMP_TAB)
-    char hexdigit[] = "0123456789ABCDEF";
-
-    const unsigned char *pt = addr;
-    char buff[HEXADUMP_BUF_SIZE+1];
-    memset (buff, ' ', HEXADUMP_BUF_SIZE);
-    buff[HEXADUMP_BUF_SIZE] = '\0';
-    while (len > 0) {
-        int dpl;
-        for (dpl = 0; dpl < 16 && len>0; dpl++, len--) {
-           buff[3*dpl] = hexdigit[((*pt) >> 4) & 0xf];
-           buff[3*dpl+1] = hexdigit[(*pt) & 0xf];
-           buff[3*16+HEXADUMP_TAB+dpl] = (*pt>=0x20 && *pt<0x7f) ? *pt : '.';
-           pt++;
-        }
-        for (;dpl < 16; dpl++) {
-           buff[3*dpl] = ' ';
-           buff[3*dpl+1] = ' ';
-           buff[3*16+HEXADUMP_TAB+dpl] = ' ';
-        }
-        slapi_log_err(SLAPI_LOG_INFO, msg, "[0x%08lx]  %s\n", offset, buff);
-        offset += 16;
-    }
-}
 #else
 #define DEBUG_SUBCOUNT_MSG(msg, ...)
 #define DUMP_SUBCOUNT_KEY(msg, key, ret)

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -4281,6 +4281,10 @@ dup_writer_queue_item(WriterQueueData_t *wqd)
 
 void dbmdb_import_writeq_push(ImportCtx_t *ctx, WriterQueueData_t *wqd)
 {
+    struct ldbminfo *li = (struct ldbminfo *)ctx->job->inst->inst_be->be_database->plg_private;
+    if (wqd->key.mv_size >= li->li_max_key_len) {
+        *(char*)1 = 1;
+    }
     dbmdb_import_q_push(&ctx->writerq, wqd);
 }
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -4281,10 +4281,6 @@ dup_writer_queue_item(WriterQueueData_t *wqd)
 
 void dbmdb_import_writeq_push(ImportCtx_t *ctx, WriterQueueData_t *wqd)
 {
-    struct ldbminfo *li = (struct ldbminfo *)ctx->job->inst->inst_be->be_database->plg_private;
-    if (wqd->key.mv_size >= li->li_max_key_len) {
-        *(char*)1 = 1;
-    }
     dbmdb_import_q_push(&ctx->writerq, wqd);
 }
 

--- a/ldap/servers/slapd/back-ldbm/index.c
+++ b/ldap/servers/slapd/back-ldbm/index.c
@@ -894,7 +894,7 @@ prepare_key(backend *be, struct attrinfo *a, char **buf, size_t *buflen,
     int rc = 0;
 
     /* Hash large index key if necessary */
-    if (INDEX_KEY_LENGHT(bvp->bv_len,plen) >=  li->li_max_key_len) {
+    if (INDEX_KEY_LENGTH(bvp->bv_len,plen) >=  li->li_max_key_len) {
         rc = attrcrypt_hash_large_index_key(be, prefix, a, bvp, &hashed_bvp);
         if (rc) {
             slapi_log_err(SLAPI_LOG_ERR, "index_read_ext_allids",

--- a/ldap/servers/slapd/back-ldbm/index.c
+++ b/ldap/servers/slapd/back-ldbm/index.c
@@ -894,7 +894,7 @@ prepare_key(backend *be, struct attrinfo *a, char **buf, size_t *buflen,
     int rc = 0;
 
     /* Hash large index key if necessary */
-    if (bvp->bv_len+plen+2 >=  li->li_max_key_len) {
+    if (INDEX_KEY_LENGHT(bvp->bv_len,plen) >=  li->li_max_key_len) {
         rc = attrcrypt_hash_large_index_key(be, prefix, a, bvp, &hashed_bvp);
         if (rc) {
             slapi_log_err(SLAPI_LOG_ERR, "index_read_ext_allids",

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -1084,7 +1084,7 @@ attrcrypt_hash_large_index_key(backend *be, const char *prefix, struct attrinfo 
     int ret = 0;
     struct berval *out_berval = NULL;
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
-    size_t final_key_len = INDEX_KEY_LENGHT(in->bv_len, strlen(prefix));
+    size_t final_key_len = INDEX_KEY_LENGTH(in->bv_len, strlen(prefix));
 
     /* If the index key is too long (i.e mdb case) we must hash it */
     if (final_key_len >=  li->li_max_key_len) {

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -1084,7 +1084,7 @@ attrcrypt_hash_large_index_key(backend *be, const char *prefix, struct attrinfo 
     int ret = 0;
     struct berval *out_berval = NULL;
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
-    size_t final_key_len = in->bv_len + strlen(prefix) + 2;
+    size_t final_key_len = INDEX_KEY_LENGHT(in->bv_len, strlen(prefix));
 
     /* If the index key is too long (i.e mdb case) we must hash it */
     if (final_key_len >=  li->li_max_key_len) {
@@ -1107,8 +1107,6 @@ attrcrypt_hash_large_index_key(backend *be, const char *prefix, struct attrinfo 
             /* Compute hash for the key without the prefix */
             PK11_DigestOp(c, (unsigned char *)in->bv_val, in->bv_len);
             PK11_DigestFinal(c, hash, &hashLen, sizeof hash);
-            /* Add HASH_PREFIX before the prefix */
-            /* slapi_ch_smprintf looks buggy "%c%s" does not produce expected result */
 
             /* Build the key: hash value in hexa */
             hkey = slapi_ch_malloc(1+2*sizeof hash);

--- a/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attrcrypt.c
@@ -1079,15 +1079,15 @@ attrcrypt_decrypt_index_key(backend *be,
  *                  :     NULL - no hash or failure
  */
 int
-attrcrypt_hash_large_index_key(backend *be, char **prefix, struct attrinfo *ai, const struct berval *in, struct berval **out)
+attrcrypt_hash_large_index_key(backend *be, const char *prefix, struct attrinfo *ai, const struct berval *in, struct berval **out)
 {
     int ret = 0;
     struct berval *out_berval = NULL;
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
-    char *new_prefix;
+    size_t final_key_len = in->bv_len + strlen(prefix) + 2;
 
     /* If the index key is too long (i.e mdb case) we must hash it */
-    if (in->bv_len >=  li->li_max_key_len) {
+    if (final_key_len >=  li->li_max_key_len) {
         PK11Context *c = PK11_CreateDigestContext(SEC_OID_MD5);
         if (c != NULL) {
             unsigned char hash[32];
@@ -1101,16 +1101,15 @@ attrcrypt_hash_large_index_key(backend *be, char **prefix, struct attrinfo *ai, 
                 return ENOMEM;
             }
             slapi_log_err(SLAPI_LOG_TRACE, "attrcrypt_hash_large_index_key",
-                          "Key lenght (%lu) >= max key lenght (%lu) so key must be hashed\n", in->bv_len, li->li_max_key_len);
+                          "Key lenght (%lu) >= max key lenght (%lu) so key must be hashed\n", final_key_len, li->li_max_key_len);
             slapi_be_set_flag(be, SLAPI_BE_FLAG_DONT_BYPASS_FILTERTEST);
             PK11_DigestBegin(c);
             /* Compute hash for the key without the prefix */
             PK11_DigestOp(c, (unsigned char *)in->bv_val, in->bv_len);
             PK11_DigestFinal(c, hash, &hashLen, sizeof hash);
             /* Add HASH_PREFIX before the prefix */
-            new_prefix = slapi_ch_smprintf("%c%s", HASH_PREFIX, *prefix);
-            index_free_prefix(*prefix);
-            *prefix = new_prefix;
+            /* slapi_ch_smprintf looks buggy "%c%s" does not produce expected result */
+
             /* Build the key: hash value in hexa */
             hkey = slapi_ch_malloc(1+2*sizeof hash);
             out_berval->bv_val = hkey;

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -622,7 +622,7 @@ int attrcrypt_encrypt_entry_inplace(backend *be, const struct backentry *inout);
 int attrcrypt_encrypt_entry(backend *be, const struct backentry *in, struct backentry **out);
 int attrcrypt_encrypt_index_key(backend *be, struct attrinfo *ai, const struct berval *in, struct berval **out);
 int attrcrypt_decrypt_index_key(backend *be, struct attrinfo *ai, const struct berval *in, struct berval **out);
-int attrcrypt_hash_large_index_key(backend *be, char **prefix, struct attrinfo *ai, const struct berval *in, struct berval **out);
+int attrcrypt_hash_large_index_key(backend *be, const char *prefix, struct attrinfo *ai, const struct berval *in, struct berval **out);
 int attrcrypt_init(ldbm_instance *li);
 int attrcrypt_cleanup_private(ldbm_instance *li);
 

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1527,6 +1527,8 @@ void slapi_pblock_set_task_warning(Slapi_PBlock *pb, task_warning warning);
 int slapi_exists_or_add_internal(Slapi_DN *dn, const char *filter, const char *entry, const char *modifier_name);
 
 void slapi_log_backtrace(int loglevel);
+void slapi_log_hexadump(int loglevel, char *fname, const void *addr, size_t len);
+
 
 /*
  * accesslog.c


### PR DESCRIPTION
Problem with the key prefix handling when key is too long and must be hashed. 
The issue is that the # that is prepended is not reset when iterating over the valueset values (Ending up with very long prefix)

Also refactored the code to avoid duplicate the code that prepare the key from the attribute value (used when updating the index or retrieving a value from an index)

Issue: #7267 

Reviewed by: @tbordaz , @vashirov (Thanks!)

## Summary by Sourcery

Fix handling of oversized index keys by centralizing key preparation and improve diagnostics for MDB import and indexing failures.

Bug Fixes:
- Correct index key prefix handling when long attribute values require hashing to prevent MDB_BAD_VALSIZE and malformed keys.
- Ensure large index keys are hashed based on full key length including prefix rather than value length alone.

Enhancements:
- Introduce a shared helper to prepare index keys (including hashing and encryption) for both index updates and reads, reducing duplication and inconsistencies.
- Add detailed logging and hex dumps for MDB import write, transaction, and queue element failures to aid debugging.
- Expose a reusable hex-dump logging utility and replace backend-specific implementations with the shared version.

Tests:
- Add a regression test that creates and validates a user with 512 large sn attribute values to cover large multi-valued index scenarios.