### PR TITLE
Issue 7380 - Internal op with negative wtime and large optime

### DIFF
--- a/ldap/servers/slapd/plugin_internal_op.c
+++ b/ldap/servers/slapd/plugin_internal_op.c
@@ -383,6 +383,7 @@ seq_internal_callback_pb(Slapi_PBlock *pb, void *callback_data, plugin_result_ca
     set_common_params(pb);
 
     slapi_td_internal_op_start();
+    slapi_operation_set_time_started(op);
     if (be->be_seq != NULL) {
         rc = (*be->be_seq)(pb);
     } else {


### PR DESCRIPTION
Description:
The retro CL plugin triggers internal operations that log incorrect wtime and optime to the server access logs.This happens because seq_internal_callback_pb() calls the backend directly without setting the operation start time.

Fix:
Add slapi_operation_set_time_started(op) to seq_internal_callback_pb() to record when the operation actually starts processing.

Fixes: https://github.com/389ds/389-ds-base/issues/7380

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Fix incorrect wtime and optime values in access logs for internal operations triggered by the retro CL plugin by recording the operation start time.