### PR TITLE
Issue 7271 - Add new plugin pre-close function check to plugin_invoke_plugin_pb

### DIFF
--- a/ldap/servers/slapd/plugin.c
+++ b/ldap/servers/slapd/plugin.c
@@ -3647,6 +3647,7 @@ plugin_invoke_plugin_pb(struct slapdplugin *plugin, int operation, Slapi_PBlock 
     if (operation == SLAPI_PLUGIN_START_FN ||
         operation == SLAPI_PLUGIN_POSTSTART_FN ||
         operation == SLAPI_PLUGIN_CLOSE_FN ||
+        operation == SLAPI_PLUGIN_PRE_CLOSE_FN ||
         operation == SLAPI_PLUGIN_CLEANUP_FN ||
         operation == SLAPI_PLUGIN_BE_PRE_CLOSE_FN ||
         operation == SLAPI_PLUGIN_BE_POST_OPEN_FN ||


### PR DESCRIPTION
Description:

In plugin_invoke_plugin_pb we were not checking for the new pre-close function which led to an error in the logs: pb_op is NULL. In a debug build this leads to an assertion error at shutdown.

relates: https://github.com/389ds/389-ds-base/issues/7271

## Summary by Sourcery

Bug Fixes:
- Ensure the plugin pre-close function is checked and invoked in plugin_invoke_plugin_pb to prevent NULL pb_op errors and shutdown assertions.