### PR TITLE
Issue 3658 - UI/CLI - show progress of db tasks

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -804,7 +804,7 @@ def test_basic_db2index(topology_st):
     for indexNum, index in enumerate(indexes):
         if index in ["entryrdn", "ancestorid"]:
             assert topology_st.standalone.searchErrorsLog(
-                f'INFO - {dbprefix}_db2index - {DEFAULT_BENAME}: Indexing {index}')
+                f'INFO - {dbprefix}_db2index - {DEFAULT_BENAME}: Indexing: {index}')
         else:
             assert topology_st.standalone.searchErrorsLog(
                 f'INFO - {dbprefix}_db2index - {DEFAULT_BENAME}: Indexing attribute: {index}')

--- a/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
@@ -7,15 +7,19 @@
 # --- END COPYRIGHT BLOCK ---
 #
 import logging
-import pytest
 import os
-from lib389._constants import DEFAULT_SUFFIX
+import subprocess
+import uuid
+
+import pytest
+
+from lib389._constants import DEFAULT_SUFFIX, DN_DM
 # from lib389.topologies import topology_m1 as topo
 from lib389.topologies import topology_st as topo
 from lib389.tasks import (ImportTask, ExportTask, BackupTask, RestoreTask, AutomemberRebuildMembershipTask,
                           AutomemberAbortRebuildTask, MemberUidFixupTask, MemberOfFixupTask, USNTombstoneCleanupTask,
                           DBCompactTask, EntryUUIDFixupTask, SchemaReloadTask, SyntaxValidateTask,
-                          FixupLinkedAttributesTask, DBCompactTask)
+                          FixupLinkedAttributesTask)
 from lib389.plugins import USNPlugin, POSIXWinsyncPlugin, LinkedAttributesPlugin, AutoMembershipPlugin, MemberOfPlugin
 from lib389.dbgen import dbgen_users
 from lib389.idm.user import UserAccount
@@ -23,6 +27,180 @@ from lib389.idm.group import Groups
 from lib389.idm.posixgroup import PosixGroups
 
 log = logging.getLogger(__name__)
+
+DSCONF = '/usr/sbin/dsconf'
+# Enough entries for import/export/reindex to emit multiple nsTaskLog updates when --watch is used.
+WATCH_TEST_NUM_USERS = 20000
+
+
+def _dsconf_base_cmd(inst):
+    return [DSCONF, inst.serverid, '-D', DN_DM, '-w', 'password']
+
+
+def _run_dsconf(inst, argv, timeout=7200):
+    """Run dsconf; return (returncode, combined stdout+stderr)."""
+    cmd = _dsconf_base_cmd(inst) + argv
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    out = (proc.stdout or '') + (proc.stderr or '')
+    return proc.returncode, out
+
+
+def _non_empty_lines(text):
+    return [ln for ln in text.splitlines() if ln.strip()]
+
+
+def test_dsconf_task_watch_output(topo):
+    """dsconf backend / backup tasks: ``--watch`` yields more output than default
+
+    Verifies that ``task.watch()``-driven progress (incremental nsTaskLog lines) appears when
+    ``-w`` / ``--watch`` is passed, and that the non-watch paths stay comparatively minimal.
+
+    Reindex is compared with ``--wait`` alone versus ``--wait --watch``; without ``--wait``,
+    ``backend index reindex`` returns immediately and does not wait for the task.
+
+    Backup ``create`` / ``restore`` use ``--timeout 0`` so the default 120s task limit does not
+    fire on a large database.
+
+    :id: 7c4e8a91-2b0d-4f6e-9c1d-8a3e5f7b0d2c
+    :setup: Standalone Instance
+    :steps:
+        1. Online-import a large LDIF without ``--watch``; capture output line count
+        2. Re-import the same LDIF with ``--watch``; capture output — expect more lines
+        3. Export without ``--watch``; then export with ``--watch`` — expect more lines on watch
+        4. ``backend index reindex`` with ``--wait`` only vs ``--wait --watch`` — expect more lines with watch
+        5. ``backup create`` to a dedicated directory without ``--watch``, then to another with ``--watch``
+        6. ``backup restore`` from each archive without / with ``--watch``
+    :expectedresults:
+        1. Import succeeds; non-watch output has few lines
+        2. Import with watch succeeds; strictly more non-empty log lines than without watch
+        3. Both exports succeed; watch run is more verbose
+        4. Both reindex runs succeed; watch run is more verbose
+        5. Both backup creates succeed; watch run is more verbose
+        6. Both restores succeed; watch run is more verbose
+    """
+    inst = topo.standalone
+    be = 'userRoot'
+    tag = uuid.uuid4().hex[:12]
+    import_ldif = os.path.join(inst.ldifdir, 'dsconf_watch_test_import.ldif')
+    export_ldif_a = os.path.join(inst.ldifdir, 'dsconf_watch_test_export_a.ldif')
+    export_ldif_b = os.path.join(inst.ldifdir, 'dsconf_watch_test_export_b.ldif')
+
+    dbgen_users(
+        inst,
+        WATCH_TEST_NUM_USERS,
+        import_ldif,
+        DEFAULT_SUFFIX,
+        parent='ou=people,' + DEFAULT_SUFFIX,
+        generic=True,
+    )
+
+    # import
+    rc, out_imp_nowatch = _run_dsconf(
+        inst,
+        ['backend', 'import', be, import_ldif],
+    )
+    assert rc == 0, out_imp_nowatch
+    lines_imp_nowatch = len(_non_empty_lines(out_imp_nowatch))
+    assert "Processing file" not in out_imp_nowatch, "'Processing file' should not be in the output"
+
+    rc, out_imp_watch = _run_dsconf(
+        inst,
+        ['backend', 'import', be, import_ldif, '--watch'],
+    )
+    assert rc == 0, out_imp_watch
+    lines_imp_watch = len(_non_empty_lines(out_imp_watch))
+    assert lines_imp_watch > lines_imp_nowatch, (
+        f'import --watch should log more lines than without (got {lines_imp_watch} vs {lines_imp_nowatch})'
+    )
+    assert "Processing file" in out_imp_watch, "'Processing file' should be in the output"
+
+    # export
+    rc, out_exp_nowatch = _run_dsconf(
+        inst,
+        ['backend', 'export', be, '-l', export_ldif_a],
+    )
+    assert rc == 0, out_exp_nowatch
+    lines_exp_nowatch = len(_non_empty_lines(out_exp_nowatch))
+    assert "userRoot: Processed" not in out_exp_nowatch, "'userRoot: Processed' should not be in the output"
+
+    rc, out_exp_watch = _run_dsconf(
+        inst,
+        ['backend', 'export', be, '-l', export_ldif_b, '--watch'],
+    )
+    assert rc == 0, out_exp_watch
+    lines_exp_watch = len(_non_empty_lines(out_exp_watch))
+    assert lines_exp_watch > lines_exp_nowatch, (
+        f'export --watch should log more lines than without (got {lines_exp_watch} vs {lines_exp_nowatch})'
+    )
+    assert "userRoot: Processed" in out_exp_watch, "'userRoot: Processed' should be in the output"
+
+    # reindex
+    rc, out_idx_nowatch = _run_dsconf(
+        inst,
+        ['backend', 'index', 'reindex', be, '--wait'],
+    )
+    assert rc == 0, out_idx_nowatch
+    lines_idx_nowatch = len(_non_empty_lines(out_idx_nowatch))
+    assert "Indexing attribute:" not in out_idx_nowatch, "'Indexing attribute:' should not be in the output"
+
+    rc, out_idx_watch = _run_dsconf(
+        inst,
+        ['backend', 'index', 'reindex', be, '--wait', '--watch'],
+    )
+    assert rc == 0, out_idx_watch
+    lines_idx_watch = len(_non_empty_lines(out_idx_watch))
+    assert lines_idx_watch > lines_idx_nowatch, (
+        f'reindex --watch should log more lines than --wait alone (got {lines_idx_watch} vs {lines_idx_nowatch})'
+    )
+    assert "Indexing attribute:" in out_idx_watch, "'Indexing attribute:' should be in the output"
+
+    # backup create
+    bak_create_a = os.path.join(inst.ds_paths.backup_dir, f'dsconf_watch_backup_create_a_{tag}')
+    bak_create_b = os.path.join(inst.ds_paths.backup_dir, f'dsconf_watch_backup_create_b_{tag}')
+
+    rc, out_bak_c_nowatch = _run_dsconf(
+        inst,
+        ['backup', 'create', bak_create_a],
+    )
+    assert rc == 0, out_bak_c_nowatch
+    lines_bak_c_nowatch = len(_non_empty_lines(out_bak_c_nowatch))
+    assert "Copying" not in out_bak_c_nowatch, "'Copying' should not be in the output"
+
+    rc, out_bak_c_watch = _run_dsconf(
+        inst,
+        ['backup', 'create', bak_create_b, '--watch'],
+    )
+    assert rc == 0, out_bak_c_watch
+    lines_bak_c_watch = len(_non_empty_lines(out_bak_c_watch))
+    assert lines_bak_c_watch > lines_bak_c_nowatch, (
+        f'backup create --watch should log more lines (got {lines_bak_c_watch} vs {lines_bak_c_nowatch})'
+    )
+    assert "Copying" in out_bak_c_watch, "'Copying' should be in the output"
+
+    # backup restore
+    rc, out_bak_r_nowatch = _run_dsconf(
+        inst,
+        ['backup', 'restore', bak_create_a, '--timeout', '0'],
+    )
+    assert rc == 0, out_bak_r_nowatch
+    lines_bak_r_nowatch = len(_non_empty_lines(out_bak_r_nowatch))
+    assert "Copying" not in out_bak_r_nowatch, "'Copying' should not be in the output"
+
+    rc, out_bak_r_watch = _run_dsconf(
+        inst,
+        ['backup', 'restore', bak_create_b, '--timeout', '0', '--watch'],
+    )
+    assert rc == 0, out_bak_r_watch
+    lines_bak_r_watch = len(_non_empty_lines(out_bak_r_watch))
+    assert lines_bak_r_watch > lines_bak_r_nowatch, (
+        f'backup restore --watch should log more lines (got {lines_bak_r_watch} vs {lines_bak_r_nowatch})'
+    )
+    assert "Copying" in out_bak_r_watch, "'Copying' should be in the output"
 
 
 def test_task_timeout(topo):

