### PR TITLE
Issue 7342 - CI - repl config regression

### DIFF
--- a/dirsrvtests/tests/suites/replication/replica_config_test.py
+++ b/dirsrvtests/tests/suites/replication/replica_config_test.py
@@ -213,6 +213,8 @@ def test_replica_config_add_nonexistent_replicaroot(topo):
     """
     inst = topo.standalone
     dn = "cn=replica,cn=dc\\3Dexample\\2Cdc\\3Dcom,cn=mapping tree,cn=config"
+    
+    replica_reset(topo)
 
     entry = Entry((dn, {
         'objectclass': [


### PR DESCRIPTION
Description:
Test failed to purge existing repl info

Fixes: https://github.com/389ds/389-ds-base/issues/7342

Co-authored-by: Mark Reynolds <mreynolds@redhat.com>

Reviewed by:

## Summary by Sourcery

Tests:
- Reset replica state at the start of the replica_config_add_nonexistent_replicaroot test to avoid interference from pre-existing repl info.