### PR TITLE
Issue 7296 - Introduce time limits for GH Actions

### DIFF
--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -9,9 +9,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -20,21 +20,22 @@ jobs:
   rust-tests:
     name: Cargo Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container:
       image: quay.io/389ds/ci-images:fedora
-    
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v6
+
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      
+
       - name: Setup and build
         run: |
           autoreconf -fvi
           ./configure --enable-debug
           make V=0
-        
+
       - name: Run Rust tests
         run: make check-local

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -5,9 +5,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -15,6 +15,7 @@ permissions:
 jobs:
   compile:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +63,7 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checkout and configure
         run: autoreconf -fvi && ./configure
         env:
@@ -72,11 +73,11 @@ jobs:
           CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
           LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
 
-      - uses: ammaraskar/gcc-problem-matcher@master
+      - uses: ammaraskar/gcc-problem-matcher@0.3.0
       - name: Build using ${{ matrix.compiler }}
         run: bash -c "(make V=0 2> >(tee /dev/stderr)) > log.txt"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           path: log.txt

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       image: quay.io/389ds/ci-images:fedora
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checkout and configure
         run: autoreconf -fvi && ./configure
 

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   actions: read
@@ -29,13 +29,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -51,7 +52,7 @@ jobs:
         run: tar -cvf dist.tar dist/
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rpms
           path: dist.tar
@@ -59,6 +60,7 @@ jobs:
   test:
     name: LMDB Test
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     needs: build
     strategy:
       fail-fast: false
@@ -66,7 +68,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -98,7 +100,7 @@ jobs:
         df -h
 
     - name: Download RPMs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: rpms
 
@@ -133,7 +135,7 @@ jobs:
 
     - name: Upload pytest test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
         path: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,9 +8,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -19,11 +19,12 @@ jobs:
   npm-audit-ci:
     name: npm-audit-ci
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: quay.io/389ds/ci-images:test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run NPM Audit CI
         run: cd $GITHUB_WORKSPACE/src/cockpit/389-console && npx --yes audit-ci --config audit-ci.json

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   actions: read
@@ -29,13 +29,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -51,7 +52,7 @@ jobs:
         run: tar -cvf dist.tar dist/
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rpms
           path: dist.tar
@@ -59,6 +60,7 @@ jobs:
   test:
     name: BDB Test
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     needs: build
     strategy:
       fail-fast: false
@@ -66,7 +68,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -98,7 +100,7 @@ jobs:
         df -h
 
     - name: Download RPMs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: rpms
 
@@ -139,7 +141,7 @@ jobs:
 
     - name: Upload pytest test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version || github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.get_version.outputs.version }}
@@ -60,13 +60,13 @@ jobs:
           TAG=${{ steps.get_version.outputs.version }} make -f rpm.mk dist-bz2
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.get_version.outputs.version }}.tar.bz2
           path: ${{ steps.get_version.outputs.version }}.tar.bz2
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           files: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,9 +6,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: 
+permissions:
   actions: read
   packages: read
   contents: read
@@ -16,11 +16,12 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: quay.io/389ds/ci-images:test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run testimony
         if: always()

--- a/src/lib389/lib389/topologies.py
+++ b/src/lib389/lib389/topologies.py
@@ -34,9 +34,9 @@ else:
 log = logging.getLogger(__name__)
 
 
-# Github kills workflow after 6 hours so lets keep 1 hour margin
+# Github kills workflow after 90 minutes so lets keep 5 minutes margin
 # For workflow and test initialization, and artifacts collection
-DEFAULT_TEST_TIMEOUT = 5 * 3600
+DEFAULT_TEST_TIMEOUT = 85 * 60
 
 _test_timeout = DEFAULT_TEST_TIMEOUT
 


### PR DESCRIPTION
Description:
* Limit test jobs to 90 mins, compile to 30 mins.
* Bump actions versions.

Fixes: https://github.com/389ds/389-ds-base/issues/7296

## Summary by Sourcery

Introduce time limits and modernize GitHub Actions workflows.

CI:
- Add explicit timeout limits for compile, test, npm audit, validation, and cargo test workflows to prevent excessively long runs.
- Scope workflow concurrency cancellation to pull_request events instead of all event types.
- Upgrade various GitHub Actions (checkout, upload/download-artifact, gcc-problem-matcher, gh-release) to newer major or tagged versions across workflows.