--- a/dirsrvtests/tests/suites/clu/dsctl_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tasks_test.py
@@ -1,0 +1,169 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import os
+import subprocess
+import uuid
+
+import pytest
+
+from lib389._constants import DEFAULT_BENAME, DEFAULT_SUFFIX, DN_DM
+from lib389.topologies import topology_st as topo
+from lib389.dbgen import dbgen_users
+
+DSCONF = '/usr/sbin/dsconf'
+DSCTL = '/usr/sbin/dsctl'
+WATCH_TEST_NUM_USERS = 20000
+
+
+def _dsconf_base_cmd(inst):
+    return [DSCONF, inst.serverid, '-D', DN_DM, '-w', 'password']
+
+
+def _run_dsconf(inst, argv, timeout=7200):
+    """Run dsconf; return (returncode, combined stdout+stderr)."""
+    cmd = _dsconf_base_cmd(inst) + argv
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    out = (proc.stdout or '') + (proc.stderr or '')
+    return proc.returncode, out
+
+
+def _non_empty_lines(text):
+    return [ln for ln in text.splitlines() if ln.strip()]
+
+
+def _dsctl_base_cmd(inst):
+    return [DSCTL, inst.serverid]
+
+
+def _run_dsctl(inst, argv, timeout=7200):
+    """Run dsctl; return (returncode, combined stdout+stderr)."""
+    cmd = _dsctl_base_cmd(inst) + argv
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    out = (proc.stdout or '') + (proc.stderr or '')
+    return proc.returncode, out
+
+
+def test_dsctl_task_watch_output(topo):
+    """dsctl db2ldif, ldif2db, db2bak, bak2db: ``--watch`` yields more output than default
+
+    Offline ns-slapd tools are run with ``-V`` when ``--watch`` is set; that verbose output is
+    logged at INFO so it is visible without ``dsctl -v``.
+
+    :id: 3f8a2c10-9e4b-4d7a-8f2e-1c0d5b6a7e9f
+    :setup: Standalone Instance (stopped for offline db utilities)
+    :steps:
+        1. Online-import a large LDIF via dsconf to populate the database
+        2. Stop the server; run ``db2ldif`` without then with ``--watch``
+        3. Run ``ldif2db`` twice with the same LDIF (without / with ``--watch``)
+        4. Run ``db2bak`` to two new archive paths (without / with ``--watch``)
+        5. Run ``bak2db`` from each archive (without / with ``--watch``)
+        6. Start the server
+    :expectedresults:
+        1. Each dsctl invocation succeeds (rc 0)
+        2. For each pair, the ``--watch`` run has strictly more non-empty output lines
+    """
+    inst = topo.standalone
+    tag = uuid.uuid4().hex[:12]
+    be = DEFAULT_BENAME
+
+    ldif_populate = os.path.join(inst.ldifdir, f'dsctl_watch_populate_{tag}.ldif')
+    dbgen_users(
+        inst,
+        WATCH_TEST_NUM_USERS,
+        ldif_populate,
+        DEFAULT_SUFFIX,
+        parent='ou=people,' + DEFAULT_SUFFIX,
+        generic=True,
+    )
+
+    rc, out = _run_dsconf(inst, ['backend', 'import', be, ldif_populate])
+    assert rc == 0, out
+
+    inst.stop()
+
+    try:
+        export_a = os.path.join(inst.ldifdir, f'dsctl_watch_db2ldif_a_{tag}.ldif')
+        export_b = os.path.join(inst.ldifdir, f'dsctl_watch_db2ldif_b_{tag}.ldif')
+
+        # db2ldif
+        rc, out_db2ldif_nowatch = _run_dsctl(inst, ['db2ldif', be, export_a])
+        assert rc == 0, out_db2ldif_nowatch
+        lines_db2ldif_nowatch = len(_non_empty_lines(out_db2ldif_nowatch))
+        assert "export userRoot: " not in out_db2ldif_nowatch, "'export userRoot: ' should not be in the output"
+
+        rc, out_db2ldif_watch = _run_dsctl(inst, ['db2ldif', be, export_b, '--watch'])
+        assert rc == 0, out_db2ldif_watch
+        lines_db2ldif_watch = len(_non_empty_lines(out_db2ldif_watch))
+        assert lines_db2ldif_watch > lines_db2ldif_nowatch, (
+            f'db2ldif --watch should log more lines (got {lines_db2ldif_watch} vs {lines_db2ldif_nowatch})'
+        )
+        assert "export userRoot: " in out_db2ldif_watch, "'export userRoot: ' should be in the output"
+
+        # ldif2db
+        rc, out_ldif2db_nowatch = _run_dsctl(inst, ['ldif2db', be, ldif_populate])
+        assert rc == 0, out_ldif2db_nowatch
+        lines_ldif2db_nowatch = len(_non_empty_lines(out_ldif2db_nowatch))
+        assert "import userRoot: Import complete" not in out_ldif2db_nowatch, "'import userRoot: Import complete' should not be in the output"
+
+        rc, out_ldif2db_watch = _run_dsctl(inst, ['ldif2db', be, ldif_populate, '--watch'])
+        assert rc == 0, out_ldif2db_watch
+        lines_ldif2db_watch = len(_non_empty_lines(out_ldif2db_watch))
+        assert lines_ldif2db_watch > lines_ldif2db_nowatch, (
+            f'ldif2db --watch should log more lines (got {lines_ldif2db_watch} vs {lines_ldif2db_nowatch})'
+        )
+        assert "import userRoot: Import complete" in out_ldif2db_watch, "'import userRoot: Import complete' should be in the output"
+
+        bak_a = os.path.join(inst.ds_paths.backup_dir, f'dsctl_watch_bak_a_{tag}')
+        bak_b = os.path.join(inst.ds_paths.backup_dir, f'dsctl_watch_bak_b_{tag}')
+
+        # db2bak
+        rc, out_db2bak_nowatch = _run_dsctl(inst, ['db2bak', bak_a])
+        assert rc == 0, out_db2bak_nowatch
+        lines_db2bak_nowatch = len(_non_empty_lines(out_db2bak_nowatch))
+        assert "archive_copyfile - Copying" not in out_db2bak_nowatch, "'archive_copyfile - Copying' should not be in the output"
+
+        rc, out_db2bak_watch = _run_dsctl(inst, ['db2bak', bak_b, '--watch'])
+        assert rc == 0, out_db2bak_watch
+        lines_db2bak_watch = len(_non_empty_lines(out_db2bak_watch))
+        assert lines_db2bak_watch > lines_db2bak_nowatch, (
+            f'db2bak --watch should log more lines (got {lines_db2bak_watch} vs {lines_db2bak_nowatch})'
+        )
+        assert "archive_copyfile - Copying" in out_db2bak_watch, "'archive_copyfile - Copying' should be in the output"
+
+        # bak2db
+        rc, out_bak2db_nowatch = _run_dsctl(inst, ['bak2db', bak_a])
+        assert rc == 0, out_bak2db_nowatch
+        lines_bak2db_nowatch = len(_non_empty_lines(out_bak2db_nowatch))
+        assert "- Copying" not in out_bak2db_nowatch, "'- Copying' should not be in the output"
+
+        rc, out_bak2db_watch = _run_dsctl(inst, ['bak2db', bak_b, '--watch'])
+        assert rc == 0, out_bak2db_watch
+        lines_bak2db_watch = len(_non_empty_lines(out_bak2db_watch))
+        assert lines_bak2db_watch > lines_bak2db_nowatch, (
+            f'bak2db --watch should log more lines (got {lines_bak2db_watch} vs {lines_bak2db_nowatch})'
+        )
+        assert "- Copying" in out_bak2db_watch, "'- Copying' should be in the output"
+
+    finally:
+        inst.start()
+
+
+if __name__ == '__main__':
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(['-s', CURRENT_FILE])

--- a/dirsrvtests/tests/suites/import/import_warning_test.py
+++ b/dirsrvtests/tests/suites/import/import_warning_test.py
@@ -105,6 +105,7 @@ def test_import_warning(topology_st):
     args.include_suffixes = 'dc=example,dc=com'
     args.exclude_suffixes = None
     args.timeout = 0
+    args.watch = False
 
     log.info('Import the LDIF file')
     backend_import(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)

--- a/ldap/servers/slapd/back-ldbm/archive.c
+++ b/ldap/servers/slapd/back-ldbm/archive.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -166,7 +166,13 @@ ldbm_back_archive2ldbm(Slapi_PBlock *pb)
         return -1;
     }
 
-    directory = rel2abspath(rawdirectory);
+    if(!is_abspath(rawdirectory)) {
+        char *bakdir = config_get_bakdir();
+        directory = slapi_ch_smprintf("%s/%s", bakdir, rawdirectory);
+        slapi_ch_free_string(&bakdir);
+    } else {
+        directory = slapi_ch_strdup(rawdirectory);
+    }
 
     /* No ldbm be's exist until we process the config information. */
     if (run_from_cmdline) {
@@ -309,7 +315,13 @@ ldbm_back_ldbm2archive(Slapi_PBlock *pb)
     }
 
     /* Initialize directory */
-    directory = rel2abspath(rawdirectory);
+    if (!is_abspath(rawdirectory)) {
+        char *bakdir = config_get_bakdir();
+        directory = slapi_ch_smprintf("%s/%s", bakdir, rawdirectory);
+        slapi_ch_free_string(&bakdir);
+    } else {
+        directory = slapi_ch_strdup(rawdirectory);
+    }
 
     if (stat(directory, &sbuf) == 0) {
         if (slapd_comp_path(directory, li->li_directory) == 0) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1479,15 +1479,15 @@ bdb_db2index(Slapi_PBlock *pb)
                 /* the ai was added above, if it didn't already exist */
                 PR_ASSERT(ai != NULL);
                 if (strcasecmp(attrs[i] + 1, LDBM_ANCESTORID_STR) == 0) {
-                    slapi_task_log_notice(task, "%s: Indexing %s",
+                    slapi_task_log_notice(task, "%s: Indexing: %s",
                         inst->inst_name, LDBM_ANCESTORID_STR);
-                    slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing %s\n",
+                    slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing: %s\n",
                                   inst->inst_name, LDBM_ANCESTORID_STR);
                     index_ext |= DB2INDEX_ANCESTORID;
                 } else if (strcasecmp(attrs[i] + 1, LDBM_ENTRYRDN_STR) == 0) {
-                    slapi_task_log_notice(task, "%s: Indexing %s",
+                    slapi_task_log_notice(task, "%s: Indexing: %s",
                                           inst->inst_name, LDBM_ENTRYRDN_STR);
-                    slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing %s\n",
+                    slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing: %s\n",
                                   inst->inst_name, LDBM_ENTRYRDN_STR);
                     index_ext |= DB2INDEX_ENTRYRDN;
                 } else if (strcasecmp(attrs[i] + 1, LDBM_ENTRYDN_STR) == 0) {

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2020 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -3431,8 +3431,11 @@ dbmdb_add_import_index(ImportCtx_t *ctx, const char *name, IndexInfo *ii)
     if (ctx->role == IM_INDEX) {
         /* Required by CI test */
         if (a->flags & MII_NOATTR) {
+            if (job->task) {
+                slapi_task_log_notice(job->task, "%s: Indexing: %s", job->inst->inst_name, mii->name);
+            }
             slapi_log_err(SLAPI_LOG_INFO, "dbmdb_db2index",
-                          "%s: Indexing %s\n", job->inst->inst_name, mii->name);
+                          "%s: Indexing: %s\n", job->inst->inst_name, mii->name);
         } else {
             if (ii->ai->ai_indexmask == INDEX_VLV) {
                 if (job->task) {

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -801,7 +801,7 @@ dbmdb_database_size(struct ldbminfo *li)
  */
 
 int
-dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unused)), int mode)
+dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unused)), int mode, Slapi_Task *task)
 {
 #ifdef DB_USE_64LFS
 #define OPEN_FUNCTION dbmdb_open_large
@@ -824,6 +824,10 @@ dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unu
     if (-1 == source_fd) {
         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_copyfile", "Failed to open source file %s by \"%s\"\n",
                       source, strerror(errno));
+        if (task) {
+            slapi_task_log_notice(task, "Failed to open source file %s by \"%s\"",
+                                  source, strerror(errno));
+        }
         goto error;
     }
     /* Open destination file */
@@ -831,10 +835,17 @@ dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unu
     if (-1 == dest_fd) {
         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_copyfile", "Failed to open dest file %s by \"%s\"\n",
                       destination, strerror(errno));
+        if (task) {
+            slapi_task_log_notice(task, "Failed to open dest file %s by \"%s\"",
+                                  destination, strerror(errno));
+        }
         goto error;
     }
     slapi_log_err(SLAPI_LOG_INFO,
                   "dbmdb_copyfile", "Copying %s to %s\n", source, destination);
+    if (task) {
+        slapi_task_log_notice(task, "Copying %s to %s", source, destination);
+    }
     /* Loop round reading data and writing it */
     while (1) {
         int i;
@@ -845,6 +856,10 @@ dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unu
             if (return_value < 0) {
                 slapi_log_err(SLAPI_LOG_ERR, "dbmdb_copyfile", "Failed to read by \"%s\": rval = %d\n",
                               strerror(errno), return_value);
+                if (task) {
+                    slapi_task_log_notice(task, "Failed to read by \"%s\": rval = %d",
+                                          strerror(errno), return_value);
+                }
             }
             break;
         }
