### PR TITLE
Issue 7304 - retrocl should not cache DN

### DIFF
--- a/ldap/servers/slapd/back-ldbm/ldbm_add.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_add.c
@@ -1397,8 +1397,11 @@ common_return:
                 struct backdn *bdn = dncache_find_id(&inst->inst_dncache,
                                                      addingentry->ep_id);
                 if (bdn) { /* already in the dncache */
+                    if (is_remove_from_cache) {
+                        CACHE_REMOVE(&inst->inst_dncache, bdn);
+                    }
                     CACHE_RETURN(&inst->inst_dncache, &bdn);
-                } else { /* not in the dncache yet */
+                } else if (!is_remove_from_cache) { /* not in the dncache yet */
                     Slapi_DN *addingsdn =
                         slapi_sdn_dup(slapi_entry_get_sdn(addingentry->ep_entry));
                     if (addingsdn) {


### PR DESCRIPTION
Description:

When adding a record to the retro changelog we pass in the flag SLAPI_OP_FLAG_NEVER_CACHE to prevent the entry from being cached, but we still update the DN cache leading to unexpected memory growth.

relates: https://github.com/389ds/389-ds-base/issues/7304

## Summary by Sourcery

Bug Fixes:
- Avoid updating or keeping DN cache entries when operations are marked to not use the cache, preventing memory leaks in the DN cache.