### PR TITLE
Issue - UI - Add progress steppers to Security, Database, and Replica…

### DIFF
--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -13,6 +13,8 @@ import { LocalPwPolicy } from "./lib/database/localPwp.jsx";
 import {
     Button,
     Card,
+    ProgressStepper,
+    ProgressStep,
     Form,
     FormGroup,
     FormSelect,
@@ -42,6 +44,9 @@ import {
 import { PropTypes } from "prop-types";
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import { PlusIcon } from '@patternfly/react-icons/dist/js/icons/plus-icon';
+import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 const DB_CONFIG = "dbconfig";
 const CHAINING_CONFIG = "chaining-config";
 const BACKUP_CONFIG = "backups";
@@ -93,6 +98,14 @@ export class Database extends React.Component {
             chainingLoading: false,
             // Suffix
             suffixLoading: false,
+            suffixConfigLoaded: false,
+            suffixConfigLoading: false,
+            suffixVlvLoaded: false,
+            suffixVlvLoading: false,
+            suffixAttrEncLoaded: false,
+            suffixAttrEncLoading: false,
+            suffixIndexesLoaded: false,
+            suffixIndexesLoading: false,
             modalSpinning: false,
             attributes: [],
             objectClasses: [],
@@ -107,6 +120,20 @@ export class Database extends React.Component {
             suffixList: [],
             pwdStorageSchemes: [],
             loaded: false,
+            globalConfigLoaded: false,
+            globalConfigLoading: false,
+            chainingConfigLoaded: false,
+            chainingConfigLoading: false,
+            ldifsLoaded: false,
+            ldifsLoading: false,
+            backupsLoaded: false,
+            backupsLoading: false,
+            pwdSchemesLoaded: false,
+            pwdSchemesLoading: false,
+            suffixListLoaded: false,
+            suffixListLoading: false,
+            suffixTreeLoaded: false,
+            suffixTreeLoading: false,
         };
 
         // General
@@ -140,29 +167,49 @@ export class Database extends React.Component {
         // Other
         this.loadSuffixTree = this.loadSuffixTree.bind(this);
         this.enableTree = this.enableTree.bind(this);
+        this.resetLoadProgress = this.resetLoadProgress.bind(this);
+    }
+
+    resetLoadProgress() {
+        this.setState({
+            loaded: false,
+            globalConfigLoaded: false,
+            globalConfigLoading: false,
+            chainingConfigLoaded: false,
+            chainingConfigLoading: false,
+            ldifsLoaded: false,
+            ldifsLoading: false,
+            backupsLoaded: false,
+            backupsLoading: false,
+            pwdSchemesLoaded: false,
+            pwdSchemesLoading: false,
+            suffixListLoaded: false,
+            suffixListLoading: false,
+            suffixTreeLoaded: false,
+            suffixTreeLoading: false,
+        });
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.wasActiveList.includes(2)) {
             if (this.state.firstLoad) {
                 if (!this.state.loaded) {
+                    this.resetLoadProgress();
                     this.loadGlobalConfig();
-                    this.loadChainingConfig();
-                    this.loadLDIFs();
-                    this.loadBackups();
-                    this.loadSuffixList();
-                    this.loadPwdStorageSchemes();
+                } else {
+                    this.loadSuffixTree(false);
                 }
-                this.loadSuffixTree(false);
             } else {
                 if (this.props.serverId !== prevProps.serverId) {
-                    this.loadSuffixTree(false);
+                    this.resetLoadProgress();
+                    this.loadGlobalConfig();
                 }
             }
         }
     }
 
-    loadSuffixList () {
+    loadSuffixList (reloading = false) {
+        this.setState({ suffixListLoading: true });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "backend", "suffix", "list", "--suffix"
@@ -173,12 +220,35 @@ export class Database extends React.Component {
                 .done(content => {
                     const suffixList = JSON.parse(content);
                     this.setState(() => (
-                        { suffixList: suffixList.items }
-                    ));
+                        {
+                            suffixList: suffixList.items,
+                            suffixListLoaded: true,
+                            suffixListLoading: false,
+                        }
+                    ), () => {
+                        if (!reloading) {
+                            this.loadSuffixTree(false);
+                        }
+                    });
+                }).fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading suffix list - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        suffixListLoaded: true,
+                        suffixListLoading: false,
+                    }, () => {
+                        if (!reloading) {
+                            this.loadSuffixTree(false);
+                        }
+                    });
                 });
     }
 
-    loadPwdStorageSchemes () {
+    loadPwdStorageSchemes (reloading = false) {
+        this.setState({ pwdSchemesLoading: true });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "pwpolicy", "list-schemes"
@@ -189,15 +259,34 @@ export class Database extends React.Component {
                 .done(content => {
                     const schemes = JSON.parse(content);
                     this.setState(() => (
-                        { pwdStorageSchemes: schemes.items }
-                    ));
+                        {
+                            pwdStorageSchemes: schemes.items,
+                            pwdSchemesLoaded: true,
+                            pwdSchemesLoading: false,
+                        }
+                    ), () => {
+                        if (!reloading) {
+                            this.loadSuffixList();
+                        }
+                    });
+                }).fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading password storage schemes - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        pwdSchemesLoaded: true,
+                        pwdSchemesLoading: false,
+                    }, () => {
+                        if (!reloading) {
+                            this.loadSuffixList();
+                        }
+                    });
                 });
     }
 
-    loadNDN() {
-        this.setState({
-            loaded: false,
-        });
+    loadNDN(reloading = false) {
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "config", "get", "nsslapd-ndn-cache-max-size", "nsslapd-ndn-cache-enabled"
@@ -215,9 +304,14 @@ export class Database extends React.Component {
                             ndncachemaxsize: attrs['nsslapd-ndn-cache-max-size'][0],
                             ndn_cache_enabled: ndn_cache_enabled,
                         },
+                        globalConfigLoaded: true,
+                        globalConfigLoading: false,
                         configUpdated: 0,
-                        loaded: true,
-                    }));
+                    }), () => {
+                        if (!reloading) {
+                            this.loadChainingConfig();
+                        }
+                    });
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
@@ -226,15 +320,21 @@ export class Database extends React.Component {
                         cockpit.format(_("Error loading server configuration for database- $0"), errMsg.desc)
                     );
                     this.setState({
-                        loaded: true,
+                        globalConfigLoaded: true,
+                        globalConfigLoading: false,
+                    }, () => {
+                        if (!reloading) {
+                            this.loadChainingConfig();
+                        }
                     });
                 });
     }
 
