### PR TITLE
Issue 7312 - UI - Database Maximum Size cannot be easily set by typing

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -427,7 +427,7 @@ export class Database extends React.Component {
                                         pagelooklimit: attrs['nsslapd-pagedlookthroughlimit'][0],
                                         pagescanlimit: attrs['nsslapd-pagedidlistscanlimit'][0],
                                         rangelooklimit: attrs['nsslapd-rangelookthroughlimit'][0],
-                                        mdbmaxsize: attrs['nsslapd-mdb-max-size'][0],
+                                        mdbmaxsize: Math.floor(attrs['nsslapd-mdb-max-size'][0] / (1024 * 1024)),
                                         mdbmaxreaders: attrs['nsslapd-mdb-max-readers'][0],
                                         mdbmaxdbs: attrs['nsslapd-mdb-max-dbs'][0],
                                         dbhomedir: dbhome,

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1338,66 +1338,54 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
         this.dn_syntax_oids = ["1.3.6.1.4.1.1466.115.121.1.34",
                                "1.3.6.1.4.1.1466.115.121.1.12"];
-        this.maxValue = 2147483647;
 
         // Field validation rules configuration
-        this.fieldValidationRules = {
-            mdbmaxsize: {
-                getRange: () => ({
-                    min: 100,
-                    max: Math.floor(this.state.availDbSizeBytes / (1024 * 1024))
-                }),
-                specialValues: []
-            },
-            mdbmaxreaders: {
-                getRange: () => ({ min: 26, max: 200 }),
-                specialValues: [0]  // 0 = auto-tune
-            },
-            mdbmaxdbs: {
-                getRange: () => ({ min: 131, max: 5000 }),
-                specialValues: [0]  // 0 = auto-tune
-            },
-            autosize: {
-                getRange: () => ({ min: 1, max: 100 }),
-                specialValues: [0]  // 0 = auto-tune
-            },
-            looklimit: {
-                getRange: () => ({ min: 0, max: this.maxValue }),
-                specialValues: [-1]  // -1 = unlimited
-            },
-            ndncachemaxsize: {
-                getRange: () => ({ min: 1000000, max: this.maxValue }),
-                specialValues: []
-            },
-            idscanlimit: {
-                getRange: () => ({ min: 100, max: this.maxValue }),
-                specialValues: []
-            },
-            pagelooklimit: {
-                getRange: () => ({ min: 0, max: this.maxValue }),
-                specialValues: [-1]  // -1 = unlimited
-            },
-            pagescanlimit: {
-                getRange: () => ({ min: 0, max: this.maxValue }),
-                specialValues: [-1]  // -1 = unlimited
-            },
-            rangelooklimit: {
-                getRange: () => ({ min: 0, max: this.maxValue }),
-                specialValues: [-1]  // -1 = unlimited
+        this.fieldValidationRules = (fieldId) => {
+            switch(fieldId) {
+                case 'mdbmaxsize':
+                    return {
+                        min: 100,
+                        max: Math.floor(this.state.availDbSizeBytes / (1024 * 1024)),
+                        special: null
+                    };
+                case 'mdbmaxreaders':
+                    return { min: 26, max: 200, special: 0 };  // 0 = auto-tune
+                case 'mdbmaxdbs':
+                    return { min: 131, max: 5000, special: 0 };  // 0 = auto-tune
+                case 'autosize':
+                    return { min: 1, max: 100, special: 0 };  // 0 = auto-tune
+                case 'looklimit':
+                    return { min: 0, max: this.maxValue, special: -1 };  // -1 = unlimited
+                case 'ndncachemaxsize':
+                    return { min: 1024000, max: this.maxValue, special: null };
+                case 'idscanlimit':
+                    return { min: 100, max: this.maxValue, special: null };
+                case 'pagelooklimit':
+                    return { min: 0, max: this.maxValue, special: -1 };  // -1 = unlimited
+                case 'pagescanlimit':
+                    return { min: 100, max: this.maxValue, special: -1 };  // -1 = unlimited
+                case 'rangelooklimit':
+                    return { min: 0, max: this.maxValue, special: -1 };  // -1 = unlimited
+                default:
+                    console.warn(`No validation rules for field: ${fieldId}. Using default values.`);
+                    return { min: 0, max: this.maxValue, special: null };
             }
         };
 
-        this.onConfigMinus = (id, special, lower) => {
+        this.onConfigMinus = (id) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             let error = { ...this.state.error };
-            const rules = this.fieldValidationRules[id];
-            const min = rules ? rules.getRange().min : 0;
+            const rules = this.fieldValidationRules(id);
+            const { min, special } = rules;
 
-            if (special !== null && value === lower) {
-                value = special;
-            } else if (special !== null && value === special) {
+            if (special !== null && value === special) {
+                // at special, cant go any lower
                 return;
+            } else if (value === min && special !== null && special < min) {
+                // min to special
+                value = special;
             } else if (value <= min) {
+                // at min or below, cant go any lower
                 return;
             } else {
                 value -= 1;
@@ -1421,16 +1409,20 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }, () => { this.validateSaveBtn(id) });
         };
 
-        this.onConfigChangeBlur = (id, special, lower, upper) => {
+        this.onConfigChangeBlur = (id) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             let error = { ...this.state.error };
+            const rules = this.fieldValidationRules(id);
+            const { min, max, special } = rules;
 
             if (special !== null && value === special) {
-                // nothing to do
-            } else if (value < lower) {
-                value = lower;
-            } else if (value > upper) {
-                value = upper;
+                // at special, nothing to do
+            } else if (value < min) {
+                // below min, clamp to min
+                value = min;
+            } else if (value > max) {
+                // above max, clamp to max
+                value = max;
             }
 
             error[id] = !this.isFieldValid(id, value);
@@ -1440,15 +1432,17 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }, () => { this.validateSaveBtn(id) });
         };
 
-        this.onConfigPlus = (id, special, lower) => {
+        this.onConfigPlus = (id) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             let error = { ...this.state.error };
-            const rules = this.fieldValidationRules[id];
-            const max = rules ? rules.getRange().max : this.maxValue;
+            const rules = this.fieldValidationRules(id);
+            const { min, max, special } = rules;
 
             if (special !== null && value === special) {
-                value = lower;
+                // special to min
+                value = min;
             } else if (value >= max) {
+                // at max, cant go any higher
                 return;
             } else {
                 value += 1;
@@ -1470,18 +1464,36 @@ export class GlobalDatabaseConfigMDB extends React.Component {
     }
 
     isFieldValid(fieldId, value) {
-        const rules = this.fieldValidationRules[fieldId];
-        if (!rules) {
-            return true;
-        }
-
+        const rules = this.fieldValidationRules(fieldId);
         const numValue = Number(value);
-        if (rules.specialValues && rules.specialValues.includes(numValue)) {
+
+        if (rules.special !== null && rules.special === numValue) {
             return true;
         }
 
-        const { min, max } = rules.getRange();
+        const { min, max } = rules;
         return numValue >= min && numValue <= max;
+    }
+
+    getFieldMinValue(fieldId) {
+        const rules = this.fieldValidationRules(fieldId);
+        const { min, special } = rules;
+
+        if (special !== null && special < min) {
+            return special;
+        }
+
+        return min;
+    }
+
+    getFieldMaxValue(fieldId) {
+        const rules = this.fieldValidationRules(fieldId);
+        return rules.max;
+    }
+
+    // int32 max
+    get maxValue() {
+        return 2147483647;
     }
 
     componentDidMount() {
@@ -1517,6 +1529,21 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             if (this.state.error[config_attr]) {
                 saveBtnDisabled = true;
                 break;
+            }
+        }
+
+        // prevent saving invalid values
+        if (!saveBtnDisabled) {
+            const numberInputFields = [
+                "looklimit", "idscanlimit", "pagelooklimit",
+                "pagescanlimit", "rangelooklimit", "ndncachemaxsize",
+                "mdbmaxsize", "mdbmaxreaders", "mdbmaxdbs", "autosize"
+            ];
+            for (const config_attr of numberInputFields) {
+                if (!this.isFieldValid(config_attr, this.state[config_attr])) {
+                    saveBtnDisabled = true;
+                    break;
+                }
             }
         }
 
@@ -1739,13 +1766,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                         </GridItem>
                         <GridItem span={9}>
                             <NumberInput
-                                value={this.state.autosize}
-                                min={1}
-                                max={100}
-                                onMinus={() => { this.onConfigMinus("autosize", 0, 1) }}
+                                value={Number(this.state.autosize)}
+                                min={this.getFieldMinValue("autosize")}
+                                max={this.getFieldMaxValue("autosize")}
+                                onMinus={() => { this.onConfigMinus("autosize") }}
                                 onChange={(e) => { this.onConfigChange(e, "autosize") }}
-                                onBlur={() => { this.onConfigChangeBlur("autosize", 0, 1, 100) }}
-                                onPlus={() => { this.onConfigPlus("autosize", 0, 1) }}
+                                onBlur={() => { this.onConfigChangeBlur("autosize") }}
+                                onPlus={() => { this.onConfigPlus("autosize") }}
                                 inputName="input"
                                 inputAriaLabel="number input"
                                 minusBtnAriaLabel="minus"
@@ -1808,13 +1835,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.mdbmaxsize}
-                                                min={100}
-                                                max={mdbmaxsizeMB}
-                                                onMinus={() => { this.onConfigMinus("mdbmaxsize", null, 100) }}
+                                                value={Number(this.state.mdbmaxsize)}
+                                                min={this.getFieldMinValue("mdbmaxsize")}
+                                                max={this.getFieldMaxValue("mdbmaxsize")}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxsize") }}
                                                 onChange={(e) => { this.onConfigChange(e, "mdbmaxsize") }}
-                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxsize", null, 100, mdbmaxsizeMB) }}
-                                                onPlus={() => { this.onConfigPlus("mdbmaxsize", null, 100) }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxsize") }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxsize") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1842,13 +1869,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.looklimit}
-                                                min={-1}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("looklimit", -1, 0) }}
+                                                value={Number(this.state.looklimit)}
+                                                min={this.getFieldMinValue("looklimit")}
+                                                max={this.getFieldMaxValue("looklimit")}
+                                                onMinus={() => { this.onConfigMinus("looklimit") }}
                                                 onChange={(e) => { this.onConfigChange(e, "looklimit") }}
