### PR TITLE
Issue 6724 - Log fine grained details of operation timing

### DIFF
--- a/dirsrvtests/tests/suites/logging/access_fgot_test.py
+++ b/dirsrvtests/tests/suites/logging/access_fgot_test.py
@@ -72,6 +72,7 @@ def get_last_logs(inst, nblines, jsonlog):
 
 def test_wqtime(setup_json):
     """Check wqtime impact when not having enough worker threads
+
     :id: 8559e688-220b-11f1-b2cc-c85309d5c3e3
     :setup: Standalone instance with very few working threads
     :steps:
@@ -101,6 +102,7 @@ def test_wqtime(setup_json):
 @pytest.mark.parametrize("tested_key", tested_keys)
 def test_fgot_config(setup_json, tested_key):
     """Check fine grain operation timing configuration
+
     :id: 38af4f8a-26c0-11f1-920b-c85309d5c3e3
     :setup: Standalone instance with very few working threads
     :steps:

--- a/dirsrvtests/tests/suites/logging/access_fgot_test.py
+++ b/dirsrvtests/tests/suites/logging/access_fgot_test.py
@@ -96,7 +96,7 @@ def test_wqtime(setup_json):
         ratio = int(100 * wqtime / etime)
         if (ratio > max_wqtime_ratio):
             max_wqtime_ratio = ratio
-    assert ratio > 50
+    assert max_wqtime_ratio > 50
 
 
 @pytest.mark.parametrize("tested_key", tested_keys)

