### PR TITLE
Issue 7319 - UI - Action menu for certificates remains in empty certificate list

### DIFF
--- a/src/cockpit/389-console/src/lib/security/securityTables.jsx
+++ b/src/cockpit/389-console/src/lib/security/securityTables.jsx
@@ -601,11 +601,13 @@ class CertTable extends React.Component {
                                             {cell.content}
                                         </Td>
                                     ))}
-                                    <Td isActionCell>
-                                        <ActionsColumn
-                                            items={this.getActionsForRow(row)}
-                                        />
-                                    </Td>
+                                    {hasRows && (
+                                        <Td isActionCell>
+                                            <ActionsColumn
+                                                items={this.getActionsForRow(row)}
+                                            />
+                                        </Td>
+                                    )}
                                 </Tr>
                                 {row.isOpen && (
                                     <Tr isExpanded={true}>


### PR DESCRIPTION
Description:
Action buttons were displayed even when tables were empty

Fix:
Added hasRows condition to pnly show actions when the table contains data

Fixes: https://github.com/389ds/389-ds-base/issues/7319

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Prevent action menus from appearing on rows when the certificate table has no data.