### PR TITLE
Issue 7281 - UI - Add encryption module management

### DIFF
--- a/dirsrvtests/tests/suites/webui/server/server_test.py
+++ b/dirsrvtests/tests/suites/webui/server/server_test.py
@@ -344,6 +344,39 @@ def test_security_log_availability(topology_st, page, browser_name):
     assert frame.get_by_text('Log Archive Exceeds (in MB)').is_visible()
 
 
+def test_security_encryption_modules_availability(topology_st, page, browser_name):
+    """ Test Encryption Modules tab visibility and controls
+
+    :id: b8a36f2e-381a-49ce-bf3a-4fe25a83f02a
+    :setup: Standalone instance
+    :steps:
+         1. Click on Security button on the side panel and check if Security Configuration tab is visible.
+         2. Click on Encryption Modules tab and check if Add Encryption Module button is visible.
+         3. Check if table headers Module Name and Server Certificate Name are visible.
+    :expectedresults:
+         1. Element is visible.
+         2. Element is visible.
+         3. Elements are visible.
+    """
+    setup_login(page)
+    time.sleep(1)
+    frame = check_frame_assignment(page, browser_name)
+
+    log.info('Click on Security button and check if element is loaded.')
+    frame.locator('#security-config').click()
+    frame.get_by_role('tab', name='Security Configuration').wait_for()
+    assert frame.get_by_role('tab', name='Security Configuration').is_visible()
+
+    log.info('Click on Encryption Modules tab and check if Add Encryption Module button is visible.')
+    frame.get_by_role('tab', name='Encryption Modules').click()
+    frame.get_by_role('button', name='Add Encryption Module').wait_for()
+    assert frame.get_by_role('button', name='Add Encryption Module').is_visible()
+
+    log.info('Check if encryption modules table headers are visible.')
+    assert frame.get_by_role('columnheader', name='Module Name').is_visible()
+    assert frame.get_by_role('columnheader', name='Server Certificate Name').is_visible()
+
+
 if __name__ == '__main__':
     # Run isolated
     # -s for DEBUG mode

--- a/src/cockpit/389-console/src/dsBasicComponents.jsx
+++ b/src/cockpit/389-console/src/dsBasicComponents.jsx
@@ -477,6 +477,7 @@ const TypeaheadSelect = ({
                                 className={option.className}
                                 id={createItemId(option.value)}
                                 value={option.value}
+                                isDisabled={option.isDisabled}
                                 isSelected={isSelected}
                                 hasCheckbox={isMulti && hasCheckbox}
                                 ref={null}
@@ -504,7 +505,9 @@ TypeaheadSelect.propTypes = {
             PropTypes.shape({
                 value: PropTypes.string.isRequired,
                 label: PropTypes.string,
-                description: PropTypes.string
+                description: PropTypes.string,
+                isDisabled: PropTypes.bool,
+                className: PropTypes.string,
             })
         ])
     ),