-                                                onBlur={() => { this.onConfigChangeBlur("looklimit", -1, 0, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("looklimit", -1, 0) }}
+                                                onBlur={() => { this.onConfigChangeBlur("looklimit") }}
+                                                onPlus={() => { this.onConfigPlus("looklimit") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1870,13 +1897,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.idscanlimit}
-                                                min={100}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("idscanlimit", null, 100) }}
+                                                value={Number(this.state.idscanlimit)}
+                                                min={this.getFieldMinValue("idscanlimit")}
+                                                max={this.getFieldMaxValue("idscanlimit")}
+                                                onMinus={() => { this.onConfigMinus("idscanlimit") }}
                                                 onChange={(e) => { this.onConfigChange(e, "idscanlimit") }}
-                                                onBlur={() => { this.onConfigChangeBlur("idscanlimit", null, 100, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("idscanlimit", null, 100) }}
+                                                onBlur={() => { this.onConfigChangeBlur("idscanlimit") }}
+                                                onPlus={() => { this.onConfigPlus("idscanlimit") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1898,13 +1925,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.pagelooklimit}
-                                                min={-1}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("pagelooklimit", -1, 0) }}
+                                                value={Number(this.state.pagelooklimit)}
+                                                min={this.getFieldMinValue("pagelooklimit")}
+                                                max={this.getFieldMaxValue("pagelooklimit")}
+                                                onMinus={() => { this.onConfigMinus("pagelooklimit") }}
                                                 onChange={(e) => { this.onConfigChange(e, "pagelooklimit") }}
