### PR TITLE
Issue 7370 - Runtime LSan/TSan injection for pytest

### DIFF
--- a/dirsrvtests/conftest.py
+++ b/dirsrvtests/conftest.py
@@ -16,6 +16,8 @@ import os
 import gzip
 
 from .report import getReport
+from .sanitizers import SANITIZERS, find_library
+from lib389 import DirSrv
 from lib389.paths import Paths
 from enum import Enum
 
@@ -26,6 +28,8 @@ if "WEBUI" in os.environ:
 
 pkgs = ['389-ds-base', 'nss', 'nspr', 'openldap', 'cyrus-sasl']
 p = Paths()
+log = logging.getLogger(__name__)
+
 
 class FIPSState(Enum):
     ENABLED = 'enabled'
@@ -62,6 +66,137 @@ def is_fips():
         return FIPSState.DISABLED
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--sanitizer",
+        action="store",
+        default=None,
+        choices=["lsan", "tsan"],
+        help="Inject a runtime sanitizer into ns-slapd via LD_PRELOAD. "
+             "Requires host setup: see dirsrvtests/sanitizers/README.md"
+    )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def sanitizer_setup(request):
+    """Inject LSan/TSan into ns-slapd via LD_PRELOAD when --sanitizer is given.
+
+    For systemd: writes a drop-in conf to dirsrv@<inst>.service.d/ so that
+    Environment=LD_PRELOAD and sanitizer options are picked up on start.
+
+    For non-systemd (containers, prefix builds): sets the variables on
+    os.environ and routes through the ASAN code path in DirSrv.start()
+    so they reach the ns-slapd subprocess.
+
+    Collects sanitizer reports after each stop and cleans up at session end.
+    """
+    name = request.config.getoption("--sanitizer")
+    if name is None:
+        yield None
+        return
+
+    config = SANITIZERS[name]
+    library = find_library(config['lib_glob'])
+    if not library:
+        pytest.skip("%s not found (glob: %s). Install: dnf install %s"
+                    % (name.upper(), config['lib_glob'], config['package']))
+
+    log.info("Sanitizer %s enabled (library: %s)", name, library)
+    log.info("Reports will appear in pytest output and "
+             "{run_dir}/ns-slapd-{instance}.%s.<pid> files. "
+             "No reports? Check: sysctl fs.suid_dumpable=1, setenforce 0", name)
+
+    # Monkeypatch DirSrv.start() and stop() to inject the sanitizer library.
+    dropin_files = {}  # {dropin_path: dropin_dir} for systemd cleanup
+    _orig_start = DirSrv.start
+    _orig_stop = DirSrv.stop
+
+    def _patched_start(self, timeout=120, post_open=True):
+        log_path = os.path.join(
+            self.ds_paths.run_dir, "ns-slapd-%s.%s" % (self.serverid, name))
+
+        sanitizer_env = {
+            'LD_PRELOAD': library,
+            config['env_var']: '%s:log_path=%s' % (config['options'], log_path),
+        }
+
+        if self.with_systemd_running():
+            # Use a systemd drop-in — this overrides the jemalloc LD_PRELOAD
+            # from custom.conf (drop-ins are applied alphabetically and
+            # sanitizer.conf sorts after custom.conf).
+            dropin_dir = '/etc/systemd/system/dirsrv@%s.service.d' % self.serverid
+            dropin_path = os.path.join(dropin_dir, 'sanitizer.conf')
+            if dropin_path not in dropin_files:
+                try:
+                    os.makedirs(dropin_dir, exist_ok=True)
+                    with open(dropin_path, 'w') as f:
+                        f.write("[Service]\n")
+                        for k, v in sanitizer_env.items():
+                            f.write("Environment=%s=%s\n" % (k, v))
+                    subprocess.check_call(['systemctl', 'daemon-reload'])
+                    dropin_files[dropin_path] = dropin_dir
+                except (PermissionError, subprocess.CalledProcessError) as e:
+                    log.error("Cannot configure systemd drop-in for %s: %s",
+                              self.serverid, e)
+        else:
+            # For non-systemd (containers, prefix builds): put sanitizer
+            # vars into os.environ and force the ASAN code path in
+            # DirSrv.start() so that env.update(os.environ) picks them up.
+            # This avoids adding test-only hooks to the production lib389.
+            saved_asan = self.ds_paths.asan_enabled
+            self.ds_paths.asan_enabled = True
+            os.environ.update(sanitizer_env)
+            try:
+                _orig_start(self, timeout, post_open)
+            finally:
+                self.ds_paths.asan_enabled = saved_asan
+                for key in sanitizer_env:
+                    os.environ.pop(key, None)
+            return
+
+        _orig_start(self, timeout, post_open)
+
+    def _patched_stop(self, timeout=120):
+        try:
+            _orig_stop(self, timeout)
+        finally:
+            pattern = os.path.join(
+                self.ds_paths.run_dir,
+                "ns-slapd-%s.%s*" % (self.serverid, name))
+            for report_path in sorted(glob.glob(pattern)):
+                try:
+                    with open(report_path, 'r', errors='replace') as f:
+                        content = f.read().strip()
+                    if content and ('ERROR:' in content or 'SUMMARY:' in content):
+                        log.warning("Sanitizer report (%s):\n%s",
+                                    os.path.basename(report_path), content)
+                except OSError:
+                    pass
+
+    DirSrv.start = _patched_start
+    DirSrv.stop = _patched_stop
+
+    yield name
+
+    # Teardown: restore originals and clean up.
+    DirSrv.start = _orig_start
+    DirSrv.stop = _orig_stop
+
+    for dropin_path, dropin_dir in dropin_files.items():
+        try:
+            os.remove(dropin_path)
+            # Remove the directory only if we left it empty
+            if not os.listdir(dropin_dir):
+                os.rmdir(dropin_dir)
+        except OSError as e:
+            log.warning("Cleanup failed for %s: %s", dropin_path, e)
+    if dropin_files:
+        try:
+            subprocess.check_call(['systemctl', 'daemon-reload'])
+        except subprocess.CalledProcessError:
+            pass
+
+
 @pytest.fixture(autouse=True)
 def _environment(request):
     if "_metadata" in dir(request.config):
