### PR TITLE
Issue 7271 - plugins that create threads need to update active thread count

### DIFF
--- a/ldap/servers/plugins/replication/repl5_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_protocol.c
@@ -23,6 +23,7 @@
 
 #include "repl5.h"
 #include "repl5_prot_private.h"
+#include "slap.h"
 
 #define PROTOCOL_5_INCREMENTAL 1
 #define PROTOCOL_5_TOTAL 2
@@ -237,6 +238,8 @@ prot_thread_main(void *arg)
         return;
     }
 
+    g_incr_active_threadcnt();
+
     set_thread_private_agmtname(agmt_get_long_name(agmt));
 
     done = 0;
@@ -301,6 +304,8 @@ prot_thread_main(void *arg)
             done = 1;
         }
     }
+
+    g_decr_active_threadcnt();
 }
 
 /*

--- a/ldap/servers/plugins/retrocl/retrocl_trim.c
+++ b/ldap/servers/plugins/retrocl/retrocl_trim.c
@@ -243,6 +243,8 @@ trim_changelog(void)
 
     now_interval = slapi_current_rel_time_t(); /* monotonic time for interval */
 
+    g_incr_active_threadcnt();
+
     PR_Lock(ts.ts_s_trim_mutex);
     max_age = ts.ts_c_max_age;
     trim_interval = ts.ts_c_trim_interval;
@@ -257,7 +259,7 @@ trim_changelog(void)
          */
         done = 0;
         now_maxage = slapi_current_utc_time(); /* real time for trim candidates */
-        while (!done && retrocl_trimming == 1) {
+        while (!done && retrocl_trimming == 1 && !slapi_is_shutting_down()) {
             int did_delete;
 
             did_delete = 0;
@@ -309,6 +311,9 @@ trim_changelog(void)
                       "trim_changelog: removed %d change records\n",
                       num_deleted);
     }
+
+    g_decr_active_threadcnt();
+
     return rc;
 }
 


### PR DESCRIPTION
… count

Description:

Plugins that create threads need to up to the global active thread count. Otherwise when the server is being stopped the plugin's close function gets called while these threads are still running and still using the plugin configuration. This can lead to crashes.

relates: https://github.com/389ds/389-ds-base/issues/7271

## Summary by Sourcery

Track background plugin threads in the global active thread count to prevent shutdown races with still-running plugin operations.

Bug Fixes:
- Ensure sync plugin result-sending threads update the global active thread count while running.
- Ensure replication protocol worker threads are accounted for in the global active thread count.
- Ensure retro changelog trimming and replica tombstone reaper threads are tracked in the global active thread count to avoid plugin-use-after-close crashes.

Enhancements:
- Perform minor whitespace and formatting cleanups in the sync plugin code.