-                                                onBlur={() => { this.onConfigChangeBlur("pagelooklimit", -1, 0, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("pagelooklimit", -1, 0) }}
+                                                onBlur={() => { this.onConfigChangeBlur("pagelooklimit") }}
+                                                onPlus={() => { this.onConfigPlus("pagelooklimit") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1926,13 +1953,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.pagescanlimit}
-                                                min={-1}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("pagescanlimit", -1, 0) }}
+                                                value={Number(this.state.pagescanlimit)}
+                                                min={this.getFieldMinValue("pagescanlimit")}
+                                                max={this.getFieldMaxValue("pagescanlimit")}
+                                                onMinus={() => { this.onConfigMinus("pagescanlimit") }}
                                                 onChange={(e) => { this.onConfigChange(e, "pagescanlimit") }}
-                                                onBlur={() => { this.onConfigChangeBlur("pagescanlimit", -1, 0, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("pagescanlimit", -1, 0) }}
+                                                onBlur={() => { this.onConfigChangeBlur("pagescanlimit") }}
+                                                onPlus={() => { this.onConfigPlus("pagescanlimit") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1954,13 +1981,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.rangelooklimit}
-                                                min={-1}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("rangelooklimit", -1, 0) }}
+                                                value={Number(this.state.rangelooklimit)}
+                                                min={this.getFieldMinValue("rangelooklimit")}
+                                                max={this.getFieldMaxValue("rangelooklimit")}
+                                                onMinus={() => { this.onConfigMinus("rangelooklimit") }}
                                                 onChange={(e) => { this.onConfigChange(e, "rangelooklimit") }}
-                                                onBlur={() => { this.onConfigChangeBlur("rangelooklimit", -1, 0, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("rangelooklimit", -1, 0) }}
+                                                onBlur={() => { this.onConfigChangeBlur("rangelooklimit") }}
+                                                onPlus={() => { this.onConfigPlus("rangelooklimit") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2004,13 +2031,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.ndncachemaxsize}
-                                                min={1000000}
-                                                max={this.maxValue}
-                                                onMinus={() => { this.onConfigMinus("ndncachemaxsize", null, 1000000) }}
+                                                value={Number(this.state.ndncachemaxsize)}
+                                                min={this.getFieldMinValue("ndncachemaxsize")}
+                                                max={this.getFieldMaxValue("ndncachemaxsize")}
+                                                onMinus={() => { this.onConfigMinus("ndncachemaxsize") }}
                                                 onChange={(e) => { this.onConfigChange(e, "ndncachemaxsize") }}
-                                                onBlur={() => { this.onConfigChangeBlur("ndncachemaxsize", null, 1000000, this.maxValue) }}
-                                                onPlus={() => { this.onConfigPlus("ndncachemaxsize", null, 1000000) }}
+                                                onBlur={() => { this.onConfigChangeBlur("ndncachemaxsize") }}
+                                                onPlus={() => { this.onConfigPlus("ndncachemaxsize") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2068,13 +2095,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.mdbmaxreaders}
-                                                min={0}
-                                                max={200}
-                                                onMinus={() => { this.onConfigMinus("mdbmaxreaders", 0, 26) }}
+                                                value={Number(this.state.mdbmaxreaders)}
+                                                min={this.getFieldMinValue("mdbmaxreaders")}
+                                                max={this.getFieldMaxValue("mdbmaxreaders")}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxreaders") }}
                                                 onChange={(e) => { this.onConfigChange(e, "mdbmaxreaders") }}
-                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxreaders", 0, 26, 200) }}
-                                                onPlus={() => { this.onConfigPlus("mdbmaxreaders", 0, 26) }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxreaders") }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxreaders") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2096,13 +2123,13 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.mdbmaxdbs}
-                                                min={0}
-                                                max={5000}
-                                                onMinus={() => { this.onConfigMinus("mdbmaxdbs", 0, 131) }}
+                                                value={Number(this.state.mdbmaxdbs)}
+                                                min={this.getFieldMinValue("mdbmaxdbs")}
+                                                max={this.getFieldMaxValue("mdbmaxdbs")}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxdbs") }}
                                                 onChange={(e) => { this.onConfigChange(e, "mdbmaxdbs") }}
-                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxdbs", 0, 131, 5000) }}
-                                                onPlus={() => { this.onConfigPlus("mdbmaxdbs", 0, 131) }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxdbs") }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxdbs") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2127,10 +2154,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.autosize}
                                                 min={0}
                                                 max={100}
-                                                onMinus={() => { this.onConfigMinus("autosize", 0, 1) }}
+                                                onMinus={() => { this.onConfigMinus("autosize") }}
                                                 onChange={(e) => { this.onConfigChange(e, "autosize") }}
-                                                onBlur={() => { this.onConfigChangeBlur("autosize", 0, 1, 100) }}
-                                                onPlus={() => { this.onConfigPlus("autosize", 0, 1) }}
+                                                onBlur={() => { this.onConfigChangeBlur("autosize") }}
+                                                onPlus={() => { this.onConfigPlus("autosize") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1331,6 +1331,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         };
 
         this.validateSaveBtn = this.validateSaveBtn.bind(this);
+        this.validateFieldRange = this.validateFieldRange.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleSaveDBConfig = this.handleSaveDBConfig.bind(this);
         this.loadAvailableDiskSpace = this.loadAvailableDiskSpace.bind(this);
@@ -1338,21 +1339,55 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         this.dn_syntax_oids = ["1.3.6.1.4.1.1466.115.121.1.34",
                                "1.3.6.1.4.1.1466.115.121.1.12"];
         this.maxValue = 2147483647;
-        this.onMinusConfig = (id) => {
-            if (id === "mdbmaxsize") {
-                const currentMB = Number(this.state[id]);
-                const value = Math.max(currentMB - 1, 100);
-                this.setState({
-                    [id]: value
-                }, () => { this.validateSaveBtn() });
-            } else {
-                this.setState({
-                    [id]: Number(this.state[id]) - 1,
-                }, () => { this.validateSaveBtn() });
+
+        // Field validation rules configuration
+        this.fieldValidationRules = {
+            mdbmaxsize: {
+                getRange: () => ({
+                    min: 100,
+                    max: Math.floor(this.state.availDbSizeBytes / (1024 * 1024))
+                }),
+                specialValues: []
+            },
+            mdbmaxreaders: {
+                getRange: () => ({ min: 26, max: 200 }),
+                specialValues: [0]  // 0 = auto-tune
+            },
+            mdbmaxdbs: {
+                getRange: () => ({ min: 131, max: 5000 }),
+                specialValues: [0]  // 0 = auto-tune
+            },
+            autosize: {
+                getRange: () => ({ min: 1, max: 100 }),
+                specialValues: [0]  // 0 = auto-tune
+            },
+            looklimit: {
+                getRange: () => ({ min: 0, max: this.maxValue }),
+                specialValues: [-1]  // -1 = unlimited
+            },
+            ndncachemaxsize: {
+                getRange: () => ({ min: 1000000, max: this.maxValue }),
+                specialValues: []
+            },
+            idscanlimit: {
+                getRange: () => ({ min: 100, max: this.maxValue }),
+                specialValues: []
+            },
+            pagelooklimit: {
+                getRange: () => ({ min: 0, max: this.maxValue }),
+                specialValues: [-1]  // -1 = unlimited
+            },
+            pagescanlimit: {
+                getRange: () => ({ min: 0, max: this.maxValue }),
+                specialValues: [-1]  // -1 = unlimited
+            },
+            rangelooklimit: {
+                getRange: () => ({ min: 0, max: this.maxValue }),
+                specialValues: [-1]  // -1 = unlimited
             }
         };
 
-        this.onRangeConfigMinus = (id, special, lower) => {
+        this.onConfigMinus = (id, special, lower) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             if (value === lower) {
                 value = special;
@@ -1361,15 +1396,17 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }
             this.setState({
                 [id]: value
-            }, () => { this.validateSaveBtn() });
+            }, () => { this.validateSaveBtn(id) });
         };
 
-        this.onRangeConfigChange = (event, id) => {
+        this.onConfigChange = (event, id) => {
             const value = isNaN(event.target.value) ? 0 : Number(event.target.value);
-            this.setState({ [id]: value });
+            this.setState({
+                [id]: value
+            }, () => { this.validateSaveBtn(id) });
         };
 
-        this.onRangeConfigChangeBlur = (id, special, lower, upper) => {
+        this.onConfigChangeBlur = (id, special, lower, upper) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             if (special !== null && value === special) {
                 // nothing to do
@@ -1380,52 +1417,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }
             this.setState({
                 [id]: value
-            }, () => { this.validateSaveBtn() });
+            }, () => { this.validateSaveBtn(id) });
         };
 
-        this.onConfigChange = (event, id, min, max) => {
-            let maxValue = this.maxValue;
-            if (max !== 0) {
-                maxValue = max;
-            }
-            const newValue = isNaN(event.target.value) ? 0 : Number(event.target.value);
-            if (id === "mdbmaxsize") {
-                const newValueBytes = newValue * (1024 * 1024);
-                this.setState({
-                    [id]: (newValueBytes > max ? max : newValueBytes < min ? min : newValueBytes)
-                }, () => { this.validateSaveBtn() });
-            } else {
-                let error = this.state.error;
-                let badValue = false;
-                const newValue = isNaN(event.target.value) ? 0 : Number(event.target.value);
-                if (newValue > maxValue || newValue < min) {
-                    badValue = true;
-
-                }
-                error[id] = badValue;
-                this.setState({
-                    [id]: newValue,
-                    error,
-                }, () => { this.validateSaveBtn() });
-            }
-        };
-
-        this.onPlusConfig = (id) => {
-            if (id === "mdbmaxsize") {
-                const currentMB = Number(this.state[id]);
-                const maxsizeMB = Math.floor(this.state.availDbSizeBytes / (1024 * 1024));
-                const value = Math.min(currentMB + 1, maxsizeMB);
-                this.setState({
-                    [id]: value
-                }, () => { this.validateSaveBtn() });
-            } else {
-                this.setState({
-                    [id]: Number(this.state[id]) + 1,
-                }, () => { this.validateSaveBtn() });
-            }
-        };
-
-        this.onRangeConfigPlus = (id, special, lower) => {
+        this.onConfigPlus = (id, special, lower) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
             if (value === special) {
                 value = lower;
@@ -1434,7 +1429,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }
             this.setState({
                 [id]: value
-            }, () => { this.validateSaveBtn() });
+            }, () => { this.validateSaveBtn(id) });
         };
 
         // Toggle currently active tab
