### PR TITLE
Issue 7358 - NSACLPlugin - acl_access_allowed - Missing aclpb 1

### DIFF
--- a/ldap/servers/plugins/sync/sync_util.c
+++ b/ldap/servers/plugins/sync/sync_util.c
@@ -870,6 +870,7 @@ sync_pblock_copy(Slapi_PBlock *src)
     Slapi_Operation *operation;
     Slapi_Operation *operation_new;
     Slapi_Connection *connection;
+    Slapi_Backend *be = NULL;
     LDAPControl **ctrls = NULL;
     int *scope;
     int *deref;
@@ -882,11 +883,13 @@ sync_pblock_copy(Slapi_PBlock *src)
     int *sizelimit;
     int *timelimit;
     struct slapdplugin *pi;
+    char *requestor_dn = NULL;
     ber_int_t msgid;
     ber_tag_t tag;
 
     slapi_pblock_get(src, SLAPI_OPERATION, &operation);
     slapi_pblock_get(src, SLAPI_CONNECTION, &connection);
+    slapi_pblock_get(src, SLAPI_BACKEND, &be);
     slapi_pblock_get(src, SLAPI_SEARCH_SCOPE, &scope);
     slapi_pblock_get(src, SLAPI_SEARCH_DEREF, &deref);
     slapi_pblock_get(src, SLAPI_PLUGIN_SYNTAX_FILTER_NORMALIZED, &filter_normalized);
@@ -895,6 +898,7 @@ sync_pblock_copy(Slapi_PBlock *src)
     slapi_pblock_get(src, SLAPI_SEARCH_REQATTRS, &reqattrs);
     slapi_pblock_get(src, SLAPI_SEARCH_ATTRSONLY, &attrsonly);
     slapi_pblock_get(src, SLAPI_REQUESTOR_ISROOT, &isroot);
+    slapi_pblock_get(src, SLAPI_REQUESTOR_DN, &requestor_dn);
     slapi_pblock_get(src, SLAPI_SEARCH_SIZELIMIT, &sizelimit);
     slapi_pblock_get(src, SLAPI_SEARCH_TIMELIMIT, &timelimit);
     slapi_pblock_get(src, SLAPI_REQCONTROLS, &ctrls);
@@ -907,8 +911,10 @@ sync_pblock_copy(Slapi_PBlock *src)
     slapi_operation_set_msgid(operation_new, msgid);
     tag = slapi_operation_get_tag(operation);
     slapi_operation_set_tag(operation_new, tag);
+    operation_new->o_extension = factory_create_extension(get_operation_object_type(), operation_new, connection);
     slapi_pblock_set(dest, SLAPI_OPERATION, operation_new);
     slapi_pblock_set(dest, SLAPI_CONNECTION, connection);
+    slapi_pblock_set(dest, SLAPI_BACKEND, be);
     slapi_pblock_set(dest, SLAPI_SEARCH_SCOPE, &scope);
     slapi_pblock_set(dest, SLAPI_SEARCH_DEREF, &deref);
     slapi_pblock_set(dest, SLAPI_PLUGIN_SYNTAX_FILTER_NORMALIZED, &filter_normalized);
@@ -919,6 +925,7 @@ sync_pblock_copy(Slapi_PBlock *src)
     slapi_pblock_set(dest, SLAPI_SEARCH_REQATTRS, reqattrs_dup);
     slapi_pblock_set(dest, SLAPI_SEARCH_ATTRSONLY, &attrsonly);
     slapi_pblock_set(dest, SLAPI_REQUESTOR_ISROOT, &isroot);
+    slapi_pblock_set(dest, SLAPI_REQUESTOR_DN, requestor_dn);
     slapi_pblock_set(dest, SLAPI_SEARCH_SIZELIMIT, &sizelimit);
     slapi_pblock_set(dest, SLAPI_SEARCH_TIMELIMIT, &timelimit);
     slapi_pblock_set(dest, SLAPI_REQCONTROLS, ctrls);


### PR DESCRIPTION
Bug Description:
`sync_pblock_copy()` creates a new operation using `slapi_operation_new(0)` without calling `factory_create_extension()`, so the ACL pblock extension is never initialized. When the sync-send thread evaluates a filter with access checks finds no aclpb and logs 'Missing aclpb 1', returning LDAP_OPERATIONS_ERROR to the client.

Fix Description:
Call `factory_create_extension()` after creating the new operation so that all operation extensions (including the ACL pblock) are properly initialized. Also copy SLAPI_REQUESTOR_DN so that ACL checks evaluate against the correct bind identity.

Fixes: https://github.com/389ds/389-ds-base/issues/7358

## Summary by Sourcery

Ensure sync plugin operations are created with fully initialized extensions and correct requestor identity for ACL evaluation.

Bug Fixes:
- Initialize operation extensions when creating sync operations so the ACL pblock is present and access checks no longer fail with 'Missing aclpb 1'.
- Propagate the original requestor DN into cloned sync operations so ACL checks run under the correct bind identity.