### PR TITLE
Issue 7378 - Make sure suffix entry always gets assigned ID 1

### DIFF
--- a/dirsrvtests/tests/suites/replication/ruv_before_suffix_entryid_test.py
+++ b/dirsrvtests/tests/suites/replication/ruv_before_suffix_entryid_test.py
@@ -1,0 +1,133 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+"""Exercise objectclass index entry IDs when the suffix is created after replication."""
+
+import logging
+import os
+import re
+import pytest
+
+from lib389._constants import DEFAULT_BENAME, DEFAULT_SUFFIX
+from lib389.idm.domain import Domain
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.replica import Replicas
+from lib389.topologies import topology_no_sample
+
+pytestmark = pytest.mark.tier2
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def _assert_oc_index_missing_key(inst, key):
+    """Dump the objectclass index with dbscan -r; equality key ``key`` must not appear."""
+    inst.stop()
+    try:
+        if inst.get_db_lib() == "mdb":
+            path = os.path.join(inst.dbdir, DEFAULT_BENAME.lower(), "objectclass")
+        else:
+            path = os.path.join(inst.dbdir, DEFAULT_BENAME, "objectclass.db")
+        out = inst.dbscan(
+            None,
+            None,
+            args=["-f", path, "-r"],
+            stopping=False,
+            check_result=False,
+        ).decode("utf-8", errors="replace")
+    finally:
+        inst.start()
+    log.info("dbscan objectclass index (expect no %s):\n%s", key, out)
+    for line in out.splitlines():
+        if line.strip() == key:
+            raise AssertionError(
+                f"objectclass index unexpectedly contains equality key {key!r}:\n{out}"
+            )
+
+
+def _assert_oc_index_key_contains_id(inst, key, eid):
+    """Run dbscan -r on the objectclass index; require key and entry ID (see dbscan idl_format)."""
+    inst.stop()
+    try:
+        if inst.get_db_lib() == "mdb":
+            path = os.path.join(inst.dbdir, DEFAULT_BENAME.lower(), "objectclass")
+        else:
+            path = os.path.join(inst.dbdir, DEFAULT_BENAME, "objectclass.db")
+        out = inst.dbscan(
+            None,
+            None,
+            args=["-f", path, "-k", key, "-r"],
+            stopping=False,
+            check_result=False,
+        ).decode("utf-8", errors="replace")
+    finally:
+        inst.start()
+    log.info("dbscan -k %s output:\n%s", key, out)
+    if not re.search(rf"\b{eid}\b", out):
+        raise AssertionError(
+            f"expected objectclass index key {key!r} to list id {eid}; output:\n{out}"
+        )
+
+
+def test_objectclass_index_ids_repl_before_suffix(topology_no_sample):
+    """objectclass equality keys track entry IDs when the suffix is added after replication.
+
+    :id: c4a8e2b1-7f3d-4a1e-9c02-8b6d5e4f3a10
+    :setup: Standalone instance with userRoot for dc=example,dc=com but no suffix entry;
+            replication enabled as a single supplier.
+    :steps:
+        1. Enable replication on the backend (no suffix entry yet).
+        2. dbscan objectclass index must not have an ``=domain`` key yet.
+        3. dbscan objectclass index: ``=nstombstone`` must include ID 2 (RUV tombstone).
+        4. Add the suffix entry (dc=example,dc=com).
+        5. dbscan: ``=domain`` must include ID 1.
+        6. Add an organizationalUnit under the suffix.
+        7. dbscan: ``=organizationalunit`` must include ID 3.
+    :expectedresults:
+        1. Replication is configured.
+        2. No domain objectclass key before the suffix exists.
+        3. Tombstone objectclass is indexed for the RUV entry.
+        4. Suffix entry exists.
+        5. Domain objectclass maps to the suffix entry id.
+        6. OU entry exists.
+        7. organizationalUnit objectclass maps to the new entry id.
+    """
+    inst = topology_no_sample.standalone
+
+    log.info("Enable replication (supplier) without creating the suffix entry")
+    replicas = Replicas(inst)
+    replicas.create(properties={
+        'cn': 'replica',
+        'nsDS5ReplicaRoot': DEFAULT_SUFFIX,
+        'nsDS5ReplicaId': '1',
+        'nsDS5Flags': '1',
+        'nsDS5ReplicaType': '3',
+        'nsDS5ReplicaBindDN': 'cn=replication manager,cn=config',
+    })
+
+    log.info("Objectclass index must not have =domain before the suffix entry exists")
+    _assert_oc_index_missing_key(inst, "=domain")
+
+    log.info("Check RUV tombstone is indexed on objectclass with id 2")
+    _assert_oc_index_key_contains_id(inst, "=nstombstone", 2)
+
+    log.info("Create suffix entry %s", DEFAULT_SUFFIX)
+    Domain(inst, DEFAULT_SUFFIX).create(properties={"dc": "example"})
+
+    log.info("Check domain objectclass is indexed with id 1")
+    _assert_oc_index_key_contains_id(inst, "=domain", 1)
+
+    log.info("Create organizational unit ou=testou under the suffix")
+    OrganizationalUnits(inst, DEFAULT_SUFFIX).create(properties={"ou": "testou"})
+
+    log.info("Check organizationalUnit objectclass is indexed with id 3")
+    _assert_oc_index_key_contains_id(inst, "=organizationalunit", 3)

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -818,6 +818,7 @@ typedef struct ldbm_instance
 
     PRLock *inst_nextid_mutex;
     ID inst_nextid;
