### PR TITLE
Issue 7368 - UI - global password policy page is missing passwordmintokenlength

### DIFF
--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1206,6 +1206,23 @@ export class GlobalPwPolicy extends React.Component {
                             />
                         </GridItem>
                         {renderValidationError("passwordmaxclasschars", this.state.invalidFields)}
+                        <GridItem className="ds-label" offset={6} span={3}>
+                            {_("Minimum Token Length")}
+                        </GridItem>
+                        <GridItem span={1} title={_("The smallest attribute value used when checking if the password contains any of the user's account information (passwordMinTokenLength).")}>
+                            <TextInput
+                                type="number"
+                                value={this.state.passwordmintokenlength}
+                                id="passwordmintokenlength"
+                                aria-describedby="passwordmintokenlength"
+                                name="passwordmintokenlength"
+                                onChange={(e, str) => {
+                                    this.handleSyntaxChange(e);
+                                }}
+                                {...getValidationProps("passwordmintokenlength", this.state.invalidFields)}
+                            />
+                        </GridItem>
+                        {renderValidationError("passwordmintokenlength", this.state.invalidFields)}
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>


### PR DESCRIPTION
Description:

The input field for passwordmintokenlength was missing on the global password policy page, but it was present on the local password policy page

relates: https://github.com/389ds/389-ds-base/issues/7368

## Summary by Sourcery

Bug Fixes:
- Expose the passwordMinTokenLength option on the global password policy page to match the local policy configuration.