### PR TITLE
Issue 7093 - A password policy can be created even when an identical policy already exists

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -25,7 +25,7 @@ from lib389.idm.user import UserAccounts, UserAccount
 from lib389._constants import DEFAULT_SUFFIX
 from lib389.pwpolicy import PwPolicyManager, PwPolicyEntries
 from lib389.idm.account import Account
-from lib389.idm.nscontainer import nsContainers
+from lib389.idm.nscontainer import nsContainers, nsContainer
 from lib389.cos import CosPointerDefinitions, CosTemplates
 import ldap
 
@@ -114,8 +114,11 @@ def policy_qoutes_setup(topology_m1, request):
     USER_SELF_MOD_ACI = '(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)'
     ANON_ACI = "(targetattr=\"*\")(version 3.0; acl \"Anonymous Read access\"; allow (read,search,compare) userdn = \"ldap:///anyone\";)"
     suffix = Domain(inst, DEFAULT_SUFFIX)
-    suffix.add('aci', USER_SELF_MOD_ACI)
-    suffix.add('aci', ANON_ACI)
+    existing_acis = suffix.get_attr_vals_utf8('aci') or []
+    if USER_SELF_MOD_ACI not in existing_acis:
+        suffix.add('aci', USER_SELF_MOD_ACI)
+    if ANON_ACI not in existing_acis:
+        suffix.add('aci', ANON_ACI)
 
     ous = []
     for suffix, ou in [(DEFAULT_SUFFIX, 'dirsec'), (f'ou=people,{DEFAULT_SUFFIX}', 'others')]:
@@ -124,6 +127,7 @@ def policy_qoutes_setup(topology_m1, request):
         })
         ous.append(created_ou)
 
+    users = []
     for uid, cn, sn, givenname, userpasseord, gid, ou in [
         ('dbyers', 'Danny Byers', 'Byers', 'Danny', 'dby3rs1', '10001', 'ou=dirsec'),
         ('orla', 'Orla Hegarty', 'Hegarty', 'Orla', '000rla1', '10002', 'ou=dirsec'),
@@ -134,7 +138,8 @@ def policy_qoutes_setup(topology_m1, request):
         ('accntlusr', 'AccountControl User', 'ControlUser', 'Account', 'AcControl123', '10007', 'ou=dirsec'),
         ('nocntlusr', 'NoAccountControl User', 'ControlUser', 'NoAccount', 'NoControl123', '10008', 'ou=dirsec')
     ]:
-        create_user(inst, uid, cn, sn, givenname, userpasseord, gid, ou)
+        users.append(create_user(inst, uid, cn, sn, givenname, userpasseord, gid, ou))
+
     policy_props = {'passwordexp': 'off',
                     'passwordchange': 'off',
                     'passwordmustchange': 'off',
@@ -152,24 +157,32 @@ def policy_qoutes_setup(topology_m1, request):
                     'passwordStorageScheme': 'CLEAR',
                     'passwordwarning': '86400'
                     }
+    pwp_dns = []
     pwp = PwPolicyManager(inst)
     for dn_dn in (f'uid=orla,ou=dirsec,{DEFAULT_SUFFIX}',
                   f'uid=joe,ou=People,{DEFAULT_SUFFIX}'):
+        pwp_dns.append(dn_dn)
         pwp.create_user_policy(dn_dn, policy_props)
 
     # The function creates PwPolicyEntry with cn: "<DN>" value instead of <DN>
     create_subtree_policy_custom(inst, f'ou=People,{DEFAULT_SUFFIX}', policy_props)
 
     def fin():
-        # Remove the OrganizationalUnits that was created for this test case
+        for dn in pwp_dns:
+            pwp.delete_local_policy(dn)
+
+        for user in users:
+            user.delete()
+
         for ou in ous:
