### PR TITLE
Issue 7300 - Add OS-level thread names to all server threads

### DIFF
--- a/dirsrvtests/tests/suites/threads/thread_naming_test.py
+++ b/dirsrvtests/tests/suites/threads/thread_naming_test.py
@@ -43,12 +43,12 @@ def test_thread_names_present(topology_st):
     :setup: Standalone instance
     :steps:
         1. Get the server PID
-        2. Read thread names from /proc/<pid>/task/*/comm
+        2. Read thread names from /proc/{pid}/task/{tid}/comm
         3. Verify expected thread names are present
     :expectedresults:
         1. PID is obtained
         2. Thread names are readable
-        3. Core thread names (listener, worker-*, ct-list-*, event-q,
+        3. Core thread names (listener, worker, ct-list, event-q,
            housekeep) are found
     """
     inst = topology_st.standalone

--- a/dirsrvtests/tests/suites/threads/thread_naming_test.py
+++ b/dirsrvtests/tests/suites/threads/thread_naming_test.py
@@ -1,0 +1,81 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import platform
+import pytest
+
+from lib389 import pid_from_file
+from lib389.topologies import topology_st
+
+pytestmark = pytest.mark.tier1
+
+logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def _get_thread_names(pid):
+    """Read thread names from /proc/<pid>/task/*/comm"""
+    names = []
+    task_dir = f"/proc/{pid}/task"
+    if not os.path.isdir(task_dir):
+        pytest.skip(f"{task_dir} not available")
+    for tid in os.listdir(task_dir):
+        comm_path = os.path.join(task_dir, tid, "comm")
+        try:
+            with open(comm_path, "r") as f:
+                names.append(f.read().strip())
+        except (FileNotFoundError, PermissionError):
+            pass
+    return names
+
+
+def test_thread_names_present(topology_st):
+    """Test that key threads have been named via pthread_setname_np
+
+    :id: a95b4eca-e806-48dc-8c91-debbc3ef4053
+    :setup: Standalone instance
+    :steps:
+        1. Get the server PID
+        2. Read thread names from /proc/<pid>/task/*/comm
+        3. Verify expected thread names are present
+    :expectedresults:
+        1. PID is obtained
+        2. Thread names are readable
+        3. Core thread names (listener, worker-*, ct-list-*, event-q,
+           housekeep) are found
+    """
+    inst = topology_st.standalone
+    pid = str(pid_from_file(inst.ds_paths.pid_file))
+    log.info(f"Server PID: {pid}")
+
+    thread_names = _get_thread_names(pid)
+    log.info(f"Found {len(thread_names)} threads: {sorted(set(thread_names))}")
+
+    # Verify the listener thread
+    assert "listener" in thread_names, \
+        f"'listener' thread not found in {thread_names}"
+
+    # Verify at least one worker thread
+    worker_threads = [n for n in thread_names if n.startswith("worker-")]
+    assert len(worker_threads) > 0, \
+        f"No 'worker-*' threads found in {thread_names}"
+
+    # Verify at least one connection table list thread
+    ct_threads = [n for n in thread_names if n.startswith("ct-list-")]
+    assert len(ct_threads) > 0, \
+        f"No 'ct-list-*' threads found in {thread_names}"
+
+    # Verify event queue thread
+    assert "event-q" in thread_names, \
+        f"'event-q' thread not found in {thread_names}"
+
+    # Verify housekeeping thread
+    assert "housekeep" in thread_names, \
+        f"'housekeep' thread not found in {thread_names}"

--- a/ldap/servers/plugins/automember/automember.c
+++ b/ldap/servers/plugins/automember/automember.c
@@ -2301,6 +2301,7 @@ automember_task_abort(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eAfter __at
 void
 automember_task_abort_thread(void *arg)
 {
+    slapi_set_thread_name("automem-abort");
     Slapi_Task *task = (Slapi_Task *)arg;
 
     slapi_task_inc_refcount(task);
@@ -2457,6 +2458,7 @@ out:
 void
 automember_rebuild_task_thread(void *arg)
 {
+    slapi_set_thread_name("automem-rebld");
     Slapi_Task *task = (Slapi_Task *)arg;
     struct configEntry *config = NULL;
     Slapi_PBlock *search_pb = NULL;
@@ -2760,6 +2762,7 @@ out:
 void
 automember_export_task_thread(void *arg)
 {
+    slapi_set_thread_name("automem-exprt");
     Slapi_Task *task = (Slapi_Task *)arg;
     Slapi_PBlock *search_pb = NULL;
     Slapi_Entry **entries = NULL;
@@ -2950,6 +2953,7 @@ out:
 void
 automember_map_task_thread(void *arg)
 {
+    slapi_set_thread_name("automem-map");
     Slapi_Task *task = (Slapi_Task *)arg;
     Slapi_Entry *e = NULL;
     int result = SLAPI_DSE_CALLBACK_OK;

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -373,6 +373,7 @@ out:
 static void
 cos_cache_wait_on_change(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("cos-cache");
     slapi_log_err(SLAPI_LOG_TRACE, COS_PLUGIN_SUBSYSTEM, "--> cos_cache_wait_on_change thread\n");
 
     slapi_lock_mutex(stop_lock);

--- a/ldap/servers/plugins/linkedattrs/fixup_task.c
+++ b/ldap/servers/plugins/linkedattrs/fixup_task.c
@@ -107,6 +107,7 @@ linked_attrs_fixup_task_destructor(Slapi_Task *task)
 static void
 linked_attrs_fixup_task_thread(void *arg)
 {
+    slapi_set_thread_name("linked-fix");
     Slapi_Task *task = (Slapi_Task *)arg;
     task_data *td = NULL;
     PRCList *main_config = NULL;

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -1018,6 +1018,7 @@ is_memberof_plugin_started(struct slapdplugin **plg_addr)
 void
 deferred_thread_func(void *arg)
 {
+    slapi_set_thread_name("memberof-def");
     MemberofDeferredList *deferred_list = (MemberofDeferredList *) arg;
     MemberofDeferredTask *task;
     struct slapdplugin *plg = NULL;
@@ -3923,6 +3924,7 @@ memberof_qsort_compare(const void *a, const void *b)
 void
 memberof_fixup_task_thread(void *arg)
 {
+    slapi_set_thread_name("memberof-fix");
     MemberOfConfig configCopy = {0};
     Slapi_Task *task = (Slapi_Task *)arg;
     task_data *td = NULL;

--- a/ldap/servers/plugins/posix-winsync/posix-group-task.c
+++ b/ldap/servers/plugins/posix-winsync/posix-group-task.c
@@ -1,3 +1,7 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <string.h>
 #include "posix-wsp-ident.h"
 #include "posix-group-func.h"
@@ -426,6 +430,7 @@ bail:
 static void
 posix_group_fixup_task_thread(void *arg)
 {
+    slapi_set_thread_name("posix-grp-fix");
     slapi_log_err(SLAPI_LOG_PLUGIN, POSIX_WINSYNC_PLUGIN_NAME,
                   "_task_thread ==>\n");
 

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -1403,6 +1403,7 @@ referint_postop_close(Slapi_PBlock *pb __attribute__((unused)))
 void
 referint_thread_func(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("referint");
     PRFileDesc *prfd = NULL;
     char *logfilename = NULL;
     char thisline[MAX_LINE];

--- a/ldap/servers/plugins/replication/cl5_api.c
+++ b/ldap/servers/plugins/replication/cl5_api.c
@@ -2487,6 +2487,7 @@ _cl5DBClose(void)
 static int
 _cl5TrimMain(void *param)
 {
+    slapi_set_thread_name("cl-trim");
     struct timespec current_time = {0};
     struct timespec prev_time = {0};
     Replica *replica = (Replica *)param;

--- a/ldap/servers/plugins/replication/cl5_test.c
+++ b/ldap/servers/plugins/replication/cl5_test.c
@@ -493,6 +493,7 @@ clearCSNList(CSN ***csnList, int count)
 static void
 threadMain(void *data)
 {
+    slapi_set_thread_name("cl5-test");
     int entryCount = *(int *)data;
     CSN **csnList;
 

--- a/ldap/servers/plugins/replication/repl5_inc_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_inc_protocol.c
@@ -237,6 +237,7 @@ repl5_inc_log_operation_failure(int operation_code, int ldap_error, char *ldap_e
 static void
 repl5_inc_result_threadmain(void *param)
 {
+    slapi_set_thread_name("repl-inc-res");
     result_data *rd = (result_data *)param;
     ConnResult conres = 0;
     Repl_Connection *conn = rd->prp->conn;

--- a/ldap/servers/plugins/replication/repl5_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_protocol.c
@@ -226,6 +226,7 @@ finished                (any)                   finished
 static void
 prot_thread_main(void *arg)
 {
+    slapi_set_thread_name("repl-prot");
     Repl_Protocol *rp = (Repl_Protocol *)arg;
     int done;
     Repl_Agmt *agmt = NULL;

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -3237,6 +3237,7 @@ process_reap_entry(Slapi_Entry *entry, void *cb_data)
 static void
 _replica_reap_tombstones(void *arg)
 {
+    slapi_set_thread_name("tomb-reap");
     const char *replica_name = (const char *)arg;
     Slapi_PBlock *pb = NULL;
     Replica *replica = NULL;

--- a/ldap/servers/plugins/replication/repl5_replica_config.c
+++ b/ldap/servers/plugins/replication/repl5_replica_config.c
@@ -1313,6 +1313,7 @@ _replica_config_get_mtnode_ext(const Slapi_Entry *e)
 void
 replica_csngen_test_thread(void *arg)
 {
+    slapi_set_thread_name("csn-test");
     csngen_test_data *data = (csngen_test_data *)arg;
     int rc = 0;
     if (data->task) {

--- a/ldap/servers/plugins/replication/repl5_tot_protocol.c
+++ b/ldap/servers/plugins/replication/repl5_tot_protocol.c
@@ -105,6 +105,7 @@ repl5_tot_log_operation_failure(int ldap_error, char *ldap_error_string, const c
 static void
 repl5_tot_result_threadmain(void *param)
 {
+    slapi_set_thread_name("repl-tot-res");
     callback_data *cb = (callback_data *)param;
     ConnResult conres = 0;
     Repl_Connection *conn = cb->prp->conn;

--- a/ldap/servers/plugins/replication/repl_cleanallruv.c
+++ b/ldap/servers/plugins/replication/repl_cleanallruv.c
@@ -1124,6 +1124,7 @@ out:
 void
 replica_abort_task_thread(void *arg)
 {
+    slapi_set_thread_name("abort-ruv");
     cleanruv_data *data = (cleanruv_data *)arg;
     Repl_Agmt *agmt;
     Object *agmt_obj;
@@ -2068,6 +2069,7 @@ done:
 void
 replica_cleanallruv_thread_ext(void *arg)
 {
+    slapi_set_thread_name("clean-ruv-ext");
     replica_cleanallruv_thread(arg);
 }
 
@@ -2086,6 +2088,7 @@ replica_cleanallruv_thread_ext(void *arg)
 static void
 replica_cleanallruv_thread(void *arg)
 {
+    slapi_set_thread_name("clean-ruv");
     cleanruv_data *data = arg;
     Object *agmt_obj = NULL;
     Object *ruv_obj = NULL;

--- a/ldap/servers/plugins/retrocl/retrocl_trim.c
+++ b/ldap/servers/plugins/retrocl/retrocl_trim.c
@@ -334,6 +334,7 @@ static int retrocl_active_threads;
 static void
 changelog_trim_thread_fn(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("retrocl-trim");
     PR_AtomicIncrement(&retrocl_active_threads);
     trim_changelog();
     PR_AtomicDecrement(&retrocl_active_threads);

--- a/ldap/servers/plugins/roles/roles_cache.c
+++ b/ldap/servers/plugins/roles/roles_cache.c
@@ -359,6 +359,7 @@ roles_cache_create_suffix(Slapi_DN *sdn)
 static void
 roles_cache_wait_on_change(void *arg)
 {
+    slapi_set_thread_name("roles-cache");
     roles_cache_def *roles_def = (roles_cache_def *)arg;
 
     slapi_log_err(SLAPI_LOG_PLUGIN, ROLES_PLUGIN_SUBSYSTEM, "--> roles_cache_wait_on_change\n");

--- a/ldap/servers/plugins/schema_reload/schema_reload.c
+++ b/ldap/servers/plugins/schema_reload/schema_reload.c
@@ -125,6 +125,7 @@ typedef struct _task_data
 static void
 schemareload_thread(void *arg)
 {
+    slapi_set_thread_name("schema-reload");
     Slapi_Task *task = (Slapi_Task *)arg;
     int rv = 0;
     int total_work = 2;

--- a/ldap/servers/plugins/sync/sync_persist.c
+++ b/ldap/servers/plugins/sync/sync_persist.c
@@ -195,7 +195,7 @@ ignore_op_pl(Slapi_PBlock *pb)
  * of the completed operation.
  * When all operations are completed, if the primary operation is successful it
  * flushes (enqueue) the operations to the sync repl queue(s), else it just free
- * the pending list (skipping enqueue). 
+ * the pending list (skipping enqueue).
  */
 static void
 sync_update_persist_op(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eprev, ber_int_t op_tag, char *label)