--- a/src/cockpit/389-console/src/lib/security/encryptionModules.jsx
+++ b/src/cockpit/389-console/src/lib/security/encryptionModules.jsx
@@ -1,0 +1,395 @@
+import cockpit from "cockpit";
+import React from "react";
+import PropTypes from "prop-types";
+import { log_cmd } from "../tools.jsx";
+import { DoubleConfirmModal } from "../notifications.jsx";
+import { EncryptionModuleTable } from "./securityTables.jsx";
+
+const _ = cockpit.gettext;
+
+// Returns a normalized attribute value from dsconf JSON output.
+function getModuleAttrValue(attrs, attrName, defaultValue = "") {
+    const rawValue = attrs?.[attrName];
+    if (Array.isArray(rawValue)) {
+        return rawValue.length > 0 ? rawValue[0] : defaultValue;
+    }
+    if (rawValue === null || rawValue === undefined) {
+        return defaultValue;
+    }
+    return rawValue;
+}
+
+// Maps module objects into the table row shape used by the UI table component.
+function makeEncryptionModuleRows(modules) {
+    return modules.map(module => ({
+        name: module.name,
+        certNickname: module.certNickname,
+        activated: module.activated,
+        token: module.token,
+        serverCertExtractFile: module.serverCertExtractFile,
+        serverKeyExtractFile: module.serverKeyExtractFile,
+    }));
+}
+
+// Converts a raw encryption-module entry into normalized UI data.
+function normalizeEncryptionModuleEntry(entry) {
+    const attrs = entry?.attrs || entry || {};
+    return {
+        name: getModuleAttrValue(attrs, "cn", ""),
+        certNickname: getModuleAttrValue(attrs, "nssslpersonalityssl", ""),
+        activated: getModuleAttrValue(attrs, "nssslactivation", "off").toLowerCase(),
+        token: getModuleAttrValue(attrs, "nsssltoken", "internal (software)"),
+        serverCertExtractFile: getModuleAttrValue(attrs, "servercertextractfile", ""),
+        serverKeyExtractFile: getModuleAttrValue(attrs, "serverkeyextractfile", ""),
+        dn: entry?.dn || "",
+    };
+}
+
+function EncryptionModules({ addNotification, serverId, serverCertNames }) {
+    const [modules, setModules] = React.useState([]);
+    const [rows, setRows] = React.useState([]);
+    const [loadError, setLoadError] = React.useState("");
+    const [partialDataCount, setPartialDataCount] = React.useState(0);
+    const [certOptions, setCertOptions] = React.useState([]);
+    const [actionInProgress, setActionInProgress] = React.useState(false);
+    const [showToggleConfirm, setShowToggleConfirm] = React.useState(false);
+    const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
+    const [confirmChecked, setConfirmChecked] = React.useState(false);
+    const [confirmSpinning, setConfirmSpinning] = React.useState(false);
+    const [pendingModule, setPendingModule] = React.useState(null);
+    const [pendingModuleActivate, setPendingModuleActivate] = React.useState(false);
+    const [loading, setLoading] = React.useState(true);
+
+    // Parse dsconf JSON errors and fallback safely for unexpected output.
+    const parseCmdError = React.useCallback(err => {
+        try {
+            const errObj = JSON.parse(err);
+            let msg = errObj.desc;
+            if ("info" in errObj) {
+                msg = `${errObj.desc} - ${errObj.info}`;
+            }
+            return msg;
+        } catch (e) {
+            return err?.toString() || _("Unexpected error");
+        }
+    }, []);
+
+    // Build a consistent user-facing error string for module operations.
+    const formatOpError = React.useCallback((opName, targetName, msg) => {
+        // Localize the operation name so the full message is translated
+        const opLabel = _(opName);
+        const target = targetName ? cockpit.format(_(" for '$0'"), targetName) : "";
+        return cockpit.format(_("Failed to $0$1 - $2"), opLabel, target, msg);
+    }, []);
+
+    // Mark cert nicknames already bound to a different module as non-selectable.
+    const buildEncryptionModuleCertOptions = React.useCallback((moduleList, certNames) => {
+        const usageByCert = {};
+        for (const module of moduleList) {
+            if (module.certNickname) {
+                usageByCert[module.certNickname] = module.name;
+            }
+        }
+
+        return (certNames || []).map(nickname => ({
+            nickname,
+            inUseByModule: usageByCert[nickname] || null,
+            selectable: !usageByCert[nickname],
+            isAdHoc: false,
+        }));
+    }, []);
+
+    // Load module list and normalize it for table rendering and selectors.
+    const loadEncryptionModules = React.useCallback(() => {
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "security", "encryption-module", "list"
+        ];
+        log_cmd("loadEncryptionModules", "Load encryption modules", cmd);
+        cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .done(content => {
+                    const moduleResp = JSON.parse(content);
+                    const moduleItems = moduleResp.items || [];
+                    const normalizedModules = moduleItems.map(item => normalizeEncryptionModuleEntry(item));
+                    const cleanModules = normalizedModules.filter(module => module.name !== "");
+                    const partialCount = normalizedModules.length - cleanModules.length;
+                    const tableRows = makeEncryptionModuleRows(cleanModules);
+                    const moduleCertOptions = buildEncryptionModuleCertOptions(cleanModules, serverCertNames);
+                    setModules(cleanModules);
+                    setRows(tableRows);
+                    setCertOptions(moduleCertOptions);
+                    setLoadError("");
+                    setPartialDataCount(partialCount);
+                    setLoading(false);
+                })
+                .fail(err => {
+                    const msg = parseCmdError(err);
+                    setModules([]);
+                    setRows([]);
+                    setCertOptions([]);
+                    setLoadError(msg);
+                    setPartialDataCount(0);
+                    setLoading(false);
+                    addNotification(
+                        "error",
+                        cockpit.format(_("Error loading encryption modules - $0"), msg)
+                    );
+                });
+    }, [addNotification, buildEncryptionModuleCertOptions, parseCmdError, serverCertNames, serverId]);
+
+    // Load module data when the tab component is first rendered.
+    React.useEffect(() => {
+        loadEncryptionModules();
+    }, [loadEncryptionModules]);
+
+    // Recompute cert select options if certificate inventory changes.
+    React.useEffect(() => {
+        setCertOptions(buildEncryptionModuleCertOptions(modules, serverCertNames));
+    }, [buildEncryptionModuleCertOptions, modules, serverCertNames]);
+
+    // Execute a module mutation command with shared in-flight guards/notifications.
+    const runEncryptionModuleOperation = React.useCallback(({ cmd, opName, successMsg, actionTarget: targetName = "" }) => {
+        if (actionInProgress) {
+            return Promise.reject(new Error("busy"));
+        }
+        log_cmd("runEncryptionModuleOperation", opName, cmd);
+        setActionInProgress(true);
+
+        return cockpit
+                .spawn(cmd, { superuser: true, err: "message" })
+                .then(() => {
+                    addNotification("success", successMsg);
+                    setActionInProgress(false);
+                    loadEncryptionModules();
+                })
+                .catch(err => {
+                    const msg = parseCmdError(err);
+                    const formattedMsg = formatOpError(opName, targetName, msg);
+                    addNotification("error", formattedMsg);
+                    setActionInProgress(false);
+                    throw err;
+                });
+    }, [actionInProgress, addNotification, formatOpError, loadEncryptionModules, parseCmdError]);
+
+    // Build and execute dsconf add command for a new encryption module.
+    const createEncryptionModule = React.useCallback((payload, onSuccessClose) => {
+        if (actionInProgress) {
+            return;
+        }
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "security", "encryption-module", "add", payload.name,
+            "--cert-nickname", payload.certNickname,
+            "--token", payload.token,
+        ];
+        if (payload.activated) {
+            cmd.push("--activated");
+        }
+        if (payload.serverCertExtractFile) {
+            cmd.push("--server-cert-extract-file", payload.serverCertExtractFile);
+        }
+        if (payload.serverKeyExtractFile) {
+            cmd.push("--server-key-extract-file", payload.serverKeyExtractFile);
+        }
+
+        runEncryptionModuleOperation({
+            cmd,
+            opName: "create encryption module",
+            actionTarget: payload.name,
+            successMsg: cockpit.format(_("Successfully created encryption module '$0'."), payload.name),
+        }).then(() => {
+            onSuccessClose();
+        }).catch(() => {});
+    }, [actionInProgress, runEncryptionModuleOperation, serverId]);
+
+    // Build and execute dsconf edit command for an existing module.
+    const editEncryptionModule = React.useCallback((moduleName, payload, onSuccessClose) => {
+        if (actionInProgress) {
+            return;
+        }
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "security", "encryption-module", "edit", moduleName,
+            "--cert-nickname", payload.certNickname,
+            "--token", payload.token,
+        ];
+
+        if (payload.activated) {
+            cmd.push("--activate");
+        } else {
+            cmd.push("--deactivate");
+        }
+        if (payload.serverCertExtractFile) {
+            cmd.push("--server-cert-extract-file", payload.serverCertExtractFile);
+        }
+        if (payload.serverKeyExtractFile) {
+            cmd.push("--server-key-extract-file", payload.serverKeyExtractFile);
+        }
+
+        runEncryptionModuleOperation({
+            cmd,
+            opName: "edit encryption module",
+            actionTarget: moduleName,
+            successMsg: cockpit.format(_("Successfully updated encryption module '$0'."), moduleName),
+        }).then(() => {
+            onSuccessClose();
+        }).catch(() => {});
+    }, [actionInProgress, runEncryptionModuleOperation, serverId]);
+
+    // Open confirmation dialog for module activation state changes.
+    const openToggleConfirm = React.useCallback((module, activate) => {
+        setShowToggleConfirm(true);
+        setConfirmChecked(false);
+        setConfirmSpinning(false);
+        setPendingModule(module);
+        setPendingModuleActivate(activate);
+    }, []);
+
+    // Open confirmation dialog for module deletion.
+    const openDeleteConfirm = React.useCallback(module => {
+        setShowDeleteConfirm(true);
+        setConfirmChecked(false);
+        setConfirmSpinning(false);
+        setPendingModule(module);
+    }, []);
+
+    // Close active confirmation dialog unless an action is still spinning.
+    const closeConfirm = React.useCallback(() => {
+        if (confirmSpinning) {
+            return;
+        }
+        setShowToggleConfirm(false);
+        setShowDeleteConfirm(false);
+        setConfirmChecked(false);
+        setConfirmSpinning(false);
+        setPendingModule(null);
+        setPendingModuleActivate(false);
+    }, [confirmSpinning]);
+
+    // Handle checkbox state in double-confirm modal.
+    const onConfirmChange = React.useCallback(e => {
+        const value = e.target.type === "checkbox" ? e.target.checked : e.target.value;
+        setConfirmChecked(value);
+    }, []);
+
+    // Submit enable/disable after explicit user confirmation.
+    const confirmToggle = React.useCallback(() => {
+        if (!pendingModule || actionInProgress || confirmSpinning) {
+            return;
+        }
+
+        const activate = pendingModuleActivate;
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "security", "encryption-module", "edit", pendingModule.name,
+            activate ? "--activate" : "--deactivate",
+        ];
+        setConfirmSpinning(true);
+        runEncryptionModuleOperation({
+            cmd,
+            opName: activate ? "enable encryption module" : "disable encryption module",
+            actionTarget: pendingModule.name,
+            successMsg: cockpit.format(
+                activate
+                    ? _("Successfully enabled encryption module '$0'.")
+                    : _("Successfully disabled encryption module '$0'."),
+                pendingModule.name
+            ),
+        }).then(() => {
+            setShowToggleConfirm(false);
+            setConfirmChecked(false);
+            setConfirmSpinning(false);
+            setPendingModule(null);
+            setPendingModuleActivate(false);
+        }).catch(() => {
+            setConfirmSpinning(false);
+        });
+    }, [actionInProgress, confirmSpinning, pendingModule, pendingModuleActivate, runEncryptionModuleOperation, serverId]);
+
+    // Submit delete after explicit user confirmation.
+    const confirmDelete = React.useCallback(() => {
+        if (!pendingModule || actionInProgress || confirmSpinning) {
+            return;
+        }
+
+        const cmd = [
+            "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+            "security", "encryption-module", "delete", pendingModule.name,
+        ];
+        setConfirmSpinning(true);
+        runEncryptionModuleOperation({
+            cmd,
+            opName: "delete encryption module",
+            actionTarget: pendingModule.name,
+            successMsg: cockpit.format(_("Successfully deleted encryption module '$0'."), pendingModule.name),
+        }).then(() => {
+            setShowDeleteConfirm(false);
+            setConfirmChecked(false);
+            setConfirmSpinning(false);
+            setPendingModule(null);
+            setPendingModuleActivate(false);
+        }).catch(() => {
+            setConfirmSpinning(false);
+        });
+    }, [actionInProgress, confirmSpinning, pendingModule, runEncryptionModuleOperation, serverId]);
+
+    // Render module table and confirmation dialogs owned by this container.
+    return (
+        <>
+            <EncryptionModuleTable
+                modules={modules}
+                rows={rows}
+                certOptions={certOptions}
+                loading={loading}
+                loadError={loadError}
+                partialDataCount={partialDataCount}
+                actionInProgress={actionInProgress}
+                onCreateModule={createEncryptionModule}
+                onEditModule={editEncryptionModule}
+                onToggleModule={openToggleConfirm}
+                onDeleteModule={openDeleteConfirm}
+            />
+
+            <DoubleConfirmModal
+                showModal={showToggleConfirm}
+                closeHandler={closeConfirm}
+                handleChange={onConfirmChange}
+                actionHandler={confirmToggle}
+                spinning={confirmSpinning}
+                item={pendingModule ? pendingModule.name : ""}
+                checked={confirmChecked}
+                mTitle={pendingModuleActivate ? _("Enable Encryption Module") : _("Disable Encryption Module")}
+                mMsg={pendingModuleActivate
+                    ? _("Are you sure you want to enable this encryption module?")
+                    : _("Are you sure you want to disable this encryption module?")}
+                mSpinningMsg={pendingModuleActivate ? _("Enabling ...") : _("Disabling ...")}
+                mBtnName={pendingModuleActivate ? _("Enable") : _("Disable")}
+            />
+
+            <DoubleConfirmModal
+                showModal={showDeleteConfirm}
+                closeHandler={closeConfirm}
+                handleChange={onConfirmChange}
+                actionHandler={confirmDelete}
+                spinning={confirmSpinning}
+                item={pendingModule ? pendingModule.name : ""}
+                checked={confirmChecked}
+                mTitle={_("Delete Encryption Module")}
+                mMsg={(pendingModule && pendingModule.activated === "on")
+                    ? _("This encryption module is currently active. Deleting active modules is allowed but requires confirmation. Continue?")
+                    : _("Are you sure you want to delete this encryption module?")}
+                mSpinningMsg={_("Deleting ...")}
+                mBtnName={_("Delete")}
+            />
+        </>
+    );
+}
+
+EncryptionModules.propTypes = {
+    addNotification: PropTypes.func,
+    serverId: PropTypes.string,
+    serverCertNames: PropTypes.array,
+};
+
+export default EncryptionModules;

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { DoubleConfirmModal } from "./lib/notifications.jsx";
 import { log_cmd } from "./lib/tools.jsx";
 import { CertificateManagement } from "./lib/security/certificateManagement.jsx";
