### PR TITLE
Issue 7325 - UI - new error parser missing import

### DIFF
--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -1,5 +1,7 @@
 import cockpit from "cockpit";
 
+const _ = cockpit.gettext;
+
 export function searchFilter(searchFilterValue, columnsToSearch, rows) {
     if (searchFilterValue && rows && rows.length) {
         const filteredRows = [];


### PR DESCRIPTION
Description:

Missing import for cockpit.gettext

relates: https://github.com/389ds/389-ds-base/issues/7325

## Summary by Sourcery

Bug Fixes:
- Fix missing cockpit.gettext import required by the new error parser and related UI code.