+    bool inst_ruv_inserted_first;
 
     PRCondVar *inst_indexer_cv; /* indexer thread cond var */
     PRThread *inst_indexer_tid; /* for the indexer thread */

--- a/ldap/servers/slapd/back-ldbm/ldbm_add.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_add.c
@@ -634,13 +634,24 @@ ldbm_back_add(Slapi_PBlock *pb)
                  */
                 Slapi_DN nscpEntrySDN;
                 addingentry = backentry_init(e);
-                if ((addingentry->ep_id = next_id(be)) >= MAXID) {
-                    slapi_log_err(SLAPI_LOG_ERR, "ldbm_back_add ",
-                                  "Maximum ID reached, cannot add entry to "
-                                  "backend '%s'\n",
-                                  be->be_name);
-                    ldap_result_code = LDAP_OPERATIONS_ERROR;
-                    goto error_return;
+                if (is_ruv && next_id_get(be) == 1) {
+                    /* First entry in DB, but the RUV should not be ID 1 */
+                    inst->inst_ruv_inserted_first = true;
+                    addingentry->ep_id = 2;
+                } else {
+                    if ((addingentry->ep_id = next_id(be)) >= MAXID) {
+                        slapi_log_err(SLAPI_LOG_ERR, "ldbm_back_add ",
+                                      "Maximum ID reached, cannot add entry to "
+                                      "backend '%s'\n",
+                                      be->be_name);
+                        ldap_result_code = LDAP_OPERATIONS_ERROR;
+                        goto error_return;
+                    }
+                    if (addingentry->ep_id == 1 && inst->inst_ruv_inserted_first) {
+                        /* We need to bump the next id to advance past the RUV id*/
+                        inst->inst_ruv_inserted_first = false;
+                        next_id(be);
+                    }
                 }
                 addingentry_id_assigned = 1;
 

--- a/ldap/servers/slapd/back-ldbm/nextid.c
+++ b/ldap/servers/slapd/back-ldbm/nextid.c
@@ -155,7 +155,21 @@ get_ids_from_disk(backend *be)
         if (0 == return_value) {
             return_value = dblayer_cursor_op(&dbc, DBI_OP_MOVE_TO_LAST, &key, &value);
             if ((0 == return_value) && (NULL != key.dptr)) {
-                inst->inst_nextid = id_stored_to_internal(key.dptr) + 1;
+                ID id = id_stored_to_internal(key.dptr);
+                int32_t count = 0;
+
+                if (dblayer_get_entries_count(be, id2entrydb, NULL, &count) == 0 &&
+                    count == 1 &&
+                    id == 2)
+                {
+                    /* This can only happen if the only entry in the db is the
+                     * RUV entry (which has ID 2). Set the nextid to 1 for when
+                     * we add the suffix entry */
+                    inst->inst_nextid = 1;
+                    inst->inst_ruv_inserted_first = true;
+                } else {
+                    inst->inst_nextid = id + 1;
+                }
             } else {
                 inst->inst_nextid = 1; /* error case: set 1 */
             }

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3134,7 +3134,7 @@ class DirSrv(SimpleLDAPObject, object):
                 return True
             return False
 
-    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False, args=None, stopping=True) -> bytes:
+    def dbscan(self, bename=None, index=None, key=None, width=None, isRaw=False, args=None, stopping=True, check_result=True) -> bytes:
         """Wrapper around dbscan tool that analyzes and extracts information
         from an import Directory Server database file
 
@@ -3186,7 +3186,8 @@ class DirSrv(SimpleLDAPObject, object):
         self.log.info('Running script: %s', cmd)
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            result.check_returncode();
+            if check_result:
+                result.check_returncode()
         except subprocess.CalledProcessError:
             self.log.error('Failed to run dbscan: "%s"' % result)
             raise ValueError('Failed to run dbscan')


### PR DESCRIPTION
Description:

When enabling replication and we add the database RUV tombstone entry check if this is the first entry being added.  If it is, then set the ID to 2, and set a flag indicating that after we add the suffix entry to bump the next ID count past the RUV entry id.

And at server startup when we get the "next id from disk" also check if there if only the RUV entry.  If it is, then set the next ID to 1 (for the suffix) and set the ruv flag that indicating that the entry ID count needs to be bumped past the RUV entry when the suffix is finally added.

For some reason dbscan returns error 3 even on success.  So a parameter was added to lib389's dbscan interface to skip checking the return code.

relates: https://github.com/389ds/389-ds-base/issues/7378

CI test assisted by: Cursor

## Summary by Sourcery

Ensure correct assignment and recovery of entry IDs when the RUV tombstone is created before the suffix entry, and relax dbscan return-code checking to support new tests.

Bug Fixes:
- Guarantee the RUV tombstone entry never consumes entry ID 1, reserving ID 1 for the suffix entry even when replication is enabled before the suffix exists.
- Handle server startup when only the RUV entry is present so that the next assigned ID is set correctly for the suffix and subsequent entries.

Enhancements:
- Add a flag to track when the RUV entry was inserted before the suffix so that the next-id counter can be adjusted appropriately.
- Extend lib389's dbscan wrapper with an option to skip checking the subprocess return code when dbscan reports nonstandard success values.

Tests:
- Add a replication test verifying objectclass index keys map to the expected entry IDs when the suffix entry is created after replication is enabled.