### PR TITLE
Issue 7420 - Inconsistencies in the password policy log messages

### DIFF
--- a/dirsrvtests/tests/suites/password/pwdPolicy_logging_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_logging_test.py
@@ -116,7 +116,7 @@ def test_debug_logging(topo):
         local_user.replace('userpassword', passwd_val)
     time.sleep(1)
 
-    err_msg = "PWDPOLICY_DEBUG - invalid password syntax - password must be at least 6 characters long: Entry " + \
+    err_msg = "PWDPOLICY_DEBUG - Invalid password syntax - password must be at least 6 characters long: Entry " + \
               "\\(uid=local_user,ou=people,dc=example,dc=com\\) Policy \\(cn="
     assert inst.searchErrorsLog(err_msg)
 
@@ -126,7 +126,7 @@ def test_debug_logging(topo):
         global_user.replace('userpassword', passwd_val)
     time.sleep(1)
 
-    err_msg = "PWDPOLICY_DEBUG - invalid password syntax - password must be at least 8 characters long: Entry " + \
+    err_msg = "PWDPOLICY_DEBUG - Invalid password syntax - password must be at least 8 characters long: Entry " + \
               "\\(uid=global_user,ou=global,dc=example,dc=com\\) Policy \\(Global\\)"
     assert inst.searchErrorsLog(err_msg)
 

--- a/ldap/servers/slapd/charray.c
+++ b/ldap/servers/slapd/charray.c
@@ -511,7 +511,7 @@ charray_normdn_add(char ***chararray, char *dn, char *errstr)
     char *normdn = NULL;
     rc = slapi_dn_normalize_ext(dn, 0, &normdn, &len);
     if (rc < 0) {
-        slapi_log_err(SLAPI_LOG_ERR, "charray_normdn_add - Invalid dn: \"%s\" %s\n",
+        slapi_log_err(SLAPI_LOG_ERR, "charray_normdn_add", "Invalid dn: \"%s\" %s\n",
                       dn, errstr ? errstr : "");
         return rc;
     } else if (0 == rc) {

--- a/ldap/servers/slapd/compare.c
+++ b/ldap/servers/slapd/compare.c
@@ -126,8 +126,8 @@ do_compare(Slapi_PBlock *pb)
     /* target spec is used to decide which plugins are applicable for the operation */
     operation_set_target_spec(pb_op, &sdn);
 
-    slapi_log_err(SLAPI_LOG_ARGS, "do_compare: dn (%s) attr (%s)\n",
-                  rawdn, ava.ava_type, 0);
+    slapi_log_err(SLAPI_LOG_ARGS, "do_compare", "dn (%s) attr (%s)\n",
+                  rawdn, ava.ava_type);
 
     if (log_format != LOG_FORMAT_DEFAULT) {
         slapd_log_pblock logpb = {0};

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -124,7 +124,7 @@ do_modify(Slapi_PBlock *pb)
         send_ldap_result(pb, LDAP_OPERATIONS_ERROR,
                          NULL, "operation is NULL parameter", 0, NULL);
         slapi_log_err(SLAPI_LOG_ERR, "do_modify",
-            "NULL param:  pb_conn (0x%p) operation (0x%p)\n", pb_conn, operation);
+            "NULL param: pb_conn (0x%p) operation (0x%p)\n", pb_conn, operation);
         return;
     }
 
@@ -291,7 +291,7 @@ do_modify(Slapi_PBlock *pb)
             slapi_pblock_get(pb, SLAPI_OPERATION_ID, &opid);
             slapi_log_err(SLAPI_LOG_ERR, "do_modify",
                           "Rejecting replicated password policy operation(conn=%"PRIu64" op=%d) for "
-                          "entry %s.  To allow these changes to be accepted, set passwordIsGlobalPolicy to 'on' in "
+                          "entry %s. To allow these changes to be accepted, set passwordIsGlobalPolicy to 'on' in "
                           "cn=config.\n",
                           connid, opid, rawdn);
         }
@@ -1348,7 +1348,7 @@ op_shared_allow_pw_change(Slapi_PBlock *pb, LDAPMod *mod, char **old_pw, Slapi_M
                 slapi_pwpolicy_make_response_control(pb, -1, -1, LDAP_PWPOLICY_PWDMODNOTALLOWED);
             }
             slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                          "user is not allowed to change password.  Entry (%s) Policy (%s)\n",
