### PR TITLE
Issue 4148 - Add unit tests for CSN clock error handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1988,6 +1988,7 @@ test_slapd_SOURCES = test/main.c \
 	test/libslapd/operation/v3_compat.c \
 	test/libslapd/spal/meminfo.c \
 	test/libslapd/haproxy/parse.c \
+	test/libslapd/csngen/clock_error.c \
 	test/plugins/test.c \
 	test/plugins/pwdstorage/pbkdf2.c
 

--- a/ldap/servers/slapd/csngen.c
+++ b/ldap/servers/slapd/csngen.c
@@ -166,6 +166,14 @@ csngen_free(CSNGen **gen)
     slapi_ch_free((void **)gen);
 }
 
+void
+csngen_set_gettime(CSNGen *gen, int32_t (*gettime)(struct timespec *tp))
+{
+    if (gen) {
+        gen->gettime = gettime;
+    }
+}
+
 int
 csngen_new_csn(CSNGen *gen, CSN **csn, PRBool notify)
 {

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -244,6 +244,8 @@ typedef struct csngen CSNGen;
 CSNGen *csngen_new(ReplicaId rid, Slapi_Attr *state);
 /* frees csn generator data structure */
 void csngen_free(CSNGen **gen);
+/* overrides the clock source used by the generator (for testing) */
+void csngen_set_gettime(CSNGen *gen, int32_t (*gettime)(struct timespec *tp));
 /* generates new csn. If notify is non-zero, the generator calls
    "generate" functions registered through csngen_register_callbacks call */
 int csngen_new_csn(CSNGen *gen, CSN **csn, PRBool notify);

--- a/test/libslapd/csngen/clock_error.c
+++ b/test/libslapd/csngen/clock_error.c
@@ -1,0 +1,187 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2026 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#include "../../test_slapd.h"
+#include <slapi-private.h>
+#include <time.h>
+
+/* Mock clock globals */
+static int mock_clock_should_fail = 0;
+static time_t mock_clock_time = 0;
+static time_t mock_clock_jump = 0;
+
+static int32_t
+mock_clock_gettime_fail(struct timespec *tp)
+{
+    if (mock_clock_should_fail) {
+        return -1;
+    }
+    
+    if (mock_clock_time == 0) {
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        mock_clock_time = now.tv_sec;
+    } else if (mock_clock_jump != 0) {
+        mock_clock_time += mock_clock_jump;
+        mock_clock_jump = 0;
+    } else {
+        mock_clock_time += 1;
+    }
+    
+    tp->tv_sec = mock_clock_time;
+    tp->tv_nsec = 0;
+    return 0;
+}
+
+void
+test_libslapd_csngen_clock_failure(void **state __attribute__((unused)))
+{
+    CSNGen *gen = csngen_new(1, NULL);
+    CSN *csn = NULL;
+    int rc;
+
+    assert_non_null(gen);
+    csngen_set_gettime(gen, mock_clock_gettime_fail);
+    
+    mock_clock_should_fail = 0;
+    mock_clock_time = 0;
+    mock_clock_jump = 0;
+    
+    rc = csngen_new_csn(gen, &csn, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    csn_free(&csn);
+    
+    mock_clock_should_fail = 1;
+    rc = csngen_new_csn(gen, &csn, PR_FALSE);
+    assert_int_equal(rc, CSN_TIME_ERROR);
+    /* Note: csn may not be set to NULL on error, just check return code */
+    
+    csngen_free(&gen);
+}
+
+void
+test_libslapd_csngen_large_time_jump(void **state __attribute__((unused)))
+{
+    CSNGen *gen = csngen_new(1, NULL);
+    CSN *csn1 = NULL;
+    CSN *csn2 = NULL;
+    int rc;
+
+    assert_non_null(gen);
+    csngen_set_gettime(gen, mock_clock_gettime_fail);
+    
+    mock_clock_should_fail = 0;
+    mock_clock_time = 0;
+    mock_clock_jump = 0;
+    
+    rc = csngen_new_csn(gen, &csn1, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    
+    mock_clock_jump = 31 * 24 * 60 * 60;
+    rc = csngen_new_csn(gen, &csn2, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    assert_true(csn_compare(csn1, csn2) < 0);
+    
+    csn_free(&csn1);
+    csn_free(&csn2);
+    csngen_free(&gen);
+}
+
+void
+test_libslapd_csngen_time_backwards(void **state __attribute__((unused)))
+{
+    CSNGen *gen = csngen_new(1, NULL);
+    CSN *csn1 = NULL;
+    CSN *csn2 = NULL;
+    int rc;
+
+    assert_non_null(gen);
+    csngen_set_gettime(gen, mock_clock_gettime_fail);
+    
+    mock_clock_should_fail = 0;
+    mock_clock_time = 0;
+    mock_clock_jump = 0;
+    
+    rc = csngen_new_csn(gen, &csn1, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    
+    mock_clock_jump = -3600;
+    rc = csngen_new_csn(gen, &csn2, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    assert_true(csn_compare(csn1, csn2) < 0);
+    
+    csn_free(&csn1);
+    csn_free(&csn2);
+    csngen_free(&gen);
+}
+
+void
+test_libslapd_csngen_multiple_clock_failures(void **state __attribute__((unused)))
+{
+    CSNGen *gen = csngen_new(1, NULL);
+    CSN *csn = NULL;
+    int rc;
+
+    assert_non_null(gen);
+    csngen_set_gettime(gen, mock_clock_gettime_fail);
+    
+    mock_clock_should_fail = 0;
+    mock_clock_time = 0;
+    mock_clock_jump = 0;
+    
+    rc = csngen_new_csn(gen, &csn, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    csn_free(&csn);
+    
+    mock_clock_should_fail = 1;
+    for (int i = 0; i < 5; i++) {
+        rc = csngen_new_csn(gen, &csn, PR_FALSE);
+        assert_int_equal(rc, CSN_TIME_ERROR);
+        /* Note: csn may not be set to NULL on error, just check return code */
+    }
+    
+    mock_clock_should_fail = 0;
+    rc = csngen_new_csn(gen, &csn, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    csn_free(&csn);
+    
+    csngen_free(&gen);
+}
+
+void
+test_libslapd_csngen_seqnum_handling(void **state __attribute__((unused)))
+{
+    CSNGen *gen = csngen_new(1, NULL);
+    CSN *csn1 = NULL;
+    CSN *csn2 = NULL;
+    CSN *csn3 = NULL;
+    int rc;
+
+    assert_non_null(gen);
+    csngen_set_gettime(gen, mock_clock_gettime_fail);
+
+    mock_clock_should_fail = 0;
+    mock_clock_time = 0;
+    mock_clock_jump = 0;
+
+    rc = csngen_new_csn(gen, &csn1, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+
+    rc = csngen_new_csn(gen, &csn2, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    assert_true(csn_compare(csn1, csn2) < 0);
+
+    rc = csngen_new_csn(gen, &csn3, PR_FALSE);
+    assert_int_equal(rc, CSN_SUCCESS);
+    assert_true(csn_compare(csn2, csn3) < 0);
+
+    csn_free(&csn1);
+    csn_free(&csn2);
+    csn_free(&csn3);
+    csngen_free(&gen);
+}

--- a/test/libslapd/test.c
+++ b/test/libslapd/test.c
@@ -46,6 +46,12 @@ run_libslapd_tests(void)
         cmocka_unit_test(test_haproxy_netmask_precomputation),
         cmocka_unit_test(test_haproxy_ip_matches_cidr),
         cmocka_unit_test(test_haproxy_ipv4_mask_edge_cases),
+        /* CSN Generator clock error tests (Bug 1837105) */
+        cmocka_unit_test(test_libslapd_csngen_clock_failure),
+        cmocka_unit_test(test_libslapd_csngen_large_time_jump),
+        cmocka_unit_test(test_libslapd_csngen_time_backwards),
+        cmocka_unit_test(test_libslapd_csngen_multiple_clock_failures),
+        cmocka_unit_test(test_libslapd_csngen_seqnum_handling),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/test_slapd.h
+++ b/test/test_slapd.h
@@ -68,6 +68,13 @@ void test_haproxy_netmask_precomputation(void **state);
 void test_haproxy_ip_matches_cidr(void **state);
 void test_haproxy_ipv4_mask_edge_cases(void **state);
 
+/* libslapd-csngen-clock-error (Bug 1837105 / Issue #4148) */
+void test_libslapd_csngen_clock_failure(void **state);
+void test_libslapd_csngen_large_time_jump(void **state);
+void test_libslapd_csngen_time_backwards(void **state);
+void test_libslapd_csngen_multiple_clock_failures(void **state);
+void test_libslapd_csngen_seqnum_handling(void **state);
+
 /* plugins */
 
 void test_plugin_hello(void **state);


### PR DESCRIPTION
Description: Add 5 CMOCKA unit tests validating CSN generator properly handles clock failures and time skew detection.

Relates: https://github.com/389ds/389-ds-base/issues/4148

Reviewed by: ???

## Summary by Sourcery

Add unit tests for CSN generator clock error and time-skew handling in libslapd and wire them into the test binary build.

Build:
- Include the new CSN generator clock error test source file in the test_slapd build configuration.

Tests:
- Introduce CMocka tests covering CSN generator behavior on clock failures, large forward jumps, backward time shifts, repeated failures, and sequence number progression.