### PR TITLE
Issue 7337 - UI - refactor all error handling to use getApiErrorMessge

### DIFF
--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -45,7 +45,7 @@ import EditorTreeView from './lib/ldap_editor/treeView.jsx';
 import { SearchDatabase } from './lib/ldap_editor/search.jsx';
 import GenericWizard from './lib/ldap_editor/wizards/genericWizard.jsx';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -311,15 +311,15 @@ export class LDAPEditor extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     console.error(
                         "handleLockUnlockEntry",
                         `${entryType} ${operationType} operation failed -`,
-                        errMsg.desc
+                        errMsg
                     );
                     this.props.addNotification(
-                        `${errMsg.desc.includes(`is already ${operationType === "unlock" ? "active" : "locked"}`) ? 'warning' : 'error'}`,
-                        `${errMsg.desc}`
+                        `${errMsg.includes(`is already ${operationType === "unlock" ? "active" : "locked"}`) ? 'warning' : 'error'}`,
+                        `${errMsg}`
                     );
                     this.setState({
                         entryMenuIsOpen: !this.state.entryMenuIsOpen,
@@ -653,12 +653,12 @@ export class LDAPEditor extends React.Component {
                             }
                         })
                         .fail(err => {
-                            const errMsg = JSON.parse(err);
-                            if ((entryDn !== 'Root DSE') && (entryStateIcon !== "") && !(errMsg.desc.includes("Root suffix can't be locked or unlocked"))) {
+                            const errMsg = getApiErrorMessage(err);
+                            if ((entryDn !== 'Root DSE') && (entryStateIcon !== "") && !(errMsg.includes("Root suffix can't be locked or unlocked"))) {
                                 console.error(
                                     "handleCollapse",
                                     `${isRole ? "role" : "account"} account entry-status operation failed`,
-                                    errMsg.desc
+                                    errMsg
                                 );
                                 entryState = _("error: please, check browser logs");
                                 entryStateIcon = <ExclamationCircleIcon className="ds-pf-red-color ct-exclamation-circle" />;

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn, valid_db_name } from "./lib/tools.jsx";
+import { log_cmd, valid_dn, valid_db_name, getApiErrorMessage } from "./lib/tools.jsx";
 import {
     ChainingConfig,
     ChainingDatabaseConfig
@@ -231,10 +231,10 @@ export class Database extends React.Component {
                         }
                     });
                 }).fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading suffix list - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading suffix list - $0"), errMsg)
                     );
                     this.setState({
                         suffixListLoaded: true,
@@ -270,10 +270,10 @@ export class Database extends React.Component {
                         }
                     });
                 }).fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading password storage schemes - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading password storage schemes - $0"), errMsg)
                     );
                     this.setState({
                         pwdSchemesLoaded: true,
@@ -314,10 +314,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading server configuration for database- $0"), errMsg.desc)
+                        cockpit.format(_("Error loading server configuration for database- $0"), errMsg)
                     );
                     this.setState({
                         globalConfigLoaded: true,
@@ -445,10 +445,10 @@ export class Database extends React.Component {
                 }
                 )
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading database configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading database configuration - $0"), errMsg)
                     );
                     this.loadNDN(reloading); // updates the loading state
                 });
@@ -533,10 +533,10 @@ export class Database extends React.Component {
                     ), this.loadAvailableControls());
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading default chaining configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading default chaining configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false
@@ -590,10 +590,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading chaining configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading chaining configuration - $0"), errMsg)
                     );
                     this.setState({
                         chainingConfigLoading: false,
@@ -785,10 +785,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error getting chaining link configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error getting chaining link configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1013,10 +1013,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating suffix - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating suffix - $0"), errMsg)
                     );
                     this.closeSuffixModal();
                     this.setState({
@@ -1138,10 +1138,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading indexes for $0 - $1"), suffix, errMsg.desc)
+                        cockpit.format(_("Error loading indexes for $0 - $1"), suffix, errMsg)
                     );
                 });
     }
