### PR TITLE
Issue 7457 - Refactor memberOf perf test

### DIFF
--- a/dirsrvtests/tests/perf/memberof_test.py
+++ b/dirsrvtests/tests/perf/memberof_test.py
@@ -1,34 +1,97 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2017 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import os
+import time
+import logging
+import statistics
+
+import ldap
+import ldif
 import pytest
-import subprocess
-from lib389 import Entry
-from lib389.tasks import Tasks
-from lib389.dseldif import DSEldif
+
+from lib389.config import BDB_LDBMConfig, Config, LMDB_LDBMConfig
+from lib389.dbgen import dbgen_users, dbgen_groups
+from lib389.idm.account import Accounts
+from lib389.idm.group import Group, Groups
+from lib389.idm.user import UserAccounts
+try:
+    from lib389.monitor import MonitorMemberOf
+except ImportError:
+    # Older lib389 (no deferred memberOf monitor support). Sync polling falls
+    # back to the count-based check below — no behaviour change.
+    MonitorMemberOf = None
+from lib389.plugins import MemberOfPlugin, ManagedEntriesPlugin, AutoMembershipPlugin
+from lib389.tasks import ImportTask
+from lib389.utils import get_default_db_lib
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.topologies import topology_st as topo, set_timeout as set_topo_timeout
+
 from create_data import RHDSDataLDIF
-from lib389.properties import TASK_WAIT
-from lib389.utils import ldap, os, time, logging, ds_is_older
-from lib389._constants import SUFFIX, DN_SCHEMA, DN_DM, DEFAULT_SUFFIX, PASSWORD, PLUGIN_MEMBER_OF, \
-    PLUGIN_MANAGED_ENTRY, PLUGIN_AUTOMEMBER, DN_CONFIG_LDBM, HOST_STANDALONE, PORT_STANDALONE
-from lib389.topologies import topology_st as topo
 
 pytestmark = pytest.mark.tier3
 
-MEMOF_PLUGIN = ('cn=' + PLUGIN_MEMBER_OF + ',cn=plugins,cn=config')
-MAN_ENTRY_PLUGIN = ('cn=' + PLUGIN_MANAGED_ENTRY + ',cn=plugins,cn=config')
-AUTO_MEM_PLUGIN = ('cn=' + PLUGIN_AUTOMEMBER + ',cn=plugins,cn=config')
-DOMAIN = 'redhat.com'
-LDAP_MOD = '/usr/bin/ldapmodify'
-FILTER = 'objectClass=*'
-USER_FILTER = '(|(uid=user*)(cn=group*))'
+
+@pytest.fixture(autouse=True, scope="module")
+def _disable_topology_timeout():
+    """Bulk imports here can run >85 min; disable the topology watchdog for this module."""
+    set_topo_timeout(0)
+    yield
+    set_topo_timeout(-1)
+
+
 MEMBEROF_ATTR = 'memberOf'
