### PR TITLE
Issue 7339 - Return the exact DN during export

### DIFF
--- a/dirsrvtests/tests/suites/export/export_test.py
+++ b/dirsrvtests/tests/suites/export/export_test.py
@@ -9,6 +9,8 @@
 import os
 import pytest
 import subprocess
+import ldap
+from lib389.idm.organizationalunit import OrganizationalUnit
 from lib389.topologies import topology_st as topo
 from lib389._constants import DEFAULT_SUFFIX, DEFAULT_BENAME
 from lib389.utils import *
@@ -133,3 +135,49 @@ def test_dbtasks_db2ldif_with_non_accessible_ldif_file_path_output(topo):
 
     log.info("Restarting the instance...")
     topo.standalone.start()
+
+
+def test_db2ldif_preserves_dn_case_in_exported_ldif(topo):
+    """Ensure db2ldif keeps the original DN case in exported LDIF.
+
+    :id: a3af2131-1134-43d2-9cf5-838bf53ec23f
+    :setup: Standalone Instance
+    :steps:
+        1. Add an organizational unit with DN "ou=test_dn_case,dc=EXAMPLE,dc=COM"
+        2. Stop the server
+        3. Perform offline db2ldif export
+        4. Verify the exported LDIF contains the DN with unchanged case
+    :expectedresults:
+        1. Entry is added successfully
+        2. Server stops cleanly
+        3. Offline export succeeds
+        4. DN case is preserved in the exported LDIF file
+    """
+    topo.standalone.start()
+
+    test_dn = "ou=test_dn_case,dc=EXAMPLE,dc=COM"
+    test_rdn_value = "test_dn_case"
+    export_ldif = os.path.join(topo.standalone.get_ldif_dir(), "export_dn_case.ldif")
+    test_ou = OrganizationalUnit(topo.standalone, test_dn)
+
+    log.info("Adding test entry with mixed-case DN suffix")
+    test_ou.create(properties={'ou': test_rdn_value})
+
+    log.info("Stopping the instance...")
+    topo.standalone.stop()
+    try:
+        log.info("Running offline db2ldif export")
+        assert topo.standalone.db2ldif(DEFAULT_BENAME, (DEFAULT_SUFFIX,), None, None, None, export_ldif)
+    finally:
+        log.info("Restarting the instance...")
+        topo.standalone.start()
+
+    log.info("Checking exported LDIF preserves the exact DN case")
+    with open(export_ldif, "r", encoding="utf-8") as export_file:
+        content = export_file.read()
+    assert f"dn: {test_dn}" in content
+
+    # Cleanup test artifacts
+    test_ou.delete()
+    if os.path.exists(export_ldif):
+        os.remove(export_ldif)

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -690,6 +690,7 @@ bdb_db2ldif(Slapi_PBlock *pb)
     export_args eargs = {0};
     int32_t suffix_written = 0;
     int32_t skip_ruv = 0;
+    int return_orig_dn = config_get_return_orig_dn();
 
     slapi_log_err(SLAPI_LOG_TRACE, "bdb_db2ldif", "=>\n");
 
@@ -1073,6 +1074,7 @@ bdb_db2ldif(Slapi_PBlock *pb)
             char *dn = NULL;
             struct backdn *bdn = NULL;
             Slapi_RDN psrdn = {0};
