### PR TITLE
Issue 6942 - Crash in `slapi_sdn_get_ndn()`

### DIFF
--- a/dirsrvtests/tests/suites/betxns/entrycache_dn_hash_corruption_test.py
+++ b/dirsrvtests/tests/suites/betxns/entrycache_dn_hash_corruption_test.py
@@ -1,0 +1,443 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import time
+import shutil
+import logging
+import subprocess
+import threading
+import pytest
+import ldap
+
+from lib389.topologies import topology_m2
+from lib389._mapped_object import DSLdapObject
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.idm.user import UserAccounts
+from lib389.replica import ReplicationManager
+from lib389.utils import get_default_db_lib
+from lib389.config import BDB_LDBMConfig, LMDB_LDBMConfig
+
+DEBUGGING = os.getenv('DEBUGGING', default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+PLUGIN_SOURCE = r"""
+/*
+ * dn-hash-corruption plugin
+ *
+ *   For every ADD under the configured container (default ou=test),
+ *   prepends 'x' to the uid RDN value:
+ *   uid=w1u42,ou=test,dc=example,dc=com -> uid=xw1u42,ou=test,dc=example,dc=com
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include "slapi-plugin.h"
+
+#define PLUGIN_NAME "dn-hash-corruption"
+
+/* TRIGGER_PARENT_RDN is the parent RDN prefix that selects which
+ * entries the plugin modifies.
+ */
+#ifndef TRIGGER_PARENT_RDN
+#define TRIGGER_PARENT_RDN "ou=test"
+#endif
+#define TRIGGER_PARENT_RDN_LEN (sizeof(TRIGGER_PARENT_RDN) - 1)
+
+static Slapi_PluginDesc plugin_desc = {
+    PLUGIN_NAME, "reproducer", "1.0",
+    "Triggers entry cache DN hash corruption"
+};
+static Slapi_ComponentId *plugin_id = NULL;
+
+/*
+ * betxn pre-add callback.
+ * Runs after `cache_add_tentative()` inserted the entry into `c_dntable`
+ * under the original DN, but before `CACHE_ADD()` re-inserts it.
+ * Changing the DN here puts the entry in two different hash slots.
+ */
+static int dnhashcorr_betxn_pre_add(Slapi_PBlock *pb)
+{
+    Slapi_Entry *entry = NULL;
+    const char *dn = NULL;
+    char *parent_dn = NULL;
+    char *old_uid = NULL;
+    char *new_uid = NULL;
+    char *new_dn = NULL;
+    Slapi_DN *sdn = NULL;
+
+    slapi_pblock_get(pb, SLAPI_ADD_ENTRY, &entry);
+    if (!entry) return 0;
+
+    dn = slapi_entry_get_dn_const(entry);
+    if (!dn) return 0;
+
+    /* Only target entries under the configured container */
+    parent_dn = slapi_dn_parent(dn);
+    if (!parent_dn) return 0;
+    if (strncasecmp(parent_dn, TRIGGER_PARENT_RDN, TRIGGER_PARENT_RDN_LEN) != 0) {
+        slapi_ch_free_string(&parent_dn);
+        return 0;
+    }
+
+    /* Get the current uid attribute value */
+    old_uid = slapi_entry_attr_get_charptr(entry, "uid");
+    if (!old_uid) {
+        slapi_ch_free_string(&parent_dn);
+        return 0;
+    }
+
+    /*
+     * Build new DN by prepending 'x' to the uid value.
+     * This changes the NDN hash -> entry ends up in two hash slots.
+     */
+    new_dn = slapi_ch_smprintf("uid=x%s,%s", old_uid, parent_dn);
+    slapi_ch_free_string(&parent_dn);
+    if (!new_dn) {
+        slapi_ch_free_string(&old_uid);
+        return 0;
+    }
+
+    /*
+     * Replace the entry's SDN in-place.
+     * The entry is still linked in c_dntable under the old NDN hash (slot A).
+     * After this CACHE_ADD will insert it under the new NDN hash (slot B).
+     */
+    sdn = slapi_entry_get_sdn(entry);
+    slapi_sdn_set_dn_passin(sdn, new_dn);
+    slapi_sdn_get_ndn(sdn);
+
+    /* Update uid attribute to match new RDN to avoid naming violation */
+    new_uid = slapi_ch_smprintf("x%s", old_uid);
+    slapi_entry_attr_set_charptr(entry, "uid", new_uid);
+    slapi_ch_free_string(&new_uid);
+    slapi_ch_free_string(&old_uid);
+
+    return 0;
+}
+
+static int dnhashcorr_start(Slapi_PBlock *pb)
+{
+    slapi_log_error(SLAPI_LOG_FATAL, PLUGIN_NAME, "DN hash corruption reproducer plugin started\n");
+    return 0;
+}
+
+int dnhashcorr_init(Slapi_PBlock *pb)
+{
+    int rc = 0;
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_VERSION, SLAPI_PLUGIN_VERSION_03);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_DESCRIPTION, (void *)&plugin_desc);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_START_FN, (void *)dnhashcorr_start);
+    rc |= slapi_pblock_set(pb, SLAPI_PLUGIN_BE_TXN_PRE_ADD_FN, (void *)dnhashcorr_betxn_pre_add);
+    rc |= slapi_pblock_get(pb, SLAPI_PLUGIN_IDENTITY, &plugin_id);
+    if (rc) return -1;
+    return 0;
+}
+"""
+
+CONTAINER_OU = 'test'
+WORKLOAD_DURATION = 300
+NUM_SEED = 100
+NUM_ADD_WORKERS = 4
+NUM_SEARCH_WORKERS = 4
+NUM_DELETE_WORKERS = 2
+
+PLUGIN_DN = 'cn=DN Hash Corruption,cn=plugins,cn=config'
+
+
+def _compile_and_install_plugin(inst, tmp_dir):
+    """Compile the reproducer plugin and install it into the instance's
+    plugin directory.
+    """
+    src_file = os.path.join(tmp_dir, 'dn_hash_corruption_plugin.c')
+    obj_file = os.path.join(tmp_dir, 'dn_hash_corruption_plugin.o')
+    so_file = os.path.join(tmp_dir, 'libdn-hash-corruption-plugin.so')
+
+    with open(src_file, 'w') as f:
+        f.write(PLUGIN_SOURCE)
+
+    cmd = (
+        f'/usr/bin/gcc -I/usr/include/dirsrv -I/usr/include/nspr4 '
+        f'-I/usr/include/nss3 -g -O2 -Wall '
+        f'-DTRIGGER_PARENT_RDN=\'"ou={CONTAINER_OU}"\' '
+        f'-c {src_file} -fPIC -DPIC -o {obj_file}'
+    )
+    subprocess.run(cmd, shell=True, check=True)
+
+    cmd = (
+        f'/usr/bin/gcc -shared -fPIC -DPIC {obj_file} '
+        f'-Wl,-rpath -Wl,/usr/lib64/dirsrv -L/usr/lib64/dirsrv/ '
+        f'/usr/lib64/dirsrv/libslapd.so.0 -lldap -llber -lc '
+        f'-Wl,-z,now -Wl,-soname -Wl,libdn-hash-corruption-plugin.so '
+        f'-o {so_file}'
+    )
+    subprocess.run(cmd, shell=True, check=True)
+
+    plugin_dir = inst.get_plugin_dir()
+    installed_path = os.path.join(plugin_dir,
+                                  'libdn-hash-corruption-plugin.so')
+    shutil.copy(so_file, installed_path)
+    os.chmod(installed_path, 0o755)
+    subprocess.run(['restorecon', installed_path], check=False)
+
+
+def _load_plugin(inst):
+    """Load the DN hash corruption plugin."""
+    plugin = DSLdapObject(inst, PLUGIN_DN)
+    plugin._rdn_attribute = 'cn'
+    plugin._create_objectclasses = [
+        'top',
+        'nsSlapdPlugin',
+        'extensibleObject',
+    ]
+    plugin._protected = False
+    plugin.create(properties={
+        'cn': 'DN Hash Corruption',
+        'nsslapd-pluginPath': 'libdn-hash-corruption-plugin',
+        'nsslapd-pluginInitfunc': 'dnhashcorr_init',
+        'nsslapd-pluginType': 'betxnpreoperation',
+        'nsslapd-pluginEnabled': 'on',
+        'nsslapd-plugin-depends-on-type': 'database',
+        'nsslapd-pluginId': 'dn-hash-corruption',
+        'nsslapd-pluginVersion': '1.0',
+        'nsslapd-pluginVendor': '389 Project',
+        'nsslapd-pluginDescription': 'Triggers entry cache DN hash corruption',
+    })
+
+
+def _shrink_entry_cache(inst):
+    """Shrink entry cache to create pressure."""
+    if get_default_db_lib() == 'bdb':
+        config_ldbm = BDB_LDBMConfig(inst)
+    else:
+        config_ldbm = LMDB_LDBMConfig(inst)
+    config_ldbm.set('nsslapd-cache-autosize', '0')
+
+    inst.restart()
+
+    userroot = DSLdapObject(inst, 'cn=userRoot,cn=ldbm database,cn=plugins,cn=config')
+    userroot.replace('nsslapd-cachememsize', '512000')
+
+
+def _add_worker(inst, suffix, worker_id, stop_event, error_list):
+    """Continuously adds entries under the test container."""
+    users = UserAccounts(inst, suffix, rdn=f'ou={CONTAINER_OU}')
+    n = 0
+    while not stop_event.is_set():
+        n += 1
+        uid = f'w{worker_id}u{n}'
+        try:
+            users.create(properties={
+                'uid': uid,
+                'cn': uid,
+                'sn': uid,
+                'uidNumber': str(10000 + worker_id * 10000 + n),
+                'gidNumber': '1000',
+                'homeDirectory': f'/home/{uid}',
+            })
+        except (ldap.ALREADY_EXISTS, ldap.LDAPError):
+            pass
+        except ldap.SERVER_DOWN:
+            error_list.append(f'SERVER_DOWN during add on {inst.serverid}')
+            return
+
+
+def _search_worker(inst, suffix, stop_event, error_list):
+    """Continuously searches entries to walk the DN hash chains."""
+    users = UserAccounts(inst, suffix, rdn=f'ou={CONTAINER_OU}')
+    while not stop_event.is_set():
+        try:
+            users.filter('(uid=w*)')
+        except ldap.SERVER_DOWN:
+            error_list.append(f'SERVER_DOWN during search on {inst.serverid}')
+            return
+        except ldap.LDAPError:
+            pass
+
+        try:
+            users.filter('(uid=x*)')
+        except ldap.SERVER_DOWN:
+            error_list.append(f'SERVER_DOWN during search on {inst.serverid}')
+            return
+        except ldap.LDAPError:
+            pass
+
+
+def _delete_worker(inst, suffix, stop_event, error_list):
+    """Finds and deletes plugin-renamed entries (uid=x*).
+    """
+    users = UserAccounts(inst, suffix, rdn=f'ou={CONTAINER_OU}')
+    while not stop_event.is_set():
+        try:
+            results = users.filter('(uid=x*)')
+            for entry in results[:50]:
+                try:
+                    entry.delete()
+                except (ldap.NO_SUCH_OBJECT, ldap.LDAPError):
+                    pass
+                except ldap.SERVER_DOWN:
+                    error_list.append(
+                        f'SERVER_DOWN during delete on {inst.serverid}')
+                    return
+        except ldap.SERVER_DOWN:
+            error_list.append(
+                f'SERVER_DOWN during delete-search on {inst.serverid}')
+            return
+        except ldap.LDAPError:
+            pass
+        time.sleep(0.1)
+
+
+@pytest.fixture(scope="function")
+def setup_plugin(topology_m2, request):
+    """Compile, install and load the reproducer plugin on both suppliers."""
+    S1 = topology_m2.ms["supplier1"]
+    S2 = topology_m2.ms["supplier2"]
+
+    tmp_dir = f'/tmp/dn_hash_corruption_test_{os.getpid()}'
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    log.info("Compiling and installing reproducer plugin")
+    for inst in [S1, S2]:
+        _compile_and_install_plugin(inst, tmp_dir)
+
+    log.info("Shrinking entry cache")
+    for inst in [S1, S2]:
+        _shrink_entry_cache(inst)
+
+    log.info(f"Creating test container ou={CONTAINER_OU}")
+    ous = OrganizationalUnits(S1, DEFAULT_SUFFIX)
+    ous.create(properties={'ou': CONTAINER_OU})
+
+    log.info(f"Creating {NUM_SEED} seed entries")
+    users = UserAccounts(S1, DEFAULT_SUFFIX, rdn=f'ou={CONTAINER_OU}')
+    for i in range(1, NUM_SEED + 1):
+        uid = f'seed{i}'
+        users.create(properties={
+            'uid': uid,
+            'cn': uid,
+            'sn': uid,
+            'uidNumber': str(i),
+            'gidNumber': '1000',
+            'homeDirectory': f'/home/{uid}',
+        })
+
+    repl = ReplicationManager(DEFAULT_SUFFIX)
+    repl.wait_for_replication(S1, S2, timeout=300)
+
+    log.info("Loading reproducer plugin and restarting")
+    for inst in [S1, S2]:
+        _load_plugin(inst)
+        inst.restart()
+        time.sleep(2)
+
+    for inst in [S1, S2]:
+        plugin = DSLdapObject(inst, PLUGIN_DN)
+        assert plugin.exists(), f"Plugin not found on {inst.serverid}"
+        log.info(f"Plugin loaded on {inst.serverid}")
+
+    def fin():
+        log.info("Cleaning up plugin test...")
+        if os.path.isdir(tmp_dir):
+            shutil.rmtree(tmp_dir)
+        for inst in [S1, S2]:
+            inst.restart()
+
+    request.addfinalizer(fin)
+    return S1, S2
+
+
+def test_entrycache_dn_hash_corruption(setup_plugin):
+    """Test that entry cache DN hash corruption via in-place DN change
+    does not crash the server.
+
+    :id: 7d1c0af5-1f0f-454a-8114-ea419a93a410
+    :setup: Two supplier replication topology with reproducer plugin
+    :steps:
+        1. Run concurrent add/search/delete workload for WORKLOAD_DURATION seconds
+        2. Verify both servers survived without crashing
+    :expectedresults:
+        1. Workload runs without SERVER_DOWN errors
+        2. Both servers are alive and responding
+    """
+    S1, S2 = setup_plugin
+
+    log.info(f"Starting concurrent workload for {WORKLOAD_DURATION}s")
+    stop_event = threading.Event()
+    errors = []
+    threads = []
+
+    for inst in [S1, S2]:
+        for w in range(1, NUM_ADD_WORKERS + 1):
+            t = threading.Thread(
+                target=_add_worker,
+                args=(inst, DEFAULT_SUFFIX, w, stop_event, errors),
+                daemon=True)
+            t.start()
+            threads.append(t)
+
+        for _ in range(NUM_SEARCH_WORKERS):
+            t = threading.Thread(
+                target=_search_worker,
+                args=(inst, DEFAULT_SUFFIX, stop_event, errors),
+                daemon=True)
+            t.start()
+            threads.append(t)
+
+        for _ in range(NUM_DELETE_WORKERS):
+            t = threading.Thread(
+                target=_delete_worker,
+                args=(inst, DEFAULT_SUFFIX, stop_event, errors),
+                daemon=True)
+            t.start()
+            threads.append(t)
+
+    log.info(f"Started {len(threads)} worker threads")
+
+    check_interval = 5
+    elapsed = 0
+    while elapsed < WORKLOAD_DURATION:
+        time.sleep(check_interval)
+        elapsed += check_interval
+
+        if errors:
+            log.error(f"SERVER_DOWN detected after ~{elapsed}s: {errors}")
+            break
+
+        for inst in [S1, S2]:
+            try:
+                inst.rootdse.get_attr_val_utf8('supportedLDAPVersion')
+            except ldap.SERVER_DOWN:
+                errors.append(f'{inst.serverid} crashed after ~{elapsed}s')
+                break
+            except ldap.LDAPError:
+                pass
+        if errors:
+            break
+
+        if elapsed % 30 == 0:
+            log.info(f"  {elapsed}s elapsed - servers still running...")
+
+    stop_event.set()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, (f"Server crashed during workload! Errors: {errors}")
+
+    for inst in [S1, S2]:
+        assert inst.status(), f"{inst.serverid} is not responding"
+        log.info(f"{inst.serverid} survived the workload")
+
+    log.info(f"Test PASSED: Both servers survived {WORKLOAD_DURATION}s workload")

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -361,6 +361,9 @@ struct backentry
     uint64_t ep_weight;             /* for cache eviction */
     bool ep_is_dynamic;             /* is the entry a dynamic entry and must be
                                      * removed from cache asap */
+    char *ep_dn_hash_ndn;           /* saved NDN from tentative add, used to
+                                     * remove stale hash entry if the DN was
+                                     * changed in-place */
 };
 
 /* From ep_type through ep_create_time MUST be identical to backcommon */

