### PR TITLE
Issue 7426 - logconv.py is out of sync with server-emitted note codes

### DIFF
--- a/dirsrvtests/tests/suites/logging/logconv_test.py
+++ b/dirsrvtests/tests/suites/logging/logconv_test.py
@@ -5,6 +5,7 @@
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
+import json
 import ldap
 import logging
 import os
@@ -29,6 +30,8 @@ from lib389._mapped_object import DSLdapObjects
 from lib389.config import CertmapLegacy
 from lib389.nss_ssl import NssSsl
 from lib389.topologies import create_topology
+
+pytestmark = pytest.mark.tier1
 
 log = logging.getLogger(__name__)
 
@@ -141,7 +144,6 @@ class TestLogconv:
             "ldaps_conns": r"- LDAPS connections:\s+(\d+)",
             "starttls_conns": r"- StartTLS Extended Ops:\s+(\d+)",
 
-
             # Operations
             "operations": r"^Total Operations:\s+(\d+)",
             "results": r"^Total Results:\s+(\d+)",
@@ -187,6 +189,8 @@ class TestLogconv:
             "unindexed_searches": r"^Unindexed Searches:\s+(\d+)",
             "unindexed_components": r"^Unindexed Components:\s+(\d+)",
             "multi_factor_auth": r"^Multi-factor Authentications:\s+(\d+)",
+            "async_ops": r"^Asynchronous Operations:\s+(\d+)",
+            "blocked_ops": r"^Blocked Operations:\s+(\d+)",
             "smart_referrals": r"^Smart Referrals Received:\s+(\d+)",
         }
 
@@ -1407,6 +1411,126 @@ class TestLogconv:
         output = self.run_logconv()
         logconv_stats = self.extract_logconv_stats(output)
         assert self.validate_logconv_stats(expected, logconv_stats, "test_pool_stats")