-            inst.delete_branch_s(ou.dn, ldap.SCOPE_SUBTREE, filterstr="(|(objectclass=*)(objectclass=ldapsubentry))")
+            ou.delete()
+
     request.addfinalizer(fin)
 
     return pwp
 
-@pytest.fixture(scope="module")
-def policy_setup(topo):
+@pytest.fixture(scope="function")
+def policy_setup(topo, request):
     """
     Will do pretest setup.
     """
@@ -178,13 +191,19 @@ def policy_setup(topo):
     USER_SELF_MOD_ACI = '(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)'
     ANON_ACI = "(targetattr=\"*\")(version 3.0; acl \"Anonymous Read access\"; allow (read,search,compare) userdn = \"ldap:///anyone\";)"
     suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
-    suffix.add('aci', USER_SELF_MOD_ACI)
-    suffix.add('aci', ANON_ACI)
+    existing_acis = suffix.get_attr_vals_utf8('aci') or []
+    if USER_SELF_MOD_ACI not in existing_acis:
+        suffix.add('aci', USER_SELF_MOD_ACI)
+    if ANON_ACI not in existing_acis:
+        suffix.add('aci', ANON_ACI)
 
+    ous = []
     for suffix, ou in [(DEFAULT_SUFFIX, 'dirsec'), (f'ou=people,{DEFAULT_SUFFIX}', 'others')]:
-        OrganizationalUnits(topo.standalone, suffix).create(properties={
+        ous.append(OrganizationalUnits(topo.standalone, suffix).create(properties={
             'ou': ou
-        })
+        }))
+
+    users = []
     for uid, cn, sn, givenname, userpasseord, gid, ou in [
         ('dbyers', 'Danny Byers', 'Byers', 'Danny', 'dby3rs1', '10001', 'ou=dirsec'),
         ('orla', 'Orla Hegarty', 'Hegarty', 'Orla', '000rla1', '10002', 'ou=dirsec'),
@@ -195,7 +214,8 @@ def policy_setup(topo):
         ('accntlusr', 'AccountControl User', 'ControlUser', 'Account', 'AcControl123', '10007', 'ou=dirsec'),
         ('nocntlusr', 'NoAccountControl User', 'ControlUser', 'NoAccount', 'NoControl123', '10008', 'ou=dirsec')
     ]:
-        create_user(topo.standalone, uid, cn, sn, givenname, userpasseord, gid, ou)
+        users.append(create_user(topo.standalone, uid, cn, sn, givenname, userpasseord, gid, ou))
+
     policy_props = {'passwordexp': 'off',
                     'passwordchange': 'off',
                     'passwordmustchange': 'off',
@@ -213,11 +233,28 @@ def policy_setup(topo):
                     'passwordStorageScheme': 'CLEAR',
                     'passwordwarning': '86400'
                     }
+    pwp_dns = []
     pwp = PwPolicyManager(topo.standalone)
     for dn_dn in (f'uid=orla,ou=dirsec,{DEFAULT_SUFFIX}',
                   f'uid=joe,ou=People,{DEFAULT_SUFFIX}'):
+        pwp_dns.append(dn_dn)
         pwp.create_user_policy(dn_dn, policy_props)
+
     pwp.create_subtree_policy(f'ou=People,{DEFAULT_SUFFIX}', policy_props)
+
+    def fin():
+        pwp.delete_local_policy(f'ou=People,{DEFAULT_SUFFIX}')
+
+        for dn in pwp_dns:
+            pwp.delete_local_policy(dn)
+
+        for user in users:
+            user.delete()
+
+        for ou in ous:
+            ou.delete()
+
+    request.addfinalizer(fin)
 
 
 def change_password(topo, user_password_new_pass_list):
@@ -287,6 +324,26 @@ def fixture_for_password_change(request, topo):
         ])
         request.addfinalizer(final_task)
 
