### PR TITLE
Issue 7275 - UI - Improve password policy field validation in Cockpit UI

### DIFF
--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -23,6 +23,12 @@ import {
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { SyncAltIcon } from '@patternfly/react-icons';
+import {
+    getValidationProps,
+    hasInvalidField,
+    renderValidationError,
+    updateFieldValidation,
+} from "./pwpValidation.jsx";
 
 const _ = cockpit.gettext;
 
@@ -114,6 +120,7 @@ export class GlobalPwPolicy extends React.Component {
             saveSyntaxDisabled: true,
             saveTPRDisabled: true,
             isSelectOpen: false,
+            invalidFields: {},
         };
 
         // Toggle currently active tab
@@ -242,6 +249,7 @@ export class GlobalPwPolicy extends React.Component {
         const stateUpdate = {
             [attr]: value,
             saveGeneralDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         };
 
         this.setState(stateUpdate, () => {
@@ -363,6 +371,7 @@ export class GlobalPwPolicy extends React.Component {
         this.setState({
             [attr]: value,
             saveExpDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         });
     }
 
@@ -440,6 +449,7 @@ export class GlobalPwPolicy extends React.Component {
         this.setState({
             [attr]: value,
             saveLockoutDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         });
     }
 
@@ -541,12 +551,14 @@ export class GlobalPwPolicy extends React.Component {
             this.setState({
                 [attr]: Array.isArray(selection) ? selection : [],
                 saveSyntaxDisabled: disableSaveBtn,
+                invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
                 isSelectOpen: false
             });
         } else {
             this.setState({
                 [attr]: value,
                 saveSyntaxDisabled: disableSaveBtn,
+                invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
                 isSelectOpen: false
             });
         }
@@ -841,6 +853,7 @@ export class GlobalPwPolicy extends React.Component {
                         {
                             loaded: true,
                             loading: false,
+                            invalidFields: {},
                             saveGeneralDisabled: true,
                             savePasswordStorageDisabled: true,
                             saveUserDisabled: true,
@@ -996,10 +1009,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordminlength"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminlength"
+                                {...getValidationProps("passwordminlength", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminlength", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Alpha's")}
@@ -1012,10 +1027,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordminalphas"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminalphas"
+                                {...getValidationProps("passwordminalphas", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminalphas", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -1030,10 +1047,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmindigits"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmindigits"
+                                {...getValidationProps("passwordmindigits", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmindigits", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Special")}
@@ -1046,10 +1065,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordminspecials"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminspecials"
+                                {...getValidationProps("passwordminspecials", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminspecials", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -1064,10 +1085,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordminuppers"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminuppers"
+                                {...getValidationProps("passwordminuppers", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminuppers", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Lowercase")}
@@ -1080,10 +1103,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordminlowers"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminlowers"
+                                {...getValidationProps("passwordminlowers", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminlowers", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -1098,10 +1123,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmin8bit"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmin8bit"
+                                {...getValidationProps("passwordmin8bit", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmin8bit", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Categories")}
@@ -1114,10 +1141,12 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmincategories"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmincategories"
+                                {...getValidationProps("passwordmincategories", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmincategories", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -1132,11 +1161,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmaxsequence"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxsequence"
+                                {...getValidationProps("passwordmaxsequence", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxsequence", this.state.invalidFields)}
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Max Sequence Sets")}
                         </GridItem>
@@ -1148,11 +1179,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmaxseqsets"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxseqsets"
+                                {...getValidationProps("passwordmaxseqsets", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxseqsets", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>
@@ -1166,11 +1199,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmaxclasschars"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxclasschars"
+                                {...getValidationProps("passwordmaxclasschars", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxclasschars", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>
@@ -1251,12 +1286,14 @@ export class GlobalPwPolicy extends React.Component {
                                 type="number"
                                 id="passwordmaxfailure"
                                 aria-describedby="horizontal-form-name-helper"
-                                name="passwordmaxpasswordmaxfailureclasschars"
+                                name="passwordmaxfailure"
+                                {...getValidationProps("passwordmaxfailure", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxfailure", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of seconds until an accounts failure count is reset (passwordResetFailureCount).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1269,11 +1306,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordresetfailurecount"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordresetfailurecount"
+                                {...getValidationProps("passwordresetfailurecount", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordresetfailurecount", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of seconds, duration, before the account gets unlocked (passwordLockoutDuration).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1286,11 +1325,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordlockoutduration"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordlockoutduration"
+                                {...getValidationProps("passwordlockoutduration", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordlockoutduration", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Do not lockout the user account forever, instead the account will unlock based on the lockout duration (passwordUnlock).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1322,11 +1363,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordmaxage"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxage"
+                                {...getValidationProps("passwordmaxage", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxage", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of logins that are allowed after the password has expired (passwordGraceLimit).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1339,11 +1382,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordgracelimit"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordgracelimit"
+                                {...getValidationProps("passwordgracelimit", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordgracelimit", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Set the time (in seconds), before a password is about to expire, to send a warning. (passwordWarning).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1356,11 +1401,13 @@ export class GlobalPwPolicy extends React.Component {
                                 id="passwordwarning"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordwarning"
+                                {...getValidationProps("passwordwarning", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordwarning", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Always return a password expiring control when requested (passwordSendExpiringTime).")}>
                         <GridItem className="ds-label" span={5}>
@@ -1493,10 +1540,12 @@ export class GlobalPwPolicy extends React.Component {
                                                 id="passwordinhistory"
                                                 aria-describedby="horizontal-form-name-helper"
                                                 name="passwordinhistory"
+                                                {...getValidationProps("passwordinhistory", this.state.invalidFields)}
                                                 onChange={(e, checked) => {
                                                     this.handleGeneralChange(e);
                                                 }}
                                             />
+                                            {renderValidationError("passwordinhistory", this.state.invalidFields)}
                                         </div>
                                     </GridItem>
                                 </Grid>
@@ -1555,11 +1604,13 @@ export class GlobalPwPolicy extends React.Component {
                                             id="passwordminage"
                                             aria-describedby="horizontal-form-name-helper"
                                             name="passwordminage"
+                                            {...getValidationProps("passwordminage", this.state.invalidFields)}
                                             onChange={(e, checked) => {
                                                 this.handleGeneralChange(e);
                                             }}
                                         />
                                     </GridItem>
+                                    {renderValidationError("passwordminage", this.state.invalidFields)}
                                 </Grid>
                                 <Grid
                                     title={_("The DN for a password administrator or administrator group (passwordAdminDN).")}
@@ -1596,7 +1647,7 @@ export class GlobalPwPolicy extends React.Component {
                                 </Grid>
                             </Form>
                             <Button
-                                isDisabled={this.state.saveGeneralDisabled && this.state.savePasswordStorageDisabled || this.state.saving}
+                                isDisabled={this.state.saveGeneralDisabled && this.state.savePasswordStorageDisabled || this.state.saving || hasInvalidField(general_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left-sm"
                                 onClick={this.handleSaveGeneral}
@@ -1624,7 +1675,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwExpirationRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveExpDisabled || this.state.saving}
+                                isDisabled={this.state.saveExpDisabled || this.state.saving || hasInvalidField(exp_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.handleSaveExp}
@@ -1652,7 +1703,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwLockoutRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveLockoutDisabled || this.state.saving}
+                                isDisabled={this.state.saveLockoutDisabled || this.state.saving || hasInvalidField(lockout_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.handleSaveLockout}
@@ -1680,7 +1731,7 @@ export class GlobalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving}
+                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving || hasInvalidField(syntax_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left"
                                 onClick={this.handleSaveSyntax}

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -25,6 +25,12 @@ import {
 	TextVariants,
 	ValidatedOptions
 } from '@patternfly/react-core';
+import {
+    getValidationProps,
+    hasInvalidField,
+    renderValidationError,
+    updateFieldValidation,
+} from "./pwpValidation.jsx";
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { SyncAltIcon } from "@patternfly/react-icons";
 import PropTypes from "prop-types";
@@ -213,11 +219,13 @@ class CreatePolicy extends React.Component {
                                         id="create_passwordminage"
                                         aria-describedby="horizontal-form-name-helper"
                                         name="create_passwordminage"
+                                        {...getValidationProps("create_passwordminage", this.props.invalidCreateFields)}
                                         onChange={(e, checked) => {
                                             this.props.handleChange(e);
                                         }}
                                     />
                                 </GridItem>
+                                {renderValidationError("create_passwordminage", this.props.invalidCreateFields)}
                             </Grid>
                             <Grid
                                 className="ds-margin-top"
@@ -309,10 +317,12 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordinhistory"
                                             aria-describedby="horizontal-form-name-helper"
                                             name="create_passwordinhistory"
+                                            {...getValidationProps("create_passwordinhistory", this.props.invalidCreateFields)}
                                             onChange={(e, checked) => {
                                                 this.props.handleChange(e);
                                             }}
                                         />
+                                        {renderValidationError("create_passwordinhistory", this.props.invalidCreateFields)}
                                     </div>
                                 </GridItem>
                             </Grid>
@@ -352,12 +362,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordmaxage"
                                             aria-describedby="create_passwordmaxage"
                                             name="create_passwordmaxage"
+                                            {...getValidationProps("create_passwordmaxage", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordexp}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordmaxage", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("The number of logins that are allowed after the password has expired (passwordGraceLimit).")}>
                                     <GridItem className="ds-label" span={4}>
@@ -369,12 +381,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordgracelimit"
                                             aria-describedby="create_passwordgracelimit"
                                             name="create_passwordgracelimit"
+                                            {...getValidationProps("create_passwordgracelimit", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordexp}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordgracelimit", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Set the time (in seconds), before a password is about to expire, to send a warning. (passwordWarning).")}>
                                     <GridItem className="ds-label" span={4}>
@@ -386,12 +400,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordwarning"
                                             aria-describedby="create_passwordwarning"
                                             name="create_passwordwarning"
+                                            {...getValidationProps("create_passwordwarning", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordexp}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordwarning", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Always return a password expiring control when requested (passwordSendExpiringTime).")}>
                                     <GridItem span={4}>
@@ -441,12 +457,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordmaxfailure"
                                             aria-describedby="create_passwordmaxfailure"
                                             name="create_passwordmaxfailure"
+                                            {...getValidationProps("create_passwordmaxfailure", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordlockout}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordmaxfailure", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("The number of seconds until an accounts failure count is reset (passwordResetFailureCount).")}>
                                     <GridItem className="ds-label" span={4}>
@@ -458,12 +476,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordresetfailurecount"
                                             aria-describedby="create_passwordresetfailurecount"
                                             name="create_passwordresetfailurecount"
+                                            {...getValidationProps("create_passwordresetfailurecount", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordlockout}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordresetfailurecount", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("The number of seconds, duration, before the account gets unlocked (passwordLockoutDuration).")}>
                                     <GridItem className="ds-label" span={4}>
@@ -475,12 +495,14 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordlockoutduration"
                                             aria-describedby="create_passwordlockoutduration"
                                             name="create_passwordlockoutduration"
+                                            {...getValidationProps("create_passwordlockoutduration", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordlockout}
                                         />
                                     </GridItem>
+                                    {renderValidationError("create_passwordlockoutduration", this.props.invalidCreateFields)}
                                 </Grid>
                                 <Grid className="ds-margin-top" title={_("Do not lockout the user account forever, instead the account will unlock based on the lockout duration (passwordUnlock).")}>
                                     <GridItem span={6}>
@@ -532,8 +554,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordminlength", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordminlength", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Minimum Alpha's")}
@@ -547,8 +571,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordminalphas", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordminalphas", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -564,8 +590,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordmindigits", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmindigits", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Minimum Special")}
@@ -579,8 +607,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordminspecials", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordminspecials", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -596,8 +626,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordminuppers", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordminuppers", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Minimum Lowercase")}
@@ -611,8 +643,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordminlowers", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordminlowers", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -628,8 +662,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordmin8bit", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmin8bit", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Minimum Categories")}
@@ -643,8 +679,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordmincategories", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmincategories", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -660,8 +698,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordmintokenlength", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmintokenlength", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Max Repeated Chars")}
@@ -675,8 +715,10 @@ class CreatePolicy extends React.Component {
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
+                                            {...getValidationProps("create_passwordmaxrepeats", this.props.invalidCreateFields)}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmaxrepeats", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -689,11 +731,13 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordmaxsequence"
                                             aria-describedby="create_passwordmaxsequence"
                                             name="create_passwordmaxsequence"
+                                            {...getValidationProps("create_passwordmaxsequence", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmaxsequence", this.props.invalidCreateFields)}
                                     </GridItem>
                                     <GridItem className="ds-label" offset={5} span={3}>
                                         {_("Max Sequence Sets")}
@@ -704,11 +748,13 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordmaxseqsets"
                                             aria-describedby="create_passwordmaxseqsets"
                                             name="create_passwordmaxseqsets"
+                                            {...getValidationProps("create_passwordmaxseqsets", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmaxseqsets", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid className="ds-margin-top">
@@ -721,11 +767,13 @@ class CreatePolicy extends React.Component {
                                             id="create_passwordmaxclasschars"
                                             aria-describedby="create_passwordmaxclasschars"
                                             name="create_passwordmaxclasschars"
+                                            {...getValidationProps("create_passwordmaxclasschars", this.props.invalidCreateFields)}
                                             onChange={(e, str) => {
                                                 this.props.handleChange(e);
                                             }}
                                             isDisabled={!this.props.passwordchecksyntax}
                                         />
+                                        {renderValidationError("create_passwordmaxclasschars", this.props.invalidCreateFields)}
                                     </GridItem>
                                 </Grid>
                                 <Grid
@@ -1082,6 +1130,9 @@ export class LocalPwPolicy extends React.Component {
             _create_passwordtprdelayvalidfrom:  "-1",
             _create_passwordadmindn: "",
             _create_passwordadminskipinfoupdate: false,
+            // Validation
+            invalidFields: {},
+            invalidCreateFields: {},
             // Select typeahead
             isUserAttrsCreateOpen: false,
             isUserAttrsEditOpen: false,
@@ -1314,19 +1365,27 @@ export class LocalPwPolicy extends React.Component {
             }
         }
 
+        // Validate constrained fields for create
+        const newInvalidCreateFields = updateFieldValidation(this.state.invalidCreateFields, attr, value);
+        if (newInvalidCreateFields[attr]) {
+            disableSaveBtn = true;
+        }
+
         // Select Typeahead
         if (selection) {
             this.setState({
                 [attr]: Array.isArray(selection) ? selection : [],
                 createDisabled: disableSaveBtn,
                 invalid_dn,
+                invalidCreateFields: newInvalidCreateFields,
                 isUserAttrsCreateOpen: false
             });
         } else { // Checkbox
             this.setState({
                 [attr]: value,
                 createDisabled: disableSaveBtn,
-                invalid_dn
+                invalid_dn,
+                invalidCreateFields: newInvalidCreateFields,
             });
         }
     }
@@ -1418,6 +1477,7 @@ export class LocalPwPolicy extends React.Component {
         this.setState({
             [attr]: value,
             saveGeneralDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         });
     }
 
@@ -1495,6 +1555,7 @@ export class LocalPwPolicy extends React.Component {
         this.setState({
             [attr]: value,
             saveExpDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         });
     }
 
@@ -1572,6 +1633,7 @@ export class LocalPwPolicy extends React.Component {
         this.setState({
             [attr]: value,
             saveLockoutDisabled: disableSaveBtn,
+            invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
         });
     }
 
@@ -1672,12 +1734,14 @@ export class LocalPwPolicy extends React.Component {
             this.setState({
                 [attr]: Array.isArray(selection) ? selection : [],
                 saveSyntaxDisabled: disableSaveBtn,
+                invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
                 isUserAttrsEditOpen: false
             });
         } else {
             this.setState({
                 [attr]: value,
                 saveSyntaxDisabled: disableSaveBtn,
+                invalidFields: updateFieldValidation(this.state.invalidFields, attr, value),
                 isUserAttrsEditOpen: false
             });
         }
@@ -1867,6 +1931,8 @@ export class LocalPwPolicy extends React.Component {
                         policyName: "",
                         deleteName: "",
                         showDeletePolicy: false,
+                        invalidFields: {},
+                        invalidCreateFields: {},
                         // Reset edit and create tab
                         saveGeneralDisabled: true,
                         saveUserDisabled: true,
@@ -2391,10 +2457,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordminlength"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminlength"
+                                {...getValidationProps("passwordminlength", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminlength", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Alpha's")}
@@ -2407,10 +2475,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordminalphas"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminalphas"
+                                {...getValidationProps("passwordminalphas", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminalphas", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -2425,10 +2495,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmindigits"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmindigits"
+                                {...getValidationProps("passwordmindigits", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmindigits", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Special")}
@@ -2441,10 +2513,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordminspecials"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminspecials"
+                                {...getValidationProps("passwordminspecials", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminspecials", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -2459,10 +2533,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordminuppers"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminuppers"
+                                {...getValidationProps("passwordminuppers", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminuppers", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Lowercase")}
@@ -2475,10 +2551,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordminlowers"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordminlowers"
+                                {...getValidationProps("passwordminlowers", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordminlowers", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -2493,10 +2571,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmin8bit"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmin8bit"
+                                {...getValidationProps("passwordmin8bit", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmin8bit", this.state.invalidFields)}
                         </GridItem>
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Minimum Categories")}
@@ -2509,10 +2589,12 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmincategories"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmincategories"
+                                {...getValidationProps("passwordmincategories", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
+                            {renderValidationError("passwordmincategories", this.state.invalidFields)}
                         </GridItem>
                     </Grid>
                     <Grid className="ds-margin-top">
@@ -2527,11 +2609,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmaxsequence"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxsequence"
+                                {...getValidationProps("passwordmaxsequence", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxsequence", this.state.invalidFields)}
                         <GridItem className="ds-label" offset={6} span={3}>
                             {_("Max Sequence Sets")}
                         </GridItem>
@@ -2543,11 +2627,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmaxseqsets"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxseqsets"
+                                {...getValidationProps("passwordmaxseqsets", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxseqsets", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>
@@ -2561,11 +2647,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmaxclasschars"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxclasschars"
+                                {...getValidationProps("passwordmaxclasschars", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleSyntaxChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxclasschars", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>
@@ -2646,12 +2734,14 @@ export class LocalPwPolicy extends React.Component {
                                 type="number"
                                 id="passwordmaxfailure"
                                 aria-describedby="horizontal-form-name-helper"
-                                name="passwordmaxpasswordmaxfailureclasschars"
+                                name="passwordmaxfailure"
+                                {...getValidationProps("passwordmaxfailure", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxfailure", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of seconds until an accounts failure count is reset (passwordResetFailureCount).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2664,11 +2754,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordresetfailurecount"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordresetfailurecount"
+                                {...getValidationProps("passwordresetfailurecount", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordresetfailurecount", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of seconds, duration, before the account gets unlocked (passwordLockoutDuration).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2681,11 +2773,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordlockoutduration"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordlockoutduration"
+                                {...getValidationProps("passwordlockoutduration", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleLockoutChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordlockoutduration", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Do not lockout the user account forever, instead the account will unlock based on the lockout duration (passwordUnlock).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2717,11 +2811,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordmaxage"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordmaxage"
+                                {...getValidationProps("passwordmaxage", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordmaxage", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("The number of logins that are allowed after the password has expired (passwordGraceLimit).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2734,11 +2830,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordgracelimit"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordgracelimit"
+                                {...getValidationProps("passwordgracelimit", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordgracelimit", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Set the time (in seconds), before a password is about to expire, to send a warning. (passwordWarning).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2751,11 +2849,13 @@ export class LocalPwPolicy extends React.Component {
                                 id="passwordwarning"
                                 aria-describedby="horizontal-form-name-helper"
                                 name="passwordwarning"
+                                {...getValidationProps("passwordwarning", this.state.invalidFields)}
                                 onChange={(e, checked) => {
                                     this.handleExpChange(e);
                                 }}
                             />
                         </GridItem>
+                        {renderValidationError("passwordwarning", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top" title={_("Always return a password expiring control when requested (passwordSendExpiringTime).")}>
                         <GridItem className="ds-label" span={5}>
@@ -2849,10 +2949,12 @@ export class LocalPwPolicy extends React.Component {
                                                 id="passwordinhistory"
                                                 aria-describedby="horizontal-form-name-helper"
                                                 name="passwordinhistory"
+                                                {...getValidationProps("passwordinhistory", this.state.invalidFields)}
                                                 onChange={(e, checked) => {
                                                     this.handleGeneralChange(e);
                                                 }}
                                             />
+                                            {renderValidationError("passwordinhistory", this.state.invalidFields)}
                                         </div>
                                     </GridItem>
                                 </Grid>
@@ -2892,11 +2994,13 @@ export class LocalPwPolicy extends React.Component {
                                             id="passwordminage"
                                             aria-describedby="horizontal-form-name-helper"
                                             name="passwordminage"
+                                            {...getValidationProps("passwordminage", this.state.invalidFields)}
                                             onChange={(e, checked) => {
                                                 this.handleGeneralChange(e);
                                             }}
                                         />
                                     </GridItem>
+                                    {renderValidationError("passwordminage", this.state.invalidFields)}
                                 </Grid>
                                 <Grid
                                     title={_("The DN for a password administrator or administrator group (passwordAdminDN).")}
@@ -2933,7 +3037,7 @@ export class LocalPwPolicy extends React.Component {
                                 </Grid>
                             </Form>
                             <Button
-                                isDisabled={this.state.saveGeneralDisabled || this.state.saving}
+                                isDisabled={this.state.saveGeneralDisabled || this.state.saving || hasInvalidField(general_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left-sm ds-margin-bottom-md"
                                 onClick={this.handleSaveGeneral}
@@ -2961,7 +3065,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwExpirationRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveExpDisabled || this.state.saving}
+                                isDisabled={this.state.saveExpDisabled || this.state.saving || hasInvalidField(exp_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-lg ds-margin-left"
                                 onClick={this.handleSaveExp}
@@ -2989,7 +3093,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwLockoutRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveLockoutDisabled || this.state.saving}
+                                isDisabled={this.state.saveLockoutDisabled || this.state.saving || hasInvalidField(lockout_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-lg ds-margin-left"
                                 onClick={this.handleSaveLockout}
@@ -3017,7 +3121,7 @@ export class LocalPwPolicy extends React.Component {
                                 {pwSyntaxRows}
                             </Form>
                             <Button
-                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving}
+                                isDisabled={this.state.saveSyntaxDisabled || this.state.saving || hasInvalidField(syntax_attrs, this.state.invalidFields)}
                                 variant="primary"
                                 className="ds-margin-top-xlg ds-margin-left ds-margin-bottom-md"
                                 onClick={this.handleSaveSyntax}
@@ -3167,6 +3271,7 @@ export class LocalPwPolicy extends React.Component {
                             create_passwordstoragescheme={this.state.create_passwordstoragescheme}
                             create_passwordadmindn={this.state.create_passwordadmindn}
                             create_passwordadminskipinfoupdate={this.state.create_passwordadminskipinfoupdate}
+                            invalidCreateFields={this.state.invalidCreateFields}
                             onUserAttrsCreateToggle={this.handleUserAttrsCreateToggle}
                             onUserAttrsCreateClear={this.handleUserAttrsCreateClear}
                             isUserAttrsCreateOpen={this.state.isUserAttrsCreateOpen}

--- a/src/cockpit/389-console/src/lib/database/pwpValidation.jsx
+++ b/src/cockpit/389-console/src/lib/database/pwpValidation.jsx
@@ -1,0 +1,105 @@
+import cockpit from "cockpit";
+import React from "react";
+import {
+    FormHelperText,
+    GridItem,
+    ValidatedOptions,
+} from "@patternfly/react-core";
+
+const _ = cockpit.gettext;
+
+export const FIELD_RANGES = {
+    passwordinhistory: { min: 0, max: 24 },
+    passwordminlength: { min: 2, max: 512 },
+    passwordmindigits: { min: 0, max: 64 },
+    passwordminalphas: { min: 0, max: 64 },
+    passwordminuppers: { min: 0, max: 64 },
+    passwordminlowers: { min: 0, max: 64 },
+    passwordminspecials: { min: 0, max: 64 },
+    passwordmin8bit: { min: 0, max: 64 },
+    passwordmaxrepeats: { min: 0, max: 64 },
+    passwordmincategories: { min: 0, max: 5 },
+    passwordmintokenlength: { min: 1, max: 64 },
+    passwordmaxfailure: { min: 1, max: 32767 },
+    passwordmaxsequence: { min: 0 },
+    passwordmaxseqsets: { min: 0 },
+    passwordmaxclasschars: { min: 0 },
+    passwordresetfailurecount: { min: 0 },
+    passwordlockoutduration: { min: 0 },
+    passwordminage: { min: 0 },
+    passwordmaxage: { min: 0 },
+    passwordgracelimit: { min: 0 },
+    passwordwarning: { min: 0 },
+};
+
+// Strips create_ prefix to find the base field name in FIELD_RANGES
+const baseFieldName = (attr) => {
+    return attr.startsWith("create_") ? attr.substring(7) : attr;
+};
+
+// Returns true if the value is invalid for the given field
+export const validateField = (attr, value) => {
+    const range = FIELD_RANGES[baseFieldName(attr)];
+    if (!range) return false;
+    const num = Number(value);
+    if (value === "" || isNaN(num) || !Number.isInteger(num) || num < range.min) {
+        return true;
+    }
+    if (range.max !== undefined && num > range.max) {
+        return true;
+    }
+    return false;
+};
+
+// Returns a new invalidFields map after validating a field change
+export const updateFieldValidation = (invalidFields, attr, value) => {
+    const newInvalidFields = { ...invalidFields };
+    if (FIELD_RANGES[baseFieldName(attr)]) {
+        if (validateField(attr, value)) {
+            newInvalidFields[attr] = true;
+        } else {
+            delete newInvalidFields[attr];
+        }
+    }
+    return newInvalidFields;
+};
+
+// Returns { min, max?, validated } props to spread on a TextInput
+export const getValidationProps = (fieldName, invalidFields) => {
+    const range = FIELD_RANGES[baseFieldName(fieldName)];
+    if (!range) return {};
+    const props = { min: range.min };
+    if (range.max !== undefined) {
+        props.max = range.max;
+    }
+    props.validated = invalidFields[fieldName]
+        ? ValidatedOptions.error
+        : ValidatedOptions.default;
+    return props;
+};
+
+// Returns FormHelperText JSX when the field is invalid, or null
+export const renderValidationError = (fieldName, invalidFields) => {
+    const range = FIELD_RANGES[baseFieldName(fieldName)];
+    if (!range || !invalidFields[fieldName]) return null;
+    const msg =
+        range.max !== undefined
+            ? cockpit.format(
+                _("Value must be a number from $0 to $1"),
+                range.min,
+                range.max
+            )
+            : _("Value must be a non-negative integer");
+    return (
+        <GridItem span={5}>
+            <FormHelperText isError isHidden={false}>
+                {msg}
+            </FormHelperText>
+        </GridItem>
+    );
+};
+
+// Returns true if any attr in the group is invalid
+export const hasInvalidField = (attrs, invalidFields) => {
+    return attrs.some((a) => invalidFields[a]);
+};

--- a/src/cockpit/389-console/src/lib/database/pwpValidation.jsx
+++ b/src/cockpit/389-console/src/lib/database/pwpValidation.jsx
@@ -92,7 +92,7 @@ export const renderValidationError = (fieldName, invalidFields) => {
             : _("Value must be a non-negative integer");
     return (
         <GridItem span={5}>
-            <FormHelperText isError isHidden={false}>
+            <FormHelperText className="ds-left-margin" isError isHidden={false}>
                 {msg}
             </FormHelperText>
         </GridItem>


### PR DESCRIPTION
Description: Password policy fields in the Cockpit UI lack client-side validation. Invalid values only produce generic server-side errors after clicking Save. Add a shared pwpValidation module and inline validation to all numeric password policy fields in globalPwp.jsx and localPwp.jsx.

Fixes: https://github.com/389ds/389-ds-base/issues/7275

Reviewed by: ?

## Summary by Sourcery

Add shared client-side validation for password policy numeric fields in Cockpit’s global and local password policy UIs and prevent saving when values are out of range.

New Features:
- Introduce a reusable pwpValidation module providing range definitions and helpers for validating password policy numeric fields.

Enhancements:
- Wire inline validation and error messaging into global and local password policy forms, including create flows, and tie save button states to the presence of invalid fields.