@@ -221,7 +221,7 @@ sync_update_persist_op(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eprev, ber
         ignore_op_pl(pb);
         return;
     }
-    
+
     /* Retrieve the result of the operation */
     if (slapi_op_internal(pb)) {
         slapi_pblock_get(pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
@@ -287,11 +287,11 @@ sync_update_persist_op(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eprev, ber
         }
     }
     if (!curr_op) {
-        slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM, "%s - operation (op=0x%lx, idx_pl=%d) not found on the pendling list\n", 
+        slapi_log_err(SLAPI_LOG_ERR, SYNC_PLUGIN_SUBSYSTEM, "%s - operation (op=0x%lx, idx_pl=%d) not found on the pendling list\n",
                       label, (ulong) pb_op, ident->idx_pl);
         PR_ASSERT(curr_op);
     }
-    
+
     /* for diagnostic of the pending list, dump its content if it is too long */
     for (count = 0, curr_op = prim_op; curr_op; count++, curr_op = curr_op->next);
     if (loglevel_is_set(SLAPI_LOG_PLUGIN) && (count > 10)) {
@@ -368,7 +368,7 @@ sync_update_persist_op(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *eprev, ber
             if (enqueue_it) {
                 sync_queue_change(curr_op);
             }
-            
+
             /* now free this pending operation */
             next = curr_op->next;
             slapi_entry_free(curr_op->entry);
@@ -920,6 +920,7 @@ sync_release_connection(Slapi_PBlock *pb, Slapi_Connection *conn, Slapi_Operatio
 static void
 sync_send_results(void *arg)
 {
+    slapi_set_thread_name("sync-send");
     SyncRequest *req = (SyncRequest *)arg;
     SyncQueueNode *qnode, *qnodenext;
     int conn_acq_flag = 0;

--- a/ldap/servers/plugins/syntaxes/validate_task.c
+++ b/ldap/servers/plugins/syntaxes/validate_task.c
@@ -166,6 +166,7 @@ syntax_validate_task_destructor(Slapi_Task *task)
 static void
 syntax_validate_task_thread(void *arg)
 {
+    slapi_set_thread_name("syntax-valid");
     int rc = 0;
     Slapi_Task *task = (Slapi_Task *)arg;
     task_data *td = NULL;

--- a/ldap/servers/plugins/usn/usn_cleanup.c
+++ b/ldap/servers/plugins/usn/usn_cleanup.c
@@ -45,6 +45,7 @@ usn_cleanup_close(void)
 static void
 usn_cleanup_thread(void *arg)
 {
+    slapi_set_thread_name("usn-cleanup");
     Slapi_Task *task = (Slapi_Task *)arg;
     int rv = 0;
     int total_work = 2;

--- a/ldap/servers/plugins/views/views.c
+++ b/ldap/servers/plugins/views/views.c
@@ -1717,5 +1717,6 @@ views_cache_backend_state_change(void *handle __attribute__((unused)), char *be_
 static void
 views_cache_act_on_change_thread(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("views-cache");
     views_cache_create();
 }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -2573,6 +2573,7 @@ error:
 void
 bdb_import_main(void *arg)
 {
+    slapi_set_thread_name("bdb-import");
     /* For online import tasks increment/decrement the global thread count */
     g_incr_active_threadcnt();
     import_main_offline(arg);

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -343,6 +343,7 @@ bdb_import_add_created_attrs(Slapi_Entry *e)
 void
 bdb_import_producer(void *param)
 {
+    slapi_set_thread_name("bdb-imp-prod");
     ImportWorkerInfo *info = (ImportWorkerInfo *)param;
     ImportJob *job = info->job;
     ID id = job->first_ID, id_filestart = id;
@@ -2317,6 +2318,7 @@ bdb_foreman_do_entryrdn(ImportJob *job, FifoItem *fi)
 void
 bdb_import_foreman(void *param)
 {
+    slapi_set_thread_name("bdb-imp-frmn");
     ImportWorkerInfo *info = (ImportWorkerInfo *)param;
     ImportJob *job = info->job;
     ldbm_instance *inst = job->inst;
@@ -2615,6 +2617,7 @@ error:
 void
 bdb_import_worker(void *param)
 {
+    slapi_set_thread_name("bdb-imp-work");
     ImportWorkerInfo *info = (ImportWorkerInfo *)param;
     ImportJob *job = info->job;
     ldbm_instance *inst = job->inst;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -3110,6 +3110,7 @@ bdb_start_perf_thread(struct ldbminfo *li)
 static int
 bdb_perf_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-perf");
     struct ldbminfo *li = NULL;
 
     PR_ASSERT(NULL != param);
@@ -3160,6 +3161,7 @@ bdb_start_locks_monitoring_thread(struct ldbminfo *li)
 static int
 bdb_locks_monitoring_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-lock-mon");
     int ret = 0;
     uint64_t current_locks = 0;
     uint64_t max_locks = 0;
@@ -3370,6 +3372,7 @@ bdb_txn_test_init_cfg(bdb_txn_test_cfg *cfg)
 static int
 bdb_txn_test_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-txn-test");
     struct ldbminfo *li = NULL;
     Object *inst_obj;
     int rc = 0;
@@ -3668,6 +3671,7 @@ bdb_start_txn_test_thread(struct ldbminfo *li)
 static int
 bdb_deadlock_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-deadlock");
     int rval = -1;
     struct ldbminfo *li = NULL;
     PRIntervalTime interval; /*NSPR timeout stuffy*/
@@ -3765,6 +3769,7 @@ bdb_start_log_flush_thread(struct ldbminfo *li)
 static int
 bdb_log_flush_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-logflush");
     PRIntervalTime interval_flush, interval_def;
     PRIntervalTime last_flush = 0;
     int i;
@@ -3998,6 +4003,7 @@ bdb_write_compact_start_time(time_t when, void *arg)
 static int
 bdb_checkpoint_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-chkpoint");
     PRIntervalTime interval;
     int rval = -1;
     struct ldbminfo *li = NULL;
@@ -4242,6 +4248,7 @@ bdb_start_trickle_thread(struct ldbminfo *li)
 static int
 bdb_trickle_threadmain(void *param)
 {
+    slapi_set_thread_name("bdb-trickle");
     PRIntervalTime interval; /*NSPR timeout stuffy*/
     int rval = -1;
     dblayer_private *priv = NULL;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -1165,6 +1165,7 @@ error:
 void
 dbmdb_import_main(void *arg)
 {
+    slapi_set_thread_name("import");
     /* For online import tasks increment/decrement the global thread count */
     g_incr_active_threadcnt();
     dbmdb_public_dbmdb_import_main(arg);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -1149,6 +1149,7 @@ log_wqelmt(int loglvl, char *fname, WorkerQueueData_t *wqelmt)
 void
 dbmdb_import_producer(void *param)
 {
+    slapi_set_thread_name("import-prod");
     ImportWorkerInfo *info = (ImportWorkerInfo *)param;
     ImportJob *job = info->job;
     ImportCtx_t *ctx = job->writer_ctx;
@@ -3286,6 +3287,7 @@ init_pseudo_txn(ImportCtx_t *ctx)
 void
 dbmdb_import_worker(void *param)
 {
+    slapi_set_thread_name("import-worker");
     WorkerQueueData_t *wqelmnt = (WorkerQueueData_t*)param;
     ImportWorkerInfo *info = &wqelmnt->winfo;
     ImportJob *job = info->job;
@@ -3923,6 +3925,7 @@ cmp_key_addr(const void *i1, const void *i2)
 void
 dbmdb_import_writer(void*param)
 {
+    slapi_set_thread_name("import-writer");
     ImportWorkerInfo *info = (ImportWorkerInfo*)param;
     ImportJob *job = info->job;
     ImportCtx_t *ctx = job->writer_ctx;
@@ -3966,9 +3969,9 @@ dbmdb_import_writer(void*param)
                     slapi_log_err(SLAPI_LOG_ERR, "dbmdb_import_writer",
                                   "Failed to write record in dbi %s. Error is 0x%x: %s.\n",
                                   slot->dbi->dbname, rc, mdb_strerror(rc));
-                    slapi_log_hexadump(SLAPI_LOG_ERR, "dbmdb_import_writer:key", 
+                    slapi_log_hexadump(SLAPI_LOG_ERR, "dbmdb_import_writer:key",
                                        slot->key.mv_data, slot->key.mv_size);
-                    slapi_log_hexadump(SLAPI_LOG_ERR, "dbmdb_import_writer:data", 
+                    slapi_log_hexadump(SLAPI_LOG_ERR, "dbmdb_import_writer:data",
                                        slot->data.mv_data, slot->data.mv_size);
                 }
             }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -2203,6 +2203,13 @@ cache_built:
     return NULL;
 }
 
+static void *
+dbmdb_recno_cache_build_thread(void *arg)
+{
+    slapi_set_thread_name("recno-cache");
+    return dbmdb_recno_cache_build(arg);
+}
+
 /* Find nearest recno cache record from the key */
 int dbmdb_recno_cache_lookup(dbi_cursor_t *cursor, MDB_val *cache_key, dbmdb_recno_cache_elmt_t **rce)
 {
@@ -2231,7 +2238,7 @@ int dbmdb_recno_cache_lookup(dbi_cursor_t *cursor, MDB_val *cache_key, dbmdb_rec
             rc = rcctx.rc;
         } else if (rcctx.mode == RCMODE_USE_NEW_THREAD) {
             pthread_t tid;
-            rc = pthread_create(&tid, NULL, dbmdb_recno_cache_build, &rcctx);
+            rc = pthread_create(&tid, NULL, dbmdb_recno_cache_build_thread, &rcctx);
             if (rc ==0) {
                 rc = pthread_join(tid, NULL);
             }

--- a/ldap/servers/slapd/back-ldbm/import.c
+++ b/ldap/servers/slapd/back-ldbm/import.c
@@ -412,6 +412,13 @@ db2ldif_skip_all(void *args)
     return NULL;
 }
 
+static void *
+db2ldif_skip_all_thread(void *args)
+{
+    slapi_set_thread_name("db2ldif-skip");
+    return db2ldif_skip_all(args);
+}
+
 bool
 db2ldif_is_suffix_in_ldif(Slapi_PBlock *pb, ldbm_instance *inst)
 {
@@ -459,7 +466,7 @@ db2ldif_is_suffix_in_ldif(Slapi_PBlock *pb, ldbm_instance *inst)
      */
     g_incr_active_threadcnt();  /* decreased in db2ldif_skip_all */
     if (task->task_dn == NULL ||
-        pthread_create(&tid, NULL, db2ldif_skip_all, task) != 0) {
+        pthread_create(&tid, NULL, db2ldif_skip_all_thread, task) != 0) {
             db2ldif_skip_all(task);
     } else {
         pthread_detach(tid);

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1727,6 +1727,9 @@ connection_threadmain(void *arg)
 {
     Slapi_PBlock *pb = slapi_pblock_new();
     int32_t *snmp_vars_idx = (int32_t *) arg;
+    char tname[16];
+    snprintf(tname, sizeof(tname), "worker-%d", *snmp_vars_idx);
+    slapi_set_thread_name(tname);
     /* wait forever for new pb until one is available or shutdown */
     int32_t interval = 0; /* used be  10 seconds */
     Connection *conn = NULL;

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -315,15 +315,15 @@ csngen_adjust_time(CSNGen *gen, const CSN *csn)
         /* To avoid beat phenomena between suppliers let put 1 second in local_offset
          * it will be eaten at next clock tick rather than increasing remote offset
          * If we do not do that we will have a time skew drift of 1 second per 2 seconds
-         * if suppliers are desynchronized by 0.5 second 
+         * if suppliers are desynchronized by 0.5 second
          */
         if (gen->state.local_offset == 0) {
             gen->state.local_offset++;
             gen->state.remote_offset--;
         }
     }
-    /* Time to compute seqnum so that 
-     *   new csn >= remote csn and new csn >= old local csn 
+    /* Time to compute seqnum so that
+     *   new csn >= remote csn and new csn >= old local csn
      */
     new_time = CSN_CALC_TSTAMP(gen);
     PR_ASSERT(new_time >= old_time);
@@ -570,7 +570,7 @@ _csngen_adjust_local_time(CSNGen *gen)
     time_t cur_time;
     int rc;
 
-    
+
     if ((rc = gen->gettime(&now)) != 0) {
         /* Failed to get system time, we must abort */
         slapi_log_err(SLAPI_LOG_ERR, "csngen_new_csn",
@@ -617,7 +617,7 @@ _csngen_adjust_local_time(CSNGen *gen)
     gen->state.sampled_time = cur_time;
     gen->state.local_offset = MAX_VAL(0, gen->state.local_offset - time_diff);
     /* new local_offset = MAX_VAL(0, old sample_time + old local_offset - cur_time)
-     * ==> new local_offset >= 0 and 
+     * ==> new local_offset >= 0 and
      *     new local_offset + cur_time >= old sample_time + old local_offset
      * ==> new local_offset + cur_time + remote_offset >=
      *            sample_time + old local_offset + remote_offset
@@ -731,6 +731,7 @@ _csngen_stop_test_threads(void)
 static void
 _csngen_gen_tester_main(void *data)
 {
+    slapi_set_thread_name("csn-gen-test");
     CSNGen *gen = (CSNGen *)data;
     CSN *csn = NULL;
     char buff[CSN_STRSIZE];
@@ -761,6 +762,7 @@ _csngen_gen_tester_main(void *data)
 static void
 _csngen_remote_tester_main(void *data)
 {
+    slapi_set_thread_name("csn-rmt-test");
     CSNGen *gen = (CSNGen *)data;
     CSN *csn;
     time_t csn_time;
@@ -798,6 +800,7 @@ _csngen_remote_tester_main(void *data)
 static void
 _csngen_local_tester_main(void *data)
 {
+    slapi_set_thread_name("csn-lcl-test");
     CSNGen *gen = (CSNGen *)data;
 
     PR_ASSERT(gen);

--- a/ldap/servers/slapd/daemon.c
+++ b/ldap/servers/slapd/daemon.c
@@ -459,6 +459,7 @@ disk_mon_check_diskspace(char **dirs, uint64_t threshold, uint64_t *disk_space)
 void
 disk_monitoring_thread(void *nothing __attribute__((unused)))
 {
+    slapi_set_thread_name("disk-mon");
     char **dirs = NULL;
     char *dirstr = NULL;
     uint64_t previous_mark = 0;
@@ -916,6 +917,7 @@ handle_listeners(struct POLL_STRUCT *fds)
 void
 accept_thread(void *vports)
 {
+    slapi_set_thread_name("listener");
     daemon_ports_t *ports = (daemon_ports_t *)vports;
     Connection_Table *ct = the_connection_table;
     PRIntn num_poll = 0;
@@ -994,6 +996,7 @@ accept_thread(void *vports)
 void
 accept_thread(void *vports)
 {
+    slapi_set_thread_name("listener");
     daemon_ports_t *ports = (daemon_ports_t *)vports;
     Connection_Table *ct = the_connection_table;
     PRIntn num_poll = 0;
@@ -1552,6 +1555,9 @@ void
 ct_list_thread(uint64_t threadnum)
 {
     uint64_t threadid = (uint64_t) threadnum;
+    char tname[16];
+    snprintf(tname, sizeof(tname), "ct-list-%lu", (unsigned long)threadid);
+    slapi_set_thread_name(tname);
 
     while (!slapi_is_shutting_down()) {
          int select_return = 0;

--- a/ldap/servers/slapd/eventq-deprecated.c
+++ b/ldap/servers/slapd/eventq-deprecated.c
@@ -302,6 +302,7 @@ eq_call_all(void)
 static void
 eq_loop(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("event-q-old");
     while (eq_running) {
         time_t curtime = slapi_current_utc_time();
         PRIntervalTime timeout;

--- a/ldap/servers/slapd/eventq.c
+++ b/ldap/servers/slapd/eventq.c
@@ -298,6 +298,7 @@ eq_call_all_rel(void)
 static void
 eq_loop_rel(void *arg __attribute__((unused)))
 {
+    slapi_set_thread_name("event-q");
     while (eq_rel_running) {
         time_t curtime = slapi_current_rel_time_t();
         int until;

--- a/ldap/servers/slapd/house.c
+++ b/ldap/servers/slapd/house.c
@@ -30,6 +30,7 @@ static pthread_cond_t housekeeping_cvar;
 static void
 housecleaning(void *cur_time __attribute__((unused)))
 {
+    slapi_set_thread_name("housekeep");
     while (!g_get_shutdown()) {
         struct timespec current_time = {0};
         /*

--- a/ldap/servers/slapd/psearch.c
+++ b/ldap/servers/slapd/psearch.c
@@ -263,6 +263,7 @@ pe_ch_free(PSEQNode **pe)
 static void
 ps_send_results(void *arg)
 {
+    slapi_set_thread_name("ps-send");
     PSearch *ps = (PSearch *)arg;
     PSEQNode *peq, *peqnext;
     struct slapi_filter *filter = 0;

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -6109,6 +6109,9 @@ int slapi_wait_condvar(Slapi_CondVar *cvar, struct timeval *timeout) __attribute
 int slapi_notify_condvar(Slapi_CondVar *cvar, int notify_all);
 int slapi_wait_condvar_pt(Slapi_CondVar *cvar, Slapi_Mutex *mutex, struct timeval *timeout);
 
+/* Set OS-level thread name for visibility in ps, top, perf, etc. (max 15 chars) */
+void slapi_set_thread_name(const char *name);
+
 /**
  * Creates a new read/write lock
  * If prio_writer the rwlock gives priority on writers

--- a/ldap/servers/slapd/task.c
+++ b/ldap/servers/slapd/task.c
@@ -1124,6 +1124,7 @@ out:
 static void
 task_export_thread(void *arg)
 {
+    slapi_set_thread_name("export");
     Slapi_PBlock *pb = (Slapi_PBlock *)arg;
     // I think someone is mis-using this point to store multiple names ...
     char **instance_names = NULL;
@@ -1503,6 +1504,7 @@ out:
 static void
 task_backup_thread(void *arg)
 {
+    slapi_set_thread_name("backup");
     Slapi_PBlock *pb = (Slapi_PBlock *)arg;
     Slapi_Task *task = NULL;
     struct slapdplugin *pb_plugin;
@@ -1654,6 +1656,7 @@ out:
 static void
 task_restore_thread(void *arg)
 {
+    slapi_set_thread_name("restore");
     Slapi_PBlock *pb = (Slapi_PBlock *)arg;
     Slapi_Task *task = NULL;
     struct slapdplugin *pb_plugin;
@@ -1808,6 +1811,7 @@ out:
 static void
 task_index_thread(void *arg)
 {
+    slapi_set_thread_name("index");
     Slapi_PBlock *pb = (Slapi_PBlock *)arg;
     char *instance_name = NULL;
     char **db2index_attrs = NULL;
@@ -2366,6 +2370,7 @@ struct task_tombstone_data
 static void
 task_fixup_tombstone_thread(void *arg)
 {
+    slapi_set_thread_name("tombfix");
     struct task_tombstone_data *task_data = arg;
     Slapi_Entry **entries = NULL;
     Slapi_Task *task = task_data->task;
@@ -2648,6 +2653,7 @@ compact_db_task_destructor(Slapi_Task *task)
 static void
 task_compact_thread(void *arg)
 {
+    slapi_set_thread_name("compact");
     struct task_compact_data *task_data = arg;
     Slapi_Task *task = task_data->task;
     Slapi_Backend *be = NULL;
@@ -2733,6 +2739,7 @@ task_compact_db_add(Slapi_PBlock *pb,
 static void
 task_ldapi_reload_thread(void *arg)
 {
+	slapi_set_thread_name("ldapi-reload");
 	Slapi_Task *task = (Slapi_Task *)arg;
 
 	initialize_ldapi_auth_dn_mappings(LDAPI_RELOAD);

--- a/ldap/servers/slapd/test-plugins/sampletask.c
+++ b/ldap/servers/slapd/test-plugins/sampletask.c
@@ -48,6 +48,10 @@
  * [...] - Sample task finished.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "slapi-plugin.h"
 #include "nspr.h"
 
@@ -88,6 +92,7 @@ task_sampletask_start(Slapi_PBlock *pb)
 static void
 task_sampletask_thread(void *arg)
 {
+    slapi_set_thread_name("sample-task");
     Slapi_Task *task = (Slapi_Task *)arg;
     char *myarg = NULL;
     int i, rv = 0;

--- a/ldap/servers/slapd/thread_data.c
+++ b/ldap/servers/slapd/thread_data.c
@@ -60,6 +60,14 @@ slapi_td_init(void)
  *  Wrapper Functions
  */
 
+/* Set OS-level thread name (visible in ps, top, perf, pstack, etc.)
+ * The name is silently truncated to 15 characters by the kernel. */
+void
+slapi_set_thread_name(const char *name)
+{
+    pthread_setname_np(pthread_self(), name);
+}
+
 /* plugin list locking */
 int32_t
 slapi_td_set_plugin_locked()

--- a/ldap/servers/slapd/vattr.c
+++ b/ldap/servers/slapd/vattr.c
@@ -140,6 +140,7 @@ vattr_cleanup()
 static void
 vattr_check_thread(void *arg)
 {
+    slapi_set_thread_name("vattr-chk");
     Slapi_Backend *be = NULL;
     char *cookie = NULL;
     Slapi_DN *base_sdn = NULL;


### PR DESCRIPTION
Description: Add slapi_set_thread_name() API wrapping pthread_setname_np and apply it to all server threads.
Workers appear as worker-0..N, the listener as "listener", replication threads as "repl-prot", "repl-inc-res", etc.

For functions that serve as both thread entry points and direct calls (db2ldif_skip_all, dbmdb_recno_cache_build), thin wrapper functions are used to keep thread naming separate from the core logic.

Fixes: https://github.com/389ds/389-ds-base/issues/7300

Reviewed by: ?

## Summary by Sourcery

Introduce a common API for setting OS-level thread names and apply consistent naming across core server, backend, and plugin threads for improved observability and diagnostics.

New Features:
- Add slapi_set_thread_name() API to expose OS-level thread naming to the server and plugins, and use it to assign descriptive names to key threads (listener, workers, replication, tasks, caches, and maintenance).

Enhancements:
- Refactor shared thread entry functions to use thin wrapper thread routines where needed to keep thread naming separate from core logic.
- Include config.h in select plugins to ensure proper feature detection for the new threading support.

Tests:
- Add an integration test that inspects /proc for the server process to verify that key threads (listener, worker-*, ct-list-*, event-q, housekeep) are correctly named at the OS level.