+def _cli_args(dn, **extraargs):
+    args = FakeArgs()
+    args.DN = dn
+    args.suffix = False
+    args.json = False
+    args.verbose = False
+    args.pwdchange = None
+    args.pwdlockout = None
+    for key, value in extraargs.items():
+        setattr(args, key, value)
+    return args
+
+def _assert_no_duplicate_in_logs(logcap):
+    logged_output = []
+    for rec in logcap.outputs:
+        msg = rec.getMessage()
+        for line in msg.splitlines():
+            if line.strip():
+                logged_output.append(line)
+    assert len(logged_output) == len(set(logged_output))
 
 def test_password_change_section(topo, policy_setup, fixture_for_password_change):
     """Password Change Section.
@@ -1595,6 +1652,14 @@ def test_pwpolicy_list(topo, request):
     # Cleanup
     def fin():
         try:
+            del_local_policy(inst, None, topo.logcap.log, _cli_args([people.dn]))
+        except Exception:
+            pass
+        try:
+            people.delete()
+        except Exception:
+            pass
+        try:
             backend_entry.delete()
         except Exception:
             pass
@@ -1635,30 +1700,8 @@ def test_duplicate_pwpolicy(topo, request):
     """
     inst = topo.standalone
 
-    def _cli_args(dn, **extraargs):
-        args = FakeArgs()
-        args.DN = dn
-        args.suffix = False
-        args.json = False
-        args.verbose = False
-        args.pwdchange = None
-        args.passwordlockout = None
-        for key, value in extraargs.items():
-            setattr(args, key, value)
-        return args
-
-    def _assert_no_duplicate_in_logs(logcap):
-        logged_output = []
-        for rec in logcap.outputs:
-            msg = rec.getMessage()
-            for line in msg.splitlines():
-                if line.strip():
-                    logged_output.append(line)
-        assert len(logged_output) == len(set(logged_output))
-
-    # Ensure OU exists
-    ous = OrganizationalUnits(topo.standalone, DEFAULT_SUFFIX)
-    ous.ensure_state(properties={'ou': 'people'})
+    # Verify OU exists
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
     people = ous.get("People")
     assert people.exists()
 
@@ -1674,8 +1717,8 @@ def test_duplicate_pwpolicy(topo, request):
 
     # Update an existing subtree pwp
     topo.logcap.flush()
-    create_subtree_policy(inst, None, topo.logcap.log, _cli_args([people.dn], pwdchange='on', passwordlockout='on'))
-    assert topo.logcap.contains("Password policy successfully updated")
+    create_subtree_policy(inst, None, topo.logcap.log, _cli_args([people.dn], pwdchange='on', pwdlockout='on'))
+    assert topo.logcap.contains("Successfully updated password policy")
 
     # Verify there are no duplicates listed
     topo.logcap.flush()
@@ -1702,8 +1745,8 @@ def test_duplicate_pwpolicy(topo, request):
 
     # Update an existing user pwp
     topo.logcap.flush()
-    create_user_policy(inst, None, topo.logcap.log, _cli_args([test_user.dn], pwdchange='on', passwordlockout='on'))
-    assert topo.logcap.contains("Password policy successfully updated")
+    create_user_policy(inst, None, topo.logcap.log, _cli_args([test_user.dn], pwdchange='on', pwdlockout='on'))
+    assert topo.logcap.contains("Successfully updated password policy")
 
     # Verify there are no duplicates listed
     topo.logcap.flush()
@@ -1712,10 +1755,75 @@ def test_duplicate_pwpolicy(topo, request):
 
     # Cleanup
     def fin():
+        try:
             del_local_policy(inst, None, topo.logcap.log, _cli_args([test_user.dn]))
             test_user.delete()
+        except Exception:
+            pass
 
     request.addfinalizer(fin)
