### PR TITLE
Issue 7327 - dsctl healthcheck DSMOLE0001 inaccurate recommendations with multiple backends

### DIFF
--- a/dirsrvtests/tests/suites/memberof_plugin/memberof_include_scopes_test.py
+++ b/dirsrvtests/tests/suites/memberof_plugin/memberof_include_scopes_test.py
@@ -10,6 +10,7 @@ import pytest
 import os
 import ldap
 import time
+from lib389.backend import Backends
 from lib389.utils import ensure_str
 from lib389.topologies import topology_st as topo
 from lib389._constants import *
@@ -17,6 +18,8 @@ from lib389.plugins import MemberOfPlugin, ReferentialIntegrityPlugin
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.idm.group import Group, Groups
 from lib389.idm.nscontainer import nsContainers
+from lib389.idm.domain import Domain
+from lib389.idm.organizationalunit import OrganizationalUnit
 
 SUBTREE_1 = 'cn=sub1,%s' % SUFFIX
 SUBTREE_2 = 'cn=sub2,%s' % SUFFIX
@@ -130,6 +133,89 @@ def test_multiple_scopes(topo):
     group = Group(topo.standalone,  dn=GROUP_DN)
     assert not group.present("member", INCLUDED_USER)
     assert not group.present("member", EXCLUDED_USER)
+
+def test_memberof_scope_multiple_backends(topology_st):
+    """Test memberOf plugin correctly handles multiple backends with different scopes
+
+    :id: 96419128-70a4-4a81-943e-8d1e9c92f241
+    :setup: Instance with multiple backends
+    :steps:
+        1. Create out of scope backend
+        2. Create domain and OU's for out of scope backend
+        3. Create groups and users in both backends
+        4. Enable MO plugin and set scope to backend 1
+        5. Add users to groups in both backends
+        6. Verify in scope user has memberOf attr value of in scope group dn
+        7. Verify out scope user has an empty memberOf attr value
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success, trigger MO update
+        6. Success
+        7. Success
+    """
+    inst = topology_st.standalone
+    outscope_suffix = 'dc=other,dc=org'
+
+    # Create a backend 2
+    backends = Backends(inst)
+    outscope_be = backends.create(properties={
+        'cn': 'testBackend',
+        'nsslapd-suffix': outscope_suffix
+    })
+
+    # Create domain entry for backend 2
+    domain = Domain(inst, outscope_suffix)
+    domain.create(properties={
+        'dc': 'other'
+    })
+
+    # Create OUs for backend 2
+    people_ou = OrganizationalUnit(inst, f'ou=People,{outscope_suffix}')
+    people_ou.create(properties={'ou': 'People'})
+    groups_ou = OrganizationalUnit(inst, f'ou=Groups,{outscope_suffix}')
+    groups_ou.create(properties={'ou': 'Groups'})
+
+    # Create test groups and users
+    inscope_users = UserAccounts(inst, 'dc=example,dc=com')
+    inscope_groups = Groups(inst, 'dc=example,dc=com')
+    inscope_user = inscope_users.create_test_user(uid=1000)
+    inscope_group = inscope_groups.create(properties={'cn': 'testgroup1'})  # NO MEMBERS initially
+
+    outscope_users = UserAccounts(inst, outscope_suffix)
+    outscope_groups = Groups(inst, outscope_suffix)
+    outscope_user = outscope_users.create_test_user(uid=2000)
+    outscope_group = outscope_groups.create(properties={'cn': 'testgroup2'})  # NO MEMBERS initially
+
+    # Configure memberof plugin with backend 1 scope
+    memberof = MemberOfPlugin(inst)
+    memberof.enable()
+    memberof.replace('memberOfEntryScope', 'dc=example,dc=com')
+    inst.restart()
+
+    # Trigger memberof processing
+    inscope_group.add('member', inscope_user.dn)
+    outscope_group.add('member', outscope_user.dn)
+
+    # Sleep for a bit
+    time.sleep(2)
+
+    # In scope user should have memberOf attribute
+    inscope_user_entry = inscope_user.get_attrs_vals_utf8(['memberOf'])
+    assert inscope_user_entry['memberOf'] == [inscope_group.dn]
+
+    # Out of scope user should not have memberOf attribute
+    outscope_user_entry = outscope_user.get_attrs_vals_utf8(['memberOf'])
+    assert outscope_user_entry['memberOf'] == []
+
+    # Cleanup
+    inscope_group.delete()
+    inscope_user.delete()
+    outscope_group.delete()
+    outscope_user.delete()
+    outscope_be.delete()
 
 if __name__ == '__main__':
     # Run isolated

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -794,16 +794,21 @@ class MemberOfPlugin(Plugin):
             from lib389.backend import Backends
             backends = Backends(self._instance).list()
             attrs = self.get_attr_vals_utf8_l("memberofgroupattr")
