### PR TITLE
Issue 7383 - During online total init, the idranges list is sorted th…

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -297,6 +297,16 @@ typedef struct IdRange {
     struct IdRange *next;
 } IdRange_t;
 
+/*
+ * Partition of the 32-bit ID space into IDRANGE_NUM_BUCKETS (4096) slices
+ * (IDRANGE_BUCKET_SHIFT high bits).  Each slice has its own merged range list
+ * and optional hash of sparse singletons — see idl_common.c.
+ */
+#define IDRANGE_NUM_BUCKETS 4096
+#define IDRANGE_BUCKET_SHIFT 20 /* (1U << IDRANGE_BUCKET_SHIFT) IDs per bucket */
+
+typedef struct IdRangeSet IdRangeSet_t;
+
 
 typedef size_t idl_iterator;
 

--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -287,7 +287,9 @@ typedef struct _idlist_set
 /*
  * used by the supplier during online total init
  * it stores the ranges of ID that are already present
- * in the candidate list ('parentid>=1')
+ * in the candidate list ('parentid>=1').
+ * Ranges are sorted with higher IDs first (largest range begins
+ * at the head); each [first..last] still has first <= last.
  */
 typedef struct IdRange {
     ID first;

--- a/ldap/servers/slapd/back-ldbm/idl_common.c
+++ b/ldap/servers/slapd/back-ldbm/idl_common.c
@@ -15,7 +15,12 @@
 
 #include "back-ldbm.h"
 
-/* #define LDAP_DEBUG_IDRANGE 1 -- PR_ASSERT IdRange order/non-overlap after idrange_add_id */
+struct IdRangeSet {
+    IdRange_t *ranges[IDRANGE_NUM_BUCKETS];
+    PLHashTable *hash[IDRANGE_NUM_BUCKETS];
+};
+
+/* #define LDAP_DEBUG_IDRANGE 1 -- PR_ASSERT IdRange order/non-overlap after idrange_add_to_ranges */
 #ifdef LDAP_DEBUG_IDRANGE
 static void
 idrange_debug_check_invariants(IdRange_t *head)
@@ -30,14 +35,6 @@ idrange_debug_check_invariants(IdRange_t *head)
         }
     }
 }
-
-#define IDRANGE_ADD_ID_RETURN(head_ptr, val)     \
-    do {                                         \
-        idrange_debug_check_invariants(*(head_ptr)); \
-        return (val);                            \
-    } while (0)
-#else
-#define IDRANGE_ADD_ID_RETURN(head_ptr, val) return (val)
 #endif /* LDAP_DEBUG_IDRANGE */
 
 size_t
@@ -197,20 +194,75 @@ idl_min(IDList *a, IDList *b)
     return (a->b_nids > b->b_nids ? b : a);
 }
 
