### PR TITLE
Issue 7417 - UI - global password policy syntax settings missing passwordMaxRepeats

### DIFF
--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1226,6 +1226,25 @@ export class GlobalPwPolicy extends React.Component {
                     </Grid>
                     <Grid className="ds-margin-top">
                         <GridItem className="ds-label" span={3}>
+                            {_("Max Repeated Chars")}
+                        </GridItem>
+                        <GridItem span={1} title={_("The maximum number of times the same character can sequentially appear in a password (passwordMaxRepeats).")}>
+                            <TextInput
+                                type="number"
+                                value={this.state.passwordmaxrepeats}
+                                id="passwordmaxrepeats"
+                                aria-describedby="passwordmaxrepeats"
+                                name="passwordmaxrepeats"
+                                onChange={(e, str) => {
+                                    this.handleSyntaxChange(e);
+                                }}
+                                {...getValidationProps("passwordmaxrepeats", this.state.invalidFields)}
+                            />
+                            {renderValidationError("passwordmaxrepeats", this.state.invalidFields)}
+                        </GridItem>
+                    </Grid>
+                    <Grid className="ds-margin-top">
+                        <GridItem className="ds-label" span={3}>
                             {_("Prohibited Words")}
                         </GridItem>
                         <GridItem span={9}>


### PR DESCRIPTION
Description:

The global password policy syntax settings were missing passwordMaxRepeats, but it is present under the local password policy settings.

relates: https://github.com/389ds/389-ds-base/issues/7417

## Summary by Sourcery

Enhancements:
- Expose the passwordMaxRepeats syntax setting in the global password policy form to align it with local policy settings.