### PR TITLE
Issue 7284 - CI - Fix test_grace_limit_section after pwpolicy validat…

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -1427,8 +1427,11 @@ def test_grace_limit_section(topo, policy_setup, _fixture_for_grace_limit):
     for att1, att2 in [('passwordGraceLimit', '10')]:
         _do_transaction_for_pwp(topo, att1, att2)
     # removing the passwordgracelimit attribute should make it default to 0
-    for att1, att2 in [('passwordGraceLimit', ' ')]:
-        _do_transaction_for_pwp(topo, att1, att2)
+    pwp = PwPolicyManager(topo.standalone)
+    for dn in [f'uid=orla,ou=dirsec,{DEFAULT_SUFFIX}',
+               f'uid=joe,ou=people,{DEFAULT_SUFFIX}',
+               f'ou=people,{DEFAULT_SUFFIX}']:
+        pwp.get_pwpolicy_entry(dn).remove_all('passwordGraceLimit')
     change_password_with_admin(topo, [
         ('uid=orla,ou=dirsec', '000rLb1'),
         ('uid=joe,ou=people', '00J0e1'),


### PR DESCRIPTION
…ion fix

Description:
The test replaced passwordGraceLimit with a space to remove it, which is now correctly rejected after attr_check_minmax validation was tightened. Use remove_all() to properly delete the attribute instead.

Fixes: #7284

Reviewed by: ???

## Summary by Sourcery

Tests:
- Update password grace limit section test to delete passwordGraceLimit using the policy manager instead of setting it to a blank value.