+                          "User is not allowed to change password: Entry (%s) Policy (%s)\n",
                           slapi_sdn_get_dn(&sdn),
                           pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
             send_ldap_result(pb, LDAP_UNWILLING_TO_PERFORM, NULL,

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -884,7 +884,7 @@ check_pw_minage(Slapi_PBlock *pb, const Slapi_DN *sdn, struct berval **vals __at
                                                          LDAP_PWPOLICY_PWDTOOYOUNG);
                 }
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                              "password within minimum age: Entry (%s) Policy (%s)\n",
+                              "Password within minimum age: Entry (%s) Policy (%s)\n",
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
 
                 pw_send_ldap_result(pb, LDAP_CONSTRAINT_VIOLATION, NULL, "within password minimum age", 0, NULL);
@@ -1122,7 +1122,7 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
                 ((internal_op && pb_conn && !slapi_dn_isroot(pb_conn->c_dn)) ||
                  (!internal_op && !pw_is_pwp_admin(pb, pwpolicy, PWP_ADMIN_OR_ROOTDN))))
             {
-                report_pw_violation(pb, dn, pwresponse_req, "invalid password syntax - passwords with storage scheme are not allowed");
+                report_pw_violation(pb, dn, pwresponse_req, "Invalid password syntax - passwords with storage scheme are not allowed");
                 return (1);
             } else {
                 /* We want to skip syntax checking since this is a pre-hashed password. But if the user
@@ -1225,7 +1225,7 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
             /* check for the minimum password length */
             if (pwpolicy->pw_minlength > (int)ldap_utf8characters((char *)pwd)) {
                 report_pw_violation(pb, dn, pwresponse_req,
-                        "invalid password syntax - password must be at least %d characters long",
+                        "Invalid password syntax - password must be at least %d characters long",
                         pwpolicy->pw_minlength);
                 return (1);
             }
@@ -1290,42 +1290,42 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
             if (pwpolicy->pw_mindigits > num_digits) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d digit characters",
+                            "Invalid password syntax - password must contain at least %d digit characters",
                             pwpolicy->pw_mindigits);
             } else if (pwpolicy->pw_minalphas > num_alphas) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d alphabetic characters",
+                            "Invalid password syntax - password must contain at least %d alphabetic characters",
                             pwpolicy->pw_minalphas);
             } else if (pwpolicy->pw_minuppers > num_uppers) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d uppercase characters",
+                            "Invalid password syntax - password must contain at least %d uppercase characters",
                             pwpolicy->pw_minuppers);
             } else if (pwpolicy->pw_minlowers > num_lowers) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d lowercase characters",
+                            "Invalid password syntax - password must contain at least %d lowercase characters",
                             pwpolicy->pw_minlowers);
             } else if (pwpolicy->pw_minspecials > num_specials) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d special characters",
+                            "Invalid password syntax - password must contain at least %d special characters",
                             pwpolicy->pw_minspecials);
             } else if (pwpolicy->pw_min8bit > num_8bit) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d 8-bit characters",
+                            "Invalid password syntax - password must contain at least %d 8-bit characters",
                             pwpolicy->pw_min8bit);
             } else if ((pwpolicy->pw_maxrepeats != 0) && (pwpolicy->pw_maxrepeats < (max_repeated + 1))) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - a character cannot be repeated more than %d times",
+                            "Invalid password syntax - a character cannot be repeated more than %d times",
                             (pwpolicy->pw_maxrepeats));
             } else if (pwpolicy->pw_mincategories > num_categories) {
                 syntax_violation = 1;
                 PR_snprintf(errormsg, sizeof(errormsg) - 1,
-                            "invalid password syntax - password must contain at least %d character "
+                            "Invalid password syntax - password must contain at least %d character "
                             "categories (valid categories are digit, uppercase, lowercase, special, and 8-bit characters)",
                             pwpolicy->pw_mincategories);
             }
@@ -1371,7 +1371,7 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
                     }
                     pw_send_ldap_result(pb, LDAP_CONSTRAINT_VIOLATION, NULL, "password in history", 0, NULL);
                     slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                                  "password in history: Entry (%s) Policy (%s)\n",
+                                  "Password in history: Entry (%s) Policy (%s)\n",
                                   dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                     slapi_entry_free(e);
                     return (1);