@@ -859,10 +874,17 @@ dbmdb_copyfile(char *source, char *destination, int overwrite __attribute__((unu
                 /* means error */
                 slapi_log_err(SLAPI_LOG_ERR, "dbmdb_copyfile", "Failed to write by \"%s\"; real: %d bytes, exp: %lu bytes\n",
                               strerror(errno), return_value, bytes_to_write);
+                if (task) {
+                    slapi_task_log_notice(task, "Failed to write by \"%s\"; real: %d bytes, exp: %lu bytes",
+                                          strerror(errno), return_value, bytes_to_write);
+                }
                 if (return_value > 0) {
                     bytes_to_write -= return_value;
                     ptr += return_value;
                     slapi_log_err(SLAPI_LOG_NOTICE, "dbmdb_copyfile", "Retrying to write %lu bytes\n", bytes_to_write);
+                    if (task) {
+                        slapi_task_log_notice(task, "Retrying to write %lu bytes", bytes_to_write);
+                    }
                 } else {
                     break;
                 }
@@ -960,7 +982,7 @@ dbmdb_backup(struct ldbminfo *li, char *dest_dir, Slapi_Task *task)
     if (task) {
         slapi_task_log_notice(task, "Backing up file (%s)", pathname2);
     }
-    return_value = dbmdb_copyfile(pathname1, pathname2, 0, li->li_mode | 0400);
+    return_value = dbmdb_copyfile(pathname1, pathname2, 0, li->li_mode | 0400, task);
     if (0 > return_value) {
         slapi_log_err(SLAPI_LOG_ERR,
                       "dbmdb_backup", "Error in copying version file "
@@ -982,8 +1004,11 @@ dbmdb_backup(struct ldbminfo *li, char *dest_dir, Slapi_Task *task)
     /* Backup the config files */
     if (ldbm_archive_config(dest_dir, task) != 0) {
         slapi_log_err(SLAPI_LOG_ERR, "dbmdb_backup",
-                "Backup of config files failed or is incomplete\n");
-         if (0 == return_value) {
+                      "Backup of config files failed or is incomplete\n");
+        if (task) {
+            slapi_task_log_notice(task, "Backup of config files failed or is incomplete");
+        }
+        if (0 == return_value) {
             return_value = -1;
         }
     }
@@ -1022,7 +1047,7 @@ dbmdb_restore_file(struct ldbminfo *li, Slapi_Task *task, const char *src_dir, c
 {
     char *pathname1 = slapi_ch_smprintf("%s/%s", src_dir, filename);
     char *pathname2 = slapi_ch_smprintf("%s/%s", MDB_CONFIG(li)->home, filename);
-    int return_value = dbmdb_copyfile(pathname1, pathname2, PR_TRUE, li->li_mode);
+    int return_value = dbmdb_copyfile(pathname1, pathname2, PR_TRUE, li->li_mode, task);
     if (return_value) {
         slapi_log_err(SLAPI_LOG_ERR,
                       "dbmdb_restore", "Failed to copy database map file to %s.\n", pathname2);
@@ -1065,8 +1090,8 @@ dbmdb_restore(struct ldbminfo *li, char *src_dir, Slapi_Task *task)
         }
         return LDAP_UNWILLING_TO_PERFORM;
     } else if (!S_ISDIR(sbuf.st_mode)) {
-        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_restore", "Backup directory %s is not "
-                                                        "a directory.\n",
+        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_restore",
+                      "Backup directory %s is not a directory.\n",
                       src_dir);
         if (task) {
             slapi_task_log_notice(task, "Restore: backup directory %s is not a directory.",
@@ -1129,14 +1154,21 @@ dbmdb_restore(struct ldbminfo *li, char *src_dir, Slapi_Task *task)
         goto error_out;
     }
 
-    if (0 != tmp_rval)
+    if (0 != tmp_rval) {
         slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_restore", "Unable to verify the index configuration\n");
+        if (task) {
+            slapi_task_log_notice(task, "Unable to verify the index configuration");
+        }
+    }
 
     if (li->li_flags & SLAPI_TASK_RUNNING_FROM_COMMANDLINE) {
         /* command line: close the database down again */
         tmp_rval = dblayer_close(li, dbmode);
         if (0 != tmp_rval) {
             slapi_log_err(SLAPI_LOG_ERR, "dbmdb_restore", "Failed to close database\n");
+            if (task) {
+                slapi_task_log_notice(task, "Failed to close database");
+            }
         }
     } else {
         allinstance_set_busy(li); /* on-line mode */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -381,7 +381,7 @@ int dbmdb_idl_new_compare_dups(dbmdb_dbi_t * db __attribute__((unused)), const M
 
 int dbmdb_delete_indices(ldbm_instance *inst);
 uint32_t dbmdb_get_optimal_block_size(struct ldbminfo *li);
-int dbmdb_copyfile(char *source, char *destination, int overwrite, int mode);
+int dbmdb_copyfile(char *source, char *destination, int overwrite, int mode, Slapi_Task *task);
 int dbmdb_delete_instance_dir(backend *be);
 uint64_t dbmdb_database_size(struct ldbminfo *li);
 

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -229,6 +229,7 @@ textarea {
     min-height: 250px;
     font-size: 14px !important;
     font-family: monospace !important;
+
 }
 
 .ds-logarea {

--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -30,6 +30,7 @@ import {
     ValidatedOptions,
     Spinner,
 } from "@patternfly/react-core";
+import { LogViewer } from '@patternfly/react-log-viewer';
 
 const _ = cockpit.gettext;
 
@@ -50,6 +51,8 @@ export class CreateInstanceModal extends React.Component {
             createInitDB: "noInit",
             loadingCreate: false,
             createOK: false,
+            createBuffer: "",
+            createCompleted: false,
             modalMsg: "",
             errObj: {},
         };
@@ -224,7 +227,8 @@ export class CreateInstanceModal extends React.Component {
          * [6] Remove setup file
          */
         this.setState({
-            loadingCreate: true
+            loadingCreate: true,
+            createBuffer: ""
         });
         const hostname_cmd = ["hostnamectl", "status", "--static"];
         log_cmd("handleCreateInstance", "Get FQDN ...", hostname_cmd);
@@ -288,6 +292,7 @@ export class CreateInstanceModal extends React.Component {
                                                 '/usr/bin/echo -e \'' + setup_inf + '\' >> ' + setup_file
                                             ];
 
+                                            let createBuffer = "";
                                             // Do not log inf file as it contains the DM password
                                             log_cmd("handleCreateInstance", "Apply changes to INF file...", "");
                                             cockpit
@@ -346,6 +351,11 @@ export class CreateInstanceModal extends React.Component {
                                                                         funcDesc: _("Set Directory Manager password...")
                                                                     };
                                                                     callCmdStreamPassword(config);
+                                                                })
+                                                                .stream(line => {
+                                                                    this.setState({
+                                                                        createBuffer: this.state.createBuffer + line
+                                                                    });
                                                                 });
                                                     });
                                         });
@@ -370,6 +380,7 @@ export class CreateInstanceModal extends React.Component {
             createTLSCert,
             createInitDB,
             createOK,
+            createBuffer,
             errObj,
         } = this.state;
 
@@ -380,6 +391,16 @@ export class CreateInstanceModal extends React.Component {
             extraPrimaryProps.spinnerAriaValueText = "Saving";
         }
 
+        let createBufferItem = null;
+        if (createBuffer !== "") {
+            createBufferItem = <LogViewer
+                data={createBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={createBuffer.length}
+                height="200px"
+            />;
+        }
         return (
             <Modal
                 variant={ModalVariant.medium}
@@ -672,7 +693,8 @@ export class CreateInstanceModal extends React.Component {
                                 </GridItem>
                             </Grid>
                         </div>
-                        <div className={createDBCheckbox ? "ds-margin-bottom" : "ds-margin-bottom-md"} />
+                        {createBufferItem}
+                        <div className={createDBCheckbox ? "ds-margin-top ds-margin-bottom" : "ds-margin-top ds-margin-bottom-md"} />
                     </Form>
                 </div>
             </Modal>
@@ -801,7 +823,10 @@ export class ManageBackupsModal extends React.Component {
             deleteBackup: "",
             modalSpinning: false,
             modalChecked: false,
-            errObj: {}
+            errObj: {},
+            backupBuffer: "",
+            backupCompleted: false,
+            restoreCompleted: false,
         };
 
         this.handleNavSelect = this.handleNavSelect.bind(this);
@@ -841,7 +866,9 @@ export class ManageBackupsModal extends React.Component {
 
     closeBackupModal() {
         this.setState({
-            showBackupModal: false
+            showBackupModal: false,
+            backupBuffer: "",
+            backupCompleted: false,
         });
     }
 
@@ -852,13 +879,15 @@ export class ManageBackupsModal extends React.Component {
             backupName: name,
             modalChecked: false,
             modalSpinning: false,
+            backupCompleted: false,
         });
     }
 
     closeConfirmBackup() {
         // call importLDIF
         this.setState({
-            showConfirmBackup: false
+            showConfirmBackup: false,
+            backupCompleted: false,
         });
     }
 
@@ -868,6 +897,7 @@ export class ManageBackupsModal extends React.Component {
             backupName: name,
             modalChecked: false,
             modalSpinning: false,
+            backupBuffer: ""
         });
     }
 
@@ -876,7 +906,8 @@ export class ManageBackupsModal extends React.Component {
         this.setState({
             showConfirmRestore: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupBuffer: ""
         });
     }
 
@@ -917,7 +948,8 @@ export class ManageBackupsModal extends React.Component {
 
     doBackup() {
         this.setState({
-            backupSpinning: true
+            backupSpinning: true,
+            backupBuffer: ""
         });
 
         const cmd = ["dsctl", "-j", this.props.serverId, "status"];
@@ -943,13 +975,18 @@ export class ManageBackupsModal extends React.Component {
                             }
                             cmd.push(this.state.backupName);
                         }
+                        cmd.push("--watch");
 
+                        let backupBuffer = "";
                         log_cmd("doBackup", "Add backup task online", cmd);
                         cockpit
-                                .spawn(cmd, { superuser: true, err: "message" })
+                                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                                 .done(content => {
                                     this.props.reload();
-                                    this.closeBackupModal();
+                                    this.setState({
+                                        backupCompleted: true,
+                                        backupSpinning: false,
+                                    });
                                     const cmd = [
                                         "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
                                         "config", "get", "nsslapd-bakdir"
@@ -968,25 +1005,35 @@ export class ManageBackupsModal extends React.Component {
                                             .fail(err => {
                                                 const errMsg = getApiErrorMessage(err);
                                                 this.props.addNotification(
-                                                    "success",
-                                                    _("Server has been backed up.")
-                                                );
-                                                this.props.addNotification(
                                                     "error",
-                                                    cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg)
+                                                    cockpit.format(_("Error while trying to get the server's backup directory - $0"), errMsg)
                                                 );
+                                                this.setState({
+                                                    backupBuffer: "",
+                                                    backupCompleted: true,
+                                                });
                                             });
                                 })
                                 .fail(err => {
                                     const errMsg = getApiErrorMessage(err);
                                     this.props.reload();
-                                    this.closeBackupModal();
+                                    this.setState({
+                                        backupCompleted: true,
+                                        backupSpinning: false,
+                                    });
                                     this.props.addNotification(
                                         "error",
                                         cockpit.format(_("Failure backing up server - $0"), errMsg)
                                     );
+                                })
+                                .stream(data => {
+                                    backupBuffer += data;
+                                    this.setState({
+                                        backupBuffer: backupBuffer
+                                    });
                                 });
                     } else {
+                        let backupBuffer = "";
                         const cmd = ["dsctl", "-j", this.props.serverId, "db2bak"];
                         if (this.state.backupName !== "") {
                             if (bad_file_name(this.state.backupName)) {
@@ -998,22 +1045,36 @@ export class ManageBackupsModal extends React.Component {
                             }
                             cmd.push(this.state.backupName);
                         }
+                        cmd.push("--watch");
+
                         log_cmd("doBackup", "Doing backup of the server offline", cmd);
                         cockpit
-                                .spawn(cmd, { superuser: true })
+                                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                                 .done(content => {
                                     this.props.reload();
-                                    this.closeBackupModal();
+                                    this.setState({
+                                        backupCompleted: true,
+                                        backupSpinning: false,
+                                    });
                                     this.props.addNotification("success", _("Server has been backed up"));
                                 })
                                 .fail(err => {
                                     const errMsg = getApiErrorMessage(err);
                                     this.props.reload();
-                                    this.closeBackupModal();
+                                    this.setState({
+                                        backupCompleted: true,
+                                        backupSpinning: false,
+                                    });
                                     this.props.addNotification(
                                         "error",
                                         cockpit.format(_("Failure backing up server - $0"), errMsg)
                                     );
+                                })
+                                .stream(data => {
+                                    backupBuffer += data;
+                                    this.setState({
+                                        backupBuffer: backupBuffer
+                                    });
                                 });
                     }
                 })
@@ -1025,8 +1086,10 @@ export class ManageBackupsModal extends React.Component {
 
     restoreBackup() {
         this.setState({
-            modalSpinning: true
+            modalSpinning: true,
+            backupBuffer: ""
         });
+        let backupBuffer = "";
         const cmd = ["dsctl", "-j", this.props.serverId, "status"];
         cockpit
                 .spawn(cmd, { superuser: true })
@@ -1039,22 +1102,35 @@ export class ManageBackupsModal extends React.Component {
                             "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
                             "backup",
                             "restore",
-                            this.state.backupName
+                            this.state.backupName,
+                            "--watch"
                         ];
                         log_cmd("restoreBackup", "Restoring server online", cmd);
                         cockpit
-                                .spawn(cmd, { superuser: true, err: "message" })
+                                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                                 .done(content => {
-                                    this.closeConfirmRestore();
+                                    this.setState({
+                                        restoreCompleted: true,
+                                        modalSpinning: false,
+                                    });
                                     this.props.addNotification("success", _("Server has been restored"));
                                 })
                                 .fail(err => {
                                     const errMsg = getApiErrorMessage(err);
-                                    this.closeConfirmRestore();
+                                    this.setState({
+                                        restoreCompleted: true,
+                                        modalSpinning: false,
+                                    });
                                     this.props.addNotification(
                                         "error",
                                         cockpit.format(_("Failure restoring up server - $0"), errMsg)
                                     );
+                                })
+                                .stream(data => {
+                                    backupBuffer += data;
+                                    this.setState({
+                                        backupBuffer: backupBuffer
+                                    });
                                 });
                     } else {
                         const cmd = [
@@ -1062,22 +1138,35 @@ export class ManageBackupsModal extends React.Component {
                             "-j",
                             this.props.serverId,
                             "bak2db",
-                            this.state.backupName
+                            this.state.backupName,
+                            "--watch"
                         ];
                         log_cmd("restoreBackup", "Restoring server offline", cmd);
                         cockpit
-                                .spawn(cmd, { superuser: true, err: "message" })
+                                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                                 .done(content => {
-                                    this.closeRestoreSpinningModal();
+                                    this.setState({
+                                        restoreCompleted: true,
+                                        modalSpinning: false,
+                                    });
                                     this.props.addNotification("success", _("Server has been restored"));
                                 })
                                 .fail(err => {
                                     const errMsg = getApiErrorMessage(err);
-                                    this.closeRestoreSpinningModal();
+                                    this.setState({
+                                        restoreCompleted: true,
+                                        modalSpinning: false,
+                                    });
                                     this.props.addNotification(
                                         "error",
                                         cockpit.format(_("Failure restoring up server - $0"), errMsg)
                                     );
+                                })
+                                .stream(data => {
+                                    backupBuffer += data;
+                                    this.setState({
+                                        backupBuffer: backupBuffer
+                                    });
                                 });
                     }
                 })
@@ -1140,6 +1229,17 @@ export class ManageBackupsModal extends React.Component {
     render() {
         const { showModal, closeHandler, backups } = this.props;
 
+        let bufferItem = null;
+        if (this.state.backupBuffer !== "") {
+            bufferItem = <LogViewer
+                data={this.state.backupBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.backupBuffer.length}
+                height="200px"
+            />;
+        }
+
         return (
             <div>
                 <Modal
@@ -1168,7 +1268,9 @@ export class ManageBackupsModal extends React.Component {
                     handleChange={this.onModalChange}
                     saveHandler={this.validateBackup}
                     spinning={this.state.backupSpinning}
+                    watchBuffer={bufferItem}
                     error={this.state.errObj}
+                    backupCompleted={this.state.backupCompleted}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmRestore}
@@ -1176,12 +1278,12 @@ export class ManageBackupsModal extends React.Component {
                     handleChange={this.onModalChange}
                     actionHandler={this.restoreBackup}
                     spinning={this.state.modalSpinning}
-                    item={this.state.backupName}
+                    item={bufferItem ? bufferItem : this.state.backupName}
                     checked={this.state.modalChecked}
                     mTitle={_("Restore Backup")}
                     mMsg={_("Are you sure you want to restore this backup?")}
                     mSpinningMsg={_("Restoring ...")}
-                    mBtnName={_("Restore Backup")}
+                    mBtnName={this.state.restoreCompleted ? null : _("Restore Backup")}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmBackupDelete}
@@ -1202,7 +1304,7 @@ export class ManageBackupsModal extends React.Component {
                     handleChange={this.onModalChange}
                     actionHandler={this.deleteBackup}
                     spinning={this.state.modalSpinning}
-                    item={this.state.doBackup}
+                    item={bufferItem ? bufferItem : this.state.backupName}
                     checked={this.state.modalChecked}
                     mTitle={_("Replace Existing Backup")}
                     mMsg={_(" backup already eixsts with the same name, do you want to replace it?")}

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -12,7 +12,6 @@ import {
     GridItem,
     Modal,
     ModalVariant,
-    Spinner,
     Tab,
     Tabs,
     TabTitleText,
@@ -22,6 +21,7 @@ import {
     TextVariants,
     ValidatedOptions,
 } from "@patternfly/react-core";
+import { LogViewer } from '@patternfly/react-log-viewer';
 import { log_cmd, bad_file_name, getApiErrorMessage } from "../tools.jsx";
 import PropTypes from "prop-types";
 
@@ -36,18 +36,22 @@ export class Backups extends React.Component {
             showConfirmBackup: false,
             showConfirmRestoreReplace: false,
             showConfirmLDIFReplace: false,
-            showRestoreSpinningModal: false,
-            showDelBackupSpinningModal: false,
             showBackupModal: false,
             backupSpinning: false,
             backupName: "",
             deleteBackup: "",
+            backupBuffer: "",
+            importBuffer: "",
+            exportBuffer: "",
+            restoreBuffer: "",
+            backupCompleted: false,
+            restoreCompleted: false,
+            exportCompleted: false,
+            importCompleted: false,
             // LDIF
             showConfirmLDIFDelete: false,
             showConfirmLDIFImport: false,
             showConfirmRestore: false,
-            showLDIFSpinningModal: false,
-            showLDIFDeleteSpinningModal: false,
             showExportModal: false,
             exportSpinner: false,
             includeReplData: false,
@@ -106,30 +110,23 @@ export class Backups extends React.Component {
             ldifName: "",
             ldifSuffix: this.props.suffixes[0],
             includeReplData: false,
+            exportBuffer: "",
+            exportCompleted: false,
         });
     }
 
     closeExportModal () {
         this.setState({
-            showExportModal: false
+            showExportModal: false,
+            exportBuffer: "",
+            exportCompleted: false,
         });
     }
 
     closeConfirmLDIFReplace () {
         this.setState({
-            showConfirmLDIFReplace: false
-        });
-    }
-
-    showRestoreSpinningModal () {
-        this.setState({
-            showRestoreSpinningModal: true
-        });
-    }
-
-    closeRestoreSpinningModal () {
-        this.setState({
-            showRestoreSpinningModal: false
+            showConfirmLDIFReplace: false,
+            exportCompleted: false,
         });
     }
 
@@ -137,13 +134,16 @@ export class Backups extends React.Component {
         this.setState({
             showBackupModal: true,
             backupSpinning: false,
-            backupName: ""
+            backupName: "",
+            backupCompleted: false,
         });
     }
 
     closeBackupModal () {
         this.setState({
             showBackupModal: false,
+            backupBuffer: "",
+            backupCompleted: false,
         });
     }
 
@@ -153,7 +153,9 @@ export class Backups extends React.Component {
             ldifName: name,
             ldifSuffix: suffix,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            importBuffer: "",
+            importCompleted: false,
         });
     }
 
@@ -162,7 +164,9 @@ export class Backups extends React.Component {
         this.setState({
             showConfirmLDIFImport: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            importBuffer: "",
+            importCompleted: false,
         });
     }
 
@@ -191,7 +195,9 @@ export class Backups extends React.Component {
             showConfirmBackup: true,
             backupName: name,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupBuffer: "",
+            backupCompleted: false,
         });
     }
 
@@ -200,7 +206,9 @@ export class Backups extends React.Component {
         this.setState({
             showConfirmBackup: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupBuffer: "",
+            backupCompleted: false,
         });
     }
 
@@ -209,7 +217,9 @@ export class Backups extends React.Component {
             showConfirmRestore: true,
             backupName: name,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            restoreBuffer: "",
+            restoreCompleted: false,
         });
     }
 
@@ -218,7 +228,9 @@ export class Backups extends React.Component {
         this.setState({
             showConfirmRestore: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            restoreBuffer: "",
+            restoreCompleted: false,
         });
     }
 
@@ -228,7 +240,8 @@ export class Backups extends React.Component {
             showConfirmBackupDelete: true,
             backupName: name,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupCompleted: false,
         });
     }
 
@@ -237,7 +250,8 @@ export class Backups extends React.Component {
         this.setState({
             showConfirmBackupDelete: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupCompleted: false,
         });
     }
 
@@ -245,7 +259,9 @@ export class Backups extends React.Component {
         this.setState({
             showConfirmRestoreReplace: false,
             modalSpinning: false,
-            modalChecked: false
+            modalChecked: false,
+            backupBuffer: "",
+            restoreCompleted: false,
         });
     }
 
@@ -257,18 +273,24 @@ export class Backups extends React.Component {
 
     importLDIF() {
         this.setState({
-            modalSpinning: true
+            modalSpinning: true,
+            importBuffer: "",
         });
 
+        let importBuffer = "";
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "import", this.state.ldifSuffix, this.state.ldifName, "--encrypted"
+            "backend", "import", this.state.ldifSuffix, this.state.ldifName, "--encrypted",
+            "--watch"
         ];
         log_cmd("importLDIF", "Importing LDIF", cmd);
         cockpit
-                .spawn(cmd, { superuser: true, err: "message" })
+                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
-                    this.closeConfirmLDIFImport();
+                    this.setState({
+                        modalSpinning: false,
+                        importCompleted: true,
+                    });
                     this.props.addNotification(
                         "success",
                         _("LDIF was successfully imported")
@@ -276,11 +298,20 @@ export class Backups extends React.Component {
                 })
                 .fail(err => {
                     const errMsg = getApiErrorMessage(err);
-                    this.closeConfirmLDIFImport();
+                    this.setState({
+                        modalSpinning: false,
+                        importCompleted: true,
+                    });
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Failure importing LDIF - $0"), errMsg)
                     );
+                })
+                .stream(data => {
+                    importBuffer += data;
+                    this.setState({
+                        importBuffer: importBuffer
+                    });
                 });
     }
 
