### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/VERSION.sh
+++ b/VERSION.sh
@@ -10,7 +10,7 @@ vendor="389 Project"
 # PACKAGE_VERSION is constructed from these
 VERSION_MAJOR=3
 VERSION_MINOR=2
-VERSION_MAINT=0
+VERSION_MAINT=1
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=
 VERSION_DATE=$(date -u +%Y%m%d%H%M)

--- a/src/lib389/pyproject.toml
+++ b/src/lib389/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lib389"
-version = "3.2.0"  # Should match the main 389-ds-base version
+version = "3.2.1"  # Should match the main 389-ds-base version
 description = "A library for accessing, testing, and configuring the 389 Directory Server"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}


### PR DESCRIPTION
Bump main to 3.2.1

## Summary by Sourcery

Bump project version to 3.2.1 across core scripts and Python packaging metadata.

Build:
- Update VERSION.sh to set the maintenance version to 3.2.1.

Chores:
- Align lib389 pyproject version with the main project at 3.2.1.