-DN_ATTR = 'dn:'
+USER_SELECTOR = '(uid=user*)'
+GROUP_SELECTOR = '(cn=group*)'
+TASK_TIMEOUT = 0
+
+# Multiplier for perf parameters. Default 1.0 runs the full matrix below;
+# e.g. MOF_PERF_SCALE=0.2 shrinks user/group/iter counts to a quick smoke run.
+PERF_SCALE = float(os.environ.get('MOF_PERF_SCALE', '1.0'))
+
+
+def _s(n, minimum=1):
+    return max(minimum, int(n * PERF_SCALE))
+
+
+def _smul(n, multiple):
+    """Scale n and round down to a multiple of `multiple`, never below `multiple`."""
+    return max(multiple, (int(n * PERF_SCALE) // multiple) * multiple)
+
+
+NESTGRPS_IMPORT_PARAMS = [
+    (_s(20000), _smul(200, 20), 20, 10, 5),
+    (_s(50000), _smul(500, 50), 50, 10, 10),
+    (_s(100000), _smul(1000, 100), 100, 20, 20),
+]
+
+NESTGRPS_ADD_PARAMS = [
+    (_s(20000), _smul(100, 20), 20, 10, 5),
+    (_s(50000), _smul(200, 50), 50, 10, 10),
+    (_s(100000), _smul(100, 20), 20, 10, 10),
+]
+
+# iters >= 20 keeps the p95 quantile meaningful.
+REPLACE_MEMBER_LIST_PARAMS = [
+    (_s(50000), _s(100, 20), 'on'),
+    (_s(50000), _s(100, 20), 'off'),
+]
+
+LDIF2DB_DENSE_PARAMS = [
+    (20, _s(2000), False, 'on', _s(3)),
+    (20, _s(2000), True, 'on', _s(3)),
+    (20, _s(2000), False, 'off', _s(3)),
+    (20, _s(2000), True, 'off', _s(3)),
+    (50, _s(5000), False, 'on', _s(3)),
+    (50, _s(5000), True, 'on', _s(3)),
+    (50, _s(5000), False, 'off', _s(3)),
+    (50, _s(5000), True, 'off', _s(3)),
+]
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
@@ -36,65 +99,46 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def memberof_setup(topo, request):
-    """Configure required plugins and restart the server"""
+    """Enable memberOf, managedEntries, autoMembers; tune LDBM for bulk imports."""
 
-    log.info('Configuring memberOf, managedEntry and autoMembers plugins and restarting the server')
-    topo.standalone.simple_bind_s(DN_DM, PASSWORD)
-    try:
-        topo.standalone.plugins.enable(name=PLUGIN_MEMBER_OF)
-    except ldap.LDAPError as e:
-        log.error('Failed to enable {} plugin'.format(PLUGIN_MEMBER_OF))
-        raise e
-    try:
-        topo.standalone.plugins.enable(name=PLUGIN_MANAGED_ENTRY)
-        topo.standalone.plugins.enable(name=PLUGIN_AUTOMEMBER)
-    except ldap.LDAPError as e:
-        log.error('Failed to enable {}, {} plugins'.format(PLUGIN_MANAGED_ENTRY, PLUGIN_AUTOMEMBER))
-        raise e
+    log.info('Enabling memberOf, managedEntries and autoMembers plugins')
+    memberof = MemberOfPlugin(topo.standalone)
+    managed_entries = ManagedEntriesPlugin(topo.standalone)
+    automember = AutoMembershipPlugin(topo.standalone)
+    memberof.enable()
+    managed_entries.enable()
+    automember.enable()
 
-    log.info('Change config values for db-locks and dbcachesize to import large ldif files')
-    if ds_is_older('1.3.6'):
-        topo.standalone.stop(timeout=10)
-        dse_ldif = DSEldif(topo.standalone)
-        try:
-            dse_ldif.replace(DN_CONFIG_LDBM, 'nsslapd-db-locks', '100000')
-            dse_ldif.replace(DN_CONFIG_LDBM, 'nsslapd-dbcachesize', '10000000')
-        except:
-            log.error('Failed to replace cn=config values of db-locks and dbcachesize')
-            raise
-        topo.standalone.start(timeout=10)
+    log.info('Tune LDBM config for large bulk imports')
+    if get_default_db_lib() == 'bdb':
+        BDB_LDBMConfig(topo.standalone).replace_many(
+            ('nsslapd-cache-autosize', '0'),
+            ('nsslapd-db-locks', '100000'),
+            ('nsslapd-dbcachesize', '10000000'),
+        )
     else:
-        try:
-            topo.standalone.modify_s(DN_CONFIG_LDBM, [(ldap.MOD_REPLACE, 'nsslapd-db-locks', '100000')])
-            topo.standalone.modify_s(DN_CONFIG_LDBM, [(ldap.MOD_REPLACE, 'nsslapd-cache-autosize', '0')])
-            topo.standalone.modify_s(DN_CONFIG_LDBM, [(ldap.MOD_REPLACE, 'nsslapd-dbcachesize', '10000000')])
-        except ldap.LDAPError as e:
-            log.error(
-                'Failed to replace values of nsslapd-db-locks and nsslapd-dbcachesize {}'.format(e.message['desc']))
-            raise e
-        topo.standalone.restart(timeout=10)
+        LMDB_LDBMConfig(topo.standalone).replace('nsslapd-cache-autosize', '0')
+    # 200 MB: MOD_REPLACE with tens of thousands of members exceeds the 2 MB default.
+    Config(topo.standalone).set('nsslapd-maxbersize', str(209715200))
+    topo.standalone.restart()
 
     def fin():
-        log.info('Disabling plugins {}, {}, {}'.format(PLUGIN_MEMBER_OF, PLUGIN_MANAGED_ENTRY, PLUGIN_AUTOMEMBER))
-        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
-        try:
-            topo.standalone.plugins.disable(name=PLUGIN_MEMBER_OF)
-            topo.standalone.plugins.disable(name=PLUGIN_MANAGED_ENTRY)
-            topo.standalone.plugins.disable(name=PLUGIN_AUTOMEMBER)
-        except ldap.LDAPError as e:
-            log.error('Failed to disable plugins, {}'.format(e.message['desc']))
-            assert False
-        topo.standalone.restart(timeout=10)
+        log.info('Disabling memberOf, managedEntries and autoMembers plugins')
+        if topo.standalone.status() is False:
+            topo.standalone.start()
+        memberof.disable()
+        managed_entries.disable()
+        automember.disable()
+        topo.standalone.restart()
 
     request.addfinalizer(fin)
 
 
 def _create_base_ldif(topo, import_base=False):
-    """Create base ldif file to clean entries from suffix"""
+    """Write a base LDIF (suffix + ou=people + ou=groups)."""
 
-    log.info('Add base entry for online import')
     ldif_dir = topo.standalone.get_ldif_dir()
-    ldif_file = os.path.join(ldif_dir, '/perf.ldif')
+    ldif_file = os.path.join(ldif_dir, 'perf.ldif')
     log.info('LDIF FILE is this: {}'.format(ldif_file))
     base_ldif = """dn: dc=example,dc=com
 objectclass: top
@@ -113,37 +157,36 @@ ou: groups
 """
     with open(ldif_file, "w") as fd:
         fd.write(base_ldif)
+    os.chmod(ldif_file, 0o644)
+
     if import_base:
         log.info('Adding base entry to suffix to remove users/groups and leave only the OUs')
-        try:
-            topo.standalone.tasks.importLDIF(suffix=SUFFIX, input_file=ldif_file, args={TASK_WAIT: True})
-        except ValueError as e:
-            log.error('Online import failed' + e.message('desc'))
-            assert False
-    else:
-        log.info('Return LDIF file')
-        return ldif_file
+        import_task = ImportTask(topo.standalone)
+        import_task.import_suffix_from_ldif(ldiffile=ldif_file, suffix=DEFAULT_SUFFIX)
+        import_task.wait(timeout=TASK_TIMEOUT)
+        assert import_task.get_exit_code() == 0, 'Online import failed'
+        return None
+
+    log.info('Return LDIF file')
+    return ldif_file
 
 
 def _run_fixup_memberof(topo):
-    """Run fixup memberOf task and measure the time taken"""
+    """Run the memberOf fixup task and return elapsed seconds."""
 
     log.info('Running fixup memberOf task and measuring the time taken')
+    memberof = MemberOfPlugin(topo.standalone)
     start = time.time()
-    try:
-        topo.standalone.tasks.fixupMemberOf(suffix=SUFFIX, args={TASK_WAIT: True})
-    except ValueError as e:
-        log.error('Running fixup MemberOf task failed' + e.message('desc'))
-        assert False
+    task = memberof.fixup(basedn=DEFAULT_SUFFIX)
+    task.wait(timeout=TASK_TIMEOUT)
     end = time.time()
-    cmd_time = int(end - start)
-    return cmd_time
+    assert task.get_exit_code() == 0, 'fixupMemberOf task failed'
+    return int(end - start)
 
 
 def _nested_import_add_ldif(topo, nof_users, nof_groups, grps_user, ngrps_user, nof_depth, is_import=False):
-    """Create LDIF files for given nof users, groups and nested group levels"""
+    """Generate users + nested groups LDIF; import or ldapmodify it. Return elapsed seconds."""
 
-    log.info('Checking if the operation is Import or Ldapadd')
     if is_import:
         log.info('Import: Create base entry before adding users and groups')
         exp_entries = nof_users + nof_groups
@@ -151,82 +194,124 @@ def _nested_import_add_ldif(topo, nof_users, nof_groups, grps_user, ngrps_user, 
         log.info('Create data LDIF file by appending users, groups and nested groups')
         with open(data_ldif, 'a') as file1:
             data = RHDSDataLDIF(stream=file1, users=nof_users, groups=nof_groups, grps_puser=grps_user,
-                                nest_level=nof_depth, ngrps_puser=ngrps_user, basedn=SUFFIX)
+                                nest_level=nof_depth, ngrps_puser=ngrps_user, basedn=DEFAULT_SUFFIX)
             data.do_magic()
+        os.chmod(data_ldif, 0o644)
+
         start = time.time()
         log.info('Run importLDIF task to add entries to Server')
-        try:
-            topo.standalone.tasks.importLDIF(suffix=SUFFIX, input_file=data_ldif, args={TASK_WAIT: True})
-        except ValueError as e:
-            log.error('Online import failed' + e.message('desc'))
-            assert False
+        import_task = ImportTask(topo.standalone)
+        import_task.import_suffix_from_ldif(ldiffile=data_ldif, suffix=DEFAULT_SUFFIX)
+        import_task.wait(timeout=TASK_TIMEOUT)
         end = time.time()
+        assert import_task.get_exit_code() == 0, 'Online import failed'
         time_import = int(end - start)
 
         log.info('Check if number of entries created matches the expected entries')
-        users_groups = topo.standalone.search_s(SUFFIX, ldap.SCOPE_SUBTREE, USER_FILTER, [DN_ATTR])
-        act_entries = str(users_groups).count(DN_ATTR)
-        log.info('Expected entries: {}, Actual entries: {}'.format(exp_entries, act_entries))
+        accounts = Accounts(topo.standalone, DEFAULT_SUFFIX)
+        act_users = len(accounts.filter(USER_SELECTOR))
+        act_groups = len(Groups(topo.standalone, DEFAULT_SUFFIX, rdn='ou=groups').filter(GROUP_SELECTOR))
+        act_entries = act_users + act_groups
+        log.info('Expected entries: {}, Actual entries: {} (users={}, groups={})'.format(
+            exp_entries, act_entries, act_users, act_groups))
         assert act_entries == exp_entries
         return time_import
-    else:
-        log.info('Ldapadd: Create data LDIF file with users, groups and nested groups')
-        ldif_dir = topo.standalone.get_ldif_dir()
-        data_ldif = os.path.join(ldif_dir, '/perf_add.ldif')
-        with open(data_ldif, 'w') as file1:
-            data = RHDSDataLDIF(stream=file1, users=nof_users, groups=nof_groups, grps_puser=grps_user,
-                                nest_level=nof_depth, ngrps_puser=ngrps_user, basedn=SUFFIX)
-            data.do_magic()
-        start = time.time()
-        log.info('Run LDAPMODIFY to add entries to Server')
-        try:
-            subprocess.check_output(
-                [LDAP_MOD, '-cx', '-D', DN_DM, '-w', PASSWORD, '-h', HOST_STANDALONE, '-p', str(PORT_STANDALONE), '-af',
-                 data_ldif])
-        except subprocess.CalledProcessError as e:
-            log.error('LDAPMODIFY failed to add entries, error:{:s}'.format(str(e)))
-            raise e
-        end = time.time()
-        cmd_time = int(end - start)
-        log.info('Time taken to complete LDAPADD: {} secs'.format(cmd_time))
-        return cmd_time
+
+    log.info('Ldapadd: Create data LDIF file with users, groups and nested groups')
+    ldif_dir = topo.standalone.get_ldif_dir()
+    data_ldif = os.path.join(ldif_dir, 'perf_add.ldif')
+    with open(data_ldif, 'w') as file1:
+        data = RHDSDataLDIF(stream=file1, users=nof_users, groups=nof_groups, grps_puser=grps_user,
+                            nest_level=nof_depth, ngrps_puser=ngrps_user, basedn=DEFAULT_SUFFIX)
+        data.do_magic()
+
+    with open(data_ldif, 'rb') as fp:
+        parser = ldif.LDIFRecordList(fp)
+        parser.parse()
+
+    start = time.time()
+    log.info('Add {} entries to Server'.format(len(parser.all_records)))
+    for dn, attrs in parser.all_records:
+        topo.standalone.add_ext_s(dn, list(attrs.items()), escapehatch='i am sure')
+    end = time.time()
+    cmd_time = int(end - start)
+    log.info('Time taken to complete LDAPADD: {} secs'.format(cmd_time))
+    return cmd_time
+
+
+def _count_memberof_values(topo):
+    """Return total memberOf value count across the suffix.
+
+    Uses a direct subtree search rather than Accounts.filter(): for a 100k-user
+    run the result holds ~10M memberOf values, and skipping the per-entry
+    Account-object wrapping is a meaningful win.
+    """
+    entries = topo.standalone.search_ext_s(
+        DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+        '({}=*)'.format(MEMBEROF_ATTR),
+        [MEMBEROF_ATTR],
+        escapehatch='i am sure',
+    )
+    return sum(len(e.data.get(MEMBEROF_ATTR, [])) for e in entries)
+
+
+def _deferred_memberof_idle(topo):
+    """True/False if the deferred memberOf monitor reports idle/busy.
+    Returns None when monitoring isn't available (deferred mode disabled,
+    or older lib389 / server without the cn=MemberOf Plugin,cn=monitor entry).
+    """
+    if MonitorMemberOf is None:
+        return None
+    try:
+        status = MonitorMemberOf(topo.standalone).get_status()
+    except (ValueError, ldap.NO_SUCH_OBJECT):
+        return None
+    pending = int((status.get('TotalPending') or ['0'])[0])
+    current = int((status.get('CurrentTasks') or ['0'])[0])
+    return pending == 0 and current == 0
 
 
 def _sync_memberof_attrs(topo, exp_memberof):
-    """Check if expected entries are created or attributes are synced"""
+    """Poll until memberOf count reaches exp_memberof; return wall-clock seconds.
 
+    Why: the prior loop slept a fixed 30s between checks and ran a full
+    Accounts.filter() walk every iteration. After a fixup the count typically
+    matches on the first try, so each extra iteration paid 30s of pure waste.
+    """
     log.info('_sync_memberof_attrs: Check if expected memberOf attributes are synced/created')
+    start_wall = time.time()
+    deadline = start_wall + 10 * 60 * 60
+    delay = 1
     loop = 0
-    start = time.time()
-    entries = topo.standalone.search_s(SUFFIX, ldap.SCOPE_SUBTREE, FILTER, [MEMBEROF_ATTR])
-    act_memberof = str(entries).count(MEMBEROF_ATTR)
-    end = time.time()
-    cmd_time = int(end - start)
-    log.info('Loop-{}, expected memberOf attrs: {}, synced: {}, time for search-{} secs'.format(loop, exp_memberof,
-                                                                                                act_memberof, cmd_time))
-    while act_memberof != exp_memberof:
-        loop = loop + 1
-        time.sleep(30)
-        start = time.time()
-        entries = topo.standalone.search_s(SUFFIX, ldap.SCOPE_SUBTREE, FILTER, [MEMBEROF_ATTR])
-        act_memberof = str(entries).count(MEMBEROF_ATTR)
-        end = time.time()
-        cmd_time = cmd_time + int(end - start)
-        log.info('Loop-{}, expected memberOf attrs: {}, synced: {}, time for search-{} secs'.format(loop, exp_memberof,
-                                                                                                    act_memberof,
-                                                                                                    cmd_time))
-        # Worst case scenario, exit the test after 10hrs of wait
-        if loop > 1200:
+    act_memberof = -1
+    while True:
+        idle = _deferred_memberof_idle(topo)
+        if idle is False:
+            log.info('Loop-{}, deferred memberOf queue not yet drained, sleeping {}s'.format(loop, delay))
+        else:
+            t0 = time.time()
+            act_memberof = _count_memberof_values(topo)
+            search_secs = int(time.time() - t0)
+            log.info('Loop-{}, expected memberOf attrs: {}, synced: {}, search-time={} secs'.format(
+                loop, exp_memberof, act_memberof, search_secs))
+            if act_memberof == exp_memberof:
+                break
+
+        if time.time() > deadline:
             log.error('Either syncing memberOf attrs takes too long or some issue with the test itself')
             assert False
-    sync_time = 1 + loop * 30
+
+        time.sleep(delay)
+        delay = min(30, delay * 2)
+        loop += 1
+
+    sync_time = int(time.time() - start_wall)
     log.info('Expected memberOf attrs: {}, Actual memberOf attrs: {}'.format(exp_memberof, act_memberof))
-    assert act_memberof == exp_memberof
     return sync_time
 
 
 @pytest.mark.parametrize("nof_users, nof_groups, grps_user, ngrps_user, nof_depth",
-                         [(20000, 200, 20, 10, 5), (50000, 500, 50, 10, 10), (100000, 1000, 100, 20, 20)])
+                         NESTGRPS_IMPORT_PARAMS)
 def test_nestgrps_import(topo, memberof_setup, nof_users, nof_groups, grps_user, ngrps_user, nof_depth):
     """Import large users and nested groups with N depth and measure the time taken
 
@@ -240,7 +325,14 @@ def test_nestgrps_import(topo, memberof_setup, nof_users, nof_groups, grps_user,
             5. Check if memberOf attributes are synced for all users and groups
             6. Compare the actual no of memberOf attributes to the expected
             7. Measure the time taken to sync memberOf attributes
-    :expectedresults: MemberOf attributes should be synced
+    :expectedresults:
+            1. LDIF file generated
+            2. Online import succeeds
+            3. Entry count matches nof_users + nof_groups
+            4. fixupMemberOf task exits with code 0
+            5. memberOf count converges to the expected value
+            6. Counts match
+            7. Elapsed time is logged
     """
 
     exp_memberof = (nof_users * grps_user) + (
@@ -256,13 +348,12 @@ def test_nestgrps_import(topo, memberof_setup, nof_users, nof_groups, grps_user,
     sync_memberof = _sync_memberof_attrs(topo, exp_memberof)
 
     total_time = import_time + fixup_time + sync_memberof
-    log.info('Time for import-{}secs, fixup task-{}secs, total time for memberOf sync: {}secs'.format(import_time,
-                                                                                                      fixup_time,
-                                                                                                      total_time))
+    log.info('Time for import-{}secs, fixup task-{}secs, total time for memberOf sync: {}secs'.format(
+        import_time, fixup_time, total_time))
 
 
 @pytest.mark.parametrize("nof_users, nof_groups, grps_user, ngrps_user, nof_depth",
-                         [(20000, 100, 20, 10, 5), (50000, 200, 50, 10, 10), (100000, 100, 20, 10, 10)])
+                         NESTGRPS_ADD_PARAMS)
 def test_nestgrps_add(topo, memberof_setup, nof_users, nof_groups, grps_user, ngrps_user, nof_depth):
     """Import large users and nested groups with n depth and measure the time taken
 
@@ -275,7 +366,13 @@ def test_nestgrps_add(topo, memberof_setup, nof_users, nof_groups, grps_user, ng
             4. Check if memberOf attributes are synced for all users and groups
             5. Compare the actual no of memberOf attributes to the expected
             6. Measure the time taken to sync memberOf attributes
-    :expectedresults: MemberOf attributes should be created and synced
+    :expectedresults:
+            1. LDIF file generated
+            2. All entries added without LDAP error
+            3. Entry count matches nof_users + nof_groups
+            4. memberOf count converges to the expected value
+            5. Counts match
+            6. Elapsed time is logged
     """
 
     exp_memberof = (nof_users * grps_user) + (
@@ -293,7 +390,7 @@ def test_nestgrps_add(topo, memberof_setup, nof_users, nof_groups, grps_user, ng
 
 
 @pytest.mark.parametrize("nof_users, nof_groups, grps_user, ngrps_user, nof_depth",
-                         [(20000, 200, 20, 10, 5), (50000, 500, 50, 10, 10), (100000, 1000, 100, 20, 20)])
+                         NESTGRPS_IMPORT_PARAMS)
 def test_mod_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngrps_user, nof_depth):
     """Import bulk entries, modify nested groups at N depth and measure the time taken
 
@@ -305,7 +402,12 @@ def test_mod_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
             3. Check new memberOf attributes created for users and groups
             4. Compare the actual memberOf attributes with the expected
             5. Measure the time taken to sync memberOf attributes
-    :expectedresults: MemberOf attributes should be modified and synced
+    :expectedresults:
+            1. Import + initial fixup succeed and memberOf reaches the baseline count
+            2. Each user creation and add_member succeeds
+            3. memberOf count converges to the post-modification expected value
+            4. Counts match
+            5. Elapsed time is logged
     """
 
     exp_memberof = (nof_users * grps_user) + (
@@ -316,31 +418,26 @@ def test_mod_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
     fixup_time = _run_fixup_memberof(topo)
     sync_memberof = _sync_memberof_attrs(topo, exp_memberof)
     total_time = import_time + fixup_time + sync_memberof
-    log.info('Time for import-{}secs, fixup task-{}secs, total time for memberOf sync: {}secs'.format(import_time,
-                                                                                                      fixup_time,
-                                                                                                      total_time))
+    log.info('Time for import-{}secs, fixup task-{}secs, total time for memberOf sync: {}secs'.format(
+        import_time, fixup_time, total_time))
 
     log.info('Add {} users to existing nested groups at all depth level'.format(nof_groups))
     log.info('Add one user to each groups at different nest levels')
+    users = UserAccounts(topo.standalone, DEFAULT_SUFFIX, rdn='ou=people')
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX, rdn='ou=groups')
     start = time.time()
     for usr in range(nof_groups):
         usrrdn = 'newcliusr{}'.format(usr)
-        userdn = 'uid={},ou=people,{}'.format(usrrdn, SUFFIX)
-        groupdn = 'cn=group{},ou=groups,{}'.format(usr, SUFFIX)
-        try:
-            topo.standalone.add_s(Entry((userdn, {
-                'objectclass': 'top person inetUser inetOrgperson'.split(),
-                'cn': usrrdn,
-                'sn': usrrdn,
-                'userpassword': 'Secret123'})))
-        except ldap.LDAPError as e:
-            log.error('Failed to add {} user: error {}'.format(userdn, e.message['desc']))
-            raise
-        try:
-            topo.standalone.modify_s(groupdn, [(ldap.MOD_ADD, 'member', userdn)])
-        except ldap.LDAPError as e:
-            log.error('Error-{}: Failed to add user to group'.format(e.message['desc']))
-            assert False
+        user = users.create(properties={
+            'uid': usrrdn,
+            'cn': usrrdn,
+            'sn': usrrdn,
+            'uidNumber': str(100000 + usr),
+            'gidNumber': str(100000 + usr),
+            'homeDirectory': '/home/{}'.format(usrrdn),
+            'userPassword': 'Secret123',
+        })
+        groups.get('group{}'.format(usr)).add_member(user.dn)
     end = time.time()
     cmd_time = int(end - start)
 
@@ -353,7 +450,7 @@ def test_mod_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
 
 
 @pytest.mark.parametrize("nof_users, nof_groups, grps_user, ngrps_user, nof_depth",
-                         [(20000, 200, 20, 10, 5), (50000, 500, 50, 10, 10), (100000, 1000, 100, 20, 20)])
+                         NESTGRPS_IMPORT_PARAMS)
 def test_del_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngrps_user, nof_depth):
     """Import bulk entries, delete nested groups at N depth and measure the time taken
 
@@ -366,7 +463,13 @@ def test_del_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
             4. Check memberOf attributes deleted for users and groups
             5. Compare the actual memberOf attributes with the expected
             6. Measure the time taken to sync memberOf attributes
-    :expectedresults: MemberOf attributes should be deleted and synced
+    :expectedresults:
+            1. Online import succeeds and entry counts match
+            2. fixupMemberOf task exits with code 0 and memberOf reaches the baseline count
+            3. Each group delete succeeds
+            4. memberOf count converges to the post-delete expected value
+            5. Counts match
+            6. Elapsed time is logged
     """
 
     exp_memberof = (nof_users * grps_user) + (
@@ -380,14 +483,10 @@ def test_del_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
     log.info('Time taken to complete add users + memberOf sync: {} secs'.format(total_time))
 
     log.info('Delete {} groups from nested groups at depth level-{}'.format(nof_depth, nof_depth))
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX, rdn='ou=groups')
     start = time.time()
     for nos in range(nof_depth, nof_groups, grps_user):