+#define IDRANGE_BUCKET_HASH_SIZE 256
+
+static PLHashNumber
+idrange_hash_id(const void *key)
+{
+    unsigned long ik = (unsigned long)key;
+    return (PLHashNumber)((ik ^ (ik >> 16)) % IDRANGE_BUCKET_HASH_SIZE);
+}
+
+static PRIntn
+idrange_hash_compare(const void *a, const void *b)
+{
+    return ((unsigned long)a == (unsigned long)b) ? 1 : 0;
+}
+
+static int
+idrange_id_in_ranges_list(IdRange_t *range, ID id)
+{
+    IdRange_t *r;
+
+    for (r = range; r; r = r->next) {
+        if (id > r->last) {
+            break;
+        }
+        if (id >= r->first) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+idrange_set_contains(IdRangeSet_t *set, ID id)
+{
+    size_t b;
+
+    if (set == NULL || NOID == id) {
+        return 0;
+    }
+    b = (size_t)(id >> IDRANGE_BUCKET_SHIFT);
+    if (set->hash[b] && PL_HashTableLookup(set->hash[b], (void *)(unsigned long)id)) {
+        return 1;
+    }
+    return idrange_id_in_ranges_list(set->ranges[b], id);
+}
+
+static void
+idrange_ensure_bucket_hash(IdRangeSet_t *set, size_t b)
+{
+    if (set->hash[b] != NULL) {
+        return;
+    }
+    set->hash[b] = PL_NewHashTable(IDRANGE_BUCKET_HASH_SIZE, idrange_hash_id,
+                                   idrange_hash_compare, idrange_hash_compare, NULL, NULL);
+}
+
 /*
  * This is a faster version of idl_id_is_in_idlist.
- * idl_id_is_in_idlist uses an array of ID so lookup is expensive
- * idl_id_is_in_idlist_ranges uses a list of ranges of ID lookup is faster
- * (ranges sorted high-to-low: head has the highest IDs).
+ * idl_id_is_in_idlist uses an array of ID so lookup is expensive.
+ * idl_id_is_in_idlist_ranges uses IdRangeSet_t: 4096 bucket-local range lists
+ * (and per-bucket hash for sparse singletons).  Lookup is O(length of one bucket).
  * returns
- *   1: 'id' is present in idrange_list
- *   0: 'id' is not present in idrange_list
+ *   1: 'id' is present in the set
+ *   0: 'id' is not present in the set
  */
 int
-idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id)
+idl_id_is_in_idlist_ranges(IDList *idl, IdRangeSet_t *set, ID id)
 {
-    IdRange_t *range = idrange_list;
-    int found = 0;
+    size_t b;
 
     if (NULL == idl || NOID == id) {
         return 0; /* not in the list */
@@ -218,20 +270,14 @@ idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id)
     if (ALLIDS(idl)) {
         return 1; /* in the list */
     }
-
-    for (; range; range = range->next) {
-        if (id > range->last) {
-            /* id is above this range; remaining ranges are lower */
-            break;
-        }
-        if (id >= range->first) {
-            /* in [last..first] (and range->last >= id) */
-            found = 1;
-            break;
-        }
-        /* id < range->first: may fall in a smaller range later in the list */
+    if (set == NULL) {
+        return 0;
     }
-    return found;
+    b = (size_t)(id >> IDRANGE_BUCKET_SHIFT);
+    if (set->hash[b] && PL_HashTableLookup(set->hash[b], (void *)(unsigned long)id)) {
+        return 1;
+    }
+    return idrange_id_in_ranges_list(set->ranges[b], id);
 }
 
 /* This function is used during the online total initialisation
@@ -240,22 +286,19 @@ idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id)
  */
 void idrange_free(IdRange_t **head)
 {
-    IdRange_t *curr, *sav;
+    IdRange_t *curr;
+    IdRange_t *next;
 
     if ((head == NULL) || (*head == NULL)) {
         return;
     }
     curr = *head;
-    sav = NULL;
-    for (; curr;) {
-        sav = curr;
-        curr = curr->next;
-        slapi_ch_free((void *) &sav);
-    }
-    if (sav) {
-        slapi_ch_free((void *) &sav);
-    }
     *head = NULL;
+    while (curr) {
+        next = curr->next;
+        slapi_ch_free((void **)&curr);
+        curr = next;
+    }
 }
 
 /* Union adjacent/overlapping ranges: *keeper* stays linked in the list,
@@ -275,31 +318,41 @@ idrange_merge_adjacent(IdRange_t *keeper, IdRange_t *victim)
     return keeper;
 }
 
-/* This function is used during the online total initialisation
- * Because a MODRDN can move entries under a parent that
- * has a higher ID we need to sort the IDList so that parents
- * are sent, to the consumer, before the children are sent.
- * The sorting with a simple IDlist does not scale instead
- * a list of IDs ranges is much faster.
- * In that list we only ADD/lookup ID.
- * Ranges are kept sorted high-to-low (head holds the highest IDs).
+#ifdef LDAP_DEBUG_IDRANGE
+#define IDRANGE_ADD_TO_RANGES_END(head_ptr)     \
+    do {                                        \
+        idrange_debug_check_invariants(*(head_ptr)); \
+        return;                                 \
+    } while (0)
+#else
+#define IDRANGE_ADD_TO_RANGES_END(head_ptr) return
+#endif
+
+/*
+ * Merge id into one bucket's range list. If singleton_hash is non-NULL,
+ * a new isolated id is stored in that bucket's hash instead of a one-id range.
  */
-IdRange_t *idrange_add_id(IdRange_t **head, ID id)
+static void
+idrange_add_to_ranges(IdRange_t **head, ID id, PLHashTable *singleton_hash)
 {
     if (head == NULL) {
-        slapi_log_err(SLAPI_LOG_ERR, "idrange_add_id",
-                      "Can not add ID %d in non defined list\n", id);
-        return NULL;
+        slapi_log_err(SLAPI_LOG_ERR, "idrange_add_to_ranges",
+                      "Can not add ID %u in non defined list\n", id);
+        return;
     }
 
     if (*head == NULL) {
-        /* This is the first range */
-        IdRange_t *new_range = (IdRange_t *)slapi_ch_malloc(sizeof(IdRange_t));
-        new_range->first = id;
-        new_range->last = id;
-        new_range->next = NULL;
-        *head = new_range;
-        IDRANGE_ADD_ID_RETURN(head, *head);
+        if (singleton_hash) {
+            PL_HashTableAdd(singleton_hash, (void *)(unsigned long)id, (void *)1);
+            IDRANGE_ADD_TO_RANGES_END(head);
+        } else {
+            IdRange_t *new_range = (IdRange_t *)slapi_ch_malloc(sizeof(IdRange_t));
+            new_range->first = id;
+            new_range->last = id;
+            new_range->next = NULL;
+            *head = new_range;
+            IDRANGE_ADD_TO_RANGES_END(head);
+        }
     }
 
     IdRange_t *curr = *head, *prev = NULL;
@@ -308,7 +361,7 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
     while (curr) {
         if (id >= curr->first && id <= curr->last) {
             /* inside a range, nothing to do */
-            IDRANGE_ADD_ID_RETURN(head, curr);
+            IDRANGE_ADD_TO_RANGES_END(head);
         }
 
         if (id == curr->last + 1) {
@@ -316,13 +369,13 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
             curr->last = id;
             if (prev && curr->last + 1 >= prev->first) {
                 idrange_merge_adjacent(prev, curr);
-                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                              "(id=%d) merge current with previous range [%d..%d]\n", id, prev->first, prev->last);
-                IDRANGE_ADD_ID_RETURN(head, prev);
+                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                              "(id=%u) merge current with previous range [%u..%u]\n", id, prev->first, prev->last);
+                IDRANGE_ADD_TO_RANGES_END(head);
             }
-            slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                          "(id=%d) extend forward current range [%d..%d]\n", id, curr->first, curr->last);
-            IDRANGE_ADD_ID_RETURN(head, curr);
+            slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                          "(id=%u) extend forward current range [%u..%u]\n", id, curr->first, curr->last);
+            IDRANGE_ADD_TO_RANGES_END(head);
         }
 
         if (id + 1 == curr->first) {
@@ -331,13 +384,13 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
             IdRange_t *next = curr->next;
             if (next && next->last + 1 >= curr->first) {
                 idrange_merge_adjacent(curr, next);
-                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                              "(id=%d) merge current with next range [%d..%d]\n", id, curr->first, curr->last);
+                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                              "(id=%u) merge current with next range [%u..%u]\n", id, curr->first, curr->last);
             } else {
-                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                              "(id=%d) extend backward current range [%d..%d]\n", id, curr->first, curr->last);
+                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                              "(id=%u) extend backward current range [%u..%u]\n", id, curr->first, curr->last);
             }