+
+def test_subtree_pwpolicy_cos_repair(topo, request):
+    """Verify that a missing or corrupted CoS entry is repaired when
+    create_subtree_policy() is run again.
+
+    :id: da15d1d9-5e45-4af1-9d5d-9db93ef0f552
+    :setup: Standalone
+    :steps:
+        1. Ensure OU exists
+        2. Create subtree password policy
+        3. Manually delete the related CoS template entry
+        4. Run create_subtree_policy again
+        5. Verify CoS entry is recreated
+        6. Verify repair/update status is reported
+    :expectedresults:
+        1. Success
+        2. Success
+        3. CoS entry deleted
+        4. Policy command runs successfully
+        5. CoS entry exists again
+        6. Repair/update message reported
+    """
+    inst = topo.standalone
+
+    # Verify OU exists
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    people = ous.get("People")
+    assert people.exists()
+
+    # Add subtree pwp
+    topo.logcap.flush()
+    create_subtree_policy(inst, None, topo.logcap.log, _cli_args([people.dn]))
+    assert topo.logcap.contains("Successfully created new password policy")
+
+    # Verify the pwp subtree container exists
+    pwp_container = nsContainer(inst, 'cn=nsPwPolicyContainer,%s' % people.dn)
+    assert pwp_container.exists()
+
+    # Break the pwp cos chain by deleting the cos template
+    cos_templates = CosTemplates(inst, pwp_container.dn)
+    cos_template = cos_templates.get('cn=nsPwTemplateEntry,%s' % people.dn)
+    assert cos_template.exists()
+    cos_template.delete()
+    assert not cos_template.exists()
+
+    # Create a subtree pwp to repair the broken pwp CoS chain
+    topo.logcap.flush()
+    create_subtree_policy(inst, None, topo.logcap.log, _cli_args([people.dn]))
+    assert topo.logcap.contains("Successfully updated password policy")
+
+    cos_template = cos_templates.get('cn=nsPwTemplateEntry,%s' % people.dn)
+    assert cos_template.exists()
+
+    # Cleanup
+    def fin():
+        try:
+            del_local_policy(inst, None, topo.logcap.log, _cli_args([people.dn]))
+        except Exception:
+            pass
+
+    request.addfinalizer(fin)
+
 
 if __name__ == "__main__":
     CURRENT_FILE = os.path.realpath(__file__)

--- a/src/cockpit/389-console/po/ja.po
+++ b/src/cockpit/389-console/po/ja.po
@@ -5878,7 +5878,7 @@ msgstr "パスワードの有効期限"
 msgid "Create New Policy"
 msgstr "ポリシーを作成"
 