@@ -1319,10 +1319,10 @@ export class Database extends React.Component {
                                                         });
                                                     })
                                                     .fail(err => {
-                                                        const errMsg = JSON.parse(err);
+                                                        const errMsg = getApiErrorMessage(err);
                                                         this.props.addNotification(
                                                             "error",
-                                                            cockpit.format(_("Error loading indexes for $0 - $1"), suffix, errMsg.desc)
+                                                            cockpit.format(_("Error loading indexes for $0 - $1"), suffix, errMsg)
                                                         );
                                                         this.setState({
                                                             suffixIndexesLoading: false,
@@ -1331,10 +1331,10 @@ export class Database extends React.Component {
                                                     });
                                         })
                                         .fail(err => {
-                                            const errMsg = JSON.parse(err);
+                                            const errMsg = getApiErrorMessage(err);
                                             this.props.addNotification(
                                                 "error",
-                                                cockpit.format(_("Error attribute encryption for $0 - $1"), suffix, errMsg.desc)
+                                                cockpit.format(_("Error attribute encryption for $0 - $1"), suffix, errMsg)
                                             );
                                             this.setState({
                                                 suffixAttrEncLoading: false,
@@ -1343,10 +1343,10 @@ export class Database extends React.Component {
                                         });
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error loading VLV indexes for $0 - $1"), suffix, errMsg.desc)
+                                    cockpit.format(_("Error loading VLV indexes for $0 - $1"), suffix, errMsg)
                                 );
                                 this.setState({
                                     suffixVlvLoading: false,
@@ -1355,10 +1355,10 @@ export class Database extends React.Component {
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading config for $0 - $1"), suffix, errMsg.desc)
+                        cockpit.format(_("Error loading config for $0 - $1"), suffix, errMsg)
                     );
                     this.setState({
                         suffixConfigLoading: false,
@@ -1393,10 +1393,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading LDIF files - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading LDIF files - $0"), errMsg)
                     );
                     this.setState({
                         ldifsLoading: false,
@@ -1439,10 +1439,10 @@ export class Database extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading backups - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading backups - $0"), errMsg)
                     );
                     this.setState({
                         backupsLoading: false,
@@ -1498,10 +1498,10 @@ export class Database extends React.Component {
                                 }, this.update_tree_nodes);
                             })
                 }).fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading schema - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading schema - $0"), errMsg)
                     );
                     this.update_tree_nodes();
                 });

--- a/src/cockpit/389-console/src/ds.jsx
+++ b/src/cockpit/389-console/src/ds.jsx
@@ -9,7 +9,7 @@ import { Server } from "./server.jsx";
 import { DoubleConfirmModal } from "./lib/notifications.jsx";
 import { ManageBackupsModal, SchemaReloadModal, CreateInstanceModal } from "./dsModals.jsx";
 import { LDAPEditor } from "./LDAPEditor.jsx";
-import { log_cmd } from "./lib/tools.jsx";
+import { getApiErrorMessage, log_cmd } from "./lib/tools.jsx";
 import {
 	Alert,
 	AlertGroup,
@@ -289,8 +289,8 @@ export class DSInstance extends React.Component {
                                                 }
                                             })
                                             .fail(err => {
-                                                const errMsg = JSON.parse(err);
-                                                console.log("setServerId failed: ", errMsg.desc);
+                                                const errMsg = getApiErrorMessage(err);
+                                                console.log("setServerId failed: ", errMsg);
                                                 this.setState(
                                                     {
                                                         pageLoadingState: {
@@ -313,8 +313,8 @@ export class DSInstance extends React.Component {
                                             });
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
-                                    console.log("setServerId failed: ", errMsg.desc);
+                                    const errMsg = getApiErrorMessage(err);
+                                    console.log("setServerId failed: ", errMsg);
                                     this.setState(
                                         {
                                             pageLoadingState: {
@@ -355,8 +355,8 @@ export class DSInstance extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    console.log("setServerId failed: ", errMsg.desc);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log("setServerId failed: ", errMsg);
                     this.setState(
                         {
                             pageLoadingState: {
@@ -478,12 +478,12 @@ export class DSInstance extends React.Component {
                 })
                 .fail(err => {
                     this.updateProgress(25);
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (!initializing) {
                         // Don't log an error when first initializing the UI
                         this.addNotification(
                             "error",
-                            cockpit.format(_("Load Backups operation failed - $0"), errMsg.desc)
+                            cockpit.format(_("Load Backups operation failed - $0"), errMsg)
                         );
                     }
                     this.setState({
@@ -528,11 +528,11 @@ export class DSInstance extends React.Component {
                     this.addNotification("success", _("Instance was successfully removed"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadInstanceList();
                     this.addNotification(
                         "error",
-                        cockpit.format(_("Error during instance remove operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during instance remove operation - $0"), errMsg)
                     );
                 });
         this.closeDeleteConfirm();
@@ -576,20 +576,20 @@ export class DSInstance extends React.Component {
                                     this.addNotification("success", cockpit.format(_("Instance was successfully $0"), action + "ed"));
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.addNotification(
                                         "error",
-                                        cockpit.format(_("Error during instance $0 operation - $1"), action, errMsg.desc)
+                                        cockpit.format(_("Error during instance $0 operation - $1"), action, errMsg)
                                     );
                                     this.loadInstanceList(this.state.serverId, action);
                                 });
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.addNotification(
                         "error",
-                        cockpit.format(_("Error during instance check status operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during instance check status operation - $0"), errMsg)
                     );
                     this.loadInstanceList(this.state.serverId, action);
                 });

--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -9,7 +9,8 @@ import {
     bad_file_name,
     valid_dn,
     valid_db_name,
-    callCmdStreamPassword
+    callCmdStreamPassword,
+    getApiErrorMessage
 } from "./lib/tools.jsx";
 import {
     Button,
@@ -230,11 +231,11 @@ export class CreateInstanceModal extends React.Component {
         cockpit
                 .spawn(hostname_cmd, { superuser: true, err: "message" })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loadingCreate: false
                     });
-                    addNotification("error", cockpit.format(_("Failed to get hostname! $0"), errMsg.desc));
+                    addNotification("error", cockpit.format(_("Failed to get hostname! $0"), errMsg));
                 })
                 .done(data => {
                     /*
@@ -312,14 +313,14 @@ export class CreateInstanceModal extends React.Component {
                                                                     err: "message"
                                                                 })
                                                                 .fail(err => {
-                                                                    const errMsg = JSON.parse(err.message);
+                                                                    const errMsg = getApiErrorMessage(err.message);
                                                                     cockpit.spawn(rm_cmd, { superuser: true }); // Remove Inf file with clear text password
                                                                     this.setState({
                                                                         loadingCreate: false
                                                                     });
                                                                     addNotification(
                                                                         "error",
-                                                                        `${errMsg.desc}`
+                                                                        `${errMsg}`
                                                                     );
                                                                 })
                                                                 .done(() => {
@@ -720,8 +721,8 @@ export class SchemaReloadModal extends React.Component {
                     closeHandler();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    addNotification("error", cockpit.format(_("Failed to reload schema files - $0"), errMsg.desc));
+                    const errMsg = getApiErrorMessage(err);
+                    addNotification("error", cockpit.format(_("Failed to reload schema files - $0"), errMsg));
                     closeHandler();
                 });
     }
@@ -965,24 +966,24 @@ export class ManageBackupsModal extends React.Component {
                                                 );
                                             })
                                             .fail(err => {
-                                                const errMsg = JSON.parse(err);
+                                                const errMsg = getApiErrorMessage(err);
                                                 this.props.addNotification(
                                                     "success",
                                                     _("Server has been backed up.")
                                                 );
                                                 this.props.addNotification(
                                                     "error",
-                                                    cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg.desc)
+                                                    cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg)
                                                 );
                                             });
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.props.reload();
                                     this.closeBackupModal();
                                     this.props.addNotification(
                                         "error",
-                                        cockpit.format(_("Failure backing up server - $0"), errMsg.desc)
+                                        cockpit.format(_("Failure backing up server - $0"), errMsg)
                                     );
                                 });
                     } else {
@@ -1006,19 +1007,19 @@ export class ManageBackupsModal extends React.Component {
                                     this.props.addNotification("success", _("Server has been backed up"));
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.props.reload();
                                     this.closeBackupModal();
                                     this.props.addNotification(
                                         "error",
-                                        cockpit.format(_("Failure backing up server - $0"), errMsg.desc)
+                                        cockpit.format(_("Failure backing up server - $0"), errMsg)
                                     );
                                 });
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    console.log("Failed to check the server status", errMsg.desc);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log("Failed to check the server status", errMsg);
                 });
     }
 
@@ -1048,11 +1049,11 @@ export class ManageBackupsModal extends React.Component {
                                     this.props.addNotification("success", _("Server has been restored"));
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.closeConfirmRestore();
                                     this.props.addNotification(
                                         "error",
-                                        cockpit.format(_("Failure restoring up server - $0"), errMsg.desc)
+                                        cockpit.format(_("Failure restoring up server - $0"), errMsg)
                                     );
                                 });
                     } else {
@@ -1071,18 +1072,18 @@ export class ManageBackupsModal extends React.Component {
                                     this.props.addNotification("success", _("Server has been restored"));
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.closeRestoreSpinningModal();
                                     this.props.addNotification(
                                         "error",
-                                        cockpit.format(_("Failure restoring up server - $0"), errMsg.desc)
+                                        cockpit.format(_("Failure restoring up server - $0"), errMsg)
                                     );
                                 });
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    console.log("Failed to check the server status", errMsg.desc);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log("Failed to check the server status", errMsg);
                 });
     }
 
@@ -1109,12 +1110,12 @@ export class ManageBackupsModal extends React.Component {
                     this.props.addNotification("success", _("Backup was successfully deleted"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.setState({
                         modalSpinning: false,
                     });
-                    this.props.addNotification("error", cockpit.format(_("Failure deleting backup - $0"), errMsg.desc));
+                    this.props.addNotification("error", cockpit.format(_("Failure deleting backup - $0"), errMsg));
                 });
     }
 

--- a/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
+++ b/src/cockpit/389-console/src/lib/database/attrEncryption.jsx
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -98,11 +98,11 @@ export class AttrEncryption extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to add encrypted attribute - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to add encrypted attribute - $0"), errMsg)
                     );
                     this.setState({
                         saving: false,
@@ -131,11 +131,11 @@ export class AttrEncryption extends React.Component {
                     this.closeConfirmAttrDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure deleting encrypted attribute - $0"), errMsg.desc)
+                        cockpit.format(_("Failure deleting encrypted attribute - $0"), errMsg)
                     );
                     this.closeConfirmAttrDelete();
                 });

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -22,7 +22,7 @@ import {
     TextVariants,
     ValidatedOptions,
 } from "@patternfly/react-core";
-import { log_cmd, bad_file_name } from "../tools.jsx";
+import { log_cmd, bad_file_name, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -275,11 +275,11 @@ export class Backups extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeConfirmLDIFImport();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure importing LDIF - $0"), errMsg.desc)
+                        cockpit.format(_("Failure importing LDIF - $0"), errMsg)
                     );
                 });
     }
@@ -304,12 +304,12 @@ export class Backups extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
                     this.closeConfirmLDIFDelete();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure deleting LDIF file - $0"), errMsg.desc)
+                        cockpit.format(_("Failure deleting LDIF file - $0"), errMsg)
                     );
                 });
     }
@@ -368,25 +368,25 @@ export class Backups extends React.Component {
                                 );
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "success",
                                     _("Server has been backed up.")
                                 );
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg.desc)
+                                    cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg)
                                 );
                             });
                 }
                 )
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
                     this.closeBackupModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure backing up server - $0"), errMsg.desc)
+                        cockpit.format(_("Failure backing up server - $0"), errMsg)
                     );
                 });
     }
@@ -418,11 +418,11 @@ export class Backups extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeRestoreSpinningModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure restoring up server - $0"), errMsg.desc)
+                        cockpit.format(_("Failure restoring up server - $0"), errMsg)
                     );
                 });
     }
@@ -446,12 +446,12 @@ export class Backups extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
                     this.closeConfirmBackupDelete();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure deleting backup - $0"), errMsg.desc)
+                        cockpit.format(_("Failure deleting backup - $0"), errMsg)
                     );
                 });
     }
@@ -553,24 +553,24 @@ export class Backups extends React.Component {
                                 );
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "success",
                                     _("Database export complete.")
                                 );
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error while trying to get the server's LDIF directory- $0"), errMsg.desc)
+                                    cockpit.format(_("Error while trying to get the server's LDIF directory- $0"), errMsg)
                                 );
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
                     this.closeExportModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error exporting database - $0"), errMsg.desc)
+                        cockpit.format(_("Error exporting database - $0"), errMsg)
                     );
                     this.setState({
                         showExportModal: false,

--- a/src/cockpit/389-console/src/lib/database/chaining.jsx
+++ b/src/cockpit/389-console/src/lib/database/chaining.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
-import { log_cmd, callCmdStreamPassword } from "../tools.jsx";
+import { log_cmd, callCmdStreamPassword, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -273,11 +273,11 @@ export class ChainingDatabaseConfig extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload();
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error updating chaining configuration - $0"), errMsg.desc)
+                            cockpit.format(_("Error updating chaining configuration - $0"), errMsg)
                         );
                         this.setState({
                             saving: false
@@ -340,7 +340,7 @@ export class ChainingDatabaseConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         modalSpinning: false,
                     });
@@ -348,7 +348,7 @@ export class ChainingDatabaseConfig extends React.Component {
                     this.props.reload(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating chaining controls - $0,"), errMsg.desc)
+                        cockpit.format(_("Error updating chaining controls - $0,"), errMsg)
                     );
                 });
     }
@@ -386,11 +386,11 @@ export class ChainingDatabaseConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error removing chaining controls - $0"), errMsg.desc)
+                        cockpit.format(_("Error removing chaining controls - $0"), errMsg)
                     );
                 });
     }
@@ -459,7 +459,7 @@ export class ChainingDatabaseConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeCompsModal();
                     this.props.reload();
                     this.setState({
@@ -467,7 +467,7 @@ export class ChainingDatabaseConfig extends React.Component {
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating chaining components - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating chaining components - $0"), errMsg)
                     );
                 });
     }
@@ -496,11 +496,11 @@ export class ChainingDatabaseConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error removing chaining components - $0"), errMsg.desc)
+                        cockpit.format(_("Error removing chaining components - $0"), errMsg)
                     );
                 });
     }
@@ -1331,11 +1331,11 @@ export class ChainingConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.loadSuffixTree(true);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete database link - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to delete database link - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { displayBytes, log_cmd } from "../tools.jsx";
+import { displayBytes, log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Alert,
     Button,
@@ -353,14 +353,14 @@ export class GlobalDatabaseConfig extends React.Component {
                         }
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.state.activeTabKey);
                         this.setState({
                             saving: false
                         });
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error updating configuration - $0"), errMsg.desc)
+                            cockpit.format(_("Error updating configuration - $0"), errMsg)
                         );
                     });
         } else {
@@ -526,14 +526,14 @@ export class GlobalDatabaseConfig extends React.Component {
                         this.save_ndn_cache(requireRestart);
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.state.activeTabKey);
                         this.setState({
                             saving: false
                         });
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error updating configuration - $0"), errMsg.desc)
+                            cockpit.format(_("Error updating configuration - $0"), errMsg)
                         );
                     });
         } else {
@@ -1602,14 +1602,14 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                         }
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.state.activeTabKey);
                         this.setState({
                             saving: false
                         });
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error updating configuration - $0"), errMsg.desc)
+                            cockpit.format(_("Error updating configuration - $0"), errMsg)
                         );
                     });
         } else {
@@ -1700,14 +1700,14 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                         this.save_ndn_cache(requireRestart);
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.state.activeTabKey);
                         this.setState({
                             saving: false
                         });
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error updating configuration - $0"), errMsg.desc)
+                            cockpit.format(_("Error updating configuration - $0"), errMsg)
                         );
                     });
         } else {

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
 	Alert,
 	Button,
@@ -212,14 +212,14 @@ export class GlobalPwPolicy extends React.Component {
                 );
             })
             .fail(err => {
-                const errMsg = JSON.parse(err);
+                const errMsg = getApiErrorMessage(err);
                 this.handleLoadGlobal();
                 this.setState({
                     saving: false
                 });
                 this.props.addNotification(
                     "error",
-                    cockpit.format(_("Error updating number of iterations for password storage scheme - $0"), errMsg.desc)
+                    cockpit.format(_("Error updating number of iterations for password storage scheme - $0"), errMsg)
                 );
             });
     }
@@ -308,14 +308,14 @@ export class GlobalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadGlobal();
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -413,14 +413,14 @@ export class GlobalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadGlobal();
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -491,14 +491,14 @@ export class GlobalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadGlobal();
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -602,14 +602,14 @@ export class GlobalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadGlobal();
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -672,14 +672,14 @@ export class GlobalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadGlobal();
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -734,7 +734,7 @@ export class GlobalPwPolicy extends React.Component {
                 this.setState(stateUpdates);
             })
             .fail(err => {
-                const errMsg = JSON.parse(err);
+                const errMsg = getApiErrorMessage(err);
                 this.setState({
                     loading: false,
                     'nsslapd-pwdpbkdf2numiterations': '',
@@ -742,7 +742,7 @@ export class GlobalPwPolicy extends React.Component {
                 });
                 this.props.addNotification(
                     "error",
-                    cockpit.format(_("Error loading password storage settings - $0"), errMsg.desc)
+                    cockpit.format(_("Error loading password storage settings - $0"), errMsg)
                 );
             });
     }
@@ -957,14 +957,14 @@ export class GlobalPwPolicy extends React.Component {
                         });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loaded: true,
                         loading: false,
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading global password policy - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading global password policy - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/database/indexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/indexes.jsx
@@ -2,7 +2,7 @@ import cockpit from "cockpit";
 import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { IndexTable } from "./databaseTables.jsx";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -194,19 +194,19 @@ export class SuffixIndexes extends React.Component {
                                             }
                                         })
                                         .fail(err => {
-                                            const errMsg = JSON.parse(err);
+                                            const errMsg = getApiErrorMessage(err);
                                             this.props.addNotification(
                                                 "error",
-                                                cockpit.format(_("Failed to get attributes - $0"), errMsg.desc)
+                                                cockpit.format(_("Failed to get attributes - $0"), errMsg)
                                             );
                                         });
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to get matching rules - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to get matching rules - $0"), errMsg)
                     );
                 });
     }
@@ -341,12 +341,12 @@ export class SuffixIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.closeIndexModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating index - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating index - $0"), errMsg)
                     );
                     this.setState({
                         saving: false,
@@ -423,10 +423,10 @@ export class SuffixIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error indexing attribute $0 - $1"), attr, errMsg.desc)
+                        cockpit.format(_("Error indexing attribute $0 - $1"), attr, errMsg)
                     );
                     this.setState({
                         saving: false,
@@ -518,12 +518,12 @@ export class SuffixIndexes extends React.Component {
                         }
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.props.suffix);
                         this.closeEditIndexModal();
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error editing index - $0"), errMsg.desc)
+                            cockpit.format(_("Error editing index - $0"), errMsg)
                         );
                         this.setState({
                             saving: false,
@@ -592,11 +592,11 @@ export class SuffixIndexes extends React.Component {
                     this.closeConfirmDeleteIndex();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error deleting index - $0"), errMsg.desc)
+                        cockpit.format(_("Error deleting index - $0"), errMsg)
                     );
                     this.closeConfirmDeleteIndex();
                 });

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { PwpTable } from "./databaseTables.jsx";
 import {
@@ -1459,14 +1459,14 @@ export class LocalPwPolicy extends React.Component {
                     this.props.addNotification(type, message);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadPolicies();
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating password policy - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating password policy - $0"), errMsg)
                     );
                 });
     }
@@ -1537,14 +1537,14 @@ export class LocalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadLocal(this.state.policyName);
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1615,14 +1615,14 @@ export class LocalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadLocal(this.state.policyName);
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1693,14 +1693,14 @@ export class LocalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadLocal(this.state.policyName);
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1803,14 +1803,14 @@ export class LocalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadLocal(this.state.policyName);
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1873,14 +1873,14 @@ export class LocalPwPolicy extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadLocal(this.state.policyName);
                     this.setState({
                         saving: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating password policy configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1907,11 +1907,11 @@ export class LocalPwPolicy extends React.Component {
                 })
 
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadPolicies();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error deleting local password policy - $0"), errMsg.desc)
+                        cockpit.format(_("Error deleting local password policy - $0"), errMsg)
                     );
                 });
     }
@@ -2125,26 +2125,26 @@ export class LocalPwPolicy extends React.Component {
                                     }, this.props.enableTree);
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.setState({
                                         loaded: true,
                                         loading: false,
                                     });
                                     this.props.addNotification(
                                         "error",
-                                        cockpit.format(_("Error loading global password storage scheme - $0"), errMsg.desc)
+                                        cockpit.format(_("Error loading global password storage scheme - $0"), errMsg)
                                     );
                                 });
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loaded: true,
                         loading: false,
                     }, this.props.enableTree);
                     console.log(
-                        `Error loading local password policies - ${errMsg.desc}`
+                        `Error loading local password policies - ${errMsg}`
                     );
                 });
     }
@@ -2435,14 +2435,14 @@ export class LocalPwPolicy extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loaded: true,
                         loading: false,
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading local password policy - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading local password policy - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/database/referrals.jsx
+++ b/src/cockpit/389-console/src/lib/database/referrals.jsx
@@ -14,7 +14,7 @@ import {
     TextInput,
     ValidatedOptions,
 } from "@patternfly/react-core";
-import { log_cmd, valid_port, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_port, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -123,11 +123,11 @@ export class SuffixReferrals extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure deleting referral - $0"), errMsg.desc)
+                        cockpit.format(_("Failure deleting referral - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false,
@@ -162,12 +162,12 @@ export class SuffixReferrals extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.closeRefModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure creating referral - $0"), errMsg.desc)
+                        cockpit.format(_("Failure creating referral - $0"), errMsg)
                     );
                     this.setState({
                         saving: false

--- a/src/cockpit/389-console/src/lib/database/suffix.jsx
+++ b/src/cockpit/389-console/src/lib/database/suffix.jsx
@@ -6,7 +6,7 @@ import { SuffixConfig } from "./suffixConfig.jsx";
 import { SuffixReferrals } from "./referrals.jsx";
 import { SuffixIndexes } from "./indexes.jsx";
 import { VLVIndexes } from "./vlvIndexes.jsx";
-import { log_cmd, bad_file_name } from "../tools.jsx";
+import { log_cmd, bad_file_name, getApiErrorMessage } from "../tools.jsx";
 import {
     ImportModal,
     ExportModal,
@@ -277,10 +277,10 @@ export class Suffix extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error importing LDIF file - $0"), errMsg.desc)
+                        cockpit.format(_("Error importing LDIF file - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false,
@@ -389,23 +389,23 @@ export class Suffix extends React.Component {
                                 );
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "success",
                                     _("Database export complete.")
                                 );
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error while trying to get the server's LDIF directory- $0"), errMsg.desc)
+                                    cockpit.format(_("Error while trying to get the server's LDIF directory- $0"), errMsg)
                                 );
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reloadLDIFs();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error exporting database - $0"), errMsg.desc)
+                        cockpit.format(_("Error exporting database - $0"), errMsg)
                     );
                     this.setState({
                         showExportModal: false,
@@ -453,10 +453,10 @@ export class Suffix extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to reindex database - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to reindex database - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false,
@@ -516,12 +516,12 @@ export class Suffix extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.loadSuffixTree(false);
                     this.closeSubSuffixModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating sub-suffix - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating sub-suffix - $0"), errMsg)
                     );
                     this.setState({
                         subSuffixSaving: false
@@ -578,12 +578,12 @@ export class Suffix extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.loadSuffixTree(false);
                     this.closeLinkModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating database link - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating database link - $0"), errMsg)
                     );
                     this.setState({
                         linkSaving: false
@@ -759,12 +759,12 @@ export class Suffix extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.loadSuffixTree(true);
                     this.closeDeleteConfirm();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error deleting database - $0"), errMsg.desc)
+                        cockpit.format(_("Error deleting database - $0"), errMsg)
                     );
                 });
     }
@@ -829,11 +829,11 @@ export class Suffix extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reload(this.props.suffix);
-                        let msg = errMsg.desc;
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",

--- a/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
+++ b/src/cockpit/389-console/src/lib/database/vlvIndexes.jsx
@@ -2,7 +2,7 @@ import cockpit from "cockpit";
 import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { VLVTable } from "./databaseTables.jsx";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -191,12 +191,12 @@ export class VLVIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeCreateSortIndex();
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to add VLV index entry - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to add VLV index entry - $0"), errMsg)
                     );
                     this.setState({
                         updating: false,
@@ -246,12 +246,12 @@ export class VLVIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeDeleteSortIndexConfirm();
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete VLV sort index - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to delete VLV sort index - $0"), errMsg)
                     );
                     this.setState({
                         updating: false,
@@ -289,11 +289,11 @@ export class VLVIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.closeVLVModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed create VLV search entry - $0"), errMsg.desc)
+                        cockpit.format(_("Failed create VLV search entry - $0"), errMsg)
                     );
                     this.setState({
                         saving: false
@@ -336,11 +336,11 @@ export class VLVIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to deletre VLV index - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to deletre VLV index - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false
@@ -383,11 +383,11 @@ export class VLVIndexes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to index VLV index - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to index VLV index - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -44,7 +44,7 @@ import {
 } from './lib/utils.jsx';
 import { ENTRY_MENU } from './lib/constants.jsx';
 import EditorTableView from './tableView.jsx';
-import { log_cmd, valid_dn } from '../tools.jsx';
+import { getApiErrorMessage, log_cmd, valid_dn } from '../tools.jsx';
 import GenericWizard from './wizards/genericWizard.jsx';
 
 const _ = cockpit.gettext;
@@ -365,12 +365,12 @@ export class SearchDatabase extends React.Component {
                                 }
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
-                                if ((info.isLockable) && !(errMsg.desc.includes("Root suffix can't be locked or unlocked"))) {
+                                const errMsg = getApiErrorMessage(err);
+                                if ((info.isLockable) && !(errMsg.includes("Root suffix can't be locked or unlocked"))) {
                                     console.error(
                                         "processResults",
                                         `${info.isRole ? "role" : "account"} account entry-status operation failed`,
-                                        errMsg.desc
+                                        errMsg
                                     );
                                     entryState = "error: please, check browser logs";
                                     entryStateIcon = <ExclamationCircleIcon className="ds-pf-red-color ct-exclamation-circle" />;
@@ -571,15 +571,15 @@ export class SearchDatabase extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     console.error(
                         "handleLockUnlockEntry",
                         `${entryType} ${operationType} operation failed -`,
-                        errMsg.desc
+                        errMsg
                     );
                     this.props.addNotification(
-                        `${errMsg.desc.includes(`is already ${operationType === "unlock" ? "active" : "locked"}`) ? 'warning' : 'error'}`,
-                        `${errMsg.desc}`
+                        `${errMsg.includes(`is already ${operationType === "unlock" ? "active" : "locked"}`) ? 'warning' : 'error'}`,
+                        `${errMsg}`
                     );
                     this.setState({
                         entryMenuIsOpen: !this.state.entryMenuIsOpen,

--- a/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
@@ -58,7 +58,7 @@ import GenericPagination from './lib/genericPagination.jsx';
 import LdapNavigator from './lib/ldapNavigator.jsx';
 import CreateRootSuffix from './lib/rootSuffix.jsx';
 import { ENTRY_MENU } from './lib/constants.jsx';
-import { log_cmd } from "../tools.jsx";
+import { getApiErrorMessage, log_cmd } from "../tools.jsx";
 import {
     showCertificate,
     b64DecodeUnicode
@@ -334,12 +334,12 @@ class EditorTreeView extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if ((entryDn !== 'Root DSE') && (entryStateIcon !== "") && !(errMsg.desc.includes("Root suffix can't be locked or unlocked"))) {
+                    const errMsg = getApiErrorMessage(err);
+                    if ((entryDn !== 'Root DSE') && (entryStateIcon !== "") && !(errMsg.includes("Root suffix can't be locked or unlocked"))) {
                         console.error(
                             "updateEntryRow",
                             `${isRole ? "role" : "account"} account entry-status operation failed`,
-                            errMsg.desc
+                            errMsg
                         );
                         entryState = "error: please, check browser logs";
                         entryStateIcon = <ExclamationCircleIcon className="ds-pf-red-color ct-exclamation-circle" />;

--- a/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replLogAnalysis.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     Accordion,
@@ -677,7 +677,7 @@ export class ReplLogAnalysis extends React.Component {
             .fail(err => {
                 let errMsg;
                 try {
-                    const errorObj = JSON.parse(err);
+                    const errorObj = getApiErrorMessage(err);
                     errMsg = errorObj.desc || errorObj.message || err.toString();
                 } catch (e) {
                     errMsg = err.toString();

--- a/src/cockpit/389-console/src/lib/monitor/replMonAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonAgmts.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     AgmtTable,
@@ -43,10 +43,10 @@ export class ReplAgmtMonitor extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to poke replication agreement $0 - $1"), agmt_name, errMsg.desc)
+                        cockpit.format(_("Failed to poke replication agreement $0 - $1"), agmt_name, errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/monitor/replMonConflict.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonConflict.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     ConflictTable,
@@ -125,10 +125,10 @@ export class ReplMonConflict extends React.Component {
                     this.closeConfirmConvertConflict();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to convert conflict entry entry: $0 - $1"), this.state.conflictEntry, errMsg.desc)
+                        cockpit.format(_("Failed to convert conflict entry entry: $0 - $1"), this.state.conflictEntry, errMsg)
                     );
                     this.closeConfirmConvertConflict();
                 });
@@ -153,10 +153,10 @@ export class ReplMonConflict extends React.Component {
                     this.closeConfirmSwapConflict();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to swap in conflict entry: $0 - $1"), this.state.conflictEntry, errMsg.desc)
+                        cockpit.format(_("Failed to swap in conflict entry: $0 - $1"), this.state.conflictEntry, errMsg)
                     );
                     this.closeConfirmSwapConflict();
                 });
@@ -182,10 +182,10 @@ export class ReplMonConflict extends React.Component {
                     this.closeConfirmConvertConflict();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete conflict entry: $0 - $1"), this.state.conflictEntry, errMsg.desc)
+                        cockpit.format(_("Failed to delete conflict entry: $0 - $1"), this.state.conflictEntry, errMsg)
                     );
                     this.closeConfirmDeleteConflict();
                 });
@@ -243,10 +243,10 @@ export class ReplMonConflict extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to get conflict entries: $0 - $1"), dn, errMsg.desc)
+                        cockpit.format(_("Failed to get conflict entries: $0 - $1"), dn, errMsg)
                     );
                 });
     }
@@ -292,10 +292,10 @@ export class ReplMonConflict extends React.Component {
                     this.closeConfirmConvertGlue();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to convert glue entry: $0 - $1"), this.state.glueEntry, errMsg.desc)
+                        cockpit.format(_("Failed to convert glue entry: $0 - $1"), this.state.glueEntry, errMsg)
                     );
                     this.closeConfirmConvertGlue();
                 });
@@ -333,10 +333,10 @@ export class ReplMonConflict extends React.Component {
                     this.closeConfirmDeleteGlue();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete glue entry: $0 - $1"), this.state.glueEntry, errMsg.desc)
+                        cockpit.format(_("Failed to delete glue entry: $0 - $1"), this.state.glueEntry, errMsg)
                     );
                     this.closeConfirmDeleteGlue();
                 });

--- a/src/cockpit/389-console/src/lib/monitor/replMonWinsync.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonWinsync.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     WinsyncAgmtTable,
@@ -42,10 +42,10 @@ export class ReplAgmtWinsync extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to poke replication winsync agreement $0 - $1"), agmt_name, errMsg.desc)
+                        cockpit.format(_("Failed to poke replication winsync agreement $0 - $1"), agmt_name, errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
+++ b/src/cockpit/389-console/src/lib/monitor/replMonitor.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cockpit from "cockpit";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     ReportCredentialsTable,
@@ -232,8 +232,8 @@ export class ReplMonitor extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg.desc}`);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg}`);
                     this.setState({
                         loadingDSRC: false,
                     });
@@ -280,10 +280,10 @@ export class ReplMonitor extends React.Component {
                         }
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Failed to get config nsslapd-port, nsslapd-localhost and nasslapd-rootdn: $0"), errMsg.desc)
+                            cockpit.format(_("Failed to get config nsslapd-port, nsslapd-localhost and nasslapd-rootdn: $0"), errMsg)
                         );
                     });
         }
@@ -756,21 +756,21 @@ export class ReplMonitor extends React.Component {
                                             );
                                         })
                                         .fail(err => {
-                                            const errMsg = JSON.parse(err);
+                                            const errMsg = getApiErrorMessage(err);
                                             this.setState({
                                                 showConfirmOverwriteDSRC: false
                                             });
                                             this.props.addNotification(
                                                 "error",
-                                                cockpit.format(_("Failed to delete from .dsrc file: $0"), errMsg.desc)
+                                                cockpit.format(_("Failed to delete from .dsrc file: $0"), errMsg)
                                             );
                                         });
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Failed to add to .dsrc content: $0"), errMsg.desc)
+                                    cockpit.format(_("Failed to add to .dsrc content: $0"), errMsg)
                                 );
                                 this.setState({
                                     showConfirmOverwriteDSRC: false
@@ -778,10 +778,10 @@ export class ReplMonitor extends React.Component {
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to get .dsrc content: $0"), errMsg.desc)
+                        cockpit.format(_("Failed to get .dsrc content: $0"), errMsg)
                     );
                     this.setState({
                         showConfirmOverwriteDSRC: false
@@ -918,10 +918,10 @@ export class ReplMonitor extends React.Component {
                     });
                 })
                 .fail(() => {
-                    const errMsg = JSON.parse(buffer);
+                    const errMsg = getApiErrorMessage(buffer);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Sync report has failed - $0"), errMsg.desc)
+                        cockpit.format(_("Sync report has failed - $0"), errMsg)
                     );
                     this.setState({
                         dynamicCredentialsList: [],
@@ -1142,10 +1142,10 @@ export class ReplMonitor extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg)
                     );
                     this.loadDSRC();
                 });
@@ -1168,10 +1168,10 @@ export class ReplMonitor extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg)
                     );
                     this.loadDSRC();
                 });
@@ -1206,10 +1206,10 @@ export class ReplMonitor extends React.Component {
                     this.loadDSRC();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg)
                     );
                     this.loadDSRC();
                 });
@@ -1237,10 +1237,10 @@ export class ReplMonitor extends React.Component {
                     this.loadDSRC();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update .dsrc information: $0"), errMsg)
                     );
                     this.loadDSRC();
                 });

--- a/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/accountPolicy.jsx
@@ -15,7 +15,7 @@ import {
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import {
     DoubleConfirmModal,
     WarningModal
@@ -519,10 +519,10 @@ class AccountPolicy extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                     );
                     this.props.pluginListHandler();
                     this.handleCloseModal();
@@ -586,10 +586,10 @@ class AccountPolicy extends React.Component {
                     this.handleCloseModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.closeConfirmDelete();
@@ -751,11 +751,11 @@ class AccountPolicy extends React.Component {
                     this.props.pluginListHandler();
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error", cockpit.format(_("Error during update - $0"), errMsg)

--- a/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/attributeUniqueness.jsx
@@ -24,7 +24,7 @@ import { AttrUniqConfigTable } from "./pluginTables.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -309,8 +309,8 @@ class AttributeUniqueness extends React.Component {
                 })
                 .fail(err => {
                     if (err !== 0) {
-                        const errMsg = JSON.parse(err);
-                        console.log("loadConfigs failed", errMsg.desc);
+                        const errMsg = getApiErrorMessage(err);
+                        console.log("loadConfigs failed", errMsg);
                     }
                 });
     }
@@ -581,10 +581,10 @@ class AttributeUniqueness extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                     );
                     this.loadConfigs();
                     this.handleCloseModal();
@@ -644,10 +644,10 @@ class AttributeUniqueness extends React.Component {
                     this.closeConfirmDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.loadConfigs();
                     this.closeConfirmDelete();

--- a/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/autoMembership.jsx
@@ -22,7 +22,7 @@ import {
 import { AutoMembershipDefinitionTable, AutoMembershipRegexTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, listsEqual, valid_dn } from "../tools.jsx";
+import { log_cmd, listsEqual, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -358,9 +358,9 @@ class AutoMembership extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadDefinitions failed", errMsg.desc);
+                        console.log("loadDefinitions failed", errMsg);
                     }
                 });
     }
@@ -405,9 +405,9 @@ class AutoMembership extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadRegexes failed", errMsg.desc);
+                        console.log("loadRegexes failed", errMsg);
                     }
                 });
     }
@@ -626,11 +626,11 @@ class AutoMembership extends React.Component {
                         this.props.toggleLoadingHandler();
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
-                        if (errMsg.desc.indexOf("nothing to set") === 0) {
+                        const errMsg = getApiErrorMessage(err);
+                        if (errMsg.indexOf("nothing to set") === 0) {
                             this.props.addNotification(
                                 "error",
-                                cockpit.format(_("Error during the definition entry $0 operation - $1"), action, errMsg.desc)
+                                cockpit.format(_("Error during the definition entry $0 operation - $1"), action, errMsg)
                             );
                         } else {
                             this.purgeRegexUpdate();
@@ -677,10 +677,10 @@ class AutoMembership extends React.Component {
                         );
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error during the regex \"$0\" entry delete operation - $1"), regexToDelete, errMsg.desc)
+                            cockpit.format(_("Error during the regex \"$0\" entry delete operation - $1"), regexToDelete, errMsg)
                         );
                     });
         }
@@ -769,10 +769,10 @@ class AutoMembership extends React.Component {
                         );
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error during the regex \"$0\" entry $1 operation - $2"), regexName, action, errMsg.desc)
+                            cockpit.format(_("Error during the regex \"$0\" entry $1 operation - $2"), regexName, action, errMsg)
                         );
                     });
         }
@@ -826,10 +826,10 @@ class AutoMembership extends React.Component {
                     this.closeConfirmDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the definition entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the definition entry removal operation - $0"), errMsg)
                     );
                     this.loadDefinitions();
                     this.closeConfirmDelete();

--- a/src/cockpit/389-console/src/lib/plugins/dna.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/dna.jsx
@@ -25,7 +25,7 @@ import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { DNATable, DNASharedTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -234,9 +234,9 @@ class DNAPlugin extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadConfigs failed", errMsg.desc);
+                        console.log("loadConfigs failed", errMsg);
                     }
                     this.setState({
                         loading: false,
@@ -276,9 +276,9 @@ class DNAPlugin extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadSharedConfigs failed", errMsg.desc);
+                        console.log("loadSharedConfigs failed", errMsg);
                     }
                 });
     }
@@ -553,11 +553,11 @@ class DNAPlugin extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (muteError !== true) {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                            cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                         );
                     }
                     this.loadConfigs();
@@ -601,10 +601,10 @@ class DNAPlugin extends React.Component {
                     this.handleCloseModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.closeDeleteConfirm();
                     this.loadConfigs();
@@ -760,10 +760,10 @@ class DNAPlugin extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry set operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry set operation - $0"), errMsg)
                     );
                     this.loadSharedConfigs(this.state.sharedConfigEntry);
                     this.handleCloseSharedModal();
@@ -807,10 +807,10 @@ class DNAPlugin extends React.Component {
                     this.loadSharedConfigs(this.state.sharedConfigEntry);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the shared config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the shared config entry removal operation - $0"), errMsg)
                     );
                     this.closeSharedDeleteConfirm();
                     this.loadSharedConfigs(this.state.sharedConfigEntry);

--- a/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/linkedAttributes.jsx
@@ -14,7 +14,7 @@ import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { LinkedAttributesTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -181,9 +181,9 @@ class LinkedAttributes extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadConfigs failed", errMsg.desc);
+                        console.log("loadConfigs failed", errMsg);
                     }
                 });
     }
@@ -324,10 +324,10 @@ class LinkedAttributes extends React.Component {
                     this.props.toggleLoadingHandler();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                     );
                     this.loadConfigs();
                     this.handleCloseModal();
@@ -368,10 +368,10 @@ class LinkedAttributes extends React.Component {
                     this.closeConfirmDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.loadConfigs();
                     this.handleCloseModal();

--- a/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/managedEntries.jsx
@@ -32,7 +32,7 @@ import {
 import { ManagedDefinitionTable, ManagedTemplateTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -332,9 +332,9 @@ class ManagedEntries extends React.Component {
                                 });
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 if (err !== 0) {
-                                    console.log("loadConfigs failed getting definitions", errMsg.desc);
+                                    console.log("loadConfigs failed getting definitions", errMsg);
                                 }
                                 this.setState({
                                     loading: false
@@ -342,9 +342,9 @@ class ManagedEntries extends React.Component {
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadConfigs failed getting templates", errMsg.desc);
+                        console.log("loadConfigs failed getting templates", errMsg);
                     }
                     this.setState({
                         loading: false
@@ -663,10 +663,10 @@ class ManagedEntries extends React.Component {
                     this.loadConfigs();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the definition entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the definition entry removal operation - $0"), errMsg)
                     );
                     this.loadConfigs();
                 });
@@ -720,10 +720,10 @@ class ManagedEntries extends React.Component {
                     this.handleCloseDefModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                     );
                     this.loadConfigs();
                     this.handleCloseDefModal();
@@ -804,11 +804,11 @@ class ManagedEntries extends React.Component {
                     this.handleCloseTempModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleCloseTempModal();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the template entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the template entry $0 operation - $1"), action, errMsg)
                     );
                     this.toggleLoading();
                 });
@@ -844,10 +844,10 @@ class ManagedEntries extends React.Component {
                     this.closeTempDeleteConfirm();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the template entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the template entry removal operation - $0"), errMsg)
                     );
                     this.closeTempDeleteConfirm();
                     this.toggleLoading();
@@ -885,8 +885,8 @@ class ManagedEntries extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    this.props.addNotification("error", cockpit.format(_("Failed to get attributes - $0"), errMsg.desc));
+                    const errMsg = getApiErrorMessage(err);
+                    this.props.addNotification("error", cockpit.format(_("Failed to get attributes - $0"), errMsg));
                 });
     }
 

--- a/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/memberOf.jsx
@@ -23,7 +23,7 @@ import {
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
-import { log_cmd, valid_dn, listsEqual, parentExists, valid_filter } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, parentExists, valid_filter, getApiErrorMessage } from "../tools.jsx";
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { MemberOfTable } from "./pluginTables.jsx";
 import {
@@ -739,10 +739,10 @@ class MemberOf extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Fixup task for $0 has failed $1"), this.state.fixupDN, errMsg.desc)
+                            cockpit.format(_("Fixup task for $0 has failed $1"), this.state.fixupDN, errMsg)
                         );
                         this.props.toggleLoadingHandler();
                         this.setState({
@@ -1070,10 +1070,10 @@ class MemberOf extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                            cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                         );
                         this.props.pluginListHandler();
                         this.handleCloseModal();
@@ -1119,10 +1119,10 @@ class MemberOf extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.handleCloseModal();
@@ -1388,11 +1388,11 @@ class MemberOf extends React.Component {
                     this.props.pluginListHandler();
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error", cockpit.format(_("Error during update - $0"), errMsg)
@@ -1509,11 +1509,11 @@ class MemberOf extends React.Component {
                     }
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error", cockpit.format(_("Error during update - $0"), errMsg)

--- a/src/cockpit/389-console/src/lib/plugins/pamPassThru.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pamPassThru.jsx
@@ -17,7 +17,7 @@ import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { PassthroughAuthConfigsTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -270,9 +270,9 @@ class PAMPassthroughAuthentication extends React.Component {
                     this.props.toggleLoadingHandler();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadPAMConfigs failed", errMsg.desc);
+                        console.log("loadPAMConfigs failed", errMsg);
                     }
                     this.props.toggleLoadingHandler();
                 });
@@ -476,10 +476,10 @@ class PAMPassthroughAuthentication extends React.Component {
                     this.props.toggleLoadingHandler();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the pamConfig entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the pamConfig entry removal operation - $0"), errMsg)
                     );
                     this.loadPAMConfigs();
                     this.closeConfirmDeleteConfig();
@@ -585,10 +585,10 @@ class PAMPassthroughAuthentication extends React.Component {
                     this.handleClosePAMModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the pamConfig entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the pamConfig entry $0 operation - $1"), action, errMsg)
                     );
                     this.loadPAMConfigs();
                     this.handleClosePAMModal();

--- a/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/passthroughAuthentication.jsx
@@ -17,7 +17,7 @@ import {
 import { PassthroughAuthURLsTable } from "./pluginTables.jsx";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -223,9 +223,9 @@ class PassthroughAuthentication extends React.Component {
                     this.props.toggleLoadingHandler();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     if (err !== 0) {
-                        console.log("loadURLs failed", errMsg.desc);
+                        console.log("loadURLs failed", errMsg);
                     }
                     this.props.toggleLoadingHandler();
                 });
@@ -312,10 +312,10 @@ class PassthroughAuthentication extends React.Component {
                     this.closeConfirmDeleteURL();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the URL removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the URL removal operation - $0"), errMsg)
                     );
                     this.loadURLs();
                     this.closeConfirmDeleteURL();
@@ -385,10 +385,10 @@ class PassthroughAuthentication extends React.Component {
                     this.handleCloseURLModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the URL $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the URL $0 operation - $1"), action, errMsg)
                     );
                     this.loadURLs();
                     this.handleCloseURLModal();

--- a/src/cockpit/389-console/src/lib/plugins/pluginBasicConfig.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/pluginBasicConfig.jsx
@@ -11,7 +11,7 @@ import {
     TextVariants,
 } from "@patternfly/react-core";
 import PropTypes from "prop-types";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -134,10 +134,10 @@ class PluginBasicConfig extends React.Component {
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     addNotification(
                         "error",
-                        cockpit.format(_("Error during $0 plugin modification - $1"), pluginName, errMsg.desc)
+                        cockpit.format(_("Error during $0 plugin modification - $1"), pluginName, errMsg)
                     );
                     toggleLoadingHandler();
                     this.setState({ disableSwitch: false });

--- a/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/referentialIntegrity.jsx
@@ -15,7 +15,7 @@ import {
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { listsEqual, log_cmd, valid_dn, file_is_path } from "../tools.jsx";
+import { listsEqual, log_cmd, valid_dn, file_is_path, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 
 const _ = cockpit.gettext;
@@ -373,11 +373,11 @@ class ReferentialIntegrity extends React.Component {
                     this.props.pluginListHandler();
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error", cockpit.format(_("Error during update - $0"), errMsg)
@@ -599,10 +599,10 @@ class ReferentialIntegrity extends React.Component {
                     this.handleCloseModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg.desc)
+                        cockpit.format(_("Error during the config entry $0 operation - $1"), action, errMsg)
                     );
                     this.props.pluginListHandler();
                     this.handleCloseModal();
@@ -640,10 +640,10 @@ class ReferentialIntegrity extends React.Component {
                     this.handleCloseModal();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during the config entry removal operation - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.closeConfirmDelete();

--- a/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/retroChangelog.jsx
@@ -17,7 +17,7 @@ import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { log_cmd, valid_dn, listsEqual } from "../tools.jsx";
+import { log_cmd, valid_dn, listsEqual, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -328,10 +328,10 @@ class RetroChangelog extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update Retro Changelog Plugin - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update Retro Changelog Plugin - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.setState({

--- a/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/rootDNAccessControl.jsx
@@ -12,7 +12,7 @@ import {
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { log_cmd, listsEqual } from "../tools.jsx";
+import { log_cmd, listsEqual, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -409,10 +409,10 @@ class RootDNAccessControl extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update RootDN Access Control Plugin - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update RootDN Access Control Plugin - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.setState({

--- a/src/cockpit/389-console/src/lib/plugins/usn.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/usn.jsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     WrenchIcon,
 } from '@patternfly/react-icons';
@@ -125,10 +125,10 @@ class USNPlugin extends React.Component {
                     this.setState({ disableSwitch: false });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     addNotification(
                         "error",
-                        cockpit.format(_("Error during global USN mode modification - $0"), errMsg.desc)
+                        cockpit.format(_("Error during global USN mode modification - $0"), errMsg)
                     );
                     toggleLoadingHandler();
                     this.setState({ disableSwitch: false });
@@ -170,8 +170,8 @@ class USNPlugin extends React.Component {
                 })
                 .fail(err => {
                     if (err !== 0) {
-                        const errMsg = JSON.parse(err);
-                        console.log("Get global USN failed", errMsg.desc);
+                        const errMsg = getApiErrorMessage(err);
+                        console.log("Get global USN failed", errMsg);
                     }
                     this.setState({
                         disableSwitch: false
@@ -226,10 +226,10 @@ class USNPlugin extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Cleanup USN Tombstones task has failed $0"), errMsg.desc)
+                            cockpit.format(_("Cleanup USN Tombstones task has failed $0"), errMsg)
                         );
                         this.props.toggleLoadingHandler();
                         this.setState({

--- a/src/cockpit/389-console/src/lib/plugins/winsync.jsx
+++ b/src/cockpit/389-console/src/lib/plugins/winsync.jsx
@@ -14,7 +14,7 @@ import {
 } from "@patternfly/react-core";
 import PropTypes from "prop-types";
 import PluginBasicConfig from "./pluginBasicConfig.jsx";
-import { log_cmd, valid_dn } from "../tools.jsx";
+import { log_cmd, valid_dn, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -109,10 +109,10 @@ class WinSync extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Fixup task for $0 has failed $1"), this.state.fixupDN, errMsg.desc)
+                        cockpit.format(_("Fixup task for $0 has failed $1"), this.state.fixupDN, errMsg)
                     );
                     this.setState({
                         fixupModalShow: false,
@@ -261,10 +261,10 @@ class WinSync extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to update Posix winsync plugin - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to update Posix winsync plugin - $0"), errMsg)
                     );
                     this.props.pluginListHandler();
                     this.setState({

--- a/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replAgmts.jsx
@@ -1061,10 +1061,10 @@ export class ReplAgmts extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to get agreement information for: \"$0\" - $1"), agmtName, errMsg.desc)
+                        cockpit.format(_("Failed to get agreement information for: \"$0\" - $1"), agmtName, errMsg)
                     );
                 });
     }
@@ -1225,10 +1225,10 @@ export class ReplAgmts extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         'error',
-                        cockpit.format(_("Failed to poke replication agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to poke replication agreement - $0"), errMsg)
                     );
                 });
     }
@@ -1256,10 +1256,10 @@ export class ReplAgmts extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         'error',
-                        cockpit.format(_("Failed to initialize replication agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to initialize replication agreement - $0"), errMsg)
                     );
                     this.setState({
                         showConfirmInitAgmt: false
@@ -1314,10 +1314,10 @@ export class ReplAgmts extends React.Component {
                         _("Successfully enabled replication agreement"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to enabled replication agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to enabled replication agreement - $0"), errMsg)
                     );
                 });
     }
@@ -1339,10 +1339,10 @@ export class ReplAgmts extends React.Component {
                         _("Successfully disabled replication agreement"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to disable replication agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to disable replication agreement - $0"), errMsg)
                     );
                 });
     }
@@ -1366,10 +1366,10 @@ export class ReplAgmts extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete replication agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to delete replication agreement - $0"), errMsg)
                     );
                     this.setState({
                         showConfirmDeleteAgmt: false,

--- a/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replChangelog.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -144,14 +144,14 @@ export class Changelog extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.reloadChangelog();
                         this.setState({
                             saving: false
                         });
-                        let msg = errMsg.desc;
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",
@@ -238,10 +238,10 @@ export class Changelog extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to reload changelog for \"$0\" - $1"), this.props.suffix, errMsg.desc)
+                        cockpit.format(_("Failed to reload changelog for \"$0\" - $1"), this.props.suffix, errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/replication/replConfig.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replConfig.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn, callCmdStreamPassword } from "../tools.jsx";
+import { log_cmd, valid_dn, callCmdStreamPassword, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { ManagerTable } from "./replTables.jsx";
 import { AddEditManagerModal, ChangeReplRoleModal } from "./replModals.jsx";
@@ -161,11 +161,11 @@ export class ReplConfig extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to $0 replica - $1"), action, errMsg.desc)
+                        cockpit.format(_("Failed to $0 replica - $1"), action, errMsg)
                     );
                     this.setState({
                         roleChangeSpinning: false,
@@ -434,11 +434,11 @@ export class ReplConfig extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reloadConfig(this.props.suffix);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failure removing Replication Manager - $0"), errMsg.desc)
+                        cockpit.format(_("Failure removing Replication Manager - $0"), errMsg)
                     );
                     this.setState({
                         modalSpinning: false
@@ -507,14 +507,14 @@ export class ReplConfig extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.props.reloadConfig(this.props.suffix);
                         this.setState({
                             saving: false
                         });
-                        let msg = errMsg.desc;
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",

--- a/src/cockpit/389-console/src/lib/replication/replSuffix.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replSuffix.jsx
@@ -21,7 +21,7 @@ import {
 } from "@patternfly/react-core";
 import { SyncAltIcon, TreeIcon, CloneIcon, LeafIcon } from "@patternfly/react-icons";
 import PropTypes from "prop-types";
-import { log_cmd, valid_dn, callCmdStreamPassword } from "../tools.jsx";
+import { log_cmd, valid_dn, callCmdStreamPassword, getApiErrorMessage } from "../tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -275,10 +275,10 @@ export class ReplSuffix extends React.Component {
                     this.setState({
                         modalSpinning: false
                     });
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to disable replication for $0 - $1"), this.props.suffix, errMsg.desc)
+                        cockpit.format(_("Failed to disable replication for $0 - $1"), this.props.suffix, errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/replication/replTasks.jsx
+++ b/src/cockpit/389-console/src/lib/replication/replTasks.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, bad_file_name } from "../tools.jsx";
+import { log_cmd, bad_file_name, getApiErrorMessage } from "../tools.jsx";
 import { RUVTable } from "./replTables.jsx";
 import { ExportCLModal } from "./replModals.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
@@ -153,10 +153,10 @@ export class ReplRUV extends React.Component {
                     this.closeConfirmCleanRUV();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to start CleanAllRUV task - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to start CleanAllRUV task - $0"), errMsg)
                     );
                     this.closeConfirmCleanRUV();
                 });
@@ -218,10 +218,10 @@ export class ReplRUV extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error importing changelog LDIF - $0"), errMsg.desc)
+                        cockpit.format(_("Error importing changelog LDIF - $0"), errMsg)
                     );
                     this.setState({
                         showConfirmCLImport: false,
@@ -271,10 +271,10 @@ export class ReplRUV extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error importing changelog LDIF - $0"), errMsg.desc)
+                        cockpit.format(_("Error importing changelog LDIF - $0"), errMsg)
                     );
                     this.setState({
                         showCLExport: false,

--- a/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
+++ b/src/cockpit/389-console/src/lib/replication/winsyncAgmts.jsx
@@ -3,10 +3,7 @@ import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { ReplAgmtTable } from "./replTables.jsx";
 import { WinsyncAgmtModal } from "./replModals.jsx";
-import {
-    log_cmd, valid_dn, valid_port,
-    listsEqual, callCmdStreamPassword
-} from "../tools.jsx";
+import { log_cmd, valid_dn, valid_port, listsEqual, callCmdStreamPassword, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 import {
     Button,
@@ -744,10 +741,10 @@ export class WinsyncAgmts extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to get agreement information for: \"$0\" - $1"), agmtName, errMsg.desc)
+                        cockpit.format(_("Failed to get agreement information for: \"$0\" - $1"), agmtName, errMsg)
                     );
                 });
     }
@@ -881,10 +878,10 @@ export class WinsyncAgmts extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         'error',
-                        cockpit.format(_("Failed to poke winsync agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to poke winsync agreement - $0"), errMsg)
                     );
                 });
     }
@@ -913,10 +910,10 @@ export class WinsyncAgmts extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         'error',
-                        cockpit.format(_("Failed to initialize winsync agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to initialize winsync agreement - $0"), errMsg)
                     );
                     this.setState({
                         showConfirmInitAgmt: false
@@ -971,10 +968,10 @@ export class WinsyncAgmts extends React.Component {
                         _("Successfully enabled winsync agreement"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to enabled winsync agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to enabled winsync agreement - $0"), errMsg)
                     );
                 });
     }
@@ -996,10 +993,10 @@ export class WinsyncAgmts extends React.Component {
                         _("Successfully disabled winsync agreement"));
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to disable winsync agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to disable winsync agreement - $0"), errMsg)
                     );
                 });
     }
@@ -1024,10 +1021,10 @@ export class WinsyncAgmts extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Failed to delete winsync agreement - $0"), errMsg.desc)
+                        cockpit.format(_("Failed to delete winsync agreement - $0"), errMsg)
                     );
                     this.setState({
                         showConfirmDeleteAgmt: false,

--- a/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
+++ b/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
@@ -25,7 +25,7 @@ import {
     ExportCertModal,
 } from "./securityModals.jsx";
 import PropTypes from "prop-types";
-import { log_cmd } from "../../lib/tools.jsx";
+import { getApiErrorMessage, log_cmd } from "../../lib/tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -430,11 +430,7 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.setState({
                         showExportModal: false,
                         exportNickname: '',
@@ -570,17 +566,9 @@ export class CertificateManagement extends React.Component {
                                         this.closeAddModal();
                                     })
                                     .fail(err => {
-                                        let msg = _("Unknown error");
-                                        try {
-                                            const errMsg = buffer ? JSON.parse(buffer) : JSON.parse(err);
-                                            msg = errMsg.desc || errMsg.message || buffer || err;
-                                            if ('info' in errMsg) {
-                                                msg = errMsg.desc + " - " + errMsg.info;
-                                            }
-                                        } catch (e) {
-                                            // If parsing fails, use buffer or error directly
-                                            msg = buffer || err || _("Unknown error");
-                                        }
+                                        const msg = buffer
+                                            ? getApiErrorMessage(buffer)
+                                            : getApiErrorMessage(err);
                                         this.deleteTmpCert(certFile);
                                         this.closeAddCAModal();
                                         this.closeAddModal();
@@ -621,11 +609,7 @@ export class CertificateManagement extends React.Component {
                                         this.closeAddModal();
                                     })
                                     .fail(err => {
-                                        const errMsg = JSON.parse(err);
-                                        let msg = errMsg.desc;
-                                        if ('info' in errMsg) {
-                                            msg = errMsg.desc + " - " + errMsg.info;
-                                        }
+                                        const msg = getApiErrorMessage(err);
                                         this.deleteTmpCert(certFile);
                                         this.closeAddCAModal();
                                         this.closeAddModal();
@@ -700,17 +684,9 @@ export class CertificateManagement extends React.Component {
                             );
                         })
                         .fail(err => {
-                            let msg = _("Unknown error");
-                            try {
-                                const errMsg = buffer ? JSON.parse(buffer) : JSON.parse(err);
-                                msg = errMsg.desc || errMsg.message || buffer || err;
-                                if ('info' in errMsg) {
-                                    msg = errMsg.desc + " - " + errMsg.info;
-                                }
-                            } catch (e) {
-                                // If parsing fails, use buffer or error directly
-                                msg = buffer || err || _("Unknown error");
-                            }
+                            const msg = buffer
+                                ? getApiErrorMessage(buffer)
+                                : getApiErrorMessage(err);
                             this.closeAddCAModal();
                             this.closeAddModal();
                             this.setState({
@@ -750,11 +726,7 @@ export class CertificateManagement extends React.Component {
                             );
                         })
                         .fail(err => {
-                            const errMsg = JSON.parse(err);
-                            let msg = errMsg.desc;
-                            if ('info' in errMsg) {
-                                msg = errMsg.desc + " - " + errMsg.info;
-                            }
+                            const msg = getApiErrorMessage(err);
                             this.closeAddCAModal();
                             this.closeAddModal();
                             this.setState({
@@ -800,8 +772,8 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if (errMsg.desc.includes('certutil -s: improperly formatted name:')) {
+                    const errMsg = getApiErrorMessage(err);
+                    if (errMsg.includes('certutil -s: improperly formatted name:')) {
                         this.props.addNotification(
                             "error",
                             _("Error Improperly formatted subject")
@@ -809,7 +781,7 @@ export class CertificateManagement extends React.Component {
                     } else {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error creating CSR - $0"), errMsg.desc)
+                            cockpit.format(_("Error creating CSR - $0"), errMsg)
                         );
                     }
                     this.setState({
@@ -843,10 +815,10 @@ export class CertificateManagement extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error displaying CSR - $0"), errMsg.desc)
+                        cockpit.format(_("Error displaying CSR - $0"), errMsg)
                     );
                 });
     }
@@ -903,11 +875,7 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.setState({
                         certName: '',
                         modalSpinning: false,
@@ -946,11 +914,7 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.setState({
                         csrName: '',
                         csrSubject: '',
@@ -989,11 +953,7 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.setState({
                         keyID: '',
                         modalSpinning: false,
@@ -1084,11 +1044,7 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.setState({
                         showEditModal: false,
                         flags: '',
@@ -1295,11 +1251,7 @@ export class CertificateManagement extends React.Component {
                     }, this.getCertFiles);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error loading server certificates - $0"), msg)
@@ -1326,11 +1278,7 @@ export class CertificateManagement extends React.Component {
                     }, this.reloadOrphanKeys);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error loading CSRs - $0"), msg)
@@ -1359,11 +1307,11 @@ export class CertificateManagement extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if (!errMsg.desc.includes('certutil: no keys found')) {
+                    const errMsg = getApiErrorMessage(err);
+                    if (!errMsg.includes('certutil: no keys found')) {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error loading Orphan Keys - $0"), errMsg.desc)
+                            cockpit.format(_("Error loading Orphan Keys - $0"), errMsg)
                         );
                     }
                     this.setState({
@@ -1394,11 +1342,7 @@ export class CertificateManagement extends React.Component {
                     }, this.reloadCerts);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
-                    if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
-                    }
+                    const msg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error loading CA certificates - $0"), msg)

--- a/src/cockpit/389-console/src/lib/security/ciphers.jsx
+++ b/src/cockpit/389-console/src/lib/security/ciphers.jsx
@@ -16,7 +16,7 @@ import {
 	TextVariants
 } from '@patternfly/react-core';
 import TypeaheadSelect from "../../dsBasicComponents.jsx";
-import { log_cmd } from "../../lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../../lib/tools.jsx";
 import PropTypes from "prop-types";
 
 const _ = cockpit.gettext;
@@ -180,10 +180,10 @@ export class Ciphers extends React.Component {
                     this.props.reload();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",

--- a/src/cockpit/389-console/src/lib/security/encryptionModules.jsx
+++ b/src/cockpit/389-console/src/lib/security/encryptionModules.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { EncryptionModuleTable } from "./securityTables.jsx";
 
@@ -63,7 +63,7 @@ function EncryptionModules({ addNotification, serverId, serverCertNames }) {
     // Parse dsconf JSON errors and fallback safely for unexpected output.
     const parseCmdError = React.useCallback(err => {
         try {
-            const errObj = JSON.parse(err);
+            const errObj = getApiErrorMessage(err);
             let msg = errObj.desc;
             if ("info" in errObj) {
                 msg = `${errObj.desc} - ${errObj.info}`;

--- a/src/cockpit/389-console/src/lib/server/accessLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/accessLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -310,12 +310,12 @@ export class ServerAccessLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.refreshConfig(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error saving Access Log settings - $0"), errMsg.desc)
+                        cockpit.format(_("Error saving Access Log settings - $0"), errMsg)
                     );
                 });
     }
@@ -409,10 +409,10 @@ export class ServerAccessLog extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Access Log configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Access Log configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/server/auditLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { listsEqual, log_cmd } from "../tools.jsx";
+import { listsEqual, log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -299,12 +299,12 @@ export class ServerAuditLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.refreshConfig(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error saving Audit Log settings - $0"), errMsg.desc)
+                        cockpit.format(_("Error saving Audit Log settings - $0"), errMsg)
                     );
                 });
     }
@@ -399,10 +399,10 @@ export class ServerAuditLog extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Audit Log configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Audit Log configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/auditfailLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -251,12 +251,12 @@ export class ServerAuditFailLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.refreshConfig(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error saving Audit Fail Log settings - $0"), errMsg.desc)
+                        cockpit.format(_("Error saving Audit Fail Log settings - $0"), errMsg)
                     );
                 });
     }
@@ -329,10 +329,10 @@ export class ServerAuditFailLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Audit Fail Log configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Audit Fail Log configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/server/errorLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/errorLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -336,12 +336,12 @@ export class ServerErrorLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.handleRefreshConfig(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error saving Error Log settings - $0"), errMsg.desc)
+                        cockpit.format(_("Error saving Error Log settings - $0"), errMsg)
                     );
                 });
     }
@@ -438,10 +438,10 @@ export class ServerErrorLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Error Log configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Error Log configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/server/ldapi.jsx
+++ b/src/cockpit/389-console/src/lib/server/ldapi.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -181,13 +181,13 @@ export class ServerLDAPI extends React.Component {
                     }, this.handleLoadConfig);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loading: false
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading server configuration - $0"), errMsg)
                     );
                 });
     }
@@ -229,13 +229,13 @@ export class ServerLDAPI extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loading: false
                     }, this.reloadConfig);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating LDAPI configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating LDAPI configuration - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/server/sasl.jsx
+++ b/src/cockpit/389-console/src/lib/server/sasl.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import { DoubleConfirmModal } from "../notifications.jsx";
-import { log_cmd, listsEqual } from "../tools.jsx";
+import { log_cmd, listsEqual, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -408,11 +408,11 @@ export class ServerSASL extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadConfig();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error creating new SASL Mapping - $0"), errMsg.desc)
+                        cockpit.format(_("Error creating new SASL Mapping - $0"), errMsg)
                     );
                 });
     }
@@ -464,22 +464,22 @@ export class ServerSASL extends React.Component {
                                 );
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.closeMapping();
                                 this.handleLoadConfig();
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error updating SASL Mapping - $0"), errMsg.desc)
+                                    cockpit.format(_("Error updating SASL Mapping - $0"), errMsg)
                                 );
                             });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadConfig();
                     this.closeMapping();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error replacing SASL Mapping - $0"), errMsg.desc)
+                        cockpit.format(_("Error replacing SASL Mapping - $0"), errMsg)
                     );
                 });
     }
@@ -515,12 +515,12 @@ export class ServerSASL extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadConfig();
                     this.closeConfirmDelete();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error deleting SASL Mapping - $0"), errMsg.desc)
+                        cockpit.format(_("Error deleting SASL Mapping - $0"), errMsg)
                     );
                 });
     }
@@ -572,11 +572,11 @@ export class ServerSASL extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleLoadConfig();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating SASL configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating SASL configuration - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/lib/server/securityLog.jsx
+++ b/src/cockpit/389-console/src/lib/server/securityLog.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -252,12 +252,12 @@ export class ServerSecurityLog extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.reload();
                     this.refreshConfig(1);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error saving Security Log settings - $0"), errMsg.desc)
+                        cockpit.format(_("Error saving Security Log settings - $0"), errMsg)
                     );
                 });
     }
@@ -334,10 +334,10 @@ export class ServerSecurityLog extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Security Log configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Security Log configuration - $0"), errMsg)
                     );
                     this.setState({
                         loading: false,

--- a/src/cockpit/389-console/src/lib/server/settings.jsx
+++ b/src/cockpit/389-console/src/lib/server/settings.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, valid_dn, isValidIpAddress, isValidIpAddressOrCIDR, is_port_in_use } from "../tools.jsx";
+import { log_cmd, valid_dn, isValidIpAddress, isValidIpAddressOrCIDR, is_port_in_use, getApiErrorMessage } from "../tools.jsx";
 import {
 	Button,
 	Checkbox,
@@ -567,11 +567,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.reloadRootDN();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating Directory Manager configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating Directory Manager configuration - $0"), errMsg)
                     );
                 });
     }
@@ -604,13 +604,13 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         rootDNReloading: false,
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error reloading Directory Manager configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error reloading Directory Manager configuration - $0"), errMsg)
                     );
                 });
     }
@@ -648,11 +648,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.reloadDiskMonitoring();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating Disk Monitoring configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating Disk Monitoring configuration - $0"), errMsg)
                     );
                 });
     }
@@ -695,13 +695,13 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         diskMonReloading: false,
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error reloading Disk Monitoring configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error reloading Disk Monitoring configuration - $0"), errMsg)
                     );
                 });
     }
@@ -732,11 +732,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                                     );
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     this.reloadAdvanced();
                                     this.props.addNotification(
                                         "error",
-                                        `Error updating Advanced configuration - ${errMsg.desc}`
+                                        `Error updating Advanced configuration - ${errMsg}`
                                     );
                                 });
                     } else {
@@ -748,11 +748,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.reloadAdvanced();
                     this.props.addNotification(
                         "error",
-                        `Error updating Advanced configuration - ${errMsg.desc}`
+                        `Error updating Advanced configuration - ${errMsg}`
                     );
                 });
     }
@@ -811,11 +811,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.reloadAdvanced();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating Advanced configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating Advanced configuration - $0"), errMsg)
                     );
                 });
     }
@@ -912,10 +912,10 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading Advanced configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading Advanced configuration - $0"), errMsg)
                     );
                     this.setState({
                         advReloading: false,
@@ -951,11 +951,11 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.handleReloadConfig();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating server configuration - $0"), errMsg)
                     );
                 });
     }
@@ -1005,10 +1005,10 @@ async validateSaveBtn(nav_tab, attr, value) {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error reloading server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error reloading server configuration - $0"), errMsg)
                     );
                     this.setState({
                         configReloading: false,

--- a/src/cockpit/389-console/src/lib/server/tuning.jsx
+++ b/src/cockpit/389-console/src/lib/server/tuning.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "../tools.jsx";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
 import {
     Button,
     Checkbox,
@@ -194,13 +194,13 @@ export class ServerTuning extends React.Component {
                     }, this.props.enableTree());
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loaded: true
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading server configuration - $0"), errMsg)
                     );
                 });
     }
@@ -240,11 +240,11 @@ export class ServerTuning extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.loadConfig();
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error updating tuning configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error updating tuning configuration - $0"), errMsg)
                     );
                 });
     }

--- a/src/cockpit/389-console/src/monitor.jsx
+++ b/src/cockpit/389-console/src/monitor.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 import PropTypes from "prop-types";
 import ServerMonitor from "./lib/monitor/serverMonitor.jsx";
 import { DatabaseMonitor, DatabaseMonitorMDB } from "./lib/monitor/dbMonitor.jsx";
@@ -643,8 +643,8 @@ export class Monitor extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    console.log("getDBEngine - Error detecting DB implementation type -", errMsg.desc);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log("getDBEngine - Error detecting DB implementation type -", errMsg);
                 });
     }
 
@@ -832,8 +832,8 @@ export class Monitor extends React.Component {
                 })
                 .fail(err => {
                     // No dsrc file, thats ok
-                    const errMsg = JSON.parse(err);
-                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg.desc}`);
+                    const errMsg = getApiErrorMessage(err);
+                    console.log(`loadDSRC: Could not load .dsrc file: ${errMsg}`);
                     this.setState({
                         replLoading: false,
                     });

--- a/src/cockpit/389-console/src/plugins.jsx
+++ b/src/cockpit/389-console/src/plugins.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 import { DoubleConfirmModal } from "./lib/notifications.jsx";
 import {
     Grid,
@@ -151,8 +151,8 @@ export class Plugins extends React.Component {
                                 });
                             })
                             .fail(err => {
-                                const errMsg = JSON.parse(err);
-                                this.props.addNotification("error", cockpit.format(_("Failed to get objectClasses - $0"), errMsg.desc));
+                                const errMsg = getApiErrorMessage(err);
+                                this.props.addNotification("error", cockpit.format(_("Failed to get objectClasses - $0"), errMsg));
                             });
                 });
     }
@@ -207,10 +207,10 @@ export class Plugins extends React.Component {
                     }
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("$0 error during plugin loading"), errMsg.desc)
+                        cockpit.format(_("$0 error during plugin loading"), errMsg)
                     );
                 });
     }
@@ -268,13 +268,13 @@ export class Plugins extends React.Component {
                     this.toggleLoading();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if (errMsg.desc.indexOf("nothing to set") >= 0) {
+                    const errMsg = getApiErrorMessage(err);
+                    if (errMsg.indexOf("nothing to set") >= 0) {
                         nothingToSetErr = true;
                     } else {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("$0 error during $1 modification"), errMsg.desc, data.name)
+                            cockpit.format(_("$0 error during $1 modification"), errMsg, data.name)
                         );
                     }
                     this.closePluginModal();
@@ -306,10 +306,10 @@ export class Plugins extends React.Component {
                                     console.info("savePlugin", "Result", content);
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
+                                    const errMsg = getApiErrorMessage(err);
                                     if (
-                                        (errMsg.desc.indexOf("nothing to set") >= 0 && nothingToSetErr) ||
-                                errMsg.desc.indexOf("nothing to set") < 0
+                                        (errMsg.indexOf("nothing to set") >= 0 && nothingToSetErr) ||
+                                errMsg.indexOf("nothing to set") < 0
                                     ) {
                                         if (basicPluginSuccess) {
                                             this.props.addNotification(
@@ -320,7 +320,7 @@ export class Plugins extends React.Component {
                                         }
                                         this.props.addNotification(
                                             "error",
-                                            cockpit.format(_("$0 error during $1 modification"), errMsg.desc, data.name)
+                                            cockpit.format(_("$0 error during $1 modification"), errMsg, data.name)
                                         );
                                     }
                                     this.toggleLoading();
@@ -378,10 +378,10 @@ export class Plugins extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during $0 plugin modification - $1"), this.state.togglePluginName, errMsg.desc)
+                        cockpit.format(_("Error during $0 plugin modification - $1"), this.state.togglePluginName, errMsg)
                     );
                     // toggleLoadingHandler();
                     this.setState({

--- a/src/cockpit/389-console/src/replication.jsx
+++ b/src/cockpit/389-console/src/replication.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 import { ReplSuffix } from "./lib/replication/replSuffix.jsx";
 import PropTypes from "prop-types";
 import {
@@ -652,11 +652,11 @@ export class Replication extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if (errMsg.desc !== "No such object") {
+                    const errMsg = getApiErrorMessage(err);
+                    if (errMsg !== "No such object") {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error loading suffix RUV - $0"), errMsg.desc)
+                            cockpit.format(_("Error loading suffix RUV - $0"), errMsg)
                         );
                     }
                     this.setState({
@@ -994,12 +994,12 @@ export class Replication extends React.Component {
                                                                     });
                                                                 })
                                                                 .fail(err => {
-                                                                    const errMsg = JSON.parse(err);
-                                                                    if (errMsg.desc !== "No such object" &&
-                                                                        !errMsg.desc.includes('There is no RUV for suffix')) {
+                                                                    const errMsg = getApiErrorMessage(err);
+                                                                    if (errMsg !== "No such object" &&
+                                                                        !errMsg.includes('There is no RUV for suffix')) {
                                                                         this.props.addNotification(
                                                                             "error",
-                                                                            cockpit.format(_("Error loading suffix RUV - $0"), errMsg.desc)
+                                                                            cockpit.format(_("Error loading suffix RUV - $0"), errMsg)
                                                                         );
                                                                     }
                                                                     this.setState({
@@ -1012,10 +1012,10 @@ export class Replication extends React.Component {
                                                                 });
                                                     })
                                                     .fail(err => {
-                                                        const errMsg = JSON.parse(err);
+                                                        const errMsg = getApiErrorMessage(err);
                                                         this.props.addNotification(
                                                             "error",
-                                                            cockpit.format(_("Error loading winsync agreements - $0"), errMsg.desc)
+                                                            cockpit.format(_("Error loading winsync agreements - $0"), errMsg)
                                                         );
                                                         this.setState({
                                                             winsyncLoading: false,
@@ -1027,10 +1027,10 @@ export class Replication extends React.Component {
                                                     });
                                             })
                                             .fail(err => {
-                                                const errMsg = JSON.parse(err);
+                                                const errMsg = getApiErrorMessage(err);
                                                 this.props.addNotification(
                                                     "error",
-                                                    cockpit.format(_("Error loading replication agreements configuration - $0"), errMsg.desc)
+                                                    cockpit.format(_("Error loading replication agreements configuration - $0"), errMsg)
                                                 );
                                                 this.setState({
                                                     agmtsLoading: false,
@@ -1043,10 +1043,10 @@ export class Replication extends React.Component {
                             })
                             .fail(err => {
                                 // changelog failure
-                                const errMsg = JSON.parse(err);
+                                const errMsg = getApiErrorMessage(err);
                                 this.props.addNotification(
                                     "error",
-                                    cockpit.format(_("Error loading replication changelog configuration - $0"), errMsg.desc)
+                                    cockpit.format(_("Error loading replication changelog configuration - $0"), errMsg)
                                 );
                                 this.setState({
                                     changelogLoading: false,
@@ -1093,10 +1093,10 @@ export class Replication extends React.Component {
                         attrsLoading: false,
                     });
                 }).fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading attributes - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading attributes - $0"), errMsg)
                     );
                     this.setState({
                         attributes: [],

--- a/src/cockpit/389-console/src/schema.jsx
+++ b/src/cockpit/389-console/src/schema.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd, searchFilter, listsEqual } from "./lib/tools.jsx";
+import { log_cmd, searchFilter, listsEqual, getApiErrorMessage } from "./lib/tools.jsx";
 import {
     ObjectClassesTable,
     AttributesTable,
@@ -395,8 +395,8 @@ export class Schema extends React.Component {
                 })
                 .fail(err => {
                     if (err !== 0) {
-                        const errMsg = JSON.parse(err);
-                        console.log("loadSyntaxes failed: ", errMsg.desc);
+                        const errMsg = getApiErrorMessage(err);
+                        console.log("loadSyntaxes failed: ", errMsg);
                     }
                 });
     }
@@ -483,8 +483,8 @@ export class Schema extends React.Component {
                 })
                 .fail(err => {
                     if (err !== 0) {
-                        const errMsg = JSON.parse(err);
-                        console.log("loadSchemaData failed: ", errMsg.desc);
+                        const errMsg = getApiErrorMessage(err);
+                        console.log("loadSchemaData failed: ", errMsg);
                     }
                     if (initialLoading) {
                         this.toggleLoading("allSchema");
@@ -663,10 +663,10 @@ export class Schema extends React.Component {
                     this.closeConfirmOCDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during ObjectClass removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during ObjectClass removal operation - $0"), errMsg)
                     );
                     this.loadSchemaData();
                     this.closeConfirmOCDelete();
@@ -740,11 +740,11 @@ export class Schema extends React.Component {
                         this.toggleLoading("ocModal");
                     })
                     .fail(err => {
-                        let errMsg = JSON.parse(err);
+                        let errMsg = getApiErrorMessage(err);
                         if ('info' in errMsg) {
-                            errMsg = errMsg.desc + " " + errMsg.info;
+                            errMsg = errMsg + " " + errMsg.info;
                         } else {
-                            errMsg = errMsg.desc;
+                            errMsg = errMsg;
                         }
                         this.props.addNotification(
                             "error",
@@ -957,10 +957,10 @@ export class Schema extends React.Component {
                     this.closeConfirmAttrDelete();
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error during Attribute removal operation - $0"), errMsg.desc)
+                        cockpit.format(_("Error during Attribute removal operation - $0"), errMsg)
                     );
                     this.loadSchemaData();
                     this.closeConfirmAttrDelete();
@@ -1057,11 +1057,11 @@ export class Schema extends React.Component {
                     this.toggleLoading("atModal");
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error",
@@ -1168,11 +1168,11 @@ export class Schema extends React.Component {
                     this.toggleLoading("atModal");
                 })
                 .fail(err => {
-                    let errMsg = JSON.parse(err);
+                    let errMsg = getApiErrorMessage(err);
                     if ('info' in errMsg) {
-                        errMsg = errMsg.desc + " " + errMsg.info;
+                        errMsg = errMsg + " " + errMsg.info;
                     } else {
-                        errMsg = errMsg.desc;
+                        errMsg = errMsg;
                     }
                     this.props.addNotification(
                         "error",

--- a/src/cockpit/389-console/src/security.jsx
+++ b/src/cockpit/389-console/src/security.jsx
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import { DoubleConfirmModal } from "./lib/notifications.jsx";
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 import { CertificateManagement } from "./lib/security/certificateManagement.jsx";
 import EncryptionModules from "./lib/security/encryptionModules.jsx";
 import { SecurityEnableModal } from "./lib/security/securityModals.jsx";
@@ -317,10 +317,10 @@ export class Security extends React.Component {
                     }, this.loadEnabledCiphers);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -346,10 +346,10 @@ export class Security extends React.Component {
                     }, this.loadCerts);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -385,10 +385,10 @@ export class Security extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -425,10 +425,10 @@ export class Security extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -459,10 +459,10 @@ export class Security extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -494,11 +494,11 @@ export class Security extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    if (!errMsg.desc.includes('certutil: no keys found')) {
+                    const errMsg = getApiErrorMessage(err);
+                    if (!errMsg.includes('certutil: no keys found')) {
                         this.props.addNotification(
                             "error",
-                            cockpit.format(_("Error loading Orphan Keys - $0"), errMsg.desc)
+                            cockpit.format(_("Error loading Orphan Keys - $0"), errMsg)
                         );
                     }
                     this.setState({
@@ -529,10 +529,10 @@ export class Security extends React.Component {
                     ), this.loadSupportedCiphers);
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -645,10 +645,10 @@ export class Security extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -738,10 +738,10 @@ export class Security extends React.Component {
                                     });
                                 })
                                 .fail(err => {
-                                    const errMsg = JSON.parse(err);
-                                    let msg = errMsg.desc;
+                                    const errMsg = getApiErrorMessage(err);
+                                    let msg = errMsg;
                                     if ('info' in errMsg) {
-                                        msg = errMsg.desc + " - " + errMsg.info;
+                                        msg = errMsg + " - " + errMsg.info;
                                     }
                                     this.props.addNotification(
                                         "error",
@@ -754,10 +754,10 @@ export class Security extends React.Component {
                                 });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
-                        let msg = errMsg.desc;
+                        const errMsg = getApiErrorMessage(err);
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",
@@ -788,10 +788,10 @@ export class Security extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
-                        let msg = errMsg.desc;
+                        const errMsg = getApiErrorMessage(err);
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",
@@ -832,10 +832,10 @@ export class Security extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
-                    let msg = errMsg.desc;
+                    const errMsg = getApiErrorMessage(err);
+                    let msg = errMsg;
                     if ('info' in errMsg) {
-                        msg = errMsg.desc + " - " + errMsg.info;
+                        msg = errMsg + " - " + errMsg.info;
                     }
                     this.props.addNotification(
                         "error",
@@ -960,14 +960,14 @@ export class Security extends React.Component {
                         }
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.loadSecurityConfig();
                         this.setState({
                             saving: false
                         });
-                        let msg = errMsg.desc;
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",
@@ -1002,14 +1002,14 @@ export class Security extends React.Component {
                         });
                     })
                     .fail(err => {
-                        const errMsg = JSON.parse(err);
+                        const errMsg = getApiErrorMessage(err);
                         this.loadSecurityConfig();
                         this.setState({
                             saving: false
                         });
-                        let msg = errMsg.desc;
+                        let msg = errMsg;
                         if ('info' in errMsg) {
-                            msg = errMsg.desc + " - " + errMsg.info;
+                            msg = errMsg + " - " + errMsg.info;
                         }
                         this.props.addNotification(
                             "error",

--- a/src/cockpit/389-console/src/server.jsx
+++ b/src/cockpit/389-console/src/server.jsx
@@ -1,6 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
-import { log_cmd } from "./lib/tools.jsx";
+import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 import PropTypes from "prop-types";
 import { ServerSettings } from "./lib/server/settings.jsx";
 import { ServerTuning } from "./lib/server/tuning.jsx";
@@ -122,13 +122,13 @@ export class Server extends React.Component {
                     );
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.setState({
                         loaded: true
                     });
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error loading server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error loading server configuration - $0"), errMsg)
                     );
                 });
     }
@@ -149,10 +149,10 @@ export class Server extends React.Component {
                     });
                 })
                 .fail(err => {
-                    const errMsg = JSON.parse(err);
+                    const errMsg = getApiErrorMessage(err);
                     this.props.addNotification(
                         "error",
-                        cockpit.format(_("Error reloading server configuration - $0"), errMsg.desc)
+                        cockpit.format(_("Error reloading server configuration - $0"), errMsg)
                     );
                 });
     }


### PR DESCRIPTION
Description:

Since dsconf/dsctl/dsidm can return errors in text and JSON so we need to use the new getApiErrorMessage() function to safely parse the error in fail() and generate the error message.

relates: https://github.com/389ds/389-ds-base/issues/7337

Generated-by: Cursor
