### PR TITLE
Issue 7375 - CI - Fix flaky dsconf_tasks_test watch output

### DIFF
--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -114,6 +114,8 @@ class Task(DSLdapObject):
         log = self.get_attr_val_utf8("nsTaskLog")
         if log is None:
             log = ""
+        if log:
+            self._log.info(log)
         while not self.is_complete():
             time.sleep(1)
             next_log = self.get_attr_val_utf8("nsTaskLog")


### PR DESCRIPTION
Description: Print the initial nsTaskLog snapshot in Task.watch() so early log lines are not silently dropped.

Relates: #7375

Reviewed by: ??

## Summary by Sourcery

Bug Fixes:
- Ensure Task.watch() prints any existing nsTaskLog content before entering the polling loop so early log lines are not lost.