+            bool free_dn = false;
 
             /* get a parent pid */
             rc = get_value_from_string((const char *)data.dptr,
@@ -1131,6 +1133,11 @@ bdb_db2ldif(Slapi_PBlock *pb)
                 dn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
                 slapi_rdn_done(&psrdn);
+            } else if (return_orig_dn &&
+                       get_value_from_string((const char *)data.dptr, "dsentrydn", &dn) == 0)
+            {
+                /* Use the DN from dsEntryDN, but we need to free it later */
+                free_dn = true;
             } else {
                 int myrc = 0;
                 Slapi_DN *sdn = NULL;
@@ -1198,6 +1205,9 @@ bdb_db2ldif(Slapi_PBlock *pb)
             ep->ep_entry = slapi_str2entry_ext(dn, NULL, data.dptr,
                                                str2entry_options | SLAPI_STR2ENTRY_NO_ENTRYDN);
             slapi_ch_free_string(&rdn);
+            if (free_dn) {
+                slapi_ch_free_string(&dn);
+            }
         }
 
         slapi_ch_free(&(data.data));

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
@@ -489,7 +489,7 @@ dbmdb_export_one_entry(struct ldbminfo *li,
         slapi_ch_free_string(&pw);
     }
     data.mv_data = slapi_entry2str_with_options(expargs->ep->ep_entry,
-                                             &len, expargs->options);
+                                                &len, expargs->options);
     data.mv_size = len + 1;
 
     if (expargs->printkey & EXPORT_PRINTKEY) {
@@ -594,6 +594,7 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
     dbmdb_cursor_t cur = {0};
     uint size = 0;
     int wrc = 0;
+    int return_orig_dn = config_get_return_orig_dn();
 
     slapi_log_err(SLAPI_LOG_TRACE, "dbmdb_db2ldif", "=>\n");
 
@@ -960,6 +961,7 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
             char *dn = NULL;
             struct backdn *bdn = NULL;
             Slapi_RDN psrdn = {0};
+            bool free_dn = false;
 
             /* get a parent pid */
             rc = get_value_from_string((const char *)data.mv_data,
@@ -1015,7 +1017,14 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
                 dn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
                 slapi_rdn_done(&psrdn);
+            } else if (return_orig_dn &&
+                       get_value_from_string((const char *)data.mv_data, "dsentrydn", &dn) == 0)
+            {
+                /* Use the DN from dsEntryDN, but we need to free it later */
+                free_dn = true;
             } else {
+                /* Did not find a DN in dsEntryDN attribute, so build it from
+                 * scratch using the entryrdn index. */
                 int myrc = 0;
                 Slapi_DN *sdn = NULL;
                 rc = entryrdn_lookup_dn(be, rdn, temp_id, &dn, NULL, NULL);
@@ -1080,8 +1089,11 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
                 }
             }
             ep->ep_entry = slapi_str2entry_ext(dn, NULL, data.mv_data,
-                                            str2entry_options | SLAPI_STR2ENTRY_NO_ENTRYDN);
+                                               str2entry_options | SLAPI_STR2ENTRY_NO_ENTRYDN);
             slapi_ch_free_string(&rdn);
+            if (free_dn) {
+                slapi_ch_free_string(&dn);
+            }
         }
 
         if ((ep->ep_entry) != NULL) {
@@ -1150,10 +1162,11 @@ bye:
         close(fd);
     }
     if (wrc) {
-        slapi_log_err(SLAPI_LOG_INFO, "dbmdb_export_one_entry", "export %s: Failed to write in export file. errno=%d\n", inst->inst_name, errno);
+        slapi_log_err(SLAPI_LOG_INFO, "dbmdb_export_one_entry",
+                      "export %s: Failed to write in export file. errno=%d\n",
+                      inst->inst_name, errno);
         return_value = wrc;
     }
-
 
     slapi_log_err(SLAPI_LOG_TRACE, "dbmdb_db2ldif", "<=\n");
 


### PR DESCRIPTION
Description:

During an export if the entry is not in the DN cache we rebuild the DN from scratch using the entryrdn index, but this resets the case of the DN.

If we want to use the original case of the DN, and the dsEntryDN attribute is present then use that DN for exported ldif.

relates: https://github.com/389ds/389-ds-base/issues/7339

## Summary by Sourcery

Preserve original distinguished name (DN) casing when exporting entries to LDIF using db2ldif, leveraging stored dsEntryDN values when configured.

New Features:
- Add support for using the stored dsEntryDN attribute during db2ldif export to retain the original DN case when the corresponding configuration option is enabled.

Bug Fixes:
- Ensure offline db2ldif exports no longer normalize or alter DN case when a dsEntryDN value is available, preventing case changes in exported LDIF.

Tests:
- Add a regression test that verifies db2ldif exports preserve the exact DN case in the generated LDIF file.