@@ -1443,6 +1438,23 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                 activeTabKey: tabIndex
             });
         };
+    }
+
+    // Validate range for a specific field using configuration rules
+    validateFieldRange(fieldId, value) {
+        const rules = this.fieldValidationRules[fieldId];
+        if (!rules) return true; // No validation rules defined for this field
+
+        const numValue = Number(value);
+
+        // Check if it's a special value (like 0 for auto-tune, -1 for unlimited)
+        if (rules.specialValues && rules.specialValues.includes(numValue)) {
+            return true;
+        }
+
+        // Check range
+        const { min, max } = rules.getRange();
+        return numValue >= min && numValue <= max;
     }
 
     componentDidMount() {
@@ -1455,7 +1467,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         this.ismounted = false;
     }
 
-    validateSaveBtn() {
+    validateSaveBtn(fieldId) {
         let saveBtnDisabled = true;
         const check_attrs = [
             "looklimit", "idscanlimit", "pagelooklimit",
@@ -1481,6 +1493,11 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             }
         }
 
+        // Validate range for the specific field that triggered this validation
+        if (!saveBtnDisabled && !this.validateFieldRange(fieldId, this.state[fieldId])) {
+            saveBtnDisabled = true;
+        }
+
         this.setState({
             saveBtnDisabled
         });
@@ -1493,7 +1510,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
         this.setState({
             [attr]: value,
-        }, () => { this.validateSaveBtn() });
+        }, () => { this.validateSaveBtn(attr) });
     }
 
     save_ndn_cache(requireRestart) {
@@ -1698,11 +1715,12 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                         <GridItem span={9}>
                             <NumberInput
                                 value={this.state.autosize}
-                                min={0}
+                                min={1}
                                 max={100}
-                                onMinus={() => { this.onMinusConfig("autosize") }}
-                                onChange={(e) => { this.onConfigChange(e, "autosize", 0, 100) }}
-                                onPlus={() => { this.onPlusConfig("autosize") }}
+                                onMinus={() => { this.onConfigMinus("autosize", 0, 1) }}
+                                onChange={(e) => { this.onConfigChange(e, "autosize") }}
+                                onBlur={() => { this.onConfigChangeBlur("autosize", 0, 1, 100) }}
+                                onPlus={() => { this.onConfigPlus("autosize", 0, 1) }}
                                 inputName="input"
                                 inputAriaLabel="number input"
                                 minusBtnAriaLabel="minus"
@@ -1732,7 +1750,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             attr.name[0].toLowerCase() !== this.state.dynamiclistattr.toLowerCase()
         );
 