--- a/ldap/servers/slapd/back-ldbm/backentry.c
+++ b/ldap/servers/slapd/back-ldbm/backentry.c
@@ -31,6 +31,7 @@ backentry_free(struct backentry **bep)
     if (ep->ep_mutexp != NULL) {
         PR_DestroyMonitor(ep->ep_mutexp);
     }
+    slapi_ch_free_string(&ep->ep_dn_hash_ndn);
     slapi_ch_free((void **)&ep);
     *bep = NULL;
 }

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -278,6 +278,53 @@ remove_hash(Hashtable *ht, const void *key, uint32_t keylen)
     return 0;
 }
 
+/*
+ * cache_remove_dn_hash - Remove an entry from the DN hash table
+ * using its current normalized DN.
+ *
+ * This must be called while holding the cache lock (CACHE_LOCK).
+ */
+void
+cache_remove_dn_hash(struct cache *cache, struct backentry *e)
+{
+    const char *ndn = slapi_sdn_get_ndn(backentry_get_sdn(e));
+    if (ndn) {
+        remove_hash(cache->c_dntable, (void *)ndn, strlen(ndn));
+    }
+}
+
+/*
+ * remove_hash_entry - Remove a specific entry pointer from a hash table,
+ * using a saved key to locate the correct hash slot.
+ *
+ * This is used when an entry's DN has been changed in-place after it was added
+ * to c_dntable.
+ *
+ * Returns 1 if the entry was found and removed, 0 otherwise.
+ */
+static int
+remove_hash_entry(Hashtable *ht, const void *key, uint32_t keylen, void *entry)
+{
+    u_long val = HASH_VALUE(key, keylen);
+    u_long slot = val % ht->size;
+    void *e = ht->slot[slot];
+    void *laste = NULL;
+
+    while (e) {
+        if (e == entry) {
+            if (laste)
+                HASH_NEXT(ht, laste) = HASH_NEXT(ht, e);
+            else
+                ht->slot[slot] = HASH_NEXT(ht, e);
+            HASH_NEXT(ht, e) = NULL;
+            return 1;
+        }
+        laste = e;
+        e = HASH_NEXT(ht, e);
+    }
+    return 0;
+}
+
 #ifdef LDAP_CACHE_DEBUG
 void
 dump_hash(Hashtable *ht)