-            IDRANGE_ADD_ID_RETURN(head, curr);
+            IDRANGE_ADD_TO_RANGES_END(head);
         }
 
         /* id lies strictly above this block: insert a new node before curr */
@@ -349,23 +402,95 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
         prev = curr;
         curr = curr->next;
     }
-    /* insert a new standalone IdRange between prev and curr */
-    IdRange_t *new_range = (IdRange_t *)slapi_ch_malloc(sizeof(IdRange_t));
-    new_range->first = id;
-    new_range->last = id;
-    new_range->next = curr;
-
-    if (prev) {
-        slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                      "(id=%d) add new range [%d..%d]\n", id, new_range->first, new_range->last);
-        prev->next = new_range;
-    } else {
-        /* insert at head */
-        slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                      "(id=%d) head range [%d..%d]\n", id, new_range->first, new_range->last);
-        *head = new_range;
+    if (singleton_hash) {
+        PL_HashTableAdd(singleton_hash, (void *)(unsigned long)id, (void *)1);
+        IDRANGE_ADD_TO_RANGES_END(head);
     }
-    IDRANGE_ADD_ID_RETURN(head, *head);
+
+    {
+        IdRange_t *new_range = (IdRange_t *)slapi_ch_malloc(sizeof(IdRange_t));
+        new_range->first = id;
+        new_range->last = id;
+        new_range->next = curr;
+
+        if (prev) {
+            slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                          "(id=%u) add new range [%u..%u]\n", id, new_range->first, new_range->last);
+            prev->next = new_range;
+        } else {
+            slapi_log_err(SLAPI_LOG_REPL, "idrange_add_to_ranges",
+                          "(id=%u) head range [%u..%u]\n", id, new_range->first, new_range->last);
+            *head = new_range;
+        }
+        IDRANGE_ADD_TO_RANGES_END(head);
+    }
+}
+
+void
+idrange_set_init(IdRangeSet_t **pset)
+{
+    if (pset == NULL) {
+        return;
+    }
+    *pset = (IdRangeSet_t *)slapi_ch_calloc(1, sizeof(IdRangeSet_t));
+}
+
+void
+idrange_set_destroy(IdRangeSet_t **pset)
+{
+    size_t i;
+
+    if (pset == NULL || *pset == NULL) {
+        return;
+    }
+    for (i = 0; i < IDRANGE_NUM_BUCKETS; i++) {
+        idrange_free(&(*pset)->ranges[i]);
+        if ((*pset)->hash[i]) {
+            PL_HashTableDestroy((*pset)->hash[i]);
+            (*pset)->hash[i] = NULL;
+        }
+    }
+    slapi_ch_free((void **)pset);
+}
+
+void
+idrange_set_add_id(IdRangeSet_t *set, ID id)
+{
+    size_t b;
+    size_t bp;
+    size_t bn;
+
+    if (set == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, "idrange_set_add_id",
+                      "Can not add ID %u in non defined set\n", id);
+        return;
+    }
+    b = (size_t)(id >> IDRANGE_BUCKET_SHIFT);
+    idrange_ensure_bucket_hash(set, b);
+    if (idrange_set_contains(set, id)) {
+        return;
+    }
+    if (id > 0) {
+        bp = (size_t)((id - 1) >> IDRANGE_BUCKET_SHIFT);
+        idrange_ensure_bucket_hash(set, bp);
+        if (set->hash[bp] && PL_HashTableLookup(set->hash[bp], (void *)(unsigned long)(id - 1))) {
+            PL_HashTableRemove(set->hash[bp], (void *)(unsigned long)(id - 1));
+            idrange_add_to_ranges(&set->ranges[bp], id - 1, NULL);
+            idrange_set_add_id(set, id);
+            return;
+        }
+    }
+    if (id + 1 != 0) {
+        bn = (size_t)((id + 1) >> IDRANGE_BUCKET_SHIFT);
+        idrange_ensure_bucket_hash(set, bn);
+        if (set->hash[bn] && PL_HashTableLookup(set->hash[bn], (void *)(unsigned long)(id + 1))) {
+            PL_HashTableRemove(set->hash[bn], (void *)(unsigned long)(id + 1));
+            idrange_add_to_ranges(&set->ranges[bn], id + 1, NULL);
+            idrange_set_add_id(set, id);
+            return;
+        }
+    }
+    idrange_add_to_ranges(&set->ranges[b], id, set->hash[b]);
 }
 
 