@@ -341,17 +372,23 @@ export class Backups extends React.Component {
             }
             cmd.push(this.state.backupName);
         }
+        cmd.push("--watch");
 
+        let backupBuffer = "";
         this.setState({
-            backupSpinning: true
+            modalSpinning: true,
+            backupBuffer: "",
         });
 
         log_cmd("doBackup", "Add backup task", cmd);
         cockpit
-                .spawn(cmd, { superuser: true, err: "message" })
+                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
                     this.props.handleReload();
-                    this.closeBackupModal();
+                    this.setState({
+                        modalSpinning: false,
+                        backupCompleted: true,
+                    });
                     const cmd = [
                         "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
                         "config", "get", "nsslapd-bakdir"
@@ -378,12 +415,20 @@ export class Backups extends React.Component {
                                     cockpit.format(_("Error while trying to get the server's backup directory- $0"), errMsg)
                                 );
                             });
-                }
-                )
+                })
+                .stream(data => {
+                    backupBuffer += data;
+                    this.setState({
+                        backupBuffer: backupBuffer
+                    });
+                })
                 .fail(err => {
                     const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
-                    this.closeBackupModal();
+                    this.setState({
+                        modalSpinning: false,
+                        backupCompleted: true,
+                    });
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Failure backing up server - $0"), errMsg)
@@ -401,17 +446,22 @@ export class Backups extends React.Component {
         }
 
         this.setState({
-            modalSpinning: true
+            modalSpinning: true,
+            restoreBuffer: "",
         });
+        let restoreBuffer = "";
         const cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backup", "restore", this.state.backupName
+            "backup", "restore", this.state.backupName, "--watch"
         ];
         log_cmd("restoreBackup", "Restoring server", cmd);
         cockpit
-                .spawn(cmd, { superuser: true, err: "message" })
+                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
-                    this.closeConfirmRestore();
+                    this.setState({
+                        modalSpinning: false,
+                        restoreCompleted: true,
+                    });
                     this.props.addNotification(
                         "success",
                         _("Server has been restored")
@@ -419,11 +469,20 @@ export class Backups extends React.Component {
                 })
                 .fail(err => {
                     const errMsg = getApiErrorMessage(err);
-                    this.closeRestoreSpinningModal();
+                    this.setState({
+                        modalSpinning: false,
+                        restoreCompleted: true,
+                    });
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Failure restoring up server - $0"), errMsg)
                     );
+                })
+                .stream(data => {
+                    restoreBuffer += data;
+                    this.setState({
+                        restoreBuffer: restoreBuffer
+                    });
                 });
     }
 