-        const mdbMaxMB = Math.floor(this.state.availDbSizeBytes / (1024 * 1024));
+        const mdbmaxsizeMB = Math.floor(this.state.availDbSizeBytes / (1024 * 1024));
         return (
             <div className={this.state.saving ? "ds-disabled ds-margin-bottom-md" : "ds-margin-bottom-md"} id="db-global-page">
                 {spinner}
@@ -1767,11 +1785,11 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                             <NumberInput
                                                 value={this.state.mdbmaxsize}
                                                 min={100}
-                                                max={mdbMaxMB}
-                                                onMinus={() => { this.onMinusConfig("mdbmaxsize") }}
-                                                onChange={(e) => { this.onRangeConfigChange(e, "mdbmaxsize") }}
-                                                onBlur={() => { this.onRangeConfigChangeBlur("mdbmaxsize", null, 100, mdbMaxMB) }}
-                                                onPlus={() => { this.onPlusConfig("mdbmaxsize") }}
+                                                max={mdbmaxsizeMB}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxsize", null, 100) }}
+                                                onChange={(e) => { this.onConfigChange(e, "mdbmaxsize") }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxsize", null, 100, mdbmaxsizeMB) }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxsize", null, 100) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1802,9 +1820,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.looklimit}
                                                 min={-1}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("looklimit") }}
-                                                onChange={(e) => { this.onConfigChange(e, "looklimit", -1, 0) }}
-                                                onPlus={() => { this.onPlusConfig("looklimit") }}
+                                                onMinus={() => { this.onConfigMinus("looklimit", -1, 0) }}
+                                                onChange={(e) => { this.onConfigChange(e, "looklimit") }}
+                                                onBlur={() => { this.onConfigChangeBlur("looklimit", -1, 0, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("looklimit", -1, 0) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1829,9 +1848,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.idscanlimit}
                                                 min={100}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("idscanlimit") }}
-                                                onChange={(e) => { this.onConfigChange(e, "idscanlimit", 100, 0) }}
-                                                onPlus={() => { this.onPlusConfig("idscanlimit") }}
+                                                onMinus={() => { this.onConfigMinus("idscanlimit", null, 100) }}
+                                                onChange={(e) => { this.onConfigChange(e, "idscanlimit") }}
+                                                onBlur={() => { this.onConfigChangeBlur("idscanlimit", null, 100, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("idscanlimit", null, 100) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1856,9 +1876,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.pagelooklimit}
                                                 min={-1}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("pagelooklimit") }}
-                                                onChange={(e) => { this.onConfigChange(e, "pagelooklimit", -1, 0) }}
-                                                onPlus={() => { this.onPlusConfig("pagelooklimit") }}
+                                                onMinus={() => { this.onConfigMinus("pagelooklimit", -1, 0) }}
+                                                onChange={(e) => { this.onConfigChange(e, "pagelooklimit") }}
+                                                onBlur={() => { this.onConfigChangeBlur("pagelooklimit", -1, 0, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("pagelooklimit", -1, 0) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1883,9 +1904,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.pagescanlimit}
                                                 min={-1}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("pagescanlimit") }}
-                                                onChange={(e) => { this.onConfigChange(e, "pagescanlimit", -1, 0) }}
-                                                onPlus={() => { this.onPlusConfig("pagescanlimit") }}
+                                                onMinus={() => { this.onConfigMinus("pagescanlimit", -1, 0) }}
+                                                onChange={(e) => { this.onConfigChange(e, "pagescanlimit") }}
+                                                onBlur={() => { this.onConfigChangeBlur("pagescanlimit", -1, 0, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("pagescanlimit", -1, 0) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1910,9 +1932,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.rangelooklimit}
                                                 min={-1}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("rangelooklimit") }}