+import EncryptionModules from "./lib/security/encryptionModules.jsx";
 import { SecurityEnableModal } from "./lib/security/securityModals.jsx";
 import { Ciphers } from "./lib/security/ciphers.jsx";
 import {
@@ -37,6 +38,7 @@ const configAttrs = [
     'checkHostname',
     'allowWeakCipher',
     'nstlsallowclientrenegotiation',
+    'extractPEMFiles',
 ];
 
 const configCoreAttrs = [
@@ -101,32 +103,6 @@ export class Security extends React.Component {
             _nssslpersonalityssl: '',
             _nssslpersonalityssllist: "",
             _nstlsallowclientrenegotiation: true,
-
-            isServerCertOpen: false,
-        };
-
-        // Server Cert
-        this.handleServerCertSelect = (event, selection) => {
-            let disableSaveBtn = !this.configChanged();
-            if (this.state._nssslpersonalityssl !== selection) {
-                disableSaveBtn = false;
-            }
-            this.setState({
-                nssslpersonalityssl: selection,
-                isServerCertOpen: false,
-                disableSaveBtn,
-            });
-        };
-        this.handleServerCertToggle = (_event, isServerCertOpen) => {
-        this.setState({
-            isServerCertOpen
-        });
-        };
-        this.handleServerCertClear = () => {
-            this.setState({
-                nssslpersonalityssl: '',
-                isServerCertOpen: false
-            });
         };
 
         // Toggle currently active tab
@@ -430,12 +406,10 @@ export class Security extends React.Component {
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
                     const keys = JSON.parse(content);
-                    this.setState(() => (
-                        {
-                            serverOrphanKeys: keys,
-                            loaded: true
-                        }), this.props.enableTree()
-                    );
+                    this.setState({
+                        serverOrphanKeys: keys,
+                        loaded: true
+                    }, this.props.enableTree());
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
@@ -502,6 +476,7 @@ export class Security extends React.Component {
                     let allowWeak = false;
                     let renegot = true;
                     let checkHostname = false;
+                    let extractPEMFiles = false;
 
                     if ('nstlsallowclientrenegotiation' in config.items) {
                         if (config.items.nstlsallowclientrenegotiation === "off") {
@@ -543,6 +518,11 @@ export class Security extends React.Component {
                             cipherPref = attrs.nsssl3ciphers;
                         }
                     }
+                    if ('nsslapd-extract-pemfiles' in attrs) {
+                        if (attrs['nsslapd-extract-pemfiles'].toLowerCase() === "on") {
+                            extractPEMFiles = true;
+                        }
+                    }
 
                     this.setState(() => (
                         {
@@ -557,6 +537,7 @@ export class Security extends React.Component {
                             allowWeakCipher: allowWeak,
                             cipherPref,
                             nstlsallowclientrenegotiation: renegot,
+                            extractPEMFiles,
                             _nstlsallowclientrenegotiation: renegot,
                             _securityEnabled: secEnabled,
                             _requireSecureBinds: secReqSecBinds,
@@ -567,6 +548,7 @@ export class Security extends React.Component {
                             _sslVersionMin: attrs.sslversionmin,
                             _sslVersionMax: attrs.sslversionmax,
                             _allowWeakCipher: allowWeak,
+                            _extractPEMFiles: extractPEMFiles,
                             disableSaveBtn: true,
                         }
                     ), function() {
@@ -845,7 +827,13 @@ export class Security extends React.Component {
             }
             cmd.push("--require-secure-authentication=" + val);
         }
-
+        if (this.state._extractPEMFiles !== this.state.extractPEMFiles) {
+            let val = "off";
+            if (this.state.extractPEMFiles) {
+                val = "on";
+            }
+            cmd.push("--extract-pemfiles=" + val);
+        }
         if (this.state._nstlsallowclientrenegotiation !== this.state.nstlsallowclientrenegotiation) {
             let val = "off";
             if (this.state.nstlsallowclientrenegotiation) {
@@ -992,7 +980,6 @@ export class Security extends React.Component {
 
     render() {
         let securityPage = "";
-        const serverCert = [this.state.nssslpersonalityssl];
         let saveBtnName = _("Save Settings");
         const extraPrimaryProps = {};
         if (this.state.saving) {
@@ -1006,26 +993,6 @@ export class Security extends React.Component {
                 configPage = (
                     <div className="ds-margin-bottom-md">
                         <Form isHorizontal autoComplete="off">
-                            <Grid
-                                title={_("The name, or nickname, of the server certificate inthe NSS database the server should use (nsSSLPersonalitySSL).")}
-                            >
-                                <GridItem className="ds-label" span={3}>
-                                    {_("Server Certificate Name")}
-                                </GridItem>
-                                <GridItem span={8}>
-                                    <TypeaheadSelect
-                                        selected={serverCert}
-                                        onSelect={this.handleServerCertSelect}
-                                        onClear={this.handleServerCertClear}
-                                        options={this.state.serverCertNames}
-                                        isOpen={this.state.isServerCertOpen}
-                                        onToggle={this.handleServerCertToggle}
-                                        placeholder={_("Type a sever certificate nickname...")}
-                                        noResultsText={_("There are no matching entries")}
-                                        ariaLabel="Type a server certificate nickname"
-                                    />
-                                </GridItem>
-                            </Grid>
                             <Grid
                                 title={_("The minimum SSL/TLS version the server will accept (sslversionmin).")}
                             >
@@ -1171,6 +1138,20 @@ export class Security extends React.Component {
                                     />
                                 </GridItem>
                             </Grid>
+                            <Grid
+                                title={_("At server shutdown extract the server\'s certificates and keys to PEM files (nsslapd-extract-pemfiles).")}
+                            >
+                                <GridItem className="ds-label" span={4}>
+                                    <Checkbox
+                                        id="extractPEMFiles"
+                                        isChecked={this.state.extractPEMFiles}
+                                        onChange={(e, checked) => {
+                                            this.handleChange(e);
+                                        }}
+                                        label={_("Extract PEM Files")}
+                                    />
+                                </GridItem>
+                            </Grid>
                         </Form>
                         <Button
                             variant="primary"
@@ -1248,6 +1229,15 @@ export class Security extends React.Component {
                                         enabledCiphers={this.state.enabledCiphers}
                                         addNotification={this.props.addNotification}
                                         reload={this.loadSecurityConfig}
+                                    />
+                                </div>
+                            </Tab>
+                            <Tab eventKey={3} title={<TabTitleText>{_("Encryption Modules")}</TabTitleText>}>
+                                <div className="ds-indent ds-tab-table">
+                                    <EncryptionModules
+                                        serverId={this.props.serverId}
+                                        addNotification={this.props.addNotification}
+                                        serverCertNames={this.state.serverCertNames}
                                     />
                                 </div>
                             </Tab>

--- a/src/lib389/lib389/cli_conf/security.py
+++ b/src/lib389/lib389/cli_conf/security.py
@@ -43,6 +43,9 @@ SECURITY_ATTRS_MAP = OrderedDict([
     ('check-hostname', Props(Config, 'nsslapd-ssl-check-hostname',
                              'Checks the subject of remote certificate against the hostname',
                              onoff)),
+    ('extract-pemfiles', Props(Config, 'nsslapd-extract-pemfiles',
+                               'At server shutdown extract the server\'s certificates and keys to PEM files',
+                               onoff)),
     ('verify-cert-chain-on-startup', Props(Config, 'nsslapd-validate-cert',
                                            'Validates the server certificate during startup',
                                            ('warn', *onoff))),
@@ -102,7 +105,7 @@ def _security_generic_set(inst, basedn, log, args, attrs_map):
             dsobj.replace(props.attr, arg)
         else:
             dsobj.remove_all(props.attr)
-    log.info(f"Successfully updated security configuration ({props.attr})")
+    log.info("Successfully updated security configuration")
 
 
 def _security_generic_get_parser(parent, attrs_map, help):
@@ -122,9 +125,8 @@ def _security_generic_set_parser(parent, attrs_map, help, description):
 def _security_ciphers_change(mode, ciphers, inst, log):
     log = log.getChild('_security_ciphers_change')
     if ('default' in ciphers) or ('all' in ciphers):
-        log.error(('Use ciphers\' names only. Keywords "default" and "all" are ignored. '
-                   'Please, instead specify them manually using \'set\' command.'))
-        return
+        raise ValueError("Use ciphers' names only. Keywords 'default' and 'all' are "
+                         "ignored. Please, instead specify them manually using 'set' command.")
     enc = Encryption(inst)
     if enc.change_ciphers(mode, ciphers) is False:
         log.error('Setting new ciphers failed.')
@@ -280,8 +282,7 @@ def cert_add(inst, basedn, log, args):
     certmgr = CertManager(instance=inst)
     cert = certmgr.get_cert(args.name)
     if cert:
-        log.info(f"Certificate '{args.name}' already exists, skipping")
-        return
+        raise ValueError(f"Certificate '{args.name}' already exists")
 
     certmgr.add_cert(
         args.file,
@@ -352,8 +353,7 @@ def cert_get(inst, basedn, log, args):
     certmgr = CertManager(instance=inst)
     cert = certmgr.get_cert(args.name)
     if not cert:
-        log.error(f"Certificate '{args.name}' not found.")
-        return
+        raise ValueError(f"Certificate '{args.name}' not found.")
 
     if "C" in cert.get("trust_flags", ""):
         return
@@ -370,8 +370,7 @@ def cacert_get(inst, basedn, log, args):
     certmgr = CertManager(instance=inst)
     cert = certmgr.get_cert(args.name)
     if not cert:
-        log.error(f"Certificate '{args.name}' not found.")
-        return
+        raise ValueError(f"Certificate '{args.name}' not found.")
 
     if "C" not in cert.get("trust_flags", ""):
         return
@@ -537,14 +536,14 @@ def encryption_module_delete(inst, basedn, log, args):
     """Delete an encryption module
     """
     if args.name.lower() == "rsa":
-        log.error("Cannot delete RSA encryption module")
-        return
+        # Currently RSA is hardcoded into attribute encryption so it can not
+        # be deleted at this time
+        raise ValueError("Deletion of RSA encryption module is not allowed")
 
     try:
         encryption_module = EncryptionModules(instance=inst).get(args.name)
     except ldap.NO_SUCH_OBJECT as e:
-        log.error(f"Failed to get encryption module '{args.name}'")
-        return
+        raise ValueError(f"Encryption module '{args.name}' not found")
 
     encryption_module.delete()
     log.info("Successfully deleted encryption module")
@@ -556,12 +555,10 @@ def encryption_module_edit(inst, basedn, log, args):
     try:
         encryption_module = EncryptionModules(instance=inst).get(args.name)
     except ldap.NO_SUCH_OBJECT as e:
-        log.error(f"Failed to get encryption module '{args.name}'")
-        return
+        raise ValueError(f"Encryption module '{args.name}' not found")
 
     if args.activate and args.deactivate:
-        log.error("Cannot activate and deactivate an encryption module at the same time")
-        return
+        raise ValueError("Cannot activate and deactivate an encryption module at the same time")
 
     replace_list = []
     if args.cert_nickname is not None:
@@ -616,8 +613,7 @@ def encryption_module_get(inst, basedn, log, args):
     try:
         encryption_module = EncryptionModules(instance=inst).get(args.name)
     except ldap.NO_SUCH_OBJECT as e:
-        log.error(f"Failed to get encryption module '{args.name}'")
-        return
+        raise ValueError(f"Encryption module '{args.name}' not found")
 
     if args.json:
         entry = encryption_module.get_all_attrs_json()


### PR DESCRIPTION
Description:

Implement the Security page Encryption Modules tab with list/create/edit/enable-disable/delete workflows.

relates: https://github.com/389ds/389-ds-base/issues/7281

Assisted by: Cursor

## Summary by Sourcery

Add a new Security page tab for managing encryption modules with full CRUD and activation workflows backed by dsconf operations.

New Features:
- Introduce an Encryption Modules tab in the Security UI to list, create, edit, enable/disable, and delete encryption modules.
- Add a reusable encryption module modal and table component with validation and certificate selection that prevents reusing the same certificate across modules.

Enhancements:
- Extend the shared TypeaheadSelect component to support disabled options and additional option metadata used by the encryption module certificate selector.

Tests:
- Add a web UI test that verifies the Encryption Modules tab, its primary actions, and table headers are visible in the Security page.