### PR TITLE
Issue 7307 - Expose work queue and worker utilization metrics

### DIFF
--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -7,8 +7,10 @@
 # --- END COPYRIGHT BLOCK ---
 #
 import logging
+import ldap
 import pytest
 import os
+import threading
 from lib389.monitor import *
 from lib389.backend import Backends, DatabaseConfig
 from lib389._constants import *
@@ -211,6 +213,162 @@ def test_monitor_connections(topo):
     finally:
         conn.close()
         log.info("LDAP monitoring connection closed via conn.close()")
+
+
+def test_monitor_work_queue(topo):
+    """Verify work queue metrics are exposed via cn=monitor
+
+    :id: 7e2f74ac-e662-4e70-b4f3-a010295d8b99
+    :setup: Standalone Instance
+    :steps:
+        1. Query cn=monitor for work queue attributes
+        2. Verify all 4 attributes are present and parseable as integers
+        3. Verify current values are non-negative
+        4. Verify max values >= current values
+        5. Generate some load and verify maxbusyworkers > 0
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+    """
+    inst = topo.standalone
+    monitor = Monitor(inst)
+
+    # Get work queue metrics
+    (currentworkqueue, maxworkqueue,
+     currentbusyworkers, maxbusyworkers) = monitor.get_work_queue()
+
+    # Verify all attributes are present and parseable as integers
+    cur_wq = int(currentworkqueue[0])
+    max_wq = int(maxworkqueue[0])
+    cur_bw = int(currentbusyworkers[0])
+    max_bw = int(maxbusyworkers[0])
+
+    log.info(f"currentworkqueue={cur_wq}, maxworkqueue={max_wq}, "
+             f"currentbusyworkers={cur_bw}, maxbusyworkers={max_bw}")
+
+    # Verify non-negative values
+    assert cur_wq >= 0, f"currentworkqueue should be >= 0, got {cur_wq}"
+    assert max_wq >= 0, f"maxworkqueue should be >= 0, got {max_wq}"
+    assert cur_bw >= 0, f"currentbusyworkers should be >= 0, got {cur_bw}"
+    assert max_bw >= 0, f"maxbusyworkers should be >= 0, got {max_bw}"
+
+    # Verify max >= current
+    assert max_wq >= cur_wq, f"maxworkqueue ({max_wq}) should be >= currentworkqueue ({cur_wq})"
+    assert max_bw >= cur_bw, f"maxbusyworkers ({max_bw}) should be >= currentbusyworkers ({cur_bw})"
+
+    # Generate some load - several searches to ensure at least one worker was busy
+    for _ in range(10):
+        inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, '(objectclass=*)')
+
+    # Re-check - maxbusyworkers should now be > 0
+    (_, _, _, maxbusyworkers) = monitor.get_work_queue()
+    max_bw = int(maxbusyworkers[0])
+    log.info(f"After load: maxbusyworkers={max_bw}")
+    assert max_bw > 0, f"maxbusyworkers should be > 0 after generating load, got {max_bw}"
+
+    # Also verify the attributes appear in get_status()
+    status = monitor.get_status()
+    assert 'currentworkqueue' in status
+    assert 'maxworkqueue' in status
+    assert 'currentbusyworkers' in status
+    assert 'maxbusyworkers' in status
+
+
+def test_monitor_busy_workers_concurrent(topo):
+    """Verify currentbusyworkers increments under concurrent operations
+
+    :id: b86971df-3627-499a-975c-f46c47b199fc
+    :setup: Standalone Instance
+    :steps:
+        1. Record maxbusyworkers before load
+        2. Launch multiple threads performing searches concurrently
+        3. While threads are running, sample currentbusyworkers
+        4. Verify maxbusyworkers increased and currentbusyworkers
+           returns to a low value after threads finish
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+    inst = topo.standalone
+    monitor = Monitor(inst)
+
+    NUM_THREADS = 10
+    SEARCHES_PER_THREAD = 50
+    errors = []
+    peak_busy = [0]
+    peak_lock = threading.Lock()
+
+    def search_worker():
+        """Perform repeated searches to keep a worker thread busy"""
+        try:
+            conn = ldap.initialize(inst.ldapuri)
+            conn.simple_bind_s(DN_DM, PW_DM)
+            for _ in range(SEARCHES_PER_THREAD):
+                conn.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+                              '(objectclass=*)')
+            conn.unbind_s()
+        except Exception as e:
+            errors.append(str(e))
+
+    def monitor_sampler(stop_event):
+        """Sample currentbusyworkers while load is running"""
+        while not stop_event.is_set():
+            try:
+                (_, _, currentbusyworkers, _) = monitor.get_work_queue()
+                val = int(currentbusyworkers[0])
+                with peak_lock:
+                    if val > peak_busy[0]:
+                        peak_busy[0] = val
+            except Exception:
+                pass
+
+    # Record baseline
+    (_, _, _, maxbusyworkers_before) = monitor.get_work_queue()
+    max_bw_before = int(maxbusyworkers_before[0])
+    log.info(f"Before concurrent load: maxbusyworkers={max_bw_before}")
+
+    # Start the monitor sampler
+    stop_event = threading.Event()
+    sampler = threading.Thread(target=monitor_sampler, args=(stop_event,))
+    sampler.start()
+
+    # Launch concurrent search threads
+    threads = []
+    for _ in range(NUM_THREADS):
+        t = threading.Thread(target=search_worker)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # Stop the sampler
+    stop_event.set()
+    sampler.join()
+
+    assert not errors, f"Search threads reported errors: {errors}"
+
+    # Check that we observed concurrent busy workers
+    log.info(f"Peak sampled currentbusyworkers during load: {peak_busy[0]}")
+    assert peak_busy[0] > 0, \
+        "currentbusyworkers was never > 0 during concurrent load"
+
+    # Verify maxbusyworkers reflects the concurrent activity
+    (_, _, currentbusyworkers, maxbusyworkers) = monitor.get_work_queue()
+    max_bw_after = int(maxbusyworkers[0])
+    cur_bw_after = int(currentbusyworkers[0])
+    log.info(f"After concurrent load: maxbusyworkers={max_bw_after}, "
+             f"currentbusyworkers={cur_bw_after}")
+
+    assert max_bw_after > 0, \
+        f"maxbusyworkers should be > 0 after concurrent load, got {max_bw_after}"
+    assert max_bw_after >= max_bw_before, \
+        f"maxbusyworkers should not decrease: before={max_bw_before}, after={max_bw_after}"
 
 
 if __name__ == '__main__':

--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -369,6 +369,8 @@ def test_monitor_busy_workers_concurrent(topo):
         f"maxbusyworkers should be > 0 after concurrent load, got {max_bw_after}"
     assert max_bw_after >= max_bw_before, \
         f"maxbusyworkers should not decrease: before={max_bw_before}, after={max_bw_after}"
+    assert cur_bw_after < NUM_THREADS, \
+        f"currentbusyworkers should drop back after load completes, got {cur_bw_after}"
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1741,7 +1741,7 @@ connection_threadmain(void *arg)
     int doshutdown = 0;
     int maxthreads = 0;
     long bypasspollcnt = 0;
-    int is_busy = 0;
+    bool is_busy = false;
 
 #if defined(hpux)
     /* Arrange to ignore SIGPIPE signals. */
@@ -1769,7 +1769,7 @@ connection_threadmain(void *arg)
 
             /* Mark this worker as idle before blocking on the work queue */
             if (is_busy) {
-                is_busy = 0;
+                is_busy = false;
                 slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
             }
 
@@ -1870,14 +1870,14 @@ connection_threadmain(void *arg)
         }
         /* Once we're here we have a pb - mark this worker as busy */
         if (!is_busy) {
-            is_busy = 1;
+            is_busy = true;
             int32_t val = slapi_atomic_incr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
             /*
              * Best-effort high-water mark: without a CAS primitive two threads
              * could race and briefly regress the value, but it self-corrects on
              * the next higher peak.  Acceptable for a monitoring-only metric.
              */
-            if (val > slapi_atomic_load_32(&max_busy_workers, __ATOMIC_RELAXED)) {
+            while (val > slapi_atomic_load_32(&max_busy_workers, __ATOMIC_RELAXED)) {
                 slapi_atomic_store_32(&max_busy_workers, val, __ATOMIC_RELAXED);
             }
         }

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -78,6 +78,8 @@ static PRStack *work_q_stack;         /* stack of work_q structs so we don't hav
 static PRInt32 work_q_stack_size;     /* size of work_q_stack */
 static PRInt32 work_q_stack_size_max; /* max size of work_q_stack */
 static PRInt32 op_shutdown = 0;       /* if non-zero, server is shutting down */
+static int32_t current_busy_workers = 0;   /* workers currently processing ops */
+static int32_t max_busy_workers = 0;       /* high water mark of busy workers */
 
 #define LDAP_SOCKET_IO_BUFFER_SIZE 512 /* Size of the buffer we give to the I/O system for reads */
 
@@ -1739,6 +1741,7 @@ connection_threadmain(void *arg)
     int doshutdown = 0;
     int maxthreads = 0;
     long bypasspollcnt = 0;
+    int is_busy = 0;
 
 #if defined(hpux)
     /* Arrange to ignore SIGPIPE signals. */
@@ -1753,6 +1756,9 @@ connection_threadmain(void *arg)
         if (op_shutdown) {
             slapi_log_err(SLAPI_LOG_TRACE, "connection_threadmain",
                           "op_thread received shutdown signal\n");
+            if (is_busy) {
+                slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+            }
             slapi_pblock_destroy(pb);
             g_decr_active_threadcnt();
             return;
@@ -1760,6 +1766,12 @@ connection_threadmain(void *arg)
 
         if (!thread_turbo_flag && !more_data) {
 	        Connection *pb_conn = NULL;
+
+            /* Mark this worker as idle before blocking on the work queue */
+            if (is_busy) {
+                is_busy = 0;
+                slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+            }
 
             /* If more data is left from the previous connection_read_operation,
                we should finish the op now.  Client might be thinking it's
@@ -1774,6 +1786,9 @@ connection_threadmain(void *arg)
             case CONN_SHUTDOWN:
                 slapi_log_err(SLAPI_LOG_TRACE, "connection_threadmain",
                               "op_thread received shutdown signal\n");
+                if (is_busy) {
+                    slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+                }
                 slapi_pblock_destroy(pb);
                 g_decr_active_threadcnt();
                 return;
@@ -1786,6 +1801,9 @@ connection_threadmain(void *arg)
                 slapi_pblock_get(pb, SLAPI_CONNECTION, &pb_conn);
                 if (pb_conn == NULL) {
                     slapi_log_err(SLAPI_LOG_ERR, "connection_threadmain", "pb_conn is NULL\n");
+                    if (is_busy) {
+                        slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+                    }
                     slapi_pblock_destroy(pb);
                     g_decr_active_threadcnt();
                     return;
@@ -1850,11 +1868,26 @@ connection_threadmain(void *arg)
                 slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsInOps);
             }
         }
-        /* Once we're here we have a pb */
+        /* Once we're here we have a pb - mark this worker as busy */
+        if (!is_busy) {
+            is_busy = 1;
+            int32_t val = slapi_atomic_incr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+            /*
+             * Best-effort high-water mark: without a CAS primitive two threads
+             * could race and briefly regress the value, but it self-corrects on
+             * the next higher peak.  Acceptable for a monitoring-only metric.
+             */
+            if (val > slapi_atomic_load_32(&max_busy_workers, __ATOMIC_RELAXED)) {
+                slapi_atomic_store_32(&max_busy_workers, val, __ATOMIC_RELAXED);
+            }
+        }
         slapi_pblock_get(pb, SLAPI_CONNECTION, &conn);
         slapi_pblock_get(pb, SLAPI_OPERATION, &op);
         if (conn == NULL || op == NULL) {
             slapi_log_err(SLAPI_LOG_ERR, "connection_threadmain", "NULL param: conn (0x%p) op (0x%p)\n", conn, op);
+            if (is_busy) {
+                slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+            }
             slapi_pblock_destroy(pb);
             g_decr_active_threadcnt();
             return;
@@ -2059,6 +2092,9 @@ connection_threadmain(void *arg)
 
     done:
         if (doshutdown) {
+            if (is_busy) {
+                slapi_atomic_decr_32(&current_busy_workers, __ATOMIC_ACQ_REL);
+            }
             pthread_mutex_lock(&(conn->c_mutex));
             connection_remove_operation_ext(pb, conn, op);
             connection_make_readable_nolock(conn);
@@ -2263,6 +2299,36 @@ get_work_q(struct Slapi_op_stack **op_stack_obj)
     destroy_work_q(&tmp);
 
     return (wqitem);
+}
+
+/* Work queue metric getters - lock-free reads using atomics */
+
+int32_t
+get_work_q_size(void)
+{
+    int32_t val = slapi_atomic_load_32((int32_t *)&work_q_size, __ATOMIC_ACQUIRE);
+    return val > 0 ? val : 0;
+}
+
+int32_t
+get_work_q_size_max(void)
+{
+    int32_t val = slapi_atomic_load_32((int32_t *)&work_q_size_max, __ATOMIC_ACQUIRE);
+    return val > 0 ? val : 0;
+}
+
+int32_t
+get_busy_worker_count(void)
+{
+    int32_t val = slapi_atomic_load_32(&current_busy_workers, __ATOMIC_ACQUIRE);
+    return val > 0 ? val : 0;
+}
+
+int32_t
+get_max_busy_worker_count(void)
+{
+    int32_t val = slapi_atomic_load_32(&max_busy_workers, __ATOMIC_ACQUIRE);
+    return val > 0 ? val : 0;
 }
 
 /* Helper functions common to both varieties of connection code: */

--- a/ldap/servers/slapd/monitor.c
+++ b/ldap/servers/slapd/monitor.c
@@ -116,6 +116,22 @@ monitor_info(Slapi_PBlock *pb __attribute__((unused)),
 
     slapi_ch_free((void **)&cookie);
 
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRId32, get_work_q_size());
+    val.bv_val = buf;
+    attrlist_replace(&e->e_attrs, "currentworkqueue", vals);
+
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRId32, get_work_q_size_max());
+    val.bv_val = buf;
+    attrlist_replace(&e->e_attrs, "maxworkqueue", vals);
+
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRId32, get_busy_worker_count());
+    val.bv_val = buf;
+    attrlist_replace(&e->e_attrs, "currentbusyworkers", vals);
+
+    val.bv_len = snprintf(buf, sizeof(buf), "%" PRId32, get_max_busy_worker_count());
+    val.bv_val = buf;
+    attrlist_replace(&e->e_attrs, "maxbusyworkers", vals);
+
     *returncode = LDAP_SUCCESS;
     return SLAPI_DSE_CALLBACK_OK;
 }

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -1563,6 +1563,10 @@ int connection_is_active_nolock(Connection *conn);
 ber_slen_t openldap_read_function(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len);
 int32_t connection_has_psearch(Connection *c);
 void free_worker_thread_indexes(void);
+int32_t get_work_q_size(void);
+int32_t get_work_q_size_max(void);
+int32_t get_busy_worker_count(void);
+int32_t get_max_busy_worker_count(void);
 
 /*
  * saslbind.c

--- a/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/serverMonitor.jsx
@@ -634,6 +634,30 @@ export class ServerMonitor extends React.Component {
                             <GridItem span={2}>
                                 <b>{numToCommas(this.props.data.maxthreadsperconnhits)}</b>
                             </GridItem>
+                            <GridItem span={3} title="Worker threads currently processing an operation">
+                                {_("Busy Workers")}
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{numToCommas(this.props.data.currentbusyworkers)}</b>
+                            </GridItem>
+                            <GridItem span={3} title="Peak number of busy worker threads since startup">
+                                {_("Max Busy Workers")}
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{numToCommas(this.props.data.maxbusyworkers)}</b>
+                            </GridItem>
+                            <GridItem span={3} title="Operations currently waiting in the work queue">
+                                {_("Work Queue Size")}
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{numToCommas(this.props.data.currentworkqueue)}</b>
+                            </GridItem>
+                            <GridItem span={3} title="High-water mark of work queue depth since startup">
+                                {_("Max Work Queue Size")}
+                            </GridItem>
+                            <GridItem span={2}>
+                                <b>{numToCommas(this.props.data.maxworkqueue)}</b>
+                            </GridItem>
                             <GridItem span={3}>
                                 {_("Total Connections")}
                             </GridItem>

--- a/src/lib389/lib389/monitor.py
+++ b/src/lib389/lib389/monitor.py
@@ -55,6 +55,18 @@ class Monitor(DSLdapObject):
         maxthreadsperconnhits = self.get_attr_vals_utf8('maxthreadsperconnhits')
         return (threads, currentconnectionsatmaxthreads, maxthreadsperconnhits)
 
+    def get_work_queue(self):
+        """Get work queue related attributes value for cn=monitor
+
+        :returns: Values of currentworkqueue, maxworkqueue,
+                  currentbusyworkers, maxbusyworkers attributes of cn=monitor
+        """
+        currentworkqueue = self.get_attr_vals_utf8('currentworkqueue')
+        maxworkqueue = self.get_attr_vals_utf8('maxworkqueue')
+        currentbusyworkers = self.get_attr_vals_utf8('currentbusyworkers')
+        maxbusyworkers = self.get_attr_vals_utf8('maxbusyworkers')
+        return (currentworkqueue, maxworkqueue, currentbusyworkers, maxbusyworkers)
+
     def get_backends(self):
         """Get backends related attributes value for cn=monitor
 