--- a/dirsrvtests/tests/suites/logging/access_fgot_test.py
+++ b/dirsrvtests/tests/suites/logging/access_fgot_test.py
@@ -1,0 +1,138 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2025 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import itertools
+import ldap
+import pytest
+import re
+import subprocess
+import time
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.dirsrv_log import DirsrvAccessJSONLog, DirsrvAccessLog
+from lib389.topologies import topology_st as topo
+
+
+log = logging.getLogger(__name__)
+
+FGOT_KEYS = [ 'wqtime', 'wtime', 'etime', 'optime', 'writetime' ]
+tested_keys = []
+for r in range(1,len(FGOT_KEYS)):
+    tested_keys.extend(itertools.combinations(FGOT_KEYS, r))
+
+@pytest.fixture(scope="module")
+def setup_topo(topo):
+    """Configure log settings and threads number"""
+    inst = topo.standalone
+    inst.config.set("nsslapd-accesslog-level", "256")
+    inst.config.replace('nsslapd-accesslog-logbuffering', 'off')
+    inst.config.replace('nsslapd-threadnumber', '3')
+    inst.restart()
+    return topo
+
+
+@pytest.fixture(params=[True,False])
+def setup_json(request, setup_topo):
+    inst = setup_topo.standalone
+    format = 'json' if request.param else 'default'
+    inst.config.replace('nsslapd-accesslog-log-format', format)
+    return (setup_topo, request.param)
+
+
+def get_last_logs(inst, nblines, jsonlog):
+    if jsonlog:
+        access_log = DirsrvAccessJSONLog(inst)
+    else:
+        access_log = DirsrvAccessLog(inst)
+    log_lines = access_log.readlines()
+    while (len(log_lines) > nblines):
+        log_lines.pop(0)
+    if jsonlog:
+        for line in log_lines:
+            event = access_log.parse_line(line)
+            if event is None or 'header' in event:
+                # Skip non-json or header lines
+                continue
+            if event['operation'] == 'RESULT':
+                yield event
+    else:
+        pattern = r'(\w+)=("(?:[^"\\]|\\.)*"|\S+)'
+        for line in log_lines:
+            if 'RESULT' in line:
+                matches = re.findall(pattern, line)
+                d = { m[0]: m[1] for m in matches }
+                yield d
+
+
+def test_wqtime(setup_json):
+    """Check wqtime impact when not having enough worker threads
+    :id: 8559e688-220b-11f1-b2cc-c85309d5c3e3
+    :setup: Standalone instance with very few working threads
+    :steps:
+        1. Hammer server with searches using ldclt
+        2. Check that on some operations wqtime is the main contributor
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    topo, json_log = setup_json
+
+    inst = topo.standalone
+    cmd = [ 'ldclt', '-H', f'ldap://localhost:{inst.port}', '-e',
+            'esearch', '-f', '(uid=*)', '-N', '3' ]
+    subprocess.run(cmd, check=True)
+
+    max_wqtime_ratio = 0
+    for event in get_last_logs(inst, 40, json_log):
+        wqtime = float(event['wqtime'])
+        etime = float(event['etime'])
+        ratio = int(100 * wqtime / etime)
+        if (ratio > max_wqtime_ratio):
+            max_wqtime_ratio = ratio
+    assert ratio > 50
+
+
+@pytest.mark.parametrize("tested_key", tested_keys)
+def test_fgot_config(setup_json, tested_key):
+    """Check fine grain operation timing configuration
+    :id: 8559e688-220b-11f1-b2cc-c85309d5c3e3
+    :setup: Standalone instance with very few working threads
+    :steps:
+        1. Configure ds-fine-grain-operation-timing toi tested value
+        2. Perform a search
+        3. Check that result has the proper fine grain operation timing
+           keywords that are set and nonme of the unset one
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    topo, json_log = setup_json
+    inst = topo.standalone
+
+    fgot_val = "+".join(tested_key)
+    inst.config.replace('ds-fine-grain-operation-timing', fgot_val)
+    inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, "(uid=*)")
+    # Wait enough to ensure the result is logged
+    log.info(f'Trying: {tested_key}')
+    time.sleep(2)
+    event = next(get_last_logs(inst, 1, json_log))
+    log.info(f'Got: {event}')
+    for k in FGOT_KEYS:
+        if k in tested_key:
+            assert k in event
+        else:
+            assert k not in event
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/logging/access_fgot_test.py
+++ b/dirsrvtests/tests/suites/logging/access_fgot_test.py
@@ -101,7 +101,7 @@ def test_wqtime(setup_json):
 @pytest.mark.parametrize("tested_key", tested_keys)
 def test_fgot_config(setup_json, tested_key):
     """Check fine grain operation timing configuration
-    :id: 8559e688-220b-11f1-b2cc-c85309d5c3e3
+    :id: 38af4f8a-26c0-11f1-920b-c85309d5c3e3
     :setup: Standalone instance with very few working threads
     :steps:
         1. Configure ds-fine-grain-operation-timing toi tested value

--- a/dirsrvtests/tests/suites/logging/logconv_test.py
+++ b/dirsrvtests/tests/suites/logging/logconv_test.py
@@ -32,6 +32,10 @@ from lib389.topologies import create_topology
 
 log = logging.getLogger(__name__)
 
+PREFIX = os.getenv("PREFIX", default="")
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+
 @pytest.fixture(scope="class", params=["default", "json"])
 def topo_shared(request):
     """Create DS standalone instance"""
@@ -39,9 +43,10 @@ def topo_shared(request):
     topology = create_topology({ReplicaRole.STANDALONE: 1})
     topology.standalone.config.set('nsslapd-accesslog-logbuffering', "off")
     topology.standalone.config.set('nsslapd-accesslog-log-format', log_format)
+    topology.standalone.config.set("nsslapd-accesslog-level", "256")
 
     def fin():
-        if topology.standalone.exists():
+        if not DEBUGGING and topology.standalone.exists():
             topology.standalone.delete()
     request.addfinalizer(fin)
 
@@ -254,7 +259,7 @@ class TestLogconv:
                 errors.append(f"{test_name} - {key}: expected {expected_val}, got {existing_val}")
 
         if errors:
-            print("\n".join(errors))
+            log.error("\n".join(errors))
             return False
 
         return True
@@ -719,7 +724,7 @@ class TestLogconv:
 
         self.inst.config.set('nsslapd-ldapilisten', 'on')
         self.inst.config.set('nsslapd-ldapiautobind', 'on')
-        self.inst.config.set('nsslapd-ldapifilepath', f'/var/run/slapd-{self.inst.serverid}.socket')
+        self.inst.config.set('nsslapd-ldapifilepath', f'{PREFIX}/var/run/slapd-{self.inst.serverid}.socket')
 
         expected = {
             "mods": 3,

--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -881,7 +881,7 @@ class logAnalyser:
                     return False
 
                 # Read Fine Grain Operation Timing
-                pattern = rf'.*\s([a-z]+time)=(\S+)\s'
+                pattern = rf'\s([a-z]+time)=([0-9.]+)'
                 for key,val in re.findall(pattern, line):
                     groups[key] = val
 

--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -503,7 +503,7 @@ class logAnalyser:
                 \serr=(?P<err>\d+)                                  # err=int
                 \stag=(?P<tag>\d+)                                  # tag=int
                 \snentries=(?P<nentries>\d+)                        # nentries=int
-                (?:\s[^=]+time=[^ ]+)*                              # fine grain operation timing
+                (?:\s[a-z]+time=[^ ]+)*                             # fine grain operation timing
                 (?:\sdn="(?P<dn>[^"]*)")?                           # Optional: dn="", dn="strings"
                 (?:,\s+(?P<sasl_msg>SASL\s+bind\s+in\s+progress))?  # Optional: SASL bind in progress
                 (?:\s+notes=(?P<notes>[A-Z]))?                      # Optional: notes[A-Z]
@@ -881,7 +881,7 @@ class logAnalyser:
                     return False
 
                 # Read Fine Grain Operation Timing
-                pattern = rf'.*\s([^=]+time)=(\S+)\s'
+                pattern = rf'.*\s([a-z]+time)=(\S+)\s'
                 for key,val in re.findall(pattern, line):
                     groups[key] = val
 
@@ -3395,7 +3395,7 @@ def main():
         wqtimes = sorted(db.result.wqtime_duration, reverse=True)
         num_wqtimes = len(wqtimes)
         if num_wqtimes > 0:
-            print(f"\n----- Top {db.size_limit} Longest wtimes (wait times) -----\n")
+            print(f"\n----- Top {db.size_limit} Longest wqtimes (work queue times) -----\n")
             for num, wqtime in enumerate(wqtimes):
                 if num >= db.size_limit:
                     break
@@ -3405,7 +3405,7 @@ def main():
         writetimes = sorted(db.result.writetime_duration, reverse=True)
         num_writetimes = len(writetimes)
         if num_writetimes > 0:
-            print(f"\n----- Top {db.size_limit} Longest writetimes (wait times) -----\n")
+            print(f"\n----- Top {db.size_limit} Longest writetimes (write I/O times) -----\n")
             for num, writetime in enumerate(writetimes):
                 if num >= db.size_limit:
                     break
@@ -3526,7 +3526,7 @@ def main():
                 rec_count += 1
 
             if round(avg_writetime, 9) > 0.5:
-                print(f"\n {rec_count}. Your average writetime is {avg_wtime:.9f}. Maybe the application is not reading the results in a timely way.\n")
+                print(f"\n {rec_count}. Your average writetime is {avg_writetime:.9f}. Maybe the application is not reading the results in a timely way.\n")
                 rec_count += 1
 
             if round(avg_optime, 9) > 0:

--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -307,11 +307,15 @@ class ResultData:
 
     total_etime: float = 0.0
     total_wtime: float = 0.0
+    total_wqtime: float = 0.0
+    total_writetime: float = 0.0
     total_optime: float = 0.0
     etime_stat: float = 0.0
 
     etime_duration: List[float] = field(default_factory=list)
     wtime_duration: List[float] = field(default_factory=list)
+    wqtime_duration: List[float] = field(default_factory=list)
+    writetime_duration: List[float] = field(default_factory=list)
     optime_duration: List[float] = field(default_factory=list)
 
     nentries_num: List[int] = field(default_factory=list)
@@ -499,9 +503,7 @@ class logAnalyser:
                 \serr=(?P<err>\d+)                                  # err=int
                 \stag=(?P<tag>\d+)                                  # tag=int
                 \snentries=(?P<nentries>\d+)                        # nentries=int
-                \swtime=(?P<wtime>\d+\.\d+)                         # wtime=float
-                \soptime=(?P<optime>\d+\.\d+)                       # optime=float
-                \setime=(?P<etime>\d+\.\d+)                         # etime=float
+                (?:\s[^=]+time=[^ ]+)*                              # fine grain operation timing
                 (?:\sdn="(?P<dn>[^"]*)")?                           # Optional: dn="", dn="strings"
                 (?:,\s+(?P<sasl_msg>SASL\s+bind\s+in\s+progress))?  # Optional: SASL bind in progress
                 (?:\s+notes=(?P<notes>[A-Z]))?                      # Optional: notes[A-Z]
@@ -878,6 +880,11 @@ class logAnalyser:
                     self.logger.error(f"Failed to get group from match line: {line} - {e}.")
                     return False
 
+                # Read Fine Grain Operation Timing
+                pattern = rf'.*\s([^=]+time)=(\S+)\s'
+                for key,val in re.findall(pattern, line):
+                    groups[key] = val
+
                 timestamp_raw = groups.get('timestamp')
                 if timestamp_raw:
                     try:
@@ -1097,6 +1104,8 @@ class logAnalyser:
             "op_id": self.convert_to_int(log_entry.get('op_id', None)),
             "etime": log_entry.get('etime', None),
             "wtime": log_entry.get('wtime', None),
+            "wqtime": log_entry.get('wqtime', None),
+            "writetime": log_entry.get('writetime', None),
             "optime": log_entry.get('optime', None),
             "nentries": self.convert_to_int(log_entry.get('nentries', None)),
             "tag": self.convert_to_int(log_entry.get('tag', None)),
@@ -1133,6 +1142,8 @@ class logAnalyser:
         bind_dn = log_entry.get("bind_dn", "")
         etime = log_entry.get("etime", "")
         wtime = log_entry.get("wtime", "")
+        wqtime = log_entry.get("wqtime", "")
+        writetime = log_entry.get("writetime", "")
         optime = log_entry.get("optime", "")
         nentries = log_entry.get("nentries", None)
         tag = log_entry.get("tag", None)
@@ -1181,6 +1192,26 @@ class logAnalyser:
                 self.result.total_wtime += wtime_f
             except ValueError:
                 self.logger.debug(f"Invalid wtime format: {wtime}")
+
+        if wqtime and isinstance(wqtime, str):
+            try:
+                wqtime_f = float(wqtime)
+                heapq.heappush(self.result.wqtime_duration, wqtime_f)
+                if len(self.result.wqtime_duration) > self.size_limit:
+                    heapq.heappop(self.result.wqtime_duration)
+                self.result.total_wqtime += wqtime_f
+            except ValueError:
+                self.logger.debug(f"Invalid wqtime format: {wqtime}")
+
+        if writetime and isinstance(writetime, str):
+            try:
+                writetime_f = float(writetime)
+                heapq.heappush(self.result.writetime_duration, writetime_f)
+                if len(self.result.writetime_duration) > self.size_limit:
+                    heapq.heappop(self.result.writetime_duration)
+                self.result.total_writetime += writetime_f
+            except ValueError:
+                self.logger.debug(f"Invalid writetime format: {writetime}")
 
         if optime and isinstance(optime, str):
             try:
@@ -3002,6 +3033,8 @@ def main():
     num_time_count = db.result.counters['timestamp']
     if num_time_count:
         avg_wtime = round(db.result.total_wtime/num_time_count, 9)
+        avg_wqtime = round(db.result.total_wqtime/num_time_count, 9)
+        avg_writetime = round(db.result.total_writetime/num_time_count, 9)
         avg_optime = round(db.result.total_optime/num_time_count, 9)
         avg_etime = round(db.result.total_etime/num_time_count, 9)
     num_fd_taken = db.connection.counters['fd_taken']
@@ -3105,6 +3138,8 @@ def main():
 
     if num_time_count:
         print(f"\nAverage wtime (wait time):      {avg_wtime:.9f}")
+        print(f"Average wqtime (work queue wait time):     {avg_wqtime:.9f}")
+        print(f"Average writetime (write I/O time):  {avg_writetime:.9f}")
         print(f"Average optime (op time):       {avg_optime:.9f}")
         print(f"Average etime (elapsed time):   {avg_etime:.9f}")
     print(f"\nMulti-factor Authentications:   {db.result.counters['notesM']}")
@@ -3356,6 +3391,26 @@ def main():
                     break
                 print(f"wtime={wtime:<12}")
 
+        # Longest work queue times
+        wqtimes = sorted(db.result.wqtime_duration, reverse=True)
+        num_wqtimes = len(wqtimes)
+        if num_wqtimes > 0:
+            print(f"\n----- Top {db.size_limit} Longest wtimes (wait times) -----\n")
+            for num, wqtime in enumerate(wqtimes):
+                if num >= db.size_limit:
+                    break
+                print(f"wqtime={wqtime:<12}")
+
+        # Longest write I/O times
+        writetimes = sorted(db.result.writetime_duration, reverse=True)
+        num_writetimes = len(writetimes)
+        if num_writetimes > 0:
+            print(f"\n----- Top {db.size_limit} Longest writetimes (wait times) -----\n")
+            for num, writetime in enumerate(writetimes):
+                if num >= db.size_limit:
+                    break
+                print(f"writetime={writetime:<12}")
+
         # Longest operation times
         optimes = sorted(db.result.optime_duration, reverse=True)
         num_optimes = len(optimes)
@@ -3464,6 +3519,14 @@ def main():
 
             if round(avg_wtime, 9) > 0.5:
                 print(f"\n {rec_count}. Your average wtime is {avg_wtime:.9f}. You may need to increase the number of worker threads (nsslapd-threadnumber).\n")
+                rec_count += 1
+
+            if round(avg_wqtime, 9) > 0.5:
+                print(f"\n {rec_count}. Your average wqtime is {avg_wqtime:.9f}. You may need to increase the number of worker threads (nsslapd-threadnumber).\n")
+                rec_count += 1
+
+            if round(avg_writetime, 9) > 0.5:
+                print(f"\n {rec_count}. Your average writetime is {avg_wtime:.9f}. Maybe the application is not reading the results in a timely way.\n")
                 rec_count += 1
 
             if round(avg_optime, 9) > 0:

--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -763,9 +763,6 @@ slapd_log_access_result(slapd_log_pblock *logpb)
 
     /* Done with JSON object - free it */
     json_object_put(json_obj);
-    for (fgot_id_t id=0; id<FGOT_MAX; id++) {
-        slapi_ch_free_string(&logpb->fgot[id]);
-    }
 
     return rc;
 }

--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -638,10 +638,11 @@ slapi_log_fgot_text(struct op *op, char *buff, size_t buflen)
             snprintf(tbuff, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "",
                      (int64_t)(t->tv_sec), (int64_t)(t->tv_nsec));
             size_t len = strlen(name)+strlen(tbuff)+2;
-            if (buff+len < buffend) {
-                sprintf(buff, " %s=%s", name, tbuff);
-                buff += len;
+            if (buff+len >= buffend) {
+                break;
             }
+            sprintf(buff, " %s=%s", name, tbuff);
+            buff += len;
         }
     }
 }

--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -615,13 +615,22 @@ slapd_log_access_modrdn(slapd_log_pblock *logpb)
 }
 
 void
-slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb)
+slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb, char *buff, size_t buflen)
 {
     for (fgot_id_t id=0; id<FGOT_MAX; id++) {
+        if (buflen < ETIME_BUFSIZ) {
+            break;
+        }
         if (op->o_fgots[id].enabled) {
             struct timespec *t = &op->o_fgots[id].c;
-            logpb->fgot[id] = slapi_ch_smprintf("%" PRId64 ".%.09" PRId64 "",
+            size_t len;
+            snprintf(buff, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "",
                      (int64_t)(t->tv_sec), (int64_t)(t->tv_nsec));
+            logpb->fgot[id] = buff;
+            len = strlen(buff);
+            buff[len++] = 0;
+            buff += len;
+            buflen -= len;
         }
     }
 }

--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -614,6 +614,37 @@ slapd_log_access_modrdn(slapd_log_pblock *logpb)
     return rc;
 }
 
+void
+slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb)
+{
+    for (fgot_id_t id=0; id<FGOT_MAX; id++) {
+        if (op->o_fgots[id].enabled) {
+            struct timespec *t = &op->o_fgots[id].c;
+            logpb->fgot[id] = slapi_ch_smprintf("%" PRId64 ".%.09" PRId64 "",
+                     (int64_t)(t->tv_sec), (int64_t)(t->tv_nsec));
+        }
+    }
+}
+
+void
+slapi_log_fgot_text(struct op *op, char *buff, size_t buflen)
+{
+    char *buffend = buff+buflen-1;
+    for (fgot_id_t id=0; id<FGOT_MAX; id++) {
+        const char *name = fgot_get_name(id);
+        if (op->o_fgots[id].enabled) {
+            char tbuff[ETIME_BUFSIZ];
+            struct timespec *t = &op->o_fgots[id].c;
+            snprintf(tbuff, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "",
+                     (int64_t)(t->tv_sec), (int64_t)(t->tv_nsec));
+            size_t len = strlen(name)+strlen(tbuff)+2;
+            if (buff+len < buffend) {
+                sprintf(buff, " %s=%s", name, tbuff);
+                buff += len;
+            }
+        }
+    }
+}
 
 /*
  * RESULT
@@ -709,6 +740,12 @@ slapd_log_access_result(slapd_log_pblock *logpb)
     }
     json_add_str(json_obj, "sid", logpb->sid);
     json_add_str(json_obj, "bind_dn", logpb->bind_dn);
+    for (fgot_id_t id=0; id<FGOT_MAX; id++) {
+        if (logpb->fgot[id]) {
+            const char *name = fgot_get_name(id);
+            json_add_str(json_obj, name, logpb->fgot[id]);
+        }
+    }
 
     /* Convert json object to string and log it */
     msg = (char *)json_object_to_json_string_ext(json_obj, logpb->log_format);
@@ -716,6 +753,9 @@ slapd_log_access_result(slapd_log_pblock *logpb)
 
     /* Done with JSON object - free it */
     json_object_put(json_obj);
+    for (fgot_id_t id=0; id<FGOT_MAX; id++) {
+        slapi_ch_free_string(&logpb->fgot[id]);
+    }
 
     return rc;
 }

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2234,6 +2234,7 @@ add_work_q(work_q_item *wqitem, struct Slapi_op_stack *op_stack_obj)
     new_work_q->work_item = wqitem;
     new_work_q->op_stack_obj = op_stack_obj;
     new_work_q->next_work_item = NULL;
+    fgot_start(op_stack_obj->op, FGOT_WQ);
 
     pthread_mutex_lock(&work_q_lock);
     if (tail_work_q == NULL) {
@@ -2278,6 +2279,7 @@ get_work_q(struct Slapi_op_stack **op_stack_obj)
     PR_AtomicDecrement(&work_q_size); /* decrement q size */
     /* Free the memory used by the item found. */
     destroy_work_q(&tmp);
+    fgot_end((*op_stack_obj)->op, FGOT_WQ);
 
     return (wqitem);
 }

--- a/ldap/servers/slapd/fe.h
+++ b/ldap/servers/slapd/fe.h
@@ -172,6 +172,7 @@ void sasl_map_read_unlock(void);
 /*
  * operation.c
  */
+void fgot_set(struct op *op, fgot_id_t fgot_id, struct timespec *t);
 void fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2);
 void fgot_start(struct op *op, fgot_id_t fgot_id);
 void fgot_end(struct op *op, fgot_id_t fgot_id);

--- a/ldap/servers/slapd/fe.h
+++ b/ldap/servers/slapd/fe.h
@@ -169,4 +169,7 @@ int sasl_map_done(void);
 void sasl_map_read_lock(void);
 void sasl_map_read_unlock(void);
 
+void fgot_start(struct op *op, fgot_id_t fgot_id);
+void fgot_end(struct op *op, fgot_id_t fgot_id);
+
 #endif

--- a/ldap/servers/slapd/fe.h
+++ b/ldap/servers/slapd/fe.h
@@ -169,6 +169,10 @@ int sasl_map_done(void);
 void sasl_map_read_lock(void);
 void sasl_map_read_unlock(void);
 
+/*
+ * operation.c
+ */
+void fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2);
 void fgot_start(struct op *op, fgot_id_t fgot_id);
 void fgot_end(struct op *op, fgot_id_t fgot_id);
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -10328,13 +10328,6 @@ fgot_is_allowed(const char *name, uint64_t *flags)
     return false;
 }
 
-bool
-config_check_fgot(fgot_id_t fgot_id)
-{
-    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
-    return ((1UL<<fgot_id) & slapdFrontendConfig->fgot_flags);
-}
-
 char *
 config_get_fgot()
 {

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -271,6 +271,7 @@ slapi_onoff_t init_enable_ldapssotoken;
 slapi_onoff_t init_return_orig_dn;
 slapi_onoff_t init_pw_admin_skip_info;
 
+
 static int
 isInt(ConfigVarType type)
 {
@@ -1466,6 +1467,11 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.return_orig_dn,
      CONFIG_ON_OFF, (ConfigGetFunc)config_get_return_orig_dn, &init_return_orig_dn, NULL},
+    {CONFIG_FGOT_ATTRIBUTE, config_set_fgot,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.fgot,
+     CONFIG_STRING, (ConfigGetFunc)config_get_fgot,
+     NULL, NULL /* deletion is not allowed */}
     /* End config */
     };
 
@@ -10256,6 +10262,119 @@ config_get_malloc_mmap_threshold()
     retVal = slapdFrontendConfig->malloc_mmap_threshold;
     return retVal;
 }
+
+static struct {
+    const char *name;
+    fgot_id_t id;
+} fgot_allowed_values_table[] = {
+    { "wqtime", FGOT_WQ },
+    { "wq", FGOT_WQ },
+    { "writetime", FGOT_WRITE },
+    { "write", FGOT_WRITE },
+    { 0 }
+};
+
+const char *
+fgot_allowed_values()
+{
+    static char names[20];
+    size_t len = 0;
+    if (!names[0]) {
+        for (size_t i=0; fgot_allowed_values_table[i].name; i++) {
+            size_t len2 = strlen(fgot_allowed_values_table[i].name);
+            if (len+len2+1 < sizeof names) {
+                strcpy(names+len, fgot_allowed_values_table[i].name);
+                len += len2;
+                if (fgot_allowed_values_table[i+1].name) {
+                    names[len++] = ',';
+                }
+            }
+        }
+    }
+    return names;
+}
+
+const char *
+fgot_get_name(fgot_id_t id)
+{
+    for (size_t i=0; fgot_allowed_values_table[i].name; i++) {
+        if (fgot_allowed_values_table[i].id == id) {
+            return fgot_allowed_values_table[i].name;
+        }
+    }
+    return "???";
+}
+
+static bool
+fgot_is_allowed(const char *name, uint64_t *flags)
+{
+    for (size_t i=0; fgot_allowed_values_table[i].name; i++) {
+        if (strcasecmp(name, fgot_allowed_values_table[i].name) == 0) {
+            fgot_id_t id = fgot_allowed_values_table[i].id;
+            *flags |= 1UL << id;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+config_check_fgot(fgot_id_t fgot_id)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    return ((1UL<<fgot_id) & slapdFrontendConfig->fgot_flags);
+}
+
+char *
+config_get_fgot()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char *retVal;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = config_copy_strval(slapdFrontendConfig->fgot);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+int
+config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    int retVal = LDAP_SUCCESS;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    uint64_t flags = 0;
+
+    if (value != NULL) {
+        char *pt = slapi_ch_strdup(value);
+        const char *delim = " \t\n+|,";
+        char *iter = NULL;
+        for(char *elem=ldap_utf8strtok_r(pt, delim, &iter);
+            elem != NULL && retVal == LDAP_SUCCESS;
+            elem=ldap_utf8strtok_r(NULL, delim, &iter)) {
+            if (*elem == 0) {
+                /* Ignore empty elements */
+                continue;
+            }
+            if (!fgot_is_allowed(elem, &flags)) {
+                retVal = LDAP_UNWILLING_TO_PERFORM;
+                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, 
+                    "(%s) value (%s) is invalid. Should be a subset of %s\n",
+                    attrname, value, fgot_allowed_values());
+            }
+        }
+    }
+    if (apply && retVal == LDAP_SUCCESS) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        slapi_ch_free((void **)&slapdFrontendConfig->fgot);
+        slapdFrontendConfig->fgot = slapi_ch_strdup(value);
+        slapdFrontendConfig->fgot_flags = flags;
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+
 #endif
 #endif
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1471,7 +1471,7 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.fgot,
      CONFIG_STRING, (ConfigGetFunc)config_get_fgot,
-     NULL, NULL /* deletion is not allowed */}
+     SLAPD_DEFAULT_FGOT, NULL }
     /* End config */
     };
 
@@ -2089,6 +2089,10 @@ FrontendConfig_init(void)
     /* Initialize parsed HAProxy trusted IP entries */
     cfg->haproxy_trusted_ip_parsed = NULL;
     cfg->haproxy_trusted_ip_parsed_count = 0;
+
+    /* Initialize Fine Grain Operation Timing */
+    cfg->fgot = slapi_ch_strdup(SLAPD_DEFAULT_FGOT);
+    cfg->fgot_flags = SLAPD_DEFAULT_FGOT_FLAGS;
 
     /* Done, unlock!  */
     CFG_UNLOCK_WRITE(cfg);
@@ -10271,6 +10275,12 @@ static struct {
     { "wq", FGOT_WQ },
     { "writetime", FGOT_WRITE },
     { "write", FGOT_WRITE },
+    { "optime", FGOT_OP },
+    { "op", FGOT_OP },
+    { "etime", FGOT_ETIME },
+    { "e", FGOT_ETIME },
+    { "wtime", FGOT_W },
+    { "w", FGOT_W },
     { 0 }
 };
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -10287,7 +10287,7 @@ static struct {
 const char *
 fgot_allowed_values()
 {
-    static char names[20];
+    static char names[128];
     size_t len = 0;
     if (!names[0]) {
         for (size_t i=0; fgot_allowed_values_table[i].name; i++) {

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -10373,6 +10373,7 @@ config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply)
                     attrname, value, fgot_allowed_values());
             }
         }
+        slapi_ch_free_string(&pt);
     }
     if (apply && retVal == LDAP_SUCCESS) {
         CFG_LOCK_WRITE(slapdFrontendConfig);

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -146,6 +146,7 @@ void
 operation_init(Slapi_Operation *o, int flags)
 {
     if (NULL != o) {
+        slapdFrontendConfig_t *fecfg = getFrontendConfig();
         BerElement *ber = o->o_ber; /* may have already been set */
         /* We can't get rid of this til we remove the operation stack. */
         memset(o, 0, sizeof(Slapi_Operation));
@@ -164,6 +165,13 @@ operation_init(Slapi_Operation *o, int flags)
         o->o_flags = flags;
         o->o_reverse_search_state = 0;
         o->o_pagedresults_sizelimit = -1;
+        if (fecfg) {
+            for(fgot_id_t id=0; id < FGOT_MAX; id++) {
+                if ((1UL<<id) & fecfg->fgot_flags) {
+                    o->o_fgots[id].enabled = true;
+                }
+            }
+        }
     }
 }
 
@@ -787,7 +795,7 @@ void
 fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2)
 {
     struct timespec elapsed;
-    if (config_check_fgot(fgot_id) || op->o_fgots[fgot_id].enabled) {
+    if (op->o_fgots[fgot_id].enabled) {
         op->o_fgots[fgot_id].enabled = true;
         slapi_timespec_diff(t1, t2, &elapsed);
         slapi_timespec_add(&op->o_fgots[fgot_id].c, &elapsed);
@@ -798,8 +806,7 @@ fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct times
 void
 fgot_start(struct op *op, fgot_id_t fgot_id)
 {
-    if (config_check_fgot(fgot_id)) {
-        op->o_fgots[fgot_id].enabled = true;
+    if (op->o_fgots[fgot_id].enabled) {
         clock_gettime(CLOCK_MONOTONIC, &op->o_fgots[fgot_id].s);
     }
 }

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -650,8 +650,8 @@ slapi_operation_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
     struct timespec o_hr_time_now;
     clock_gettime(CLOCK_MONOTONIC, &o_hr_time_now);
-    fgot_compute(o, FGOT_ETIME, &o_hr_time_now, &o->o_hr_time_rel);
-    *elapsed = o->o_fgots[FGOT_ETIME].c;
+
+    slapi_timespec_diff(&o_hr_time_now, &(o->o_hr_time_rel), elapsed);
 }
 
 void
@@ -766,16 +766,15 @@ slapi_operation_op_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
     struct timespec o_hr_time_now;
     clock_gettime(CLOCK_MONOTONIC, &o_hr_time_now);
-    fgot_compute(o, FGOT_OP, &o_hr_time_now, &o->o_hr_time_started_rel);
-    *elapsed = o->o_fgots[FGOT_OP].c;
+
+    slapi_timespec_diff(&o_hr_time_now, &(o->o_hr_time_started_rel), elapsed);
 }
 
 /* The time diff the operation waited in the work queue */
 void
 slapi_operation_workq_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
-    fgot_compute(o, FGOT_W, &o->o_hr_time_started_rel, &o->o_hr_time_rel);
-    *elapsed = o->o_fgots[FGOT_W].c;
+    slapi_timespec_diff(&(o->o_hr_time_started_rel), &(o->o_hr_time_rel), elapsed);
 }
 
 LDAPControl **
@@ -790,13 +789,21 @@ operation_get_result_controls(const Operation *o)
     return o->o_results.result_controls;
 }
 
+/* Set t in cumulative fine grain operation timing slot */
+void
+fgot_set(struct op *op, fgot_id_t fgot_id, struct timespec *t)
+{
+    if (op->o_fgots[fgot_id].enabled) {
+        op->o_fgots[fgot_id].c = *t;
+    }
+}
+
 /* Add t1-t2 in cumulative fine grain operation timing slot */
 void
 fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2)
 {
-    struct timespec elapsed;
     if (op->o_fgots[fgot_id].enabled) {
-        op->o_fgots[fgot_id].enabled = true;
+        struct timespec elapsed;
         slapi_timespec_diff(t1, t2, &elapsed);
         slapi_timespec_add(&op->o_fgots[fgot_id].c, &elapsed);
     }

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -787,7 +787,6 @@ void
 fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2)
 {
     struct timespec elapsed;
-    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     if (config_check_fgot(fgot_id) || op->o_fgots[fgot_id].enabled) {
         op->o_fgots[fgot_id].enabled = true;
         slapi_timespec_diff(t1, t2, &elapsed);

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -780,3 +780,24 @@ operation_get_result_controls(const Operation *o)
 {
     return o->o_results.result_controls;
 }
+
+void
+fgot_start(struct op *op, fgot_id_t fgot_id)
+{
+    if (config_check_fgot(fgot_id)) {
+        op->o_fgots[fgot_id].enabled = true;
+        clock_gettime(CLOCK_MONOTONIC, &op->o_fgots[fgot_id].s);
+    }
+}
+
+void
+fgot_end(struct op *op, fgot_id_t fgot_id)
+{
+    if (op->o_fgots[fgot_id].enabled) {
+        struct timespec now;
+        struct timespec elapsed;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        slapi_timespec_diff(&now, &op->o_fgots[fgot_id].s, &elapsed);
+        slapi_timespec_add(&op->o_fgots[fgot_id].c, &elapsed);
+    }
+}

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -642,8 +642,8 @@ slapi_operation_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
     struct timespec o_hr_time_now;
     clock_gettime(CLOCK_MONOTONIC, &o_hr_time_now);
-
-    slapi_timespec_diff(&o_hr_time_now, &(o->o_hr_time_rel), elapsed);
+    fgot_compute(o, FGOT_ETIME, &o_hr_time_now, &o->o_hr_time_rel);
+    *elapsed = o->o_fgots[FGOT_ETIME].c;
 }
 
 void
@@ -758,15 +758,16 @@ slapi_operation_op_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
     struct timespec o_hr_time_now;
     clock_gettime(CLOCK_MONOTONIC, &o_hr_time_now);
-
-    slapi_timespec_diff(&o_hr_time_now, &(o->o_hr_time_started_rel), elapsed);
+    fgot_compute(o, FGOT_OP, &o_hr_time_now, &o->o_hr_time_started_rel);
+    *elapsed = o->o_fgots[FGOT_OP].c;
 }
 
 /* The time diff the operation waited in the work queue */
 void
 slapi_operation_workq_time_elapsed(Slapi_Operation *o, struct timespec *elapsed)
 {
-    slapi_timespec_diff(&(o->o_hr_time_started_rel), &(o->o_hr_time_rel), elapsed);
+    fgot_compute(o, FGOT_W, &o->o_hr_time_started_rel, &o->o_hr_time_rel);
+    *elapsed = o->o_fgots[FGOT_W].c;
 }
 
 LDAPControl **
@@ -781,6 +782,20 @@ operation_get_result_controls(const Operation *o)
     return o->o_results.result_controls;
 }
 
+/* Add t1-t2 in cumulative fine grain operation timing slot */
+void
+fgot_compute(struct op *op, fgot_id_t fgot_id, struct timespec *t1, struct timespec *t2)
+{
+    struct timespec elapsed;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    if (config_check_fgot(fgot_id) || op->o_fgots[fgot_id].enabled) {
+        op->o_fgots[fgot_id].enabled = true;
+        slapi_timespec_diff(t1, t2, &elapsed);
+        slapi_timespec_add(&op->o_fgots[fgot_id].c, &elapsed);
+    }
+}
+
+/* Start cumulative fine grain operation timing */
 void
 fgot_start(struct op *op, fgot_id_t fgot_id)
 {
@@ -790,14 +805,13 @@ fgot_start(struct op *op, fgot_id_t fgot_id)
     }
 }
 
+/* End cumulative fine grain operation timing */
 void
 fgot_end(struct op *op, fgot_id_t fgot_id)
 {
     if (op->o_fgots[fgot_id].enabled) {
         struct timespec now;
-        struct timespec elapsed;
         clock_gettime(CLOCK_MONOTONIC, &now);
-        slapi_timespec_diff(&now, &op->o_fgots[fgot_id].s, &elapsed);
-        slapi_timespec_add(&op->o_fgots[fgot_id].c, &elapsed);
+        fgot_compute(op, fgot_id, &now, &op->o_fgots[fgot_id].s);
     }
 }

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -656,7 +656,6 @@ int config_get_tcp_fin_timeout(void);
 int config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_tcp_keepalive_time(void);
 
-bool config_check_fgot(fgot_id_t fgot_id);
 int32_t config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply);
 char * config_get_fgot(void);
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -656,6 +656,10 @@ int config_get_tcp_fin_timeout(void);
 int config_set_tcp_keepalive_time(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_tcp_keepalive_time(void);
 
+bool config_check_fgot(fgot_id_t fgot_id);
+int32_t config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply);
+char * config_get_fgot(void);
+
 int is_abspath(const char *);
 char *rel2abspath(char *);
 char *rel2abspath_ext(char *, char *);

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2184,6 +2184,7 @@ log_op_stat(Slapi_PBlock *pb, uint64_t connid, int32_t op_id, int32_t op_interna
                 logpb.conn_time = start_time;
                 logpb.conn_id = connid;
                 logpb.op_id = op_id;
+
                 for (key_info = op_stat->search_stat->keys_lookup; key_info; key_info = key_info->next) {
                     slapi_timespec_diff(&key_info->key_lookup_end, &key_info->key_lookup_start, &duration);
                     snprintf(stat_etime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)duration.tv_sec, (int64_t)duration.tv_nsec);
@@ -2321,12 +2322,16 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
 
     /* total elapsed time */
     slapi_operation_time_elapsed(op, &o_hr_time_end);
+    fgot_set(op, FGOT_ETIME, &o_hr_time_end);
 
     /* wait time */
     slapi_operation_workq_time_elapsed(op, &o_hr_time_end);
+    fgot_set(op, FGOT_W, &o_hr_time_end);
 
     /* op time */
     slapi_operation_op_time_elapsed(op, &o_hr_time_end);
+    fgot_set(op, FGOT_OP, &o_hr_time_end);
+
     operation_notes = slapi_pblock_get_operation_notes(pb);
     if (0 == operation_notes) {
         notes_str = "";

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2357,7 +2357,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
         logpb.msg = NULL;
         logpb.sid = sessionTrackingId;
         logpb.tag = tag;
-        slapi_log_fgot_json(op, &logpb);
+        slapi_log_fgot_json(op, &logpb, buff_fgot, FGOT_BUFSIZ);
     }
 
 #define LOG_CONN_OP_FMT_INT_INT "conn=Internal(%" PRIu64 ") op=%d(%d)(%d) RESULT err=%d"

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -1924,9 +1924,11 @@ flush_ber(
     } else {
         ber_get_option(ber, LBER_OPT_BYTES_TO_WRITE, &bytes);
 
+        fgot_start(op, FGOT_WRITE);
         PR_Lock(conn->c_pdumutex);
         rc = ber_flush(conn->c_sb, ber, 1);
         PR_Unlock(conn->c_pdumutex);
+        fgot_end(op, FGOT_WRITE);
 
         if (rc != 0) {
             int oserr = errno;
@@ -2182,7 +2184,6 @@ log_op_stat(Slapi_PBlock *pb, uint64_t connid, int32_t op_id, int32_t op_interna
                 logpb.conn_time = start_time;
                 logpb.conn_id = connid;
                 logpb.op_id = op_id;
-
                 for (key_info = op_stat->search_stat->keys_lookup; key_info; key_info = key_info->next) {
                     slapi_timespec_diff(&key_info->key_lookup_end, &key_info->key_lookup_start, &duration);
                     snprintf(stat_etime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)duration.tv_sec, (int64_t)duration.tv_nsec);
@@ -2295,6 +2296,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
     time_t start_time;
     int32_t log_format = config_get_accesslog_log_format();
     slapd_log_pblock logpb = {0};
+    char buff_fgot[FGOT_BUFSIZ];
 
     get_internal_conn_op(&connid, &op_id, &op_internal_id, &op_nested_count, &start_time);
     slapi_pblock_get(pb, SLAPI_PAGED_RESULTS_INDEX, &pr_idx);
@@ -2331,7 +2333,6 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
     /* op time */
     slapi_operation_op_time_elapsed(op, &o_hr_time_end);
     snprintf(optime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)o_hr_time_end.tv_sec, (int64_t)o_hr_time_end.tv_nsec);
-
     operation_notes = slapi_pblock_get_operation_notes(pb);
     if (0 == operation_notes) {
         notes_str = "";
@@ -2351,6 +2352,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 sprintf(csn_str, " csn=%s", csn_as_string(operationcsn, PR_FALSE, tmp_csn_str));
             }
         }
+        slapi_log_fgot_text(op, buff_fgot, FGOT_BUFSIZ);
     } else {
         /* Start prepping the JSON result block */
         slapd_log_pblock_init(&logpb, log_format, pb);
@@ -2364,6 +2366,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
         logpb.msg = NULL;
         logpb.sid = sessionTrackingId;
         logpb.tag = tag;
+        slapi_log_fgot_json(op, &logpb);
     }
 
 #define LOG_CONN_OP_FMT_INT_INT "conn=Internal(%" PRIu64 ") op=%d(%d)(%d) RESULT err=%d"
@@ -2382,11 +2385,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
                                  " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s"
-                                 ", SASL bind in progress\n",
+                                 "%s, SASL bind in progress\n",
                                  op->o_connid,
                                  op->o_opid,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
         } else {
@@ -2401,7 +2404,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s, SASL bind in progress\n"
+#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s, SASL bind in progress\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_SASLMSG_FMT :
                                            LOG_CONN_OP_FMT_EXT_INT LOG_SASLMSG_FMT,
@@ -2410,7 +2413,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_internal_id,
                                  op_nested_count,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
         }
@@ -2430,12 +2433,12 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s"
                                  " dn=\"%s\"\n",
                                  op->o_connid,
                                  op->o_opid,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         } else {
@@ -2451,7 +2454,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s dn=\"%s\"\n"
+#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s dn=\"%s\"\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_BINDMSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_BINDMSG_FMT,
@@ -2460,7 +2463,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_internal_id,
                                  op_nested_count,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         }
@@ -2476,12 +2479,12 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 } else {
                     slapi_log_access(LDAP_DEBUG_STATS,
                                      "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                     " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s"
+                                     " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s"
                                      " pr_idx=%d pr_cookie=%d\n",
                                      op->o_connid,
                                      op->o_opid,
                                      err, tag, nentries,
-                                     wtime, optime, etime, session_str,
+                                     wtime, optime, etime, buff_fgot, session_str,
                                      notes_str, csn_str, pr_idx, pr_cookie);
                 }
             } else {
@@ -2497,7 +2500,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     logpb.level = LDAP_DEBUG_ARGS;
                     slapd_log_access_result(&logpb);
                 } else {
-#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s pr_idx=%d pr_cookie=%d \n"
+#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s pr_idx=%d pr_cookie=%d \n"
                     slapi_log_access(LDAP_DEBUG_ARGS,
                                      connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_PRMSG_FMT :
                                                    LOG_CONN_OP_FMT_EXT_INT LOG_PRMSG_FMT,
@@ -2506,7 +2509,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                      op_internal_id,
                                      op_nested_count,
                                      err, tag, nentries,
-                                     wtime, optime, etime,
+                                     wtime, optime, etime, buff_fgot,
                                      notes_str, csn_str, session_str, pr_idx, pr_cookie);
                 }
             }
@@ -2528,11 +2531,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s\n",
+                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s%s\n",
                                  op->o_connid,
                                  op->o_opid,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, ext_str, session_str);
             }
             if (pbtxt) {
@@ -2553,7 +2556,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s\n"
+#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_MSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_MSG_FMT,
@@ -2562,7 +2565,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_internal_id,
                                  op_nested_count,
                                  err, tag, nentries,
-                                 wtime, optime, etime,
+                                 wtime, optime, etime, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
             /*

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2275,9 +2275,6 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
     int internal_op;
     CSN *operationcsn = NULL;
     char csn_str[CSN_STRSIZE + 5];
-    char etime[ETIME_BUFSIZ] = {0};
-    char wtime[ETIME_BUFSIZ] = {0};
-    char optime[ETIME_BUFSIZ] = {0};
     int pr_idx = -1;
     int pr_cookie = -1;
     uint32_t operation_notes;
@@ -2324,15 +2321,12 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
 
     /* total elapsed time */
     slapi_operation_time_elapsed(op, &o_hr_time_end);
-    snprintf(etime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)o_hr_time_end.tv_sec, (int64_t)o_hr_time_end.tv_nsec);
 
     /* wait time */
     slapi_operation_workq_time_elapsed(op, &o_hr_time_end);
-    snprintf(wtime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)o_hr_time_end.tv_sec, (int64_t)o_hr_time_end.tv_nsec);
 
     /* op time */
     slapi_operation_op_time_elapsed(op, &o_hr_time_end);
-    snprintf(optime, ETIME_BUFSIZ, "%" PRId64 ".%.09" PRId64 "", (int64_t)o_hr_time_end.tv_sec, (int64_t)o_hr_time_end.tv_nsec);
     operation_notes = slapi_pblock_get_operation_notes(pb);
     if (0 == operation_notes) {
         notes_str = "";
@@ -2358,9 +2352,6 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
         slapd_log_pblock_init(&logpb, log_format, pb);
         logpb.err = err;
         logpb.nentries = nentries;
-        logpb.wtime = wtime;
-        logpb.optime = optime;
-        logpb.etime = etime;
         logpb.notes = operation_notes;
         logpb.csn = operationcsn;
         logpb.msg = NULL;
@@ -2384,12 +2375,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s"
-                                 "%s, SASL bind in progress\n",
+                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
+                                 ", SASL bind in progress\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
         } else {
@@ -2404,7 +2394,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s, SASL bind in progress\n"
+#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s, SASL bind in progress\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_SASLMSG_FMT :
                                            LOG_CONN_OP_FMT_EXT_INT LOG_SASLMSG_FMT,
@@ -2412,8 +2402,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
         }
@@ -2433,12 +2422,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
                                  " dn=\"%s\"\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         } else {
@@ -2454,7 +2442,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s dn=\"%s\"\n"
+#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s dn=\"%s\"\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_BINDMSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_BINDMSG_FMT,
@@ -2462,8 +2450,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         }
@@ -2479,12 +2466,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 } else {
                     slapi_log_access(LDAP_DEBUG_STATS,
                                      "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                     " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s"
+                                     " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
                                      " pr_idx=%d pr_cookie=%d\n",
                                      op->o_connid,
                                      op->o_opid,
-                                     err, tag, nentries,
-                                     wtime, optime, etime, buff_fgot, session_str,
+                                     err, tag, nentries, buff_fgot, session_str,
                                      notes_str, csn_str, pr_idx, pr_cookie);
                 }
             } else {
@@ -2500,7 +2486,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     logpb.level = LDAP_DEBUG_ARGS;
                     slapd_log_access_result(&logpb);
                 } else {
-#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s pr_idx=%d pr_cookie=%d \n"
+#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s pr_idx=%d pr_cookie=%d \n"
                     slapi_log_access(LDAP_DEBUG_ARGS,
                                      connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_PRMSG_FMT :
                                                    LOG_CONN_OP_FMT_EXT_INT LOG_PRMSG_FMT,
@@ -2508,8 +2494,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                      op_id,
                                      op_internal_id,
                                      op_nested_count,
-                                     err, tag, nentries,
-                                     wtime, optime, etime, buff_fgot,
+                                     err, tag, nentries, buff_fgot,
                                      notes_str, csn_str, session_str, pr_idx, pr_cookie);
                 }
             }
@@ -2531,11 +2516,10 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s%s\n",
+                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s%s\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, ext_str, session_str);
             }
             if (pbtxt) {
@@ -2556,7 +2540,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d wtime=%s optime=%s etime=%s%s%s%s%s\n"
+#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_MSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_MSG_FMT,
@@ -2564,8 +2548,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries,
-                                 wtime, optime, etime, buff_fgot,
+                                 err, tag, nentries, buff_fgot,
                                  notes_str, csn_str, session_str);
             }
             /*
@@ -2593,10 +2576,12 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     slapi_pblock_get(pb, SLAPI_PLUGIN, &plugin);
                 }
                 plugin_dn = plugin_get_dn(plugin);
-
+                if (log_format != LOG_FORMAT_DEFAULT) {
+                    slapi_log_fgot_text(op, buff_fgot, FGOT_BUFSIZ);
+                }
                 slapi_log_err(SLAPI_LOG_ERR, "log_result", "Internal unindexed search: source (%s) "
-                                                           "search base=\"%s\" filter=\"%s\" etime=%s nentries=%d %s\n",
-                              plugin_dn, base_dn, filter_str, etime, nentries, notes_str);
+                                                           "search base=\"%s\" filter=\"%s\" %snentries=%d %s\n",
+                              plugin_dn, base_dn, filter_str, buff_fgot, nentries, notes_str);
 
                 slapi_ch_free_string(&plugin_dn);
             }

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2293,7 +2293,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
     time_t start_time;
     int32_t log_format = config_get_accesslog_log_format();
     slapd_log_pblock logpb = {0};
-    char buff_fgot[FGOT_BUFSIZ];
+    char buff_fgot[FGOT_BUFSIZ] = "";
 
     get_internal_conn_op(&connid, &op_id, &op_internal_id, &op_nested_count, &start_time);
     slapi_pblock_get(pb, SLAPI_PAGED_RESULTS_INDEX, &pr_idx);
@@ -2375,7 +2375,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
                                  ", SASL bind in progress\n",
                                  op->o_connid,
                                  op->o_opid,
@@ -2394,7 +2394,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s, SASL bind in progress\n"
+#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s, SASL bind in progress\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_SASLMSG_FMT :
                                            LOG_CONN_OP_FMT_EXT_INT LOG_SASLMSG_FMT,
@@ -2422,7 +2422,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
                                  " dn=\"%s\"\n",
                                  op->o_connid,
                                  op->o_opid,
@@ -2442,7 +2442,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s dn=\"%s\"\n"
+#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s dn=\"%s\"\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_BINDMSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_BINDMSG_FMT,
@@ -2466,7 +2466,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 } else {
                     slapi_log_access(LDAP_DEBUG_STATS,
                                      "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                     " tag=%" BERTAG_T " nentries=%d %s%s%s%s"
+                                     " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
                                      " pr_idx=%d pr_cookie=%d\n",
                                      op->o_connid,
                                      op->o_opid,
@@ -2486,7 +2486,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     logpb.level = LDAP_DEBUG_ARGS;
                     slapd_log_access_result(&logpb);
                 } else {
-#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s pr_idx=%d pr_cookie=%d \n"
+#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s pr_idx=%d pr_cookie=%d \n"
                     slapi_log_access(LDAP_DEBUG_ARGS,
                                      connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_PRMSG_FMT :
                                                    LOG_CONN_OP_FMT_EXT_INT LOG_PRMSG_FMT,
@@ -2516,7 +2516,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d %s%s%s%s%s\n",
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s\n",
                                  op->o_connid,
                                  op->o_opid,
                                  err, tag, nentries, buff_fgot,
@@ -2540,7 +2540,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d %s%s%s%s\n"
+#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_MSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_MSG_FMT,
@@ -2580,8 +2580,8 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     slapi_log_fgot_text(op, buff_fgot, FGOT_BUFSIZ);
                 }
                 slapi_log_err(SLAPI_LOG_ERR, "log_result", "Internal unindexed search: source (%s) "
-                                                           "search base=\"%s\" filter=\"%s\" %snentries=%d %s\n",
-                              plugin_dn, base_dn, filter_str, buff_fgot, nentries, notes_str);
+                                                           "search base=\"%s\" filter=\"%s\" nentries=%d%s%s\n",
+                              plugin_dn, base_dn, filter_str, nentries, buff_fgot, notes_str);
 
                 slapi_ch_free_string(&plugin_dn);
             }

--- a/ldap/servers/slapd/sasl_io.c
+++ b/ldap/servers/slapd/sasl_io.c
@@ -556,6 +556,7 @@ sasl_io_send(PRFileDesc *fd, const void *buf, PRInt32 amount, PRIntn flags, PRIn
     PRInt32 ret = 0;
     sasl_io_private *sp = sasl_get_io_private(fd);
     Connection *c = sp->conn;
+    Operation *op = c->c_ops; /* In theory during bind there is only a single active operation */
 
     slapi_log_err(SLAPI_LOG_CONNS,
                   "sasl_io_send", "Writing %d bytes\n", amount);
@@ -585,8 +586,10 @@ sasl_io_send(PRFileDesc *fd, const void *buf, PRInt32 amount, PRIntn flags, PRIn
             PR_SetError(PR_BUFFER_OVERFLOW_ERROR, EMSGSIZE);
             return PR_FAILURE;
         }
+        fgot_start(op, FGOT_WRITE);
         ret = PR_Send(fd->lower, sp->send_buffer + sp->send_offset,
                       sp->send_size - sp->send_offset, flags, timeout);
+        fgot_end(op, FGOT_WRITE);
         /* we need to return the amount of cleartext sent */
         if (ret == (sp->send_size - sp->send_offset)) {
             ret = amount;        /* sent amount of data requested by caller */
@@ -606,7 +609,9 @@ sasl_io_send(PRFileDesc *fd, const void *buf, PRInt32 amount, PRIntn flags, PRIn
         }
         /* else - ret is error - caller will handle */
     } else {
+        fgot_start(op, FGOT_WRITE);
         ret = PR_Send(fd->lower, buf, amount, flags, timeout);
+        fgot_end(op, FGOT_WRITE);
     }
 
     return ret;

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2421,6 +2421,8 @@ typedef struct _slapdEntryPoints
 #define CONFIG_REFERRAL_CHECK_PERIOD "nsslapd-referral-check-period"
 #define CONFIG_RETURN_ENTRY_DN "nsslapd-return-original-entrydn"
 #define CONFIG_FGOT_ATTRIBUTE "ds-fine-grain-operation-timing"
+#define SLAPD_DEFAULT_FGOT "wtime+wqtime+optime+etime"
+#define SLAPD_DEFAULT_FGOT_FLAGS ((1UL<<FGOT_W)|(1UL<<FGOT_WQ)|(1UL<<FGOT_OP)|(1UL<<FGOT_ETIME))
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
 

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -88,6 +88,8 @@ static char ptokPBE[34] = "Internal (Software) Token        ";
 #include <netinet/in.h>
 #include <stdbool.h>
 #include <time.h> /* For timespec definitions */
+#include "intrinsics.h"
+
 
 /* Macros for paged results lock parameter */
 #define PR_LOCKED true
@@ -249,6 +251,7 @@ typedef void (*VFPV)(); /* takes undefined arguments */
 #define SLAPD_INVALID_SOCKET_INDEX (-1)
 
 #define ETIME_BUFSIZ 42 /* room for struct timespec */
+#define FGOT_BUFSIZ 200 /* room for fine grtain operation timing */
 
 /* ============================================================================
  *       CONFIGURATION DEFAULTS
@@ -1648,6 +1651,7 @@ typedef struct op
     struct slapi_operation_results o_results;
     int o_pagedresults_sizelimit;
     int o_reverse_search_state;
+    fgot_t o_fgots[FGOT_MAX];                        /* Fine grain operation timing counters */
 } Operation;
 
 /*
@@ -2416,6 +2420,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_RETURN_DEFAULT_OPATTR "nsslapd-return-default-opattr"
 #define CONFIG_REFERRAL_CHECK_PERIOD "nsslapd-referral-check-period"
 #define CONFIG_RETURN_ENTRY_DN "nsslapd-return-original-entrydn"
+#define CONFIG_FGOT_ATTRIBUTE "ds-fine-grain-operation-timing"
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
 
@@ -2786,6 +2791,8 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t return_orig_dn;
     slapi_onoff_t pw_admin_skip_info;
     char *auditlog_display_attrs;
+    char *fgot;
+    uint64_t fgot_flags;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */
@@ -2903,8 +2910,6 @@ extern char *attr_dataversion;
 #endif /* USE_TIMERS */
 
 #define LDIF_CSNPREFIX_MAXLENGTH 6 /* sizeof(xxcsn-) */
-
-#include "intrinsics.h"
 
 /* printkey: import & export */
 #define EXPORT_PRINTKEY 0x1

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1543,9 +1543,12 @@ typedef struct fgot_t {
 } fgot_t;
 
 typedef enum fgot_id_t {
-    FGOT_WQ, /* Time spent in Work Queue */
-    FGOT_WRITE, /* Time spent sending data over the network */
-    FGOT_MAX /* Should be the last one */
+    FGOT_WQ,     /* Time spent in Work Queue */
+    FGOT_W,      /* Time spent before starting processing the operation */
+    FGOT_OP,     /* Time spent after starting processing the operation */
+    FGOT_WRITE,  /* Time spent sending data over the network */
+    FGOT_ETIME,  /* Time spent to fully process an operation */
+    FGOT_MAX     /* Fgot table size - Should be the last enum */
 } fgot_id_t;
 
 typedef struct slapd_log_pblock {

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1535,6 +1535,19 @@ void slapi_log_hexadump(int loglevel, char *fname, const void *addr, size_t len)
 /*
  * accesslog.c
  */
+/* Fine grain operation timing */
+typedef struct fgot_t {
+    bool enabled;
+    struct timespec c;  /* Cumuled time */
+    struct timespec s;  /* Start time */
+} fgot_t;
+
+typedef enum fgot_id_t {
+    FGOT_WQ, /* Time spent in Work Queue */
+    FGOT_WRITE, /* Time spent sending data over the network */
+    FGOT_MAX /* Should be the last one */
+} fgot_id_t;
+
 typedef struct slapd_log_pblock {
     int32_t log_format;
     Slapi_PBlock *pb;
@@ -1636,6 +1649,7 @@ typedef struct slapd_log_pblock {
     const char *err_str;
     LDAPControl **request_controls;
     LDAPControl **response_controls;
+    char *fgot[FGOT_MAX];
 } slapd_log_pblock;
 
 int32_t slapd_log_access_abandon(slapd_log_pblock *logpb);
@@ -1663,6 +1677,9 @@ int32_t slapd_log_access_extop_info(slapd_log_pblock *logpb);
 int32_t slapd_log_access_sort(slapd_log_pblock *logpb);
 int32_t slapd_log_access_tls(slapd_log_pblock *logpb);
 int32_t slapd_log_access_tls_client_auth(slapd_log_pblock *logpb);
+void slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb);
+void slapi_log_fgot_text(struct op *op, char *buff, size_t buflen);
+const char*fgot_get_name(fgot_id_t id);
 
 #ifdef __cplusplus
 }

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1680,7 +1680,7 @@ int32_t slapd_log_access_extop_info(slapd_log_pblock *logpb);
 int32_t slapd_log_access_sort(slapd_log_pblock *logpb);
 int32_t slapd_log_access_tls(slapd_log_pblock *logpb);
 int32_t slapd_log_access_tls_client_auth(slapd_log_pblock *logpb);
-void slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb);
+void slapi_log_fgot_json(struct op *op, slapd_log_pblock *logpb, char *buff, size_t buflen);
 void slapi_log_fgot_text(struct op *op, char *buff, size_t buflen);
 const char*fgot_get_name(fgot_id_t id);
 


### PR DESCRIPTION
- Implement 2 new timing measure:
   wqtime (time spent to wait for working threads)
   write time (time spend to write results over the network (included poll time if needed)
- Allow to select set of timing measure among
wqtime, wtime, writetime, optime, etime

Design document is https://www.port389.org/docs/389ds/design/fine-grain-operation-timing.html

Issues: #6724 and #6326 

Reviewed by: @droideck . @mreynolds389, @tbordaz (Thanks !)

## Summary by Sourcery

Add configurable fine-grained operation timing and expose it in access logs.

New Features:
- Introduce fine-grained operation timing counters for different phases of request processing, including work queue, wait, processing, write, and total times.
- Add a configurable ds-fine-grain-operation-timing setting to control which timing metrics are collected and logged, with sensible defaults.

Enhancements:
- Include fine-grained timing data in both text and JSON access log formats, replacing legacy etime/wtime/optime fields with a unified, extensible representation.
- Track network write time for both regular and SASL I/O paths to better understand response delivery latency.

Tests:
- Add integration tests to verify fine-grained timing configuration combinations and to ensure work-queue wait time is reflected correctly in access logs.