@@ -517,7 +576,8 @@ export class Backups extends React.Component {
         // Do import
         const export_cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "export", this.state.ldifSuffix, "--encrypted", "--ldif=" + this.state.ldifName
+            "backend", "export", this.state.ldifSuffix, "--encrypted", "--ldif=" + this.state.ldifName,
+            "--watch"
         ];
 
         if (this.state.includeReplData) {
@@ -526,16 +586,18 @@ export class Backups extends React.Component {
 
         this.setState({
             exportSpinner: true,
+            exportBuffer: "",
         });
 
+        let exportBuffer = "";
         log_cmd("doExport", "Do online export", export_cmd);
         cockpit
                 .spawn(export_cmd, { superuser: true, err: "message" })
                 .done(content => {
                     this.props.handleReload();
-                    this.closeExportModal();
                     this.setState({
-                        showExportModal: false,
+                        exportSpinner: false,
+                        exportCompleted: true,
                     });
                     const cmd = [
                         "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
@@ -567,13 +629,19 @@ export class Backups extends React.Component {
                 .fail(err => {
                     const errMsg = getApiErrorMessage(err);
                     this.props.handleReload();
-                    this.closeExportModal();
+                    this.setState({
+                        exportSpinner: false,
+                        exportCompleted: true,
+                    });
                     this.props.addNotification(
                         "error",
                         cockpit.format(_("Error exporting database - $0"), errMsg)
                     );
+                })
+                .stream(data => {
+                    exportBuffer += data;
                     this.setState({
-                        showExportModal: false,
+                        exportBuffer: exportBuffer
                     });
                 });
     }
@@ -584,6 +652,48 @@ export class Backups extends React.Component {
         if (this.props.refreshing) {
             refreshBtnName = _("Refreshing ...");
             extraPrimaryProps.spinnerAriaValueText = _("Refreshing");
+        }
+
+        let restoreBufferItem = null;
+        if (this.state.restoreBuffer !== "") {
+            restoreBufferItem = <LogViewer
+                data={this.state.restoreBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.restoreBuffer.length}
+                height="200px"
+            />;
+        }
+
+        let exportBufferItem = null;
+        if (this.state.exportBuffer !== "") {
+            exportBufferItem = <LogViewer
+                data={this.state.exportBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.exportBuffer.length}
+                height="200px"
+            />;
+        }
+        let importBufferItem = null;
+        if (this.state.importBuffer !== "") {
+            importBufferItem = <LogViewer
+                data={this.state.importBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.importBuffer.length}
+                height="200px"
+            />;
+        }
+        let backupBufferItem = null;
+        if (this.state.backupBuffer !== "") {
+            backupBufferItem = <LogViewer
+                data={this.state.backupBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.backupBuffer.length}
+                height="200px"
+            />;
         }
 
         return (
@@ -671,6 +781,8 @@ export class Backups extends React.Component {
                     includeReplData={this.state.includeReplData}
                     ldifSuffix={this.state.ldifSuffix}
                     ldifName={this.state.ldifName}
+                    watchBuffer={exportBufferItem}
+                    exportCompleted={this.state.exportCompleted}
                 />
                 <BackupModal
                     showModal={this.state.showBackupModal}
@@ -678,12 +790,9 @@ export class Backups extends React.Component {
                     handleChange={this.onChange}
                     saveHandler={this.validateBackup}
                     spinning={this.state.backupSpinning}
+                    watchBuffer={backupBufferItem}
                     error={this.state.errObj}
-                />
-                <ImportingModal
-                    showModal={this.state.showLDIFSpinningModal}
-                    closeHandler={this.closeLDIFSpinningModal}
-                    msg={this.state.ldifName}
+                    backupCompleted={this.state.backupCompleted}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmLDIFDelete}
@@ -704,12 +813,12 @@ export class Backups extends React.Component {
                     handleChange={this.onConfirmChange}
                     actionHandler={this.importLDIF}
                     spinning={this.state.modalSpinning}
-                    item={this.state.ldifName}
+                    item={importBufferItem ? importBufferItem : this.state.ldifName}
                     checked={this.state.modalChecked}
                     mTitle={_("Import LDIF File")}
                     mMsg={_("Are you sure you want to import this LDIF?")}
                     mSpinningMsg={_("Importing LDIF ...")}
-                    mBtnName={_("Import LDIF")}
+                    mBtnName={this.state.importCompleted ? null : _("Import LDIF")}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmRestore}
@@ -717,12 +826,12 @@ export class Backups extends React.Component {
                     handleChange={this.onConfirmChange}
                     actionHandler={this.restoreBackup}
                     spinning={this.state.modalSpinning}
-                    item={this.state.backupName}
+                    item={restoreBufferItem ? restoreBufferItem : this.state.backupName}
                     checked={this.state.modalChecked}
                     mTitle={_("Restore Database")}
                     mMsg={_("Are you sure you want to restore from this backup?")}
                     mSpinningMsg={_("Restoring ...")}
-                    mBtnName={_("Restore")}
+                    mBtnName={this.state.restoreCompleted ? null : _("Restore")}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showConfirmBackupDelete}
@@ -756,7 +865,7 @@ export class Backups extends React.Component {
                     handleChange={this.onConfirmChange}
                     actionHandler={this.doExport}
                     spinning={this.state.modalSpinning}
-                    item={this.state.ldifName}
+                    item={exportBufferItem ? exportBufferItem : this.state.ldifName}
                     checked={this.state.modalChecked}
                     mTitle={_("Replace Existing LDIF File")}
                     mMsg={_("A LDIF file already exists with the same name, do you want to replace it?")}
@@ -780,6 +889,9 @@ class ExportModal extends React.Component {
             error,
             ldifSuffix,
             ldifName,
+            includeReplData,
+            watchBuffer,
+            exportCompleted,
         } = this.props;
         let createBtnName = _("Create LDIF");
         const extraPrimaryProps = {};
@@ -800,6 +912,26 @@ class ExportModal extends React.Component {
             <FormSelectOption key={suffix} value={suffix} label={suffix} />
         ));
 
+        const actions = [];
+        if (!exportCompleted) {
+            actions.push(
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    onClick={saveHandler}
+                    isLoading={spinning}
+                    isDisabled={spinning || ldifName === ""}
+                    {...extraPrimaryProps}
+                >
+                    {createBtnName}
+                </Button>
+            );
+        }
+        actions.push(
+            <Button key="close" variant="link" onClick={closeHandler}>
+                {_("Close")}
+            </Button>
+        );
         return (
             <Modal
                 variant={ModalVariant.medium}
@@ -807,22 +939,7 @@ class ExportModal extends React.Component {
                 isOpen={showModal}
                 aria-labelledby="ds-modal"
                 onClose={closeHandler}
-                actions={[
-                    <Button
-                        key="confirm"
-                        variant="primary"
-                        onClick={saveHandler}
-                        isLoading={spinning}
-                        spinnerAriaValueText={spinning ? _("Creating ...") : undefined}
-                        isDisabled={spinning || ldifName === ""}
-                        {...extraPrimaryProps}
-                    >
-                        {createBtnName}
-                    </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
-                    </Button>
-                ]}
+                actions={actions}
             >
                 <Form isHorizontal autoComplete="off">
                     <Grid className="ds-margin-top">
@@ -860,13 +977,16 @@ class ExportModal extends React.Component {
                             <Checkbox
                                 id="includeReplData"
                                 className="ds-indent ds-margin-top"
-                                isChecked={this.props.includeReplData}
+                                isChecked={includeReplData}
                                 onChange={(e, checked) => {
                                     handleChange(e);
                                 }}
                                 title={_("Include the replication metadata needed to restore or initialize another replica.")}
                                 label={_("Include Replication Data")}
                             />
+                        </GridItem>
+                        <GridItem span={12} className="ds-margin-top-lg">
+                            {watchBuffer}
                         </GridItem>
                     </Grid>
                     {exportMsg}
@@ -884,7 +1004,9 @@ export class BackupModal extends React.Component {
             handleChange,
             saveHandler,
             spinning,
-            error
+            watchBuffer,
+            error,
+            backupCompleted,
         } = this.props;
         let createBtnName = _("Create Backup");
         const extraPrimaryProps = {};
@@ -901,6 +1023,26 @@ export class BackupModal extends React.Component {
             );
         }
 
+        const actions = [];
+        if (!backupCompleted) {
+            actions.push(
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    onClick={saveHandler}
+                    isLoading={spinning}
+                    isDisabled={spinning}
+                    {...extraPrimaryProps}
+                >
+                    {createBtnName}
+                </Button>
+            );
+        }
+        actions.push(
+            <Button key="close" variant="link" onClick={closeHandler}>
+                {_("Close")}
+            </Button>
+        );
         return (
             <Modal
                 variant={ModalVariant.medium}
@@ -908,22 +1050,7 @@ export class BackupModal extends React.Component {
                 isOpen={showModal}
                 aria-labelledby="ds-modal"
                 onClose={closeHandler}
-                actions={[
-                    <Button
-                        key="confirm"
-                        variant="primary"
-                        onClick={saveHandler}
-                        isLoading={spinning}
-                        isDisabled={spinning}
-                        spinnerAriaValueText={spinning ? _("Creating ...") : undefined}
-                        {...extraPrimaryProps}
-                    >
-                        {createBtnName}
-                    </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
-                    </Button>
-                ]}
+                actions={actions}
             >
                 <Form isHorizontal autoComplete="off">
                     <Grid
@@ -938,45 +1065,16 @@ export class BackupModal extends React.Component {
                                 type="text"
                                 id="backupName"
                                 aria-describedby="horizontal-form-name-helper"
-                                name="ldifName"
+                                name="backupName"
                                 onChange={(event, value) => { handleChange(event) }}
                                 validated={error.backupName ? ValidatedOptions.error : ValidatedOptions.default}
                             />
                         </GridItem>
+                        <GridItem span={12} className="ds-margin-top-lg">
+                            {watchBuffer}
+                        </GridItem>
                     </Grid>
                     {exportMsg}
-                </Form>
-            </Modal>
-        );
-    }
-}
-
-export class ImportingModal extends React.Component {
-    render() {
-        const {
-            showModal,
-            closeHandler,
-            msg
-        } = this.props;
-
-        return (
-            <Modal
-                variant={ModalVariant.small}
-                title={_("Import LDIF File")}
-                isOpen={showModal}
-                aria-labelledby="ds-modal"
-                onClose={closeHandler}
-                actions={[
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Close")}
-                    </Button>
-                ]}
-            >
-                <Form horizontal autoComplete="off">
-                    <div className="ds-modal-spinner">
-                        <Spinner size="md" />{_("Importing LDIF ")}<b>{msg}</b> ...
-                        <p className="ds-margin-top"><font size="2">{_("(You can safely close this window)")})</font></p>
-                    </div>
                 </Form>
             </Modal>
         );
@@ -992,7 +1090,12 @@ ExportModal.propTypes = {
     saveHandler: PropTypes.func,
     spinning: PropTypes.bool,
     error: PropTypes.object,
-    suffixes: PropTypes.array
+    suffixes: PropTypes.array,
+    includeReplData: PropTypes.bool,
+    ldifSuffix: PropTypes.string,
+    ldifName: PropTypes.string,
+    watchBuffer: PropTypes.node,
+    exportCompleted: PropTypes.bool,
 };
 
 BackupModal.propTypes = {
@@ -1002,12 +1105,8 @@ BackupModal.propTypes = {
     saveHandler: PropTypes.func,
     spinning: PropTypes.bool,
     error: PropTypes.object,
-};
-
-ImportingModal.propTypes = {
-    showModal: PropTypes.bool,
-    closeHandler: PropTypes.func,
-    msg: PropTypes.string
+    watchBuffer: PropTypes.node,
+    backupCompleted: PropTypes.bool,
 };
 
 Backups.propTypes = {

--- a/src/cockpit/389-console/src/lib/database/databaseModal.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseModal.jsx
@@ -60,8 +60,8 @@ class CreateLinkModal extends React.Component {
                     >
                         {saveBtnName}
                     </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
+                    <Button key="close" variant="link" onClick={closeHandler}>
+                        {_("Close")}
                     </Button>
                 ]}
             >
@@ -278,8 +278,8 @@ class CreateSubSuffixModal extends React.Component {
                     >
                         {saveBtnName}
                     </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
+                    <Button key="close" variant="link" onClick={closeHandler}>
+                        {_("Close")}
                     </Button>
                 ]}
             >
@@ -361,14 +361,30 @@ class ExportModal extends React.Component {
             includeReplData,
             saveHandler,
             spinning,
-            error
+            item,
+            error,
+            exportCompleted
         } = this.props;
         let saveBtnName = _("Export Database");
         const extraPrimaryProps = {};
         if (spinning) {
             saveBtnName = _("Exporting ...");
-            extraPrimaryProps.spinnerAriaValueText = _("Creating");
+            extraPrimaryProps.spinnerAriaValueText = _("Exporting");
         }
+
+        const actions = [];
+        if (!exportCompleted) {
+            actions.push(
+                <Button key="confirm" variant="primary" onClick={saveHandler} isDisabled={this.props.saveBtnDisabled || spinning} {...extraPrimaryProps}>
+                    {saveBtnName}
+                </Button>
+            );
+        }
+        actions.push(
+            <Button key="close" variant="link" onClick={closeHandler}>
+                {_("Close")}
+            </Button>
+        );
 
         return (
             <Modal
@@ -376,22 +392,7 @@ class ExportModal extends React.Component {
                 title={_("Export Database To LDIF File")}
                 isOpen={showModal}
                 onClose={closeHandler}
-                actions={[
-                    <Button
-                        key="export"
-                        variant="primary"
-                        onClick={saveHandler}
-                        isLoading={spinning}
-                        spinnerAriaValueText={spinning ? _("Creating Suffix") : undefined}
-                        {...extraPrimaryProps}
-                        isDisabled={this.props.saveBtnDisabled || spinning}
-                    >
-                        {saveBtnName}
-                    </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
-                    </Button>
-                ]}
+                actions={actions}
             >
                 <Form isHorizontal autoComplete="off">
                     <Grid title={_("Name of exported LDIF file.")}>
@@ -403,6 +404,7 @@ class ExportModal extends React.Component {
                                 type="text"
                                 id="ldifLocation"
                                 aria-describedby="horizontal-form-name-helper"
+                                isDisabled={spinning || exportCompleted}
                                 name="ldifLocation"
                                 onChange={(e, val) => {
                                     handleChange(e);
@@ -419,10 +421,12 @@ class ExportModal extends React.Component {
                                     handleChange(e);
                                 }}
                                 isChecked={includeReplData}
+                                isDisabled={spinning || exportCompleted}
                                 label={_("Include Replication Data")}
                             />
                         </GridItem>
                     </Grid>
+                    {item}
                 </Form>
             </Modal>
         );
@@ -454,8 +458,8 @@ class ImportModal extends React.Component {
                 isOpen={showModal}
                 onClose={closeHandler}
                 actions={[
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
+                    <Button key="close" variant="link" onClick={closeHandler}>
+                        {_("Close")}
                     </Button>
                 ]}
             >
@@ -536,13 +540,15 @@ ExportModal.propTypes = {
     handleChange: PropTypes.func,
     saveHandler: PropTypes.func,
     error: PropTypes.object,
-    spinning: PropTypes.bool
+    spinning: PropTypes.bool,
+    item: PropTypes.node,
 };
 
 ExportModal.defaultProps = {
     showModal: false,
     error: {},
-    spinning: false
+    spinning: false,
+    item: null
 };
 
 ImportModal.propTypes = {

--- a/src/cockpit/389-console/src/lib/database/suffix.jsx
+++ b/src/cockpit/389-console/src/lib/database/suffix.jsx
@@ -1,5 +1,6 @@
 import cockpit from "cockpit";
 import React from "react";
+import { LogViewer } from '@patternfly/react-log-viewer';
 import { DoubleConfirmModal } from "../notifications.jsx";
 import { AttrEncryption } from "./attrEncryption.jsx";
 import { SuffixConfig } from "./suffixConfig.jsx";
@@ -72,13 +73,18 @@ export class Suffix extends React.Component {
             showExportModal: false,
             ldifLocation: "",
             attrEncryption: false,
-            exportSpinner: false,
             showConfirmLDIFImport: false,
             importLDIFName: "",
             deleleLDIFName: "",
             modalChecked: false,
             modalSpinning: false,
             includeReplData: false,
+            importBuffer: "",
+            exportBuffer: "",
+            reindexBuffer: "",
+            importCompleted: false,
+            exportCompleted: false,
+            reindexCompleted: false,
             // Reindex all
             showReindexConfirm: false,
             // Create Sub Suffix
@@ -184,12 +190,15 @@ export class Suffix extends React.Component {
             attrEncryption: false,
             showImportModal: true,
             errObj: {},
+            importCompleted: false,
         });
     }
 
     closeImportModal() {
         this.setState({
-            showImportModal: false
+            showImportModal: false,
+            importBuffer: "",
+            importCompleted: false,
         });
     }
 
@@ -248,6 +257,8 @@ export class Suffix extends React.Component {
             showConfirmLDIFImport: false,
             modalChecked: false,
             modalSpinning: false,
+            importBuffer: "",
+            importCompleted: false,
         });
     }
 
@@ -255,16 +266,20 @@ export class Suffix extends React.Component {
         // Do import
         const import_cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "import", this.props.suffix, this.state.importLDIFName, "--encrypted"
+            "backend", "import", this.props.suffix, this.state.importLDIFName, "--encrypted",
+            "--watch"
         ];
 
         this.setState({
             modalSpinning: true,
+            importBuffer: "",
         });
+
+        let buffer = "";
 
         log_cmd("doImport", "Do online import", import_cmd);
         cockpit
-                .spawn(import_cmd, { superuser: true, err: "message" })
+                .spawn(import_cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
                     this.props.addNotification(
                         "success",
@@ -272,8 +287,8 @@ export class Suffix extends React.Component {
                     );
                     this.setState({
                         modalSpinning: false,
-                        showConfirmLDIFImport: false,
                         showImportModal: false,
+                        importCompleted: true,
                     });
                 })
                 .fail(err => {
@@ -284,7 +299,13 @@ export class Suffix extends React.Component {
                     );
                     this.setState({
                         modalSpinning: false,
-                        showConfirmLDIFImport: false
+                        importCompleted: true,
+                    });
+                })
+                .stream(line => {
+                    buffer += line;
+                    this.setState({
+                        importBuffer: buffer
                     });
                 });
     }
@@ -307,16 +328,19 @@ export class Suffix extends React.Component {
             ldifLocation: "",
             attrEncryption: false,
             showExportModal: true,
-            exportSpinner: false,
+            modalSpinning: false,
             includeReplData: false,
             errObj: {},
+            exportCompleted: false,
         });
     }
 
     closeExportModal() {
         this.setState({
             showExportModal: false,
-            exportSpinner: false
+            modalSpinning: false,
+            exportBuffer: "",
+            exportCompleted: false,
         });
     }
 
@@ -350,7 +374,8 @@ export class Suffix extends React.Component {
         // Do Export
         const export_cmd = [
             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "export", this.props.suffix, "--ldif=" + this.state.ldifLocation
+            "backend", "export", this.props.suffix, "--ldif=" + this.state.ldifLocation,
+            "--watch"
         ];
 
         if (this.state.attrEncryption) {
@@ -362,22 +387,26 @@ export class Suffix extends React.Component {
         }
 
         this.setState({
-            exportSpinner: true,
+            modalSpinning: true,
+            exportBuffer: "",
         });
+        let buffer = "";
 
         log_cmd("doExport", "Do online export", export_cmd);
         cockpit
-                .spawn(export_cmd, { superuser: true, err: "message" })
+                .spawn(export_cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
                     this.props.reloadLDIFs();
                     this.setState({
-                        showExportModal: false,
+                        modalSpinning: false,
+                        exportCompleted: true,
                     });
+
                     const cmd = [
                         "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
                         "config", "get", "nsslapd-ldifdir"
                     ];
-                    log_cmd("doExport", "Get the backup directory", cmd);
+                    log_cmd("doExport", "Get the ldif directory", cmd);
                     cockpit
                             .spawn(cmd, { superuser: true, err: "message" })
                             .done(content => {
@@ -398,7 +427,8 @@ export class Suffix extends React.Component {
                                     "error",
                                     cockpit.format(_("Error while trying to get the server's LDIF directory- $0"), errMsg)
                                 );
-                            });
+                            })
+
                 })
                 .fail(err => {
                     const errMsg = getApiErrorMessage(err);
@@ -408,7 +438,14 @@ export class Suffix extends React.Component {
                         cockpit.format(_("Error exporting database - $0"), errMsg)
                     );
                     this.setState({
-                        showExportModal: false,
+                        modalSpinning: false,
+                        exportCompleted: true,
+                    });
+                })
+                .stream(line => {
+                    buffer += line;
+                    this.setState({
+                        exportBuffer: buffer
                     });
                 });
     }
@@ -421,6 +458,7 @@ export class Suffix extends React.Component {
             showReindexConfirm: true,
             modalChecked: false,
             modalSpinning: false,
+            reindexCompleted: false,
         });
     }
 
@@ -429,19 +467,22 @@ export class Suffix extends React.Component {
             showReindexConfirm: false,
             modalChecked: false,
             modalSpinning: false,
+            reindexCompleted: false,
         });
     }
 
     doReindex() {
         // Show index status modal
         this.setState({
-            modalSpinning: true
+            modalSpinning: true,
+            reindexBuffer: "",
         });
+        let buffer = "";
         const cmd = ["dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
-            "backend", "index", "reindex", "--wait", this.props.suffix];
+            "backend", "index", "reindex", "--watch", this.props.suffix];
         log_cmd("doReindex", "Reindex all attributes", cmd);
         cockpit
-                .spawn(cmd, { superuser: true, err: "message" })
+                .spawn(cmd, { pty: true, superuser: true, err: "message" })
                 .done(content => {
                     this.props.addNotification(
                         "success",
@@ -449,7 +490,7 @@ export class Suffix extends React.Component {
                     );
                     this.setState({
                         modalSpinning: false,
-                        showReindexConfirm: false,
+                        reindexCompleted: true,
                     });
                 })
                 .fail(err => {
@@ -460,7 +501,13 @@ export class Suffix extends React.Component {
                     );
                     this.setState({
                         modalSpinning: false,
-                        showReindexConfirm: false,
+                        reindexCompleted: true,
+                    });
+                })
+                .stream(line => {
+                    buffer += line;
+                    this.setState({
+                        reindexBuffer: buffer
                     });
                 });
     }
@@ -878,13 +925,44 @@ export class Suffix extends React.Component {
             </DropdownItem>,
         ];
 
+        let confirmImportItem = this.state.importLDIFName;
+        if (this.state.importBuffer !== "") {
+            confirmImportItem = <LogViewer
+                data={this.state.importBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.importBuffer.length}
+                height="200px"
+            />;
+        }
+        let exportItem = null;
+        if (this.state.exportBuffer !== "") {
+            exportItem = <LogViewer
+                data={this.state.exportBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.exportBuffer.length}
+                height="200px"
+            />;
+        }
+        let reindexItem = null;
+        if (this.state.reindexBuffer !== "") {
+            reindexItem = <LogViewer
+                data={this.state.reindexBuffer}
+                isTextWrapped={false}
+                hasLineNumbers={false}
+                scrollToRow={this.state.reindexBuffer.length}
+                height="200px"
+            />;
+        }
+
         return (
             <div id="suffix-page">
                 <Grid>
                     <GridItem className="ds-suffix-header" span={9}>
                         <SuffixIcon />
                         &nbsp;&nbsp;{this.props.suffix} (<i>{this.props.bename}</i>)
-                        <Button 
+                        <Button
                             variant="plain"
                             aria-label={_("Refresh suffix")}
                             onClick={() => this.props.reload(this.props.suffix)}
@@ -1022,22 +1100,24 @@ export class Suffix extends React.Component {
                     handleChange={this.onChange}
                     actionHandler={this.importLDIF}
                     spinning={this.state.modalSpinning}
-                    item={this.state.importLDIFName}
+                    item={confirmImportItem}
                     checked={this.state.modalChecked}
                     mTitle={_("Initialize Database From LDIF")}
                     mMsg={_("Are you sure you want to initialize the database (it will permanently overwrite the current database)?")}
                     mSpinningMsg={_("Initializing Database ...")}
-                    mBtnName={_("Initialize Database")}
+                    mBtnName={this.state.importCompleted ? null : _("Initialize Database")}
                 />
                 <ExportModal
                     showModal={this.state.showExportModal}
                     closeHandler={this.closeExportModal}
                     handleChange={this.onExportChange}
                     saveHandler={this.doExport}
-                    spinning={this.state.exportSpinner}
+                    spinning={this.state.modalSpinning}
+                    item={exportItem}
                     error={this.state.errObj}
                     includeReplData={this.state.includeReplData}
                     saveBtnDisabled={this.state.ldifLocation === ""}
+                    exportCompleted={this.state.exportCompleted}
                 />
                 <DoubleConfirmModal
                     showModal={this.state.showReindexConfirm}
@@ -1045,12 +1125,12 @@ export class Suffix extends React.Component {
                     handleChange={this.onChange}
                     actionHandler={this.doReindex}
                     spinning={this.state.modalSpinning}
-                    item={this.props.suffix}
+                    item={reindexItem}
                     checked={this.state.modalChecked}
                     mTitle={_("Reindex All Attributes")}
                     mMsg={_("Are you sure you want to reindex all the attribute indexes?")}
                     mSpinningMsg={_("Reindexing Database ...")}
-                    mBtnName={_("Reindex")}
+                    mBtnName={this.state.reindexCompleted ? null : _("Reindex")}
                 />
             </div>
         );

--- a/src/cockpit/389-console/src/lib/notifications.jsx
+++ b/src/cockpit/389-console/src/lib/notifications.jsx
@@ -43,6 +43,19 @@ export class DoubleConfirmModal extends React.Component {
             extraPrimaryProps.spinnerAriaValueText = _("Loading");
         }
 
+        const actions = [];
+        if (btnName) {
+            actions.push(
+                <Button key="confirm" variant="primary" onClick={actionHandler} isDisabled={saveDisabled || spinning} {...extraPrimaryProps}>
+                    {btnName}
+                </Button>
+            );
+        }
+        actions.push(
+            <Button key="close" variant="link" onClick={closeHandler}>
+                {_("Close")}
+            </Button>
+        );
         return (
             <Modal
                 variant={ModalVariant.small}
@@ -51,22 +64,7 @@ export class DoubleConfirmModal extends React.Component {
                 isOpen={showModal}
                 aria-labelledby="ds-modal"
                 onClose={closeHandler}
-                actions={[
-                    <Button
-                        key="confirm"
-                        isLoading={spinning}
-                        spinnerAriaValueText={spinning ? _("Loading") : undefined}
-                        variant="primary"
-                        onClick={actionHandler}
-                        isDisabled={saveDisabled || spinning}
-                        {...extraPrimaryProps}
-                    >
-                        {btnName}
-                    </Button>,
-                    <Button key="cancel" variant="link" onClick={closeHandler}>
-                        {_("Cancel")}
-                    </Button>
-                ]}
+                actions={actions}
             >
                 <Form isHorizontal autoComplete="off">
                     <TextContent>
@@ -79,18 +77,21 @@ export class DoubleConfirmModal extends React.Component {
                             <i>{item}</i>
                         </Text>
                     </TextContent>
-                    <Grid className="ds-margin-top-xlg">
-                        <GridItem sm={12} className="ds-center">
-                            <Checkbox
-                                id="modalChecked"
-                                isChecked={checked}
-                                onChange={(e, checked) => {
-                                    handleChange(e);
-                                }}
-                                label={<><b>{_("Yes")}</b>{_(", I am sure.")}</>}
-                            />
-                        </GridItem>
-                    </Grid>
+                    {btnName && (
+                        <Grid className="ds-margin-top-xlg">
+                            <GridItem sm={12} className="ds-center">
+                                <Checkbox
+                                        id="modalChecked"
+                                        isChecked={checked}
+                                        isDisabled={spinning}
+                                        onChange={(e, checked) => {
+                                            handleChange(e);
+                                        }}
+                                        label={<><b>{_("Yes")}</b>{_(", I am sure.")}</>}
+                                    />
+                            </GridItem>
+                        </Grid>
+                    )}
                 </Form>
             </Modal>
         );

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -2746,7 +2746,7 @@ class DirSrv(SimpleLDAPObject, object):
     # server is stopped)
     #
     def ldif2db(self, bename, suffixes, excludeSuffixes, encrypt,
-                import_file, import_cl=False):
+                import_file, import_cl=False, watch=False):
         """
         @param bename - The backend name of the database to import
         @param suffixes - List/tuple of suffixes to import
@@ -2792,6 +2792,8 @@ class DirSrv(SimpleLDAPObject, object):
             cmd.append('-E')
         if import_cl:
             cmd.append('-R')
+        if watch:
+            cmd.append('-V')
 
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
@@ -2805,10 +2807,15 @@ class DirSrv(SimpleLDAPObject, object):
                                format_cmd_list(cmd), e.returncode, e.output)
                 return False
 
+        if watch:
+            for line in result.split("\n"):
+                if line.strip():
+                    self.log.info(line)
+
         return True
 
     def db2ldif(self, bename, suffixes, excludeSuffixes, encrypt, repl_data,
-                outputfile, export_cl=False):
+                outputfile, export_cl=False, watch=False):
         """
         @param bename - The backend name of the database to export
         @param suffixes - List/tuple of suffixes to export
@@ -2864,6 +2871,10 @@ class DirSrv(SimpleLDAPObject, object):
             else:
                 ldifname = os.path.join(self.ds_paths.ldif_dir, "%s-%s.ldif" % (self.serverid, tnow))
             cmd.append(ldifname)
+
+        if watch:
+            cmd.append('-V')
+
         try:
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:
@@ -2871,14 +2882,19 @@ class DirSrv(SimpleLDAPObject, object):
                            format_cmd_list(cmd), e.returncode, e.output)
             return False
 
-        self.log.debug("db2ldif output: BEGIN")
-        for line in result.split("\n"):
-            self.log.debug(line)
-        self.log.debug("db2ldif output: END")
+        if watch:
+            for line in result.split("\n"):
+                if line.strip():
+                    self.log.info(line)
+        else:
+            self.log.debug("db2ldif output: BEGIN")
+            for line in result.split("\n"):
+                self.log.debug(line)
+            self.log.debug("db2ldif output: END")
 
         return True
 
-    def bak2db(self, archive_dir):
+    def bak2db(self, archive_dir, watch=False):
         """
         @param archive_dir - The directory containing the backup
         @param bename - The backend name to restore
@@ -2902,20 +2918,27 @@ class DirSrv(SimpleLDAPObject, object):
                    'archive2db',
                    '-a', archive_dir,
                    '-D', self.get_config_dir()]
+            if watch:
+                cmd.append('-V')
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:
             self.log.debug("Command: %s failed with the return code %s and the error %s",
                            format_cmd_list(cmd), e.returncode, e.output)
             return False
 
-        self.log.debug("bak2db output: BEGIN")
-        for line in result.split("\n"):
-            self.log.debug(line)
-        self.log.debug("bak2db output: END")
+        if watch:
+            for line in result.split("\n"):
+                if line.strip():
+                    self.log.info(line)
+        else:
+            self.log.debug("bak2db output: BEGIN")
+            for line in result.split("\n"):
+                self.log.debug(line)
+            self.log.debug("bak2db output: END")
 
         return True
 
-    def db2bak(self, archive_dir):
+    def db2bak(self, archive_dir, watch=False):
         """
         @param archive_dir - The directory to write the backup to
         @return - True if the backup succeeded
@@ -2940,16 +2963,23 @@ class DirSrv(SimpleLDAPObject, object):
                    'db2archive',
                    '-a', archive_dir,
                    '-D', self.get_config_dir()]
+            if watch:
+                cmd.append('-V')
             result = subprocess.check_output(cmd, encoding='utf-8')
         except subprocess.CalledProcessError as e:
             self.log.debug("Command: %s failed with the return code %s and the error %s",
                            format_cmd_list(cmd), e.returncode, e.output)
             return False
 
-        self.log.debug("db2bak output: BEGIN")
-        for line in result.split("\n"):
-            self.log.debug(line)
-        self.log.debug("db2bak output: END")
+        if watch:
+            for line in result.split("\n"):
+                if line.strip():
+                    self.log.info(line)
+        else:
+            self.log.debug("db2bak output: BEGIN")
+            for line in result.split("\n"):
+                self.log.debug(line)
+            self.log.debug("db2bak output: END")
 
         return True
 

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -13,7 +13,7 @@ import ldap
 from lib389._constants import DN_LDBM, DN_CHAIN, DN_PLUGIN, DEFAULT_BENAME
 from lib389.properties import BACKEND_OBJECTCLASS_VALUE, BACKEND_PROPNAME_TO_ATTRNAME, BACKEND_CHAIN_BIND_DN, \
                               BACKEND_CHAIN_BIND_PW, BACKEND_CHAIN_URLS, BACKEND_PROPNAME_TO_ATTRNAME, BACKEND_NAME, \
-                              BACKEND_SUFFIX, BACKEND_SAMPLE_ENTRIES, TASK_WAIT
+                              BACKEND_SUFFIX, BACKEND_SAMPLE_ENTRIES, TASK_WAIT, TASK_WATCH
 from lib389.utils import normalizeDN, ensure_str, assert_c
 from lib389 import Entry
 
@@ -1017,14 +1017,13 @@ class Backend(DSLdapObject):
         if reindex:
             self.reindex(attr_name)
 
-    def reindex(self, attrs=None, wait=False):
+    def reindex(self, attrs=None, wait=False, watch=False):
         """Reindex the attributes for this backend
         :param attrs - an optional list of attributes to index
         :param wait - Set to true to wait for task to complete
         """
-        args = None
-        if wait:
-            args = {TASK_WAIT: True}
+        args = {TASK_WAIT: wait, TASK_WATCH: watch}
+
         bename = self.get_attr_val_utf8('cn')
         reindex_task = Tasks(self._instance)
         reindex_task.reindex(benamebase=bename, attrname=attrs, args=args)

--- a/src/lib389/lib389/cli_conf/backend.py
+++ b/src/lib389/lib389/cli_conf/backend.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -269,7 +269,10 @@ def backend_import(inst, basedn, log, args):
     task = mc.import_ldif(ldifs=args.ldifs, chunk_size=args.chunks_size, encrypted=args.encrypted,
                           gen_uniq_id=args.gen_uniq_id, only_core=args.only_core, include_suffixes=args.include_suffixes,
                           exclude_suffixes=args.exclude_suffixes)
-    task.wait(timeout=args.timeout)
+    if args.watch:
+        task.watch()
+    else:
+        task.wait(timeout=args.timeout)
     result = task.get_exit_code()
     warning = task.get_task_warn()
 
@@ -304,7 +307,10 @@ def backend_export(inst, basedn, log, args):
                           encrypted=args.encrypted, min_base64=args.min_base64, no_dump_uniq_id=args.no_dump_uniq_id,
                           replication=args.replication, not_folded=args.not_folded, no_seq_num=args.no_seq_num,
                           include_suffixes=args.include_suffixes, exclude_suffixes=args.exclude_suffixes)
-    task.wait(timeout=args.timeout)
+    if args.watch:
+        task.watch()
+    else:
+        task.wait(timeout=args.timeout)
     result = task.get_exit_code()
 
     if task.is_complete() and result == 0:
@@ -675,7 +681,7 @@ def backend_del_index(inst, basedn, log, args):
 
 def backend_reindex(inst, basedn, log, args):
     be = _get_backend(inst, args.be_name)
-    be.reindex(attrs=args.attr, wait=args.wait)
+    be.reindex(attrs=args.attr, wait=args.wait, watch=args.watch)
     log.info("Successfully reindexed database")
 
 
@@ -973,6 +979,7 @@ def create_parser(subparsers):
     reindex_parser.set_defaults(func=backend_reindex)
     reindex_parser.add_argument('--attr', action='append', help='Sets the name of the attribute to re-index. Omit this argument to re-index all attributes')
     reindex_parser.add_argument('--wait', action='store_true', help='Waits for the index task to complete and reports the status')
+    reindex_parser.add_argument('--watch', action='store_true', help='Watch the status of the reindexing task')
     reindex_parser.add_argument('be_name', help='The backend name or suffix')
 
     #############################################
@@ -1166,6 +1173,8 @@ def create_parser(subparsers):
                                help="Specifies the suffixes to be excluded")
     import_parser.add_argument('--timeout', type=int, default=0,
                                help="Set a timeout to wait for the export task.  Default is 0 (no timeout)")
+    import_parser.add_argument('-w', '--watch', action='store_true',
+                               help="Watch the status of the import")
 
     #######################################################
     # Export LDIF
@@ -1197,6 +1206,8 @@ def create_parser(subparsers):
                                help="Specifies the suffixes to be excluded")
     export_parser.add_argument('--timeout', default=0, type=int,
                                help="Set a timeout to wait for the export task.  Default is 0 (no timeout)")
+    export_parser.add_argument('-w', '--watch', action='store_true',
+                               help="Watch the status of the export")
 
     #######################################################
     # Create a new backend database

--- a/src/lib389/lib389/cli_conf/backup.py
+++ b/src/lib389/lib389/cli_conf/backup.py
@@ -1,21 +1,40 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import os
+from datetime import datetime
 from lib389.cli_base import CustomHelpFormatter
+from lib389.tasks import BackupTask, RestoreTask
 
 def backup_create(inst, basedn, log, args):
     log = log.getChild('backup_create')
 
-    task = inst.backup_online(archive=args.archive, db_type=args.db_type)
-    task.wait(timeout=args.timeout)
-    result = task.get_exit_code()
+    backup_task = BackupTask(inst)
 
-    if task.is_complete() and result == 0:
+    if args.archive is None:
+        backup_dir_name = "backup-%s" % datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        archive = os.path.join(inst.ds_paths.backup_dir, backup_dir_name)
+    else:
+        archive = args.archive
+    task_properties = {'nsArchiveDir': archive}
+
+    if args.db_type is not None:
+        task_properties['nsDatabaseType'] = args.db_type
+
+    backup_task.create(properties=task_properties)
+    if args.watch:
+        log.info("Creating backup: %s", archive)
+        backup_task.watch()
+    else:
+        backup_task.wait(timeout=args.timeout)
+
+    result = backup_task.get_exit_code()
+    if backup_task.is_complete() and result == 0:
         log.info("The backup create task has finished successfully")
     else:
         if result is None:
@@ -27,12 +46,21 @@ def backup_create(inst, basedn, log, args):
 def backup_restore(inst, basedn, log, args):
     log = log.getChild('backup_restore')
 
-    task = inst.restore_online(archive=args.archive, db_type=args.db_type)
-    task.wait(timeout=args.timeout)
-    result = task.get_exit_code()
-    task_log = task.get_task_log()
+    restore_task = RestoreTask(inst)
+    task_properties = {'nsArchiveDir': args.archive}
+    if args.db_type is not None:
+        task_properties['nsDatabaseType'] = args.db_type
+    restore_task.create(properties=task_properties)
+    if args.watch:
+        log.info("Restoring backup: %s", args.archive)
+        restore_task.watch()
+    else:
+        restore_task.wait(timeout=args.timeout)
 
-    if task.is_complete() and result == 0:
+    result = restore_task.get_exit_code()
+    task_log = restore_task.get_task_log()
+
+    if restore_task.is_complete() and result == 0:
         log.info("The backup restore task has finished successfully")
     else:
         if result is None:
@@ -56,6 +84,7 @@ def create_parser(subparsers):
                                       help="Sets the database type. Default: ldbm database")
     create_backup_parser.add_argument('--timeout', type=int, default=120,
                                       help="Sets the task timeout.  Default is 120 seconds,")
+    create_backup_parser.add_argument('--watch', action='store_true', help='Watch the status of the backup task')
 
     restore_parser = subcommands.add_parser('restore', help="Restores a database from a backup", formatter_class=CustomHelpFormatter)
     restore_parser.set_defaults(func=backup_restore)
@@ -64,3 +93,4 @@ def create_parser(subparsers):
                                 help="Sets the database type. Default: ldbm database")
     restore_parser.add_argument('--timeout', type=int, default=120,
                                 help="Sets the task timeout.  Default is 120 seconds.")