--- a/ldap/servers/slapd/back-ldbm/idl_common.c
+++ b/ldap/servers/slapd/back-ldbm/idl_common.c
@@ -15,6 +15,31 @@
 
 #include "back-ldbm.h"
 
+/* #define LDAP_DEBUG_IDRANGE 1 -- PR_ASSERT IdRange order/non-overlap after idrange_add_id */
+#ifdef LDAP_DEBUG_IDRANGE
+static void
+idrange_debug_check_invariants(IdRange_t *head)
+{
+    IdRange_t *r;
+
+    for (r = head; r != NULL; r = r->next) {
+        PR_ASSERT(r->first <= r->last);
+        if (r->next != NULL) {
+            /* sorted high-to-low on the number line; strict: no overlap (adjacency ok) */
+            PR_ASSERT(r->next->last < r->first);
+        }
+    }
+}
+
+#define IDRANGE_ADD_ID_RETURN(head_ptr, val)     \
+    do {                                         \
+        idrange_debug_check_invariants(*(head_ptr)); \
+        return (val);                            \
+    } while (0)
+#else
+#define IDRANGE_ADD_ID_RETURN(head_ptr, val) return (val)
+#endif /* LDAP_DEBUG_IDRANGE */
+
 size_t
 idl_sizeof(IDList *idl)
 {
@@ -176,6 +201,7 @@ idl_min(IDList *a, IDList *b)
  * This is a faster version of idl_id_is_in_idlist.
  * idl_id_is_in_idlist uses an array of ID so lookup is expensive
  * idl_id_is_in_idlist_ranges uses a list of ranges of ID lookup is faster
+ * (ranges sorted high-to-low: head has the highest IDs).
  * returns
  *   1: 'id' is present in idrange_list
  *   0: 'id' is not present in idrange_list
@@ -193,19 +219,17 @@ idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id)
         return 1; /* in the list */
     }
 
