### PR TITLE
Issue - UI - Improve suffix import LDIF table

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseTables.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseTables.jsx
@@ -504,7 +504,8 @@ class LDIFTable extends React.Component {
                 { title: _("LDIF File"), sortable: true },
                 { title: _("Creation Date"), sortable: true },
                 { title: _("File Size"), sortable: true },
-                { title: _("Actions"), screenReaderText: _("LDIF file actions") }
+                { title: _("Suffix"), sortable: true },
+                { title: "", screenReaderText: _("Import the LDIF file") }
             ],
         };
 
@@ -532,6 +533,7 @@ class LDIFTable extends React.Component {
                     this.props.confirmImport(name);
                 }}
                 title={_("Initialize the database with this LDIF file")}
+                size="sm"
             >
                 {_("Import")}
             </Button>
@@ -568,13 +570,6 @@ class LDIFTable extends React.Component {
             page: 1,
         });
     }
-
-    getActionsForRow = (rowData) => [
-        {
-            title: _("Import LDIF File"),
-            onClick: () => this.props.confirmImport(rowData[0])
-        }
-    ];
 
     render() {
         const { columns, rows, perPage, page, sortBy } = this.state;
@@ -618,9 +613,7 @@ class LDIFTable extends React.Component {
                                 {/* Only render the action column if we have rows */}
                                 {hasRows && (
                                     <Td isActionCell>
-                                        <ActionsColumn
-                                            items={this.getActionsForRow(row)}
-                                        />
+                                        {this.getImportButton(row[0])}
                                     </Td>
                                 )}
                             </Tr>


### PR DESCRIPTION
Description:

Under a suffix you can initialize the database using a table of available LDIF files. There is an action column with just one option (to import it). This should just be a single button since there are no other options available.

relates: https://github.com/389ds/389-ds-base/issues/7331

## Summary by Sourcery

Enhancements:
- Replace the actions dropdown in the LDIF table with a single inline import button for each row and adjust the column layout accordingly.