### PR TITLE
Issue 7402 - CLI - allow healthcheck to work when server is stopped

### DIFF
--- a/dirsrvtests/tests/perf/ndncache_test.py
+++ b/dirsrvtests/tests/perf/ndncache_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -40,8 +40,8 @@ from lib389.utils import (
     ensure_bytes,
     ensure_str,
     get_default_db_lib,
-    get_ldapurl_from_serverid,
 )
+from lib389.dseutils import get_ldapurl_from_serverid
 
 pytestmark = pytest.mark.tier3
 

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -13,6 +13,7 @@ from lib389.idm.user import UserAccount, UserAccounts
 import pytest
 from lib389.tasks import *
 from lib389.utils import *
+from lib389.dseutils import get_ldapurl_from_serverid
 from lib389.topologies import topology_st
 from lib389.dbgen import dbgen_users
 from lib389.idm.organizationalunit import OrganizationalUnits

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -13,7 +13,8 @@ from lib389.idm.user import UserAccount, UserAccounts
 import pytest
 from lib389.tasks import *
 from lib389.utils import *
-from test389.topologies import topology_st
+from lib389.dseutils import get_ldapurl_from_serverid
+from lib389.topologies import topology_st
 from lib389.dbgen import dbgen_users
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389._constants import DN_DM, PASSWORD, PW_DM, ReplicaRole

--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -14,7 +14,7 @@ import pytest
 from lib389.tasks import *
 from lib389.utils import *
 from lib389.dseutils import get_ldapurl_from_serverid
-from lib389.topologies import topology_st
+from test389.topologies import topology_st
 from lib389.dbgen import dbgen_users
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389._constants import DN_DM, PASSWORD, PW_DM, ReplicaRole

--- a/dirsrvtests/tests/suites/filter/large_filter_test.py
+++ b/dirsrvtests/tests/suites/filter/large_filter_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -21,7 +21,7 @@ from lib389.idm.user import UserAccounts, UserAccount
 from lib389.idm.account import Accounts
 from lib389.backend import Backends
 from lib389.idm.domain import Domain
-from lib389.utils import get_ldapurl_from_serverid
+from lib389.dseutils import get_ldapurl_from_serverid
 
 SUFFIX = 'dc=anuj,dc=com'
 

--- a/dirsrvtests/tests/suites/healthcheck/health_config_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_config_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -33,7 +33,17 @@ JSON_OUTPUT = '[]'
 log = logging.getLogger(__name__)
 
 
+def stop_and_flush(inst):
+    inst.stop()
+    inst.lint_clear_dse_cache()
+
+
 def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
+    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
+       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
+        searched_code = 'DSBLE0006'
+
     args = FakeArgs()
     args.instance = instance.serverid
     args.verbose = instance.verbose
@@ -42,11 +52,6 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
     args.check = ['config', 'refint', 'backends', 'monitor-disk-space', 'logs', 'memberof']
     args.dry_run = False
     args.exclude_check = []
-
-    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
-    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
-        searched_code = 'DSBLE0006'
 
     if json:
         log.info('Use healthcheck with --json option')
@@ -128,12 +133,26 @@ def test_healthcheck_RI_plugin_is_misconfigured(topology_st):
     log.info('Set the referint-update-delay attribute to a value upper than 0')
     plugin.replace('referint-update-delay', '5')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
     log.info('Set the referint-update-delay attribute back to 0')
     plugin.replace('referint-update-delay', '0')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -179,12 +198,26 @@ def test_healthcheck_RI_plugin_missing_indexes(topology_st):
     index = Index(topology_st.standalone, MEMBER_DN)
     index.replace('nsIndexType', 'approx')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
     log.info('Set the index type of the member attribute index back to eq')
     index.replace('nsIndexType', 'eq')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -225,6 +258,13 @@ def test_healthcheck_MO_plugin_missing_indexes(topology_st):
     plugin.add('memberofgroupattr', MO_GROUP_ATTR)
     time.sleep(.5)
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -233,6 +273,13 @@ def test_healthcheck_MO_plugin_missing_indexes(topology_st):
     be.add_index(MO_GROUP_ATTR, "eq", None)
     time.sleep(.5)
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
     # Restart the intsnce after changing the plugin to avoid breaking the other tests
@@ -294,12 +341,26 @@ def test_healthcheck_MO_plugin_substring_index(topology_st):
     index = Index(topology_st.standalone, MEMBER_DN)
     index.replace('nsIndexType', 'sub')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
     log.info('Set the index type of the member attribute index back to eq')
     index.replace('nsIndexType', 'eq')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -307,12 +368,26 @@ def test_healthcheck_MO_plugin_substring_index(topology_st):
     index = Index(topology_st.standalone, UNIQUE_MEMBER_DN)
     index.replace('nsIndexType', 'sub')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
     log.info('Set the index type of the uniquemember attribute index back to eq')
     index.replace('nsIndexType', 'eq')
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -364,6 +439,13 @@ def test_healthcheck_MO_plugin_global_lock(topology_st):
     assert plugin.get_attr_val_utf8('memberOfAllBackends') == "off"
     assert standalone.config.get_attr_val_utf8('nsslapd-global-backend-lock') == 'off'
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
@@ -373,10 +455,18 @@ def test_healthcheck_MO_plugin_global_lock(topology_st):
     assert plugin.get_attr_val_utf8('memberOfAllBackends') == "on"
     assert standalone.config.get_attr_val_utf8('nsslapd-global-backend-lock') == 'off'
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
     # Restart the instance after changing the plugin to avoid breaking the other tests
+    plugin.replace('memberOfAllBackends', 'off')
     standalone.restart()
 
 
@@ -405,6 +495,8 @@ def test_healthcheck_virtual_attr_incorrectly_indexed(topology_st):
     RET_CODE = 'DSVIRTLE0001'
 
     standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
+
     postal_index_properties = {
         'cn': 'postalcode',
         'nsSystemIndex': 'False',
@@ -516,7 +608,7 @@ def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
     db_cfg.set([('nsslapd-idlistscanlimit', '100')])
 
     log.info('Stopping the server and running offline import...')
-    standalone.stop()
+    stop_and_flush(standalone)
     assert standalone.ldif2db(bename=DEFAULT_BENAME, suffixes=[DEFAULT_SUFFIX], encrypt=None, excludeSuffixes=None,
                               import_file=import_ldif)
     standalone.start()
@@ -531,6 +623,13 @@ def test_healthcheck_notes_unindexed_search(topology_st, setup_ldif):
 
     standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
@@ -582,6 +681,13 @@ def test_healthcheck_notes_unknown_attribute(topology_st, setup_ldif):
     assert standalone.ds_access_log.match(r'.*notes=F.*')
 
     standalone.config.set("nsslapd-accesslog-logbuffering", "on")
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
@@ -607,10 +713,18 @@ def test_healthcheck_unauth_binds(topology_st):
     RET_CODE = 'DSCLE0003'
 
     inst = topology_st.standalone
+    inst.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('nsslapd-allow-unauthenticated-binds to on')
     inst.config.set("nsslapd-allow-unauthenticated-binds", "on")
 
+    stop_and_flush(inst)
+    try:
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
 
@@ -644,6 +758,13 @@ def test_healthcheck_accesslog_buffering(topology_st):
     log.info('nsslapd-accesslog-logbuffering to off')
     inst.config.set("nsslapd-accesslog-logbuffering", "off")
 
+    stop_and_flush(inst)
+    try:
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
 
@@ -673,10 +794,19 @@ def test_healthcheck_securitylog_buffering(topology_st):
     RET_CODE = 'DSCLE0005'
 
     inst = topology_st.standalone
+    inst.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('nsslapd-securitylog-logbuffering to off')
+    inst.config.set('nsslapd-securitylog-logging-enabled', 'on')
     inst.config.set("nsslapd-securitylog-logbuffering", "off")
 
+    stop_and_flush(inst)
+    try:
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
 
@@ -706,12 +836,20 @@ def test_healthcheck_auditlog_buffering(topology_st):
     RET_CODE = 'DSCLE0006'
 
     inst = topology_st.standalone
+    inst.config.set("nsslapd-accesslog-logbuffering", "on")
     enabled = inst.config.get_attr_val_utf8('nsslapd-auditlog-logging-enabled')
 
     log.info('nsslapd-auditlog-logbuffering to off')
     inst.config.set('nsslapd-auditlog-logging-enabled', 'on')
     inst.config.set('nsslapd-auditlog-logbuffering', 'off')
 
+    stop_and_flush(inst)
+    try:
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, inst, RET_CODE, json=True)
 

--- a/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_repl_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -207,11 +207,11 @@ def test_healthcheck_changelog_trimming_not_configured(topology_m2):
     :steps:
         1. Create a replicated topology
         2. On M1, check that value of nsslapd-changelogmaxage from cn=changelog5,cn=config is None
-        3. Use HealthCheck without --json option
-        4. Use HealthCheck with --json option
-        5. On M1, set nsslapd-changelogmaxage to 30d
-        6. Use HealthCheck without --json option
-        7. Use HealthCheck with --json option
+        3. Stop M1 and use HealthCheck without --json option (offline; reads dse.ldif)
+        4. Stop M1 and use HealthCheck with --json option
+        5. Start M1, set nsslapd-changelogmaxage to 30d
+        6. Stop M1 and use HealthCheck without --json option
+        7. Stop M1 and use HealthCheck with --json option
     :expectedresults:
         1. Success
         2. Success
@@ -235,13 +235,34 @@ def test_healthcheck_changelog_trimming_not_configured(topology_m2):
 
     time.sleep(3)
 
-    run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=False)
-    run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=True)
+    try:
+        log.info('Run healthcheck expect DSCLLE0001')
 
-    set_changelog_trimming(M1)
+        run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=False)
+        run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=True)
 
-    run_healthcheck_and_check_result(topology_m2, M1, CMD_OUTPUT, json=False)
-    run_healthcheck_and_check_result(topology_m2, M1, JSON_OUTPUT, json=True)
+        log.info("Stopped server and testing offline mode ....")
+        M1.stop()
+        M1.lint_clear_dse_cache()
+        run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=False)
+        run_healthcheck_and_check_result(topology_m2, M1, RET_CODE, json=True)
+
+        log.info('Start M1 and configure changelog trimming (requires LDAP)')
+        M1.start()
+        set_changelog_trimming(M1)
+
+        run_healthcheck_and_check_result(topology_m2, M1, CMD_OUTPUT, json=False)
+        run_healthcheck_and_check_result(topology_m2, M1, JSON_OUTPUT, json=True)
+
+        log.info("Stopped server and testing offline mode ....")
+        M1.stop()
+        M1.lint_clear_dse_cache()
+        run_healthcheck_and_check_result(topology_m2, M1, CMD_OUTPUT, json=False)
+        run_healthcheck_and_check_result(topology_m2, M1, JSON_OUTPUT, json=True)
+
+    finally:
+        if not M1.status():
+            M1.start()
 
 
 @pytest.mark.xfail(ds_is_older("1.4.1"), reason="Not implemented")
@@ -318,6 +339,12 @@ def test_healthcheck_non_replicated_suffixes(topology_m2):
     args.json = False
     args.exclude_check = []
 
+    inst.stop()
+    try:
+        health_check_run(inst, topology_m2.logcap.log, args)
+    finally:
+        if not inst.status():
+            inst.start()
     health_check_run(inst, topology_m2.logcap.log, args)
 
 

--- a/dirsrvtests/tests/suites/healthcheck/health_security_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_security_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -97,6 +97,13 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
     log.info('Configure an insecure passwordStorageScheme (SHA)')
     standalone.config.set('passwordStorageScheme', 'SHA')
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -105,6 +112,13 @@ def test_healthcheck_insecure_pwd_hash_configured(topology_st):
     standalone.config.set('passwordStorageScheme', 'PBKDF2-SHA512')
     standalone.config.set('nsslapd-rootpwstoragescheme', 'PBKDF2-SHA512')
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -151,6 +165,13 @@ def test_healthcheck_min_allowed_tls_version_too_low(topology_st):
     enc.replace('sslVersionMin', SMALL_VS)
     standalone.restart()
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -158,6 +179,13 @@ def test_healthcheck_min_allowed_tls_version_too_low(topology_st):
     enc.replace('sslVersionMin', HIGHER_VS)
     standalone.restart()
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -197,12 +225,26 @@ def test_healthcheck_resolvconf_bad_file_perm(topology_st):
     log.info('Change the /etc/resolv.conf file permissions to 444')
     os.chmod('/etc/resolv.conf', 0o444)
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
     log.info('Change the /etc/resolv.conf file permissions to 644')
     os.chmod('/etc/resolv.conf', 0o644)
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
@@ -239,12 +281,26 @@ def test_healthcheck_pwdfile_bad_file_perm(topology_st):
     log.info('Change the /etc/dirsrv/slapd-{}/pwdfile.txt permissions to 000'.format(standalone.serverid))
     os.chmod('{}/pwdfile.txt'.format(cert_dir), 0o000)
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
     log.info('Change the /etc/dirsrv/slapd-{}/pwdfile.txt permissions to 400'.format(standalone.serverid))
     os.chmod('{}/pwdfile.txt'.format(cert_dir), 0o400)
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
@@ -278,10 +334,24 @@ def test_healthcheck_certif_expiring_within_30d(topology_st):
 
     with libfaketime.fake_time(date_future):
         time.sleep(1)
+        standalone.stop()
+        try:
+            run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+            run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+        finally:
+            if not standalone.status():
+                standalone.start()
         run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
         run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
     # Try again with real time just to make sure no issues were found
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 
@@ -315,10 +385,24 @@ def test_healthcheck_certif_expired(topology_st):
 
     with libfaketime.fake_time(date_future):
         time.sleep(1)
+        standalone.stop()
+        try:
+            run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
+            run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
+        finally:
+            if not standalone.status():
+                standalone.start()
         run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=False)
         run_healthcheck_and_flush_log(topology_st, standalone, RET_CODE, json=True)
 
     # Try again with real time just to make sure no issues were found
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, JSON_OUTPUT, json=True)
 

--- a/dirsrvtests/tests/suites/healthcheck/health_skew_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_skew_test.py
@@ -25,12 +25,12 @@ log = logging.getLogger(__name__)
 
 
 def run_healthcheck_and_check_result(instance, searched_code, json=False, isnot=False):