-    loadGlobalConfig (activeTab) {
+    loadGlobalConfig (activeTab, reloading = false) {
         if (this.state.firstLoad) {
             this.setState({ firstLoad: false });
         }
+        this.setState({ globalConfigLoading: true });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "backend", "config", "get"
@@ -303,7 +403,9 @@ export class Database extends React.Component {
                                         dynamicurlattr: attrs['nsslapd-dynamic-lists-url-attr'][0],
                                     },
                                 configUpdated: 1
-                            }), () => { this.loadNDN() });
+                            }), () => {
+                                this.loadNDN(reloading);
+                            });
                     } else if (dbimplement === BE_IMPL_MDB) {
                         let db_cache_auto = false;
                         if ('nsslapd-directory' in attrs) {
@@ -336,7 +438,9 @@ export class Database extends React.Component {
                                         dynamicurlattr: attrs['nsslapd-dynamic-lists-url-attr'][0],
                                     },
                                 configUpdated: 1
-                            }), () => { this.loadNDN() });
+                            }), () => {
+                                this.loadNDN(reloading);
+                            });
                     }
                 }
                 )
@@ -346,6 +450,7 @@ export class Database extends React.Component {
                         "error",
                         cockpit.format(_("Error loading database configuration - $0"), errMsg.desc)
                     );
+                    this.loadNDN(reloading); // updates the loading state
                 });
     }
 
@@ -439,7 +544,8 @@ export class Database extends React.Component {
                 });
     }
 
-    loadChainingConfig(tabIdx) {
+    loadChainingConfig(tabIdx, reloading = false) {
+        this.setState({ chainingConfigLoading: true });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "chaining", "config-get"
@@ -473,8 +579,29 @@ export class Database extends React.Component {
                                 availableComps
                             },
                             chainingActiveKey: activeKey,
+                            chainingConfigLoaded: true,
+                            chainingConfigLoading: false,
                         }
-                    ), this.loadDefaultConfig());
+                    ), () => {
+                        this.loadDefaultConfig();
+                        if (!reloading) {
+                            this.loadLDIFs();
+                        }
+                    });
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading chaining configuration - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        chainingConfigLoading: false,
+                        chainingConfigLoaded: true,
+                    });
+                    if (!reloading) {
+                        this.loadLDIFs();
+                    }
                 });
     }
 
@@ -495,7 +622,8 @@ export class Database extends React.Component {
         }
     }
 
-    loadSuffixTree(fullReset) {
+    loadSuffixTree(fullReset, reloading = false) {
+        this.setState({ suffixTreeLoading: true });
         const treeData = [
             {
                 name: _("Global Database Configuration"),
@@ -572,6 +700,8 @@ export class Database extends React.Component {
                     this.setState(() => ({
                         nodes: treeData,
                         node_name: current_node,
+                        suffixTreeLoaded: true,
+                        suffixTreeLoading: false,
                     }), this.loadSchema);
                 })
                 .fail(err => {
@@ -584,6 +714,8 @@ export class Database extends React.Component {
                     this.setState(() => ({
                         nodes: treeData,
                         node_name: current_node,
+                        suffixTreeLoaded: true,
+                        suffixTreeLoading: false,
                     }), this.loadSchema);
                 });
     }
@@ -875,7 +1007,7 @@ export class Database extends React.Component {
                     );
                     // Refresh tree
                     this.loadSuffixTree(false);
-                    this.loadSuffixList();
+                    this.loadSuffixList(true);
                     this.setState({
                         modalSpinning: false
                     });
@@ -1042,7 +1174,15 @@ export class Database extends React.Component {
         // the loading is finished
         this.setState({
             activeKey: 1,
-            suffixLoading: true
+            suffixLoading: true,
+            suffixConfigLoaded: false,
+            suffixConfigLoading: true,
+            suffixVlvLoaded: false,
+            suffixVlvLoading: false,
+            suffixAttrEncLoaded: false,
+            suffixAttrEncLoading: false,
+            suffixIndexesLoaded: false,
+            suffixIndexesLoading: false,
         }, this.loadSchema());
 
         const cmd = [
@@ -1079,7 +1219,10 @@ export class Database extends React.Component {
                             dbstate: config.attrs['nsslapd-state'][0],
                             readOnly: readonly,
                             requireIndex: requireindex,
-                        }
+                        },
+                        suffixConfigLoaded: true,
+                        suffixConfigLoading: false,
+                        suffixVlvLoading: true,
                     }, this.getAutoTuning(suffix));
 
                     // Now load VLV indexes
@@ -1097,6 +1240,12 @@ export class Database extends React.Component {
                                         ...this.state[suffix],
                                         vlvItems: config.items,
                                     }
+                                }, () => {
+                                    this.setState({
+                                        suffixVlvLoaded: true,
+                                        suffixVlvLoading: false,
+                                        suffixAttrEncLoading: true,
+                                    });
                                 });
 
                                 const cmd = [
@@ -1117,6 +1266,12 @@ export class Database extends React.Component {
                                                     ...this.state[suffix],
                                                     encAttrsRows: rows
                                                 }
+                                            }, () => {
+                                                this.setState({
+                                                    suffixAttrEncLoaded: true,
+                                                    suffixAttrEncLoading: false,
+                                                    suffixIndexesLoading: true,
+                                                });
                                             });
                                             const index_cmd = [
                                                 "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
@@ -1158,6 +1313,8 @@ export class Database extends React.Component {
                                                                 indexRows: rows,
                                                                 systemIndexRows: systemRows,
                                                             },
+                                                            suffixIndexesLoaded: true,
+                                                            suffixIndexesLoading: false,
                                                             suffixLoading: false
                                                         });
                                                     })
@@ -1168,6 +1325,7 @@ export class Database extends React.Component {
                                                             cockpit.format(_("Error loading indexes for $0 - $1"), suffix, errMsg.desc)
                                                         );
                                                         this.setState({
+                                                            suffixIndexesLoading: false,
                                                             suffixLoading: false
                                                         });
                                                     });
@@ -1179,6 +1337,7 @@ export class Database extends React.Component {
                                                 cockpit.format(_("Error attribute encryption for $0 - $1"), suffix, errMsg.desc)
                                             );
                                             this.setState({
+                                                suffixAttrEncLoading: false,
                                                 suffixLoading: false
                                             });
                                         });
@@ -1190,6 +1349,7 @@ export class Database extends React.Component {
                                     cockpit.format(_("Error loading VLV indexes for $0 - $1"), suffix, errMsg.desc)
                                 );
                                 this.setState({
+                                    suffixVlvLoading: false,
                                     suffixLoading: false
                                 });
                             });
