### PR TITLE
Issue 7435 - Add AGENTS.md to support AI coding assistants

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,8 @@
+---
+description: Always read the AGENTS.md project guide before starting any task
+alwaysApply: true
+---
+
+Before working on any task in this repository, **always** read `AGENTS.md` at the project root and the detailed guides it links to under `docs/agents/`.
+
+This is mandatory for every conversation - do not skip it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md for 389 Directory Server (389-ds-base)
+
+This file provides guidance for AI assistants and coding agents working with this codebase.
+
+389 Directory Server is a highly usable, fully featured, reliable and secure LDAP server implementation written primarily in C and Rust, with a Python management library (lib389) and a Cockpit-based web UI.
+
+## Project Structure
+
+| Path | Description |
+|------|-------------|
+| `ldap/` | Core LDAP server: ns-slapd daemon, bundled plugins, schema, LDIF |
+| `ldap/servers/snmp` | SNMP sub-agent (ldap-agent): exposes ops/entries/entity stats via AgentX, sends server up/down traps; includes redhat-directory.mib |
+| `ldap/servers/slapd/tools` | Tools: dbscan, ldclt, pwdhash (pwenc), chkvlv, eggencode, mkdep |
+| `lib/` | Shared C libraries (base, ldaputil, libaccess, libadmin, libsi18n) |
+| `include/` | Public and internal C headers |
+| `src/` | Rust code, lib389 Python library, Cockpit web UI, svrcore |
+| `dirsrvtests/` | Python/pytest integration test suites |
+| `test/` | C unit tests (cmocka-based) |
+| `rpm/` | RPM spec templates and packaging helpers |
+| `.github/` | GitHub Actions CI workflows |
+
+## Building
+
+Autotools-based (not CMake):
+
+```bash
+autoreconf -fiv
+./configure --enable-debug --with-openldap --enable-cmocka
+make
+make lib389
+sudo make install
+sudo make lib389-install
+```
+
+## Detailed Guides
+
+- [Project Architecture](docs/agents/architecture.md) — source layout, lib389, SLAPI plugin system, coding conventions
+- [Testing](docs/agents/testing.md) — pytest structure, writing tests, docstring format, fixtures, best practices
+- [Building and CI](docs/agents/building.md) — build system, RPM packaging, CI workflows
+- [Contributing](docs/agents/contributing.md) — commit message format, PR guidelines, code review
+
+## External Documentation
+
+- [389 Directory Server Wiki](https://www.port389.org/)
+- [Building Guide](https://www.port389.org/docs/389ds/development/building.html)
+- [Coding Style Guide](https://www.port389.org/docs/389ds/development/coding-style.html)
+- [Contributing Guide](https://www.port389.org/docs/389ds/contributing.html)
+- [Test Framework Guide](https://www.port389.org/docs/389ds/FAQ/upstream-test-framework.html)
+- [Writing lib389 Tests](https://www.port389.org/docs/389ds/howto/howto-write-lib389.html)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,93 @@
+# Project Architecture
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `autogen.sh` | Bootstraps autotools (run before `./configure`) |
+| `configure.ac` | Autoconf configuration (compiler checks, optional ASAN/TSAN, BDB/LMDB, Rust) |
+| `Makefile.am` | Main automake build definition |
+| `VERSION.sh` | Release version consumed by configure and RPM |
+| `rpm.mk` | RPM build targets |
+| `src/Cargo.toml` | Rust workspace root |
+| `.clang-format` | C code formatting rules |
+| `.packit.yaml` | Packit downstream build automation |
+
+## Server Source (`ldap/`)
+
+- `ldap/servers/slapd/` — main **ns-slapd** daemon: LDAP operations, connection handling, DSE, backends under `back-ldbm/` (LMDB and BDB layers), controls, logging, SSL, password policy
+- `ldap/servers/plugins/` — bundled SLAPI plugins, one directory per plugin (e.g. `memberof/`, `replication/`, `dna/`, `acl/`, `acctpolicy/`)
+- `ldap/servers/snmp/` — SNMP subagent
+- `ldap/schema/` — LDAP schema definitions
+- `ldap/ldif/` — LDIF samples and tooling data
+
+## lib389 Python Library (`src/lib389/`)
+
+lib389 is the Python library for managing and testing 389 Directory Server instances. It provides:
+
+- **`DirSrv`** class — programmatic control of server instances (start/stop/restart, LDAP operations, configuration)
+- **IDM helpers** — `lib389.idm.user`, `lib389.idm.group`, `lib389.idm.organizationalunit`, etc.
+- **Replication** — `Replicas`, `Changelog5`, `ReplicationManager`
+- **Plugins** — `DNAPlugin`, `MemberOfPlugin`, `RetroChangelogPlugin`, etc.
+- **Tasks** — import/export, reindex, fixup tasks
+- **Topology fixtures** — `topology_st` (standalone), `topology_m2` (2 suppliers), `topology_m3`, `topology_m4`, etc.
+- **CLI tools** — `dsconf`, `dsctl`, `dsidm`, `dscreate`, `openldap_to_ds`
+- **Instance creation** — INF-file-based setup via `dscreate` and `SetupDs`
+
+Key paths within lib389:
+
+| Path | Contents |
+|------|----------|
+| `lib389/__init__.py` | Core `DirSrv` class, constants, utilities |
+| `lib389/topologies.py` | Pytest fixtures for test topologies |
+| `lib389/replica.py` | Replication, changelog classes |
+| `lib389/plugins.py` | Plugin configuration classes |
+| `lib389/idm/` | Identity management (users, groups, accounts, roles) |
+| `lib389/instance/setup.py` | Instance creation and setup |
+| `lib389/paths.py` | Path resolution for installed instances |
+| `lib389/cli_conf/` | CLI subcommand implementations |
+| `lib389/tests/` | lib389 internal unit tests |
+| `pyproject.toml` | Package metadata and dependencies |
+
+## Cockpit Web UI (`src/cockpit/389-console/`)
+
+React-based web administration console. Uses PatternFly components. Built with npm/esbuild.
+
+## SLAPI Plugin Architecture
+
+Plugins are C shared libraries under `ldap/servers/plugins/`, one directory per plugin. Each plugin:
+
+1. Includes `slapi-plugin.h`
+2. Defines a `Slapi_PluginDesc` struct with name, vendor, version, description
+3. Implements an `_init` function that registers callbacks via `slapi_pblock_set()`:
+   - Pre/post operation callbacks (`SLAPI_PLUGIN_PRE_MODIFY_FN`, `SLAPI_PLUGIN_POST_ADD_FN`, etc.)
+   - Start/close functions
+   - Backend transaction variants (betxn)
+4. Optionally registers additional plugin types via `slapi_register_plugin()`
+
+API documentation is generated via Doxygen from `docs/slapi.doxy.in` and the header `ldap/servers/slapd/slapi-plugin.h`.
+
+## Coding Conventions
+
+### C code
+
+- Follow `.clang-format` for formatting
+- Use SLAPI API functions for memory management (`slapi_ch_strdup`, `slapi_ch_free_string`, etc.)
+- Log via `slapi_log_err()` with appropriate severity levels
+- Plugin entry points follow the `pluginname_operation_callback` naming pattern
+
+### Python code (tests and lib389)
+
+- Copyright header block at the top of every file
+- Use `logging.getLogger(__name__)` for log output
+- Module-level `pytestmark` for tier assignment
+- Structured docstrings with `:id:`, `:setup:`, `:steps:`, `:expectedresults:`
+- Prefer `f-strings` for string formatting in new code
+- Use `ensure_bytes()` / `ensure_str()` from `lib389.utils` for LDAP value encoding
+
+### Naming conventions
+
+- Test files: `<feature>_test.py` (in suites)
+- Test functions: `test_<descriptive_name>`
+- Constants: `UPPER_SNAKE_CASE`
+- Fixtures: `lowercase_with_underscores`

--- a/docs/agents/building.md
+++ b/docs/agents/building.md
@@ -1,0 +1,41 @@
+# Building and CI
+
+## Build System
+
+The project uses **Autotools** (not CMake):
+
+```bash
+autoreconf -fiv
+./configure --enable-debug --with-openldap --enable-cmocka
+make
+make lib389
+sudo make install
+sudo make lib389-install
+```
+
+Optional flags: `--enable-asan`, `--enable-tsan`, `--enable-ubsan` for sanitizer builds (development/debugging only).
+
+## RPM Builds
+
+```bash
+make -f rpm.mk dist-bz2 rpms
+```
+
+## Rust Components
+
+Rust code lives under `src/` with `Cargo.toml` workspace. Built automatically by the main `make` via cargo integration in `Makefile.am`.
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`:
+
+| Workflow | Purpose |
+|----------|---------|
+| `compile.yml` | Multi-compiler matrix (GCC/Clang) with strict flags and `-fanalyzer` |
+| `pytest.yml` | Build RPMs, run pytest suites in Docker (BDB backend) |
+| `lmdbpytest.yml` | Pytest suites for LMDB backend |
+| `cargotest.yml` | Rust unit tests |
+| `npm.yml` | Cockpit/npm audit |
+| `coverity.yml` | Coverity static analysis |
+| `validate.yml` | Validation checks |
+| `release.yml` | Release automation |

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -1,0 +1,103 @@
+# Contributing to 389 Directory Server
+
+## Reporting Issues
+
+File bugs and feature requests on [GitHub Issues](https://github.com/389ds/389-ds-base/issues). Check the backlog first to avoid duplicates. The repository provides two issue templates (both automatically labeled `needs triage`):
+
+### Bug Report
+
+Use this template when reporting a defect. Fill in each section:
+
+- **Issue Description** — clear, concise summary of the bug
+- **Package Version and Platform** — OS/distro, exact package version (e.g. `389-ds-base-3.2.0-6.fc42.x86_64`), browser if UI-related
+- **Steps to Reproduce** — numbered steps to trigger the problem
+- **Expected results** — what should have happened instead
+- **Screenshots** — attach if applicable
+- **Additional context** — logs, configuration, environment details
+
+### Feature Request
+
+Use this template when suggesting new functionality:
+
+- **Is your feature request related to a problem?** — describe the pain point or use case
+- **Describe the solution you'd like** — what the desired behavior looks like
+- **Describe alternatives you've considered** — other approaches you evaluated
+- **Additional context** — mockups, screenshots, or related issues
+
+### Security Issues
+
+Security issues should **not** be reported via GitHub issues. Use [GitHub's security advisory feature](https://github.com/389ds/389-ds-base/security/advisories) instead.
+
+## Getting Started
+
+1. Fork the repository on GitHub.
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/389-ds-base.git
+   cd 389-ds-base
+   ```
+3. Create a branch for your changes:
+   ```bash
+   git checkout -b issue-NNNNN
+   ```
+4. Build and verify:
+   ```bash
+   autoreconf -fiv
+   ./configure --enable-debug --with-openldap --enable-cmocka
+   make
+   make lib389
+   sudo make install
+   sudo make lib389-install
+   make check
+   ```
+5. Commit your changes (see [Commit Messages](#commit-messages)).
+6. Push to your fork and open a Pull Request.
+
+## Pull Request Guidelines
+
+All PRs should be submitted against the `main` branch.
+
+PRs should include:
+- **Well-documented code changes.** The commit message should explain *why* the change was made.
+- **Tests.** New features and bug fixes should include test coverage.
+- **Documentation updates** if the changes affect user-facing behavior.
+
+For larger features, open an issue first so the approach can be discussed before significant implementation work.
+
+## Commit Messages
+
+This project uses the following commit message format. Every commit **must** reference a GitHub issue number:
+
+```
+Issue ##### - Short description of the change
+
+Description:
+Explain what the change does and why it is needed.
+
+Relates: https://github.com/389ds/389-ds-base/issues/#####
+
+Reviewed by: ???
+Assisted by: ???
+```
+
+### Format rules
+
+- **Subject line**: `Issue ##### - <concise summary>` (under 72 characters when possible)
+- **Blank line** after the subject
+- **Description**: Explain *what* and *why*, not just *how*
+- **Relates/Fixes**: Link to the GitHub issue. Use `Fixes:` when the commit fully resolves the issue, `Relates:` for partial work
+- **Reviewed by**: The reviewer's name or GitHub handle
+- **Assisted by**: If AI tools or other contributors assisted (e.g. `Cursor`, `Claude`)
+
+## Code Review
+
+Once a PR is submitted, a maintainer will review it. If nobody responds within two weeks, ping a maintainer.
+
+Keep an eye on CI results. If something fails, check the logs to see if it's related to your change.
+
+## Communication
+
+- [389 Directory Server Wiki](https://www.port389.org/)
+- [GitHub Issues](https://github.com/389ds/389-ds-base/issues) — bugs and feature requests
+- [GitHub Pull Requests](https://github.com/389ds/389-ds-base/pulls) — code contributions
+- [Contributing Guide on port389.org](https://www.port389.org/docs/389ds/contributing.html) — full upstream contributing guide

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,145 @@
+# Testing Guide
+
+## C Unit Tests
+
+```bash
+make check
+```
+
+Uses cmocka. To debug:
+
+```bash
+libtool --mode=execute gdb /path/to/test_binary
+```
+
+## Python Integration Tests (pytest)
+
+Tests live in `dirsrvtests/` and require lib389 to be installed. Run with pytest:
+
+```bash
+# Run a specific suite
+sudo py.test -s dirsrvtests/tests/suites/basic/
+
+# Run a specific test
+sudo py.test -v dirsrvtests/tests/suites/plugins/dna_test.py::test_function_name
+
+# Filter by tier marker
+sudo py.test -m tier0 dirsrvtests/tests/suites/
+```
+
+## Test Organization
+
+| Path | Purpose |
+|------|---------|
+| `dirsrvtests/tests/suites/<area>/` | Functional area tests (basic, replication, tls, plugins, clu, acl, etc.) |
+| `dirsrvtests/tests/tickets/` | Regression tests for specific bug tickets (`ticket#####_test.py`) |
+| `dirsrvtests/tests/stress/` | Stress and load tests |
+| `dirsrvtests/conftest.py` | Session/function fixtures, sanitizer injection, report hooks |
+| `dirsrvtests/pytest.ini` | Marker definitions: `tier0`, `tier1`, `tier2`, `tier3` |
+| `dirsrvtests/create_test.py` | Template generator for new tests |
+
+## Test Tier Markers
+
+- `tier0` — critical smoke tests
+- `tier1` — core functionality tests
+- `tier2` — extended feature tests
+- `tier3` — edge case and stress tests
+
+Assign a tier at the module level:
+
+```python
+pytestmark = pytest.mark.tier1
+```
+
+## Test Topology Fixtures
+
+Tests use predefined topology fixtures from `lib389.topologies`:
+
+```python
+from lib389.topologies import topology_st as topo          # Standalone
+from lib389.topologies import topology_m2 as topo           # 2 suppliers
+from lib389.topologies import topology_m3 as topo_m3        # 3 suppliers
+from lib389.topologies import topology_m4 as topo_m4        # 4 suppliers
+from lib389.topologies import topology_m2c2 as topo_m2c2    # 2 suppliers + 2 consumers
+```
+
+Access instances via `topo.standalone`, `topo.ms["supplier1"]`, `topo.ms["supplier2"]`, etc.
+
+## Writing Tests — Docstring Format
+
+Suite tests **must** use structured docstrings with these fields (enforced by Testimony tooling):
+
+```python
+def test_example_feature(topo):
+    """Short description of what the test verifies
+
+    :id: <unique-uuid>
+    :setup: Describe the test setup (e.g. "Standalone instance" or "Two supplier replication")
+    :steps:
+        1. First action
+        2. Second action
+        3. Third action
+    :expectedresults:
+        1. Expected outcome of step 1
+        2. Expected outcome of step 2
+        3. Expected outcome of step 3
+    """
+```
+
+Each test **must** have a unique `:id:` (UUID). Generate one using `dirsrvtests/create_test.py` or `python -c "import uuid; print(uuid.uuid4())"`. Steps and expected results must have matching numbered items.
+
+## Writing Tests — Common Patterns
+
+```python
+import pytest
+import ldap
+import logging
+import os
+from lib389.topologies import topology_st as topo
+from lib389._constants import DEFAULT_SUFFIX, PASSWORD
+from lib389.idm.user import UserAccounts, UserAccount
+from lib389.plugins import MemberOfPlugin
+from lib389.utils import ds_supports_new_changelog
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+```
+
+**Prefer modern lib389 API** over deprecated raw LDAP calls:
+- Use `UserAccount`, `UserAccounts` instead of `add_s()` / `modify_s()`
+- Use `inst.config.set()` instead of `modify_s('cn=config', ...)`
+- Use `PwPolicyManager`, `DNAPlugin`, etc. instead of raw DN manipulation
+- Use `Changelog5` / `Changelog` instead of direct changelog DN access
+- Use `pytest.raises()` for expected exceptions
+
+**Cleanup**: Use `request.addfinalizer()` or `try/finally` blocks to clean up test entries. The `DEBUGGING` env variable convention: when set, finalizers stop instances instead of deleting them.
+
+**Conditional skipping**: Prefer `@pytest.mark.skipif()` decorators over runtime `pytest.skip()` calls inside the test body. Remember that every test must retain its unique `:id:` UUID in the docstring — never remove or change an existing `:id:` when adding skip conditions. Generate a new UUID with `python3 -c "import uuid; print(uuid.uuid4())"` :
+
+```python
+@pytest.mark.skipif(ds_supports_new_changelog(),
+                    reason="This test is for legacy changelog")
+def test_legacy_changelog(topo):
+    """Verify legacy changelog behavior
+
+    :id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    :setup: Standalone instance
+    :steps:
+        1. ...
+    :expectedresults:
+        1. ...
+    """
+    ...
+```
+
+## Test Helpers and Shared Code
+
+- **Do not import directly between test files.** Place shared helpers in `conftest.py` fixtures or dedicated utility modules.
+- Fixtures in `conftest.py` are automatically discovered by pytest at each directory level.
+- Common constants like `DEFAULT_SUFFIX`, `PASSWORD`, `DN_DM` are in `lib389._constants`.


### PR DESCRIPTION
Description:
Add AGENTS.md with project context and related documentation with building, contributing and testing guidelines for AI assistants. Add rules for Cursor, Claude and Gemini.

Fixes: https://github.com/389ds/389-ds-base/issues/7435

Reviewed by: ???
Assisted by: Cursor

## Summary by Sourcery

Add AI-assistant-focused project documentation and metadata to support automated contributions.

Documentation:
- Introduce AGENTS.md with high-level project overview and links to detailed guides for AI assistants.
- Add detailed architecture, building/CI, testing, and contributing guides under docs/agents for machine-assisted development workflows.

Chores:
- Add assistant-specific entrypoints/metadata files (e.g., CLAUDE.md, GEMINI.md, Cursor rules) pointing to AGENTS.md.