### PR TITLE
Issue 7389 - Allow to ignore criticality flags for specific controls

### DIFF
--- a/dirsrvtests/tests/suites/features/ldap_controls_test.py
+++ b/dirsrvtests/tests/suites/features/ldap_controls_test.py
@@ -8,7 +8,9 @@
 
 import logging
 import pytest
+import itertools
 import ldap
+from ldap.controls import RequestControl
 from ldap.controls.readentry import PostReadControl
 from lib389.idm.user import UserAccounts, UserAccount
 from lib389.topologies import topology_st
@@ -18,6 +20,9 @@ pytestmark = pytest.mark.tier1
 
 log = logging.getLogger(__name__)
 
+MANAGE_DSAIT_OID = "2.16.840.1.113730.3.4.2"
+TESTED_CTRLS = [ MANAGE_DSAIT_OID, "test", "test1", "test2" ]
+SUPPORTED_CTRLS = [ MANAGE_DSAIT_OID, ]
 
 def test_postread_ctrl_modify(topology_st):
     """Test PostReadControl with LDAP modify operations.
@@ -77,6 +82,69 @@ def test_postread_ctrl_modify(topology_st):
     user = UserAccount(inst, user.dn)
     assert user.get_attr_val_utf8('description') == FINAL_DESC
     user.delete()
+
+
+def all_combinations(alist):
+    for listlen in range(len(alist)+1):
+        for val in itertools.combinations(alist, listlen):
+            yield val
+
+
+def try_search(inst, ignored_ctrls, sent_ctrls):
+    ctrlreqs = [ RequestControl(controlType=oid, criticality=True) \
+                       for oid in sent_ctrls ]
+    expected = False;
+    for ctrl in sent_ctrls:
+        if ctrl not in SUPPORTED_CTRLS and ctrl not in ignored_ctrls:
+            expected = True
+    log.info(f"Ignoring: {ignored_ctrls} - Sending: {sent_ctrls} - Expected: {expected}")
+    if expected:
+        with pytest.raises(ldap.UNAVAILABLE_CRITICAL_EXTENSION):
+            srch_res = inst.search_ext_s(DEFAULT_SUFFIX,
+                        ldap.SCOPE_BASE, serverctrls=ctrlreqs)
+    else:
+        srch_res = inst.search_ext_s(DEFAULT_SUFFIX,
+                    ldap.SCOPE_BASE, serverctrls=ctrlreqs)
+
+
+def set_ignored_criticality(inst, oids):
+    oids = list(oids)
+    log.info(f'set_ignored_criticality({oids})')
+    inst.config.set("ds-ignored-control-criticality", oids)
+
+
+def test_ignored_criticality(topology_st):
+    """Test ignored criticality feature
+
+    :id: e2dc765a-329f-11f1-9d0f-c85309d5c3e3
+    :setup: Standalone instance
+    :steps:
+        1. Define tested control set containing both supported and not supported controls
+        2. Generate all subsets of tested controls
+        3. For ignored_ctrls in subsets and every send_ctrls in subsets
+        4. Set the ignored criticality config parameter to ignored_ctrls
+        5. Perform a search with send_ctrls controls with critical flag
+        6. Check if UNAVAILABLE_CRITICAL_EXTENSION is returned as expected
+        7. Reset ignored criticality config parameter
+    :expectedresults:
+        1. Succes
+        2. Succes
+        3. Succes
+        4. Succes
+        5. Succes
+        6. Expect UNAVAILABLE_CRITICAL_EXTENSION if any sent control is not supported or not ignored
+        7. Succes
+    """
+    inst = topology_st.standalone
+    ctrls = { oid: ldap.controls.RequestControl(controlType=oid, criticality=True) \
+                for oid in TESTED_CTRLS }
+
+    all_sets = all_combinations(TESTED_CTRLS)
+    for ignored_ctrls in all_sets:
+        for send_ctrls in all_sets:
+            set_ignored_criticality(inst, ignored_ctrls)
+            try_search(inst, ignored_ctrls, send_ctrls)
+    set_ignored_criticality(inst, [])
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/control.c
+++ b/ldap/servers/slapd/control.c
@@ -409,7 +409,8 @@ get_ldapmessage_controls_ext(
         }
         len = -1; /* reset */
         /* if we are ignoring criticality, treat as FALSE */
-        if (ignore_criticality) {
+        if (ignore_criticality ||
+            config_is_control_criticality_ignored(new->ldctl_oid)) {
             new->ldctl_iscritical = 0;
         }
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -10427,7 +10427,7 @@ config_is_control_criticality_ignored(const char *oid)
 {
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
     bool res = false;
-    CFG_LOCK_WRITE(slapdFrontendConfig);
+    CFG_LOCK_READ(slapdFrontendConfig);
     if (slapdFrontendConfig->ignored_criticality_list) {
         char **vals = slapdFrontendConfig->ignored_criticality_list;
         for (size_t i=0; vals[i]; i++) {
@@ -10437,7 +10437,7 @@ config_is_control_criticality_ignored(const char *oid)
             }
         }
     }
-    CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
     return res;
 }
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -284,6 +284,13 @@ typedef void *(*ConfigGetFunc)(void);
 /* static Ref_Array global_referrals; */
 static slapdFrontendConfig_t global_slapdFrontendConfig;
 
+/*
+ * Special default value to allow attribute removal.
+ * Real default value is set by the set function
+ *  when value == ALLOW_ATTRIBUTE_DELETION
+ */
+static const char ALLOW_ATTRIBUTE_DELETION[] = "";
+
 static struct config_get_and_set
 {
     const char *attr_name;         /* the name of the attribute */
@@ -1471,7 +1478,12 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.fgot,
      CONFIG_STRING, (ConfigGetFunc)config_get_fgot,
-     SLAPD_DEFAULT_FGOT, NULL }
+     SLAPD_DEFAULT_FGOT, NULL },
+    {CONFIG_IGNORED_CRITICALITY_LIST_ATTRIBUTE,
+     config_set_ignored_criticality_list, NULL, 0,
+     (void **)&global_slapdFrontendConfig.ignored_criticality_list,
+     CONFIG_CHARRAY, (ConfigGetFunc)config_get_ignored_criticality_list,
+     (void*)ALLOW_ATTRIBUTE_DELETION, NULL}
     /* End config */
     };
 
@@ -10361,7 +10373,7 @@ config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply)
             }
             if (!fgot_is_allowed(elem, &flags)) {
                 retVal = LDAP_UNWILLING_TO_PERFORM;
-                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE, 
+                slapi_create_errormsg(errorbuf, SLAPI_DSE_RETURNTEXT_SIZE,
                     "(%s) value (%s) is invalid. Should be a subset of %s\n",
                     attrname, value, fgot_allowed_values());
             }
@@ -10376,6 +10388,57 @@ config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply)
         CFG_UNLOCK_WRITE(slapdFrontendConfig);
     }
     return retVal;
+}
+
+char **
+config_get_ignored_criticality_list()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    char **retVal;
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapi_ch_array_dup(slapdFrontendConfig->ignored_criticality_list);
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
+int
+config_set_ignored_criticality_list(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    int retVal = LDAP_SUCCESS;
+
+    if (value == ALLOW_ATTRIBUTE_DELETION) {
+        value = NULL;
+    }
+
+    if (apply) {
+        CFG_LOCK_WRITE(slapdFrontendConfig);
+        slapi_ch_array_free(slapdFrontendConfig->ignored_criticality_list);
+        slapdFrontendConfig->ignored_criticality_list = slapi_ch_array_dup((char**)value);
+        CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    }
+    return retVal;
+}
+
+bool
+config_is_control_criticality_ignored(const char *oid)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+    bool res = false;
+    CFG_LOCK_WRITE(slapdFrontendConfig);
+    if (slapdFrontendConfig->ignored_criticality_list) {
+        char **vals = slapdFrontendConfig->ignored_criticality_list;
+        for (size_t i=0; vals[i]; i++) {
+            if (strcasecmp(oid, vals[i]) == 0) {
+                res = true;
+                break;
+            }
+        }
+    }
+    CFG_UNLOCK_WRITE(slapdFrontendConfig);
+    return res;
 }
 
 

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -659,6 +659,10 @@ int config_get_tcp_keepalive_time(void);
 int32_t config_set_fgot(const char *attrname, char *value, char *errorbuf, int apply);
 char * config_get_fgot(void);
 
+int config_set_ignored_criticality_list(const char *attrname, char *value, char *errorbuf, int apply);
+char **config_get_ignored_criticality_list(void);
+bool config_is_control_criticality_ignored(const char *oid);
+
 int is_abspath(const char *);
 char *rel2abspath(char *);
 char *rel2abspath_ext(char *, char *);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -2423,6 +2423,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_FGOT_ATTRIBUTE "ds-fine-grain-operation-timing"
 #define SLAPD_DEFAULT_FGOT "wtime+wqtime+optime+etime"
 #define SLAPD_DEFAULT_FGOT_FLAGS ((1UL<<FGOT_W)|(1UL<<FGOT_WQ)|(1UL<<FGOT_OP)|(1UL<<FGOT_ETIME))
+#define CONFIG_IGNORED_CRITICALITY_LIST_ATTRIBUTE "ds-ignored-control-criticality"
 
 #define CONFIG_CN_USES_DN_SYNTAX_IN_DNS "nsslapd-cn-uses-dn-syntax-in-dns"
 
@@ -2795,6 +2796,7 @@ typedef struct _slapdFrontendConfig
     char *auditlog_display_attrs;
     char *fgot;
     uint64_t fgot_flags;
+    char **ignored_criticality_list;
 } slapdFrontendConfig_t;
 
 /* possible values for slapdFrontendConfig_t.schemareplace */


### PR DESCRIPTION
Add a new multivalued ds-ignored-control-criticality config attribute containing the list of control type (could be an oid or any utf-8 string) whose criticality flags will be then ignored

Issue: #7389 

Reviewed by: @mreynolds389 (Thanks!)

## Summary by Sourcery

Add support for configuring LDAP controls whose criticality flags should be ignored by the server.

New Features:
- Introduce the ds-ignored-control-criticality configuration attribute to list control OIDs or names whose criticality is ignored during request processing.

Enhancements:
- Extend control handling to treat controls in the ignored criticality list as non-critical even when marked critical.
- Add frontend configuration plumbing to store and query the ignored control criticality list.

Tests:
- Add comprehensive LDAP control tests that verify ignored criticality behavior across combinations of supported and unsupported controls.