@@ -1201,12 +1361,14 @@ export class Database extends React.Component {
                         cockpit.format(_("Error loading config for $0 - $1"), suffix, errMsg.desc)
                     );
                     this.setState({
+                        suffixConfigLoading: false,
                         suffixLoading: false
                     });
                 });
     }
 
-    loadLDIFs() {
+    loadLDIFs(reloading = false) {
+        this.setState({ ldifsLoading: true });
         const cmd = [
             "dsctl", "-j", this.props.serverId, "ldifs"
         ];
@@ -1222,16 +1384,37 @@ export class Database extends React.Component {
                     this.setState({
                         LDIFRows: rows,
                         backupRefreshing: false,
+                        ldifsLoaded: true,
+                        ldifsLoading: false,
+                    }, () => {
+                        if (!reloading) {
+                            this.loadBackups();
+                        }
                     });
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading LDIF files - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        ldifsLoading: false,
+                        ldifsLoaded: true,
+                    });
+                    if (!reloading) {
+                        this.loadBackups();
+                    }
                 });
     }
 
-    loadBackups(refreshing) {
+    loadBackups(refreshing, reloading = false) {
         if (refreshing) {
             this.setState({
                 backupRefreshing: true
             });
         }
+        this.setState({ backupsLoading: true });
         const cmd = [
             "dsctl", "-j", this.props.serverId, "backups"
         ];
@@ -1246,7 +1429,29 @@ export class Database extends React.Component {
                     }
                     this.setState({
                         BackupRows: rows,
-                    }, this.loadLDIFs());
+                        backupsLoaded: true,
+                        backupsLoading: false,
+                        backupRefreshing: false
+                    }, () => {
+                        if (!reloading && !refreshing) {
+                            this.loadPwdStorageSchemes();
+                        }
+                    });
+                })
+                .fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading backups - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        backupsLoading: false,
+                        backupRefreshing: false,
+                        backupsLoaded: true,
+                    });
+                    if (!reloading && !refreshing) {
+                        this.loadPwdStorageSchemes();
+                    }
                 });
     }
 
@@ -1289,10 +1494,16 @@ export class Database extends React.Component {
                                 this.setState({
                                     attributes: attrs,
                                     objectClasses: ocs,
-                                    attributesFullData: attrContent.items,
-                                    loaded: true
+                                    attributesFullData: attrContent.items
                                 }, this.update_tree_nodes);
                             })
+                }).fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading schema - $0"), errMsg.desc)
+                    );
+                    this.update_tree_nodes();
                 });
     }
 
@@ -1317,12 +1528,13 @@ export class Database extends React.Component {
                         <GlobalDatabaseConfig
                             serverId={this.props.serverId}
                             addNotification={this.props.addNotification}
-                            reload={this.loadGlobalConfig}
+                            reload={(activeTab) => this.loadGlobalConfig(activeTab, true)}
                             data={this.state.globalDBConfig}
                             enableTree={this.enableTree}
                             key={this.state.configUpdated}
                             objectClasses={this.state.objectClasses}
                             attributes={this.state.attributesFullData}
+                            loading={this.state.globalConfigLoading}
                         />
                     );
                 } else if (this.state.backendImplement === BE_IMPL_MDB) {
@@ -1330,12 +1542,13 @@ export class Database extends React.Component {
                         <GlobalDatabaseConfigMDB
                             serverId={this.props.serverId}
                             addNotification={this.props.addNotification}
-                            reload={this.loadGlobalConfig}
+                            reload={(activeTab) => this.loadGlobalConfig(activeTab, true)}
                             data={this.state.globalDBConfig}
                             enableTree={this.enableTree}
                             key={this.state.configUpdated}
                             attributes={this.state.attributesFullData}
                             objectClasses={this.state.objectClasses}
+                            loading={this.state.globalConfigLoading}
                         />
                     );
                 }
