### PR TITLE
Issue 7389 - Fix CONFIG_CHARRAY crash

### DIFF
--- a/dirsrvtests/tests/suites/features/ldap_controls_test.py
+++ b/dirsrvtests/tests/suites/features/ldap_controls_test.py
@@ -139,7 +139,7 @@ def test_ignored_criticality(topology_st):
     ctrls = { oid: ldap.controls.RequestControl(controlType=oid, criticality=True) \
                 for oid in TESTED_CTRLS }
 
-    all_sets = all_combinations(TESTED_CTRLS)
+    all_sets = list(all_combinations(TESTED_CTRLS))
     for ignored_ctrls in all_sets:
         for send_ctrls in all_sets:
             set_ignored_criticality(inst, ignored_ctrls)

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -9640,6 +9640,26 @@ config_set(const char *attr, struct berval **values, char *errorbuf, int apply)
                 slapi_log_err(SLAPI_LOG_ERR, "config_set",
                               "The attribute %s is read only; ignoring setting NULL value\n", attr);
             }
+        } else if (values != NULL && values[0] != NULL &&
+                   cgas->config_var_type == CONFIG_CHARRAY) {
+            char **vals = NULL;
+            for (ii = 0; !retval && values && values[ii]; ++ii) {
+                char *val = slapi_berval_get_string_copy(values[ii]);
+                charray_add(&vals, val);
+            }
+            if (cgas->setfunc) {
+                retval = (cgas->setfunc)(cgas->attr_name,
+                                         (char *)vals, errorbuf, apply);
+            } else if (cgas->logsetfunc) {
+                retval = (cgas->logsetfunc)(cgas->attr_name,
+                                            (char *)vals, cgas->whichlog,
+                                            errorbuf, apply);
+            } else {
+                slapi_log_err(SLAPI_LOG_ERR, "config_set",
+                              "The attribute %s is read only; ignoring new values\n",
+                              attr);
+            }
+            charray_free(vals);
         } else if (values != NULL) {
             for (ii = 0; !retval && values && values[ii]; ++ii) {
                 if (cgas->setfunc) {

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -9643,7 +9643,7 @@ config_set(const char *attr, struct berval **values, char *errorbuf, int apply)
         } else if (values != NULL && values[0] != NULL &&
                    cgas->config_var_type == CONFIG_CHARRAY) {
             char **vals = NULL;
-            for (ii = 0; !retval && values && values[ii]; ++ii) {
+            for (ii = 0; values && values[ii]; ++ii) {
                 char *val = slapi_berval_get_string_copy(values[ii]);
                 charray_add(&vals, val);
             }


### PR DESCRIPTION
Fix crash related to CONFIG_CHARRAY because config_set does not handles it properly.

Issue: #7389 

Reviewed by: @tbordaz and @mreynolds389 (Thanks!)

## Summary by Sourcery

Handle CONFIG_CHARRAY configuration attributes correctly in config_set and align related tests with the updated behavior.

Bug Fixes:
- Prevent crashes when updating CONFIG_CHARRAY configuration attributes by correctly constructing and passing string arrays to the setter callbacks.

Tests:
- Adjust LDAP controls feature test to materialize all control combinations as a list for iteration.