### PR TITLE
Issue 7088 - Change log level for "Can't locate CSN" error message

### DIFF
--- a/ldap/servers/plugins/replication/cl5_clcache.c
+++ b/ldap/servers/plugins/replication/cl5_clcache.c
@@ -242,7 +242,7 @@ clcache_get_buffer(Replica *replica, CLC_Buffer **buf, dbi_db_t *db, ReplicaId c
             if (0 == clcache_enqueue_busy_list(replica, db, *buf)) {
                 Slapi_Backend *be = (*buf)->buf_busy_list->bl_be;
                 /* buf_busy_list is now set, and we can get the backend. So lets initialize the dbimpl buffers */
-                
+
                 dblayer_bulk_set_buffer(be, &(*buf)->buf_bulk, &(*buf)->buf_bulkdata,
                         WORK_CLC_BUFFER_PAGE_SIZE, DBI_VF_BULK_RECORD);
                 dblayer_value_set_buffer(be, &(*buf)->buf_key, (*buf)->buf_keydata, CSN_STRSIZE +1);
@@ -412,7 +412,7 @@ clcache_load_buffer(CLC_Buffer *buf, CSN **anchorCSN, int *continue_on_miss, cha
                 buf->buf_cscbs[i]->state = CLC_STATE_READY;
             }
         } else {
-            slapi_log_err(SLAPI_LOG_ERR, buf->buf_agmt_name,
+            slapi_log_err(SLAPI_LOG_REPL, buf->buf_agmt_name,
                           "clcache_load_buffer - Can't locate CSN %s in the changelog (DB rc=%d). "
                           "If replication stops, the consumer may need to be reinitialized.\n",
                           (char *)buf->buf_key.data, rc);


### PR DESCRIPTION
Description:

There are legitimate reasons for a CSN temporarily not found in the changelog, and in recent cases it always resolves itself.  Instead of logging a scary message by default move the log level to "replication".

relates: https://github.com/389ds/389-ds-base/issues/7088

## Summary by Sourcery

Enhancements:
- Downgrade the log level of the "Can't locate CSN in the changelog" message from error to replication-specific logging.