@@ -79,6 +214,9 @@ def pytest_report_header(config):
     for pkg in pkgs:
         header += "%s: %s\n" % (pkg, get_rpm_version(pkg))
     header += "FIPS: %s" % is_fips()
+    sanitizer = config.getoption("--sanitizer", default=None)
+    if sanitizer:
+        header += "\nSanitizer: %s (runtime injection via LD_PRELOAD)" % sanitizer
     return header
 
 
@@ -100,9 +238,10 @@ def rotate_xsan_logs(request):
     if pytest_html is not None:
         # We have it installed, but let's check if we actually use it (--html=report.html)
         pytest_htmlpath = request.config.getoption('htmlpath')
-        if p.asan_enabled and pytest_htmlpath is not None:
-            # ASAN is enabled and an HTML report was requested,
-            # rotate the ASAN logs so that only relevant logs are attached to the case in the report.
+        sanitizer_active = p.asan_enabled or request.config.getoption('--sanitizer', default=None)
+        if sanitizer_active and pytest_htmlpath is not None:
+            # A sanitizer is active and an HTML report was requested,
+            # rotate the logs so that only relevant logs are attached to the case in the report.
             xsan_logs_dir = f'{p.run_dir}/bak'
             if not os.path.exists(xsan_logs_dir):
                 os.mkdir(xsan_logs_dir)

