### PR TITLE
Issue 7412 - Report thread pool saturation on per-operation access log RESULT lines

### DIFF
--- a/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
+++ b/dirsrvtests/tests/suites/ds_logs/ds_logs_test.py
@@ -24,7 +24,8 @@ from lib389.plugins import AutoMembershipPlugin, ReferentialIntegrityPlugin, Aut
 from lib389.idm.user import UserAccounts, UserAccount
 from lib389.idm.group import Groups
 from lib389.idm.organizationalunit import OrganizationalUnits
-from lib389._constants import DEFAULT_SUFFIX, LOG_ACCESS_LEVEL, PASSWORD, ErrorLog
+from lib389._constants import DEFAULT_SUFFIX, DN_DM, LOG_ACCESS_LEVEL, PASSWORD, ErrorLog
+from lib389.dirsrv_log import DirsrvAccessJSONLog
 from lib389.utils import ds_is_older, ds_is_newer
 from lib389.config import RSA
 from lib389.dseldif import DSEldif
@@ -39,6 +40,14 @@ log = logging.getLogger(__name__)
 
 PLUGIN_LOGGING = 'nsslapd-plugin-logging'
 USER1_DN = 'uid=user1,' + DEFAULT_SUFFIX
+THREAD_POOL_OP_TAGS = {
+    ldap.RES_BIND:          "BIND",
+    ldap.RES_SEARCH_RESULT: "SEARCH",
+    ldap.RES_MODIFY:        "MOD",
+    ldap.RES_ADD:           "ADD",
+    ldap.RES_DELETE:        "DEL",
+    ldap.RES_EXTENDED:      "EXTOP",
+}
 
 
 def add_users(topology_st, users_num):
@@ -1258,6 +1267,297 @@ def test_stat_internal_op(topology_st, request):
         group.delete()
 
     request.addfinalizer(fin)
