### PR TITLE
issue 6867 - check file access in dsctl ldif2db

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsctl_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsctl_tasks_test.py
@@ -15,6 +15,7 @@ import pytest
 from lib389._constants import DEFAULT_BENAME, DEFAULT_SUFFIX, DN_DM
 from lib389.topologies import topology_st as topo
 from lib389.dbgen import dbgen_users
+from tempfile import TemporaryDirectory
 
 DSCONF = '/usr/sbin/dsconf'
 DSCTL = '/usr/sbin/dsctl'
@@ -164,6 +165,74 @@ def test_dsctl_task_watch_output(topo):
         inst.start()
 
 
+def generate_ldif_file(inst, ldif, perm):
+    dbgen_users(
+        inst,
+        WATCH_TEST_NUM_USERS/100,
+        ldif,
+        DEFAULT_SUFFIX,
+        parent='ou=people,' + DEFAULT_SUFFIX,
+        generic=True,
+    )
+    os.chown(ldif, 0, 0)
+    os.chmod(ldif, perm)
+
+
+def check_import(inst, ldif, expected_error):
+    inst.log.info(f'Try importing {ldif} Expecting {expected_error}')
+    rc, out = _run_dsctl(inst, ['ldif2db', DEFAULT_BENAME, ldif])
+    inst.log.info(f'Get: {out}')
+    assert expected_error in out
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="Test not run by root")
+def test_dsctl_ldif2db_file_access(topo):
+    """Check that import file is readable
+
+    :id: 642c331e-4252-11f1-9fad-c85309d5c3e3
+    :setup: Standalone Instance (stopped for offline db utilities)
+    :steps:
+        1. Stop the server
+        2. Run ``ldif2db`` on a file with 0644 permission
+        3. Run ``ldif2db`` on a file with 0600 permission
+        4. Run ``ldif2db`` on a directory with 0711 permission
+        5. Run ``ldif2db`` on a directory with 0700 permission
+        6. Run ``ldif2db`` on a file within directory with 0700 permission
+        7. Start the server
+    :expectedresults:
+        1. Success
+        2. Success
+        3. dsctl should fail with 'User dirsrv cannot read file' error
+        4. dsctl should fail with "Can't find file" error
+        5. dsctl should fail with "Can't find file" error
+        6. dsctl should fail with 'User dirsrv cannot read file' error
+        7. Success
+    """
+    inst = topo.standalone
+
+    inst.stop()
+
+    try:
+        with TemporaryDirectory() as dir:
+            os.chmod(dir, 0o711)
+            d1 = f'{dir}/d1'
+            os.mkdir(d1)
+            os.chmod(d1, 0o700)
+            ldif1 = f'{dir}/db1.ldif'
+            ldif2 = f'{dir}/db2.ldif'
+            ldif3 = f'{d1}/db3.ldif'
+            generate_ldif_file(inst, ldif1, 0o644)
+            generate_ldif_file(inst, ldif2, 0o600)
+            generate_ldif_file(inst, ldif3, 0o644)
+            check_import(inst, ldif1, 'ldif2db successful')
+            check_import(inst, ldif2, 'ldif2db: User dirsrv cannot read')
+            check_import(inst, dir, "ldif2db: Can't find file")
+            check_import(inst, d1, "ldif2db: Can't find file")
+            check_import(inst, ldif3, 'ldif2db: User dirsrv cannot read')
+    finally:
+        inst.start()
+
+        
 if __name__ == '__main__':
     CURRENT_FILE = os.path.realpath(__file__)
     pytest.main(['-s', CURRENT_FILE])

--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -41,6 +41,7 @@ import uuid
 import json
 from shutil import copy2
 from contextlib import suppress
+from multiprocessing import Process
 
 # Deprecation
 import warnings
@@ -2745,6 +2746,40 @@ class DirSrv(SimpleLDAPObject, object):
     # The following are the functions to perform offline scripts(when the
     # server is stopped)
     #
+    def check_ldif_file_is_readable(self, import_file):
+        # Become dirsrv and check that wimport_file is still readable
+        def chown_and_test(pw, import_file):
+            if os.getuid() == 0:
+                os.setgroups([])
+                os.setgid(pw.pw_gid)
+                os.setuid(pw.pw_uid)
+            if not os.access(import_file, os.R_OK):
+                sys.exit(1)
+            sys.exit(0)
+
+        dse_ldif = DSEldif(self)
+        user = dse_ldif.get("cn=config", "nsslapd-localuser", single=True)
+        if user is None:
+            self.log.error(f'ldif2db: Unable to find nsslapd-localuser attribute in {dse_ldif.path}')
+            return False
+        try:
+            pw = pwd.getpwnam(user)
+        except KeyError:
+            self.log.error(f"ldif2db: Failed to find {user} in /etc/passwd file.")
+            return False
+        # Fork a child process, switch it to the user and check that file
+        # is still readable
+        p = Process(target=chown_and_test, args=(pw, import_file,))
+        p.start()
+        p.join()
+        if p.exitcode == 0:
+            return True
+        if p.exitcode == 1:
+            self.log.error(f'ldif2db: User {user} cannot read {import_file} file.')
+            return False
+        self.log.error(f'ldif2db: Unexpected error {p.exitcode} while checking {import_file}.')
+        return False
+
     def ldif2db(self, bename, suffixes, excludeSuffixes, encrypt,
                 import_file, import_cl=False, watch=False):
         """
@@ -2768,6 +2803,9 @@ class DirSrv(SimpleLDAPObject, object):
 
         if not os.path.isfile(import_file):
             self.log.error("ldif2db: Can't find file: %s", import_file)
+            return False
+
+        if not self.check_ldif_file_is_readable(import_file):
             return False
 
         cmd = [


### PR DESCRIPTION
check file access in dsctl ldif2db so that the command fails before clearing the backend.
in order to check that a sub process is spawed so that we can safely change its uid and gid to the instance localuser one

issue: #6867 

Reviewed by: @mreynolds389  (Thanks!)

## Summary by Sourcery

Add pre-import readability checks for ldif2db and cover them with new access control tests.

New Features:
- Validate ldif2db import files are readable by the instance local user before running the offline import command.

Bug Fixes:
- Prevent ldif2db from proceeding when the instance local user cannot read the specified LDIF file, failing early with clear error messages.

Tests:
- Add dsctl ldif2db integration test scenarios to verify behavior for various file and directory permission combinations during import.