-    """Run healthcheck and verify the expected code is in the output"""
+    """Run dsctl healthcheck and verify the expected code is in the output."""
+    expected = JSON_OUTPUT if json and searched_code == CMD_OUTPUT else searched_code
+
     cmd = ['dsctl']
     if json:
         cmd.append('--json')
-        if searched_code == CMD_OUTPUT:
-            searched_code = JSON_OUTPUT
     cmd.append(instance.serverid)
     cmd.extend(['healthcheck', '--check', 'dseldif:nsstate'])
 
@@ -46,13 +46,13 @@ def run_healthcheck_and_check_result(instance, searched_code, json=False, isnot=
     assert len(stdout) > 0
 
     if isnot:
-        assert searched_code not in stdout, \
-            f'{searched_code} should NOT be in healthcheck output but was found'
-        log.info(f'Verified {searched_code} is NOT in healthcheck output')
+        assert expected not in stdout, \
+            f'{expected} should NOT be in healthcheck output but was found'
+        log.info(f'Verified {expected} is NOT in healthcheck output')
     else:
-        assert searched_code in stdout, \
-            f'{searched_code} should be in healthcheck output but was not found'
-        log.info(f'Verified {searched_code} is in healthcheck output')
+        assert expected in stdout, \
+            f'{expected} should be in healthcheck output but was not found'
+        log.info(f'Verified {expected} is in healthcheck output')
 
 
 def test_healthcheck_time_skew_extensive(topology_m2):
@@ -108,6 +108,13 @@ def test_healthcheck_time_skew_extensive(topology_m2):
 
     # Step 5: Verify DSSKEWLE0003 is reported
     log.info('Run healthcheck and verify DSSKEWLE0003 is reported')
+    M1.stop()
+    try:
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False)
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=True)
+    finally:
+        if not M1.status():
+            M1.start()
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False)
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=True)
 
@@ -117,6 +124,13 @@ def test_healthcheck_time_skew_extensive(topology_m2):
 
     # Step 7: Verify DSSKEWLE0003 is NOT reported when ignoring time skew
     log.info('Run healthcheck and verify DSSKEWLE0003 is NOT reported')
+    M1.stop()
+    try:
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False, isnot=True)
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=True, isnot=True)
+    finally:
+        if not M1.status():
+            M1.start()
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False, isnot=True)
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=True, isnot=True)
 
@@ -135,6 +149,15 @@ def test_healthcheck_time_skew_extensive(topology_m2):
 
     # Step 11: Verify only DSSKEWLE0004 is reported (not DSSKEWLE0003)
     log.info('Run healthcheck and verify only DSSKEWLE0004 is reported')
+    M1.stop()
+    try:
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0004', json=False)
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0004', json=True)
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False, isnot=True)
+        run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=True, isnot=True)
+    finally:
+        if not M1.status():
+            M1.start()
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0004', json=False)
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0004', json=True)
     run_healthcheck_and_check_result(M1, 'DSSKEWLE0003', json=False, isnot=True)

--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -26,6 +26,11 @@ pytestmark = pytest.mark.tier1
 CMD_OUTPUT = "No issues found."
 JSON_OUTPUT = "[]"
 log = logging.getLogger(__name__)
+
+
+def stop_and_flush(inst):
+    inst.stop()
+    inst.lint_clear_dse_cache()
 
 
 @pytest.fixture(scope="function")
@@ -85,6 +90,14 @@ def log_buffering_enabled(topology_st, request):
 
 
 def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
+    if (
+        ds_is_newer("3.0.0")
+        and instance.get_db_lib() == "bdb"
+        and (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT)
+    ):
+        searched_code = "DSBLE0006"
+
     args = FakeArgs()
     args.instance = instance.serverid
     args.verbose = instance.verbose
@@ -100,14 +113,6 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
         "memberof",
     ]
     args.dry_run = False
-
-    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
-    if (
-        ds_is_newer("3.0.0")
-        and instance.get_db_lib() == "bdb"
-        and (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT)
-    ):
-        searched_code = "DSBLE0006"
 
     if json:
         log.info("Use healthcheck with --json option")
@@ -167,12 +172,31 @@ def test_missing_parentid(topology_st, log_buffering_enabled):
     parentid_index = Index(standalone, PARENTID_DN)
     parentid_index.delete()
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
+
+    # The server adds the index config entry at server startup so we need to
+    # delete it again
+    parentid_index.delete()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
     log.info("Re-add the parentId index")
     backend = Backends(standalone).get("userRoot")
     backend.add_index("parentid", ["eq"], matching_rules=["integerOrderingMatch"])
+
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
 
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
@@ -206,6 +230,13 @@ def test_missing_matching_rule(topology_st, log_buffering_enabled):
     parentid_index = Index(standalone, PARENTID_DN)
     parentid_index.remove("nsMatchingRule", "integerOrderingMatch")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -249,6 +280,17 @@ def test_usn_plugin_missing_entryusn(topology_st, usn_plugin_enabled, log_buffer
     entryusn_index = Index(standalone, ENTRYUSN_DN)
     entryusn_index.delete()
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
+
+    # The server adds the index config entry at server startup so we need to
+    # delete it again
+    entryusn_index.delete()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -256,6 +298,13 @@ def test_usn_plugin_missing_entryusn(topology_st, usn_plugin_enabled, log_buffer
     backend = Backends(standalone).get("userRoot")
     backend.add_index("entryusn", ["eq"], matching_rules=["integerOrderingMatch"])
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -294,6 +343,13 @@ def test_usn_plugin_missing_matching_rule(topology_st, usn_plugin_enabled, log_b
     entryusn_index = Index(standalone, ENTRYUSN_DN)
     entryusn_index.remove("nsMatchingRule", "integerOrderingMatch")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -301,6 +357,13 @@ def test_usn_plugin_missing_matching_rule(topology_st, usn_plugin_enabled, log_b
     entryusn_index = Index(standalone, ENTRYUSN_DN)
     entryusn_index.add("nsMatchingRule", "integerOrderingMatch")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -339,6 +402,14 @@ def test_retrocl_plugin_missing_changenumber(topology_st, retrocl_plugin_enabled
     changenumber_index = Index(standalone, changenumber_dn)
     changenumber_index.delete()
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
+
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -348,6 +419,13 @@ def test_retrocl_plugin_missing_changenumber(topology_st, retrocl_plugin_enabled
     changelog_backend.add_index("changenumber", ["eq"], matching_rules=["integerOrderingMatch"])
     log.info("Successfully re-added changeNumber index")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -386,6 +464,13 @@ def test_retrocl_plugin_missing_matching_rule(topology_st, retrocl_plugin_enable
     changenumber_index = Index(standalone, changenumber_dn)
     changenumber_index.remove("nsMatchingRule", "integerOrderingMatch")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -394,6 +479,13 @@ def test_retrocl_plugin_missing_matching_rule(topology_st, retrocl_plugin_enable
     changenumber_index.add("nsMatchingRule", "integerOrderingMatch")
     log.info("Successfully re-added integerOrderingMatch to changeNumber index")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 
@@ -433,6 +525,19 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
         index.delete()
         log.info(f"Successfully removed index: {index_dn}")
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+    finally:
+        if not standalone.status():
+            standalone.start()
+
+    # The server adds the index config entries at server startup so we need to
+    # delete it again
+    for index_dn in [PARENTID_DN, NSUNIQUEID_DN]:
+        index = Index(standalone, index_dn)
+        index.delete()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
 
@@ -442,6 +547,13 @@ def test_multiple_missing_indexes(topology_st, log_buffering_enabled):
     backend.add_index("nsuniqueid", ["eq"])
     standalone.restart()
 
+    stop_and_flush(standalone)
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+        run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
     run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
 

--- a/dirsrvtests/tests/suites/healthcheck/health_tunables_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_tunables_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -27,6 +27,11 @@ p = Paths()
 
 def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=False, searched_code2=None,
                                   list_checks=False, list_errors=False, check=None, searched_list=None):
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
+    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
+       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
+        searched_code = 'DSBLE0006'
+
     args = FakeArgs()
     args.instance = instance.serverid
     args.verbose = instance.verbose
@@ -39,11 +44,6 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code=None, json=F
 
     log.info('Use healthcheck with --json == {} option'.format(json))
     health_check_run(instance, topology.logcap.log, args)
-
-    # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
-    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
-        searched_code = 'DSBLE0006'
 
     if searched_list is not None:
         for item in searched_list:
@@ -133,7 +133,7 @@ def test_healthcheck_transparent_huge_pages(topology_st, system_thp_mode, instan
         12. Use HealthCheck with --json option
     :expectedresults:
         1. Success
-        2. HealthCheck should return code DSHTPLE0001
+        2. HealthCheck should return code DSTHPLE0001
         3. HealthCheck should return code DSTHPLE0001
         4. Success
         5. HealthCheck reports no issue found
@@ -150,5 +150,16 @@ def test_healthcheck_transparent_huge_pages(topology_st, system_thp_mode, instan
 
     _set_thp_system_mode(system_thp_mode)
     _set_thp_instance_mode(standalone, instance_thp_mode)
+
     run_healthcheck_and_flush_log(topology_st, standalone, expected_output[0], json=False)
     run_healthcheck_and_flush_log(topology_st, standalone, expected_output[1], json=True)
+
+    standalone.stop()
+
+    try:
+        run_healthcheck_and_flush_log(topology_st, standalone, expected_output[0], json=False)
+        run_healthcheck_and_flush_log(topology_st, standalone, expected_output[1], json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
+

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -34,21 +34,21 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
                                   json=False, searched_code2=None,
                                   list_checks=False, list_errors=False,
                                   check=None, searched_list=None):
+    # If we are using BDB as a backend, we will get error DSBLE0006 on new
+    # versions
+    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
+       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
+        searched_code = 'DSBLE0006'
+
     args = FakeArgs()
     args.instance = instance.serverid
     args.verbose = instance.verbose
     args.list_errors = list_errors
     args.list_checks = list_checks
     args.check = check
-    args.exclude_check = []
+    args.exclude_check = ['tunables:thp']
     args.dry_run = False
     args.json = json
-
-    # If we are using BDB as a backend, we will get error DSBLE0006 on new
-    # versions
-    if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
-        searched_code = 'DSBLE0006'
 
     log.info('Use healthcheck with --json == {} option'.format(json))
     health_check_run(instance, logcap.log, args)
@@ -62,12 +62,13 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
         log.info('Healthcheck returned searched code: %s', searched_code)
 
     if searched_code2 is not None:
+        code2 = searched_code2
         if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
            (searched_code2 is CMD_OUTPUT or searched_code2 is JSON_OUTPUT):
-            searched_code = 'DSBLE0006'
+            code2 = 'DSBLE0006'
 
-        assert logcap.contains(searched_code2)
-        log.info('Healthcheck returned searched code: %s', searched_code2)
+        assert logcap.contains(code2)
+        log.info('Healthcheck returned searched code: %s', code2)
 
     log.info('Clear the log')
     logcap.flush()
@@ -125,8 +126,10 @@ def test_healthcheck_disabled_suffix(topology_st):
     mt.replace("nsslapd-state", "disabled")
     topology_st.standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
-    run_healthcheck_and_flush_log(topology_st.logcap, topology_st.standalone, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_st.logcap, topology_st.standalone, RET_CODE, json=True)
+    standalone = topology_st.standalone
+
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
 
     # reset the suffix state
     mt.replace("nsslapd-state", "backend")
@@ -149,7 +152,15 @@ def test_healthcheck_standalone(topology_st):
     """
 
     standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
@@ -171,25 +182,42 @@ def test_healthcheck_list_checks(topology_st):
     """
 
     output_list = ['config:passwordscheme',
+                   'config:auditlog_buffering',
+                   # 'config:accesslog_buffering',  Skip test access log buffering is disabled
+                   'config:securitylog_buffering',
+                   'config:unauth_binds',
                    'backends:userroot:cl_trimming',
                    'backends:userroot:mappingtree',
                    'backends:userroot:search',
+                   'backends:userroot:system_indexes',
                    'backends:userroot:virt_attrs',
+                   'backends:userroot:backend_implementation',
+                   'backends:userroot:backend_implementation_cleanup_needed',
+                   'backends:userroot:backend_implementation_config_attributes',
                    'encryption:check_tls_version',
                    'fschecks:file_perms',
                    'refint:attr_indexes',
                    'refint:update_delay',
+                   'memberof:member_attr_indexes',
+                   'memberof:member_globalbackend_lock',
+                   'memberof:member_substring_index',
                    'monitor-disk-space:disk_space',
                    'replication:agmts_status',
                    'replication:conflicts',
+                   'replication:no_ruv',
                    'dseldif:nsstate',
                    'tls:certificate_expiration',
                    'logs:notes',
-                   'tunables:thp',
-                   ]
+                   'tunables:thp']
 
     standalone = topology_st.standalone
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_checks=True, searched_list=output_list)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_checks=True, searched_list=output_list)
 
 
@@ -243,6 +271,12 @@ def test_healthcheck_list_errors(topology_st):
 
     standalone = topology_st.standalone
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_errors=True, searched_list=output_list)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, json=False, list_errors=True, searched_list=output_list)
 
 
@@ -263,18 +297,25 @@ def test_healthcheck_check_option(topology_st):
     """
 
     output_list = ['config:passwordscheme',
+                   'config:auditlog_buffering',
                    # 'config:accesslog_buffering',  Skip test access log buffering is disabled
                    'config:securitylog_buffering',
                    'config:unauth_binds',
                    'backends:userroot:cl_trimming',
                    'backends:userroot:mappingtree',
                    'backends:userroot:search',
+                   'backends:userroot:system_indexes',
                    'backends:userroot:virt_attrs',
+                   'backends:userroot:backend_implementation',
+                   'backends:userroot:backend_implementation_cleanup_needed',
+                   'backends:userroot:backend_implementation_config_attributes',
                    'encryption:check_tls_version',
                    'fschecks:file_perms',
                    'refint:attr_indexes',
                    'refint:update_delay',
                    'memberof:member_attr_indexes',
+                   'memberof:member_globalbackend_lock',
+                   'memberof:member_substring_index',
                    'monitor-disk-space:disk_space',
                    'replication:agmts_status',
                    'replication:conflicts',
@@ -288,6 +329,14 @@ def test_healthcheck_check_option(topology_st):
     for item in output_list:
         pattern = 'Checking ' + item
         log.info('Check {}'.format(item))
+        standalone.stop()
+
+        try:
+            run_healthcheck_and_flush_log(topology_st.logcap, standalone, searched_code=pattern, json=False, check=[item],
+                                          searched_code2=CMD_OUTPUT)
+        finally:
+            if not standalone.status():
+                standalone.start()
         run_healthcheck_and_flush_log(topology_st.logcap, standalone, searched_code=pattern, json=False, check=[item],
                                       searched_code2=CMD_OUTPUT)
 
@@ -320,6 +369,15 @@ def test_healthcheck_exclude_option(topology_st):
         log.info('Exclude check: %s unwanted: %s wanted: %s',
                  exclude, unwanted, wanted)
 
+        inst.stop()
+        try:
+            run_healthcheck_exclude(topology_st.logcap, inst,
+                                    unwanted=unwanted_pattern,
+                                    wanted=wanted_pattern,
+                                    exclude_check=exclude)
+        finally:
+            if not inst.status():
+                inst.start()
         run_healthcheck_exclude(topology_st.logcap, inst,
                                 unwanted=unwanted_pattern,
                                 wanted=wanted_pattern,
@@ -345,9 +403,17 @@ def test_healthcheck_standalone_tls(topology_st):
     """
 
     standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
     standalone.enable_tls()
 
-    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT,json=False)
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
+    run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
 
@@ -379,10 +445,24 @@ def test_healthcheck_replication(topology_m2):
     M2.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('Run healthcheck for supplier1')
+    M1.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
+    finally:
+        if not M1.status():
+            M1.start()
     run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
 
     log.info('Run healthcheck for supplier2')
+    M2.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
+    finally:
+        if not M2.status():
+            M2.start()
     run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
 
@@ -416,10 +496,24 @@ def test_healthcheck_replication_tls(topology_m2):
     log.info('Run healthcheck for supplier1')
     M1.config.set("nsslapd-accesslog-logbuffering", "on")
     M2.config.set("nsslapd-accesslog-logbuffering", "on")
+    M1.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
+    finally:
+        if not M1.status():
+            M1.start()
     run_healthcheck_and_flush_log(topology_m2.logcap, M1, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_m2.logcap, M1, JSON_OUTPUT, json=True)
 
     log.info('Run healthcheck for supplier2')
+    M2.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
+    finally:
+        if not M2.status():
+            M2.start()
     run_healthcheck_and_flush_log(topology_m2.logcap, M2, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_m2.logcap, M2, JSON_OUTPUT, json=True)
 
@@ -453,12 +547,20 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
     RET_CODE2 = 'DSBLE0003'
 
     standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('Delete the dc=example,dc=com backend suffix entry in the mapping tree')
     mts = MappingTrees(standalone)
     mt = mts.get(DEFAULT_SUFFIX)
     mt.delete()
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=False, searched_code2=RET_CODE2)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE1, json=True, searched_code2=RET_CODE2)
 
@@ -469,6 +571,13 @@ def test_healthcheck_backend_missing_mapping_tree(topology_st):
         'nsslapd-backend': 'USERROOT',
     })
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, CMD_OUTPUT, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, JSON_OUTPUT, json=True)
 