-#: src/lib/database/localPwp.jsx:1396
+#: src/lib/database/localPwp.jsx:1451
 msgid "Successfully created new password policy"
 msgstr "新しいパスワードポリシーの作成に成功しました"
 

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -1435,10 +1435,28 @@ export class LocalPwPolicy extends React.Component {
                     this.setState({
                         loading: false,
                     });
-                    this.props.addNotification(
-                        "success",
-                        _("Successfully created new password policy")
-                    );
+                    let message;
+                    let type = "success";
+
+                    const response = JSON.parse(content);
+                    if (response) {
+                        switch (response.ensure_status) {
+                            case "UNCHANGED":
+                                message = _("Password policy is already up to date");
+                                break;
+                            case "UPDATED":
+                                message = _("Successfully updated password policy");
+                                break;
+                            case "ADDED":
+                                message = _("Successfully created new password policy");
+                                break;
+                            default:
+                                message = _("Unknown password policy operation");
+                                type = "error";
+                                break;
+                        }
+                    }
+                    this.props.addNotification(type, message);
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -67,6 +67,24 @@ def _gen_filter(attrtypes, values, extra=None):
     return filt
 
 
+def _normalise_attrs(attrs_dict):
+    result = {}
+
+    for k, v in attrs_dict.items():
+        key = k.lower()
+        # v is always a list
+        values = v
+        normalised = []
+        for x in values:
+            # Handle DN valued attributes
+            if is_a_dn(x):
+                x = ldap.dn.dn2str(ldap.dn.str2dn(x))
+            normalised.append(ensure_str(x))
+        result[key] = normalised
+
+    return result
+
+
 # Define wrappers around the ldap operation to have a clear diagnostic
 def _ldap_op_s(inst, f, fname, *args, **kwargs):
     # f.__name__ says 'inner' so the wanted name is provided as argument
@@ -1088,39 +1106,10 @@ class DSLdapObject(DSLogging, DSLint):
             # Strict mode, compare and update only the differences
             else:
                 # Get existing attributes
-                current_attrs_raw = self.get_all_attrs_utf8()
-                current_attrs = {}
-                for k, v in current_attrs_raw.items():
-                    key = k.lower()
-                    if not isinstance(v, list):
-                        values = [v]
-                    else:
-                        values = v
-
-                    normalised = []
-                    for x in values:
-                        # Handle DN valued attributes
-                        if is_a_dn(x):
-                            x = ldap.dn.dn2str(ldap.dn.str2dn(x))
-                        normalised.append(ensure_str(x))
-                    current_attrs[key] = normalised
+                current_attrs = _normalise_attrs(self.get_all_attrs_utf8())
 
                 # Get requested attributes
-                requested_attrs = {}
-                for k, v in valid_props.items():
-                    key = k.lower()
-                    if not isinstance(v, list):
-                        values = [v]
-                    else:
-                        values = v
-
-                    normalised = []
-                    for x in values:
-                        # Handle DN valued attributes
-                        if is_a_dn(x):
-                            x = ldap.dn.dn2str(ldap.dn.str2dn(x))
-                        normalised.append(ensure_str(x))
-                    requested_attrs[key] = normalised
+                requested_attrs = _normalise_attrs(valid_props)
 
                 # Remove operational attributes
                 for attr in self._compare_exclude:
@@ -1131,8 +1120,6 @@ class DSLdapObject(DSLogging, DSLint):
                 mods = []
                 for k, v in requested_attrs.items():
                     current_val = current_attrs.get(k, [])
-                    if not isinstance(current_val, list):
-                        current_val = [current_val]
                     if set(current_val) != set(v):
                         matches = False
                         mods.append((ldap.MOD_REPLACE, k, ensure_list_bytes(v)))
@@ -1148,8 +1135,6 @@ class DSLdapObject(DSLogging, DSLint):
                                 clientctrls=self._client_controls,
                                 escapehatch='i am sure')
                     self._ensure_status = self.ENSURE_UPDATED
-                else:
-                    self._ensure_status = self.ENSURE_UNCHANGED
 
                 return self
 

--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -74,6 +74,31 @@ def _get_pw_policy(inst, targetdn, log, use_json=None):
         log.info(response)
 
 
+def _log_policy_result(log, entry, use_json=None):
+    """
+    Logs the result of creating/updating a password policy
+    in json or text format.
+    """
+    status = entry.ensure_status
+    if status == entry.ENSURE_UNCHANGED:
+        message = 'Password policy is already up to date'
+        ensure = "UNCHANGED"
+    elif status == entry.ENSURE_UPDATED:
+        message = 'Successfully updated password policy'
+        ensure = "UPDATED"
+    elif status == entry.ENSURE_ADDED:
+        message = 'Successfully created new password policy'
+        ensure = "ADDED"
+    else:
+        message = "Unknown password policy operation"
+        ensure = "UNKNOWN"
+
+    if use_json:
+        log.info(json.dumps({"ensure_status": ensure, "message": message}, indent=4))
+    else:
+        log.info(message)
+
+
 def list_policies(inst, basedn, log, args):
     log = log.getChild('list_policies')
 
@@ -165,18 +190,16 @@ def create_subtree_policy(inst, basedn, log, args):
     # Gather the attributes
     pwp_manager = PwPolicyManager(inst)
     attrs = _args_to_attrs(args, pwp_manager.arg_to_attr)
