### PR TITLE
Issue 6641 - MODRDN fails when referint-tracked attr is MUST and SING…

### DIFF
--- a/dirsrvtests/tests/suites/plugins/modrdn_test.py
+++ b/dirsrvtests/tests/suites/plugins/modrdn_test.py
@@ -6,9 +6,11 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import logging
 import pytest
 from lib389.topologies import topology_st
 from lib389._constants import DEFAULT_SUFFIX
+from lib389._mapped_object import DSLdapObject
 from lib389.idm.group import Groups
 from lib389.idm.user import nsUserAccounts
 from lib389.plugins import (
@@ -18,6 +20,9 @@ from lib389.plugins import (
     MemberOfPlugin,
     ReferentialIntegrityPlugin,
 )
+from lib389.schema import Schema
+
+log = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.tier1
 
@@ -172,3 +177,249 @@ def test_modrdn_of_a_member_of_2_automember_groups(topology_st):
     # Check groups dont contain original username
     assert not groupA.is_member(user_orig_dn)
     assert not groupZ.is_member(user_orig_dn)
+
+
+@pytest.fixture
+def referint_setup(topology_st):
+    """Set up custom schema and referint plugin for MUST-attribute tests."""
+    inst = topology_st.standalone
+
+    schema = Schema(inst)
+    schema.add('attributetypes',
+               "( 9.9.8.1 NAME 'testOwner' "
+               "DESC 'Test owner DN attribute' "
+               "EQUALITY distinguishedNameMatch "
+               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 "
+               "SINGLE-VALUE X-ORIGIN 'test' )")
+    schema.add('attributetypes',
+               "( 9.9.8.3 NAME 'testMember' "
+               "DESC 'Test member DN attribute' "
+               "EQUALITY distinguishedNameMatch "
+               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 "
+               "X-ORIGIN 'test' )")
+    schema.add('objectclasses',
+               "( 9.9.8.2 NAME 'testOwned' "
+               "DESC 'Entry with a required owner' "
+               "SUP top AUXILIARY "
+               "MUST ( testOwner ) MAY ( testMember ) X-ORIGIN 'test' )")
+
+    referint_plugin = ReferentialIntegrityPlugin(inst)
+    referint_plugin.enable()
+    referint_plugin.ensure_present('referint-membership-attr', 'testOwner')
+    referint_plugin.ensure_present('referint-membership-attr', 'testMember')
+
+    inst.restart()
+
+    yield inst
+
+    log.info('Clean up entries')
+    base = DSLdapObject(inst, dn=DEFAULT_SUFFIX)
+    for oc in ('testOptRef', 'testOwned'):
+        for entry in base.search(scope='subtree', filter=f'(objectclass={oc})'):
+            obj = DSLdapObject(inst, dn=entry.dn)
+            obj._protected = False
+            obj.delete()
+    users = nsUserAccounts(inst, DEFAULT_SUFFIX)
+    for user in users.list():
+        user.delete()
+
+
+def test_modrdn_with_required_singlevalued_referint_attr(topology_st, referint_setup):
+    """Test that MODRDN succeeds when a referint-tracked attribute is
+    MUST and SINGLE-VALUE in the schema.
+
+    :id: 7c1e3d4a-5f2b-4a8e-9d6c-1b3e5f7a9c2d
+    :setup: Standalone instance with custom schema and referint plugin
+    :steps:
+        1. Create an owner user entry
+        2. Create an owned entry with testOwner pointing to the owner
+        3. Rename the owner entry
+        4. Verify testOwner has exactly one value pointing to new DN
+    :expectedresults:
+        1. Success
+        2. Success
+        3. MODRDN succeeds without OBJECT_CLASS_VIOLATION
+        4. Exactly one testOwner value with the renamed DN
+    """
+    inst = referint_setup
+
+    log.info('Create the owner user entry')
+    users = nsUserAccounts(inst, DEFAULT_SUFFIX)
+    owner = users.create(properties={
+        'uid': 'testowner',
+        'cn': 'testowner',
+        'uidNumber': '5000',
+        'gidNumber': '5000',
+        'homeDirectory': '/home/testowner',
+        'displayName': 'Test Owner',
+    })
+    owner_orig_dn = owner.dn
+
+    log.info('Create the owned entry with testOwner pointing to the owner')
+    owned = DSLdapObject(inst)
+    owned._create_objectclasses = ['top', 'person', 'testOwned']
+    owned.create(rdn='cn=testowned', basedn=DEFAULT_SUFFIX, properties={
+        'sn': 'testowned',
+        'testOwner': owner.dn,
+    })
+
+    log.info('Rename the owner entry')
+    owner.rename(new_rdn='uid=testowner_renamed')
+    owner_new_dn = owner.dn
+
+    log.info('Verify testOwner has exactly one value pointing to the new DN')
+    vals = owned.get_attr_vals_utf8('testOwner')
+    assert len(vals) == 1, f"Expected exactly 1 testOwner value, got {len(vals)}: {vals}"
+    assert vals[0].lower() == owner_new_dn.lower(), (
+        f"testOwner should be '{owner_new_dn}', got '{vals[0]}'"
+    )
+    assert vals[0].lower() != owner_orig_dn.lower(), (
+        f"testOwner still contains the original DN '{owner_orig_dn}'"
+    )
+
+
+def test_modrdn_with_required_multivalued_referint_attr(topology_st, referint_setup):
+    """Test MODRDN when a referint-tracked MUST attribute is multi-valued
+    but only one value remains (the one being updated).
+
+    :id: a3b4c5d6-e7f8-4a9b-8c1d-2e3f4a5b6c7d
+    :setup: Standalone instance with custom schema and referint plugin
+    :steps:
+        1. Create two user entries (owner1 and owner2)
+        2. Create an owned entry with testMember pointing to both owners
+           and testOwner pointing to owner1
+        3. Remove one testMember value so only one remains
+        4. Rename the remaining referenced owner
+        5. Verify testMember has exactly one value pointing to new DN
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. MODRDN succeeds without OBJECT_CLASS_VIOLATION
+        5. Exactly one testMember value with the renamed DN
+    """
+    inst = referint_setup
+
+    log.info('Create two user entries')
+    users = nsUserAccounts(inst, DEFAULT_SUFFIX)
+    owner1 = users.create(properties={
+        'uid': 'mvowner1',
+        'cn': 'mvowner1',
+        'uidNumber': '5010',
+        'gidNumber': '5010',
+        'homeDirectory': '/home/mvowner1',
+        'displayName': 'MV Owner 1',
+    })
+    owner2 = users.create(properties={
+        'uid': 'mvowner2',
+        'cn': 'mvowner2',
+        'uidNumber': '5011',
+        'gidNumber': '5011',
+        'homeDirectory': '/home/mvowner2',
+        'displayName': 'MV Owner 2',
+    })
+
+    log.info('Create owned entry with testMember pointing to both owners')
+    owned = DSLdapObject(inst)
+    owned._create_objectclasses = ['top', 'person', 'testOwned']
+    owned.create(rdn='cn=mvowned', basedn=DEFAULT_SUFFIX, properties={
+        'sn': 'mvowned',
+        'testOwner': owner1.dn,
+        'testMember': [owner1.dn, owner2.dn],
+    })
+
+    log.info('Remove owner2 from testMember so only owner1 remains')
+    owned.remove('testMember', owner2.dn)
+
+    vals = owned.get_attr_vals_utf8('testMember')
+    assert len(vals) == 1, f"Expected 1 testMember value before rename, got {len(vals)}"
+
+    log.info('Rename owner1')
+    owner1_orig_dn = owner1.dn
+    owner1.rename(new_rdn='uid=mvowner1_renamed')
+    owner1_new_dn = owner1.dn
+
+    log.info('Verify testMember has exactly one value pointing to the new DN')
+    vals = owned.get_attr_vals_utf8('testMember')
+    assert len(vals) == 1, f"Expected exactly 1 testMember value, got {len(vals)}: {vals}"
+    assert vals[0].lower() == owner1_new_dn.lower(), (
+        f"testMember should be '{owner1_new_dn}', got '{vals[0]}'"
+    )
+    assert vals[0].lower() != owner1_orig_dn.lower(), (
+        f"testMember still contains the original DN '{owner1_orig_dn}'"
+    )
+
+
+def test_modrdn_with_non_must_singlevalued_referint_attr(topology_st, referint_setup):
+    """Test MODRDN when a referint-tracked attribute is SINGLE-VALUE
+    but not MUST, DELETE+ADD should work normally.
+
+    :id: f1e2d3c4-b5a6-4789-8012-3456789abcde
+    :setup: Standalone instance with custom schema and referint plugin
+    :steps:
+        1. Create an owner user entry
+        2. Create an entry with optional SINGLE-VALUE testMember
+           pointing to the owner (testMember is MAY, not MUST)
+        3. Rename the owner entry
+        4. Verify testMember has exactly one value pointing to new DN
+    :expectedresults:
+        1. Success
+        2. Success
+        3. MODRDN succeeds (DELETE+ADD works since attr is not MUST)
+        4. Exactly one testMember value with the renamed DN
+    """
+    inst = referint_setup
+
+    log.info('Add a SINGLE-VALUE variant of testMember for this test')
+    schema = Schema(inst)
+    schema.add('attributetypes',
+               "( 9.9.8.4 NAME 'testSingleRef' "
+               "DESC 'Test single-value non-required DN attr' "
+               "EQUALITY distinguishedNameMatch "
+               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 "
+               "SINGLE-VALUE X-ORIGIN 'test' )")
+    schema.add('objectclasses',
+               "( 9.9.8.5 NAME 'testOptRef' "
+               "DESC 'Entry with optional single-value ref' "
+               "SUP top AUXILIARY "
+               "MAY ( testSingleRef ) X-ORIGIN 'test' )")
+
+    referint_plugin = ReferentialIntegrityPlugin(inst)
+    referint_plugin.ensure_present('referint-membership-attr', 'testSingleRef')
+    inst.restart()
+
+    log.info('Create the owner user entry')
+    users = nsUserAccounts(inst, DEFAULT_SUFFIX)
+    owner = users.create(properties={
+        'uid': 'svowner',
+        'cn': 'svowner',
+        'uidNumber': '5020',
+        'gidNumber': '5020',
+        'homeDirectory': '/home/svowner',
+        'displayName': 'SV Owner',
+    })
+    owner_orig_dn = owner.dn
+
+    log.info('Create an entry with optional testSingleRef pointing to owner')
+    entry = DSLdapObject(inst)
+    entry._create_objectclasses = ['top', 'person', 'testOptRef']
+    entry.create(rdn='cn=sventry', basedn=DEFAULT_SUFFIX, properties={
+        'sn': 'sventry',
+        'testSingleRef': owner.dn,
+    })
+
+    log.info('Rename the owner entry')
+    owner.rename(new_rdn='uid=svowner_renamed')
+    owner_new_dn = owner.dn
+
+    log.info('Verify testSingleRef has exactly one value pointing to the new DN')
+    vals = entry.get_attr_vals_utf8('testSingleRef')
+    assert len(vals) == 1, f"Expected exactly 1 testSingleRef value, got {len(vals)}: {vals}"
+    assert vals[0].lower() == owner_new_dn.lower(), (
+        f"testSingleRef should be '{owner_new_dn}', got '{vals[0]}'"
+    )
+    assert vals[0].lower() != owner_orig_dn.lower(), (
+        f"testSingleRef still contains the original DN '{owner_orig_dn}'"
+    )
+
+

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -708,29 +708,75 @@ isFatalSearchError(int search_result)
     return 1;
 }
 
