### PR TITLE
Issue 7362 - UI - Some FormSelect onChange parameters are reversed

### DIFF
--- a/src/cockpit/389-console/src/lib/database/databaseModal.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseModal.jsx
@@ -201,7 +201,7 @@ class CreateLinkModal extends React.Component {
                             {_("Bind Method")}
                         </GridItem>
                         <GridItem span={9}>
-                            <FormSelect value={bindMech} onChange={handleSelectChange} aria-label="FormSelect Input">
+                            <FormSelect value={bindMech} onChange={(event, value) => handleSelectChange(value)} aria-label="FormSelect Input">
                                 <FormSelectOption key={1} value="SIMPLE" label="SIMPLE" />
                                 <FormSelectOption key={2} value="SASL/DIGEST-MD5" label="SASL/DIGEST-MD5" />
                                 <FormSelectOption key={3} value="SASL/GSSAPI" label="SASL/GSSAPI" />
@@ -339,7 +339,7 @@ class CreateSubSuffixModal extends React.Component {
                             {_("Initialization Option")}
                         </GridItem>
                         <GridItem span={9}>
-                            <FormSelect value={initOption} onChange={handleSelectChange} aria-label="FormSelect Input">
+                            <FormSelect value={initOption} onChange={(event, value) => handleSelectChange(value)} aria-label="FormSelect Input">
                                 <FormSelectOption key={1} value="noInit" label={_("Do Not Initialize Database")} />
                                 <FormSelectOption key={2} value="addSuffix" label={_("Create The Top Sub-Suffix Entry")} />
                                 <FormSelectOption key={3} value="addSample" label={_("Add Sample Entries")} />

--- a/src/cockpit/389-console/src/lib/database/referrals.jsx
+++ b/src/cockpit/389-console/src/lib/database/referrals.jsx
@@ -56,13 +56,13 @@ export class SuffixReferrals extends React.Component {
         this.onLdapChange = this.onLdapChange.bind(this);
     }
 
-    onScopeChange(value, event) {
+    onScopeChange(event, value) {
         this.setState({
             refScope: value,
         });
     }
 
-    onLdapChange(value, event) {
+    onLdapChange(event, value) {
         this.setState({
             refProtocol: value,
         });

--- a/src/cockpit/389-console/src/lib/database/suffix.jsx
+++ b/src/cockpit/389-console/src/lib/database/suffix.jsx
@@ -638,7 +638,7 @@ export class Suffix extends React.Component {
                 });
     }
 
-    onLinkOnSelect(value, event) {
+    onLinkOnSelect(value) {
         this.setState({
             createNsbindmechanism: value,
         });
@@ -702,7 +702,7 @@ export class Suffix extends React.Component {
         });
     }
 
-    onSubSuffixOnSelect(value, event) {
+    onSubSuffixOnSelect(value) {
         let noInit = false;
         let addSuffix = false;
         let addSample = false;


### PR DESCRIPTION
Description:

Some FormSelect onChange handleers were not updated for PF5 and the parameters are reversed.

https://github.com/389ds/389-ds-base/issues/7362

## Summary by Sourcery

Align FormSelect onChange handlers with the PF5 event/value parameter order and clean up related handler signatures.

Bug Fixes:
- Correct FormSelect onChange callbacks to use the PF5 (event, value) parameter ordering so selected values are processed correctly.

Enhancements:
- Simplify select handler methods by removing unused event parameters.
- Tidy UI markup with minor formatting adjustments to button elements.