-    pwp_manager.create_subtree_policy(args.DN[0], attrs)
-
-    log.info('Successfully created subtree password policy')
+    pwp_entry = pwp_manager.create_subtree_policy(args.DN[0], attrs)
+    _log_policy_result(log, pwp_entry, args.json)
 
 
 def create_user_policy(inst, basedn, log, args):
     log = log.getChild('create_user_policy')
     pwp_manager = PwPolicyManager(inst)
     attrs = _args_to_attrs(args, pwp_manager.arg_to_attr)
-    pwp_manager.create_user_policy(args.DN[0], attrs)
-
-    log.info('Successfully created user password policy')
+    pwp_entry = pwp_manager.create_user_policy(args.DN[0], attrs)
+    _log_policy_result(log, pwp_entry, args.json)
 
 
 def set_global_policy(inst, basedn, log, args):

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -150,12 +150,12 @@ class PwPolicyManager(object):
 
         # Create the pwp container if needed
         pwp_containers = nsContainers(self._instance, basedn=parentdn)
-        pwp_container = pwp_containers.ensure_state(properties={'cn': 'nsPwPolicyContainer'})
+        pwp_container = pwp_containers.ensure_state(properties={'cn': 'nsPwPolicyContainer'}, strict=True)
 
         # Create or update the policy entry
         properties['cn'] = 'cn=nsPwPolicyEntry_user,%s' % dn
         pwp_entries = PwPolicyEntries(self._instance, pwp_container.dn)
-        pwp_entry = pwp_entries.ensure_state(properties=properties)
+        pwp_entry = pwp_entries.ensure_state(properties=properties, strict=True)
         try:
             # Add policy to the entry
             user_entry.replace('pwdpolicysubentry', pwp_entry.dn)
@@ -188,12 +188,12 @@ class PwPolicyManager(object):
 
         # Create the pwp container if needed
         pwp_containers = nsContainers(self._instance, basedn=dn)
-        pwp_container = pwp_containers.ensure_state(properties={'cn': 'nsPwPolicyContainer'})
+        pwp_container = pwp_containers.ensure_state(properties={'cn': 'nsPwPolicyContainer'}, strict=True)
 
         # Create or update the policy entry
         properties['cn'] = 'cn=nsPwPolicyEntry_subtree,%s' % dn
         pwp_entries = PwPolicyEntries(self._instance, pwp_container.dn)
-        pwp_entry = pwp_entries.ensure_state(properties=properties)
+        pwp_entry = pwp_entries.ensure_state(properties=properties, strict=True)
 
         # Ensure the CoS template entry (nsPwTemplateEntry) that points to the
         # password policy entry
@@ -202,7 +202,7 @@ class PwPolicyManager(object):
             'cosPriority': '1',
             'pwdpolicysubentry': pwp_entry.dn,
             'cn': 'cn=nsPwTemplateEntry,%s' % dn
-        })
+        }, strict=True)
 
         # Ensure the CoS specification entry at the subtree level
         cos_pointer_defs = CosPointerDefinitions(self._instance, dn)
@@ -210,7 +210,7 @@ class PwPolicyManager(object):
             'cosAttribute': 'pwdpolicysubentry default operational-default',
             'cosTemplateDn': cos_template.dn,
             'cn': 'nsPwPolicy_CoS'
-        })
+        }, strict=True)
 
         # make sure that local policies are enabled
         self.set_global_policy({'nsslapd-pwpolicy-local': 'on'})

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -158,8 +158,8 @@ class PwPolicyManager(object):
         pwp_entry = pwp_entries.ensure_state(properties=properties, strict=True)
         try:
             # Add policy to the entry if needed