-                                                onChange={(e) => { this.onConfigChange(e, "rangelooklimit", -1, 0) }}
-                                                onPlus={() => { this.onPlusConfig("rangelooklimit") }}
+                                                onMinus={() => { this.onConfigMinus("rangelooklimit", -1, 0) }}
+                                                onChange={(e) => { this.onConfigChange(e, "rangelooklimit") }}
+                                                onBlur={() => { this.onConfigChangeBlur("rangelooklimit", -1, 0, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("rangelooklimit", -1, 0) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -1959,9 +1982,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.ndncachemaxsize}
                                                 min={1000000}
                                                 max={this.maxValue}
-                                                onMinus={() => { this.onMinusConfig("ndncachemaxsize") }}
-                                                onChange={(e) => { this.onConfigChange(e, "ndncachemaxsize", 1000000, 0) }}
-                                                onPlus={() => { this.onPlusConfig("ndncachemaxsize") }}
+                                                onMinus={() => { this.onConfigMinus("ndncachemaxsize", null, 1000000) }}
+                                                onChange={(e) => { this.onConfigChange(e, "ndncachemaxsize") }}
+                                                onBlur={() => { this.onConfigChangeBlur("ndncachemaxsize", null, 1000000, this.maxValue) }}
+                                                onPlus={() => { this.onConfigPlus("ndncachemaxsize", null, 1000000) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2022,10 +2046,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.mdbmaxreaders}
                                                 min={0}
                                                 max={200}
-                                                onMinus={() => { this.onRangeConfigMinus("mdbmaxreaders", 0, 26) }}
-                                                onChange={(e) => { this.onRangeConfigChange(e, "mdbmaxreaders") }}
-                                                onBlur={() => { this.onRangeConfigChangeBlur("mdbmaxreaders", 0, 26, 200) }}
-                                                onPlus={() => { this.onRangeConfigPlus("mdbmaxreaders", 0, 26) }}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxreaders", 0, 26) }}
+                                                onChange={(e) => { this.onConfigChange(e, "mdbmaxreaders") }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxreaders", 0, 26, 200) }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxreaders", 0, 26) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2050,10 +2074,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.mdbmaxdbs}
                                                 min={0}
                                                 max={5000}
-                                                onMinus={() => { this.onRangeConfigMinus("mdbmaxdbs", 0, 131) }}
-                                                onChange={(e) => { this.onRangeConfigChange(e, "mdbmaxdbs") }}
-                                                onBlur={() => { this.onRangeConfigChangeBlur("mdbmaxdbs", 0, 131, 5000) }}
-                                                onPlus={() => { this.onRangeConfigPlus("mdbmaxdbs", 0, 131) }}
+                                                onMinus={() => { this.onConfigMinus("mdbmaxdbs", 0, 131) }}
+                                                onChange={(e) => { this.onConfigChange(e, "mdbmaxdbs") }}
+                                                onBlur={() => { this.onConfigChangeBlur("mdbmaxdbs", 0, 131, 5000) }}
+                                                onPlus={() => { this.onConfigPlus("mdbmaxdbs", 0, 131) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"
@@ -2078,9 +2102,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                                 value={this.state.autosize}
                                                 min={0}
                                                 max={100}
-                                                onMinus={() => { this.onMinusConfig("autosize") }}
-                                                onChange={(e) => { this.onConfigChange(e, "autosize", 0, 100) }}
-                                                onPlus={() => { this.onPlusConfig("autosize") }}
+                                                onMinus={() => { this.onConfigMinus("autosize", 0, 1) }}
+                                                onChange={(e) => { this.onConfigChange(e, "autosize") }}
+                                                onBlur={() => { this.onConfigChangeBlur("autosize", 0, 1, 100) }}
+                                                onPlus={() => { this.onConfigPlus("autosize", 0, 1) }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"
                                                 minusBtnAriaLabel="minus"

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1330,8 +1330,8 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             _dynamicurlattr: this.props.data.dynamicurlattr,
         };
 
+        this.isFieldValid = this.isFieldValid.bind(this);
         this.validateSaveBtn = this.validateSaveBtn.bind(this);
-        this.validateFieldRange = this.validateFieldRange.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleSaveDBConfig = this.handleSaveDBConfig.bind(this);
         this.loadAvailableDiskSpace = this.loadAvailableDiskSpace.bind(this);
@@ -1389,25 +1389,42 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
         this.onConfigMinus = (id, special, lower) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
-            if (value === lower) {
+            let error = { ...this.state.error };
+            const rules = this.fieldValidationRules[id];
+            const min = rules ? rules.getRange().min : 0;
+
+            if (special !== null && value === lower) {
                 value = special;
+            } else if (special !== null && value === special) {
+                return;
+            } else if (value <= min) {
+                return;
             } else {
                 value -= 1;
             }
+
+            error[id] = !this.isFieldValid(id, value);
             this.setState({
-                [id]: value
+                [id]: value,
+                error
             }, () => { this.validateSaveBtn(id) });
         };
 
         this.onConfigChange = (event, id) => {
             const value = isNaN(event.target.value) ? 0 : Number(event.target.value);
+            let error = { ...this.state.error };
+
+            error[id] = !this.isFieldValid(id, value);
             this.setState({
-                [id]: value
+                [id]: value,
+                error
             }, () => { this.validateSaveBtn(id) });
         };
 
         this.onConfigChangeBlur = (id, special, lower, upper) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
+            let error = { ...this.state.error };
+
             if (special !== null && value === special) {
                 // nothing to do
             } else if (value < lower) {
@@ -1415,20 +1432,32 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             } else if (value > upper) {
                 value = upper;
             }
+
+            error[id] = !this.isFieldValid(id, value);
             this.setState({
-                [id]: value
+                [id]: value,
+                error
             }, () => { this.validateSaveBtn(id) });
         };
 
         this.onConfigPlus = (id, special, lower) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
-            if (value === special) {
+            let error = { ...this.state.error };
+            const rules = this.fieldValidationRules[id];
+            const max = rules ? rules.getRange().max : this.maxValue;
+
+            if (special !== null && value === special) {
                 value = lower;
+            } else if (value >= max) {
+                return;
             } else {
                 value += 1;
             }
+
+            error[id] = !this.isFieldValid(id, value);
             this.setState({
-                [id]: value
+                [id]: value,
+                error
             }, () => { this.validateSaveBtn(id) });
         };
 
@@ -1440,19 +1469,17 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         };
     }
 
-    // Validate range for a specific field using configuration rules
-    validateFieldRange(fieldId, value) {
+    isFieldValid(fieldId, value) {
         const rules = this.fieldValidationRules[fieldId];
-        if (!rules) return true; // No validation rules defined for this field
+        if (!rules) {
+            return true;
+        }
 
         const numValue = Number(value);
-
-        // Check if it's a special value (like 0 for auto-tune, -1 for unlimited)
         if (rules.specialValues && rules.specialValues.includes(numValue)) {
             return true;
         }
 
-        // Check range
         const { min, max } = rules.getRange();
         return numValue >= min && numValue <= max;
     }
@@ -1481,36 +1508,34 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         for (const config_attr of check_attrs) {
             if (this.state[config_attr].toString() !== this.state['_' + config_attr].toString()) {
                 saveBtnDisabled = false;
-                break
+                break;
             }
         }
 
         // Check if have any errors on our attributes
         for (const config_attr of check_attrs) {
-            if (config_attr in this.state.error && this.state.error[config_attr]) {
+            if (this.state.error[config_attr]) {
                 saveBtnDisabled = true;
                 break;
             }
         }
 
-        // Validate range for the specific field that triggered this validation
-        if (!saveBtnDisabled && !this.validateFieldRange(fieldId, this.state[fieldId])) {
-            saveBtnDisabled = true;
-        }
-
-        this.setState({
-            saveBtnDisabled
-        });
+        this.setState({ saveBtnDisabled });
     }
 
     handleChange(e, str) {
         // Generic
         const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
         const attr = e.target.id;
+        const error = { ...this.state.error };
 
+        error[attr] = !this.isFieldValid(attr, value);
         this.setState({
             [attr]: value,
-        }, () => { this.validateSaveBtn(attr) });
+            error
+        }, () => {
+            this.validateSaveBtn(attr);
+        });
     }
 
     save_ndn_cache(requireRestart) {

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -90,6 +90,7 @@ class DynamicLists extends React.Component {
                             onChange={this.props.handleChange}
                             aria-label="Dynamic List Objectclass"
                             ouiaId="DynamicListObjectclassSelect"
+                            isDisabled={!this.props.dynamiclistsenabled}
                         >
                             {this.props.objectClasses.map((option, index) => (
                                 <FormSelectOption key={index} value={option.toLowerCase()} label={option} />
@@ -111,6 +112,7 @@ class DynamicLists extends React.Component {
                             onChange={this.props.handleChange}
                             aria-label="Dynamic List URL Attribute"
                             ouiaId="DynamicListURL Attr Select AttributeSelect"
+                            isDisabled={!this.props.dynamiclistsenabled}
                         >
                             {this.props.urlAttrs.map((option, index) => (
                                 <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
@@ -132,6 +134,7 @@ class DynamicLists extends React.Component {
                             onChange={this.props.handleChange}
                             aria-label="Dynamic List Attribute"
                             ouiaId="DynamicListAttributeSelect"
+                            isDisabled={!this.props.dynamiclistsenabled}
                         >
                             {this.props.dnAttrs.map((option, index) => (
                                 <FormSelectOption key={index} value={option.name[0].toLowerCase()} label={option.name[0]} />
@@ -1339,6 +1342,15 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         this.dn_syntax_oids = ["1.3.6.1.4.1.1466.115.121.1.34",
                                "1.3.6.1.4.1.1466.115.121.1.12"];
 
+        // All fields that participate in change tracking
+        this.validationFields = [
+            "looklimit", "idscanlimit", "pagelooklimit",
+            "pagescanlimit", "rangelooklimit", "ndncachemaxsize",
+            "mdbmaxsize", "mdbmaxreaders", "mdbmaxdbs", "autosize",
+            "dynamiclistsenabled", "dynamiclistattr", "dynamicoc",
+            "dynamicurlattr",
+        ];
+
         // Field validation rules configuration
         this.fieldValidationRules = (fieldId) => {
             switch(fieldId) {
@@ -1363,11 +1375,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                 case 'pagelooklimit':
                     return { min: 0, max: this.maxValue, special: -1 };  // -1 = unlimited
                 case 'pagescanlimit':
-                    return { min: 100, max: this.maxValue, special: -1 };  // -1 = unlimited
+                    return { min: 100, max: this.maxValue, special: 0 };
                 case 'rangelooklimit':
                     return { min: 0, max: this.maxValue, special: -1 };  // -1 = unlimited
                 default:
-                    console.warn(`No validation rules for field: ${fieldId}. Using default values.`);
                     return { min: 0, max: this.maxValue, special: null };
             }
         };
@@ -1463,6 +1474,12 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         };
     }
 
+    // Helper method to determine if a field has specific validation rules (NumberInput) or uses defaults (text field)
+    hasValidationRules(fieldId) {
+        const rules = this.fieldValidationRules(fieldId);
+        return !(rules.min === 0 && rules.max === this.maxValue && rules.special === null);
+    }
+
     isFieldValid(fieldId, value) {
         const rules = this.fieldValidationRules(fieldId);
         const numValue = Number(value);
@@ -1507,46 +1524,36 @@ export class GlobalDatabaseConfigMDB extends React.Component {
     }
 
     validateSaveBtn(fieldId) {
-        let saveBtnDisabled = true;
-        const check_attrs = [
-            "looklimit", "idscanlimit", "pagelooklimit",
-            "pagescanlimit", "rangelooklimit", "ndncachemaxsize",
-            "mdbmaxsize", "mdbmaxreaders", "mdbmaxdbs", "autosize",
-            "dynamiclistsenabled", "dynamiclistattr", "dynamicoc",
-            "dynamicurlattr",
-        ];
+        let hasChanges = false;
+        let hasErrors = false;
+        let hasValidationErrors = false;
 
-        // Check if a setting was changed, if so enable the save button
-        for (const config_attr of check_attrs) {
-            if (this.state[config_attr].toString() !== this.state['_' + config_attr].toString()) {
-                saveBtnDisabled = false;
-                break;
+        // Single loop to check all conditions efficiently
+        for (const fieldName of this.validationFields) {
+            // Check for changes
+            if (!hasChanges && this.state[fieldName].toString() !== this.state['_' + fieldName].toString()) {
+                hasChanges = true;
             }
-        }
 
-        // Check if have any errors on our attributes
-        for (const config_attr of check_attrs) {
-            if (this.state.error[config_attr]) {
-                saveBtnDisabled = true;
-                break;
+            // Check for existing errors
+            if (!hasErrors && this.state.error[fieldName]) {
+                hasErrors = true;
             }
-        }
 
-        // prevent saving invalid values
-        if (!saveBtnDisabled) {
-            const numberInputFields = [
-                "looklimit", "idscanlimit", "pagelooklimit",
-                "pagescanlimit", "rangelooklimit", "ndncachemaxsize",
-                "mdbmaxsize", "mdbmaxreaders", "mdbmaxdbs", "autosize"
-            ];
-            for (const config_attr of numberInputFields) {
-                if (!this.isFieldValid(config_attr, this.state[config_attr])) {
-                    saveBtnDisabled = true;
-                    break;
+            // Check for NumberInput validation errors (only if we have changes and no existing errors)
+            if (!hasValidationErrors && hasChanges && !hasErrors) {
+                if (this.hasValidationRules(fieldName) && !this.isFieldValid(fieldName, this.state[fieldName])) {
+                    hasValidationErrors = true;
                 }
             }
+
+            // Early exit if we already know the button should be disabled
+            if (hasErrors || (hasChanges && hasValidationErrors)) {
+                break;
+            }
         }
 
+        const saveBtnDisabled = !hasChanges || hasErrors || hasValidationErrors;
         this.setState({ saveBtnDisabled });
     }
 
@@ -1556,7 +1563,8 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         const attr = e.target.id;
         const error = { ...this.state.error };
 
-        error[attr] = !this.isFieldValid(attr, value);
+        error[attr] = this.hasValidationRules(attr) ? !this.isFieldValid(attr, value) : false;
+
         this.setState({
             [attr]: value,
             error
@@ -2151,9 +2159,9 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={this.state.autosize}
-                                                min={0}
-                                                max={100}
+                                                value={Number(this.state.autosize)}
+                                                min={this.getFieldMinValue("autosize")}
+                                                max={this.getFieldMaxValue("autosize")}
                                                 onMinus={() => { this.onConfigMinus("autosize") }}
                                                 onChange={(e) => { this.onConfigChange(e, "autosize") }}
                                                 onBlur={() => { this.onConfigChangeBlur("autosize") }}

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1340,8 +1340,10 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         this.maxValue = 2147483647;
         this.onMinusConfig = (id) => {
             if (id === "mdbmaxsize") {
+                const currentMB = Number(this.state[id]);
+                const value = Math.max(currentMB - 1, 100);
                 this.setState({
-                    [id]: Number(this.state[id]) - (1024 * 1024),
+                    [id]: value
                 }, () => { this.validateSaveBtn() });
             } else {
                 this.setState({
@@ -1369,7 +1371,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
         this.onRangeConfigChangeBlur = (id, special, lower, upper) => {
             let value = isNaN(this.state[id]) ? 0 : Number(this.state[id]);
-            if (value === special) {
+            if (special !== null && value === special) {
                 // nothing to do
             } else if (value < lower) {
                 value = lower;
@@ -1410,8 +1412,11 @@ export class GlobalDatabaseConfigMDB extends React.Component {
 
         this.onPlusConfig = (id) => {
             if (id === "mdbmaxsize") {
+                const currentMB = Number(this.state[id]);
+                const maxsizeMB = Math.floor(this.state.availDbSizeBytes / (1024 * 1024));
+                const value = Math.min(currentMB + 1, maxsizeMB);
                 this.setState({
-                    [id]: Number(this.state[id]) + (1024 * 1024),
+                    [id]: value
                 }, () => { this.validateSaveBtn() });
             } else {
                 this.setState({
@@ -1573,7 +1578,8 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             cmd.push("--rangelookthroughlimit=" + this.state.rangelooklimit);
         }
         if (this.state._mdbmaxsize !== this.state.mdbmaxsize) {
-            cmd.push("--mdb-max-size=" + this.state.mdbmaxsize);
+            const mdbmaxsizeMB = this.state.mdbmaxsize * 1024 * 1024;
+            cmd.push("--mdb-max-size=" + mdbmaxsizeMB);
             requireRestart = true;
         }
         if (this.state._mdbmaxreaders !== this.state.mdbmaxreaders) {
@@ -1726,6 +1732,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
             attr.name[0].toLowerCase() !== this.state.dynamiclistattr.toLowerCase()
         );
 
+        const mdbMaxMB = Math.floor(this.state.availDbSizeBytes / (1024 * 1024));
         return (
             <div className={this.state.saving ? "ds-disabled ds-margin-bottom-md" : "ds-margin-bottom-md"} id="db-global-page">
                 {spinner}
@@ -1758,11 +1765,12 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                                         </GridItem>
                                         <GridItem span={8}>
                                             <NumberInput
-                                                value={Math.floor(this.state.mdbmaxsize / (1024 * 1024))}
-                                                min={104857600 / (1024 * 1024)}
-                                                max={Math.floor(this.state.availDbSizeBytes / (1024 * 1024))}
+                                                value={this.state.mdbmaxsize}
+                                                min={100}
+                                                max={mdbMaxMB}
                                                 onMinus={() => { this.onMinusConfig("mdbmaxsize") }}
-                                                onChange={(e) => { this.onConfigChange(e, "mdbmaxsize", 104857600, this.state.availDbSizeBytes) }}
+                                                onChange={(e) => { this.onRangeConfigChange(e, "mdbmaxsize") }}
+                                                onBlur={() => { this.onRangeConfigChangeBlur("mdbmaxsize", null, 100, mdbMaxMB) }}
                                                 onPlus={() => { this.onPlusConfig("mdbmaxsize") }}
                                                 inputName="input"
                                                 inputAriaLabel="number input"


### PR DESCRIPTION
Description:
The mdb max size field was clamping user input while typing. With a min value of 100, when users tried to type values, the first digit would clamp to 100, making it impossible to enter valid values.

Fix:
Used an existing config change function that allows free typing, validation is now done in a blur function.

Tidied up the conversion from bytes to MB, converting only at the dsconf boundaries.

Fixes:
https://github.com/389ds/389-ds-base/issues/7312

Reviewed by:

## Summary by Sourcery

Adjust MDB max size configuration UI to allow free typing in megabytes with proper validation and byte conversion at the configuration boundaries.

Bug Fixes:
- Fix MDB max size input clamping that prevented users from typing valid values below the minimum while editing.
- Ensure special-value handling in range blur validation only applies when a special value is defined.

Enhancements:
- Change MDB max size increment/decrement controls to operate in megabytes within the available database size range.
- Convert MDB max size between bytes and megabytes only when reading from and writing to the underlying configuration attributes.