-            container = self.get_attr_val_utf8_l("nsslapd-plugincontainerscope")
+            scopes = self.get_attr_vals_utf8_l("memberofentryscope")
             for backend in backends:
                 suffix = backend.get_attr_val_utf8_l('nsslapd-suffix')
                 if suffix == "cn=changelog":
                     # Always skip retro changelog
                     continue
-                if container is not None:
-                    # Check if this backend is in the scope
-                    if not container.endswith(suffix):
-                        # skip this backend that is not in the scope
+                if scopes:
+                    # Is this backend suffix in scope
+                    in_scope = False
+                    for scope in scopes:
+                        if scope.endswith(suffix):
+                            in_scope = True
+                            break
+
+                    if not in_scope:
                         continue
                 indexes = backend.get_indexes()
                 for attr in attrs:
@@ -842,16 +847,21 @@ class MemberOfPlugin(Plugin):
             from lib389.backend import Backends
             backends = Backends(self._instance).list()
             membership_attrs = ['member', 'uniquemember']
-            container = self.get_attr_val_utf8_l("nsslapd-plugincontainerscope")
+            scopes = self.get_attr_vals_utf8_l("memberofentryscope")
             for backend in backends:
                 suffix = backend.get_attr_val_utf8_l('nsslapd-suffix')
                 if suffix == "cn=changelog":
                     # Always skip retro changelog
                     continue
-                if container is not None:
-                    # Check if this backend is in the scope
-                    if not container.endswith(suffix):
-                        # skip this backend that is not in the scope
+                if scopes:
+                    # Is this backend suffix in scope
+                    in_scope = False
+                    for scope in scopes:
+                        if scope.endswith(suffix):
+                            in_scope = True
+                            break
+
+                    if not in_scope:
                         continue
                 indexes = backend.get_indexes()
                 for attr in membership_attrs:

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -804,7 +804,7 @@ class MemberOfPlugin(Plugin):
                     # Is this backend suffix in scope
                     in_scope = False
                     for scope in scopes:
-                        if scope.endswith(suffix):
+                        if suffix.endswith(scope):
                             in_scope = True
                             break
 
@@ -857,7 +857,7 @@ class MemberOfPlugin(Plugin):
                     # Is this backend suffix in scope
                     in_scope = False
                     for scope in scopes:
-                        if scope.endswith(suffix):
+                        if suffix.endswith(scope):
                             in_scope = True
                             break
 

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -804,7 +804,7 @@ class MemberOfPlugin(Plugin):
                     # Is this backend suffix in scope
                     in_scope = False
                     for scope in scopes:
-                        if suffix.endswith(scope):
+                        if scope.endswith(suffix) or suffix.endswith(scope):
                             in_scope = True
                             break
 
@@ -857,7 +857,7 @@ class MemberOfPlugin(Plugin):
                     # Is this backend suffix in scope
                     in_scope = False
                     for scope in scopes:
-                        if suffix.endswith(scope):
+                        if scope.endswith(suffix) or suffix.endswith(scope):
                             in_scope = True
                             break
 


### PR DESCRIPTION
Description:
The dsctl healthcheck tool generates incorrect recommendations for the MO plugin when multiple backends are present. This commonly occurs in IPA environments where both userroot and ipaca backends exist. Healthcheck incorrectly suggests indexing attributes for backends that are not within the MemberOf plugin scope.

Fix:
Determine the MO plugin scope while iterating over backends and only generate recommendations for backends that fall within that scope.

Removed references to nsslapd-plugincontainerscope as we dont use it.

Fixes:
https://github.com/389ds/389-ds-base/issues/7327

Reviewed by:

## Summary by Sourcery

Update MemberOf plugin healthcheck logic to respect the plugin’s configured entry scopes when checking backend indexes.

Bug Fixes:
- Ensure dsctl healthcheck only recommends MemberOf-related indexes for backends that fall within the plugin’s configured entry scopes instead of all backends.
- Remove use of the deprecated/unused nsslapd-plugincontainerscope attribute in MemberOf healthcheck validations.