@@ -499,6 +608,7 @@ def test_healthcheck_unable_to_query_backend(topology_st):
     NEW_BACKEND = 'userData'
 
     standalone = topology_st.standalone
+    standalone.config.set("nsslapd-accesslog-logbuffering", "on")
 
     log.info('Create new suffix')
     backends = Backends(standalone)
@@ -512,11 +622,25 @@ def test_healthcheck_unable_to_query_backend(topology_st):
     mt_new = mts.get(NEW_SUFFIX)
     mt_new.replace('nsslapd-state', 'disabled')
 
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
 
     log.info('Enable the suffix again and check if nothing is broken')
     mt_new.replace('nsslapd-state', 'backend')
+    standalone.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
+    finally:
+        if not standalone.status():
+            standalone.start()
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, standalone, RET_CODE, json=True)
 
@@ -590,6 +714,11 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
+    inst.stop()
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+
+
 
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")
 def test_lint_backend_implementation(topology_st):
@@ -610,6 +739,13 @@ def test_lint_backend_implementation(topology_st):
     RET_CODE = 'DSBLE0006'
     inst = topology_st.standalone
 
+    inst.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -715,12 +715,9 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
     inst.stop()
-    try:
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
-    finally:
-        if not inst.status():
-            inst.start()
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+
 
 
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -715,9 +715,12 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
     inst.stop()
-    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
-    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
-
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start()
 
 
 @pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -15,7 +15,7 @@ from lib389.replica import Changelog5,  Changelog
 from lib389.utils import *
 from lib389._constants import *
 from lib389.cli_base import FakeArgs
-from lib389.topologies import topology_st, topology_no_sample, topology_m2
+from test389.topologies import topology_st, topology_no_sample, topology_m2
 from lib389.cli_ctl.health import health_check_run
 from lib389.paths import Paths
 
@@ -57,6 +57,10 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
             assert logcap.contains(item)
             log.info('Healthcheck returned searched item: %s', item)
     else:
+        if not logcap.contains(searched_code):
+            print("DEBUG logcap does not contain searched code: %s", searched_code)
+            print("DEBUG logcap contents: ", logcap.print())
+
         assert logcap.contains(searched_code)
         log.info('Healthcheck returned searched code: %s', searched_code)
 
@@ -67,7 +71,7 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
             code2 = 'DSBLE0006'
 
         assert logcap.contains(code2)
-        log.info('Healthcheck returned searched code: %s', code2)
+        log.info('Healthcheck returned searched code2: %s', code2)
 
     log.info('Clear the log')
     logcap.flush()
@@ -746,6 +750,7 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
     inst.stop()
+    print("DEBUG trying test with server stopped!!!!!!!!")
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 

--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -9,18 +9,15 @@
 
 import pytest
 import os
-from lib389 import DirSrv
-from lib389.backend import Backends, DatabaseConfig
+from lib389.backend import Backends
 from lib389.mappingTree import MappingTrees
 from lib389.replica import Changelog5,  Changelog
 from lib389.utils import *
 from lib389._constants import *
-from lib389.cli_base import FakeArgs, LogCapture
-from test389.topologies import topology_st, topology_no_sample, topology_m2
+from lib389.cli_base import FakeArgs
+from lib389.topologies import topology_st, topology_no_sample, topology_m2
 from lib389.cli_ctl.health import health_check_run
-from lib389.cli_conf.backend import db_config_set
 from lib389.paths import Paths
-from lib389.instance.setup import SetupDs
 
 CMD_OUTPUT = 'No issues found.'
 JSON_OUTPUT = '[]'
@@ -36,8 +33,10 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
                                   check=None, searched_list=None):
     # If we are using BDB as a backend, we will get error DSBLE0006 on new
     # versions
+
     if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-       (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT):
+        ((check is not None and check[0] == "backends:userroot:backend_implementation") or
+         (searched_code is CMD_OUTPUT or searched_code is JSON_OUTPUT)):
         searched_code = 'DSBLE0006'
 
     args = FakeArgs()
@@ -46,7 +45,7 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
     args.list_errors = list_errors
     args.list_checks = list_checks
     args.check = check
-    args.exclude_check = ['tunables:thp']
+    args.exclude_check = []
     args.dry_run = False
     args.json = json
 
@@ -64,7 +63,7 @@ def run_healthcheck_and_flush_log(logcap, instance, searched_code=None,
     if searched_code2 is not None:
         code2 = searched_code2
         if ds_is_newer("3.0.0") and instance.get_db_lib() == 'bdb' and \
-           (searched_code2 is CMD_OUTPUT or searched_code2 is JSON_OUTPUT):
+            (check is not None and check[0] == "backends:userroot:backend_implementation"):
             code2 = 'DSBLE0006'
 
         assert logcap.contains(code2)
@@ -321,6 +320,7 @@ def test_healthcheck_check_option(topology_st):
                    'replication:conflicts',
                    'replication:no_ruv',
                    'dseldif:nsstate',
+                   'tunables:thp',
                    'tls:certificate_expiration',
                    'logs:notes']
 
@@ -668,6 +668,37 @@ def test_healthcheck_database_not_initialized(topology_no_sample):
     run_healthcheck_and_flush_log(topology_no_sample.logcap, standalone, RET_CODE, json=True)
 
 
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")
+def test_lint_backend_implementation(topology_st):
+    """Test the lint for backend implementation mismatch
+
+    :id: eff607de-768a-4cf4-bcde-48d4c7368934
+    :setup: Custom instance with db_lib set to either mdb or bdb.
+    :steps:
+        1. Fetch the 'nsslapd-backend-implement' attribute value.
+        2. Manually set BDB as the backend implementation if MDB
+        3. Run the linting function to check if BDB is used
+    :expectedresults:
+        1. The 'nsslapd-backend-implement' attribute is fetched correctly.
+        2. The implementation is set to BDB.
+        3. The linting function identifies that BDB is still used as a backend and reports the correct severity issue.
+    """
+
+    RET_CODE = 'DSBLE0006'
+    inst = topology_st.standalone
+
+    inst.stop()
+    try:
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+    finally:
+        if not inst.status():
+            inst.start(post_open=False)
+
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
+    run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
+
+
 def create_dummy_db_files(inst, backend_type):
     # Define the sets of dummy files for each backend type
     mdb_files = ['data.mdb', 'lock.mdb', 'INFO.mdb']
@@ -715,40 +746,6 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
     inst.stop()
-    try:
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
-    finally:
-        if not inst.status():
-            inst.start()
-
-
-@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not needed for mdb")
-def test_lint_backend_implementation(topology_st):
-    """Test the lint for backend implementation mismatch
-
-    :id: eff607de-768a-4cf4-bcde-48d4c7368934
-    :setup: Custom instance with db_lib set to either mdb or bdb.
-    :steps:
-        1. Fetch the 'nsslapd-backend-implement' attribute value.
-        2. Manually set BDB as the backend implementation if MDB
-        3. Run the linting function to check if BDB is used
-    :expectedresults:
-        1. The 'nsslapd-backend-implement' attribute is fetched correctly.
-        2. The implementation is set to BDB.
-        3. The linting function identifies that BDB is still used as a backend and reports the correct severity issue.
-    """
-
-    RET_CODE = 'DSBLE0006'
-    inst = topology_st.standalone
-
-    inst.stop()
-    try:
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
-        run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
-    finally:
-        if not inst.status():
-            inst.start()
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 

--- a/dirsrvtests/tests/suites/replication/urp_test.py
+++ b/dirsrvtests/tests/suites/replication/urp_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -15,6 +15,7 @@ from itertools import permutations, product
 from contextlib import contextmanager
 from lib389.tasks import *
 from lib389.utils import *
+from lib389.dseutils import get_ldapurl_from_serverid
 from lib389.topologies import topology_m3, topology_m2, set_timeout
 from lib389.replica import *
 from lib389._constants import *

--- a/dirsrvtests/tests/suites/replication/urp_test.py
+++ b/dirsrvtests/tests/suites/replication/urp_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -15,7 +15,8 @@ from itertools import permutations, product
 from contextlib import contextmanager
 from lib389.tasks import *
 from lib389.utils import *
-from test389.topologies import topology_m3, topology_m2, set_timeout
+from lib389.dseutils import get_ldapurl_from_serverid
+from lib389.topologies import topology_m3, topology_m2, set_timeout
 from lib389.replica import *
 from lib389._constants import *
 from lib389.properties import TASK_WAIT

--- a/dirsrvtests/tests/suites/replication/urp_test.py
+++ b/dirsrvtests/tests/suites/replication/urp_test.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from lib389.tasks import *
 from lib389.utils import *
 from lib389.dseutils import get_ldapurl_from_serverid
-from lib389.topologies import topology_m3, topology_m2, set_timeout
+from test389.topologies import topology_m3, topology_m2, set_timeout
 from lib389.replica import *
 from lib389._constants import *
 from lib389.properties import TASK_WAIT

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -16,6 +16,7 @@ from datetime import datetime
 from contextlib import contextmanager, suppress
 from lib389.tasks import *
 from lib389.utils import *
+from lib389.dseutils import get_ldapurl_from_serverid
 from lib389.topologies import topology_m2, topology_st
 from lib389.replica import *
 from lib389._constants import *

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager, suppress
 from lib389.tasks import *
 from lib389.utils import *
 from lib389.dseutils import get_ldapurl_from_serverid
-from lib389.topologies import topology_m2, topology_st
+from test389.topologies import topology_m2, topology_st
 from lib389.replica import *
 from lib389._constants import *
 from lib389.properties import TASK_WAIT

--- a/dirsrvtests/tests/suites/vlv/regression_test.py
+++ b/dirsrvtests/tests/suites/vlv/regression_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -16,7 +16,8 @@ from datetime import datetime
 from contextlib import contextmanager, suppress
 from lib389.tasks import *
 from lib389.utils import *
-from test389.topologies import topology_m2, topology_st
+from lib389.dseutils import get_ldapurl_from_serverid
+from lib389.topologies import topology_m2, topology_st
 from lib389.replica import *
 from lib389._constants import *
 from lib389.properties import TASK_WAIT

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -1010,7 +1010,6 @@ deferred_mod_func(MemberofDeferredModTask *task)
     LDAPMod **mods;
     Slapi_DN *sdn;
     Slapi_Entry *pre_e = NULL;