+
+    def test_note_codes(self, topo_shared):
+        """Validate logconv handles every note code the server can emit
+        (A, U, F, P, M, N, B) without crashing.
+
+        :id: cc3631a3-91ef-4085-9b7d-a445dc5d234e
+        :setup: Standalone Instance
+        :steps:
+            1. Truncate access log
+            2. Inject SRCH/RESULT pairs (legacy or JSON depending on log format)
+               covering each known note code and one unknown
+            3. Run logconv without -V and compare summary counters
+            4. Run logconv with -V and assert each known code produces a
+               detail block; the unknown code must not
+        :expectedresults:
+            1. Success
+            2. Success
+            3. logconv exits 0 and summary counters match expected
+            4. Verbose output contains headers for A/U/F/M/N/B only
+        """
+        self.init_instance(topo_shared.standalone)
+        self.truncate_logs()
+
+        note_specs = [
+            ("A", "Unindexed Search"),
+            ("U", "Unindexed Component"),
+            ("F", "Invalid Attribute Filter"),
+            ("P", None),
+            ("M", "Multi-factor Authentication"),
+            ("N", "Asynchronous Operation"),
+            ("B", "Blocked Operation"),
+            ("Z", None),  # Future/unknown note — must be skipped gracefully.
+        ]
+
+        lines = []
+        base_dn = "dc=example,dc=com"
+        search_filter = "(cn=*)"
+        conn_id = 1
+        for idx, (code, _title) in enumerate(note_specs, start=1):
+            srch_ts = f"00:00:{idx:02d}.100000000"
+            res_ts = f"00:00:{idx:02d}.200000000"
+            if self.log_format == "json":
+                lines.append(json.dumps({
+                    "local_time": f"2026-04-17T{srch_ts} +0000",
+                    "operation": "SEARCH",
+                    "key": f"1000-{conn_id}",
+                    "conn_id": conn_id,
+                    "op_id": idx,
+                    "base_dn": base_dn,
+                    "scope": 2,
+                    "filter": search_filter,
+                    "attrs": [],
+                }) + "\n")
+                lines.append(json.dumps({
+                    "local_time": f"2026-04-17T{res_ts} +0000",
+                    "operation": "RESULT",
+                    "key": f"1000-{conn_id}",
+                    "conn_id": conn_id,
+                    "op_id": idx,
+                    "tag": 101,
+                    "err": 0,
+                    "nentries": 1,
+                    "etime": "0.001",
+                    "client_ip": "127.0.0.1",
+                    "bind_dn": "",
+                    "notes": [{
+                        "note": code,
+                        "description": "",
+                        "base_dn": base_dn,
+                        "filter": search_filter,
+                        "scope": 2,
+                    }],
+                }) + "\n")
+            else:
+                lines.append(
+                    f'[17/Apr/2026:{srch_ts} +0000] conn={conn_id} op={idx} '
+                    f'SRCH base="{base_dn}" scope=2 filter="{search_filter}" attrs=ALL\n'
+                )
+                lines.append(
+                    f'[17/Apr/2026:{res_ts} +0000] conn={conn_id} op={idx} '
+                    f'RESULT err=0 tag=101 nentries=1 etime=0.001 notes={code}\n'
+                )
+
+        with open(self.access_log_path, "w") as f:
+            f.writelines(lines)
+
+        num_codes = len(note_specs)
+        expected = {
+            "searches": num_codes,
+            "operations": num_codes,
+            "results": num_codes,
+            "unindexed_searches": 1,
+            "unindexed_components": 1,
+            "invalid_attribute_filters": 1,
+            "paged_searches": 1,
+            "multi_factor_auth": 1,
+            "async_ops": 1,
+            "blocked_ops": 1,
+        }
+
+        output = self.run_logconv()
+        logconv_stats = self.extract_logconv_stats(output)
+        assert self.validate_logconv_stats(expected, logconv_stats, "test_note_codes")
+
+        log.info("Re-run logconv with -V to exercise the per-note detail blocks")
+        verbose = subprocess.run(
+            [self.logconv_path, "-V", self.access_log_path],
+            capture_output=True, text=True,
+        )
+        assert verbose.returncode == 0, f"logconv -V failed: {verbose.stderr}"
+
+        for code, title in note_specs:
+            header = f"{title} #1 (notes={code})" if title else None
+            if title is None:
+                # Unknown note must not appear as a detail header.
+                assert f"(notes={code})" not in verbose.stdout, \
+                    f"Unexpected detail block emitted for notes={code}"
+            else:
+                assert header in verbose.stdout, \
+                    f"Missing verbose detail block for notes={code}: {header!r}"
 
 
 if __name__ == '__main__':

