### PR TITLE
Issue 7325 - UI - create an error parser for cockpit spawn errors

### DIFF
--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -477,3 +477,28 @@ export function parentExists(params) {
             })
     });
 }
+
+// Parse a cockpit spawn API error message it can be a string or a JSON object
+export function getApiErrorMessage(err) {
+    const fallback = _("Unknown error");
+    if (err === null || err === undefined) {
+        return fallback;
+    }
+
+    // cockpit.spawn with err:"message" can return either JSON or plain text.
+    const raw = typeof err === "string" ? err : err.toString();
+    try {
+        const errObj = JSON.parse(raw);
+        if (errObj && typeof errObj === "object") {
+            let msg = errObj.desc || errObj.message || raw;
+            if ("info" in errObj && errObj.info) {
+                msg = `${msg} - ${errObj.info}`;
+            }
+            return msg;
+        }
+    } catch (e) {
+        // JSON errors fall through and are returned as plain text.
+    }
+
+    return raw || fallback;
+}


### PR DESCRIPTION
Description:

When we call cockpit spawn and one of our CLI tools the error message can either be in JSON or plain text. We should have a universal parser to properly handle these types, because right now there are places were the browser crashes because it thinks the error should be in JSON when it's just a string.

relates: https://github.com/389ds/389-ds-base/issues/7325

## Summary by Sourcery

Enhancements:
- Introduce a generic error parsing utility that converts cockpit spawn errors into user-friendly messages with sensible fallbacks.