-    Slapi_Entry *post_e = NULL;
     int ret = SLAPI_PLUGIN_SUCCESS;
     int config_copied = 0;
     MemberOfConfig *mainConfig = 0;

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1370,7 +1370,7 @@ int
 referint_postop_close(Slapi_PBlock *pb __attribute__((unused)))
 {
     /* signal the batch thread to exit */
-    if (referint_get_delay() > 0) {
+    if (keeprunning) {
         pthread_mutex_lock(&keeprunning_mutex);
         keeprunning = 0;
         pthread_cond_signal(&keeprunning_cv);

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -1,6 +1,6 @@
 /** BEGIN COPYRIGHT BLOCK
  * Copyright (C) 2001 Sun Microsystems, Inc. Used by permission.
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -1416,7 +1416,7 @@ int
 referint_postop_close(Slapi_PBlock *pb __attribute__((unused)))
 {
     /* signal the batch thread to exit */
-    if (referint_get_delay() > 0) {
+    if (keeprunning) {
         pthread_mutex_lock(&keeprunning_mutex);
         keeprunning = 0;
         pthread_cond_signal(&keeprunning_cv);

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3632,3 +3632,8 @@ class DirSrv(SimpleLDAPObject, object):
         Get the pid of the running server
         """
         return pid_from_file(self.pid_file())
+
+    def lint_clear_dse_cache(self):
+        """Clear the cached dse.ldif for the instance."""
+        self._lib389_dse_lint_cache = None
+        self._lib389_dse_lint_failed = False

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3672,3 +3672,8 @@ class DirSrv(SimpleLDAPObject, object):
         Get the pid of the running server
         """
         return pid_from_file(self.pid_file())
+
+    def lint_clear_dse_cache(self):
+        """Clear the cached dse.ldif for the instance."""
+        self._lib389_dse_lint_cache = None
+        self._lib389_dse_lint_failed = False

--- a/src/lib389/lib389/_mapped_object_lint.py
+++ b/src/lib389/lib389/_mapped_object_lint.py
@@ -1,12 +1,11 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
-from abc import ABC, abstractmethod
 from functools import partial
 from inspect import signature
 from typing import (
@@ -19,6 +18,8 @@ from typing import (
     Generator,
     Any
 )
+from lib389._constants import DIRSRV_STATE_ONLINE
+from lib389.utils import ensure_bytes, ensure_str, ensure_list_str, ensure_int
 
 
 DSLintSpec = Tuple[str, Callable]
@@ -168,3 +169,89 @@ class DSLints():
                 check_name = spec
             for obj in self.list():
                 yield from obj.lint(check_name)
+
+
+def _cached_dse_ldif_for_lint(instance):
+    """Return a cached :class:`lib389.dseldif.DSEldif` for local ``dse.ldif`` reads in lint code."""
+    if not getattr(instance, 'isLocal', False):
+        return None
+    if getattr(instance, '_lib389_dse_lint_cache', None) is not None:
+        return instance._lib389_dse_lint_cache
+    if getattr(instance, '_lib389_dse_lint_failed', False):
+        return None
+    try:
+        from lib389.dseldif import DSEldif
+        dse = DSEldif(instance)
+    except (OSError, IOError, EnvironmentError):
+        instance._lib389_dse_lint_failed = True
+        return None
+    instance._lib389_dse_lint_cache = dse
+    return dse
+
+
+def lint_get_attr_val_utf8(obj, key):
+    """Like :meth:`DSLdapObject.get_attr_val_utf8`, but read ``dse.ldif`` when the server is down."""
+    if obj._instance.state == DIRSRV_STATE_ONLINE:
+        return obj.get_attr_val_utf8(key)
+    dse = _cached_dse_ldif_for_lint(obj._instance)
+    if dse is None:
+        raise ValueError("Invalid state. Cannot get properties on instance that is not ONLINE")
+
+    vals = dse.get(ensure_str(obj._dn).lower(), ensure_str(key), single=False, lower=True)
+    if vals is None:
+        return None
+    if len(vals) == 0:
+        return ''
+    return ensure_str(vals[0])
+
+
+def lint_get_attr_val_utf8_l(obj, key):
+    from lib389.utils import ensure_str
+    v = lint_get_attr_val_utf8(obj, key)
+    if v is None:
+        return None
+    return ensure_str(v).lower()
+
+
+def lint_get_attr_vals_utf8(obj, key):
+    """Like :meth:`DSLdapObject.get_attr_vals_utf8` for one attribute, with offline ``dse.ldif`` support."""
+    if obj._instance.state == DIRSRV_STATE_ONLINE:
+        return obj.get_attr_vals_utf8(key)
+    dse = _cached_dse_ldif_for_lint(obj._instance)
+    if dse is None:
+        raise ValueError("Invalid state. Cannot get properties on instance that is not ONLINE")
+    vals = dse.get(ensure_str(obj._dn).lower(), ensure_str(key), single=False, lower=True)
+    if vals is None:
+        return []
+    return ensure_list_str(vals)
+
+
+def lint_get_attr_vals_utf8_l(obj, key):
+    from lib389.utils import ensure_str
+    return [ensure_str(x).lower() for x in lint_get_attr_vals_utf8(obj, key)]
+
+
+def lint_get_attr_val(obj, key):
+    """Like :meth:`DSLdapObject.get_attr_val` (bytes), with offline ``dse.ldif`` support."""
+    if obj._instance.state == DIRSRV_STATE_ONLINE:
+        return obj.get_attr_val(key)
+    s = lint_get_attr_val_utf8(obj, key)
+    if s is None:
+        return None
+    if s == '':
+        return ''
+    return ensure_bytes(s)
+
+
+def lint_get_attr_val_int(obj, key):
+    if obj._instance.state == DIRSRV_STATE_ONLINE:
+        return obj.get_attr_val_int(key)
+    v = lint_get_attr_val_utf8(obj, key)
+    if v == '' or v is None:
+        return None
+    return ensure_int(v)
+
+
+def lint_plugin_enabled(plugin):
+    """Whether ``nsslapd-pluginEnabled`` is ``on``; works offline via ``dse.ldif``."""
+    return lint_get_attr_val_utf8(plugin, 'nsslapd-pluginEnabled') == 'on'

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -10,11 +10,11 @@ from datetime import datetime
 import os
 import copy
 import ldap
-from lib389._constants import DN_LDBM, DN_CHAIN, DN_PLUGIN, DEFAULT_BENAME
+from lib389._constants import DN_LDBM, DN_CHAIN, DN_PLUGIN, DEFAULT_BENAME, DIRSRV_STATE_ONLINE
 from lib389.properties import BACKEND_OBJECTCLASS_VALUE, BACKEND_PROPNAME_TO_ATTRNAME, BACKEND_CHAIN_BIND_DN, \
                               BACKEND_CHAIN_BIND_PW, BACKEND_CHAIN_URLS, BACKEND_PROPNAME_TO_ATTRNAME, BACKEND_NAME, \
                               BACKEND_SUFFIX, BACKEND_SAMPLE_ENTRIES, TASK_WAIT, TASK_WATCH
-from lib389.utils import normalizeDN, ensure_str, assert_c
+from lib389.utils import normalizeDN, ensure_str, assert_c, get_default_db_lib
 from lib389 import Entry
 
 # Need to fix this ....
@@ -36,6 +36,14 @@ from lib389.configurations import get_sample_entries
 
 from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSVIRTLE0001, DSCLLE0001
 from lib389.plugins import USNPlugin
+from lib389.dseldif import DSEldif
+from lib389._mapped_object_lint import (
+    lint_get_attr_val_utf8,
+    lint_get_attr_val_utf8_l,
+    lint_get_attr_vals_utf8,
+    lint_get_attr_vals_utf8_l,
+    lint_plugin_enabled,
+)
 
 
 def is_subsuffix_of(sub_parent, be_suffix, all_suffixes):
@@ -430,6 +438,14 @@ class BackendLegacy(object):
         return 'backends'
 
 
+def _index_entry_attrs_from_dse(instance, bename, attr_name):
+    """Load one index entry from ``dse.ldif`` (attribute keys lowercased)."""
+    dse = DSEldif(instance)
+    dn = "cn={},cn=index,cn={},cn=ldbm database,cn=plugins,cn=config".format(
+        attr_name.lower(), bename.lower())
+    return dse.get_entry_attrs(dn)
+
+
 class Backend(DSLdapObject):
     """Backend DSLdapObject with:
     - must attributes = ['cn', 'nsslapd-suffix']
@@ -453,16 +469,24 @@ class Backend(DSLdapObject):
         self._mts = MappingTrees(self._instance)
 
     def lint_uid(self):
-        return self.get_attr_val_utf8_l('cn').lower()
+        return lint_get_attr_val_utf8_l(self, 'cn')
 
     def _lint_virt_attrs(self):
         """Check if any virtual attribute are incorrectly indexed"""
         bename = self.lint_uid()
         indexes = self.get_indexes()
-        suffix = self.get_attr_val_utf8('nsslapd-suffix')
+        suffix = lint_get_attr_val_utf8(self, 'nsslapd-suffix')
+        server_running = self._instance.status()
+
         # First check nsrole
         try:
-            indexes.get('nsrole')
+            if server_running:
+                indexes.get('nsrole')
+            else:
+                index = DSLdapObject(self._instance,
+                                     dn=f'cn=nsrole,cn=index,cn={bename},cn=ldbm database,cn=plugins,cn=config')
+                lint_get_attr_vals_utf8_l(index, "objectclass")
+
             report = copy.deepcopy(DSVIRTLE0001)
             report['check'] = f'backends:{bename}:virt_attrs'
             report['detail'] = report['detail'].replace('ATTR', 'nsrole')
@@ -475,11 +499,15 @@ class Backend(DSLdapObject):
         except:
             pass
 
+        if not server_running:
+            # Can not check the database content when the server is not running
+            return
+
         # Check COS next
         for cosDefType in [CosIndirectDefinitions, CosPointerDefinitions, CosClassicDefinitions]:
             defs = cosDefType(self._instance, suffix).list()
             for cosDef in defs:
-                attrs = cosDef.get_attr_val_utf8_l("cosAttribute").split()
+                attrs = lint_get_attr_val_utf8_l(cosDef, "cosAttribute").split()
                 for attr in attrs:
                     if attr in ["default", "override", "operational", "operational-default", "merge-schemes"]:
                         # We are at the end, just break out
@@ -504,7 +532,7 @@ class Backend(DSLdapObject):
     def _lint_search(self):
         """Perform a search and make sure an entry is accessible
         """
-        dn = self.get_attr_val_utf8('nsslapd-suffix')
+        dn = lint_get_attr_val_utf8(self, 'nsslapd-suffix')
         bename = self.lint_uid()
         suffix = DSLdapObject(self._instance, dn=dn)
         try:
@@ -529,11 +557,24 @@ class Backend(DSLdapObject):
         * missing indices if we are local and have log access?
         """
         # Check for the missing mapping tree.
-        suffix = self.get_attr_val_utf8_l('nsslapd-suffix')
+        suffix = lint_get_attr_val_utf8_l(self, 'nsslapd-suffix')
         bename = self.lint_uid()
+        server_running = self._instance.status()
+        mt = None
         try:
-            mt = self._mts.get(suffix)
-            if mt.get_attr_val_utf8_l('nsslapd-backend') != bename.lower() and mt.get_attr_val_utf8('nsslapd-state') != 'backend':
+            if server_running:
+                mt = self._mts.get(suffix)
+            else:
+                dse = DSEldif(self._instance)
+                mapping_trees = dse.get_mapping_trees()
+                for mapping_tree in mapping_trees:
+                    suffixes = lint_get_attr_val_utf8_l(mapping_tree, 'nsslapd-suffix')
+                    for suf in suffixes:
+                        if suf.lower() == suffix:
+                            mt = mapping_tree
+                            break
+            if mt is None or (lint_get_attr_val_utf8_l(mt, 'nsslapd-backend') != bename.lower() and
+                              lint_get_attr_val_utf8(mt, 'nsslapd-state') != 'backend'):
                 raise ldap.NO_SUCH_OBJECT("We have a matching suffix, but not a backend or correct database name.")
         except ldap.NO_SUCH_OBJECT:
             result = DSBLE0001
@@ -570,8 +611,10 @@ class Backend(DSLdapObject):
 
     def _lint_backend_implementation_config_attributes(self):
         backend_impl = self._instance.get_db_lib()
-        db_config = DatabaseConfig(self._instance)
-        config_attrs = db_config.get()
+        if self._instance.state == DIRSRV_STATE_ONLINE:
+            config_attrs = DatabaseConfig(self._instance).get()
+        else:
+            config_attrs = DatabaseConfig.get_combined_flat_from_dse(self._instance)
 
         mdb_only_attrs = ['nsslapd-mdb-max-size', 'nsslapd-mdb-max-readers', 'nsslapd-mdb-max-dbs']
         bdb_only_attrs = ['nsslapd-dbcachesize',
@@ -620,18 +663,25 @@ class Backend(DSLdapObject):
     def _lint_cl_trimming(self):
         """Check that cl trimming is at least defined to prevent unbounded growth"""
         bename = self.lint_uid()
-        suffix = self.get_attr_val_utf8('nsslapd-suffix')
+        suffix = lint_get_attr_val_utf8(self, 'nsslapd-suffix')
         replicas = Replicas(self._instance)
         try:
             # Check if replication is enabled
-            replicas.get(suffix)
-            # Check the changelog
-            cl = Changelog(self._instance, suffix=suffix)
-            if cl.get_attr_val_utf8('nsslapd-changelogmaxentries') is None and \
-               cl.get_attr_val_utf8('nsslapd-changelogmaxage') is None:
+            if self._instance.status():
+                replicas = replicas.get(suffix)
+                cl = Changelog(self._instance, suffix=suffix)
+            else:
+                # Get dse replicas for this suffix
+                dse = DSEldif(self._instance)
+                replicas = dse.get_replicas()
+                if len(replicas) == 0 or not dse.suffix_replicated(suffix):
+                    return
+                cl = DSLdapObject(self._instance, dn=f'cn=changelog,cn={bename},cn=ldbm database,cn=plugins,cn=config')
+            if lint_get_attr_val_utf8(cl, 'nsslapd-changelogmaxentries') is None and \
+               lint_get_attr_val_utf8(cl, 'nsslapd-changelogmaxage') is None:
                 report = copy.deepcopy(DSCLLE0001)
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
-                report['check'] = f'backends:{bename}::cl_trimming'
+                report['check'] = f'backends:{bename}:cl_trimming'
                 yield report
         except:
             # Suffix is not replicated
@@ -641,8 +691,10 @@ class Backend(DSLdapObject):
     def _lint_system_indexes(self):
         """Check that system indexes are correctly configured"""
         bename = self.lint_uid()
-        suffix = self.get_attr_val_utf8('nsslapd-suffix')
-        indexes = self.get_indexes()
+        suffix = lint_get_attr_val_utf8(self, 'nsslapd-suffix')
+        indexes = None
+        if self._instance.state == DIRSRV_STATE_ONLINE:
+            indexes = self.get_indexes()
 
         # Default system indexes taken from ldap/servers/slapd/back-ldbm/instance.c
         # Note: entryrdn and ancestorid are internal system indexes that are not
@@ -669,7 +721,7 @@ class Backend(DSLdapObject):
 
         # RetroCL plugin creates its own backend with an additonal index for changeNumber
         # See ldap/servers/plugins/retrocl/retrocl_create.c
-        if suffix.lower() == 'cn=changelog':
+        if suffix and suffix.lower() == 'cn=changelog':
             expected_system_indexes.update({
                 'changeNumber': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'}
             })
@@ -678,7 +730,7 @@ class Backend(DSLdapObject):
         # See ldap/ldif/template-dse.ldif.in
         try:
             usn_plugin = USNPlugin(self._instance)
-            if usn_plugin.status():
+            if lint_plugin_enabled(usn_plugin):
                 expected_system_indexes.update({
                     'entryusn': {'types': ['eq'], 'matching_rule': 'integerOrderingMatch'}
                 })
@@ -691,18 +743,33 @@ class Backend(DSLdapObject):
 
         for attr_name, expected_config in expected_system_indexes.items():
             try:
-                index = indexes.get(attr_name)
-            except ldap.NO_SUCH_OBJECT:
-                # Index is missing
                 index = None
-            except Exception as e:
-                self._log.debug(f"_lint_system_indexes - Error getting index {attr_name}: {e}")
-                discrepancies.append(f"Unable to check index {attr_name}: {str(e)}")
-                continue
+                actual_types = []
+                actual_mrs = []
+                index_missing = True
 
-            try:
+                if indexes is not None:
+                    try:
+                        index = indexes.get(attr_name)
+                    except ldap.NO_SUCH_OBJECT:
+                        index = None
+                    except Exception as e:
+                        self._log.debug(f"_lint_system_indexes - Error getting index {attr_name}: {e}")
+                        discrepancies.append(f"Unable to check index {attr_name}: {str(e)}")
+                        continue
+                    index_missing = index is None
+                    if index is not None:
+                        actual_types = lint_get_attr_vals_utf8(index, 'nsIndexType') or []
+                        actual_mrs = lint_get_attr_vals_utf8(index, 'nsMatchingRule') or []
+                else:
+                    entry = _index_entry_attrs_from_dse(self._instance, bename, attr_name)
+                    index_missing = not entry
+                    if entry:
+                        actual_types = entry.get('nsindextype', []) or []
+                        actual_mrs = entry.get('nsmatchingrule', []) or []
+
                 # Check if index exists
-                if index is None:
+                if index_missing:
                     discrepancies.append(f"Missing system index: {attr_name}")
                     # Generate remediation command
                     index_types = ' '.join([f"--index-type {t}" for t in expected_config['types']])
@@ -713,9 +780,6 @@ class Backend(DSLdapObject):
                     reindex_attrs.add(attr_name)  # New index needs reindexing
                 else:
                     # Index exists, check configuration
-                    actual_types = index.get_attr_vals_utf8('nsIndexType') or []
-                    actual_mrs = index.get_attr_vals_utf8('nsMatchingRule') or []
-
                     # Normalize to lowercase for comparison
                     actual_types = [t.lower() for t in actual_types]
                     expected_types = [t.lower() for t in expected_config['types']]
@@ -991,7 +1055,7 @@ class Backend(DSLdapObject):
         for cosDefType in [CosIndirectDefinitions, CosPointerDefinitions, CosClassicDefinitions]:
             defs = cosDefType(self._instance, self.get_suffix()).list()
             for cosDef in defs:
-                attrs = cosDef.get_attr_val_utf8_l("cosAttribute").split()
+                attrs = lint_get_attr_val_utf8_l(cosDef, "cosAttribute").split()
                 for attr in attrs:
                     if attr in ["default", "override", "operational", "operational-default", "merge-schemes"]:
                         # We are at the end, just break out
@@ -1194,6 +1258,26 @@ class Backends(DSLdapObjects):
         self._childobject = Backend
         self._basedn = DN_LDBM
 
+    def list(self, paged_search=None, paged_critical=True, full_dn=False):
+        """List backends via LDAP when online; read ``dse.ldif`` when offline (e.g. healthcheck)."""
+        if self._instance.state != DIRSRV_STATE_ONLINE:
+            return self._list_from_dse(paged_search=paged_search, paged_critical=paged_critical,
+                                       full_dn=full_dn)
+        return super(Backends, self).list(paged_search=paged_search, paged_critical=paged_critical,
+                                          full_dn=full_dn)
+
+    def _list_from_dse(self, paged_search=None, paged_critical=True, full_dn=False):
+        dse = DSEldif(self._instance)
+        names = dse.get_backends()
+        insts = []
+        for name in names:
+            dn = f"cn={name},cn=ldbm database,cn=plugins,cn=config"
+            if full_dn:
+                insts.append(dn)
+            else:
+                insts.append(Backend(self._instance, dn=dn))
+        return insts
+
     @classmethod
     def lint_uid(cls):
         return 'backends'
@@ -1314,67 +1398,70 @@ class DatabaseConfig(DSLdapObject):
     :type dn: str
     """
 
+    _GLOBAL_ATTRS = [
+        'nsslapd-lookthroughlimit',
+        'nsslapd-mode',
+        'nsslapd-idlistscanlimit',
+        'nsslapd-directory',
+        'nsslapd-import-cachesize',
+        'nsslapd-idl-switch',
+        'nsslapd-search-bypass-filter-test',
+        'nsslapd-search-use-vlv-index',
+        'nsslapd-exclude-from-export',
+        'nsslapd-serial-lock',
+        'nsslapd-pagedlookthroughlimit',
+        'nsslapd-pagedidlistscanlimit',
+        'nsslapd-rangelookthroughlimit',
+        'nsslapd-backend-opt-level',
+        'nsslapd-backend-implement',
+        'nsslapd-db-durable-transaction',
+        'nsslapd-search-bypass-filter-test',
+        'nsslapd-serial-lock',
+        'nsslapd-dynamic-lists-enabled',
+        'nsslapd-dynamic-lists-attr',
+        'nsslapd-dynamic-lists-oc',
+        'nsslapd-dynamic-lists-url-attr',
+    ]
+    _DB_ATTRS = {
+        'bdb':
+            [
+                'nsslapd-dbcachesize',
+                'nsslapd-db-logdirectory',
+                'nsslapd-db-home-directory',
+                'nsslapd-db-transaction-wait',
+                'nsslapd-db-checkpoint-interval',
+                'nsslapd-db-compactdb-interval',
+                'nsslapd-db-compactdb-time',
+                'nsslapd-db-page-size',
+                'nsslapd-db-transaction-batch-val',
+                'nsslapd-db-transaction-batch-min-wait',
+                'nsslapd-db-transaction-batch-max-wait',
+                'nsslapd-db-logbuf-size',
+                'nsslapd-db-locks',
+                'nsslapd-db-locks-monitoring-enabled',
+                'nsslapd-db-locks-monitoring-threshold',
+                'nsslapd-db-locks-monitoring-pause',
+                'nsslapd-db-private-import-mem',
+                'nsslapd-import-cache-autosize',
+                'nsslapd-cache-autosize',
+                'nsslapd-cache-autosize-split',
+                'nsslapd-import-cachesize',
+                'nsslapd-db-deadlock-policy',
+            ],
+        'mdb': [
+                'nsslapd-mdb-max-size',
+                'nsslapd-mdb-max-readers',
+                'nsslapd-mdb-max-dbs',
+                'nsslapd-cache-autosize',
+            ]
+    }
+
     def __init__(self, instance, dn="cn=config,cn=ldbm database,cn=plugins,cn=config"):
         super(DatabaseConfig, self).__init__(instance, dn)
         self._rdn_attribute = 'cn'
         self._must_attributes = ['cn']
-        self._global_attrs = [
-            'nsslapd-lookthroughlimit',
-            'nsslapd-mode',
-            'nsslapd-idlistscanlimit',
-            'nsslapd-directory',
-            'nsslapd-import-cachesize',
-            'nsslapd-idl-switch',
-            'nsslapd-search-bypass-filter-test',
-            'nsslapd-search-use-vlv-index',
-            'nsslapd-exclude-from-export',
-            'nsslapd-serial-lock',
-            'nsslapd-pagedlookthroughlimit',
-            'nsslapd-pagedidlistscanlimit',
-            'nsslapd-rangelookthroughlimit',
-            'nsslapd-backend-opt-level',
-            'nsslapd-backend-implement',
-            'nsslapd-db-durable-transaction',
-            'nsslapd-search-bypass-filter-test',
-            'nsslapd-serial-lock',
-            'nsslapd-dynamic-lists-enabled',
-            'nsslapd-dynamic-lists-attr',
-            'nsslapd-dynamic-lists-oc',
-            'nsslapd-dynamic-lists-url-attr',
-        ]
-        self._db_attrs = {
-            'bdb':
-                [
-                    'nsslapd-dbcachesize',
-                    'nsslapd-db-logdirectory',
-                    'nsslapd-db-home-directory',
-                    'nsslapd-db-transaction-wait',
-                    'nsslapd-db-checkpoint-interval',
-                    'nsslapd-db-compactdb-interval',
-                    'nsslapd-db-compactdb-time',
-                    'nsslapd-db-page-size',
-                    'nsslapd-db-transaction-batch-val',
-                    'nsslapd-db-transaction-batch-min-wait',
-                    'nsslapd-db-transaction-batch-max-wait',
-                    'nsslapd-db-logbuf-size',
-                    'nsslapd-db-locks',
-                    'nsslapd-db-locks-monitoring-enabled',
-                    'nsslapd-db-locks-monitoring-threshold',
-                    'nsslapd-db-locks-monitoring-pause',
-                    'nsslapd-db-private-import-mem',
-                    'nsslapd-import-cache-autosize',
-                    'nsslapd-cache-autosize',
-                    'nsslapd-cache-autosize-split',
-                    'nsslapd-import-cachesize',
-                    'nsslapd-db-deadlock-policy',
-                ],
-            'mdb': [
-                    'nsslapd-mdb-max-size',
-                    'nsslapd-mdb-max-readers',
-                    'nsslapd-mdb-max-dbs',
-                    'nsslapd-cache-autosize',
-                ]
-        }
+        self._global_attrs = DatabaseConfig._GLOBAL_ATTRS
+        self._db_attrs = DatabaseConfig._DB_ATTRS
         self._create_objectclasses = ['top', 'extensibleObject']
         self._protected = True
         # This could be "bdb" or "mdb", use what we have configured in the global config
@@ -1385,6 +1472,28 @@ class DatabaseConfig(DSLdapObject):
         self._dbObj = DSLdapObject(self._instance, dn=self._db_dn)
         # Assert there is no overlap in different config sets
         assert_c(len(set(self._global_attrs).intersection(set(self._db_attrs['bdb']), set(self._db_attrs['mdb']))) == 0)
+
+    @classmethod
+    def get_combined_flat_from_dse(cls, instance):
+        """Return the same merged attribute dict as :meth:`get`, from ``dse.ldif`` (no LDAP)."""
+        dse = DSEldif(instance)
+        dn_global = "cn=config,cn=ldbm database,cn=plugins,cn=config"
+        ag = dse.get_entry_attrs(dn_global.lower()) or {}
+        db_impl = (ag.get('nsslapd-backend-implement') or [None])[0]
+        if db_impl is not None:
+            db_impl = db_impl.strip().lower()
+        if not db_impl:
+            db_impl = get_default_db_lib()
+        if db_impl not in cls._DB_ATTRS:
+            db_impl = get_default_db_lib()
+        dn_db = f"cn={db_impl},cn=config,cn=ldbm database,cn=plugins,cn=config"
+        attrs_db = dse.get_entry_attrs(dn_db.lower()) or {}
+        combined = {}
+        for k in cls._GLOBAL_ATTRS:
+            combined[k] = ag.get(k, [])
+        for k in cls._DB_ATTRS[db_impl]:
+            combined[k] = attrs_db.get(k, [])
+        return combined
 
     def get(self):
         """Get the combined config entries"""

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -41,6 +41,7 @@ from lib389._mapped_object_lint import (
     lint_get_attr_val_utf8,
     lint_get_attr_val_utf8_l,
     lint_get_attr_vals_utf8,
+    lint_get_attr_vals_utf8_l,
     lint_plugin_enabled,
 )
 
@@ -568,10 +569,12 @@ class Backend(DSLdapObject):
                 dse = DSEldif(self._instance)
                 mapping_trees = dse.get_mapping_trees()
                 for mapping_tree in mapping_trees:
-                    suffixes = lint_get_attr_val_utf8_l(mapping_tree, 'nsslapd-suffix')
+                    dn = mapping_tree.replace("dn: ", "")
+                    tree_obj = DSLdapObject(self._instance, dn=dn)
+                    suffixes = lint_get_attr_vals_utf8_l(tree_obj, 'cn')
                     for suf in suffixes:
-                        if suf.lower() == suffix:
-                            mt = mapping_tree
+                        if suf.lower() == suffix.lower():
+                            mt = tree_obj
                             break
             if mt is None or (lint_get_attr_val_utf8_l(mt, 'nsslapd-backend') != bename.lower() and
                               lint_get_attr_val_utf8(mt, 'nsslapd-state') != 'backend'):

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -41,7 +41,6 @@ from lib389._mapped_object_lint import (
     lint_get_attr_val_utf8,
     lint_get_attr_val_utf8_l,
     lint_get_attr_vals_utf8,
-    lint_get_attr_vals_utf8_l,
     lint_plugin_enabled,
 )
 
@@ -485,7 +484,8 @@ class Backend(DSLdapObject):
             else:
                 index = DSLdapObject(self._instance,
                                      dn=f'cn=nsrole,cn=index,cn={bename},cn=ldbm database,cn=plugins,cn=config')
-                lint_get_attr_vals_utf8_l(index, "objectclass")
+                if lint_get_attr_val_utf8_l(index, "objectclass") is None:
+                    return
 
             report = copy.deepcopy(DSVIRTLE0001)
             report['check'] = f'backends:{bename}:virt_attrs'

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -596,8 +596,11 @@ class Backend(DSLdapObject):
 
     def _lint_backend_implementation_cleanup_needed(self):
         db_files = os.listdir(self._instance.ds_paths.db_dir)
-        if self._instance.ds_paths.db_home_dir is not None and self._instance.ds_paths.db_home_dir != self._instance.ds_paths.db_dir:
+        if self._instance.ds_paths.db_home_dir is not None and \
+           self._instance.ds_paths.db_home_dir != self._instance.ds_paths.db_dir and \
+           os.path.isdir(self._instance.ds_paths.db_home_dir):
             db_files.extend(os.listdir(self._instance.ds_paths.db_home_dir))
+
         db_files = [f.lower() for f in db_files]
         db_files = sorted(set(db_files))
 

--- a/src/lib389/lib389/cli_base/__init__.py
+++ b/src/lib389/lib389/cli_base/__init__.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -16,7 +16,8 @@ import ldap
 from ldap.dn import is_dn
 from getpass import getpass
 from lib389 import DirSrv
-from lib389.utils import assert_c, get_ldapurl_from_serverid
+from lib389.utils import assert_c
+from lib389.dseutils import get_ldapurl_from_serverid
 from lib389.properties import SER_ROOT_PW, SER_ROOT_DN
 
 

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -1,16 +1,16 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import ldap
 import json
 import re
-from lib389._mapped_object import DSLdapObjects
 from lib389._mapped_object_lint import DSLint
-from lib389.cli_base import connect_instance, disconnect_instance, CustomHelpFormatter
+from lib389.cli_base import connect_instance, disconnect_instance
 from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389.backend import Backends
 from lib389.config import Encryption, Config
@@ -42,6 +42,23 @@ CHECK_OBJECTS = [
     DirsrvAccessLog,
     Tunables,
 ]
+
+# Checks that need a running server or LDAP search of database content (see healthcheck.md).
+_OFFLINE_SKIP_SPECS_EXACT = frozenset({
+    'disk_space',
+    'monitor-disk-space:disk_space',
+    'replication:agmts_status',
+    'replication:conflicts',
+    'replication:no_ruv',
+})
+
+
+def _offline_skip_spec(spec: str) -> bool:
+    if spec in _OFFLINE_SKIP_SPECS_EXACT:
+        return True
+    if spec.endswith(':search'):
+        return True
+    return False
 
 
 def _format_check_output(log, result, idx):
@@ -96,11 +113,12 @@ def _print_checks(inst, log, specs: Iterable[str]) -> None:
         log.info(f'{o.lint_uid()}:{s[0]}')
 
 
-def _run(inst, log, args, checks, exclude_checks):
+def _run(inst, log, args, checks, exclude_checks, offline=False):
     if not args.json:
         log.info("Beginning lint report, this could take a while ...")
 
     report = []
+    skipped = []
     excludes = []
     for _, skip in exclude_checks:
         excludes.append(skip[0])
@@ -111,9 +129,25 @@ def _run(inst, log, args, checks, exclude_checks):
 
         if not args.json:
             log.info(f"Checking {o.lint_uid()}:{s[0]} ...")
+
+        if offline and _offline_skip_spec(s[0]):
+            reason = 'requires running directory server or LDAP-accessible database content'
+            skipped.append({'check': s[0], 'reason': reason})
+            if not args.json:
+                log.info(f" - skipped {s[0]} - requires running server: {reason}")
+            continue
+
         try:
             report += o.lint(s[0]) or []
-        except:
+        except ValueError as e:
+            if offline and 'not ONLINE' in str(e):
+                reason = 'instance is not connected (offline); check needs LDAP'
+                skipped.append({'check': s[0], 'reason': reason})
+                if not args.json:
+                    log.info(f" - skipped {s[0]} - requires running server: {reason}")
+            else:
+                raise
+        except Exception:
             continue
 
     if not args.json:
@@ -124,7 +158,7 @@ def _run(inst, log, args, checks, exclude_checks):
         if not args.json:
             log.info("No issues found.")
         else:
-            log.info(json.dumps(report, indent=4))
+            _emit_json(log, report, skipped, [], args)
     else:
         plural = ""
         if count > 1:
@@ -137,11 +171,28 @@ def _run(inst, log, args, checks, exclude_checks):
                 idx += 1
             log.info(f'\n\n===== End Of Report ({count} Issue{plural} found) =====')
         else:
-            log.info(json.dumps(report, indent=4))
+            _emit_json(log, report, skipped, [], args)
+
+
+def _emit_json(log, report, skipped, host_errors, args):
+    """Emit JSON: list-only for backward compatibility, or wrapped object if extra sections."""
+    if skipped or host_errors:
+        payload = {'issues': report}
+        if skipped:
+            payload['skipped_requires_server'] = skipped
+        if host_errors:
+            payload['host_errors'] = host_errors
+        log.info(json.dumps(payload, indent=4))
+    else:
+        log.info(json.dumps(report, indent=4))
 
 
 def health_check_run(inst, log, args):
-    """Connect to the local server using LDAPI, and perform various health checks
+    """Connect to the local server using LDAPI, and perform various health checks.
+
+    If the server is stopped, ``connect_instance`` fails with ``SERVER_DOWN``; we keep
+    the pre-allocated ``inst`` from ``dsctl`` and run checks that do not require LDAP,
+    skipping others with explicit messages. Mode is fixed for the duration of the run.
     """
 
     if args.list_errors:
@@ -157,9 +208,13 @@ def health_check_run(inst, log, args):
     args.prompt = False
     dsrc_inst = dsrc_to_ldap(DSRC_HOME, args.instance, log.getChild('dsrc'))
     dsrc_inst = dsrc_arg_concat(args, dsrc_inst)
+    offline = False
     try:
         inst = connect_instance(dsrc_inst=dsrc_inst, verbose=args.verbose,
                                 args=args)
+    except ldap.SERVER_DOWN:
+        log.info('Directory Server instance is down — running offline-capable checks only.')
+        offline = True
     except Exception as e:
         raise ValueError('Failed to connect to Directory Server instance: ' +
                          str(e)) from e
@@ -171,7 +226,7 @@ def health_check_run(inst, log, args):
         return
 
     _run(inst, log, args, _list_checks(inst, checks),
-         _list_checks(inst, exclude_checks))
+         _list_checks(inst, exclude_checks), offline=offline)
 
     disconnect_instance(inst)
 

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -45,8 +45,6 @@ CHECK_OBJECTS = [
 
 # Checks that need a running server or LDAP search of database content (see healthcheck.md).
 _OFFLINE_SKIP_SPECS_EXACT = frozenset({
-    'disk_space',
-    'monitor-disk-space:disk_space',
     'replication:agmts_status',
     'replication:conflicts',
     'replication:no_ruv',

--- a/src/lib389/lib389/cli_ctl/health.py
+++ b/src/lib389/lib389/cli_ctl/health.py
@@ -45,9 +45,9 @@ CHECK_OBJECTS = [
 
 # Checks that need a running server or LDAP search of database content (see healthcheck.md).
 _OFFLINE_SKIP_SPECS_EXACT = frozenset({
-    'replication:agmts_status',
-    'replication:conflicts',
-    'replication:no_ruv',
+    'agmts_status',
+    'conflicts',
+    'no_ruv',
 })
 
 
@@ -145,7 +145,8 @@ def _run(inst, log, args, checks, exclude_checks, offline=False):
                     log.info(f" - skipped {s[0]} - requires running server: {reason}")
             else:
                 raise
-        except Exception:
+        except Exception as e:
+            log.debug(f"Error running check {o.lint_uid()}:{s[0]}: {e}")
             continue
 
     if not args.json:

--- a/src/lib389/lib389/config.py
+++ b/src/lib389/lib389/config.py
@@ -25,6 +25,11 @@ from lib389.utils import ensure_bytes, selinux_label_port,  selinux_present
 from lib389.lint import (
     DSCLE0002, DSCLE0003, DSCLE0004, DSCLE0005, DSCLE0006, DSELE0001
 )
+from lib389._mapped_object_lint import (
+    lint_get_attr_val,
+    lint_get_attr_val_utf8,
+    lint_get_attr_val_utf8_l,
+)
 
 class Config(DSLdapObject):
     """
@@ -205,8 +210,8 @@ class Config(DSLdapObject):
 
     def _lint_passwordscheme(self):
         allowed_schemes = ['PBKDF2-SHA512', 'PBKDF2_SHA256', 'PBKDF2_SHA512', 'GOST_YESCRYPT']
-        u_password_scheme = self.get_attr_val_utf8('passwordStorageScheme')
-        u_root_scheme = self.get_attr_val_utf8('nsslapd-rootpwstoragescheme')
+        u_password_scheme = lint_get_attr_val_utf8(self, 'passwordStorageScheme')
+        u_root_scheme = lint_get_attr_val_utf8(self, 'nsslapd-rootpwstoragescheme')
         if u_root_scheme not in allowed_schemes:
             report = copy.deepcopy(DSCLE0002)
             report['detail'] = report['detail'].replace('SCHEME', u_root_scheme)
@@ -226,7 +231,7 @@ class Config(DSLdapObject):
 
     def _lint_unauth_binds(self):
         # Allow unauthenticated binds
-        unauthbinds = self.get_attr_val_utf8_l('nsslapd-allow-unauthenticated-binds')
+        unauthbinds = lint_get_attr_val_utf8_l(self, 'nsslapd-allow-unauthenticated-binds')
         if unauthbinds == "on":
             report = copy.deepcopy(DSCLE0003)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
@@ -235,7 +240,7 @@ class Config(DSLdapObject):
 
     def _lint_accesslog_buffering(self):
         # access log buffering
-        buffering = self.get_attr_val_utf8_l('nsslapd-accesslog-logbuffering')
+        buffering = lint_get_attr_val_utf8_l(self, 'nsslapd-accesslog-logbuffering')
         if buffering == "off":
             report = copy.deepcopy(DSCLE0004)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
@@ -244,8 +249,8 @@ class Config(DSLdapObject):
 
     def _lint_auditlog_buffering(self):
         # audit log buffering
-        enabled = self.get_attr_val_utf8_l('nsslapd-auditlog-logging-enabled')
-        buffering = self.get_attr_val_utf8_l('nsslapd-auditlog-logbuffering')
+        enabled = lint_get_attr_val_utf8_l(self, 'nsslapd-auditlog-logging-enabled')
+        buffering = lint_get_attr_val_utf8_l(self, 'nsslapd-auditlog-logbuffering')
         if enabled == "on" and buffering == "off":
             report = copy.deepcopy(DSCLE0006)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
@@ -254,8 +259,8 @@ class Config(DSLdapObject):
 
     def _lint_securitylog_buffering(self):
         # security log buffering
-        enabled = self.get_attr_val_utf8_l('nsslapd-securitylog-logging-enabled')
-        buffering = self.get_attr_val_utf8_l('nsslapd-securitylog-logbuffering')
+        enabled = lint_get_attr_val_utf8_l(self, 'nsslapd-securitylog-logging-enabled')
+        buffering = lint_get_attr_val_utf8_l(self, 'nsslapd-securitylog-logbuffering')
         if enabled == "on" and buffering == "off":
             report = copy.deepcopy(DSCLE0005)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
@@ -302,7 +307,7 @@ class Encryption(DSLdapObject):
         return 'encryption'
 
     def _lint_check_tls_version(self):
-        tls_min = self.get_attr_val('sslVersionMin')
+        tls_min = lint_get_attr_val(self, 'sslVersionMin')
         if tls_min is not None and tls_min < ensure_bytes('TLS1.1'):
             report = copy.deepcopy(DSELE0001)
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -280,7 +280,7 @@ class DSEldif(DSLint):
         mapping_trees = []
         for entry in self._contents:
             if fnmatch.fnmatch(entry, "*cn=*,cn=mapping tree,cn=config*"):
-                mapping_trees.append(entry)
+                mapping_trees.append(entry.strip())
         return mapping_trees
 
 
@@ -290,7 +290,7 @@ class DSEldif(DSLint):
         replicas = []
         for entry in self._contents:
             if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
-                replicas.append(entry)
+                replicas.append(entry.strip())
         return replicas
 
     def suffix_replicated(self, suffix):
@@ -300,8 +300,8 @@ class DSEldif(DSLint):
         for entry in self._contents:
             if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
                 dn = entry.replace("dn: ", "").strip()
-                value = self.get(dn, "nsDS5ReplicaRoot")[0]
-                if value is not None and value == suffix:
+                vals = self.get(dn, "nsDS5ReplicaRoot")
+                if vals is not None and vals[0].lower() == suffix.lower():
                     return True
 
         return False

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -17,6 +17,7 @@ from datetime import timedelta
 from stat import ST_MODE
 # from lib389.utils import print_nice_time
 from lib389.paths import Paths
+from lib389.utils import ensure_str
 from lib389._mapped_object_lint import DSLint
 from lib389.lint import (
     DSPERMLE0001,
@@ -185,6 +186,47 @@ class DSEldif(DSLint):
             return vals[0] if len(vals) > 0 else None
         return vals
 
+    def get_entry_attrs(self, entry_dn):
+        """Return all attributes for one entry as ``{attr_lower: [str, ...]}`` from ``dse.ldif``.
+
+        Used when the directory server is not running but the instance ``dse.ldif`` is readable.
+        """
+        entry_dn = ensure_str(entry_dn).lower()
+        dn_line = "dn: {}\n".format(entry_dn)
+        try:
+            entry_dn_i = self._contents.index(dn_line)
+        except ValueError:
+            return {}
+
+        end_i = len(self._contents)
+        for j in range(entry_dn_i + 1, len(self._contents)):
+            if self._contents[j].startswith("dn: "):
+                end_i = j
+                break
+
+        attrs = {}
+        for line in self._contents[entry_dn_i + 1 : end_i]:
+            line = line.rstrip("\n")
+            if not line or line.startswith(" "):
+                continue
+            name, sep, rest = line.partition(":")
+            if not sep:
+                continue
+            name = name.strip()
+            rest = rest.lstrip()
+            aname = name.lower()
+            if rest.startswith(":"):
+                try:
+                    val = base64.b64decode(rest[1:].strip()).decode("utf-8")
+                except Exception:
+                    val = rest[1:].strip()
+            else:
+                val = rest
+            if aname not in attrs:
+                attrs[aname] = []
+            attrs[aname].append(val)
+        return attrs
+
     def get_indexes(self, backend):
         """Return a list of backend indexes
 
@@ -231,6 +273,39 @@ class DSEldif(DSLint):
                             pass
 
         return list(set(backends))
+
+    def get_mapping_trees(self):
+        """Return a list of mapping tree names from DSE.
+        """
+        mapping_trees = []
+        for entry in self._contents:
+            if fnmatch.fnmatch(entry, "*cn=*,cn=mapping tree,cn=config*"):
+                mapping_trees.append(entry)
+        return mapping_trees
+
+
+    def get_replicas(self):
+        """Return a list of replica names from DSE.
+        """
+        replicas = []
+        for entry in self._contents:
+            if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
+                replicas.append(entry)
+        return replicas
+
+    def suffix_replicated(self, suffix):
+        """
+        Check if the suffix is replicated in the DSE.
+        """
+        for entry in self._contents:
+            if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
+                dn = entry.replace("dn: ", "").strip()
+                value = self.get(dn, "nsDS5ReplicaRoot")[0]
+                if value is not None and value == suffix:
+                    return True
+
+        return False
+
 
     def add_entry(self, entry):
         """Add a new entry

--- a/src/lib389/lib389/dseldif.py
+++ b/src/lib389/lib389/dseldif.py
@@ -279,18 +279,20 @@ class DSEldif(DSLint):
         """
         mapping_trees = []
         for entry in self._contents:
-            if fnmatch.fnmatch(entry, "*cn=*,cn=mapping tree,cn=config*"):
+            if fnmatch.fnmatch(entry, "dn: cn=*,cn=mapping tree,cn=config*"):
                 mapping_trees.append(entry.strip())
         return mapping_trees
 
-
     def get_replicas(self):
-        """Return a list of replica names from DSE.
+        """Return a list of replica DN's from DSE.
+
+        :returns: List of replica DN's
         """
         replicas = []
         for entry in self._contents:
-            if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
-                replicas.append(entry.strip())
+            if fnmatch.fnmatch(entry, "dn: cn=replica,cn=*,cn=mapping tree,cn=config*"):
+                replicas.append(entry.strip()[4:].strip())
+
         return replicas
 
     def suffix_replicated(self, suffix):
@@ -298,7 +300,7 @@ class DSEldif(DSLint):
         Check if the suffix is replicated in the DSE.
         """
         for entry in self._contents:
-            if fnmatch.fnmatch(entry, "*cn=replica,cn=*,cn=mapping tree,cn=config*"):
+            if fnmatch.fnmatch(entry, "dn: *cn=replica,cn=*,cn=mapping tree,cn=config*"):
                 dn = entry.replace("dn: ", "").strip()
                 vals = self.get(dn, "nsDS5ReplicaRoot")
                 if vals is not None and vals[0].lower() == suffix.lower():

--- a/src/lib389/lib389/dseutils.py
+++ b/src/lib389/lib389/dseutils.py
@@ -1,0 +1,46 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+"""Helpers that read instance configuration from ``dse.ldif`` (or related paths)."""
+
+from lib389.dseldif import DSEldif
+
+
+def get_ldapurl_from_serverid(instance):
+    """Take an instance name, and get the host/port/protocol from dse.ldif
+    and return a LDAP URL to use in the CLI tools (dsconf)
+
+    :param instance: The server ID of a server instance
+    :return tuple of LDAPURL and certificate directory (for LDAPS)
+    """
+    try:
+        dse_ldif = DSEldif(None, instance)
+    except Exception:
+        return (None, None)
+
+    port = dse_ldif.get("cn=config", "nsslapd-port", single=True)
+    secureport = dse_ldif.get("cn=config", "nsslapd-secureport", single=True)
+    host = dse_ldif.get("cn=config", "nsslapd-localhost", single=True)
+    sec = dse_ldif.get("cn=config", "nsslapd-security", single=True)
+    ldapi_listen = dse_ldif.get("cn=config", "nsslapd-ldapilisten", single=True)
+    ldapi_autobind = dse_ldif.get("cn=config", "nsslapd-ldapiautobind", single=True)
+    ldapi_socket = dse_ldif.get("cn=config", "nsslapd-ldapifilepath", single=True)
+    certdir = dse_ldif.get("cn=config", "nsslapd-certdir", single=True)
+
+    if ldapi_listen is not None and ldapi_listen.lower() == "on" and \
+       ldapi_autobind is not None and ldapi_autobind.lower() == "on" and \
+       ldapi_socket is not None:
+        # Use LDAPI
+        socket = ldapi_socket.replace("/", "%2f")  # Escape the path
+        return ("ldapi://" + socket, None)
+    elif sec is not None and sec.lower() == "on" and secureport is not None:
+        # Use LDAPS
+        return ("ldaps://{}:{}".format(host, secureport), certdir)
+    else:
+        # Use LDAP
+        return ("ldap://{}:{}".format(host, port), None)

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -24,8 +24,9 @@ of LDAP ADD for example.
 A correct Mapping tree for this backend must contain the suffix name, the database name
 and be a backend type. IE:
 
-cn=o3Dexample,cn=mapping tree,cn=config
-cn: o=example
+cn=dc\\3Dexample\\2Cdc\\3Dcom,cn=mapping tree,cn=config
+cn: dc=example,dc=com
+cn: dc\=example\,dc\=com
 nsslapd-backend: userRoot
 nsslapd-state: backend
 objectClass: top

--- a/src/lib389/lib389/monitor.py
+++ b/src/lib389/lib389/monitor.py
@@ -11,7 +11,7 @@ import ldap
 import psutil
 from lib389._constants import *
 from lib389._mapped_object import DSLdapObject
-from lib389.utils import (ds_is_older)
+from lib389.utils import (ds_is_older, get_mount_point, get_disk_space)
 from lib389.lint import DSDSLE0001
 from lib389.backend import DatabaseConfig
 
@@ -525,17 +525,45 @@ class MonitorDiskSpace(DSLdapObject):
         return 'monitor-disk-space'
 
     def _lint_disk_space(self):
-        partitions = self.get_attr_vals_utf8_l("dsDisk")
-        for partition in partitions:
-            parts = partition.split()
-            percent = parts[4].split('=')[1].strip('"')
-            if int(percent) >= 90:
-                # this partition is over 90% full, not good
-                report = copy.deepcopy(DSDSLE0001)
-                report['detail'] = report['detail'].replace('PARTITION', parts[0].split('=')[1].strip('"'))
-                report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
-                report['check'] = f'monitor-disk-space:disk_space'
-                yield report
+        threshold = 90
+        if self._instance.status():
+            partitions = self.get_attr_vals_utf8_l("dsDisk")
+            for partition in partitions:
+                parts = partition.split()
+                percent = parts[4].split('=')[1].strip('"')
+                if int(percent) >= threshold:
+                    # this partition is over 90% full, not good
+                    report = copy.deepcopy(DSDSLE0001)
+                    report['detail'] = report['detail'].replace('PARTITION', parts[0].split('=')[1].strip('"'))
+                    report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                    report['check'] = f'monitor-disk-space:disk_space'
+                    yield report
+        else:
+            mounts = []
+            paths = [self._instance.ds_paths.access_log,
+                     self._instance.ds_paths.error_log,
+                     self._instance.ds_paths.audit_log,
+                     self._instance.ds_paths.security_log,
+                     self._instance.ds_paths.config_dir,
+                     self._instance.ds_paths.schema_dir,
+                     self._instance.ds_paths.ldif_dir,
+                     self._instance.ds_paths.inst_dir,
+                     self._instance.ds_paths.db_dir]
+
+            for path in paths:
+                mount_point = get_mount_point(path)
+                if mount_point not in mounts:
+                    mounts.append(mount_point)
+
+            for mount in mounts:
+                disk_space = get_disk_space(mount)
+                if disk_space['percent'] >= threshold:
+                    # this partition is over 90% full, not good
+                    report = copy.deepcopy(DSDSLE0001)
+                    report['detail'] = report['detail'].replace('PARTITION', mount)
+                    report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+                    report['check'] = f'monitor-disk-space:disk_space'
+                    yield report
 
     def get_disks(self):
         """Get an information about partitions which contains a Directory Server data"""

--- a/src/lib389/lib389/plugins.py
+++ b/src/lib389/lib389/plugins.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -12,6 +12,13 @@ import copy
 import os.path
 from lib389 import tasks
 from lib389._mapped_object import DSLdapObjects, DSLdapObject
+from lib389._mapped_object_lint import (
+    lint_get_attr_val_utf8,
+    lint_get_attr_val_utf8_l,
+    lint_get_attr_vals_utf8_l,
+    lint_get_attr_val_int,
+    lint_plugin_enabled,
+)
 from lib389.lint import DSRILE0001, DSRILE0002, DSMOLE0001, DSMOLE0002, DSMOLE0003
 from lib389.utils import ensure_str, ensure_list_bytes
 from lib389.schema import Schema
@@ -459,8 +466,8 @@ class ReferentialIntegrityPlugin(Plugin):
         return 'refint'
 
     def _lint_update_delay(self):
-        if self.status():
-            delay = self.get_attr_val_int("referint-update-delay")
+        if lint_plugin_enabled(self):
+            delay = lint_get_attr_val_int(self, "referint-update-delay")
             if delay is not None and delay != 0:
                 report = copy.deepcopy(DSRILE0001)
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
@@ -468,13 +475,16 @@ class ReferentialIntegrityPlugin(Plugin):
                 yield report
 
     def _lint_attr_indexes(self):
-        if self.status():
+        if lint_plugin_enabled(self):
             from lib389.backend import Backends
             backends = Backends(self._instance).list()
-            attrs = self.get_attr_vals_utf8_l("referint-membership-attr")
-            container = self.get_attr_val_utf8_l("nsslapd-plugincontainerscope")
+            attrs = lint_get_attr_vals_utf8_l(self, "referint-membership-attr")
+            container = lint_get_attr_val_utf8_l(self, "nsslapd-plugincontainerscope")
+            server_running = self._instance.status()
+
             for backend in backends:
-                suffix = backend.get_attr_val_utf8_l('nsslapd-suffix')
+                suffix = lint_get_attr_val_utf8_l(backend, 'nsslapd-suffix')
+                bename = lint_get_attr_val_utf8_l(backend, 'cn')
                 if suffix == "cn=changelog":
                     # Always skip retro changelog
                     continue
@@ -483,12 +493,20 @@ class ReferentialIntegrityPlugin(Plugin):
                     if not container.endswith(suffix):
                         # skip this backend that is not in the scope
                         continue
+
                 indexes = backend.get_indexes()
+
                 for attr in attrs:
                     report = copy.deepcopy(DSRILE0002)
                     try:
-                        index = indexes.get(attr)
-                        types = index.get_attr_vals_utf8_l("nsIndexType")
+                        if server_running:
+                            index = indexes.get(attr)
+                            types = index.get_attr_vals_utf8_l("nsIndexType")
+                        else:
+                            index = DSLdapObject(self._instance,
+                                                 dn=f'cn={attr},cn=index,cn={bename},cn=ldbm database,cn=plugins,cn=config')
+                            types = lint_get_attr_vals_utf8_l(index, "nsIndexType")
+
                         valid = False
                         if "eq" in types:
                             valid = True
@@ -503,6 +521,7 @@ class ReferentialIntegrityPlugin(Plugin):
                             report['items'].append(attr)
                             report['check'] = f'refint:attr_indexes'
                             yield report
+
                     except:
                         # No index at all, bad
                         report['detail'] = report['detail'].replace('ATTR', attr)
@@ -790,13 +809,17 @@ class MemberOfPlugin(Plugin):
         return 'memberof'
 
     def _lint_member_attr_indexes(self):
-        if self.status():
+        if lint_plugin_enabled(self):
             from lib389.backend import Backends
             backends = Backends(self._instance).list()
-            attrs = self.get_attr_vals_utf8_l("memberofgroupattr")
-            scopes = self.get_attr_vals_utf8_l("memberofentryscope")
+            attrs = lint_get_attr_vals_utf8_l(self, "memberofgroupattr")
+            scopes = lint_get_attr_vals_utf8_l(self, "memberofentryscope")
+            server_running = self._instance.status()
+
             for backend in backends:
-                suffix = backend.get_attr_val_utf8_l('nsslapd-suffix')
+                suffix = lint_get_attr_val_utf8_l(backend, 'nsslapd-suffix')
+                bename = lint_get_attr_val_utf8_l(backend, 'cn')
+
                 if suffix == "cn=changelog":
                     # Always skip retro changelog
                     continue
@@ -811,11 +834,18 @@ class MemberOfPlugin(Plugin):
                     if not in_scope:
                         continue
                 indexes = backend.get_indexes()
+
                 for attr in attrs:
                     report = copy.deepcopy(DSMOLE0001)
                     try:
-                        index = indexes.get(attr)
-                        types = index.get_attr_vals_utf8_l("nsIndexType")
+                        if server_running:
+                            index = indexes.get(attr)
+                            types = lint_get_attr_vals_utf8_l(index, "nsIndexType")
+                        else:
+                            index = DSLdapObject(self._instance,
+                                                 dn=f'cn={attr},cn=index,cn={bename},cn=ldbm database,cn=plugins,cn=config')
+                            types = lint_get_attr_vals_utf8_l(index, "nsIndexType")
+
                         valid = False
                         if "eq" in types:
                             valid = True
@@ -830,6 +860,7 @@ class MemberOfPlugin(Plugin):
                             report['items'].append(attr)
                             report['check'] = f'memberof:attr_indexes'
                             yield report
+
                     except:
                         # No index at all, bad
                         report['detail'] = report['detail'].replace('ATTR', attr)
@@ -843,13 +874,16 @@ class MemberOfPlugin(Plugin):
                         yield report
 
     def _lint_member_substring_index(self):
-        if self.status():
+        if lint_plugin_enabled(self):
             from lib389.backend import Backends
             backends = Backends(self._instance).list()
             membership_attrs = ['member', 'uniquemember']
-            scopes = self.get_attr_vals_utf8_l("memberofentryscope")
+            scopes = lint_get_attr_vals_utf8_l(self, "memberofentryscope")
+            server_running = self._instance.status()
+
             for backend in backends:
-                suffix = backend.get_attr_val_utf8_l('nsslapd-suffix')
+                suffix = lint_get_attr_val_utf8_l(backend, 'nsslapd-suffix')
+                bename = lint_get_attr_val_utf8_l(backend, 'cn')
                 if suffix == "cn=changelog":
                     # Always skip retro changelog
                     continue
@@ -867,8 +901,14 @@ class MemberOfPlugin(Plugin):
                 for attr in membership_attrs:
                     report = copy.deepcopy(DSMOLE0002)
                     try:
-                        index = indexes.get(attr)
-                        types = index.get_attr_vals_utf8_l("nsIndexType")
+                        if server_running:
+                            index = indexes.get(attr)
+                            types = lint_get_attr_vals_utf8_l(index, "nsIndexType")
+                        else:
+                            index = DSLdapObject(self._instance,
+                                                 dn=f'cn={attr},cn=index,cn={bename},cn=ldbm database,cn=plugins,cn=config')
+                            types = lint_get_attr_vals_utf8_l(index, "nsIndexType")
+
                         if "sub" in types:
                             report['detail'] = report['detail'].replace('ATTR', attr)
                             report['detail'] = report['detail'].replace('BACKEND', suffix)
@@ -887,13 +927,13 @@ class MemberOfPlugin(Plugin):
         Verify that when the memberOf plugin monitors all backends,
         the global backend lock is enabled. Warn if disabled.
         """
-        if self.status():
+        if lint_plugin_enabled(self):
             from lib389.config import Config
-            allbackends = self.get_attr_val_utf8_l("memberofallbackends")
+            allbackends = lint_get_attr_val_utf8_l(self, "memberofallbackends")
             config = Config(self._instance)
             if allbackends == "on":
                 GLOBAL_BE_LOCK = "nsslapd-global-backend-lock"
-                global_be_lock = config.get_attr_val_utf8(GLOBAL_BE_LOCK)
+                global_be_lock = lint_get_attr_val_utf8(config, GLOBAL_BE_LOCK)
                 if global_be_lock == "off":
                     report = copy.deepcopy(DSMOLE0003)
                     report['check'] = f'attr:{GLOBAL_BE_LOCK}'

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -22,7 +22,7 @@ from lib389._constants import CONSUMER_REPLICAID, REPLICA_RDWR_TYPE, REPLICA_FLA
                               REPLICA_FLAGS_RDONLY, REPLICA_ID, REPLICA_TYPE, REPLICA_SUFFIX, REPLICA_BINDDN, \
                               RDN_REPLICA, REPLICA_FLAGS, REPLICA_RUV_UUID, REPLICA_OC_TOMBSTONE, DN_MAPPING_TREE, \
                               DN_CONFIG, DN_PLUGIN, REPLICATION_BIND_DN, REPLICATION_BIND_PW, ReplicaRole, \
-                              defaultProperties
+                              defaultProperties, DIRSRV_STATE_ONLINE
 from lib389.properties import REPLICA_OBJECTCLASS_VALUE, REPLICA_OBJECTCLASS_VALUE, REPLICA_SUFFIX, \
                               REPLICA_PROPNAME_TO_ATTRNAME, REPL_BINDDN, REPL_TYPE, REPL_ID, REPL_FLAGS, \
                               REPL_BIND_GROUP, SER_HOST, SER_PORT, SER_SECURE_PORT, SER_ROOT_DN, SER_ROOT_PW, \
@@ -33,6 +33,7 @@ from lib389.utils import (normalizeDN, escapeDNValue, ensure_bytes, ensure_str,
                           ds_supports_new_changelog, get_timeout_scale)
 from lib389 import DirSrv, Entry, NoSuchEntryError, InvalidArgumentError
 from lib389._mapped_object import DSLdapObjects, DSLdapObject
+from lib389._mapped_object_lint import lint_get_attr_val_utf8
 from lib389.passwd import password_generate
 from lib389.mappingTree import MappingTrees
 from lib389.agreement import Agreements
@@ -44,6 +45,7 @@ from lib389.idm.group import Groups
 from lib389.idm.services import ServiceAccounts
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.conflicts import ConflictEntries
+from lib389.dseldif import DSEldif
 from lib389.lint import (DSREPLLE0001, DSREPLLE0002, DSREPLLE0003, DSREPLLE0004,
                          DSREPLLE0005, DSREPLLE0006, DSCLLE0001)
 
@@ -1184,8 +1186,8 @@ class Changelog5(DSLdapObject):
     def _lint_cl_trimming(self):
         """Check that cl trimming is at least defined to prevent unbounded growth"""
         try:
-            if self.get_attr_val_utf8('nsslapd-changelogmaxentries') is None and \
-                self.get_attr_val_utf8('nsslapd-changelogmaxage') is None:
+            if lint_get_attr_val_utf8(self, 'nsslapd-changelogmaxentries') is None and \
+                lint_get_attr_val_utf8(self, 'nsslapd-changelogmaxage') is None:
                 report = copy.deepcopy(DSCLLE0001)
                 report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
                 report['check'] = f'changelog:cl_trimming'
@@ -1813,6 +1815,17 @@ class Replicas(DSLdapObjects):
                     break
 
         return replica
+
+    def _list_from_dse(self):
+        dse = DSEldif(self._instance)
+        replicas = dse.get_replicas()
+        return replicas
+
+    def list(self, paged_search=None, paged_critical=True, full_dn=False):
+        """List backends via LDAP when online; read ``dse.ldif`` when offline (e.g. healthcheck)."""
+        if self._instance.state != DIRSRV_STATE_ONLINE:
+            return self._list_from_dse()
+        return super(Replicas, self).list(paged_search=paged_search, paged_critical=paged_critical, full_dn=full_dn)
 
     def get(self, selector=[], dn=None):
         """Get a child entry (DSLdapObject, Replica, etc.) with dn or selector

--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -1816,15 +1816,22 @@ class Replicas(DSLdapObjects):
 
         return replica
 
-    def _list_from_dse(self):
+    def _list_from_dse(self, full_dn=False):
         dse = DSEldif(self._instance)
-        replicas = dse.get_replicas()
-        return replicas
+        replica_dn_list = dse.get_replicas()
+        replicas = []
+
+        if full_dn:
+            return replica_dn_list
+        else:
+            for dn in replica_dn_list:
+                replicas.append(Replica(self._instance, dn=dn))
+            return replicas
 
     def list(self, paged_search=None, paged_critical=True, full_dn=False):
         """List backends via LDAP when online; read ``dse.ldif`` when offline (e.g. healthcheck)."""
         if self._instance.state != DIRSRV_STATE_ONLINE:
-            return self._list_from_dse()
+            return self._list_from_dse(full_dn=full_dn)
         return super(Replicas, self).list(paged_search=paged_search, paged_critical=paged_critical, full_dn=full_dn)
 
     def get(self, selector=[], dn=None):

--- a/src/lib389/lib389/tunables.py
+++ b/src/lib389/lib389/tunables.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -10,9 +10,11 @@
 import os
 import re
 import copy
+import subprocess
 from lib389._mapped_object_lint import DSLint
 from lib389 import pid_from_file
 from lib389.lint import DSTHPLE0001
+from lib389.utils import ensure_str
 
 class Tunables(DSLint):
     """A class for working with system tunables
@@ -43,23 +45,32 @@ class Tunables(DSLint):
                     return match is not None
 
 
-        def instance_thp_enabled() -> bool:
+        def instance_thp_enabled(server_running: bool) -> bool:
             pid_status_path = f"/proc/{self.pid}/status"
 
-            with open(pid_status_path, 'r') as pid_status:
-                pid_status_content = pid_status.read()
-                thp_line = None
-                for line in pid_status_content.split('\n'):
-                    if 'THP_enabled' in line:
-                        thp_line = line
-                        break
-                if thp_line is not None:
-                    thp_value = int(thp_line.split()[1])
-                    return bool(thp_value)
+            if server_running:
+                with open(pid_status_path, 'r') as pid_status:
+                    pid_status_content = pid_status.read()
+                    thp_line = None
+                    for line in pid_status_content.split('\n'):
+                        if 'THP_enabled' in line:
+                            thp_line = line
+                            break
+                    if thp_line is not None:
+                        thp_value = int(thp_line.split()[1])
+                        return bool(thp_value)
+            else:
+                # Get systemctl data for THP from systemd
+                systemctl_data = subprocess.check_output(
+                    ['systemctl', 'show', '-P', 'Environment',
+                     'dirsrv@%s' % self._instance.serverid, 'THP_enabled'])
 
+                if 'THP_DISABLE=1' in ensure_str(systemctl_data):
+                    return False
+                else:
+                    return True
 
-        if instance_thp_enabled() and systemwide_thp_enabled():
+        if instance_thp_enabled(self._instance.status()) and systemwide_thp_enabled():
             report = copy.deepcopy(DSTHPLE0001)
             report['check'] = 'tunables:transparent_huge_pages'
             yield report
-

--- a/src/lib389/lib389/tunables.py
+++ b/src/lib389/lib389/tunables.py
@@ -63,7 +63,7 @@ class Tunables(DSLint):
                 # Get systemctl data for THP from systemd
                 systemctl_data = subprocess.check_output(
                     ['systemctl', 'show', '-P', 'Environment',
-                     'dirsrv@%s' % self._instance.serverid, 'THP_enabled'])
+                     'dirsrv@%s' % self._instance.serverid])
 
                 if 'THP_DISABLE=1' in ensure_str(systemctl_data):
                     return False

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # Copyright (C) 2019 William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -45,7 +45,6 @@ import lib389
 from pathlib import Path
 from subprocess import check_output
 from lib389.paths import ( Paths, DEFAULTS_PATH )
-from lib389.dseldif import DSEldif
 from lib389._constants import (
         DEFAULT_USER, VALGRIND_WRAPPER, DN_CONFIG, CFGSUFFIX, LOCALHOST,
         ReplicaRole, CONSUMER_REPLICAID, SENSITIVE_ATTRS, DEFAULT_DB_LIB,
@@ -1519,41 +1518,6 @@ def format_cmd_list(cmd):
     """Format the subprocess command list to the quoted shell string"""
 
     return " ".join(map(shlex.quote, cmd))
-
-
-def get_ldapurl_from_serverid(instance):
-    """ Take an instance name, and get the host/port/protocol from dse.ldif
-    and return a LDAP URL to use in the CLI tools (dsconf)
-
-    :param instance: The server ID of a server instance
-    :return tuple of LDAPURL and certificate directory (for LDAPS)
-    """
-    try:
-        dse_ldif = DSEldif(None, instance)
-    except:
-        return (None, None)
-
-    port = dse_ldif.get("cn=config", "nsslapd-port", single=True)
-    secureport = dse_ldif.get("cn=config", "nsslapd-secureport", single=True)
-    host = dse_ldif.get("cn=config", "nsslapd-localhost", single=True)
-    sec = dse_ldif.get("cn=config", "nsslapd-security", single=True)
-    ldapi_listen = dse_ldif.get("cn=config", "nsslapd-ldapilisten", single=True)
-    ldapi_autobind = dse_ldif.get("cn=config", "nsslapd-ldapiautobind", single=True)
-    ldapi_socket = dse_ldif.get("cn=config", "nsslapd-ldapifilepath", single=True)
-    certdir = dse_ldif.get("cn=config", "nsslapd-certdir", single=True)
-
-    if ldapi_listen is not None and ldapi_listen.lower() == "on" and \
-       ldapi_autobind is not None and ldapi_autobind.lower() == "on" and \
-       ldapi_socket is not None:
-        # Use LDAPI
-        socket = ldapi_socket.replace("/", "%2f")  # Escape the path
-        return ("ldapi://" + socket, None)
-    elif sec is not None and sec.lower() == "on" and secureport is not None:
-        # Use LDAPS
-        return ("ldaps://{}:{}".format(host, secureport), certdir)
-    else:
-        # Use LDAP
-        return ("ldap://{}:{}".format(host, port), None)
 
 
 def get_instance_list():

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -2136,9 +2136,10 @@ def get_mount_point(dir):
 
 
 def get_disk_space(path):
-    block_size = os.statvfs(path).f_frsize
-    total_size = os.statvfs(path).f_blocks * block_size
-    available_size = os.statvfs(path).f_bavail * block_size
+    stats = os.statvfs(path)
+    block_size = stats.f_frsize
+    total_size = stats.f_blocks * block_size
+    available_size = stats.f_bavail * block_size
     used_size = total_size - available_size
     used_percent = (used_size / total_size) * 100
     return {

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -2139,6 +2139,14 @@ def get_disk_space(path):
     stats = os.statvfs(path)
     block_size = stats.f_frsize
     total_size = stats.f_blocks * block_size
+    if total_size == 0:
+        return {
+            'total': 0,
+            'available': 0,
+            'used': 0,
+            'percent': 0
+        }
+
     available_size = stats.f_bavail * block_size
     used_size = total_size - available_size
     used_percent = (used_size / total_size) * 100

--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -2126,3 +2126,24 @@ def validate_max_age(value, ignore_value=None):
     # check value using digits except for the last character which must be a duration unit
     if not re.match(r'^\d+[sSmMhHdDwW]$', value) or value[0] == '0':
         raise ValueError(f"Invalid max age value: {value}")
+
+
+def get_mount_point(dir):
+    path = os.path.realpath(os.path.abspath(dir))
+    while not os.path.ismount(path):
+        path = os.path.dirname(path)
+    return path
+
+
+def get_disk_space(path):
+    block_size = os.statvfs(path).f_frsize
+    total_size = os.statvfs(path).f_blocks * block_size
+    available_size = os.statvfs(path).f_bavail * block_size
+    used_size = total_size - available_size
+    used_percent = (used_size / total_size) * 100
+    return {
+        'total': total_size,
+        'available': available_size,
+        'used': used_size,
+        'percent': used_percent
+    }


### PR DESCRIPTION
Description:

Use and extend the DSEldif class to handle most of the lint checks that query cn=config. If a check must be skipped a message is displayed to the user.

relates: https://github.com/389ds/389-ds-base/issues/7402

Assisted by: Cursor

## Summary by Sourcery

Enable healthcheck lint checks to run in offline mode using dse.ldif when the directory server is stopped, while skipping checks that require a running instance, and update tests accordingly.

New Features:
- Allow healthcheck/DS lint to operate in an offline mode that reads configuration and index data directly from dse.ldif when the server is down.
- Expose helper utilities to read instance configuration and attributes from dse.ldif, including backend, mapping tree, replica, and database config data.

Enhancements:
- Refactor lint attribute access through helper functions that transparently use LDAP online or dse.ldif offline.
- Extend backend, replica, plugin, config, and tunables lint logic to work consistently whether the server is online or offline, including system index and changelog trimming checks.
- Improve healthcheck CLI JSON output to include metadata about skipped checks and host-level errors while preserving backward compatibility.
- Factor dse.ldif-based LDAP URL resolution into a dedicated dseutils module and update callers.
- Tighten referint plugin shutdown logic and update lint error text for backend mapping trees.

Tests:
- Expand healthcheck, configuration, replication, skew, tunables, and system index tests to cover offline healthcheck runs with the server stopped, and adjust expectations for new checks being listed and reported.