### PR TITLE
Issue 7265 - CI - fix retro changelog maxage validation test

### DIFF
--- a/dirsrvtests/tests/suites/replication/changelog_test.py
+++ b/dirsrvtests/tests/suites/replication/changelog_test.py
@@ -215,14 +215,10 @@ def add_and_check(topo, plugin, attr, val, isvalid):
                 log.fatal('%s does not have expected (%s: %s)' % (plugin, attr, val))
                 assert False
         else:
-            if plugin == CHANGELOG:
-                if entries[0].hasValue(attr, val):
-                    log.fatal('%s has unexpected (%s: %s)' % (plugin, attr, val))
-                    assert False
-            else:
-                if not entries[0].hasValue(attr, val):
-                    log.fatal('%s does not have expected (%s: %s)' % (plugin, attr, val))
-                    assert False
+            if entries[0].hasValue(attr, val):
+                log.fatal('%s has unexpected (%s: %s)' % (plugin, attr, val))
+                assert False
+
     except ldap.LDAPError as e:
         log.fatal('Unable to search for entry %s: error %s' % (plugin, e.message['desc']))
         assert False


### PR DESCRIPTION
Description:

Previously the retro changelog allowed invalid values even though they are ignored, but not they are rejected and the CI test needs to be updated

relates: https://github.com/389ds/389-ds-base/issues/7265

## Summary by Sourcery

Tests:
- Adjust changelog_test to consistently treat the presence of certain attribute values as unexpected, removing the special-case handling for the CHANGELOG plugin.