-    for(;range; range = range->next) {
+    for (; range; range = range->next) {
         if (id > range->last) {
-            /* check if it belongs to the next range */
-            continue;
+            /* id is above this range; remaining ranges are lower */
+            break;
         }
         if (id >= range->first) {
-            /* It belongs to that range [first..last ] */
+            /* in [last..first] (and range->last >= id) */
             found = 1;
             break;
-        } else {
-            /* this range is after id */
-            break;
         }
+        /* id < range->first: may fall in a smaller range later in the list */
     }
     return found;
 }
@@ -234,6 +258,23 @@ void idrange_free(IdRange_t **head)
     *head = NULL;
 }
 
+/* Union adjacent/overlapping ranges: *keeper* stays linked in the list,
+ * *victim* is freed. Returns keeper.
+ */
+static IdRange_t *
+idrange_merge_adjacent(IdRange_t *keeper, IdRange_t *victim)
+{
+    if (victim->first < keeper->first) {
+        keeper->first = victim->first;
+    }
+    if (victim->last > keeper->last) {
+        keeper->last = victim->last;
+    }
+    keeper->next = victim->next;
+    slapi_ch_free((void *)&victim);
+    return keeper;
+}
+
 /* This function is used during the online total initialisation
  * Because a MODRDN can move entries under a parent that
  * has a higher ID we need to sort the IDList so that parents
@@ -241,6 +282,7 @@ void idrange_free(IdRange_t **head)
  * The sorting with a simple IDlist does not scale instead
  * a list of IDs ranges is much faster.
  * In that list we only ADD/lookup ID.
+ * Ranges are kept sorted high-to-low (head holds the highest IDs).
  */
 IdRange_t *idrange_add_id(IdRange_t **head, ID id)
 {
@@ -257,65 +299,57 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
         new_range->last = id;
         new_range->next = NULL;
         *head = new_range;
-        return *head;
+        IDRANGE_ADD_ID_RETURN(head, *head);
     }
 
     IdRange_t *curr = *head, *prev = NULL;
 
