### PR TITLE
Issue 7284 - Creating local password policy succeeds with incorrect passwordInHistory value

### DIFF
--- a/ldap/servers/slapd/attr.c
+++ b/ldap/servers/slapd/attr.c
@@ -932,8 +932,20 @@ attr_check_minmax(const char *attr_name, char *value, long minval, long maxval, 
 {
     int retVal = LDAP_SUCCESS;
     long val;
+    char *endptr = NULL;
 
-    val = strtol(value, NULL, 0);
+    if (!value || *value == '\0') {
+        slapi_create_errormsg(errorbuf, ebuflen, "%s: attr value is NULL.", attr_name);
+        return LDAP_CONSTRAINT_VIOLATION;
+    }
+
+    errno = 0;
+    val = strtol(value, &endptr, 0);
+    if (endptr == value || *endptr != '\0' || errno != 0) {
+        slapi_create_errormsg(errorbuf, ebuflen, "%s: invalid value \"%s\".", attr_name, value);
+        return LDAP_CONSTRAINT_VIOLATION;
+    }
+
     if ((minval != -1 ? (val < minval ? 1 : 0) : 0) ||
         (maxval != -1 ? (val > maxval ? 1 : 0) : 0)) {
         slapi_create_errormsg(errorbuf, ebuflen, "%s: invalid value \"%s\".", attr_name, value);


### PR DESCRIPTION
Description:
attr_check_minmax used strtol(value, NULL, 0), which silently converted invalid strings to 0, passing subsequent range checks.

Fix:
Add checks for NULL or empty values and uses strtol with endptr to validate int input before range checks.

Fixes: https://github.com/389ds/389-ds-base/issues/7284

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Reject NULL, empty, or non-numeric attribute values instead of silently converting them to zero during range validation.