-            user_pwp_dn = user_entry.get_attr_val_utf8('pwdpolicysubentry', [])
-            if user_pwp_dn != [pwp_entry.dn]:
+            user_pwp_dn = user_entry.get_attr_val_utf8('pwdpolicysubentry')
+            if user_pwp_dn != pwp_entry.dn:
                 user_entry.replace('pwdpolicysubentry', pwp_entry.dn)
         except ldap.LDAPError as e:
             # failure, undo what we have done

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -157,8 +157,10 @@ class PwPolicyManager(object):
         pwp_entries = PwPolicyEntries(self._instance, pwp_container.dn)
         pwp_entry = pwp_entries.ensure_state(properties=properties, strict=True)
         try:
-            # Add policy to the entry
-            user_entry.replace('pwdpolicysubentry', pwp_entry.dn)
+            # Add policy to the entry if needed
+            user_pwp_dn = user_entry.get_attr_val_utf8('pwdpolicysubentry', [])
+            if user_pwp_dn != [pwp_entry.dn]:
+                user_entry.replace('pwdpolicysubentry', pwp_entry.dn)
         except ldap.LDAPError as e:
             # failure, undo what we have done
             pwp_entry.delete()
@@ -206,7 +208,7 @@ class PwPolicyManager(object):
 
         # Ensure the CoS specification entry at the subtree level
         cos_pointer_defs = CosPointerDefinitions(self._instance, dn)
-        cos_pointer_defs.ensure_state(properties={
+        cos_pointer_def = cos_pointer_defs.ensure_state(properties={
             'cosAttribute': 'pwdpolicysubentry default operational-default',
             'cosTemplateDn': cos_template.dn,
             'cn': 'nsPwPolicy_CoS'
@@ -214,6 +216,23 @@ class PwPolicyManager(object):
 
         # make sure that local policies are enabled
         self.set_global_policy({'nsslapd-pwpolicy-local': 'on'})
+
+        # Capture the outcome of each ensure_state call
+        ensure_status = [
+            pwp_container.ensure_status,
+            pwp_entry.ensure_status,
+            cos_template.ensure_status,
+            cos_pointer_def.ensure_status,
+        ]
+
+        # Determine overall status
+        if all(s == DSLdapObject.ENSURE_UNCHANGED for s in ensure_status):
+            pwp_entry._ensure_status = DSLdapObject.ENSURE_UNCHANGED
+        elif all(s == DSLdapObject.ENSURE_ADDED for s in ensure_status):
+            pwp_entry._ensure_status = DSLdapObject.ENSURE_ADDED
+        else:
+            # If any component was added/updated, consider it UPDATED (repair or modification)
+            pwp_entry._ensure_status = DSLdapObject.ENSURE_UPDATED
 
         return pwp_entry
 


### PR DESCRIPTION
Description:
Currently, during password policy creation, if an existing policy entry is found, a MOD_REPLACE operation is silently performed instead of alerting the user. This behaviour makes the operation appear successful but hides the fact that the policy already exists.

Fix:
Introduce a strict mode in ensure_state that returns the actual outcome of the operation. Update the UI to handle ensure_state responses and add CI test to verify the behaviour.

Fixes: https://github.com/389ds/389-ds-base/issues/7093

Reviewed by:

## Summary by Sourcery

Improve password policy creation to distinguish between new, updated, and unchanged policies and surface this outcome through CLI, API, and UI.

New Features:
- Expose ensure_state outcome (added, updated, unchanged) on directory objects for consumers to inspect and act upon.

Bug Fixes:
- Prevent silent overwrites when creating a password policy that already exists by treating duplicate creations as no-op updates and reporting them as unchanged.

Enhancements:
- Add a strict ensure_state mode that only applies modifications when policy attributes differ from the existing entry and tracks the resulting status.
- Update password policy CLI to return structured status and messages, and update the Cockpit UI to display accurate notifications for created, updated, and unchanged policies.

Tests:
- Add an integration test to verify duplicate subtree and user password policies are not duplicated, are reported as up to date, and that updates correctly modify existing entries.