--- a/dirsrvtests/sanitizers/README.md
+++ b/dirsrvtests/sanitizers/README.md
@@ -1,0 +1,156 @@
+# Runtime Sanitizer Support for 389-ds-base Tests
+
+Inject LeakSanitizer (LSan) or ThreadSanitizer (TSan) into `ns-slapd`
+during pytest runs **without rebuilding** with `--enable-asan` or `--enable-tsan`.
+
+Under systemd, this works by writing a drop-in to
+`dirsrv@<instance>.service.d/sanitizer.conf` that sets `LD_PRELOAD` and
+sanitizer options. For prefix builds and containers (no systemd), the
+fixture injects the same variables directly into the `ns-slapd` subprocess.
+
+## Quick Start
+
+```bash
+# One-time host setup (as root):
+sudo dirsrvtests/sanitizers/setup_host.sh
+
+# Run tests with leak detection:
+pytest --sanitizer=lsan -xvs dirsrvtests/tests/suites/syncrepl_plugin/
+
+# Run tests with thread sanitizer:
+pytest --sanitizer=tsan -xvs dirsrvtests/tests/suites/replication/
+```
+
+## Host Prerequisites
+
+### Packages
+
+```bash
+dnf install liblsan    # for --sanitizer=lsan
+dnf install libtsan    # for --sanitizer=tsan
+```
+
+### sysctl
+
+LSan/TSan use `ptrace` to suspend threads for leak/race scanning.
+Two sysctl settings are needed:
+
+```bash
+sysctl -w fs.suid_dumpable=1          # keep process dumpable after setuid
+sysctl -w kernel.yama.ptrace_scope=0  # allow same-UID ptrace
+# Persist across reboots:
+cat > /etc/sysctl.d/99-ds-sanitizers.conf <<'EOF'
+fs.suid_dumpable = 1
+kernel.yama.ptrace_scope = 0
+EOF
+```
+
+`fs.suid_dumpable=1` is critical — ns-slapd starts as root and drops
+to `dirsrv` via `setuid()`, which clears the dumpable flag by default.
+Without this setting, the sanitizer's ptrace calls fail silently and
+no reports are generated.
+
+### SELinux
+
+The `dirsrv_t` domain needs `ptrace` (thread scanning) and `execmem`
+(sanitizer trampolines) permissions that the default policy does not grant.
+
+The `setup_host.sh` script installs a targeted policy module
+(`ds_sanitizer.te`) that adds only these two permissions:
+
+```bash
+sudo dirsrvtests/sanitizers/setup_host.sh   # compiles and loads the module
+semodule -l | grep ds_sanitizer              # verify it's loaded
+semodule -r ds_sanitizer                     # remove when done
+```
+
+If the module isn't enough (no reports, ns-slapd crashes on startup),
+fall back to permissive mode while you collect the actual AVC denials:
+
+```bash
+setenforce 0                    # temporary, re-enable with: setenforce 1
+ausearch -m avc -ts recent      # find what's being denied
+```
+
+## How It Works
+
+1. `pytest --sanitizer=lsan` activates the `sanitizer_setup` fixture (session-scoped).
+2. Before each instance starts, the fixture injects `LD_PRELOAD` and `LSAN_OPTIONS`:
+   - **Under systemd:** writes a drop-in file to
+     `/etc/systemd/system/dirsrv@{instance}.service.d/sanitizer.conf`
+     with `Environment=LD_PRELOAD=...` directives (overrides the jemalloc
+     `LD_PRELOAD` from `custom.conf` because `sanitizer.conf` sorts after it).
+   - **Under containers or prefix installs:** sets the variables on
+     `os.environ` and routes through the ASAN code path in `DirSrv.start()`
+     so they reach the `ns-slapd` subprocess.
+3. `ns-slapd` starts with the sanitizer library injected.
+4. On clean shutdown, sanitizer reports are written to
+   `{run_dir}/ns-slapd-{instance}.{lsan,tsan}.<pid>`.
+5. The fixture collects reports and logs them to pytest output.
+   The existing `*san*` glob in `conftest.py` also attaches them
+   to the pytest-html report.
+6. On session teardown, drop-in files are removed and `DirSrv` is restored.
+
+## Output
+
+Sanitizer reports appear in three places:
+- **pytest console output** — logged as warnings after each instance stop
+- **Report files** — `{run_dir}/ns-slapd-{instance}.{lsan,tsan}.<pid>`
+- **pytest-html report** — if `--html=report.html` is used
+
+## Troubleshooting
+
+**No reports after test run**
+
+Check in order:
+
+1. SELinux denials (most common cause):
+```bash
+ausearch -m avc -ts recent | grep dirsrv   # look for ptrace/execmem denials
+semodule -l | grep ds_sanitizer             # policy module loaded?
+```
+If the policy module is missing, run `setup_host.sh`. As a quick test,
+try `setenforce 0` — if reports appear, the issue is SELinux.
+
+2. sysctl prerequisites (run `setup_host.sh` if not done):
+```bash
+sysctl fs.suid_dumpable          # must be 1
+sysctl kernel.yama.ptrace_scope  # must be 0
+```
+
+**"FATAL: StopTheWorld failed" or ptrace errors**
+
+The sanitizer needs `ptrace` to stop threads for scanning. This requires
+`fs.suid_dumpable=1` because ns-slapd drops from root to `dirsrv` via
+`setuid()`, which clears the dumpable flag by default.
+
+```bash
+sudo sysctl -w fs.suid_dumpable=1
+```
+
+**Reports are empty (only thread listing, no leaks/races)**
+
+The report filtering only shows files containing `ERROR:` or `SUMMARY:`.
+Raw report files are still available at `{run_dir}/ns-slapd-*.{lsan,tsan}.*`.
+
+## Limitations
+
+- **Not a substitute for ASAN builds.** `LD_PRELOAD`-based LSan only detects
+  memory leaks (unreachable allocations at exit). It cannot detect
+  use-after-free, buffer overflows, or other memory errors — those require
+  compile-time instrumentation (`--enable-asan`).
+- **TSan via `LD_PRELOAD` has limitations.** Full TSan requires compile-time
+  instrumentation. Runtime injection may miss some races.
+- **Clean shutdown required.** LSan reports leaks at `exit()`. If `ns-slapd`
+  is killed with `SIGKILL`, no report is generated.
+- **Performance overhead.** LSan adds ~2x slowdown, TSan adds ~5-15x.
+  Adjust test timeouts accordingly.
+
+## Available Sanitizers
+
+| Flag              | What it detects       | Library    | Overhead |
+|-------------------|-----------------------|------------|----------|
+| `--sanitizer=lsan`| Memory leaks          | liblsan.so | ~2x      |
+| `--sanitizer=tsan`| Data races, deadlocks | libtsan.so | ~5-15x   |
+
+For full ASAN/MSAN support, rebuild with `--enable-asan` / `--enable-msan`.