-        groupdn = 'cn=group{},ou=groups,{}'.format(nos, SUFFIX)
-        try:
-            topo.standalone.delete_s(groupdn)
-        except ldap.LDAPError as e:
-            log.error('Error-{}: Failed to delete group'.format(e.message['desc']))
-            assert False
+        groups.get('group{}'.format(nos)).delete()
     end = time.time()
     cmd_time = int(end - start)
 
@@ -396,6 +495,249 @@ def test_del_nestgrp(topo, memberof_setup, nof_users, nof_groups, grps_user, ngr
     sync_memberof = _sync_memberof_attrs(topo, exp_memberof)
     total_time = cmd_time + sync_memberof
     log.info('Time taken to delete and sync memberOf attributes: {}secs'.format(total_time))
+
+
+REPLACE_BENCH_GROUP = 'mof_replace_bench_group'
+REPLACE_BENCH_LDIF = 'mof_replace_bench.ldif'
+
+
+def _import_users(topo, total):
+    """Import 2 * total users via dbgen + ldif2db; return two DN-sorted halves."""
+
+    ldif_path = os.path.join(topo.standalone.get_ldif_dir(), REPLACE_BENCH_LDIF)
+    dbgen_users(topo.standalone, 2 * total, ldif_path, DEFAULT_SUFFIX, generic=True)
+    topo.standalone.stop()
+    assert topo.standalone.ldif2db('userRoot', None, None, None, ldif_path), 'ldif2db failed'
+    topo.standalone.start()
+    dns = sorted(u.dn for u in Accounts(topo.standalone, DEFAULT_SUFFIX).filter('(uid=user*)'))
+    assert len(dns) >= 2 * total, 'expected {} imported users, got {}'.format(2 * total, len(dns))
+    return dns[:total], dns[total:2 * total]
+
+
+def _reset_bench_group(topo, members):
+    """(Re)create the benchmark group with the given members."""
+
+    groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+    if groups.exists(REPLACE_BENCH_GROUP):
+        groups.get(REPLACE_BENCH_GROUP).delete()
+    return groups.create(properties={'cn': REPLACE_BENCH_GROUP, 'member': members})
+
+
+def _cleanup_bench_state(topo):
+    """Drop the benchmark group and its LDIF; leave imported users for the next ldif2db to overwrite."""
+
+    try:
+        if topo.standalone.status() is False:
+            topo.standalone.start()
+        groups = Groups(topo.standalone, DEFAULT_SUFFIX)
+        if groups.exists(REPLACE_BENCH_GROUP):
+            groups.get(REPLACE_BENCH_GROUP).delete()
+    except Exception as e:
+        log.warning('Bench teardown: failed to drop {}: {}'.format(REPLACE_BENCH_GROUP, e))
+
+    ldif_path = os.path.join(topo.standalone.get_ldif_dir(), REPLACE_BENCH_LDIF)
+    try:
+        if os.path.exists(ldif_path):
+            os.remove(ldif_path)
+    except OSError as e:
+        log.warning('Bench teardown: failed to remove {}: {}'.format(ldif_path, e))
+
+
+@pytest.mark.parametrize('nof_users, iters, ndn_cache', REPLACE_MEMBER_LIST_PARAMS)
+def test_replace_member_list(topo, memberof_setup, nof_users, iters, ndn_cache, request):
+    """Time MOD_REPLACE of a large member list, alternating between two disjoint sets.
+
+    :id: 44aa5375-60ce-4d23-9d8f-58ae2ba04de8
+    :feature: MemberOf Plugin
+    :setup: Standalone instance, memberOf plugin enabled
+    :steps: 1. Import 2 * nof_users users and create the bench group with the first half
+            2. Set nsslapd-ndn-cache-enabled per parametrization and restart
+            3. One warmup MOD_REPLACE to populate caches
+            4. Alternate MOD_REPLACE between the two sets for iters trials
+            5. Report median / p95 / p99; fail if p95 exceeds MOF_BENCH_CEILING when set
+    :expectedresults:
+            1. Success
+            2. Success
+            3. Success
+            4. Group holds nof_users members after the final replace
+            5. Success (p95 within ceiling if set)
+    """
+
+    request.addfinalizer(lambda: _cleanup_bench_state(topo))
+
+    log.info('Importing 2 x {} users via dbgen + ldif2db'.format(nof_users))
+    set_a, set_b = _import_users(topo, nof_users)
+
+    log.info('Priming {} with {} initial members'.format(REPLACE_BENCH_GROUP, nof_users))
+    _reset_bench_group(topo, set_a)
+
+    log.info('Setting nsslapd-ndn-cache-enabled={}'.format(ndn_cache))
+    Config(topo.standalone).set('nsslapd-ndn-cache-enabled', ndn_cache)
+    topo.standalone.restart()
+
+    group = Groups(topo.standalone, DEFAULT_SUFFIX).get(REPLACE_BENCH_GROUP)
+
+    log.info('Warmup: one throwaway MOD_REPLACE to populate caches')
+    group.replace('member', set_b)
+
+    trials = []
+    current, other = set_a, set_b
+    for i in range(iters):
+        start = time.perf_counter()
+        group.replace('member', current)
+        elapsed = time.perf_counter() - start
+
+        trials.append(elapsed)
+        log.info('trial {}/{}: {:.3f}s'.format(i + 1, iters, elapsed))
+
+        current, other = other, current
+
+    members = group.get_attr_vals_utf8('member')
+    assert members, 'group ended up with no members'
+    assert len(members) == nof_users, (
+        'expected {} members after final replace, got {}'.format(
+            nof_users, len(members)))
+
+    median = statistics.median(trials)
+    p95 = statistics.quantiles(trials, n=20)[18]
+    p99 = statistics.quantiles(trials, n=100)[98] if len(trials) >= 2 else max(trials)
+    log.info(
+        'N={} iters={} ndn_cache={} median={:.3f}s p95={:.3f}s p99={:.3f}s min={:.3f}s max={:.3f}s'.format(
+            nof_users, iters, ndn_cache, median, p95, p99, min(trials), max(trials)))
+
+    ceiling = os.environ.get('MOF_BENCH_CEILING')
+    if ceiling is not None:
+        ceiling = float(ceiling)
+        assert p95 < ceiling, (
+            'p95 {:.3f}s exceeded ceiling {:.3f}s (trials={})'.format(
+                p95, ceiling, ['{:.3f}'.format(t) for t in trials]))
+
+
+IMPORT_BENCH_LDIF = 'mof_dense_import_bench.ldif'
+IMPORT_BENCH_GROUP_NAME = 'densegroup'
+
+
+def _denormalize_member_lines(ldif_path):
+    """Rewrite every `member: <dn>` line in place to use whitespace-padded,
+    uppercase attr types. Opens the file for 'w' to preserve inode/ownership
+    set by dbgen_groups's finalize_ldif_file.
+    """
+    with open(ldif_path, 'r') as f:
+        lines = f.readlines()
+    with open(ldif_path, 'w') as f:
+        for line in lines:
+            if line.startswith('member: '):
+                dn = line[len('member: '):].rstrip('\n')
+                rdns = []
+                for rdn in dn.split(','):
+                    attr, _, value = rdn.partition('=')
+                    rdns.append('{} = {}'.format(attr.strip().upper(), value.strip()))
+                f.write('member: ' + ' , '.join(rdns) + '\n')
+            else:
+                f.write(line)
+
+
+def _time_ldif2db(topo, ldif_path):
+    if topo.standalone.status() is not False:
+        topo.standalone.stop()
+    start = time.perf_counter()
+    assert topo.standalone.ldif2db('userRoot', None, None, None, ldif_path), 'ldif2db failed'
+    elapsed = time.perf_counter() - start
+    topo.standalone.start()
+    return elapsed
+
+
+@pytest.mark.parametrize(
+    'nof_groups, members_per_group, denormalize, ndn_cache, iters',
+    LDIF2DB_DENSE_PARAMS,
+)
+def test_ldif2db_dense_member_import(topo, memberof_setup, nof_groups,
+                                     members_per_group, denormalize, ndn_cache, iters, request):
+    """Time offline ldif2db of an LDIF dense in DN-syntax member values.
+
+    :id: 65db7483-e8b4-4c33-bc6d-1c9d7467f8a4
+    :feature: MemberOf Plugin
+    :setup: Standalone instance, memberOf plugin enabled
+    :steps: 1. Build LDIF via dbgen_groups (groups + their member entries)
+            2. If denormalize, rewrite member values to whitespace-padded form
+            3. For iters trials, stop the server, run ldif2db, restart
+            4. Verify the last group holds members_per_group values
+            5. Report median / p95 / p99 import times
+            6. Fail if p95 exceeds MOF_IMPORT_BENCH_CEILING when set
+    :expectedresults:
+            1. LDIF generated
+            2. Success
+            3. Each ldif2db succeeds
+            4. Member count matches expected
+            5. Success
+            6. Success (within ceiling if set)
+    """
+
+    ldif_path = os.path.join(topo.standalone.get_ldif_dir(), IMPORT_BENCH_LDIF)
+
+    def fin():
+        try:
+            if os.path.exists(ldif_path):
+                os.remove(ldif_path)
+        except OSError as e:
+            log.warning('ldif cleanup failed: {}'.format(e))
+        if topo.standalone.status() is False:
+            topo.standalone.start()
+    request.addfinalizer(fin)
+
+    log.info('Setting nsslapd-ndn-cache-enabled={}'.format(ndn_cache))
+    Config(topo.standalone).set('nsslapd-ndn-cache-enabled', ndn_cache)
+    topo.standalone.restart()
+
+    log.info('Generating LDIF: groups={}, members/group={}, denormalize={}, ndn_cache={}'.format(
+        nof_groups, members_per_group, denormalize, ndn_cache))
+    dbgen_groups(topo.standalone, ldif_path, {
+        'name': IMPORT_BENCH_GROUP_NAME,
+        'parent': 'ou=groups,' + DEFAULT_SUFFIX,
+        'suffix': DEFAULT_SUFFIX,
+        'number': nof_groups,
+        'numMembers': members_per_group,
+        'createMembers': True,
+        'memberParent': 'ou=people,' + DEFAULT_SUFFIX,
+        'membershipAttr': 'member',
+    })
+    if denormalize:
+        _denormalize_member_lines(ldif_path)
+    log.info('LDIF size: {:.1f} MiB'.format(os.path.getsize(ldif_path) / (1024 * 1024)))
+
+    trials = []
+    for i in range(iters):
+        elapsed = _time_ldif2db(topo, ldif_path)
+        trials.append(elapsed)
+        log.info('trial {}/{}: {:.3f}s (groups={}, members/group={}, denormalize={}, ndn_cache={})'.format(
+            i + 1, iters, elapsed, nof_groups, members_per_group, denormalize, ndn_cache))
+
+    last_dn = 'cn={}-{},ou=groups,{}'.format(IMPORT_BENCH_GROUP_NAME, nof_groups, DEFAULT_SUFFIX)
+    stored = Group(topo.standalone, last_dn).get_attr_vals_utf8('member')
+    assert len(stored) == members_per_group, (
+        'last group: expected {} members, got {}'.format(members_per_group, len(stored)))
+
+    median = statistics.median(trials)
+    if len(trials) >= 20:
+        p95 = statistics.quantiles(trials, n=20)[18]
+    else:
+        p95 = max(trials)
+    if len(trials) >= 100:
+        p99 = statistics.quantiles(trials, n=100)[98]
+    else:
+        p99 = max(trials)
+    log.info(
+        'ldif2db dense-member import: groups={} members/group={} denormalize={} ndn_cache={} '
+        'iters={} median={:.3f}s p95={:.3f}s p99={:.3f}s min={:.3f}s max={:.3f}s'.format(
+            nof_groups, members_per_group, denormalize, ndn_cache, iters,
+            median, p95, p99, min(trials), max(trials)))
+
+    ceiling = os.environ.get('MOF_IMPORT_BENCH_CEILING')
+    if ceiling is not None:
+        ceiling = float(ceiling)
+        assert p95 < ceiling, (
+            'p95 {:.3f}s exceeded ceiling {:.3f}s (trials={})'.format(
+                p95, ceiling, ['{:.3f}'.format(t) for t in trials]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Description: The memberof perf test module uses old and legacy lib389 objects, polls memberOf sync on a fixed 30s sleep with a full (memberOf=*) walk per iteration, and has hard-coded perf-grade parameters that make it unusable in a CI budget.

Use correct lib389 objects, add intervals, low-power mode for smoke-runs and add two benchmarks
(test_replace_member_list, test_ldif2db_dense_member_import) that report median/p95/p99.
Fix minor issues.

Fixes: https://github.com/389ds/389-ds-base/issues/7457

Assisted by: Claude Code

Reviewed by: ?

## Summary by Sourcery

Refine and modernize the memberOf performance test suite to use current lib389 APIs, configurable workload scaling, and more precise synchronization and benchmarking of memberOf processing.

Enhancements:
- Replace legacy direct LDAP operations and constants with lib389 plugin, config, account, and group helper classes throughout the memberOf performance tests.
- Introduce environment-driven scaling (MOF_PERF_SCALE) and tuned parameter sets so the same tests can run as full benchmarks or reduced-cost smoke runs.
- Improve memberOf synchronization polling by using a monitored memberOf value count and optional deferred memberOf monitor instead of fixed-interval full-tree scans.
- Adjust LDBM and global server configuration (cache, locks, maxbersize, ndn cache) specifically for bulk import and benchmark scenarios and ensure proper setup/teardown of plugins and topology timeouts.

Tests:
- Extend the perf suite with a test that benchmarks repeated MOD_REPLACE of large group member lists and reports latency distribution (median/p95/p99) with an optional ceiling gate.
- Add a dense-member ldif2db import benchmark that generates large group/member LDIFs, optionally denormalizes DN syntax, times repeated imports, verifies member counts, and reports latency distribution.
- Harmonize and parameterize existing nested group import/add/modify/delete memberOf perf tests, including clearer expected-results documentation and stricter exit-code and count assertions.