+    restore_parser.add_argument('--watch', action='store_true', help='Watch the status of the restore task')

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -39,7 +39,7 @@ def dbtasks_db2index(inst, log, args):
 def dbtasks_db2bak(inst, log, args):
     # Needs an output name?
     inst.log = log
-    if not inst.db2bak(args.archive):
+    if not inst.db2bak(args.archive, watch=args.watch):
         log.fatal("db2bak failed")
         return False
     else:
@@ -49,7 +49,7 @@ def dbtasks_db2bak(inst, log, args):
 def dbtasks_bak2db(inst, log, args):
     # Needs the archive to restore.
     inst.log = log
-    if not inst.bak2db(args.archive):
+    if not inst.bak2db(args.archive, watch=args.watch):
         log.fatal("bak2db failed")
         return False
     else:
@@ -68,7 +68,8 @@ def dbtasks_db2ldif(inst, log, args):
 
     # Export backend
     if not inst.db2ldif(bename=args.backend, encrypt=args.encrypted, repl_data=args.replication,
-                        outputfile=args.ldif, suffixes=None, excludeSuffixes=None, export_cl=False):
+                        outputfile=args.ldif, suffixes=None, excludeSuffixes=None, export_cl=False,
+                        watch=args.watch):
         log.fatal("db2ldif failed")
         return False
     else:
@@ -82,7 +83,7 @@ def dbtasks_ldif2db(inst, log, args):
         raise ValueError("The LDIF file does not exist: " + args.ldif)
 
     ret = inst.ldif2db(bename=args.backend, encrypt=args.encrypted, import_file=args.ldif,
-                        suffixes=None, excludeSuffixes=None, import_cl=False)
+                       suffixes=None, excludeSuffixes=None, import_cl=False, watch=args.watch)
     if not ret:
         log.fatal("ldif2db failed")
         return False
@@ -519,6 +520,7 @@ def create_parser(subcommands):
     db2bak_parser = subcommands.add_parser('db2bak', help="Initialise a BDB backup of the database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)
     db2bak_parser.add_argument('archive', help="The destination for the archive. This will be created during the db2bak process.",
                                nargs='?', default=None)
+    db2bak_parser.add_argument('--watch', action='store_true', help='Watch the status of the db2bak task')
     db2bak_parser.set_defaults(func=dbtasks_db2bak)
 
     db2ldif_parser = subcommands.add_parser('db2ldif', help="Initialise an LDIF dump of the database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)
@@ -530,6 +532,7 @@ def create_parser(subcommands):
     #                                                         "This option also implies the '--replication' option is set.",
     #                             default=False, action='store_true')
     db2ldif_parser.add_argument('--encrypted', help="Export encrypted attributes", default=False, action='store_true')
+    db2ldif_parser.add_argument('--watch', action='store_true', help='Watch the status of the db2ldif task')
     db2ldif_parser.set_defaults(func=dbtasks_db2ldif)
 
     dbverify_parser = subcommands.add_parser('dbverify', help="Perform a db verification. You should only do this at direction of support", formatter_class=CustomHelpFormatter)
@@ -538,6 +541,7 @@ def create_parser(subcommands):
 
     bak2db_parser = subcommands.add_parser('bak2db', help="Restore a BDB backup of the database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)
     bak2db_parser.add_argument('archive', help="The archive to restore. This will erase all current server databases.")
+    bak2db_parser.add_argument('--watch', action='store_true', help='Watch the status of the bak2db task')
     bak2db_parser.set_defaults(func=dbtasks_bak2db)
 
     ldif2db_parser = subcommands.add_parser('ldif2db', help="Restore an LDIF dump of the database. The server must be stopped for this to proceed.", formatter_class=CustomHelpFormatter)
@@ -546,6 +550,7 @@ def create_parser(subcommands):
     ldif2db_parser.add_argument('--encrypted', help="Import encrypted attributes", default=False, action='store_true')
     # ldif2db_parser.add_argument('--include-changelog', help="Include a replication changelog LDIF file if present.  It must be named like this in order for the import to include it:  <ldif_file_name>_cl.ldif.",
     #                            default=False, action='store_true')
+    ldif2db_parser.add_argument('--watch', action='store_true', help='Watch the status of the ldif2db task')
     ldif2db_parser.set_defaults(func=dbtasks_ldif2db)
 
     backups_parser = subcommands.add_parser('backups', help="List backup's found in the server's default backup directory", formatter_class=CustomHelpFormatter)

--- a/src/lib389/lib389/properties.py
+++ b/src/lib389/lib389/properties.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -454,6 +454,7 @@ INDEX_PROPNAME_TO_ATTRNAME = {INDEX_TYPE: 'nsIndexType',
 ####################################
 
 TASK_WAIT = "wait"
+TASK_WATCH = "watch"
 TASK_TOMB_STRIP = "strip-csn"
 EXPORT_REPL_INFO = "repl-info"
 

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -7,7 +7,7 @@
 # --- END COPYRIGHT BLOCK ---
 
 import time
-import os.path
+import os
 import ldap
 from datetime import datetime
 from lib389 import Entry
@@ -16,9 +16,9 @@ from lib389.utils import ensure_str
 from lib389.exceptions import Error
 from lib389._constants import *
 from lib389.properties import (
-        TASK_WAIT, EXPORT_REPL_INFO, MT_PROPNAME_TO_ATTRNAME, MT_SUFFIX,
-        TASK_TOMB_STRIP
-        )
+    TASK_WAIT, EXPORT_REPL_INFO, MT_PROPNAME_TO_ATTRNAME, MT_SUFFIX,
+    TASK_TOMB_STRIP, TASK_WATCH
+)
 
 
 class Task(DSLdapObject):
@@ -71,7 +71,7 @@ class Task(DSLdapObject):
         return None
 
     def get_task_log(self):
-        """Return task's exit code if task is complete, else None."""
+        """Return task's log, else None."""
         if self.is_complete():
             try:
                 return (self._task_log)
@@ -100,6 +100,47 @@ class Task(DSLdapObject):
                 break
             time_passed = time_passed + sleep_interval
             time.sleep(sleep_interval)
+
+    def watch(self, timeout=None):
+        """
+        Watch the task status and display new log output until the task is
+        complete or timeout is reached.
+        """
+        time_passed = 0
+        if timeout is None or timeout == 0:
+            timeout = None
+            self._log.debug("No timeout is set, this may take a long time ...")
+
+        log = self.get_attr_val_utf8("nsTaskLog")
+        if log is None:
+            log = ""
+        while not self.is_complete():
+            time.sleep(1)
+            next_log = self.get_attr_val_utf8("nsTaskLog")
+            if next_log is None:
+                next_log = ""
+
+            # We only want to display "new" output and not write the entire
+            # task log value. So we need to get a diff of the previous log
+            # value and the new one
+            split_log = log.splitlines()
+            split_next_log = next_log.splitlines()
+            log_diff = []
+            for line in split_next_log:
+                if line not in split_log:
+                    log_diff.append(line + "\n")
+            log_out = ''.join(log_diff)
+
+            # Advance the "log" to the latest output for the next pass
+            log = next_log
+
+            if log_out != "":
+                self._log.info(log_out[:-1])
+
+            time_passed = time_passed + 1
+            if timeout is not None and time_passed >= timeout:
+                self._log.warning("Timeout reached, stopping watch ...")
+                break
 
     def create(self, rdn=None, properties={}, basedn=None):
         """Create a Task entry
@@ -448,18 +489,27 @@ class Tasks(object):
         if name in Tasks.proxied_methods:
             return DirSrv.__getattr__(self.conn, name)
 
-    def checkTask(self, entry, dowait=False):
+    def checkTask(self, entry, dowait=False, watch=False):
         '''check task status - task is complete when the nsTaskExitCode attr
         is set return a 2 tuple (true/false,code) first is false if task is
         running, true if done - if true, second is the exit code - if dowait
-        is True, this function will block until the task is complete'''
+        is True, this function will block until the task is complete
+
+        If "watch" is True then we wait for the task to finish and write status
+        updates to stdout.
+        '''
         attrlist = ['nsTaskLog', 'nsTaskStatus', 'nsTaskExitCode',
                     'nsTaskCurrentItem', 'nsTaskTotalItems', 'nsTaskWarning']
         done = False
         exitCode = 0
         warningCode = 0
         dn = entry.dn
+
+        task = Task(self.conn, dn)
         while not done:
+            if watch:
+                task.watch()
+
             entry = self.conn.getEntry(dn, attrlist=attrlist)
             self.log.debug("task entry %r", entry)
 
@@ -841,8 +891,8 @@ class Tasks(object):
 
         exitCode = 0
         warningCode = 0
-        if args is not None and args.get(TASK_WAIT, False):
-            (done, exitCode, warningCode) = self.conn.tasks.checkTask(entry, True)
+        if args is not None and (args.get(TASK_WAIT, False) or args.get(TASK_WATCH, False)):
+            (done, exitCode, warningCode) = self.conn.tasks.checkTask(entry, True, args.get(TASK_WATCH, False))
 
         if exitCode:
             self.log.error("Error: index task %s exited with %d",


### PR DESCRIPTION
Description:
    
Currently the CLI/UI does not show you the progress of
import/export/reindex/backup/restore tasks (offline & online)
    
Part 1:
    
Server code does not always update the task log, and in archive if
just a name and not a path is provided it default to writtng it to
the logs directory instead of the backup directory.

Part 2:

Update CLI to include "watch" options to write the status of tasks
in real time to stdout.

Part 3: 
Update UI to use the new watch options and to add a textarea
for the task progress

relates: https://github.com/389ds/389-ds-base/issues/3658

## Summary by Sourcery

Add real-time progress reporting for database backup, restore, import, export, and reindex operations across server, CLI, and Cockpit UI.

New Features:
- Introduce --watch options for backup, restore, import, export, and reindex CLI commands to stream task logs in real time.
- Display task progress output in Cockpit UI modals using scrollable text areas for backup, restore, import, export, and reindex operations.

Bug Fixes:
- Ensure archive backup and restore use the configured backup directory when a relative name is provided instead of defaulting to the logs directory.
- Improve server-side task logging during backup, restore, and index operations so failures and progress are recorded in the task log.

Enhancements:
- Extend backend copy and archive routines to log detailed progress to Slapi tasks, improving observability of long-running DB operations.
- Refine task handling utilities to support a watch mode that tails nsTaskLog while waiting for completion.
- Tighten Cockpit UI behaviors around long-running modals, including auto-scrolling of progress areas and disabling controls while tasks are in progress.