### PR TITLE
Issue 7279 - UI - Fix typo in export certificate dialog

### DIFF
--- a/src/cockpit/389-console/po/ja.po
+++ b/src/cockpit/389-console/po/ja.po
@@ -11560,7 +11560,7 @@ msgstr "証明書のエクスポート:"
 #: src/lib/security/securityModals.jsx:58
 msgid ""
 "Enter the full path and file name, if the path portion is omitted the "
-"cetificate is written to the server's certificate directory "
+"certificate is written to the server's certificate directory "
 msgstr ""
 "ファイル名を含むフルパスを入力してください。パス部分を省略した場合、証明書は"
 "サーバの証明書ディレクトリに書き込まれます。"

--- a/src/cockpit/389-console/src/lib/security/securityModals.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityModals.jsx
@@ -55,7 +55,7 @@ export class ExportCertModal extends React.Component {
         }
 
         const title = <>{_("Export Certificate:")} &nbsp;&nbsp;<i>{nickName}</i></>;
-        const desc = <>{_("Enter the full path and file name, if the path portion is omitted the cetificate is written to the server's certificate directory ")}<i>{certDir}</i></>;
+        const desc = <>{_("Enter the full path and file name, if the path portion is omitted the certificate is written to the server's certificate directory ")}<i>{certDir}</i></>;
 
         return (
             <Modal


### PR DESCRIPTION
Description: Fix typo "cetificate" -> "certificate" in the export certificate dialog message.

Fixes: https://github.com/389ds/389-ds-base/issues/7279

Reviewed by: ?

## Summary by Sourcery

Bug Fixes:
- Correct the misspelled word 'cetificate' to 'certificate' in the export certificate dialog message.