@@ -1344,7 +1557,7 @@ export class Database extends React.Component {
                     <ChainingDatabaseConfig
                         serverId={this.props.serverId}
                         addNotification={this.props.addNotification}
-                        reload={this.loadChainingConfig}
+                        reload={(tabIdx) => this.loadChainingConfig(tabIdx, true)}
                         data={this.state.chainingConfig}
                         enableTree={this.enableTree}
                         activeKey={this.state.chainingActiveKey}
@@ -1380,7 +1593,7 @@ export class Database extends React.Component {
                         suffixes={this.state.suffixList}
                         ldifs={this.state.LDIFRows}
                         enableTree={this.enableTree}
-                        handleReload={this.loadBackups}
+                        handleReload={(refreshing) => this.loadBackups(refreshing, true)}
                         refreshing={this.state.backupRefreshing}
                     />
                 );
@@ -1393,9 +1606,55 @@ export class Database extends React.Component {
                                 <TextContent>
                                     <Text className="ds-margin-top-xlg" component={TextVariants.h3}>
                                         {_("Loading suffix configuration for ")}<b>{this.state.node_text} ...</b>
+                                        <Spinner isInline className="ds-left-margin" size="lg" />
                                     </Text>
                                 </TextContent>
-                                <Spinner className="ds-margin-top-lg" size="xl" />
+                                <ProgressStepper
+                                    className="ds-margin-top-lg"
+                                    aria-label="Progress stepper for suffix loading stages"
+                                    isCenterAligned
+                                >
+                                    <ProgressStep
+                                        isCurrent={this.state.suffixConfigLoading}
+                                        variant={this.state.suffixConfigLoaded ? "success" : "pending"}
+                                        icon={!this.state.suffixConfigLoaded ? this.state.suffixConfigLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                                        id="suffixConfigLoading"
+                                        titleId="load suffix configuration"
+                                        aria-label="Loading suffix configuration step"
+                                    >
+                                        {!this.state.suffixConfigLoaded ? _("Loading Suffix Config") : _("Suffix Config Loaded")}
+                                    </ProgressStep>
+                                    <ProgressStep
+                                        isCurrent={this.state.suffixVlvLoading}
+                                        variant={this.state.suffixVlvLoaded ? "success" : "pending"}
+                                        icon={!this.state.suffixVlvLoaded ? this.state.suffixVlvLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                                        id="suffixVlvLoading"
+                                        titleId="load suffix vlv indexes"
+                                        aria-label="Loading suffix vlv indexes step"
+                                    >
+                                        {!this.state.suffixVlvLoaded ? _("Loading VLV Indexes") : _("VLV Indexes Loaded")}
+                                    </ProgressStep>
+                                    <ProgressStep
+                                        isCurrent={this.state.suffixAttrEncLoading}
+                                        variant={this.state.suffixAttrEncLoaded ? "success" : "pending"}
+                                        icon={!this.state.suffixAttrEncLoaded ? this.state.suffixAttrEncLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                                        id="suffixAttrEncLoading"
+                                        titleId="load suffix attribute encryption"
+                                        aria-label="Loading suffix attribute encryption step"
+                                    >
+                                        {!this.state.suffixAttrEncLoaded ? _("Loading Attribute Encryption") : _("Attribute Encryption Loaded")}
+                                    </ProgressStep>
+                                    <ProgressStep
+                                        isCurrent={this.state.suffixIndexesLoading}
+                                        variant={this.state.suffixIndexesLoaded ? "success" : "pending"}
+                                        icon={!this.state.suffixIndexesLoaded ? this.state.suffixIndexesLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                                        id="suffixIndexesLoading"
+                                        titleId="load suffix indexes"
+                                        aria-label="Loading suffix indexes step"
+                                    >
+                                        {!this.state.suffixIndexesLoaded ? _("Loading Indexes") : _("Indexes Loaded")}
+                                    </ProgressStep>
+                                </ProgressStepper>
                             </div>
                         );
                     } else {
@@ -1412,7 +1671,7 @@ export class Database extends React.Component {
                                 vlvTableKey={this.state.vlvTableKey}
                                 reloadAttrEnc={this.loadAttrEncrypt}
                                 addNotification={this.props.addNotification}
-                                reloadLDIFs={this.loadLDIFs}
+                                reloadLDIFs={() => this.loadLDIFs(true)}
                                 LDIFRows={this.state.LDIFRows}
                                 dbtype={this.state.dbtype}
                                 data={this.state[this.state.node_text]}
@@ -1474,9 +1733,85 @@ export class Database extends React.Component {
                     <TextContent>
                         <Text className="ds-margin-top-xlg" component={TextVariants.h3}>
                             {_("Loading Database Configuration ...")}
+                            <Spinner isInline className="ds-left-margin" size="lg" />
                         </Text>
                     </TextContent>
-                    <Spinner className="ds-margin-top" size="xl" />
+                    <ProgressStepper
+                        className="ds-margin-top-lg"
+                        aria-label="Progress stepper for database loading stages"
+                        isCenterAligned
+                    >
+                        <ProgressStep
+                            isCurrent={this.state.globalConfigLoading}
+                            variant={this.state.globalConfigLoaded ? "success" : "pending"}
+                            icon={!this.state.globalConfigLoaded ? this.state.globalConfigLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="globalConfigLoading"
+                            titleId="load database global configuration"
+                            aria-label="Loading database global configuration step"
+                        >
+                            {!this.state.globalConfigLoaded ? _("Loading Global Config") : _("Global Config Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.chainingConfigLoading}
+                            variant={this.state.chainingConfigLoaded ? "success" : "pending"}
+                            icon={!this.state.chainingConfigLoaded ? this.state.chainingConfigLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="chainingConfigLoading"
+                            titleId="load database chaining configuration"
+                            aria-label="Loading database chaining configuration step"
+                        >
+                            {!this.state.chainingConfigLoaded ? _("Loading Chaining Config") : _("Chaining Config Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.ldifsLoading}
+                            variant={this.state.ldifsLoaded ? "success" : "pending"}
+                            icon={!this.state.ldifsLoaded ? this.state.ldifsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="ldifLoading"
+                            titleId="load ldif files"
+                            aria-label="Loading ldif files step"
+                        >
+                            {!this.state.ldifsLoaded ? _("Loading LDIFs") : _("LDIFs Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.backupsLoading}
+                            variant={this.state.backupsLoaded ? "success" : "pending"}
+                            icon={!this.state.backupsLoaded ? this.state.backupsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="backupLoading"
+                            titleId="load backup files"
+                            aria-label="Loading backup files step"
+                        >
+                            {!this.state.backupsLoaded ? _("Loading Backups") : _("Backups Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.pwdSchemesLoading}
+                            variant={this.state.pwdSchemesLoaded ? "success" : "pending"}
+                            icon={!this.state.pwdSchemesLoaded ? this.state.pwdSchemesLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="pwdSchemesLoading"
+                            titleId="load password storage schemes"
+                            aria-label="Loading password storage schemes step"
+                        >
+                            {!this.state.pwdSchemesLoaded ? _("Loading Password Schemes") : _("Password Schemes Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.suffixListLoading}
+                            variant={this.state.suffixListLoaded ? "success" : "pending"}
+                            icon={!this.state.suffixListLoaded ? this.state.suffixListLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="suffixListLoading"
+                            titleId="load suffix list"
+                            aria-label="Loading suffix list step"
+                        >
+                            {!this.state.suffixListLoaded ? _("Loading Suffix List") : _("Suffix List Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.suffixTreeLoading}
+                            variant={this.state.suffixTreeLoaded ? "success" : "pending"}
+                            icon={!this.state.suffixTreeLoaded ? this.state.suffixTreeLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="suffixTreeLoading"
+                            titleId="load suffix tree"
+                            aria-label="Loading suffix tree step"
+                        >
+                            {!this.state.suffixTreeLoaded ? _("Loading Suffix Tree") : _("Suffix Tree Loaded")}
+                        </ProgressStep>
+                    </ProgressStepper>
                 </div>
             );
         }

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -786,7 +786,7 @@ export class GlobalDatabaseConfig extends React.Component {
         }
 
         let spinner = "";
-        if (this.state.loading) {
+        if (this.props.loading) {
             spinner = (
                 <div className="ds-loading-spinner ds-margin-top-xlg ds-center">
                     <TextContent>
@@ -794,7 +794,7 @@ export class GlobalDatabaseConfig extends React.Component {
                             Loading global database configuration ...
                         </Text>
                     </TextContent>
-                    <Spinner className="ds-margin-top" loading size="md" />
+                    <Spinner className="ds-margin-top" size="md" />
                 </div>
             );
         }
@@ -820,7 +820,7 @@ export class GlobalDatabaseConfig extends React.Component {
         return (
             <div className={this.state.saving ? "ds-disabled ds-margin-bottom-md" : "ds-margin-bottom-md"} id="db-global-page">
                 {spinner}
-                <div className={this.state.loading ? 'ds-fadeout' : 'ds-fadein'}>
+                <div className={this.props.loading ? 'ds-fadeout' : 'ds-fadein'}>
                     <TextContent>
                         <Text className="ds-config-header" component={TextVariants.h2}>
                             {_("Global Database Configuration")}
@@ -1659,7 +1659,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         let spinner = "";
         let db_cache_form;
         let db_auto_checked = false;
-        if (this.state.loading) {
+        if (this.props.loading) {
             spinner = (
                 <div className="ds-loading-spinner ds-margin-top-xlg ds-center">
                     <TextContent>
@@ -1667,7 +1667,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                             Loading global database configuration ...
                         </Text>
                     </TextContent>
-                    <Spinner className="ds-margin-top" loading size="md" />
+                    <Spinner className="ds-margin-top" size="md" />
                 </div>
             );
         }
@@ -1729,7 +1729,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
         return (
             <div className={this.state.saving ? "ds-disabled ds-margin-bottom-md" : "ds-margin-bottom-md"} id="db-global-page">
                 {spinner}
-                <div className={this.state.loading ? 'ds-fadeout' : 'ds-fadein'}>
+                <div className={this.props.loading ? 'ds-fadeout' : 'ds-fadein'}>
                     <TextContent>
                         <Text className="ds-config-header" component={TextVariants.h2}>
                             {_("Global Database Configuration")}

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/aciNew.jsx
@@ -986,8 +986,8 @@ class AddNewAci extends React.Component {
                                         isChecked={row.selected}
                                         onChange={(checked) => this.handleRightsOnSelect(null, checked, rowIndex)}
                                         aria-label={`Select ${row.cells[0]}`}
+                                        label={row.cells[0]}
                                     />
-                                    {row.cells[0]}
                                 </Td>
                                 <Td>{row.cells[1]}</Td>
                             </Tr>

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -4,7 +4,10 @@ import { log_cmd } from "./lib/tools.jsx";
 import { ReplSuffix } from "./lib/replication/replSuffix.jsx";
 import PropTypes from "prop-types";
 import {
+    Button,
     Card,
+    ProgressStepper,
+    ProgressStep,
     Spinner,
     TreeView,
     Text,
@@ -15,6 +18,9 @@ import { TreeIcon, LeafIcon, CloneIcon } from '@patternfly/react-icons';
 import {
     TopologyIcon
 } from '@patternfly/react-icons';
+import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 
 const _ = cockpit.gettext;
 
@@ -53,6 +59,20 @@ export class Replication extends React.Component {
 
             showDisableConfirm: false,
             loaded: false,
+            suffixTreeLoaded: false,
+            suffixTreeLoading: false,
+            attrsLoaded: false,
+            attrsLoading: false,
+            replConfigLoaded: false,
+            replConfigLoading: false,
+            changelogLoaded: false,
+            changelogLoading: false,
+            agmtsLoaded: false,
+            agmtsLoading: false,
+            winsyncLoaded: false,
+            winsyncLoading: false,
+            ruvLoaded: false,
+            ruvLoading: false,
         };
 
         // General
@@ -71,18 +91,38 @@ export class Replication extends React.Component {
         this.reloadChangelog = this.reloadChangelog.bind(this);
         this.loadSuffixTree = this.loadSuffixTree.bind(this);
         this.loadLDIFs = this.loadLDIFs.bind(this);
+        this.resetLoadProgress = this.resetLoadProgress.bind(this);
+    }
+
+    resetLoadProgress() {
+        this.setState({
+            loaded: false,
+            suffixTreeLoaded: false,
+            suffixTreeLoading: false,
+            attrsLoaded: false,
+            attrsLoading: false,
+            replConfigLoaded: false,
+            replConfigLoading: false,
+            changelogLoaded: false,
+            changelogLoading: false,
+            agmtsLoaded: false,
+            agmtsLoading: false,
+            winsyncLoaded: false,
+            winsyncLoading: false,
+            ruvLoaded: false,
+            ruvLoading: false,
+        }, () => {
+            this.loadSuffixTree(true);
+        });
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.wasActiveList.includes(3)) {
             if (this.state.firstLoad) {
-                this.loadSuffixTree(true);
-                if (!this.state.loaded) {
-                    this.loadAttrs();
-                }
+                this.resetLoadProgress();
             } else {
                 if (this.props.serverId !== prevProps.serverId) {
-                    this.loadSuffixTree(true);
+                    this.resetLoadProgress();
                 }
             }
         }
@@ -174,7 +214,8 @@ export class Replication extends React.Component {
         }
 
         this.setState({
-            loaded: false
+            loaded: false,
+            suffixTreeLoading: true,
         });
 
         const basicData = [
@@ -257,7 +298,11 @@ export class Replication extends React.Component {
                             }
                         }
                         this.loadReplSuffix(current_node);
+                    } else {
+                        // There are no suffixes defined
+                        this.loadReplSuffix("");
                     }
+
 
                     basicData[0].children = treeData;
                     this.setState({
@@ -265,7 +310,10 @@ export class Replication extends React.Component {
                         node_name: current_node,
                         node_type: current_type,
                         node_replicated: replicated,
+                        suffixTreeLoaded: true,
+                        suffixTreeLoading: false,
                     }, () => { this.update_tree_nodes() });
+                    this.loadAttrs();
                 })
                 .fail(err => {
                     // Handle backend get-tree failure gracefully
@@ -278,6 +326,8 @@ export class Replication extends React.Component {
                         node_name: current_node,
                         node_type: current_type,
                         node_replicated: replicated,
+                        suffixTreeLoading: false,
+                        suffixTreeLoaded: true,
                     }, () => { this.update_tree_nodes() });
                 });
     }
@@ -315,7 +365,6 @@ export class Replication extends React.Component {
     update_tree_nodes() {
         // Enable the tree, and update the titles
         this.setState({
-            loaded: true,
             disableTree: false,
         }, () => {
             const className = 'pf-c-tree-view__list-item';
@@ -634,6 +683,7 @@ export class Replication extends React.Component {
                     }
                     this.setState({
                         ldifRows: rows,
+                        loaded: true,
                     }, () => { this.update_tree_nodes() });
                 });
     }
@@ -650,6 +700,16 @@ export class Replication extends React.Component {
             activeKey: 1,
             suffixLoading: true,
             [suffix]: {},
+            replConfigLoading: true,
+            replConfigLoaded: false,
+            changelogLoaded: false,
+            changelogLoading: false,
+            agmtsLoaded: false,
+            agmtsLoading: false,
+            winsyncLoaded: false,
+            winsyncLoading: false,
+            ruvLoaded: false,
+            ruvLoading: false,
         });
 
         let cmd = [
@@ -701,7 +761,13 @@ export class Replication extends React.Component {
                             clTrimInt: "",
                             clEncrypt: false,
                         }
-                    }, this.loadLDIFs);
+                    }, () => {
+                        this.setState({
+                            replConfigLoaded: true,
+                            replConfigLoading: false,
+                            changelogLoading: true,
+                        });
+                    });
 
                     cmd = ['dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + this.props.serverId + '.socket',
                         'replication', 'get-changelog', '--suffix', suffix];
@@ -748,6 +814,12 @@ export class Replication extends React.Component {
                                         clTrimInt,
                                         clEncrypt,
                                     }
+                                }, () => {
+                                    this.setState({
+                                        changelogLoaded: true,
+                                        changelogLoading: false,
+                                        agmtsLoading: true,
+                                    });
                                 });
 
                                 // Now load agmts, then the winsync agreement, and finally the RUV
@@ -810,6 +882,12 @@ export class Replication extends React.Component {
                                                     ...this.state[suffix],
                                                     agmtRows: rows,
                                                 }
+                                            }, () => {
+                                                this.setState({
+                                                    agmtsLoaded: true,
+                                                    agmtsLoading: false,
+                                                    winsyncLoading: true,
+                                                });
                                             });
 
                                             // Load winsync agreements
@@ -872,6 +950,12 @@ export class Replication extends React.Component {
                                                                 ...this.state[suffix],
                                                                 winsyncRows: ws_rows,
                                                             }
+                                                        }, () => {
+                                                            this.setState({
+                                                                winsyncLoaded: true,
+                                                                winsyncLoading: false,
+                                                                ruvLoading: true,
+                                                            });
                                                         });
 
                                                         // Load suffix RUV
@@ -901,8 +985,12 @@ export class Replication extends React.Component {
                                                                             ...this.state[suffix],
                                                                             ruvRows: ruv_rows,
                                                                         },
+                                                                        ruvLoaded: true,
+                                                                        ruvLoading: false,
                                                                         suffixLoading: false,
-                                                                        disableTree: false
+                                                                        disableTree: false,
+                                                                    }, () => {
+                                                                        this.loadLDIFs();
                                                                     });
                                                                 })
                                                                 .fail(err => {
@@ -915,8 +1003,11 @@ export class Replication extends React.Component {
                                                                         );
                                                                     }
                                                                     this.setState({
+                                                                        ruvLoading: false,
                                                                         suffixLoading: false,
                                                                         disableTree: false
+                                                                    }, () => {
+                                                                        this.loadLDIFs();
                                                                     });
                                                                 });
                                                     })
@@ -927,8 +1018,11 @@ export class Replication extends React.Component {
                                                             cockpit.format(_("Error loading winsync agreements - $0"), errMsg.desc)
                                                         );
                                                         this.setState({
+                                                            winsyncLoading: false,
                                                             suffixLoading: false,
                                                             disableTree: false
+                                                        }, () => {
+                                                            this.loadLDIFs();
                                                         });
                                                     });
                                             })
@@ -939,8 +1033,11 @@ export class Replication extends React.Component {
                                                     cockpit.format(_("Error loading replication agreements configuration - $0"), errMsg.desc)
                                                 );
                                                 this.setState({
+                                                    agmtsLoading: false,
                                                     suffixLoading: false,
                                                     disableTree: false
+                                                }, () => {
+                                                    this.loadLDIFs();
                                                 });
                                             });
                             })
@@ -952,22 +1049,31 @@ export class Replication extends React.Component {
                                     cockpit.format(_("Error loading replication changelog configuration - $0"), errMsg.desc)
                                 );
                                 this.setState({
+                                    changelogLoading: false,
                                     suffixLoading: false,
                                     disableTree: false
+                                }, () => {
+                                    this.loadLDIFs();
                                 });
                             });
                 })
                 .fail(() => {
                     this.setState({
+                        replConfigLoading: false,
                         suffixLoading: false,
                         disableTree: false,
                         node_replicated: false
+                    }, () => {
+                        this.loadLDIFs();
                     });
                 });
     }
 
     loadAttrs() {
         // Now get the schema that various tabs use
+        this.setState({
+            attrsLoading: true,
+        });
         const attr_cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "schema", "attributetypes", "list"
@@ -983,6 +1089,19 @@ export class Replication extends React.Component {
                     }
                     this.setState({
                         attributes: attrs,
+                        attrsLoaded: true,
+                        attrsLoading: false,
+                    });
+                }).fail(err => {
+                    const errMsg = JSON.parse(err);
+                    this.props.addNotification(
+                        "error",
+                        cockpit.format(_("Error loading attributes - $0"), errMsg.desc)
+                    );
+                    this.setState({
+                        attributes: [],
+                        attrsLoaded: true,
+                        attrsLoading: false,
                     });
                 });
     }