-    /* First, find if id already falls within any existing range, or it is adjacent to any */
+    /* find if id is inside or adjacent to any range (list: high ID blocks first) */
     while (curr) {
         if (id >= curr->first && id <= curr->last) {
             /* inside a range, nothing to do */
-            return curr;
+            IDRANGE_ADD_ID_RETURN(head, curr);
         }
 
         if (id == curr->last + 1) {
-            /* Extend this range upwards */
+            /* extend toward higher values; may merge with prev (even higher) */
             curr->last = id;
-
-            /* Check for possible merge with next range */
-            IdRange_t *next = curr->next;
-            if (next && curr->last + 1 >= next->first) {
+            if (prev && curr->last + 1 >= prev->first) {
+                idrange_merge_adjacent(prev, curr);
                 slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                        "(id=%d) merge current  with next range [%d..%d]\n", id, curr->first, curr->last);
-                curr->last = (next->last > curr->last) ? next->last : curr->last;
-                curr->next = next->next;
-                slapi_ch_free((void*) &next);
-            } else {
-                slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                              "(id=%d) extend forward current range [%d..%d]\n", id, curr->first, curr->last);
+                              "(id=%d) merge current with previous range [%d..%d]\n", id, prev->first, prev->last);
+                IDRANGE_ADD_ID_RETURN(head, prev);
             }
-            return curr;
+            slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
+                          "(id=%d) extend forward current range [%d..%d]\n", id, curr->first, curr->last);
+            IDRANGE_ADD_ID_RETURN(head, curr);
         }
 
         if (id + 1 == curr->first) {
-            /* Extend this range downwards */
+            /* extend toward lower values; may merge with next (even lower) */
             curr->first = id;
-
-            /* Check for possible merge with previous range */
-            if (prev && prev->last + 1 >= curr->first) {
-                prev->last = curr->last;
-                prev->next = curr->next;
-                slapi_ch_free((void *) &curr);
+            IdRange_t *next = curr->next;
+            if (next && next->last + 1 >= curr->first) {
+                idrange_merge_adjacent(curr, next);
                 slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
-                              "(id=%d) merge current with previous range [%d..%d]\n", id, prev->first, prev->last);
-                return prev;
+                              "(id=%d) merge current with next range [%d..%d]\n", id, curr->first, curr->last);
             } else {
                 slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
                               "(id=%d) extend backward current range [%d..%d]\n", id, curr->first, curr->last);
-                return curr;
             }
+            IDRANGE_ADD_ID_RETURN(head, curr);
         }
 
-        /* If id is before the current range, break so we can insert before */
-        if (id < curr->first) {
+        /* id lies strictly above this block: insert a new node before curr */
+        if (id > curr->last) {
             break;
         }
 
+        /* id < curr->first: try a lower block */
         prev = curr;
         curr = curr->next;
     }
-    /* Need to insert a new standalone IdRange */
+    /* insert a new standalone IdRange between prev and curr */
     IdRange_t *new_range = (IdRange_t *)slapi_ch_malloc(sizeof(IdRange_t));
     new_range->first = id;
     new_range->last = id;
@@ -326,12 +360,12 @@ IdRange_t *idrange_add_id(IdRange_t **head, ID id)
                       "(id=%d) add new range [%d..%d]\n", id, new_range->first, new_range->last);
         prev->next = new_range;
     } else {
-        /* Insert at head */
+        /* insert at head */
         slapi_log_err(SLAPI_LOG_REPL, "idrange_add_id",
                       "(id=%d) head range [%d..%d]\n", id, new_range->first, new_range->last);
         *head = new_range;
     }
-    return *head;
+    IDRANGE_ADD_ID_RETURN(head, *head);
 }
 
 

