### PR TITLE
Issue 7365 - Add integration with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 9am on monday"],
+  "cargo": {
+    "enabled": true,
+    "fileMatch": ["^src/.*/Cargo\\.toml$", "^src/Cargo\\.toml$"]
+  },
+  "pip_requirements": {
+    "enabled": true,
+    "fileMatch": ["(^|/)requirements\\.txt$"]
+  },
+  "github-actions": {
+    "enabled": true,
+    "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates and pin to SHA digests",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group all Rust/Cargo dependency updates",
+      "matchManagers": ["cargo"],
+      "groupName": "rust-dependencies",
+      "automerge": false
+    },
+    {
+      "description": "Group all npm updates for the cockpit-389-ds",
+      "matchManagers": ["npm"],
+      "groupName": "cockpit-389-ds-npm",
+      "automerge": false
+    },
+    {
+      "description": "Group all Python dependency updates",
+      "matchManagers": ["pip_requirements"],
+      "groupName": "python-dependencies",
+      "automerge": false
+    }
+  ]
+}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,7 +1,7 @@
 name: Compile
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Description:
Automate updating npm, pip, cargo dependencies using Renovate bot.

Fixes: https://github.com/389ds/389-ds-base/issues/7365

## Summary by Sourcery

Configure automated dependency updates with Renovate and adjust the GitHub Actions compile workflow triggers.

New Features:
- Add initial Renovate configuration to automate dependency updates across supported package managers.

Build:
- Normalize the trigger configuration for the compile GitHub Actions workflow without changing its behavior.