+/*
+ * Check whether mods[i] and mods[i+1] form a consecutive DEL+ADD pair
+ * on the same attribute.  Such pairs must be submitted as a single
+ * atomic modify so that schema_check sees the final state (value
+ * replaced) rather than the intermediate state (required attribute
+ * removed).  This avoids OBJECT_CLASS_VIOLATION on MUST / SINGLE-VALUE
+ * attributes during MODRDN.
+ */
+static int
+_is_del_add_pair(LDAPMod **mods, size_t i)
+{
+    if (mods == NULL || mods[i] == NULL || mods[i + 1] == NULL) {
+        return 0;
+    }
+    return ((mods[i]->mod_op & LDAP_MOD_OP) == LDAP_MOD_DELETE &&
+            (mods[i + 1]->mod_op & LDAP_MOD_OP) == LDAP_MOD_ADD &&
+            strcasecmp(mods[i]->mod_type, mods[i + 1]->mod_type) == 0);
+}
+
 static int
 _do_modify(Slapi_PBlock *mod_pb, Slapi_DN *entrySDN, LDAPMod **mods)
 {
     int rc = 0;
-    LDAPMod *mod[2];
+    int op_flags = allow_repl ? OP_FLAG_REPLICATED : 0;
 
-    /* Split multiple modifications into individual modify operations */
     for (size_t i = 0; (mods != NULL) && (mods[i] != NULL); i++) {
-        mod[0] = mods[i];
-        mod[1] = NULL;
+        /*
+         * Standalone mods go through slapi_single_modify_internal_override
+         * which tolerates TYPE_OR_VALUE_EXISTS and NO_SUCH_ATTRIBUTE,
+         * preserving the idempotency behaviour for replicated operations.
+         */
+        if (_is_del_add_pair(mods, i)) {
+            LDAPMod *pair[3];
 
-        slapi_pblock_init(mod_pb);
+            pair[0] = mods[i];
+            pair[1] = mods[i + 1];
+            pair[2] = NULL;
 
-        /* Do a single mod with error overrides for DEL/ADD */
-        if (allow_repl) {
-            rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mod,
-                                                        referint_plugin_identity, OP_FLAG_REPLICATED);
+            slapi_pblock_init(mod_pb);
+            slapi_modify_internal_set_pb_ext(mod_pb, entrySDN, pair,
+                                             NULL, NULL,
+                                             referint_plugin_identity,
+                                             op_flags);
+            slapi_modify_internal_pb(mod_pb);
+            slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+            if (rc == LDAP_TYPE_OR_VALUE_EXISTS || rc == LDAP_NO_SUCH_ATTRIBUTE) {
+                rc = LDAP_SUCCESS;
+            }
+
+            i++; /* skip the ADD, handled atomically */
         } else {
-            rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mod,
-                                                        referint_plugin_identity, 0);
+            LDAPMod *single[2];
+
+            single[0] = mods[i];
+            single[1] = NULL;
+
+            slapi_pblock_init(mod_pb);
+            rc = slapi_single_modify_internal_override(mod_pb, entrySDN,
+                                                        single,
+                                                        referint_plugin_identity,
+                                                        op_flags);
         }
 
         if (rc != LDAP_SUCCESS) {
+            slapi_log_err(SLAPI_LOG_ERR, REFERINT_PLUGIN_SUBSYSTEM,
+                          "_do_modify - Failed to modify attr \"%s\" on \"%s\" "
+                          "(%d)\n",
+                          mods[i]->mod_type, slapi_sdn_get_dn(entrySDN), rc);
             return rc;
         }
     }

