### PR TITLE
Issue 7423 - cleanup pblock after freeing pre/post entries

### DIFF
--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -848,6 +848,7 @@ done:
     if (be)
         slapi_be_Unlock(be);
     slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &pse);
+    slapi_pblock_set(pb, SLAPI_ENTRY_POST_OP, NULL);
     slapi_entry_free(pse);
     slapi_ch_free((void **)&operation->o_params.p.p_add.parentuniqueid);
     slapi_entry_free(e);

--- a/ldap/servers/slapd/generation.c
+++ b/ldap/servers/slapd/generation.c
@@ -78,6 +78,7 @@ set_database_dataversion(const char *dn, const char *dataversion)
     if (NULL != pb) {
         Slapi_Entry *e;
         slapi_pblock_get(pb, SLAPI_ENTRY_PRE_OP, &e);
+        slapi_pblock_set(pb, SLAPI_ENTRY_PRE_OP, NULL);
         slapi_entry_free(e);
     }
     slapi_pblock_destroy(pb);

--- a/ldap/servers/slapd/mapping_tree.c
+++ b/ldap/servers/slapd/mapping_tree.c
@@ -3842,6 +3842,7 @@ _mtn_update_config_param(int op, char *type, char *strvalue)
      * since the internal modify could realloced mods. */
     slapi_pblock_get(confpb, SLAPI_MODIFY_MODS, &mods);
     ldap_mods_free(mods, 1 /* Free the Array and the Elements */);
+    slapi_pblock_set(confpb, SLAPI_MODIFY_MODS, NULL);
     slapi_pblock_destroy(confpb);
 
     return rc;

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -378,6 +378,7 @@ do_modify(Slapi_PBlock *pb)
 
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &normalized_mods);
     ldap_mods_free(normalized_mods, 1 /* Free the Array and the Elements */);
+    slapi_pblock_set(pb, SLAPI_MODIFY_MODS, NULL);
 
 free_and_return:;
     slapi_ch_free_string(&old_pw);

--- a/ldap/servers/slapd/modrdn.c
+++ b/ldap/servers/slapd/modrdn.c
@@ -705,11 +705,14 @@ free_and_return_nolock : {
     slapi_ch_free_string(&newdn);
 
     slapi_pblock_get(pb, SLAPI_ENTRY_PRE_OP, &ecopy);
+    slapi_pblock_set(pb, SLAPI_ENTRY_PRE_OP, NULL);
     slapi_entry_free(ecopy);
     slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &pse);
+    slapi_pblock_set(pb, SLAPI_ENTRY_POST_OP, NULL);
     slapi_entry_free(pse);
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &mods);
     ldap_mods_free(mods, 1);
+    slapi_pblock_set(pb, SLAPI_MODIFY_MODS, NULL);
     slapi_ch_free_string(&proxydn);
     slapi_ch_free_string(&proxystr);
 


### PR DESCRIPTION
Description:

There are few places where we don't see the pre/post entry in the pblock to NULL after freeing them. Just being overly cautious as some of these changes might not be needed, but it's still good to set the code example and also future-proof these areas.

relates: https://github.com/389ds/389-ds-base/issues/7423

## Summary by Sourcery

Ensure operation pblock entries are cleared after their associated resources are freed to avoid stale pointers.

Bug Fixes:
- Clear pre/post operation entries in the pblock after freeing them in modrdn and add operations to prevent use of stale entry pointers.
- Reset modify operation mods in the pblock after freeing them to avoid dangling references.
- Null out pre-op entry pointers in the generation helper after freeing the associated entries.