### PR TITLE
Issue 7348 - CI - Fix failing dsconf security CLI add cert test

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_dsctl_security_cli_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_dsctl_security_cli_test.py
@@ -1575,12 +1575,12 @@ def test_dsconf_security_certificate_import_second_cert(setup_tls):
     inst = setup_tls.standalone
     cert_path = _create_temp_cert_file()
     cert_name = 'Second-Cert'
-
     try:
         add_cmd = [
             'dsconf', inst.serverid, 'security', 'certificate', 'add',
             '--file', cert_path,
-            '--name', cert_name
+            '--name', cert_name,
+            '--do-it'
         ]
         returncode, stdout, stderr = run_cmd(add_cmd, check=False)
         # If cert already exists in this environment, continue with validation


### PR DESCRIPTION
Description:
Server side cert validation via the DynamicCerts backend uses CERT_VerifyCertificateNow() to verify the cert being added. This function is stricter than client side NSS and rejects the test cert due to cert chain validation issues, even though the certificate is valid.

Fix:
Update the CI test to use the --do-it flag, which bypasses strict validation

Fixes: https://github.com/389ds/389-ds-base/issues/7348

Reviewed by:

## Summary by Sourcery

Tests:
- Update the dsconf security certificate import test to invoke the certificate add command with the --do-it flag so it succeeds under strict validation.