--- a/ldap/servers/plugins/referint/referint.c
+++ b/ldap/servers/plugins/referint/referint.c
@@ -712,25 +712,61 @@ static int
 _do_modify(Slapi_PBlock *mod_pb, Slapi_DN *entrySDN, LDAPMod **mods)
 {
     int rc = 0;
-    LDAPMod *mod[2];
+    int op_flags = allow_repl ? OP_FLAG_REPLICATED : 0;
 
-    /* Split multiple modifications into individual modify operations */
     for (size_t i = 0; (mods != NULL) && (mods[i] != NULL); i++) {
-        mod[0] = mods[i];
-        mod[1] = NULL;
+        /*
+         * Consecutive DEL+ADD on the same attribute must be submitted
+         * as a single atomic modify so that schema_check sees the final
+         * state (value replaced) rather than the intermediate state
+         * (required attribute removed).  This avoids OBJECT_CLASS_VIOLATION
+         * on MUST / SINGLE-VALUE attributes during MODRDN.
+         *
+         * Standalone mods go through slapi_single_modify_internal_override
+         * which tolerates TYPE_OR_VALUE_EXISTS and NO_SUCH_ATTRIBUTE,
+         * preserving the idempotency behaviour for replicated operations.
+         */
+        if ((mods[i]->mod_op & LDAP_MOD_OP) == LDAP_MOD_DELETE &&
+            mods[i + 1] != NULL &&
+            (mods[i + 1]->mod_op & LDAP_MOD_OP) == LDAP_MOD_ADD &&
+            strcasecmp(mods[i]->mod_type, mods[i + 1]->mod_type) == 0) {
+            LDAPMod *pair[3];
 
-        slapi_pblock_init(mod_pb);
+            pair[0] = mods[i];
+            pair[1] = mods[i + 1];
+            pair[2] = NULL;
 
-        /* Do a single mod with error overrides for DEL/ADD */
-        if (allow_repl) {
-            rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mod,
-                                                        referint_plugin_identity, OP_FLAG_REPLICATED);
+            slapi_pblock_init(mod_pb);
+            slapi_modify_internal_set_pb_ext(mod_pb, entrySDN, pair,
+                                             NULL, NULL,
+                                             referint_plugin_identity,
+                                             op_flags);
+            slapi_modify_internal_pb(mod_pb);
+            slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+
+            if (rc == LDAP_TYPE_OR_VALUE_EXISTS || rc == LDAP_NO_SUCH_ATTRIBUTE) {
+                rc = LDAP_SUCCESS;
+            }
+
+            i++; /* skip the ADD, handled atomically */
         } else {
-            rc = slapi_single_modify_internal_override(mod_pb, entrySDN, mod,
-                                                        referint_plugin_identity, 0);
+            LDAPMod *single[2];
+
+            single[0] = mods[i];
+            single[1] = NULL;
+
+            slapi_pblock_init(mod_pb);
+            rc = slapi_single_modify_internal_override(mod_pb, entrySDN,
+                                                        single,
+                                                        referint_plugin_identity,
+                                                        op_flags);
         }
 
         if (rc != LDAP_SUCCESS) {
+            slapi_log_err(SLAPI_LOG_ERR, REFERINT_PLUGIN_SUBSYSTEM,
+                          "_do_modify - Failed to modify attr \"%s\" on \"%s\" "
+                          "(%d)\n",
+                          mods[i]->mod_type, slapi_sdn_get_dn(entrySDN), rc);
             return rc;
         }
     }


### PR DESCRIPTION
…LE-VALUE

Description: Fall back to LDAP_MOD_REPLACE when DELETE of a required attribute triggers OBJECT_CLASS_VIOLATION.

Relates: #6641

Reviewed by: ???

## Summary by Sourcery

Ensure referential integrity updates succeed when modifying required single-valued attributes during MODRDN operations.

New Features:
- Add a regression test covering MODRDN of entries with a referential-integrity-tracked attribute that is MUST and SINGLE-VALUE in the schema.

Bug Fixes:
- Handle OBJECT_CLASS_VIOLATION errors in the referential integrity plugin by retrying a DELETE+ADD sequence as a REPLACE when updating required attributes during internal modifies.

Tests:
- Introduce an automated test that defines custom schema, enables referential integrity on a DN-valued attribute, and verifies MODRDN correctly updates the referencing attribute without failing.