--- a/ldap/admin/src/logconv.py
+++ b/ldap/admin/src/logconv.py
@@ -286,8 +286,10 @@ class ResultData:
         int, {
             'result': 0,
             'notesA': 0,
+            'notesB': 0,
             'notesF': 0,
             'notesM': 0,
+            'notesN': 0,
             'notesP': 0,
             'notesU': 0,
             'timestamp': 0,
@@ -300,6 +302,9 @@ class ResultData:
     notesU: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
     notesF: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
     notesP: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
+    notesM: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
+    notesN: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
+    notesB: DefaultDict[str, Dict] = field(default_factory=lambda: defaultdict(dict))
 
     timestamp_ctr: int = 0
     entry_count: int = 0
@@ -454,12 +459,6 @@ class logAnalyser:
         """
         Set up data structures for parsing and storing log data.
         """
-        self.notesA = {}
-        self.notesF = {}
-        self.notesM = {}
-        self.notesP = {}
-        self.notesU = {}
-
         self.vlv = VLVData()
         self.server = ServerData()
         self.operation = OperationData()
@@ -1276,6 +1275,9 @@ class logAnalyser:
                 # Exclude VLV
                 if op_scope_key not in self.vlv.vlv_map:
                     result_notes = getattr(self.result, f'notes{note_code}', None)
+                    if result_notes is None:
+                        self.logger.debug(f"Unknown note code: {note_code}")
+                        continue
                     entry = result_notes.setdefault(op_scope_key, {})
 
                     # Resolve base, scope, filter (new format or fallback to maps)
@@ -2815,6 +2817,41 @@ class logAnalyser:
             self.logger.error(f"Error setting parse times. - {e}")
             raise
 
+
+def _print_note_details(notes_dict, title, code,
+                        show_search_fields=False,
+                        show_filter_only=False,
+                        show_nentries=True):
+    """Print per-operation detail blocks for a given note code.
+
+    Args:
+        notes_dict: Mapping of op_scope_key tuple to detail dict.
+        title: Human-readable section title (e.g., "Unindexed Search").
+        code: The single-letter note code (e.g., "A").
+        show_search_fields: Include Search Base, Scope, and Filter.
+        show_filter_only: Include only Search Filter (mutually exclusive with show_search_fields).
+        show_nentries: Include the Nentries line (omit for bind-only codes like M).
+    """
+    for num, key in enumerate(notes_dict, start=1):
+        data = notes_dict[key]
+        _, conn, op = key
+
+        print(f"\n  {title} #{num} (notes={code})")
+        print(f"    - Date/Time:           {data.get('time', '-')}")
+        print(f"    - Connection Number:   {conn}")
+        print(f"    - Operation Number:    {op}")
+        print(f"    - Etime:               {data.get('etime', '-')}")
+        if show_nentries:
+            print(f"    - Nentries:            {data.get('nentries', 0)}")
+        print(f"    - IP Address:          {data.get('ip', '-')}")
+        if show_search_fields:
+            print(f"    - Search Base:         {data.get('base', '-')}")
+            print(f"    - Search Scope:        {data.get('scope', '-')}")
+        if show_search_fields or show_filter_only:
+            print(f"    - Search Filter:       {data.get('filter', '-')}")
+        print(f"    - Bind DN:             {data.get('bind_dn', '-')}\n")
+
+
 def main():
     """
     Entry point for the Access Log Analyzer script.
@@ -3171,6 +3208,8 @@ def main():
         print(f"Average optime (op time):       {avg_optime:.9f}")
         print(f"Average etime (elapsed time):   {avg_etime:.9f}")
     print(f"\nMulti-factor Authentications:   {db.result.counters['notesM']}")
+    print(f"Asynchronous Operations:        {db.result.counters['notesN']}")
+    print(f"Blocked Operations:             {db.result.counters['notesB']}")
     print(f"Proxied Auth Operations:        {num_proxyd_auths}")
     print(f"Persistent Searches:            {db.search.counters['persistent']}")
     print(f"Internal Operations:            {db.operation.counters['internal']}")
@@ -3186,61 +3225,27 @@ def main():
     print(f"Paged Searches:                 {db.result.counters['notesP']}")
     num_unindexed_search = len(db.result.notesA)
     print(f"Unindexed Searches:             {num_unindexed_search}")
-    if db.verbose and num_unindexed_search > 0:
-        for num, key in enumerate(db.result.notesA, start=1):
-            data = db.result.notesA[key]
-            if isinstance(key, tuple):
-                _, conn, op = key
-
-            print(f"\n  Unindexed Search #{num} (notes=A)")
-            print(f"    - Date/Time:           {data.get('time', '-')}")
-            print(f"    - Connection Number:   {conn}")
-            print(f"    - Operation Number:    {op}")
-            print(f"    - Etime:               {data.get('etime', '-')}")
-            print(f"    - Nentries:            {data.get('nentries', 0)}")
-            print(f"    - IP Address:          {data.get('ip', '-')}")
-            print(f"    - Search Base:         {data.get('base', '-')}")
-            print(f"    - Search Scope:        {data.get('scope', '-')}")
-            print(f"    - Search Filter:       {data.get('filter', '-')}")
-            print(f"    - Bind DN:             {data.get('bind_dn', '-')}\n")
+    if db.verbose:
+        _print_note_details(db.result.notesA, "Unindexed Search", "A",
+                            show_search_fields=True)
 
     num_unindexed_component = len(db.result.notesU)
     print(f"Unindexed Components:           {num_unindexed_component}")
-    if db.verbose and num_unindexed_component > 0:
-        for num, key in enumerate(db.result.notesU, start=1):
-            data = db.result.notesU[key]
-            if isinstance(key, tuple):
-                _, conn, op = key
-
-            print(f"\n  Unindexed Component #{num} (notes=U)")
-            print(f"    - Date/Time:           {data.get('time', '-')}")
-            print(f"    - Connection Number:   {conn}")
-            print(f"    - Operation Number:    {op}")
-            print(f"    - Etime:               {data.get('etime', '-')}")
-            print(f"    - Nentries:            {data.get('nentries', 0)}")
-            print(f"    - IP Address:          {data.get('ip', '-')}")
-            print(f"    - Search Base:         {data.get('base', '-')}")
-            print(f"    - Search Scope:        {data.get('scope', '-')}")
-            print(f"    - Search Filter:       {data.get('filter', '-')}")
-            print(f"    - Bind DN:             {data.get('bind_dn', '-')}\n")
+    if db.verbose:
+        _print_note_details(db.result.notesU, "Unindexed Component", "U",
+                            show_search_fields=True)
 
     num_invalid_filter = len(db.result.notesF)
     print(f"Invalid Attribute Filters:      {num_invalid_filter}")
-    if db.verbose and num_invalid_filter > 0:
-        for num, key in enumerate(db.result.notesF, start=1):
-            data = db.result.notesF[key]
-            if isinstance(key, tuple):
-                _, conn, op = key
+    if db.verbose:
+        _print_note_details(db.result.notesF, "Invalid Attribute Filter", "F",
+                            show_filter_only=True)
 
-            print(f"\n  Invalid Attribute Filter #{num} (notes=F)")
-            print(f"    - Date/Time:           {data.get('time', '-')}")
-            print(f"    - Connection Number:   {conn}")
-            print(f"    - Operation Number:    {op}")
-            print(f"    - Etime:               {data.get('etime', '-')}")
-            print(f"    - Nentries:            {data.get('nentries', 0)}")
-            print(f"    - IP Address:          {data.get('ip', '-')}")
-            print(f"    - Search Filter:       {data.get('filter', '-')}")
-            print(f"    - Bind DN:             {data.get('bind_dn', '-')}\n")
+    if db.verbose:
+        _print_note_details(db.result.notesM, "Multi-factor Authentication", "M",
+                            show_nentries=False)
+        _print_note_details(db.result.notesN, "Asynchronous Operation", "N")
+        _print_note_details(db.result.notesB, "Blocked Operation", "B")
 
     print(f"FDs Taken:                      {num_fd_taken}")
     print(f"FDs Returned:                   {num_fd_rtn}")


### PR DESCRIPTION
Description: notes=N (asynchronous) and notes=B (blocked) were not tracked or reported, and notes=M (MFA) silently failed to produce any per-operation output because the class-level dict shadowed the ResultData field.

Add counters and detail dicts for notes=N and notes=B in ResultData, remove the shadowing assignments in logAnalyser, and log a debug message (instead of crashing) when an unrecognized note code is encountered so future codes do not break analysis.

Decrease redundancy with a shared helper.
Add a test that injects SRCH/RESULT pairs for every known note code plus an unknown one and asserts both summary counters and verbose detail blocks.

Fixes: https://github.com/389ds/389-ds-base/issues/7426

Reviewed by: ?

## Summary by Sourcery

Track and report all server-emitted note codes in logconv, including new asynchronous and blocked operation codes, while making verbose note reporting more robust and less error-prone.

New Features:
- Expose counters and verbose detail sections for asynchronous (N) and blocked (B) operations in logconv output.

Bug Fixes:
- Ensure multi-factor authentication (M) notes are correctly recorded and reported instead of being shadowed and silently ignored.
- Handle unknown note codes gracefully by logging a debug message instead of crashing during log analysis.

Enhancements:
- Refactor per-note verbose reporting into a shared helper to reduce duplication and standardize output formatting.
- Extend ResultData structures to maintain per-operation details for all supported note codes, including M, N, and B.

Tests:
- Add a tier-1 test that injects log entries for each known note code plus an unknown one to verify summary counters and verbose detail blocks in both legacy and JSON log formats.