+
+
+@pytest.fixture
+def thread_pool_log_setup(topology_st, request):
+    """Standalone instance with unbuffered plain-text access log, statlog off
+    and a clean access log on disk.
+    """
+    inst = topology_st.standalone
+    inst.config.replace("nsslapd-accesslog-logbuffering", "off")
+    inst.config.replace("nsslapd-accesslog-log-format", "default")
+    inst.config.replace("nsslapd-statlog-level", "0")
+    inst.deleteAccessLogs(restart=True)
+
+    def fin():
+        inst.config.replace("nsslapd-statlog-level", "0")
+        inst.config.replace("nsslapd-accesslog-log-format", "default")
+        for u in UserAccounts(inst, DEFAULT_SUFFIX).filter('(uid=pool_*)'):
+            try:
+                u.delete()
+            except Exception:
+                pass
+    request.addfinalizer(fin)
+    return inst
+
+
+def _exercise_all_op_types(inst, tag):
+    """Drive one of each externally-initiated op type so each produces a
+    RESULT: BIND, ADD, SEARCH, MOD, EXTOP (WhoAmI), DEL. `tag` keeps uids
+    unique across invocations.
+    """
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    uid = f'pool_{tag}'
+    inst.simple_bind_s(DN_DM, PASSWORD)
+    user = users.create(properties={
+        'uid': uid, 'sn': uid, 'cn': uid,
+        'uidNumber': '7001', 'gidNumber': '7000',
+        'homeDirectory': f'/home/{uid}',
+    })
+    inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, f'uid={uid}')
+    user.replace('description', 'pool-test')
+    inst.whoami_s()
+    user.delete()
+
+
+def test_stat_thread_pool_off_by_default(thread_pool_log_setup):
+    """Default nsslapd-statlog-level=0 emits no thread pool stats on RESULT.
+
+    :id: 8e289662-ccb7-4647-be81-a637750a5e13
+    :setup: Standalone instance, statlog-level=0
+    :steps:
+        1. Confirm nsslapd-statlog-level is 0
+        2. Exercise one of each externally-initiated op type
+        3. No RESULT line carries wbusy=
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == 0
+    _exercise_all_op_types(inst, 'default')
+    time.sleep(1)
+    assert not inst.ds_access_log.match(r'.*RESULT.*wbusy=.*')
+
+
+def test_stat_thread_pool_runtime_toggle(thread_pool_log_setup):
+    """Pool stats turn on with level=2 and back off with level=0 at runtime.
+
+    :id: cd22210b-56d1-4ab1-83c2-1c560cd86494
+    :setup: Standalone instance
+    :steps:
+        1. Runtime-set level=2 and exercise ops - RESULT lines carry pool stats
+        2. Runtime-set level=0, clear the access log, exercise ops again -
+           no RESULT line carries pool stats
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    inst = thread_pool_log_setup
+
+    inst.config.replace("nsslapd-statlog-level", "2")
+    _exercise_all_op_types(inst, 'on')
+    time.sleep(1)
+    assert inst.ds_access_log.match(r'.*RESULT.*wbusy=.*')
+
+    inst.config.replace("nsslapd-statlog-level", "0")
+    inst.deleteAccessLogs(restart=True)
+    _exercise_all_op_types(inst, 'off')
+    time.sleep(1)
+    assert not inst.ds_access_log.match(r'.*RESULT.*wbusy=.*')
+
+
+def test_stat_thread_pool_plain_text(thread_pool_log_setup):
+    """Plain-text RESULT for every external op type carries pool stats.
+
+    :id: 6c59a8cb-6bfa-4955-8fff-83bca66d4033
+    :setup: Standalone instance, statlog-level=2, default (text) format
+    :steps:
+        1. Runtime-set level=2
+        2. Exercise BIND/ADD/SEARCH/MOD/EXTOP/DEL
+        3. For each op tag a RESULT line contains wbusy=N/M wqdepth=N
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", "2")
+    _exercise_all_op_types(inst, 'plain')
+    time.sleep(1)
+
+    for op_tag, op_name in THREAD_POOL_OP_TAGS.items():
+        assert inst.ds_access_log.match(
+            rf'.*RESULT .* tag={op_tag} .*wbusy=[0-9]+/[0-9]+ '
+            rf'wqdepth=[0-9]+.*'), \
+            f"no plain-text RESULT with pool stats for {op_name} (tag={op_tag})"
+
+
+def test_stat_thread_pool_json(thread_pool_log_setup):
+    """JSON RESULT event for every external op type carries wbusy/wmax/wqdepth.
+
+    :id: fb87f936-fdba-4f63-ae68-588396cd6086
+    :setup: Standalone instance, statlog-level=2, JSON access log
+    :steps:
+        1. Runtime-switch access log format to JSON and set level=2
+        2. Exercise all op types
+        3. Every op tag has a RESULT event with wbusy, wmax and wqdepth of
+           integer type and sane values
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-accesslog-log-format", "json")
+    inst.config.replace("nsslapd-statlog-level", "2")
+    _exercise_all_op_types(inst, 'json')
+    time.sleep(1)
+
+    seen_tags = set()
+    json_log = DirsrvAccessJSONLog(inst)
+    for line in json_log.readlines():
+        event = json_log.parse_line(line)
+        if event is None or 'header' in event:
+            continue
+        if event.get('operation') != 'RESULT':
+            continue
+        if 'wbusy' not in event:
+            continue
+
+        assert 'wmax' in event
+        assert 'wqdepth' in event
+        assert isinstance(event['wbusy'], int)
+        assert isinstance(event['wmax'], int)
+        assert isinstance(event['wqdepth'], int)
+        assert event['wbusy'] >= 0
+        assert event['wmax'] > 0
+        assert event['wqdepth'] >= 0
+        assert event['wbusy'] <= event['wmax'], \
+            f"wbusy {event['wbusy']} exceeds wmax {event['wmax']}"
+
+        tag = event.get('tag')
+        if isinstance(tag, int):
+            seen_tags.add(tag)
+
+    for op_tag, op_name in THREAD_POOL_OP_TAGS.items():
+        assert op_tag in seen_tags, \
+            f"no JSON RESULT with wbusy/wmax/wqdepth for {op_name} (tag={op_tag})"
+
+
+def test_stat_thread_pool_coexists_with_index(thread_pool_log_setup):
+    """Level=3 emits both STAT index lines and RESULT pool stats.
+
+    :id: 8b4f2e2d-5a3a-4b8f-a15d-6b8e6b19f0e3
+    :setup: Standalone instance, statlog-level=3
+    :steps:
+        1. Runtime-set level=3
+        2. Exercise ops so index reads and RESULT lines are both produced
+        3. The log contains both STAT read index lines and RESULT pool stats
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", "3")
+    _exercise_all_op_types(inst, 'both')
+    time.sleep(1)
+    assert inst.ds_access_log.match(r'.*STAT read index.*')
+    assert inst.ds_access_log.match(
+        r'.*RESULT.*wbusy=[0-9]+/[0-9]+.*wqdepth=[0-9]+.*')
+
+
+@pytest.mark.parametrize("value", ["0", "1", "2", "3", "255"])
+def test_statlog_level_accepts_valid(thread_pool_log_setup, value):
+    """nsslapd-statlog-level accepts valid non-negative integer flag values.
+
+    :id: 7a5dbcec-ab26-4bc0-9e5c-2651bd198a45
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Replace nsslapd-statlog-level with the value
+        2. Re-read the attribute and confirm it matches
+    :expectedresults:
+        1. Success
+        2. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", value)
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == int(value)
+
+
+@pytest.mark.parametrize("bad", ["-1", "abc", "2abc", "9999999999999999999999"])
+def test_statlog_level_rejects_invalid(thread_pool_log_setup, bad):
+    """nsslapd-statlog-level rejects non-numeric, negative, trailing-garbage
+    and overflow values, and the stored value is not changed.
+
+    :id: 6722c48b-21d0-4f03-8501-b7f0d0aaef15
+    :parametrized: yes
+    :setup: Standalone instance, statlog-level set to 2
+    :steps:
+        1. Replace nsslapd-statlog-level with "2" (known-good baseline)
+        2. Attempt to replace with an invalid value
+        3. Confirm the value is still 2
+    :expectedresults:
+        1. Success
+        2. ldap.OPERATIONS_ERROR is raised
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", "2")
+    with pytest.raises(ldap.OPERATIONS_ERROR):
+        inst.config.replace("nsslapd-statlog-level", bad)
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == 2
+
+
+def test_statlog_level_reset_via_mod_delete(thread_pool_log_setup):
+    """mod_delete of nsslapd-statlog-level resets the value to the default (0).
+
+    :id: e0c32937-1adb-48a6-8c7c-92cd371c4146
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-statlog-level to 2
+        2. Issue a mod_delete on nsslapd-statlog-level
+        3. Confirm the value has been reset to 0
+        4. Confirm RESULT lines no longer carry pool stats
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", "2")
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == 2
+
+    inst.config.remove_all("nsslapd-statlog-level")
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == 0
+
+    inst.deleteAccessLogs(restart=True)
+    _exercise_all_op_types(inst, 'after_reset')
+    time.sleep(1)
+    assert not inst.ds_access_log.match(r'.*RESULT.*wbusy=.*')
+
+
+def test_statlog_level_persists_across_restart(thread_pool_log_setup):
+    """nsslapd-statlog-level survives a server restart and continues to
+    drive the thread-pool stat output.
+
+    :id: 75f6ca47-7b6a-4509-a725-f61ebac9a777
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-statlog-level to 2 and restart the server
+        2. Confirm the attribute is still 2
+        3. Exercise ops and confirm RESULT lines still carry pool stats
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+    """
+    inst = thread_pool_log_setup
+    inst.config.replace("nsslapd-statlog-level", "2")
+    inst.restart()
+    assert inst.config.get_attr_val_int("nsslapd-statlog-level") == 2
+
+    inst.deleteAccessLogs(restart=True)
+    _exercise_all_op_types(inst, 'restart')
+    time.sleep(1)
+    assert inst.ds_access_log.match(
+        r'.*RESULT.*wbusy=[0-9]+/[0-9]+.*wqdepth=[0-9]+.*')
+
 
 def test_referral_check(topology_st, request):
     """Check that referral detection mechanism works

--- a/dirsrvtests/tests/suites/logging/logconv_test.py
+++ b/dirsrvtests/tests/suites/logging/logconv_test.py
@@ -110,7 +110,7 @@ class TestLogconv:
         return path
 
     def truncate_logs(self):
-        """ 
+        """
         Truncate logs between test runs.
         """
         if not self.access_log_path:
@@ -140,7 +140,7 @@ class TestLogconv:
             "ldapi_conns": r"- LDAPI connections:\s+(\d+)",
             "ldaps_conns": r"- LDAPS connections:\s+(\d+)",
             "starttls_conns": r"- StartTLS Extended Ops:\s+(\d+)",
-            
+
 
             # Operations
             "operations": r"^Total Operations:\s+(\d+)",
@@ -239,7 +239,7 @@ class TestLogconv:
 
     def validate_logconv_stats(self, expected: dict, logconv_stats: dict, test_name=None):
         """
-        The comparison is loose, it passes once the actual counts are greater than or equal 
+        The comparison is loose, it passes once the actual counts are greater than or equal
         to the expected count.
 
         Args:
@@ -1357,6 +1357,53 @@ class TestLogconv:
 
         log.info("Verify logconv returned error when access log path not provided")
         assert result.returncode == 1
+
+    def test_pool_stats(self, topo_shared):
+        """Validate logconv parses RESULT lines carrying wbusy/wqdepth
+        tokens without dropping trailing fields.
+
+        :id: 2bb14b97-1b61-426b-b9b3-39909d9699c8
+        :setup: Standalone Instance
+        :steps:
+            1. Truncate access log
+            2. Inject RESULT lines with varying pool/trailing combinations
+            3. Run logconv and compare stats
+        :expectedresults:
+            1. Success
+            2. Success
+            3. Actual stats match expected
+        """
+        self.init_instance(topo_shared.standalone)
+        self.truncate_logs()
+
+        lines = [
+            '[17/Apr/2026:00:00:00.000000000 +0000] conn=1 fd=64 slot=64 connection from 127.0.0.1 to 127.0.0.1\n',
+            '[17/Apr/2026:00:00:00.050000000 +0000] conn=1 op=0 BIND dn="cn=Directory Manager" method=128 version=3\n',
+            '[17/Apr/2026:00:00:00.060000000 +0000] conn=1 op=0 RESULT err=0 tag=97 nentries=0 wtime=0.0001 optime=0.001 etime=0.0011 wbusy=2/16 wqdepth=0\n',
+            '[17/Apr/2026:00:00:00.100000000 +0000] conn=1 op=1 SRCH base="dc=example,dc=com" scope=2 filter="(idontexist=*)" attrs=ALL\n',
+            '[17/Apr/2026:00:00:00.200000000 +0000] conn=1 op=1 RESULT err=0 tag=101 nentries=0 wtime=0.0001 optime=0.001 etime=0.0011 wbusy=8/16 wqdepth=3 notes=A\n',
+            '[17/Apr/2026:00:00:00.300000000 +0000] conn=1 op=2 SRCH base="dc=example,dc=com" scope=2 filter="(cn=*)" attrs=ALL\n',
+            '[17/Apr/2026:00:00:00.400000000 +0000] conn=1 op=2 RESULT err=0 tag=101 nentries=3 wtime=0.0001 optime=0.001 etime=0.0011 wbusy=14/16 wqdepth=7\n',
+            '[17/Apr/2026:00:00:00.500000000 +0000] conn=1 op=3 SRCH base="dc=example,dc=com" scope=2 filter="(description=*)" attrs=ALL\n',
+            '[17/Apr/2026:00:00:00.600000000 +0000] conn=1 op=3 RESULT err=0 tag=101 nentries=0 wtime=0.0001 optime=0.001 etime=0.0011 notes=A\n',
+        ]
+
+        with open(self.access_log_path, "w") as f:
+            for line in lines:
+                f.write(line)
+
+        expected = {
+            "binds": 1,
+            "searches": 3,
+            "operations": 4,
+            "results": 4,
+            "unindexed_searches": 2,
+        }
+
+        output = self.run_logconv()
+        logconv_stats = self.extract_logconv_stats(output)
+        assert self.validate_logconv_stats(expected, logconv_stats, "test_pool_stats")
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/dirsrvtests/tests/suites/logging/logconv_test.py
+++ b/dirsrvtests/tests/suites/logging/logconv_test.py
@@ -1398,6 +1398,10 @@ class TestLogconv:
             "operations": 4,
             "results": 4,
             "unindexed_searches": 2,
+            "restarts": 1,
+            "total_connections": 1,
+            "ldap_conns": 1,
+            "fds_taken": 1,
         }
 
         output = self.run_logconv()

--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -324,6 +324,11 @@ class ResultData:
     error_freq: DefaultDict[str, int] = field(default_factory=lambda: defaultdict(int))
     bad_pwd_map: Dict[str, int] = field(default_factory=dict)
 
+    wbusy_ratio_samples: List[float] = field(default_factory=list)
+    wqdepth_samples: List[int] = field(default_factory=list)
+    wstats_count: int = 0
+    wmax_seen: int = 0
+
 @dataclass
 class SearchData:
     counters: Dict[str, int] = field(default_factory=lambda: defaultdict(
@@ -504,6 +509,8 @@ class logAnalyser:
                 \stag=(?P<tag>\d+)                                  # tag=int
                 \snentries=(?P<nentries>\d+)                        # nentries=int
                 (?:\s[a-z]+time=[^ ]+)*                             # fine grain operation timing
+                (?:\swbusy=(?P<wbusy>\d+)/(?P<wmax>\d+))?           # Optional: wbusy=N/M
+                (?:\swqdepth=(?P<wqdepth>\d+))?                     # Optional: wqdepth=N
                 (?:\sdn="(?P<dn>[^"]*)")?                           # Optional: dn="", dn="strings"
                 (?:,\s+(?P<sasl_msg>SASL\s+bind\s+in\s+progress))?  # Optional: SASL bind in progress
                 (?:\s+notes=(?P<notes>[A-Z]))?                      # Optional: notes[A-Z]
@@ -1111,7 +1118,10 @@ class logAnalyser:
             "tag": self.convert_to_int(log_entry.get('tag', None)),
             "err": self.convert_to_int(log_entry.get('err', None)),
             "internal_op": log_entry.get('internal', None),
-            "notes": normalised_notes 
+            "notes": normalised_notes,
+            "wbusy": self.convert_to_int(log_entry.get('wbusy', None)),
+            "wmax": self.convert_to_int(log_entry.get('wmax', None)),
+            "wqdepth": self.convert_to_int(log_entry.get('wqdepth', None)),
         }
 
         # Compute and inject connection scoped key
@@ -1222,6 +1232,24 @@ class logAnalyser:
                 self.result.total_optime += optime_f
             except ValueError:
                 self.logger.debug(f"Invalid optime format: {optime}")
+
+        # Thread pool saturation
+        wbusy = log_entry.get("wbusy")
+        wmax = log_entry.get("wmax")
+        wqdepth = log_entry.get("wqdepth")
+        if (isinstance(wbusy, int) and isinstance(wmax, int)
+                and wmax > 0 and wbusy >= 0):
+            ratio = wbusy / wmax
+            heapq.heappush(self.result.wbusy_ratio_samples, ratio)
+            if len(self.result.wbusy_ratio_samples) > self.size_limit:
+                heapq.heappop(self.result.wbusy_ratio_samples)
+            self.result.wstats_count += 1
+            if wmax > self.result.wmax_seen:
+                self.result.wmax_seen = wmax
+        if isinstance(wqdepth, int) and wqdepth >= 0:
+            heapq.heappush(self.result.wqdepth_samples, wqdepth)
+            if len(self.result.wqdepth_samples) > self.size_limit:
+                heapq.heappop(self.result.wqdepth_samples)
 
         # Stat reporting to csv file
         try:
@@ -3420,6 +3448,26 @@ def main():
                 if num >= db.size_limit:
                     break
                 print(f"optime={optime:<12}")
+
+        # Thread pool saturation
+        if db.result.wstats_count > 0:
+            wmax = db.result.wmax_seen
+            ratios = sorted(db.result.wbusy_ratio_samples, reverse=True)
+            print(f"\n----- Top {db.size_limit} Highest Thread Pool Saturation "
+                  f"(wbusy/{wmax}) -----\n")
+            for num, ratio in enumerate(ratios):
+                if num >= db.size_limit:
+                    break
+                busy = round(ratio * wmax)
+                print(f"wbusy={busy}/{wmax} ({ratio*100:.1f}%)")
+
+            depths = sorted(db.result.wqdepth_samples, reverse=True)
+            print(f"\n----- Top {db.size_limit} Deepest Work Queue Backlogs "
+                  f"(wqdepth) -----\n")
+            for num, qd in enumerate(depths):
+                if num >= db.size_limit:
+                    break
+                print(f"wqdepth={qd:<10}")
 
         # Largest nentries returned
         nentries = sorted(db.result.nentries_num, reverse=True)

--- a/ldap/servers/slapd/accesslog.c
+++ b/ldap/servers/slapd/accesslog.c
@@ -757,6 +757,16 @@ slapd_log_access_result(slapd_log_pblock *logpb)
         }
     }
 
+    /* Thread pool statistics */
+    if (logpb->wbusy >= 0) {
+        json_object_object_add(json_obj, "wbusy",
+                               json_object_new_int(logpb->wbusy));
+        json_object_object_add(json_obj, "wmax",
+                               json_object_new_int(logpb->wmax));
+        json_object_object_add(json_obj, "wqdepth",
+                               json_object_new_int(logpb->wqdepth));
+    }
+
     /* Convert json object to string and log it */
     msg = (char *)json_object_to_json_string_ext(json_obj, logpb->log_format);
     rc = slapd_log_access_json(msg);

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -2281,6 +2281,21 @@ get_work_q(struct Slapi_op_stack **op_stack_obj)
     destroy_work_q(&tmp);
     fgot_end((*op_stack_obj)->op, FGOT_WQ);
 
+    /*
+     * Capture thread pool state at dequeue time for STAT logging.
+     *   - work_q_size was already decremented above, so get_work_q_size()
+     *     returns the number of other operations still waiting in the queue
+     *   - current_busy_workers will be incremented later in connection_threadmain,
+     *     so get_busy_worker_count() returns the number of workers that
+     *     are busy while this operation was waiting in the queue
+     */
+    if (LDAP_STAT_THREAD_POOL & config_get_statlog_level()) {
+        Operation *op = (*op_stack_obj)->op;
+        op->o_wbusy = get_busy_worker_count();
+        op->o_wmax = config_get_threadnumber();
+        op->o_wqdepth = get_work_q_size();
+    }
+
     return (wqitem);
 }
 

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -749,7 +749,7 @@ static struct config_get_and_set
     {CONFIG_STATLOGLEVEL_ATTRIBUTE, config_set_statlog_level,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.statloglevel,
-     CONFIG_INT, NULL, SLAPD_DEFAULT_STATLOG_LEVEL, NULL},
+     CONFIG_INT, NULL, SLAPD_DEFAULT_STATLOG_LEVEL_STR, NULL},
     {CONFIG_SECURITYLOGLEVEL_ATTRIBUTE, config_set_securitylog_level,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.securityloglevel,

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -7356,6 +7356,9 @@ slapd_log_pblock_init(slapd_log_pblock *logpb, int32_t log_format, Slapi_PBlock 
     logpb->op_nested_count = -1;
     logpb->pr_cookie = -1;
     logpb->pr_idx = -1;
+    logpb->wbusy = -1;
+    logpb->wmax = -1;
+    logpb->wqdepth = -1;
     logpb->curr_time = slapi_current_utc_time_hr();
 
     if (conn) {

--- a/ldap/servers/slapd/operation.c
+++ b/ldap/servers/slapd/operation.c
@@ -165,6 +165,9 @@ operation_init(Slapi_Operation *o, int flags)
         o->o_flags = flags;
         o->o_reverse_search_state = 0;
         o->o_pagedresults_sizelimit = -1;
+        o->o_wbusy = -1;
+        o->o_wmax = -1;
+        o->o_wqdepth = -1;
         if (fecfg) {
             for(fgot_id_t id=0; id < FGOT_MAX; id++) {
                 if ((1UL<<id) & fecfg->fgot_flags) {

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -860,7 +860,7 @@ int lock_fclose(FILE *fp, FILE *lfp);
 #define LDAP_DEBUG_ALL_LEVELS 0xFFFFFF
 
 #define LDAP_STAT_READ_INDEX  0x00000001  /*         1 */
-#define LDAP_STAT_FREE_1      0x00000002  /*         2 */
+#define LDAP_STAT_THREAD_POOL 0x00000002  /*         2 */
 
 extern int slapd_ldap_debug;
 

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -2295,6 +2295,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
     int32_t log_format = config_get_accesslog_log_format();
     slapd_log_pblock logpb = {0};
     char buff_fgot[FGOT_BUFSIZ] = "";
+    char buff_pool[80] = "";
 
     get_internal_conn_op(&connid, &op_id, &op_internal_id, &op_nested_count, &start_time);
     slapi_pblock_get(pb, SLAPI_PAGED_RESULTS_INDEX, &pr_idx);
@@ -2352,6 +2353,14 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             }
         }
         slapi_log_fgot_text(op, buff_fgot, FGOT_BUFSIZ);
+        /* Thread pool stats for text format */
+        if ((LDAP_STAT_THREAD_POOL & config_get_statlog_level()) &&
+            !internal_op && op->o_wbusy >= 0)
+        {
+            snprintf(buff_pool, sizeof(buff_pool),
+                     " wbusy=%" PRId32 "/%" PRId32 " wqdepth=%" PRId32,
+                     op->o_wbusy, op->o_wmax, op->o_wqdepth);
+        }
     } else {
         /* Start prepping the JSON result block */
         slapd_log_pblock_init(&logpb, log_format, pb);
@@ -2363,6 +2372,14 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
         logpb.sid = sessionTrackingId;
         logpb.tag = tag;
         slapi_log_fgot_json(op, &logpb, buff_fgot, FGOT_BUFSIZ);
+        /* Thread pool stats for JSON format */
+        if ((LDAP_STAT_THREAD_POOL & config_get_statlog_level()) &&
+            !internal_op && op->o_wbusy >= 0)
+        {
+            logpb.wbusy = op->o_wbusy;
+            logpb.wmax = op->o_wmax;
+            logpb.wqdepth = op->o_wqdepth;
+        }
     }
 
 #define LOG_CONN_OP_FMT_INT_INT "conn=Internal(%" PRIu64 ") op=%d(%d)(%d) RESULT err=%d"
@@ -2380,11 +2397,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s"
                                  ", SASL bind in progress\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, session_str);
             }
         } else {
@@ -2399,7 +2416,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s, SASL bind in progress\n"
+#define LOG_SASLMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s, SASL bind in progress\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_SASLMSG_FMT :
                                            LOG_CONN_OP_FMT_EXT_INT LOG_SASLMSG_FMT,
@@ -2407,7 +2424,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, session_str);
             }
         }
@@ -2427,11 +2444,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s"
                                  " dn=\"%s\"\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         } else {
@@ -2447,7 +2464,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s dn=\"%s\"\n"
+#define LOG_BINDMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s dn=\"%s\"\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_BINDMSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_BINDMSG_FMT,
@@ -2455,7 +2472,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, session_str, dn ? dn : "");
             }
         }
@@ -2471,11 +2488,11 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 } else {
                     slapi_log_access(LDAP_DEBUG_STATS,
                                      "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                     " tag=%" BERTAG_T " nentries=%d%s%s%s%s"
+                                     " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s"
                                      " pr_idx=%d pr_cookie=%d\n",
                                      op->o_connid,
                                      op->o_opid,
-                                     err, tag, nentries, buff_fgot, session_str,
+                                     err, tag, nentries, buff_fgot, buff_pool, session_str,
                                      notes_str, csn_str, pr_idx, pr_cookie);
                 }
             } else {
@@ -2491,7 +2508,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                     logpb.level = LDAP_DEBUG_ARGS;
                     slapd_log_access_result(&logpb);
                 } else {
-#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s pr_idx=%d pr_cookie=%d \n"
+#define LOG_PRMSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s pr_idx=%d pr_cookie=%d \n"
                     slapi_log_access(LDAP_DEBUG_ARGS,
                                      connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_PRMSG_FMT :
                                                    LOG_CONN_OP_FMT_EXT_INT LOG_PRMSG_FMT,
@@ -2499,7 +2516,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                      op_id,
                                      op_internal_id,
                                      op_nested_count,
-                                     err, tag, nentries, buff_fgot,
+                                     err, tag, nentries, buff_fgot, buff_pool,
                                      notes_str, csn_str, session_str, pr_idx, pr_cookie);
                 }
             }
@@ -2521,10 +2538,10 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
             } else {
                 slapi_log_access(LDAP_DEBUG_STATS,
                                  "conn=%" PRIu64 " op=%d RESULT err=%d"
-                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s\n",
+                                 " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s%s\n",
                                  op->o_connid,
                                  op->o_opid,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, ext_str, session_str);
             }
             if (pbtxt) {
@@ -2545,7 +2562,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                 logpb.level = LDAP_DEBUG_ARGS;
                 slapd_log_access_result(&logpb);
             } else {
-#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s\n"
+#define LOG_MSG_FMT " tag=%" BERTAG_T " nentries=%d%s%s%s%s%s\n"
                 slapi_log_access(LDAP_DEBUG_ARGS,
                                  connid == 0 ? LOG_CONN_OP_FMT_INT_INT LOG_MSG_FMT :
                                                LOG_CONN_OP_FMT_EXT_INT LOG_MSG_FMT,
@@ -2553,7 +2570,7 @@ log_result(Slapi_PBlock *pb, Operation *op, int err, ber_tag_t tag, int nentries
                                  op_id,
                                  op_internal_id,
                                  op_nested_count,
-                                 err, tag, nentries, buff_fgot,
+                                 err, tag, nentries, buff_fgot, buff_pool,
                                  notes_str, csn_str, session_str);
             }
             /*

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1651,6 +1651,10 @@ typedef struct op
     struct slapi_operation_results o_results;
     int o_pagedresults_sizelimit;
     int o_reverse_search_state;
+    /* Thread pool snapshot taken at dequeue, -1 if not captured */
+    int32_t o_wbusy;
+    int32_t o_wmax;
+    int32_t o_wqdepth;
     fgot_t o_fgots[FGOT_MAX];                        /* Fine grain operation timing counters */
 } Operation;
 

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -1647,6 +1647,10 @@ typedef struct slapd_log_pblock {
     CSN *csn;
     int32_t pr_idx;
     int32_t pr_cookie;
+    /* Thread pool stats, -1 if not captured */
+    int32_t wbusy;
+    int32_t wmax;
+    int32_t wqdepth;
     /* Misc */
     const char *oid;
     const char *msg;


### PR DESCRIPTION
Description: Extend nsslapd-statlog-level with LDAP_STAT_THREAD_POOL (2). When enabled, every external operation's RESULT line in the access log includes wbusy=N/M and wqdepth=N, correlating individual operation latency with pool utilization at dequeue time.

wbusy=N/M: workers active (N) out of configured max (M). High ratio signals near-saturation before wtime detects starvation. wqdepth=N: operations still queued after this one was dequeued. Non-zero indicates backlog accumulation.

Runtime-toggleable via dsconf. Supported in plain-text (wbusy/wqdepth) and JSON (wbusy, wmax, wqdepth) formats for all externally-initiated op types. Internal operations are excluded as they bypass the work queue. logconv extended to parse and summarize pool stats.

Fixes: https://github.com/389ds/389-ds-base/issues/7412

Reviewed by: ?

## Summary by Sourcery

Add thread-pool saturation statistics to RESULT access log entries and extend tooling and tests to support and validate the new logging.

New Features:
- Log per-operation thread-pool utilization and work-queue depth in RESULT access log entries for externally-initiated operations when the appropriate statlog level flag is enabled.
- Emit thread-pool statistics in both plain-text (wbusy/wqdepth) and JSON (wbusy, wmax, wqdepth) access log formats.
- Summarize thread-pool saturation and queue backlog in logconv output using sampled wbusy/wmax ratios and wqdepth values.

Bug Fixes:
- Fix logconv legacy RESULT-line parsing so additional wbusy/wqdepth tokens do not truncate or drop trailing fields in the parsed output.

Enhancements:
- Capture thread-pool state at work-queue dequeue time and propagate it through operation structures into access logging, excluding internal operations.
- Extend the statlog level configuration to use a string default and repurpose the stat flag value 2 as LDAP_STAT_THREAD_POOL.
- Update logconv parsing to recognize wbusy/wmax/wqdepth tokens in legacy RESULT lines without impacting existing field extraction.

Tests:
- Add integration tests to verify thread-pool stats are absent by default, toggle correctly with statlog level changes, appear for all external operation types in text and JSON logs, coexist with index STAT logging, and persist across restarts and mod_delete resets.
- Add tests to validate accepted and rejected values for nsslapd-statlog-level and ensure invalid updates do not change the stored value.
- Add a logconv test that injects RESULT lines with various pool-stat combinations to confirm parsing correctness and that trailing fields are still counted properly.