@@ -190,6 +202,10 @@ class Monitor(DSLdapObject):
             'currenttime',
             'starttime',
             'nbackends',
+            'currentworkqueue',
+            'maxworkqueue',
+            'currentbusyworkers',
+            'maxbusyworkers',
         ])
         status.update(stats)
 


### PR DESCRIPTION
Description: Add four new read-only attributes to cn=monitor: currentworkqueue, maxworkqueue, currentbusyworkers, and maxbusyworkers. These let administrators detect thread pool saturation using external monitoring tools (PCP, Grafana, custom scripts).
Worker counts use lock-free atomics with defensive clamping to guarantee non-negative values.
Add tests for basic metrics validation and concurrent busy worker tracking.
Add Cockpit UI fields to Monitor - Server Statistics.

Fixes: https://github.com/389ds/389-ds-base/issues/7307

Reviewed by: ?

## Summary by Sourcery

Expose work queue and worker utilization metrics through cn=monitor and surface them in both the Python monitoring API and Cockpit UI.

New Features:
- Add cn=monitor attributes for current work queue size, maximum work queue size, current busy workers, and maximum busy workers.
- Expose the new work queue and worker metrics via lib389 Monitor helpers and the Cockpit Server Monitor page.

Enhancements:
- Track current and peak busy worker counts and work queue depth using atomic counters for low‑overhead monitoring.

Tests:
- Add monitor tests validating the new work queue and busy worker metrics, including concurrent worker activity behavior.