--- a/dirsrvtests/sanitizers/__init__.py
+++ b/dirsrvtests/sanitizers/__init__.py
@@ -1,0 +1,46 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+"""
+Runtime sanitizer config for pytest --sanitizer=lsan|tsan.
+
+Injects LeakSanitizer or ThreadSanitizer into ns-slapd via LD_PRELOAD
+without requiring an instrumented build. See README.md and setup_host.sh.
+"""
+
+import glob
+import os
+
+# Sanitizer name -> runtime configuration.
+# lib_glob targets x86_64 (Fedora/RHEL); adjust for other architectures.
+SANITIZERS = {
+    'lsan': {
+        'lib_glob': '/usr/lib64/liblsan.so*',
+        'package': 'liblsan',
+        'env_var': 'LSAN_OPTIONS',
+        'options': 'detect_leaks=1:exitcode=0:print_suppressions=0',
+    },
+    'tsan': {
+        'lib_glob': '/usr/lib64/libtsan.so*',
+        'package': 'libtsan',
+        'env_var': 'TSAN_OPTIONS',
+        'options': 'exitcode=0:second_deadlock_stack=1',
+    },
+}
+
+
+def find_library(lib_glob):
+    """Return first matching .so path, or None.
+
+    Globs because the version suffix varies across distros
+    (liblsan.so.0 vs liblsan.so.1).
+    """
+    for path in sorted(glob.glob(lib_glob)):
+        if os.path.isfile(path):
+            return path
+    return None

--- a/dirsrvtests/sanitizers/ds_sanitizer.te
+++ b/dirsrvtests/sanitizers/ds_sanitizer.te
@@ -1,0 +1,17 @@
+module ds_sanitizer 1.0;
+
+# Targeted policy for runtime sanitizer injection into ns-slapd.
+# Grants only the permissions needed for LD_PRELOAD-based LSan/TSan.
+# Install: setup_host.sh compiles and loads this module.
+# Remove:  semodule -r ds_sanitizer
+
+require {
+    type dirsrv_t;
+    class process { ptrace execmem };
+}
+
+# LSan/TSan suspend threads via ptrace for leak/race scanning at exit.
+allow dirsrv_t self:process ptrace;
+
+# Sanitizer runtimes may JIT-compile interceptor trampolines.
+allow dirsrv_t self:process execmem;