@@ -1386,7 +1386,7 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
                     if (slapi_attr_value_find(attr, (struct berval *)slapi_value_get_berval(vals[0])) == 0) {
                         pw_send_ldap_result(pb, LDAP_CONSTRAINT_VIOLATION, NULL, "password in history", 0, NULL);
                         slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                                      "password in history: Entry (%s) Policy (%s)\n",
+                                      "Password in history: Entry (%s) Policy (%s)\n",
                                       dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                         slapi_entry_free(e);
                         return (1);
@@ -1395,7 +1395,7 @@ check_pw_syntax_ext(Slapi_PBlock *pb, const Slapi_DN *sdn, Slapi_Value **vals, c
                     if (slapi_pw_find_sv(va, vals[0]) == 0) {
                         pw_send_ldap_result(pb, LDAP_CONSTRAINT_VIOLATION, NULL, "password in history", 0, NULL);
                         slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                                      "password in history: Entry (%s) Policy (%s)\n",
+                                      "Password in history: Entry (%s) Policy (%s)\n",
                                       dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                         slapi_entry_free(e);
                         return (1);
@@ -1912,7 +1912,7 @@ check_trivial_words(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Value **vals, char *
                 pw_send_ldap_result(pb, LDAP_CONSTRAINT_VIOLATION, NULL,
                                     "invalid password syntax - password based off of user entry", 0, NULL);
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                              "password based off of user entry (attr=%s token_len=%d): Entry (%s) Policy (%s)\n",
+                              "Password based off of user entry (attr=%s token_len=%d): Entry (%s) Policy (%s)\n",
                               attrtype, toklen, slapi_entry_get_dn_const(e),
                               pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                 /* Free valueset */
@@ -2187,7 +2187,7 @@ new_passwdPolicy(Slapi_PBlock *pb, const char *dn)
             if (pw_entry == NULL) {
                 slapi_log_err(SLAPI_LOG_ERR, "new_passwdPolicy",
                               "Loading global password policy for %s"
-                              " --local policy entry not found\n",
+                              " -- local policy entry not found\n",
                               dn);
                 goto done;
             }
@@ -2730,8 +2730,7 @@ slapi_check_tpr_limits(Slapi_PBlock *pb, Slapi_Entry *bind_target_entry, int sen
             update_tpr_pw_usecount(pb, bind_target_entry, (int32_t) use_count);
             if (use_count > pwpolicy->pw_tpr_maxuse) {
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                              "slapi_check_tpr_limits - "
-                              "number of bind (%u) is larger than TPR password max use (%d): Entry (%s) Policy (%s)\n",
+                              "slapi_check_tpr_limits - Number of binds (%u) is larger than TPR password max use (%d): Entry (%s) Policy (%s)\n",
                               use_count, pwpolicy->pw_tpr_maxuse,
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                 if (send_result) {
@@ -2764,7 +2763,7 @@ slapi_check_tpr_limits(Slapi_PBlock *pb, Slapi_Entry *bind_target_entry, int sen
             if (difftime(parse_genTime(cur_time_str), parse_genTime(value)) >= 0) {
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
                               "slapi_check_tpr_limits - "
-                              "attempt to bind with an expired TPR password (current=%s, expiration=%s): Entry (%s) Policy (%s)\n",
+                              "Attempt to bind with an expired TPR password (current=%s, expiration=%s): Entry (%s) Policy (%s)\n",
                               cur_time_str, value,
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                 if (send_result) {
@@ -2793,7 +2792,7 @@ slapi_check_tpr_limits(Slapi_PBlock *pb, Slapi_Entry *bind_target_entry, int sen
             if (difftime(parse_genTime(value), parse_genTime(cur_time_str)) >= 0) {
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
                               "slapi_check_tpr_limits - "
-                              "attempt to bind with TPR password not yet valid (current=%s, validity=%s): Entry (%s) Policy (%s)\n",
+                              "Attempt to bind with TPR password not yet valid (current=%s, validity=%s): Entry (%s) Policy (%s)\n",
                               cur_time_str, value,
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
                 if (send_result) {
@@ -2919,7 +2918,7 @@ slapi_check_account_lock(Slapi_PBlock *pb, Slapi_Entry *bind_target_entry, int p
                                  "Exceed password retry limit. Contact system administrator to reset.",
                                  0, NULL);
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                              "Account is locked and requires administrator reset.  Entry (%s) Policy (%s)\n",
+                              "Account is locked and requires administrator reset: Entry (%s) Policy (%s)\n",
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
             }
             goto locked;

--- a/ldap/servers/slapd/pw_mgmt.c
+++ b/ldap/servers/slapd/pw_mgmt.c
@@ -204,7 +204,7 @@ skip:
                 }
             }
             slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                          "password expired, but within grace limit (curr=%d limit=%d needpw=%d): Entry (%s) Policy (%s)\n",
+                          "Password expired, but within grace limit (curr=%d limit=%d needpw=%d): Entry (%s) Policy (%s)\n",
                           pwpolicy->pw_gracelimit, pwdGraceUserTime, needpw, dn,
                           pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
             slapi_add_pwd_control(pb, LDAP_CONTROL_PWEXPIRED, 0);
@@ -225,7 +225,7 @@ skip:
         slapi_send_ldap_result(pb, LDAP_INVALID_CREDENTIALS, NULL,
                                "password expired!", 0, NULL);
         slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                      "password expired: Entry (%s) Policy (%s)\n",
+                      "Password expired: Entry (%s) Policy (%s)\n",
                       dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
 
         /* abort bind */

--- a/ldap/servers/slapd/pw_retry.c
+++ b/ldap/servers/slapd/pw_retry.c
@@ -118,7 +118,7 @@ update_tpr_pw_usecount(Slapi_PBlock *pb, Slapi_Entry *e, int32_t use_count)
             passwdPolicy *pwpolicy = new_passwdPolicy(pb, slapi_entry_get_ndn(e));
             slapi_log_err(SLAPI_LOG_PWDPOLICY,
                           PWDPOLICY_DEBUG,
-                          "update pwdTPRUseCount=%d on entry (%s) policy (%s).\n",
+                          "Update pwdTPRUseCount=%d: Entry (%s) Policy (%s)\n",
                           use_count, slapi_entry_get_ndn(e),
                           pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
             rc = set_tpr_usecount(pb, use_count);
@@ -180,15 +180,15 @@ set_tpr_usecount_mods(Slapi_PBlock *pb, Slapi_Mods *smods, int count)
         slapi_mods_add_string(smods, LDAP_MOD_REPLACE, "pwdTPRUseCount", retry_cnt);
         slapi_log_err(SLAPI_LOG_PWDPOLICY,
                       PWDPOLICY_DEBUG,
-                      "Unsuccessful bind, increase pwdTPRUseCount = %d (max %d) - entry (%s) policy (%s)\n",
+                      "Unsuccessful bind, increase pwdTPRUseCount = %d (max %d): Entry (%s) Policy (%s)\n",
                       count, pwpolicy->pw_tpr_maxuse,
                       dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
         /* return a failure if it reaches the retry limit */
         if (count > pwpolicy->pw_tpr_maxuse) {
             slapi_log_err(SLAPI_LOG_INFO,
-                          "set_tpr_retry_cnt_mods",
+                          "set_tpr_usecount_mods",
                           "Unsuccessful bind, LDAP_CONSTRAINT_VIOLATION pwdTPRUseCount "
-                          "%d > %d - entry (%s) policy (%s)\n",
+                          "%d > %d: Entry (%s) Policy (%s)\n",
                           count,
                           pwpolicy->pw_tpr_maxuse,
                           dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");

--- a/ldap/servers/slapd/result.c
+++ b/ldap/servers/slapd/result.c
@@ -593,7 +593,7 @@ send_ldap_result_ext(
                 err = LDAP_CONSTRAINT_VIOLATION;
                 text = "Invalid credentials, you now have exceeded the password retry limit.";
                 slapi_log_err(SLAPI_LOG_PWDPOLICY, PWDPOLICY_DEBUG,
-                              "password retry limit exceeded.  Entry (%s) Policy (%s)\n",
+                              "Password retry limit exceeded: Entry (%s) Policy (%s)\n",
                               dn, pwpolicy->pw_local_dn ? pwpolicy->pw_local_dn : "Global");
             }
         }


### PR DESCRIPTION
Bug Description:
There are some inconsistencies in the password policy log messages:

- Mixed first letter case
- Different separators/punctuation before Entry/Policy fields

Fix Description:
Capitalize the first letter of PWDPOLICY_DEBUG messages, standardize punctuation before Entry/Policy fields, fix `slapi_log_err()` argument order in charray.c and compare.c, fix function name typo in pw_retry.c, and update tests to match.

Fixes: https://github.com/389ds/389-ds-base/issues/7420

## Summary by Sourcery

Standardize password policy logging messages and fix related logging issues.

Bug Fixes:
- Align PWDPOLICY_DEBUG and related log messages with consistent capitalization and punctuation across password policy code paths.
- Correct slapi_log_err() usage in compare and charray to use the proper function name parameter.
- Fix an incorrect log function name in pw_retry password retry count handling and adjust associated messages.
- Update password policy logging tests to reflect the new standardized log message formats.