### PR TITLE
Issue 7322 - Reject adding a replication agreement that points to itself

### DIFF
--- a/dirsrvtests/tests/suites/replication/acceptance_test.py
+++ b/dirsrvtests/tests/suites/replication/acceptance_test.py
@@ -693,6 +693,22 @@ def test_invalid_agmt(topo_m4):
         assert False
 
 
+def test_reject_self_referential_agmt(topo_m4):
+    """Test that creating a replication agreement pointing to self is rejected
+
+    :id: 7df2f91a-878b-4a7e-86f7-4f72ef5726c6
+    :setup: MMR with four suppliers
+    :steps:
+        1. Try to add an agreement on supplier1 that points to supplier1 host/port
+    :expectedresults:
+        1. Agreement creation should fail with UNWILLING_TO_PERFORM
+    """
+    m1 = topo_m4.ms["supplier1"]
+
+    with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+        m1.agreement.create(suffix=DEFAULT_SUFFIX, host=m1.host, port=m1.port)
+
+
 def test_warning_for_invalid_replica(topo_m4):
     """Testing logs to indicate the inconsistency when configuration is performed.
 

--- a/ldap/servers/plugins/replication/repl5.h
+++ b/ldap/servers/plugins/replication/repl5.h
@@ -715,7 +715,8 @@ void replica_set_updatedn(Replica *r, const Slapi_ValueSet *vs, int mod_op);
 void replica_set_groupdn(Replica *r, const Slapi_ValueSet *vs, int mod_op);
 char *replica_get_generation(const Replica *r);
 bool replica_check_validity(Replica *replica);
-
+int replica_get_port(Replica *r);
+int replica_get_secure_port(Replica *r);
 
 /* currently supported flags */
 #define REPLICA_LOG_CHANGES 0x1 /* enable change logging */

--- a/ldap/servers/plugins/replication/repl5_agmtlist.c
+++ b/ldap/servers/plugins/replication/repl5_agmtlist.c
@@ -26,6 +26,8 @@
 #define CONFIG_FILTER "(objectclass=nsds5replicationagreement)"
 #define WINDOWS_CONFIG_FILTER "(objectclass=nsdsWindowsreplicationagreement)"
 #define GLOBAL_CONFIG_FILTER "(|" CONFIG_FILTER WINDOWS_CONFIG_FILTER " )"
+#define AGMT_OK 0
+#define AGMT_ERROR -1
 
 
 PRCallOnceType once = {0};
@@ -123,24 +125,29 @@ agmtlist_agmt_exists(const Repl_Agmt *ra)
     return exists;
 }
 
-
 /*
  * Note: when we add the new object, we have a reference to it. We hold
  * on to this reference until the agreement is deleted (or until the
  * server is shut down).
+ * Return AGMT_OK on success
+ * Return AGMT_ERROR on generic error
  */
-int
-add_new_agreement(Slapi_Entry *e)
+static int
+add_new_agreement(Slapi_Entry *e, char **err_buffer)
 {
-    int rc = 0;
+    int rc = AGMT_OK;
     Repl_Agmt *ra = agmt_new_from_entry(e);
     Slapi_DN *replarea_sdn = NULL;
     Replica *replica = NULL;
     Object *ro = NULL;
+    char *agmt_hostname = NULL;
+    char *err_str = NULL;
+    char *server_err_str = NULL;
+    int agmt_port = 0;
 
     /* tell search result handler callback this entry was not sent */
     if (ra == NULL)
-        return 1;
+        return AGMT_ERROR;
 
     ro = object_new((void *)ra, agmt_delete);
     objset_add_obj(agmt_set, ro);
@@ -149,13 +156,43 @@ add_new_agreement(Slapi_Entry *e)
     /* get the replica for this agreement */
     replarea_sdn = agmt_get_replarea(ra);
     if (!replarea_sdn) {
-        return 1;
+        *err_buffer = slapi_ch_smprintf("problem getting the replica suffix for the agreement");
+        return AGMT_ERROR;
     }
     replica = replica_get_replica_from_dn(replarea_sdn);
     slapi_sdn_free(&replarea_sdn);
 
-    rc = replica_start_agreement(replica, ra);
+    agmt_hostname = agmt_get_hostname(ra);
+    agmt_port = agmt_get_port(ra);
 
+    if (replica && slapi_is_local_host(agmt_hostname, &err_str, &server_err_str) &&
+        (agmt_port == replica_get_port(replica) || agmt_port == replica_get_secure_port(replica)) )
+    {
+        /* You can not create an agreement that points to the local server */
+        *err_buffer = slapi_ch_smprintf("agreement hostname points to the local server instance: %s",
+                                        agmt_hostname);
+        slapi_ch_free_string(&agmt_hostname);
+        return AGMT_ERROR;
+    }
+
+    /* Log warnings if there is an issue checking the agreement or local hostname */
+    if (err_str) {
+        slapi_log_err(SLAPI_LOG_WARNING, repl_plugin_name, "add_new_agreement - "
+                      "(%s) problem with the agreement hostname (%s) - %s",
+                      slapi_entry_get_dn(e), agmt_hostname, err_str);
+    }
+    if (server_err_str) {
+        slapi_log_err(SLAPI_LOG_WARNING, repl_plugin_name, "add_new_agreement - "
+                      "(%s) problem checking the server's hostname - %s",
+                      slapi_entry_get_dn(e), server_err_str);
+    }
+    slapi_ch_free_string(&agmt_hostname);
+
+    /* All good, start the agreement */
+    rc = replica_start_agreement(replica, ra);
+    if (rc != 0) {
+        *err_buffer = slapi_ch_strdup("Problem starting the agreement");
+    }
     return rc;
 }
 
@@ -216,19 +253,29 @@ agmtlist_add_callback(Slapi_PBlock *pb,
                       Slapi_Entry *e,
                       Slapi_Entry *entryAfter __attribute__((unused)),
                       int *returncode,
-                      char *returntext __attribute__((unused)),
+                      char *returntext,
                       void *arg __attribute__((unused)))
 {
+    char buff[SLAPI_DSE_RETURNTEXT_SIZE];
+    char *err_buff = NULL;
+    char *errortext = returntext ? returntext : buff;
     int rc;
+
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "agmt_add: begin\n");
 
-    rc = add_new_agreement(e);
-    if (0 != rc) {
+    rc = add_new_agreement(e, &err_buff);
+    if (AGMT_OK != rc) {
         Slapi_DN *sdn = NULL;
         slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
-        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name, "agmtlist_add_callback - "
-                                                       "Can't start agreement \"%s\"\n",
-                      slapi_sdn_get_dn(sdn));
+        slapi_log_err(SLAPI_LOG_ERR, repl_plugin_name,
+                      "agmtlist_add_callback - (%s) %s\n",
+                      slapi_sdn_get_dn(sdn),
+                      err_buff ? err_buff : "Unknown error adding agreement");
+        if (err_buff) {
+            PR_snprintf(errortext, SLAPI_DSE_RETURNTEXT_SIZE, "%s", err_buff);
+            slapi_ch_free_string(&err_buff);
+        }
+
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         return SLAPI_DSE_CALLBACK_ERROR;
     }
@@ -704,19 +751,21 @@ static int
 handle_agmt_search(Slapi_Entry *e, void *callback_data)
 {
     int *agmtcount = (int *)callback_data;
+    char *err_buff = NULL;
     int rc;
 
     slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name,
                   "handle_agmt_search - Found replication agreement named \"%s\".\n",
                   slapi_sdn_get_dn(slapi_entry_get_sdn(e)));
-    rc = add_new_agreement(e);
-    if (0 == rc) {
+    rc = add_new_agreement(e, &err_buff);
+    if (rc == AGMT_OK) {
         (*agmtcount)++;
     } else {
         slapi_log_err(SLAPI_LOG_REPL, repl_plugin_name, "handle_agmt_search - "
-                                                        "The replication agreement named \"%s\" could not be correctly parsed. No "
-                                                        "replication will occur with this replica.\n",
-                      slapi_sdn_get_dn(slapi_entry_get_sdn(e)));
+                      "The replication agreement named \"%s\" could not be correctly parsed. No "
+                      "replication will occur with this replica. Error: %s\n",
+                      slapi_sdn_get_dn(slapi_entry_get_sdn(e)), err_buff);
+        slapi_ch_free_string(&err_buff);
     }
 
     return rc;

--- a/ldap/servers/plugins/replication/repl5_replica.c
+++ b/ldap/servers/plugins/replication/repl5_replica.c
@@ -68,6 +68,8 @@ struct replica
     uint64_t abort_session;            /* Abort the current replica session */
     cldb_Handle *cldb;                 /* database info for the changelog */
     int64_t keepalive_update_interval; /* interval to do dummy update to keep RUV fresh */
+    int repl_port;                     /* The port of the replica */
+    int repl_secure_port;              /* The secure port of the replica */
 };
 
 
@@ -173,6 +175,7 @@ int
 replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation, Replica **rp)
 {
     Replica *r;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     int rc = LDAP_SUCCESS;
 
     if (e == NULL) {
@@ -283,6 +286,10 @@ replica_new_from_entry(Slapi_Entry *e, char *errortext, PRBool is_add_operation,
                                                slapi_current_rel_time_t() + r->tombstone_reap_interval,
                                                1000 * r->tombstone_reap_interval);
     }
+
+    /* Set the host and port numbers for the replica */
+    r->repl_port = slapdFrontendConfig->port;
+    r->repl_secure_port = slapdFrontendConfig->secureport;
 
 done:
     if (rc != LDAP_SUCCESS && r) {
@@ -4350,4 +4357,16 @@ replica_set_cl_info(Replica *r, void *cl)
 {
     r->cldb = (cldb_Handle *)cl;
     return 0;
+}
+
+int
+replica_get_port(Replica *r)
+{
+    return r->repl_port;
+}
+
+int
+replica_get_secure_port(Replica *r)
+{
+    return r->repl_secure_port;
 }

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -250,28 +250,6 @@ connection_cleanup(Connection *conn)
     conn->c_ns_close_jobs = 0;
 }
 
-static char *
-get_ip_str(struct sockaddr *addr, char *str, size_t str_size)
-{
-    switch(addr->sa_family) {
-        case AF_INET:
-            if (str_size < INET_ADDRSTRLEN) {
-                break;
-            }
-            inet_ntop(AF_INET, &(((struct sockaddr_in *)addr)->sin_addr), str, INET_ADDRSTRLEN);
-            break;
-
-        case AF_INET6:
-            if (str_size < INET6_ADDRSTRLEN) {
-                break;
-            }
-            inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)addr)->sin6_addr), str, INET6_ADDRSTRLEN);
-            break;
-    }
-
-    return str;
-}
-
 /*
  * Callers of connection_reset() must hold the conn->c_mutex lock.
  */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -35,6 +35,7 @@ extern "C" {
 #include "nspr.h"
 #include <syslog.h>
 #include <plhash.h>
+#include <stdbool.h>
 
 #ifdef __GNUC__
     #define __ATTRIBUTE__(x) __attribute__(x)
@@ -8488,6 +8489,16 @@ const char * slapi_fetch_attr(Slapi_Entry *e, char *attrname, char *default_val)
  * \return - ldap result code
  */
 int32_t slapi_search_get_entry(Slapi_PBlock **pb, Slapi_DN *dn, char **attrs, Slapi_Entry **ret_entry, void *component_identity);
+
+/**
+ * Take a hostname and verify if it's the local host
+ *
+ * \param hostname - the hostname to verify
+ * \param err_str - store the error string from checking the hostname
+ * \param server_err_str - store the error string when trying to get the server's hostname info
+ * \return true if the hostname is the local host, false otherwise
+ */
+bool slapi_is_local_host(char *hostname, char **err_str, char **server_err_str);
 
 /**
  * Free the resources allocated by slapi_search_get_entry()

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1267,6 +1267,7 @@ const char *ldif_getline_ro( const char **next);
 void dup_ldif_line(struct berval *copy, const char *line, const char *endline);
 const char *get_oid_name(const char *oid);
 bool slapi_db_is_lmdb(void);
+char *get_ip_str(struct sockaddr *addr, char *str, size_t str_size);
 
 /* slapi-memberof.c */
 int slapi_memberof(Slapi_MemberOfConfig *config, Slapi_DN *member_sdn, Slapi_MemberOfResult *result);

--- a/ldap/servers/slapd/util.c
+++ b/ldap/servers/slapd/util.c
@@ -26,6 +26,7 @@
 #include "snmp_collator.h"
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <ifaddrs.h>
 #include <errno.h>
 
 #define UTIL_ESCAPE_NONE 0
@@ -1996,4 +1997,75 @@ slapi_db_is_lmdb(void)
     slapi_pblock_destroy(search_pb);
 
     return is_lmdb;
+}
+
+char *
+get_ip_str(struct sockaddr *addr, char *str, size_t str_size)
+{
+    if (addr == NULL) {
+        return str;
+    }
+
+    switch(addr->sa_family) {
+        case AF_INET:
+            if (str_size < INET_ADDRSTRLEN) {
+                break;
+            }
+            inet_ntop(AF_INET, &(((struct sockaddr_in *)addr)->sin_addr), str, INET_ADDRSTRLEN);
+            break;
+
+        case AF_INET6:
+            if (str_size < INET6_ADDRSTRLEN) {
+                break;
+            }
+            inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)addr)->sin6_addr), str, INET6_ADDRSTRLEN);
+            break;
+    }
+
+    return str;
+}
+
+/* Take a hostname and verify if it's the local host */
+bool
+slapi_is_local_host(char *hostname, char **err_str, char **server_err_str)
+{
+    struct addrinfo *info = NULL;
+    struct ifaddrs *ifap = NULL;
+    char ip_str[64] = {0};
+    char local_ip_str[64] = {0};
+    int32_t rc = 0;
+    bool is_localhost = false;
+
+    /* Get the provided hostname info */
+    rc = getaddrinfo(hostname, NULL, NULL, &info);
+    if (rc != 0) {
+        *err_str = (char *)gai_strerror(rc);
+        return false;
+    }
+
+    /* Get the local host info */
+    errno = 0;
+    rc = getifaddrs(&ifap);
+    if (rc != 0) {
+        *server_err_str = strerror(errno);
+        freeaddrinfo(info);
+        return false;
+    }
+
+    /* Compare the provided hostname info with the local host info */
+    for (struct addrinfo *ai = info; ai && !is_localhost; ai = ai->ai_next) {
+        get_ip_str(ai->ai_addr, ip_str, sizeof(ip_str));
+        for (struct ifaddrs *ifa = ifap; ifa; ifa = ifa->ifa_next) {
+            get_ip_str(ifa->ifa_addr, local_ip_str, sizeof(local_ip_str));
+            if (strcasecmp(ip_str, local_ip_str) == 0) {
+                is_localhost = true;
+                break;
+            }
+        }
+    }
+
+    freeaddrinfo(info);
+    freeifaddrs(ifap);
+
+    return is_localhost;
 }

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -1610,7 +1610,7 @@ export class Database extends React.Component {
                                     </Text>
                                 </TextContent>
                                 <ProgressStepper
-                                    className="ds-margin-top-lg"
+                                    className="ds-margin-top-xlg"
                                     aria-label="Progress stepper for suffix loading stages"
                                     isCenterAligned
                                 >
@@ -1737,7 +1737,7 @@ export class Database extends React.Component {
                         </Text>
                     </TextContent>
                     <ProgressStepper
-                        className="ds-margin-top-lg"
+                        className="ds-margin-top-xlg"
                         aria-label="Progress stepper for database loading stages"
                         isCenterAligned
                     >

--- a/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { ReplAgmtTable } from "./replTables.jsx";
 import { ReplAgmtModal } from "./replModals.jsx";
-import { log_cmd, valid_dn, valid_port, listsEqual } from "../tools.jsx";
+import { getApiErrorMessage, log_cmd, valid_dn, valid_port, listsEqual } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     Button,
@@ -1165,6 +1165,7 @@ export class ReplAgmts extends React.Component {
         log_cmd('saveAgmt', 'edit agmt', cmd);
 
         let buffer = "";
+        let error = null;
         const proc = cockpit.spawn(cmd, { pty: true, environ: ["LC_ALL=C"], superuser: true, err: "message" });
         proc
                 .done(data => {
@@ -1180,20 +1181,29 @@ export class ReplAgmts extends React.Component {
                         _("Successfully updated replication agreement")
                     );
                 })
-                .fail(_ => {
+                .fail(() => {
+                    const errMsg = getApiErrorMessage(error);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update replication agreement - $0"), buffer)
+                        cockpit.format(_("Failed to update replication agreement - $0"), errMsg)
                     );
                     this.setState({
                         savingAgmt: false
                     });
                 })
                 .stream(data => {
+                    try {
+                        // If data is JSON then it's an error
+                        JSON.parse(data);
+                        error = data; // we'll parse this later in fail()
+                        return;
+                    } catch (e) {
+                        // Ok not an JSON error proceed as normal
+                    }
                     buffer += data;
                     const lines = buffer.split("\n");
                     const last_line = lines[lines.length - 1].toLowerCase();
-                    if (last_line.includes("bootstrap")) {
+                    if (bootstrap_passwd !== "") {
                         proc.input(bootstrap_passwd + "\n", true);
                     } else {
                         proc.input(passwd + "\n", true);
@@ -1425,8 +1435,8 @@ export class ReplAgmts extends React.Component {
             if (this.state.agmtBootstrapBindDN !== "") {
                 cmd.push('--bootstrap-bind-dn=' + this.state.agmtBootstrapBindDN);
             }
-            if (this.state.agmtBootstrapBindDNPW !== "") {
-                bootstrap_passwd = this.state.agmtBootstrapBindDNPW;
+            if (this.state.agmtBootstrapBindPW !== "") {
+                bootstrap_passwd = this.state.agmtBootstrapBindPW;
             }
             if (this.state.agmtBootstrapBindMethod !== "") {
                 cmd.push('--bootstrap-bind-method=' + this.state.agmtBootstrapBindMethod);
@@ -1453,6 +1463,7 @@ export class ReplAgmts extends React.Component {
         log_cmd('createAgmt', 'Create agmt', cmd);
 
         let buffer = "";
+        let error = null;
         const proc = cockpit.spawn(cmd, { pty: true, environ: ["LC_ALL=C"], superuser: true, err: "message" });
         proc
                 .done(data => {
@@ -1471,20 +1482,29 @@ export class ReplAgmts extends React.Component {
                         this.initAgmt(this.state.agmtName);
                     }
                 })
-                .fail(_ => {
+                .fail(() => {
+                    const errMsg = getApiErrorMessage(error);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to create replication agreement - $0"), buffer)
+                        cockpit.format(_("Failed to create replication agreement - $0"), errMsg)
                     );
                     this.setState({
                         savingAgmt: false
                     });
                 })
                 .stream(data => {
+                    try {
+                        // If data is JSON then it's an error
+                        JSON.parse(data);
+                        error = data; // we'll parse this later in fail()
+                        return;
+                    } catch (e) {
+                        // Ok not an JSON error proceed as normal
+                    }
                     buffer += data;
                     const lines = buffer.split("\n");
                     const last_line = lines[lines.length - 1].toLowerCase();
-                    if (last_line.includes("bootstrap")) {
+                    if (bootstrap_passwd !== "") {
                         proc.input(bootstrap_passwd + "\n", true);
                     } else {
                         proc.input(passwd + "\n", true);

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -1136,7 +1136,7 @@ export class Replication extends React.Component {
                         </Text>
                     </TextContent>
                     <ProgressStepper
-                        className="ds-margin-top-lg"
+                        className="ds-margin-top-xlg"
                         aria-label="Progress stepper for replication loading"
                         isCenterAligned
                     >

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -1342,7 +1342,7 @@ export class Security extends React.Component {
                         </Text>
                     </TextContent>
                     <ProgressStepper
-                        className="ds-margin-top-lg"
+                        className="ds-margin-top-xlg"
                         aria-label="Progress stepper for all the various security related info"
                         isCenterAligned
                     >


### PR DESCRIPTION
Description:

There is nothing that stops you from adding a replication agreement that points to itself. This will break replication. We need to check and reject this.

relates: https://github.com/389ds/389-ds-base/issues/7322

## Summary by Sourcery

Reject replication agreements that point to the local server and surface clear errors in both backend and Cockpit UI while tightening related replica metadata and tests.

Bug Fixes:
- Prevent creation of replication agreements whose target host and port match the local replica, returning an appropriate LDAP error and message.
- Fix Cockpit replication agreement create/update flows to correctly handle structured error responses instead of raw CLI output.
- Correct usage of the bootstrap bind password field when creating replication agreements in the Cockpit UI.

Enhancements:
- Track replica hostname and ports on the replica object and expose accessors for use by replication logic.
- Improve Cockpit wizard spacing by adjusting progress stepper margins across database, replication, and security views.

Tests:
- Add an acceptance test ensuring self-referential replication agreements are rejected with LDAP_UNWILLING_TO_PERFORM.