### PR TITLE
Issue 7404 - fix latest compiler warnings

### DIFF
--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -407,7 +407,6 @@ static void
 memberof_monitor_init(const char *dn)
 {
     char *monitor_dn = NULL;
-    int rc = LDAP_SUCCESS;
 
     monitor_dn = slapi_create_dn_string(dn);
     if (!monitor_dn) {

--- a/ldap/servers/plugins/sync/sync_persist.c
+++ b/ldap/servers/plugins/sync/sync_persist.c
@@ -978,16 +978,13 @@ sync_send_results(void *arg)
 {
     slapi_set_thread_name("sync-send");
     SyncRequest *req = (SyncRequest *)arg;
-    SyncQueueNode *qnode, *qnodenext;
+    SyncQueueNode *qnode;
     int conn_acq_flag = 0;
     Slapi_Connection *conn = NULL;
     Slapi_Operation *op = req->req_orig_op;
-    LDAPControl **ctrls = NULL;
     int rc;
     PRUint64 connid;
     int opid;
-    char **attrs_dup;
-    char *strFilter;
 
     slapi_pblock_get(req->req_pblock, SLAPI_CONN_ID, &connid);
     slapi_pblock_get(req->req_pblock, SLAPI_OPERATION_ID, &opid);

--- a/ldap/servers/slapd/auth.c
+++ b/ldap/servers/slapd/auth.c
@@ -427,6 +427,8 @@ check_pqc(uint64_t connid, SSLChannelInfo *sci)
         case ssl_grp_kem_mlkem768x25519:
         case ssl_grp_kem_xyber768d00:
             return true;
+        default:
+            return false;
     }
 #endif
     return false;

--- a/ldap/servers/slapd/haproxy.c
+++ b/ldap/servers/slapd/haproxy.c
@@ -657,7 +657,6 @@ haproxy_parse_trusted_ips(struct berval **ipaddress, size_t *count_out, char *er
         char *ip_val = ipaddress[i]->bv_val;
         char *slash_pos = strchr(ip_val, '/');
         char ip_part[MAX_CIDR_STRING_LEN];
-        int is_ipv6;
 
         /* Store original for logging */
         PL_strncpyz(entries[i].original, ip_val, sizeof(entries[i].original));
@@ -835,7 +834,6 @@ haproxy_ip_matches_parsed(const PRNetAddr *ip_addr, const haproxy_trusted_entry_
 {
     size_t i;
     PRNetAddr normalized_ip;
-    char ip_str[INET6_ADDRSTRLEN];
 
     if (!entries || entry_count == 0 || !ip_addr) {
         return 0;


### PR DESCRIPTION
Description:

Fix compiler warnings

relates: https://github.com/389ds/389-ds-base/issues/7404

## Summary by Sourcery

Resolve compiler warnings in sync, authentication, HAProxy, and memberOf components by cleaning up unused variables and tightening control flow.

Enhancements:
- Remove unused variables from sync, HAProxy, and memberOf modules to eliminate compiler warnings and simplify code.
- Add an explicit default case to the post-quantum crypto group check to ensure well-defined behavior for unsupported groups.