--- a/ldap/servers/slapd/back-ldbm/idl_new.c
+++ b/ldap/servers/slapd/back-ldbm/idl_new.c
@@ -66,7 +66,7 @@ typedef struct {
     size_t leftoverlen;
     size_t leftovercnt;
     IDList *idl;
-    IdRange_t *idrange_list;
+    IdRangeSet_t *idrange_set;
     int flag_err;
     ID lastid;
     ID suffix;
@@ -436,7 +436,7 @@ idl_new_range_fetch(
     size_t leftoverlen = 32;
     size_t leftovercnt = 0;
     char *index_id = get_index_name(be, db, ai);
-    IdRange_t *idrange_list = NULL;
+    IdRangeSet_t *idrange_set = NULL;
 
 
     if (NULL == flag_err) {
@@ -462,6 +462,10 @@ idl_new_range_fetch(
 
     if (NEW_IDL_NOOP == *flag_err) {
         return NULL;
+    }
+
+    if (operator & SLAPI_OP_RANGE_NO_IDL_SORT) {
+        idrange_set_init(&idrange_set);
     }
     if (slapi_is_loglevel_set(SLAPI_LOG_FILTER)) {
         char *included = ((operator & SLAPI_OP_RANGE) == SLAPI_OP_LESS) ? "not " : "";
@@ -580,11 +584,11 @@ idl_new_range_fetch(
                      */
                     suffix = key;
                     idl_append_extend(&idl, id);
-                    idrange_add_id(&idrange_list, id);
-                } else if ((key == suffix) || idl_id_is_in_idlist_ranges(idl, idrange_list, key)) {
+                    idrange_set_add_id(idrange_set, id);
+                } else if ((key == suffix) || idl_id_is_in_idlist_ranges(idl, idrange_set, key)) {
                     /* the parent is the suffix or already in idl. */
                     idl_append_extend(&idl, id);
-                    idrange_add_id(&idrange_list, id);
+                    idrange_set_add_id(idrange_set, id);
                 } else {
                     /* Otherwise, keep the {key,id} in leftover array */
                     if (!leftover) {
@@ -692,10 +696,10 @@ error:
 
         while(remaining > 0) {
             for (size_t i = 0; i < leftovercnt; i++) {
-                if (leftover[i].key > 0 && idl_id_is_in_idlist_ranges(idl, idrange_list, leftover[i].key) != 0) {
+                if (leftover[i].key > 0 && idl_id_is_in_idlist_ranges(idl, idrange_set, leftover[i].key) != 0) {
                     /* if the leftover key has its parent in the idl */
                     idl_append_extend(&idl, leftover[i].id);
-                    idrange_add_id(&idrange_list, leftover[i].id);
+                    idrange_set_add_id(idrange_set, leftover[i].id);
                     leftover[i].key = 0;
                     remaining--;
                 }
@@ -703,7 +707,7 @@ error:
         }
     }
     slapi_ch_free((void **)&leftover);
-    idrange_free(&idrange_list);
+    idrange_set_destroy(&idrange_set);
     slapi_log_err(SLAPI_LOG_FILTER, "idl_new_range_fetch",
                   "Found %d candidates; error code is: %d\n",
                   idl ? idl->b_nids : 0, *flag_err);
@@ -780,11 +784,11 @@ idl_range_add_id_cb(dbi_val_t *key, dbi_val_t *data, void *ctx)
              */
             rctx->suffix = keyval;
             idl_append_extend(&rctx->idl, id);
-            idrange_add_id(&rctx->idrange_list, id);
-        } else if ((keyval == rctx->suffix) || idl_id_is_in_idlist_ranges(rctx->idl, rctx->idrange_list, keyval)) {
+            idrange_set_add_id(rctx->idrange_set, id);
+        } else if ((keyval == rctx->suffix) || idl_id_is_in_idlist_ranges(rctx->idl, rctx->idrange_set, keyval)) {
             /* the parent is the suffix or already in idl. */
             idl_append_extend(&rctx->idl, id);
-            idrange_add_id(&rctx->idrange_list, id);
+            idrange_set_add_id(rctx->idrange_set, id);
         } else {
             /* Otherwise, keep the {keyval,id} in leftover array */
             if (!rctx->leftover) {
@@ -885,8 +889,8 @@ idl_lmdb_range_fetch(
     idl_range_ctx.lastid = 0;
     idl_range_ctx.count = 0;
     idl_range_ctx.index_id = index_id;
-    idl_range_ctx.idrange_list = NULL;
     if (operator & SLAPI_OP_RANGE_NO_IDL_SORT) {
+        idrange_set_init(&idl_range_ctx.idrange_set);
             struct _back_info_index_key bck_info;
             /* We are doing a bulk import
              * try to retrieve the suffix entry id from the index
@@ -961,10 +965,10 @@ error:
         while(remaining > 0) {
             for (size_t i = 0; i < idl_range_ctx.leftovercnt; i++) {
                 if (idl_range_ctx.leftover[i].key > 0 &&
-                    idl_id_is_in_idlist_ranges(idl_range_ctx.idl, idl_range_ctx.idrange_list, idl_range_ctx.leftover[i].key) != 0) {
+                    idl_id_is_in_idlist_ranges(idl_range_ctx.idl, idl_range_ctx.idrange_set, idl_range_ctx.leftover[i].key) != 0) {
                     /* if the leftover key has its parent in the idl */
                     idl_append_extend(&idl_range_ctx.idl, idl_range_ctx.leftover[i].id);
-                    idrange_add_id(&idl_range_ctx.idrange_list, idl_range_ctx.leftover[i].id);
+                    idrange_set_add_id(idl_range_ctx.idrange_set, idl_range_ctx.leftover[i].id);
                     idl_range_ctx.leftover[i].key = 0;
                     remaining--;
                 }
@@ -972,7 +976,7 @@ error:
         }
     }
     slapi_ch_free((void **)&idl_range_ctx.leftover);
-    idrange_free(&idl_range_ctx.idrange_list);
+    idrange_set_destroy(&idl_range_ctx.idrange_set);
     *flag_err = idl_range_ctx.flag_err;
     slapi_log_err(SLAPI_LOG_FILTER, "idl_lmdb_range_fetch",
                   "Found %d candidates; error code is: %d\n",

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -217,9 +217,10 @@ ID idl_firstid(IDList *idl);
 ID idl_nextid(IDList *idl, ID id);
 int idl_init_private(backend *be, struct attrinfo *a);
 int idl_release_private(struct attrinfo *a);
-IdRange_t *idrange_add_id(IdRange_t **head, ID id);
-void idrange_free(IdRange_t **head);
-int idl_id_is_in_idlist_ranges(IDList *idl, IdRange_t *idrange_list, ID id);
+void idrange_set_init(IdRangeSet_t **set);
+void idrange_set_destroy(IdRangeSet_t **set);
+void idrange_set_add_id(IdRangeSet_t *set, ID id);
+int idl_id_is_in_idlist_ranges(IDList *idl, IdRangeSet_t *set, ID id);
 int idl_id_is_in_idlist(IDList *idl, ID id);
 
 idl_iterator idl_iterator_init(const IDList *idl);


### PR DESCRIPTION
…e improper way

Bug description:
	The idrange list is sorted with higher ID at the end of the list.
	If the IDs are fragmented (holes in ID values) and a high number
	of IDs (large DB) then the list size increases.
	So it requires more and more time to go through the list with high ID values.
	The IDs are always increasing so with such fragmented large DB the
	current idrange list does not scale.

Fix description:
	The ID ranges list is sorted the opposite way.
	Range with highest IDs is stored first.

fixes: #7383

Reviewed by:

Assisted by cursor

## Summary by Sourcery

Sort ID ranges in descending order and adjust range insertion and lookup logic to improve scalability of online total init on fragmented, large ID spaces.

Bug Fixes:
- Ensure ID range lookup respects the new high-to-low ordering to avoid unnecessary traversal and incorrect assumptions about remaining ranges.

Enhancements:
- Maintain ID ranges in descending order and update merge/extension logic to keep the list compact and efficient for large, fragmented databases.
- Clarify documentation comments for ID range ordering and behavior in the back-ldbm ID range utilities.