@@ -1762,6 +1809,36 @@ entrycache_add_int(struct cache *cache, struct backentry *e, int state, struct b
     }
 
     cache_lock(cache);
+
+    /*
+     * If we are confirming a tentative add (state==0, entry is CREATING),
+     * the entry is already in c_dntable under its original DN. If the DN
+     * was changed between cache_add_tentative() and this CACHE_ADD() call
+     * (e.g. by the bz628300 parent-DN adjustment in id2entry_add_ext, or
+     * by a betxn pre-add plugin), we must remove the stale old-DN hash
+     * reference BEFORE inserting under the new DN. Otherwise the entry
+     * ends up in two hash slots and the old slot becomes a dangling pointer
+     * after the entry is freed -> use-after-free crash in entry_same_dn().
+     */
+    if ((e->ep_state & ENTRY_STATE_CREATING) && (state == 0)) {
+        if (e->ep_dn_hash_ndn) {
+            if (remove_hash_entry(cache->c_dntable,
+                    e->ep_dn_hash_ndn,
+                    strlen(e->ep_dn_hash_ndn), e)) {
+                /*
+                 * Set `already_in = 1` because the tentative add already
+                 * counted this entry in `c_stats`. This flag is checked
+                 * later when `add_hash(cache->c_idtable, ...)` fails
+                 * (the ID is already in `c_idtable` from the tentative add),
+                 * so the failure is expected and we return success instead
+                 * of an error.
+                 */
+                already_in = 1;
+            }
+            slapi_ch_free_string(&e->ep_dn_hash_ndn);
+        }
+    }
+
     if (!add_hash(cache->c_dntable, (void *)ndn, strlen(ndn), e,
                   (void **)&my_alt)) {
         LOG("entry \"%s\" already in dn cache\n", ndn);
@@ -1888,6 +1965,16 @@ entrycache_add_int(struct cache *cache, struct backentry *e, int state, struct b
 
     e->ep_state &= ~ENTRY_STATE_UNAVAILABLE;
     e->ep_state |= state;
+
+    /*
+     * When this is a tentative add, save the NDN,
+     * so we can remove the entry from `c_dntable` later
+     * if the DN is changed in-place before confirmation.
+     */
+    if (state == ENTRY_STATE_CREATING) {
+        slapi_ch_free_string(&e->ep_dn_hash_ndn);
+        e->ep_dn_hash_ndn = slapi_ch_strdup(ndn);
+    }
 
     if (!already_in) {
         e->ep_refcnt = 1;

--- a/ldap/servers/slapd/back-ldbm/id2entry.c
+++ b/ldap/servers/slapd/back-ldbm/id2entry.c
@@ -148,6 +148,9 @@ id2entry_add_ext(backend *be, struct backentry *e, back_txn *txn, int encrypt, i
                         Slapi_DN *sdn = slapi_entry_get_sdn(e->ep_entry);
                         char *newdn = NULL;
                         CACHE_LOCK(&inst->inst_cache);
+                        /* Remove the entry from the DN hash table under
+                         * the old DN before changing it. */
+                        cache_remove_dn_hash(&inst->inst_cache, e);
                         slapi_sdn_done(sdn);
                         newdn = slapi_ch_smprintf("%s,%s", myrdn, parentdn);
                         slapi_sdn_init_dn_passin(sdn, newdn);

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -55,6 +55,7 @@ struct backentry *cache_find_id(struct cache *cache, ID id);
 struct backentry *cache_find_uuid(struct cache *cache, const char *uuid);
 int cache_add(struct cache *cache, void *ptr, void **alt);
 int cache_add_tentative(struct cache *cache, struct backentry *e, struct backentry **alt);
+void cache_remove_dn_hash(struct cache *cache, struct backentry *e);
 int cache_lock_entry(struct cache *cache, struct backentry *e);
 void cache_unlock_entry(struct cache *cache, struct backentry *e);
 int cache_replace(struct cache *cache, void *oldptr, void *newptr);


### PR DESCRIPTION
Bug Description:
In `id2entry_add_ext()` we have a workaround that normalizes entry DN against the parent's cached DN to fix case difference (bz628300). But `cache_add_tentative()` has already inserted the entry into the `c_dntable` hash table under the old normalized DN (slot A). When the workaround for bz628300 changes the DN in-place, the subsequent `CACHE_ADD()` inserts the entry into `c_dntable` under the new normalized DN (slot B). The entry now exists in 2 hash slots at the same time. And when the entry is later freed or evicted, only slot B is cleaned up. Slot A still contains a dangling pointer to the freed memory. Any further operation that walks the slot A hash chain (search via `id2entry` or delete via `cache_find_dn`), calls `entry_same_dn()`, which dereferences the dangling pointer, leading to SIGSEGV.

Fix Description:

1. In `id2entry_add_ext()` call `cache_remove_dn_hash()` under CACHE_LOCK immediately before the bz628300 DN change to remove the entry from its current hash slot.

2. In `entrycache_add_int()` when confirming a tentative add, call `remove_hash_entry()` to find and remove the entry by pointer. This is needed as a safety net because a betxn pre-add plugin may have already changed the DN before the bz628300 code runs.

Fixes: https://github.com/389ds/389-ds-base/issues/6942

## Summary by Sourcery

Prevent DN hash table corruption and crashes when an entry's DN changes after tentative cache insertion.

Bug Fixes:
- Ensure entries are removed from the DN cache under their old normalized DN before in-place DN changes in id2entry_add_ext to avoid duplicate hash slots and dangling pointers.
- Add a safety-net removal of cache entries by pointer when confirming tentative adds so DN changes by betxn pre-add plugins cannot leave stale hash entries.

Enhancements:
- Introduce helper functions to remove cache entries from DN and generic hash tables to keep cache state consistent.

Tests:
- Add a stress test with a custom betxn pre-add plugin that mutates DNs under load to reproduce the DN hash corruption scenario and verify servers do not crash.