### PR TITLE
Issue 7396 - Testimony failure in monitor_test.py

### DIFF
--- a/dirsrvtests/tests/suites/monitor/monitor_test.py
+++ b/dirsrvtests/tests/suites/monitor/monitor_test.py
@@ -381,6 +381,7 @@ def test_monitor_busy_workers_concurrent(topo):
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
 def test_monitor_memberof(topo):
     """Test MemberOf plugin deferred processing monitoring with real activity
+
     :id: 1c4b382a-ebaf-4d80-9232-67e1b3ab58d4
     :setup: Single instance
     :steps:


### PR DESCRIPTION
Description:
Docstring error.

Fixes: https://github.com/389ds/389-ds-base/issues/7396

Reviewed by:

## Summary by Sourcery

Documentation:
- Correct a docstring formatting error in the monitor_memberof test.