@@ -1011,9 +1130,87 @@ export class Replication extends React.Component {
             repl_page = (
                 <div className="ds-margin-top-xlg ds-center">
                     <TextContent>
-                        <Text component={TextVariants.h3}>{_("Loading Replication Information ...")}</Text>
+                        <Text component={TextVariants.h3}>
+                            {_("Loading Replication Information ...")}
+                            <Spinner isInline className="ds-left-margin" size="lg" />
+                        </Text>
                     </TextContent>
-                    <Spinner className="ds-margin-top-lg" size="xl" />
+                    <ProgressStepper
+                        className="ds-margin-top-lg"
+                        aria-label="Progress stepper for replication loading"
+                        isCenterAligned
+                    >
+                        <ProgressStep
+                            isCurrent={this.state.suffixTreeLoading}
+                            variant={this.state.suffixTreeLoaded ? "success" : "pending"}
+                            icon={!this.state.suffixTreeLoaded ? this.state.suffixTreeLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="suffixTreeLoading"
+                            titleId="load suffix tree"
+                            aria-label="Loading suffix tree step"
+                        >
+                            {!this.state.suffixTreeLoaded ? _("Loading Suffix Tree") : _("Suffix Tree Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.attrsLoading}
+                            variant={this.state.attrsLoaded ? "success" : "pending"}
+                            icon={!this.state.attrsLoaded ? this.state.attrsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="attrsLoading"
+                            titleId="load replication attributes"
+                            aria-label="Loading replication attributes step"
+                        >
+                            {!this.state.attrsLoaded ? _("Loading Schema") : _("Schema Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.replConfigLoading}
+                            variant={this.state.replConfigLoaded ? "success" : "pending"}
+                            icon={!this.state.replConfigLoaded ? this.state.replConfigLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="replConfigLoading"
+                            titleId="load replication suffix configuration"
+                            aria-label="Loading replication configuration step"
+                        >
+                            {!this.state.replConfigLoaded ? _("Loading Replication Config") : _("Replication Config Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.changelogLoading}
+                            variant={this.state.changelogLoaded ? "success" : "pending"}
+                            icon={!this.state.changelogLoaded ? this.state.changelogLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="changelogLoading"
+                            titleId="load replication changelog settings"
+                            aria-label="Loading replication changelog step"
+                        >
+                            {!this.state.changelogLoaded ? _("Loading Changelog") : _("Changelog Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.agmtsLoading}
+                            variant={this.state.agmtsLoaded ? "success" : "pending"}
+                            icon={!this.state.agmtsLoaded ? this.state.agmtsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="agmtsLoading"
+                            titleId="load replication agreements"
+                            aria-label="Loading replication agreements step"
+                        >
+                            {!this.state.agmtsLoaded ? _("Loading Agreements") : _("Agreements Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.winsyncLoading}
+                            variant={this.state.winsyncLoaded ? "success" : "pending"}
+                            icon={!this.state.winsyncLoaded ? this.state.winsyncLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="winsyncLoading"
+                            titleId="load winsync agreements"
+                            aria-label="Loading winsync agreements step"
+                        >
+                            {!this.state.winsyncLoaded ? _("Loading Winsync Agreements") : _("Winsync Agreements Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.ruvLoading}
+                            variant={this.state.ruvLoaded ? "success" : "pending"}
+                            icon={!this.state.ruvLoaded ? this.state.ruvLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="ruvLoading"
+                            titleId="load suffix ruv"
+                            aria-label="Loading suffix ruv step"
+                        >
+                            {!this.state.ruvLoaded ? _("Loading RUV") : _("RUV Loaded")}
+                        </ProgressStep>
+                    </ProgressStepper>
                 </div>
             );
         } else {
@@ -1027,7 +1224,23 @@ export class Replication extends React.Component {
                     </div>
                 );
             } else {
-                if (this.state.node_name in this.state) {
+                if (this.state.node_name === "") {
+                    repl_element = (
+                        <div className="ds-margin-top-xlg ds-center">
+                            <TextContent>
+                                <Text component={TextVariants.h3}>{_("There are no suffixes in the database")}</Text>
+                                <Button
+                                    variant="primary"
+                                    onClick={() => {
+                                        this.loadSuffixTree(true);
+                                    }}
+                                >
+                                    {_("Refresh")}
+                                </Button>
+                            </TextContent>
+                        </div>
+                    );
+                } else if (this.state.node_name in this.state) {
                     repl_element = (
                         <div>
                             <ReplSuffix
@@ -1045,7 +1258,7 @@ export class Replication extends React.Component {
                                 reloadRUV={this.reloadRUV}
                                 reloadConfig={this.reloadConfig}
                                 reloadLDIF={this.loadLDIFs}
-                                reload={this.loadSuffixTree}
+                                reload={this.resetLoadProgress}
                                 attrs={this.state.attributes}
                                 replicated={this.state.node_replicated}
                                 enableTree={this.enableTree}
@@ -1072,7 +1285,7 @@ export class Replication extends React.Component {
                             reloadRUV={this.reloadRUV}
                             reloadLDIF={this.loadLDIFs}
                             reloadConfig={this.reloadConfig}
-                            reload={this.loadSuffixTree}
+                            reload={this.resetLoadProgress}
                             attrs={this.state.attributes}
                             replicated={this.state.node_replicated}
                             enableTree={this.enableTree}

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -12,6 +12,8 @@ import {
 	Form,
 	Grid,
 	GridItem,
+	ProgressStepper,
+	ProgressStep,
 	Spinner,
 	Switch,
 	Tab,
@@ -25,6 +27,9 @@ import {
 import TypeaheadSelect from "./dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import { SyncAltIcon } from '@patternfly/react-icons';
+import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 
 const _ = cockpit.gettext;
 
@@ -103,6 +108,44 @@ export class Security extends React.Component {
             _nssslpersonalityssl: '',
             _nssslpersonalityssllist: "",
             _nstlsallowclientrenegotiation: true,
+            isServerCertOpen: false,
+            // progress steps
+            configLoaded: false,
+            configLoading: false,
+            ciphersLoaded: false,
+            ciphersLoading: false,
+            certsLoaded: false,
+            certsLoading: false,
+            caCertsLoaded: false,
+            caCertsLoading: false,
+            csrsLoaded: false,
+            csrsLoading: false,
+            orphanKeysLoaded: false,
+            orphanKeysLoading: false,
+        };
+
+        // Server Cert
+        this.handleServerCertSelect = (event, selection) => {
+            let disableSaveBtn = !this.configChanged();
+            if (this.state._nssslpersonalityssl !== selection) {
+                disableSaveBtn = false;
+            }
+            this.setState({
+                nssslpersonalityssl: selection,
+                isServerCertOpen: false,
+                disableSaveBtn,
+            });
+        };
+        this.handleServerCertToggle = (_event, isServerCertOpen) => {
+        this.setState({
+            isServerCertOpen
+        });
+        };
+        this.handleServerCertClear = () => {
+            this.setState({
+                nssslpersonalityssl: '',
+                isServerCertOpen: false
+            });
         };
 
         // Toggle currently active tab
@@ -240,11 +283,26 @@ export class Security extends React.Component {
 
     handleReloadConfig () {
         this.setState({
-            loaded: false
+            loaded: false,
+            configLoaded: false,
+            ciphersLoaded: false,
+            certsLoaded: false,
+            caCertsLoaded: false,
+            csrsLoaded: false,
+            orphanKeysLoaded: false,
+            configLoading: false,
+            ciphersLoading: false,
+            certsLoading: false,
+            caCertsLoading: false,
+            csrsLoading: false,
+            orphanKeysLoading: false,
         }, this.loadSecurityConfig);
     }
 
     loadSupportedCiphers () {
+        this.setState({
+            ciphersLoading: true,
+        });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "security", "ciphers", "list", "--supported"
@@ -283,6 +341,8 @@ export class Security extends React.Component {
                     const config = JSON.parse(content);
                     this.setState({
                         enabledCiphers: config.items,
+                        ciphersLoaded: true,
+                        ciphersLoading: false,
                     }, this.loadCerts);
                 })
                 .fail(err => {
@@ -299,6 +359,9 @@ export class Security extends React.Component {
     }
 
     loadCACerts () {
+        this.setState({
+            caCertsLoading: true,
+        });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "security", "ca-certificate", "list",
@@ -316,6 +379,8 @@ export class Security extends React.Component {
                         {
                             CACerts: certs,
                             CACertNames: certNames,
+                            caCertsLoaded: true,
+                            caCertsLoading: false,
                         }), this.loadCSRs
                     );
                 })
@@ -333,6 +398,9 @@ export class Security extends React.Component {
     }
 
     loadCerts () {
+        this.setState({
+            certsLoading: true,
+        });
         // Set loaded: true
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
@@ -351,6 +419,8 @@ export class Security extends React.Component {
                         {
                             serverCerts: certs,
                             serverCertNames: certNames,
+                            certsLoaded: true,
+                            certsLoading: false,
                         }), this.loadCACerts
                     );
                 })
@@ -368,6 +438,9 @@ export class Security extends React.Component {
     }
 
     loadCSRs () {
+        this.setState({
+            csrsLoading: true,
+        });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "security", "csr", "list",
@@ -380,6 +453,8 @@ export class Security extends React.Component {
                     this.setState(() => (
                         {
                             serverCSRs: csrs,
+                            csrsLoaded: true,
+                            csrsLoading: false,
                         }), this.loadOrphanKeys
                     );
                 })
@@ -397,6 +472,9 @@ export class Security extends React.Component {
     }
 
     loadOrphanKeys () {
+        this.setState({
+            orphanKeysLoading: true,
+        });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "security", "key", "list", "--orphan"
@@ -406,10 +484,14 @@ export class Security extends React.Component {
                 .spawn(cmd, { superuser: true, err: "message" })
                 .done(content => {
                     const keys = JSON.parse(content);
-                    this.setState({
-                        serverOrphanKeys: keys,
-                        loaded: true
-                    }, this.props.enableTree());
+                    this.setState(() => (
+                        {
+                            serverOrphanKeys: keys,
+                            loaded: true,
+                            orphanKeysLoaded: true,
+                            orphanKeysLoading: false,
+                        }), this.props.enableTree()
+                    );
                 })
                 .fail(err => {
                     const errMsg = JSON.parse(err);
@@ -441,6 +523,8 @@ export class Security extends React.Component {
                         {
                             nssslpersonalityssl: nickname,
                             _nssslpersonalityssl: nickname,
+                            configLoaded: true,
+                            configLoading: false,
                         }
                     ), this.loadSupportedCiphers);
                 })
@@ -458,6 +542,9 @@ export class Security extends React.Component {
     }
 
     loadSecurityConfig(saving) {
+        this.setState({
+            configLoading: true,
+        });
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
             "security", "get"
@@ -1247,13 +1334,79 @@ export class Security extends React.Component {
             );
         } else {
             securityPage = (
-                <div className="ds-margin-top-xlg ds-loading-spinner ds-center">
+                <div className="ds-center">
                     <TextContent>
                         <Text component={TextVariants.h3}>
-                            {_("Loading Security Information ...")}
+                            {_("Loading Security Information")}
+                            <Spinner isInline className="ds-left-margin" size="lg" />
                         </Text>
                     </TextContent>
-                    <Spinner className="ds-margin-top-lg" size="lg" />
+                    <ProgressStepper
+                        className="ds-margin-top-lg"
+                        aria-label="Progress stepper for all the various security related info"
+                        isCenterAligned
+                    >
+                        <ProgressStep
+                            isCurrent={this.state.configLoading}
+                            variant={this.state.configLoaded ? "success" : "pending"}
+                            id="configLoading"
+                            titleId="load all the core security information"
+                            aria-label="Loading the core security information step"
+                            icon={this.state.configLoading ? <InProgressIcon /> : <CheckCircleIcon />}
+                        >
+                            {!this.state.configLoaded ? _("Loading Configuration") : _("Configuration Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.ciphersLoading}
+                            variant={this.state.ciphersLoaded ? "success" : "pending"}
+                            icon={!this.state.ciphersLoaded ? this.state.ciphersLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="cipherLoading"
+                            titleId="load all the cipher information"
+                            aria-label="Loading the cipher information step"
+                        >
+                            {!this.state.ciphersLoaded ? _("Loading Ciphers") : _("Ciphers Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.certsLoading}
+                            variant={this.state.certsLoaded ? "success" : "pending"}
+                            icon={!this.state.certsLoaded ? this.state.certsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="loadCerts"
+                            titleId="load all the certificate information"
+                            aria-label="Loading the certificate information step"
+                        >
+                            {!this.state.certsLoaded ? _("Loading Certificates") : _("Certificates Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.caCertsLoading}
+                            variant={this.state.caCertsLoaded ? "success" : "pending"}
+                            icon={!this.state.caCertsLoaded ? this.state.caCertsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="caCertsLoading"
+                            titleId="load all the CA certificate information"
+                            aria-label="Loading the CA certificate information step"
+                        >
+                            {!this.state.caCertsLoaded ? _("Loading CA Certificates") : _("CA Certificates Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.csrsLoading}
+                            variant={this.state.csrsLoaded ? "success" : "pending"}
+                            icon={!this.state.csrsLoaded ? this.state.csrsLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="csrLoading"
+                            titleId="load all the CSR information"
+                            aria-label="Loading the CSR information step"
+                        >
+                            {!this.state.csrsLoaded ? _("Loading CSRs") : _("CSRs Loaded")}
+                        </ProgressStep>
+                        <ProgressStep
+                            isCurrent={this.state.orphanKeysLoading}
+                            variant={this.state.orphanKeysLoaded ? "success" : "pending"}
+                            icon={!this.state.orphanKeysLoaded ? this.state.orphanKeysLoading ? <InProgressIcon /> : <PendingIcon /> : <CheckCircleIcon />}
+                            id="orphanKeysLoading"
+                            titleId="load all the orphan key information"
+                            aria-label="Loading the orphan key information step"
+                        >
+                            {!this.state.orphanKeysLoaded ? _("Loading Orphan Keys") : _("Orphan Keys Loaded")}
+                        </ProgressStep>
+                    </ProgressStepper>
                 </div>
             );
         }


### PR DESCRIPTION
…tion tabs

Description:

The Security, Database, and Replication tabs can take a long time to load. A progress stepper would be a nice addition to give the user feedback as to why the loading is taking so long.

The database tab took extra work to get all the cockpit API calls in an ordered nested approach.

relates: https://github.com/389ds/389-ds-base/issues/7314

Assisted-by: Cursor

## Summary by Sourcery

Add progress stepper UI feedback for long-running loads in the Security, Database, and Replication cockpit tabs and wire the loading sequence to explicit stage flags.

Enhancements:
- Introduce staged loading state tracking for database configuration, suffix tree, backups, LDIFs, and related data to support progress indication and ordered reload flows.
- Add staged loading and progress tracking for replication suffix tree, schema attributes, replication configuration, changelog, agreements, winsync, RUV, and LDIFs.
- Extend security tab loading to track and display progress across core config, ciphers, certificates, CA certificates, CSRs, and orphan keys.
- Propagate loading state into global database config components and adjust their spinners and fade transitions to rely on props rather than internal state.
- Improve ACI wizard rights selection table accessibility by labeling checkboxes with the corresponding right name.