--- a/dirsrvtests/sanitizers/setup_host.sh
+++ b/dirsrvtests/sanitizers/setup_host.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+# One-time host preparation for runtime sanitizer injection.
+# Run as root before using pytest --sanitizer=lsan|tsan.
+#
+# Usage:
+#   sudo dirsrvtests/sanitizers/setup_host.sh [lsan|tsan|all]
+
+set -e
+
+TARGET=${1:-all}
+
+if [[ "$TARGET" != "lsan" && "$TARGET" != "tsan" && "$TARGET" != "all" ]]; then
+    echo "Usage: $0 [lsan|tsan|all]" >&2
+    exit 1
+fi
+
+echo "=== 389-ds-base: sanitizer host setup ==="
+
+install_packages() {
+    local pkgs=()
+    if [[ "$TARGET" == "lsan" || "$TARGET" == "all" ]]; then
+        pkgs+=(liblsan)
+    fi
+    if [[ "$TARGET" == "tsan" || "$TARGET" == "all" ]]; then
+        pkgs+=(libtsan)
+    fi
+    if [[ ${#pkgs[@]} -gt 0 ]]; then
+        echo "Installing: ${pkgs[*]}"
+        dnf install -y "${pkgs[@]}"
+    fi
+}
+
+# Sanitizers need ptrace-like access for symbolization and thread suspension.
+setup_sysctl() {
+    local val
+
+    val=$(sysctl -n fs.suid_dumpable 2>/dev/null || echo 0)
+    if [[ "$val" != "1" ]]; then
+        echo "Setting fs.suid_dumpable=1 (current: $val)"
+        sysctl -w fs.suid_dumpable=1
+    else
+        echo "fs.suid_dumpable already set to 1"
+    fi
+
+    # LSan/TSan use ptrace to suspend threads for scanning.
+    # Yama ptrace_scope=1 (default on Fedora) restricts ptrace to parent processes.
+    val=$(sysctl -n kernel.yama.ptrace_scope 2>/dev/null || echo "n/a")
+    if [[ "$val" == "1" || "$val" == "2" || "$val" == "3" ]]; then
+        echo "Setting kernel.yama.ptrace_scope=0 (current: $val)"
+        sysctl -w kernel.yama.ptrace_scope=0
+    else
+        echo "kernel.yama.ptrace_scope already set to $val"
+    fi
+
+    # Persist across reboots
+    cat > /etc/sysctl.d/99-ds-sanitizers.conf <<'SYSCTL'
+fs.suid_dumpable = 1
+kernel.yama.ptrace_scope = 0
+SYSCTL
+}
+
+setup_selinux() {
+    if ! command -v getenforce &>/dev/null; then
+        echo "SELinux not available, skipping"
+        return
+    fi
+    if [[ "$(getenforce)" == "Disabled" ]]; then
+        echo "SELinux disabled, skipping"
+        return
+    fi
+
+    # Install a targeted policy module that grants dirsrv_t only the
+    # permissions the sanitizer runtime needs (ptrace self, execmem).
+    # This is much narrower than domain_can_mmap_files or setenforce 0.
+    local script_dir
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    local te_file="${script_dir}/ds_sanitizer.te"
+
+    if [[ ! -f "$te_file" ]]; then
+        echo "WARNING: $te_file not found, cannot install SELinux policy"
+        echo "  Fall back to: setenforce 0"
+        return
+    fi
+
+    if ! command -v checkmodule &>/dev/null; then
+        echo "checkmodule not found. Install: dnf install checkpolicy"
+        echo "  Or fall back to: setenforce 0"
+        return
+    fi
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    if checkmodule -M -m -o "${tmpdir}/ds_sanitizer.mod" "$te_file" && \
+       semodule_package -o "${tmpdir}/ds_sanitizer.pp" -m "${tmpdir}/ds_sanitizer.mod" && \
+       semodule -i "${tmpdir}/ds_sanitizer.pp"; then
+        echo "SELinux: installed ds_sanitizer policy module"
+        echo "  Remove with: semodule -r ds_sanitizer"
+    else
+        echo "WARNING: failed to install SELinux policy module"
+        echo "  Fall back to: setenforce 0"
+    fi
+    rm -rf "$tmpdir"
+}
+
+install_packages
+setup_sysctl
+setup_selinux
+
+echo ""
+echo "=== Host setup complete ==="
+echo "You can now run: pytest --sanitizer=lsan tests/..."


### PR DESCRIPTION
Description: Add --sanitizer=lsan|tsan pytest option to inject sanitizers into ns-slapd without rebuilding.

Use systemd drop-in files (dirsrv@.service.d/sanitizer.conf) on systemd hosts and direct env var injection via DirSrv._start_env on containers and prefix builds. Drop-ins correctly override the jemalloc LD_PRELOAD from custom.conf.

Include setup_host.sh for sysctl configuration and a targeted SELinux policy module (ds_sanitizer.te) that grants dirsrv_t only ptrace and execmem instead of using domain_can_mmap_files or setenforce 0.

Fixes: https://github.com/389ds/389-ds-base/issues/7370

Reviewed by: ?

## Summary by Sourcery

Add pytest-time runtime sanitizer injection support for ns-slapd to enable LeakSanitizer and ThreadSanitizer without rebuilding the server.

New Features:
- Introduce a --sanitizer=lsan|tsan pytest option that injects sanitizers into ns-slapd via LD_PRELOAD for both systemd and non-systemd environments.
- Add a sanitizer_setup session fixture that configures environment/systemd drop-ins, captures sanitizer reports, and surfaces them in pytest output and reports.
- Document runtime sanitizer usage and requirements in a new dirsrvtests/sanitizers/README.md guide.
- Provide a setup_host.sh helper script to install dependencies, configure sysctl, and load a focused SELinux policy module for sanitizer support.

Enhancements:
- Extend pytest report headers to show the active runtime sanitizer when enabled.
- Generalize ASAN log rotation logic to cover all active sanitizers when generating pytest-html reports.

Documentation:
- Add detailed documentation for runtime LSan/TSan injection, host prerequisites, behavior, and troubleshooting under dirsrvtests/sanitizers/README.md.