### PR TITLE
Issue 7464 - CLI - allow dsidm to work with other user types

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_account_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_test.py
@@ -39,6 +39,7 @@ def create_test_user(topology_st, request):
         test_user.delete()
 
     properties = FakeArgs()
+    properties.user_type = 'posix'
     properties.uid = test_user_name
     properties.cn = test_user_name
     properties.sn = test_user_name
@@ -100,6 +101,7 @@ def test_dsidm_account_entry_status_with_lock(topology_st, create_test_user):
 
     args = FakeArgs()
     args.dn = test_user.dn
+    args.user_type = 'posix'
     args.json = False
     args.basedn = DEFAULT_SUFFIX
     args.scope = ldap.SCOPE_SUBTREE
@@ -160,6 +162,7 @@ def test_dsidm_account_entry_get_by_dn(topology_st, create_test_user):
 
     args = FakeArgs()
     args.dn = user_dn
+    args.user_type = 'posix'
     args.json = False
     args.basedn = DEFAULT_SUFFIX
     args.scope = ldap.SCOPE_SUBTREE
@@ -204,6 +207,7 @@ def test_dsidm_account_delete(topology_st, create_test_user):
 
     args = FakeArgs()
     args.dn = test_account.dn
+    args.user_type = 'posix'
 
     log.info('Test dsidm account delete')
     delete(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args, warn=False)
@@ -308,6 +312,7 @@ def test_dsidm_account_get_by_dn(topology_st, create_test_user):
 
     args = FakeArgs()
     args.dn = test_account.dn
+    args.user_type = 'posix'
     args.json = False
 
     account_content = ['dn: {}'.format(test_account.dn),
@@ -390,6 +395,7 @@ def test_dsidm_account_modify_by_dn(topology_st, create_test_user):
     args = FakeArgs()
     args.dn = test_account.dn
     args.changes = ['add:description:new_description']
+    args.user_type = 'posix'
 
     log.info('Test dsidm account modify add')
     modify(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args, warn=False)
@@ -435,6 +441,7 @@ def test_dsidm_account_rename_by_dn(topology_st, create_test_user):
     args.new_name = 'renamed_account'
     args.new_dn = 'uid=renamed_account,ou=people,{}'.format(DEFAULT_SUFFIX)
     args.keep_old_rdn = False
+    args.user_type = 'posix'
 
     log.info('Test dsidm account rename-by-dn')
     rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -480,6 +487,7 @@ def test_dsidm_account_rename_by_dn_keep_old_rdn(topology_st, create_test_user):
     args.new_name = 'renamed_account'
     args.new_dn = 'uid=renamed_account,ou=people,{}'.format(DEFAULT_SUFFIX)
     args.keep_old_rdn = True
+    args.user_type = 'posix'
 
     log.info('Test dsidm account rename-by-dn')
     rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -522,6 +530,7 @@ def test_dsidm_account_reset_password(topology_st, create_test_user):
     args.dn = test_account.dn
     args.new_password = 'newpasswd'
     output = 'reset password for {}'.format(test_account.dn)
+    args.user_type = 'posix'
 
     log.info('Test dsidm account reset_password')
     reset_password(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -553,6 +562,7 @@ def test_dsidm_account_change_password(topology_st, create_test_user):
     args.dn = test_account.dn
     args.new_password = 'newpasswd'
     output = 'changed password for {}'.format(test_account.dn)
+    args.user_type = 'posix'
 
     log.info('Test dsidm account change_password')
     change_password(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)

--- a/dirsrvtests/tests/suites/clu/dsidm_user_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -7,7 +7,6 @@
 # --- END COPYRIGHT BLOCK ---
 #
 import time
-import subprocess
 import pytest
 import logging
 import os
@@ -15,11 +14,12 @@ import ldap
 import json
 
 from lib389 import DEFAULT_SUFFIX
+from lib389._constants import DN_DM, PASSWORD
 from lib389.cli_idm.user import list, get, get_dn, create, delete, modify, rename
 from test389.topologies import topology_st
 from lib389.cli_base import FakeArgs
 from lib389.utils import ds_is_older, ensure_str, is_a_dn
-from lib389.idm.user import nsUserAccounts
+from lib389.idm.user import nsUserAccounts, nsUserAccount
 from . import check_value_in_log_and_reset
 
 pytestmark = pytest.mark.tier0
@@ -27,6 +27,42 @@ pytestmark = pytest.mark.tier0
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
+
+def create_user(topo, user_type):
+    """Create one entry under ou=people using nsUserAccounts + update_objectclasses."""
+    args = FakeArgs()
+    args.user_type = user_type
+    args.json = False
+
+    if user_type == 'posix':
+        args.uid = 'posix_user'
+        args.cn = 'posix_user'
+        args.displayName = 'posix_user'
+        args.uidNumber = '6100'
+        args.gidNumber = '7100'
+        args.homeDirectory = '/home/posix_user'
+        rdn = 'posix_user'
+    elif user_type == 'traditional':
+        #args.uid = 'traditional_user'
+        args.cn = 'traditional_user'
+        args.sn = 'Traditional'
+        args.selector = "cn"
+        rdn = 'traditional_user'
+    elif user_type == 'basic':
+        args.uid = 'basic_user'
+        args.cn = 'basic_user'
+        args.displayName = 'basic_user'
+        rdn = 'basic_user'
+    elif user_type == 'service':
+        args.cn = 'service_user'
+        args.description = 'service_user'
+        args.selector = "cn"
+        rdn = 'service_user'
+    else:
+        raise ValueError('Invalid user type: %s' % user_type)
+
+    create(topo.standalone, DEFAULT_SUFFIX, topo.logcap.log, args)
+    return rdn
 
 @pytest.fixture(scope="function")
 def create_test_user(topology_st, request):
@@ -76,6 +112,7 @@ def test_dsidm_user_list(topology_st, create_test_user):
     args = FakeArgs()
     args.json = False
     args.full_dn = False
+    args.user_type = 'posix'
     user_value = 'test_user_1000'
     json_list = ['type',
                  'list',
@@ -182,6 +219,7 @@ def test_dsidm_user_get_rdn(topology_st, create_test_user):
 
     args = FakeArgs()
     args.json = False
+    args.user_type = 'posix'
     args.selector = 'test_user_1000'
 
     log.info('Empty the log file to prevent false data to check about user')
@@ -223,6 +261,7 @@ def test_dsidm_user_get_dn(topology_st, create_test_user):
     args = FakeArgs()
     args.json = False
     args.dn = test_user.dn
+    args.user_type = 'posix'
 
     log.info('Empty the log file to prevent false data to check about user')
     topology_st.logcap.flush()
@@ -258,12 +297,14 @@ def test_dsidm_user_create(topology_st):
     output = 'Successfully created {}'.format(user_name)
 
     args = FakeArgs()
+    args.json = False
     args.uid = user_name
     args.cn = user_name
     args.displayName = user_name
     args.uidNumber = '1030'
     args.gidNumber = '2030'
     args.homeDirectory = '/home/{}'.format(user_name)
+    args.user_type = 'posix'
 
     log.info('Test dsidm user create')
     create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -301,6 +342,7 @@ def test_dsidm_user_delete(topology_st, create_test_user):
 
     args = FakeArgs()
     args.dn = test_user.dn
+    args.user_type = 'posix'
 
     log.info('Test dsidm user delete')
     delete(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args, warn=False)
@@ -334,6 +376,7 @@ def test_dsidm_user_modify(topology_st, create_test_user):
     args = FakeArgs()
     args.selector = 'test_user_1000'
     args.changes = ['replace:cn:test']
+    args.user_type = 'posix'
 
     log.info('Test dsidm user modify replace')
     modify(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args, warn=False)
@@ -376,6 +419,7 @@ def test_dsidm_user_rename_keep_old_rdn(topology_st, create_test_user):
     args.selector = test_user.rdn
     args.new_name = 'my_user'
     args.keep_old_rdn = True
+    args.user_type = 'posix'
 
     log.info('Test dsidm user rename')
     rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
@@ -419,6 +463,7 @@ def test_dsidm_user_rename(topology_st, create_test_user):
     args.selector = test_user.rdn
     args.new_name = 'my_user'
     args.keep_old_rdn = False
+    args.user_type = 'posix'
 
     log.info('Test dsidm user rename')
     args.new_name = 'my_user'
@@ -472,6 +517,7 @@ def test_dsidm_user_rename_nonexistent(topology_st):
         args.uidNumber = '1050'
         args.gidNumber = '2050'
         args.homeDirectory = f'/home/{original_name}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
 
@@ -480,6 +526,7 @@ def test_dsidm_user_rename_nonexistent(topology_st):
         args.selector = original_name
         args.new_name = new_name
         args.keep_old_rdn = False
+        args.user_type = 'posix'
         rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
 
@@ -542,6 +589,7 @@ def test_dsidm_user_rename_same_cn_displayname(topology_st):
         args.uidNumber = '1101'
         args.gidNumber = '2101'
         args.homeDirectory = f'/home/{user1_uid}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user1_uid}')
 
@@ -553,6 +601,7 @@ def test_dsidm_user_rename_same_cn_displayname(topology_st):
         args.uidNumber = '1102'
         args.gidNumber = '2102'
         args.homeDirectory = f'/home/{user2_uid}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user2_uid}')
 
@@ -561,6 +610,7 @@ def test_dsidm_user_rename_same_cn_displayname(topology_st):
         args.selector = user1_uid
         args.new_name = new_name
         args.keep_old_rdn = False
+        args.user_type = 'posix'
         rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
 
@@ -619,6 +669,7 @@ def test_dsidm_user_rename_to_existing_name(topology_st):
         args.uidNumber = '1201'
         args.gidNumber = '2201'
         args.homeDirectory = f'/home/{user1_uid}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user1_uid}')
 
@@ -630,6 +681,7 @@ def test_dsidm_user_rename_to_existing_name(topology_st):
         args.uidNumber = '1202'
         args.gidNumber = '2202'
         args.homeDirectory = f'/home/{user2_uid}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {user2_uid}')
 
@@ -638,7 +690,7 @@ def test_dsidm_user_rename_to_existing_name(topology_st):
         args.selector = user1_uid
         args.new_name = user2_uid
         args.keep_old_rdn = False
-
+        args.user_type = 'posix'
         try:
             rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
             assert False, "The rename operation should have failed"
@@ -694,6 +746,7 @@ def test_dsidm_user_rename_keep_old_rdn_and_search(topology_st):
         args.uidNumber = '1501'
         args.gidNumber = '2501'
         args.homeDirectory = f'/home/{original_name}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
 
@@ -702,6 +755,7 @@ def test_dsidm_user_rename_keep_old_rdn_and_search(topology_st):
         args.selector = original_name
         args.new_name = new_name
         args.keep_old_rdn = True
+        args.user_type = 'posix'
         rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
 
@@ -774,6 +828,7 @@ def test_dsidm_user_list_rdn_after_rename(topology_st):
         args.uidNumber = '1601'
         args.gidNumber = '2601'
         args.homeDirectory = f'/home/{original_name}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
 
@@ -782,6 +837,7 @@ def test_dsidm_user_list_rdn_after_rename(topology_st):
         args.selector = original_name
         args.new_name = new_name
         args.keep_old_rdn = True
+        args.user_type = 'posix'
         rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully renamed to')
 
@@ -789,18 +845,21 @@ def test_dsidm_user_list_rdn_after_rename(topology_st):
         args = FakeArgs()
         args.json = False
         args.full_dn = False
+        args.user_type = 'posix'
         list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         # Should show the new name, not the original name
         check_value_in_log_and_reset(topology_st, check_value=new_name, check_value_not=original_name)
 
         log.info('Test dsidm user list with json')
         args.json = True
+        args.user_type = 'posix'
         list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         # Should show the new name in JSON output as well
         check_value_in_log_and_reset(topology_st, check_value=new_name, check_value_not=original_name)
 
         log.info('Test full_dn option with list')
         args.full_dn = True
+        args.user_type = 'posix'
         list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         result = topology_st.logcap.get_raw_outputs()
         json_result = json.loads(result[0])
@@ -866,6 +925,7 @@ def test_dsidm_user_rename_no_changes(topology_st):
         args.uidNumber = '1800'
         args.gidNumber = '2800'
         args.homeDirectory = f'/home/{original_name}'
+        args.user_type = 'posix'
         create(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value=f'Successfully created {original_name}')
 
@@ -874,6 +934,7 @@ def test_dsidm_user_rename_no_changes(topology_st):
         args.selector = original_name
         args.new_name = new_name
         args.keep_old_rdn = True
+        args.user_type = 'posix'
         rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
         check_value_in_log_and_reset(topology_st, check_value='Successfully renamed')
 
@@ -910,6 +971,113 @@ def test_dsidm_user_rename_no_changes(topology_st):
                 test_user.delete()
         except:
             pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_create_user_list_get_modify_rename_delete_by_user_type(topology_st):
+    """create_user() for each type; dsidm list --user-type; get/modify/rename/delete.
+
+    :id: c4e90d11-6f2a-4d8e-bc01-9a8f7e3d5012
+    :setup: Standalone instance
+    """
+
+    standalone = topology_st.standalone
+
+    basic_user = create_user(topology_st, 'basic')
+    posix_user = create_user(topology_st, 'posix')
+    traditional_user = create_user(topology_st, 'traditional')
+    service_user = create_user(topology_st, 'service')
+
+    args = FakeArgs()
+    args.json = True
+    args.full_dn = False
+
+    args.user_type = 'basic'
+    topology_st.logcap.flush()
+    list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    basic_items = set(json.loads(topology_st.logcap.get_raw_outputs()[0])['items'])
+    assert basic_items >= {'basic_user', 'posix_user'}
+    assert traditional_user not in basic_items
+    assert service_user not in basic_items
+
+    args.user_type = 'posix'
+    topology_st.logcap.flush()
+    list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    posix_items = set(json.loads(topology_st.logcap.get_raw_outputs()[0])['items'])
+    assert posix_items == {'demo_user', 'posix_user'}
+
+    args.user_type = 'traditional'
+    topology_st.logcap.flush()
+    list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    trad_items = set(json.loads(topology_st.logcap.get_raw_outputs()[0])['items'])
+    assert trad_items == {'traditional_user'}
+
+    args.user_type = 'service'
+    topology_st.logcap.flush()
+    list(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    svc_items = set(json.loads(topology_st.logcap.get_raw_outputs()[0])['items'])
+    assert svc_items == {'service_user'}
+
+    selectors = {
+        'posix': 'posix_user',
+        'basic': 'basic_user',
+        'traditional': 'traditional_user',
+        'service': 'service_user',
+    }
+
+    try:
+        for ut in ('posix', 'basic', 'traditional', 'service'):
+            sel = selectors[ut]
+            renamed = '%s_rn' % sel
+
+            args = FakeArgs()
+            args.json = False
+            args.selector = sel
+            args.user_type = ut
+            topology_st.logcap.flush()
+            get(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert topology_st.logcap.contains(sel)
+
+            args = FakeArgs()
+            args.selector = sel
+            args.user_type = ut
+            args.changes = ['add:description:roundtrip_%s' % ut]
+            topology_st.logcap.flush()
+            modify(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args,
+                    warn=False)
+            assert topology_st.logcap.contains('Successfully modified')
+
+            args = FakeArgs()
+            args.selector = sel
+            args.new_name = renamed
+            args.keep_old_rdn = False
+            args.user_type = ut
+            topology_st.logcap.flush()
+            rename(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert topology_st.logcap.contains('Successfully renamed')
+
+            args = FakeArgs()
+            args.json = False
+            args.selector = renamed
+            args.user_type = ut
+            topology_st.logcap.flush()
+            get(standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+            assert topology_st.logcap.contains(renamed)
+
+    finally:
+        standalone.simple_bind_s(DN_DM, PASSWORD)
+        for ut in ('posix', 'basic', 'traditional', 'service'):
+            sel = selectors[ut]
+            renamed = '%s_rn' % sel
+            for rdn_val in (renamed, sel):
+                args = FakeArgs()
+                args.user_type = ut
+                try:
+                    delete(standalone, DEFAULT_SUFFIX, topology_st.logcap.log,
+                           args, warn=False)
+                except Exception:
+                    pass
+
 
 if __name__ == '__main__':
     # Run isolated

--- a/src/lib389/cli/dsidm
+++ b/src/lib389/cli/dsidm
@@ -35,6 +35,17 @@ from lib389.cli_base.dsrc import dsrc_to_ldap, dsrc_arg_concat
 from lib389.cli_base import format_error_to_dict, format_pretty_error
 from lib389.cli_base import parent_argparser
 
+# Pre-pass to resolve --user-type before the main parser is built. This lets
+# `dsidm inst user create` surface only the MUST-attribute flags relevant to
+# the selected user type. The side parser knows ONLY --user-type, has no
+# positionals, and uses parse_known_args so everything else passes through
+# untouched to the real parser below.
+_pre_user_type = argparse.ArgumentParser(add_help=False)
+_pre_user_type.add_argument('--user-type', dest='user_type',
+                            choices=sorted(cli_user.USER_TYPE_CHOICES),
+                            default=cli_user.DEFAULT_USER_TYPE)
+_pre_args, _ = _pre_user_type.parse_known_args(sys.argv[1:])
+
 parser = argparse.ArgumentParser(allow_abbrev=True, parents=[parent_argparser])
 # First, add the LDAP options
 parser.add_argument('instance',
@@ -71,7 +82,7 @@ cli_group.create_parser(subparsers)
 cli_init.create_parser(subparsers)
 cli_ou.create_parser(subparsers)
 cli_posixgroup.create_parser(subparsers)
-cli_user.create_parser(subparsers)
+cli_user.create_parser(subparsers, user_type=_pre_args.user_type)
 cli_client_config.create_parser(subparsers)
 cli_role.create_parser(subparsers)
 cli_service.create_parser(subparsers)

--- a/src/lib389/lib389/cli_idm/user.py
+++ b/src/lib389/lib389/cli_idm/user.py
@@ -1,13 +1,21 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2016, William Brown <william at blackhats.net.au>
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
-from lib389.idm.user import nsUserAccount, nsUserAccounts
+from lib389.idm.user import (
+    nsUserAccount,
+    nsUserAccounts,
+    BasicUserAccount,
+    BasicUserAccounts,
+    TraditionalUserAccount,
+    TraditionalUserAccounts,
+)
+from lib389.idm.services import ServiceAccount, ServiceAccounts
 from lib389.cli_base import populate_attr_arguments, _generic_modify, CustomHelpFormatter
 from lib389.cli_idm import (
     _generic_list,
@@ -21,55 +29,83 @@ from lib389.cli_idm import (
     _warn,
     )
 
-SINGULAR = nsUserAccount
-MANY = nsUserAccounts
+DEFAULT_USER_TYPE = "posix"
+USER_TYPE_CHOICES = ['basic', 'posix', 'service', 'traditional']
+SINGULAR_DICT = {
+    None: nsUserAccount,
+    'posix': nsUserAccount,
+    'basic': BasicUserAccount,
+    'service': ServiceAccount,
+    'traditional': TraditionalUserAccount,
+}
+MANY_DICT = {
+    None: nsUserAccounts,
+    'posix': nsUserAccounts,
+    'basic': BasicUserAccounts,
+    'service': ServiceAccounts,
+    'traditional': TraditionalUserAccounts,
+}
+
 RDN = 'uid'
 
 
 # These are a generic specification, try not to tamper with them
 
 def list(inst, basedn, log, args):
-    _generic_list(inst, basedn, log.getChild('_generic_list'), MANY, args)
+    _generic_list(inst, basedn, log.getChild('_generic_list'), MANY_DICT[args.user_type], args)
 
 
 def get(inst, basedn, log, args):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
-    _generic_get(inst, basedn, log.getChild('_generic_get'), MANY, rdn, args)
+    _generic_get(inst, basedn, log.getChild('_generic_get'), MANY_DICT[args.user_type], rdn, args)
 
 
 def get_dn(inst, basedn, log, args):
     dn = _get_arg( args.dn, msg="Enter dn to retrieve")
-    _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY, dn, args)
+    _generic_get_dn(inst, basedn, log.getChild('_generic_get_dn'), MANY_DICT[args.user_type], dn, args)
 
 
 def create(inst, basedn, log, args):
-    kwargs = _get_attributes(args, SINGULAR._must_attributes)
-    _generic_create(inst, basedn, log.getChild('_generic_create'), MANY, kwargs, args)
+    user_type = getattr(args, 'user_type', None) or DEFAULT_USER_TYPE
+    kwargs = _get_attributes(args, SINGULAR_DICT[user_type]._must_attributes)
+    _generic_create(inst, basedn, log.getChild('_generic_create'), MANY_DICT[args.user_type], kwargs, args)
 
 
 def delete(inst, basedn, log, args, warn=True):
     dn = _get_arg( args.dn, msg="Enter dn to delete")
     if warn:
-        _warn(dn, msg="Deleting %s %s" % (SINGULAR.__name__, dn))
-    _generic_delete(inst, basedn, log.getChild('_generic_delete'), SINGULAR, dn, args)
+        _warn(dn, msg="Deleting %s %s" % (SINGULAR_DICT[args.user_type].__name__, dn))
+    _generic_delete(inst, basedn, log.getChild('_generic_delete'), SINGULAR_DICT[args.user_type], dn, args)
 
 
 def modify(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
-    _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY, rdn, args)
+    _generic_modify(inst, basedn, log.getChild('_generic_modify'), MANY_DICT[args.user_type], rdn, args)
 
 
 def rename(inst, basedn, log, args, warn=True):
     rdn = _get_arg( args.selector, msg="Enter %s to retrieve" % RDN)
-    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY, rdn, args)
+    _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY_DICT[args.user_type], rdn, args)
 
 
-def create_parser(subparsers):
+def create_parser(subparsers, user_type=DEFAULT_USER_TYPE):
     user_parser = subparsers.add_parser('user',
                                         help='Manage posix users.  The organizationalUnit (by default "ou=people") needs '
                                              'to exist prior to managing users.')
-
     subcommands = user_parser.add_subparsers(help='action')
+    user_parser.add_argument('--user-type',
+                             choices=USER_TYPE_CHOICES,
+                             default=DEFAULT_USER_TYPE,
+                             help=f'''The type of user to manage.
+                                  "basic" is an entry based off of objectclasses:
+                                      nsPerson, nsAccount, and nsOrgPerson.
+                                  "posix" is based off of objectclasses:
+                                      nsPerson, nsAccount, nsOrgPerson, and posixAccount.
+                                  "service" is based off of objectclasses:
+                                      nsAccount and applicationProcess.
+                                  "traditional", aka legacy, is based off of objectclasses:
+                                      person, organizationalPerson, and inetOrgPerson.
+                                  The default user type is "{DEFAULT_USER_TYPE}"''')
 
     list_parser = subcommands.add_parser('list', help='list', formatter_class=CustomHelpFormatter)
     list_parser.set_defaults(func=list)
@@ -86,7 +122,7 @@ def create_parser(subparsers):
 
     create_user_parser = subcommands.add_parser('create', help='create', formatter_class=CustomHelpFormatter)
     create_user_parser.set_defaults(func=create)
-    populate_attr_arguments(create_user_parser, SINGULAR._must_attributes)
+    populate_attr_arguments(create_user_parser, SINGULAR_DICT[user_type]._must_attributes)
 
     modify_parser = subcommands.add_parser('modify', help='modify <add|delete|replace>:<attribute>:<value> ...', formatter_class=CustomHelpFormatter)
     modify_parser.set_defaults(func=modify)

--- a/src/lib389/lib389/idm/user.py
+++ b/src/lib389/lib389/idm/user.py
@@ -1,6 +1,6 @@
 # --- BEGIN COPYRIGHT BLOCK ---
 # Copyright (C) 2016, William Brown <william at blackhats.net.au>
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -91,7 +91,7 @@ class nsUserAccounts(DSLdapObjects):
     :type instance: lib389.DirSrv
     :param basedn: Suffix DN
     :type basedn: str
-    :param rdn: The DN that will be combined wit basedn
+    :param rdn: The DN that will be combined with basedn
     :type rdn: str
     """
 
@@ -113,7 +113,7 @@ class nsUserAccounts(DSLdapObjects):
         if rdn is None:
             self._basedn = basedn
         else:
-            self._basedn = '{},{}'.format(rdn, basedn)
+            self._basedn = f'{rdn},{basedn}'
 
     def create_test_user(self, uid=1000, gid=2000):
         """Create a test user with uid=test_user_UID rdn
@@ -126,15 +126,15 @@ class nsUserAccounts(DSLdapObjects):
         :returns: DSLdapObject of the created entry
         """
 
-        rdn_value = "test_user_{}".format(uid)
-        rdn = "uid={}".format(rdn_value)
+        rdn_value = f"test_user_{uid}"
+        rdn = f"uid={rdn_value}"
         properties = {
             'uid': rdn_value,
             'cn': rdn_value,
             'displayName': rdn_value,
             'uidNumber': str(uid),
             'gidNumber': str(gid),
-            'homeDirectory': '/home/{}'.format(rdn_value),
+            'homeDirectory': f'/home/{rdn_value}',
         }
         return super(nsUserAccounts, self).create(rdn, properties)
 
@@ -198,7 +198,7 @@ class UserAccounts(DSLdapObjects):
     :type instance: lib389.DirSrv
     :param basedn: Suffix DN
     :type basedn: str
-    :param rdn: The DN that will be combined wit basedn
+    :param rdn: The DN that will be combined with basedn
     :type rdn: str
     """
 
@@ -220,7 +220,7 @@ class UserAccounts(DSLdapObjects):
         if rdn is None:
             self._basedn = basedn
         else:
-            self._basedn = '{},{}'.format(rdn, basedn)
+            self._basedn = f'{rdn},{basedn}'
 
     def create_test_user(self, uid=1000, gid=2000):
         """Create a test user with uid=test_user_UID rdn
@@ -233,14 +233,189 @@ class UserAccounts(DSLdapObjects):
         :returns: DSLdapObject of the created entry
         """
 
-        rdn_value = "test_user_{}".format(uid)
-        rdn = "uid={}".format(rdn_value)
+        rdn_value = f"test_user_{uid}"
+        rdn = f"uid={rdn_value}"
         properties = {
             'uid': rdn_value,
             'cn': rdn_value,
             'sn': rdn_value,
             'uidNumber': str(uid),
             'gidNumber': str(gid),
-            'homeDirectory': '/home/{}'.format(rdn_value)
+            'homeDirectory': f'/home/{rdn_value}'
         }
         return super(UserAccounts, self).create(rdn, properties)
+
+
+# The following classes are used to manage user accounts created by the UI
+
+class TraditionalUserAccount(Account):
+    """A single instance of a TraditionalUser Account entry
+
+    This is the "Traditional" user account created by the UI
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param dn: Entry DN
+    :type dn: str
+    """
+
+    _must_attributes = ['cn', 'sn']
+
+    def __init__(self, instance, dn=None):
+        super(TraditionalUserAccount, self).__init__(instance, dn)
+        self._rdn_attribute = 'cn'
+        # Can I generate these from schema?
+        self._must_attributes = ['cn', 'sn']
+        self._create_objectclasses = [
+            'top',
+            'person',
+            'inetOrgPerson',
+            'organizationalPerson',
+        ]
+        user_compare_exclude = [
+            'nsUniqueId',
+            'modifyTimestamp',
+            'createTimestamp',
+            'entrydn'
+        ]
+        self._compare_exclude = self._compare_exclude + user_compare_exclude
+        self._protected = False
+
+    def _validate(self, rdn, properties, basedn):
+        if 'ntUserDomainId' in properties and 'ntUser' not in self._create_objectclasses:
+            self._create_objectclasses.append('ntUser')
+
+        return super(TraditionalUserAccount, self)._validate(rdn, properties, basedn)
+
+
+class TraditionalUserAccounts(DSLdapObjects):
+    """DSLdapObjects that represents all TraditionalUser Account entries in
+    suffix. By default it uses 'ou=People' as rdn.
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param basedn: Suffix DN
+    :type basedn: str
+    :param rdn: The DN that will be combined with basedn
+    :type rdn: str
+    """
+
+    def __init__(self, instance, basedn, rdn=DEFAULT_BASEDN_RDN):
+        super(TraditionalUserAccounts, self).__init__(instance)
+        self._objectclasses = [
+            'person',
+            'inetOrgPerson',
+            'organizationalPerson',
+        ]
+        self._filterattrs = [RDN, 'cn']
+        self._childobject = TraditionalUserAccount
+
+        dsrc_inst = dsrc_to_ldap(DSRC_HOME, instance.serverid, self._log)
+        if dsrc_inst is not None and 'people_rdn' in dsrc_inst and dsrc_inst['people_rdn'] is not None:
+            rdn = dsrc_inst['people_rdn']
+
+        if rdn is None:
+            self._basedn = basedn
+        else:
+            self._basedn = f'{rdn},{basedn}'
+
+    def create_test_user(self):
+        """Create a test user with uid=test_user rdn
+
+        :returns: DSLdapObject of the created entry
+        """
+
+        rdn_value = "test_user"
+        rdn = f"cn={rdn_value}"
+        properties = {
+            'uid': rdn_value,
+            'cn': rdn_value,
+            'sn': rdn_value,
+        }
+        return super(TraditionalUserAccounts, self).create(rdn, properties)
+
+class BasicUserAccount(Account):
+    """A single instance of a Basic User Account entry
+
+    This is the "Basic" user account created by the UI
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param dn: Entry DN
+    :type dn: str
+    """
+
+    _must_attributes = ['uid', 'cn', 'displayName']
+
+    def __init__(self, instance, dn=None):
+        super(BasicUserAccount, self).__init__(instance, dn)
+        self._rdn_attribute = RDN
+        # Can I generate these from schema?
+        self._must_attributes = ['uid', 'cn', 'displayName']
+        self._create_objectclasses = [
+            'top',
+            'nsPerson',
+            'nsAccount',
+            'nsOrgPerson'
+        ]
+        user_compare_exclude = [
+            'nsUniqueId',
+            'modifyTimestamp',
+            'createTimestamp',
+            'entrydn'
+        ]
+        self._compare_exclude = self._compare_exclude + user_compare_exclude
+        self._protected = False
+
+    def _validate(self, rdn, properties, basedn):
+        if 'ntUserDomainId' in properties and 'ntUser' not in self._create_objectclasses:
+            self._create_objectclasses.append('ntUser')
+
+        return super(BasicUserAccount, self)._validate(rdn, properties, basedn)
+
+
+class BasicUserAccounts(DSLdapObjects):
+    """DSLdapObjects that represents all BasicUser Account entries in
+    suffix. By default it uses 'ou=People' as rdn.
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    :param basedn: Suffix DN
+    :type basedn: str
+    :param rdn: The DN that will be combined with basedn
+    :type rdn: str
+    """
+
+    def __init__(self, instance, basedn, rdn=DEFAULT_BASEDN_RDN):
+        super(BasicUserAccounts, self).__init__(instance)
+        self._objectclasses = [
+            'nsPerson',
+            'nsAccount',
+            'nsOrgPerson'
+        ]
+        self._filterattrs = [RDN]
+        self._childobject = BasicUserAccount
+
+        dsrc_inst = dsrc_to_ldap(DSRC_HOME, instance.serverid, self._log)
+        if dsrc_inst is not None and 'people_rdn' in dsrc_inst and dsrc_inst['people_rdn'] is not None:
+            rdn = dsrc_inst['people_rdn']
+
+        if rdn is None:
+            self._basedn = basedn
+        else:
+            self._basedn = f'{rdn},{basedn}'
+
+    def create_test_user(self):
+        """Create a test user with uid=test_user rdn
+
+        :returns: DSLdapObject of the created entry
+        """
+
+        rdn_value = "test_user"
+        rdn = f"uid={rdn_value}"
+        properties = {
+            'uid': rdn_value,
+            'cn': rdn_value,
+            'sn': rdn_value,
+        }
+        return super(BasicUserAccounts, self).create(rdn, properties)


### PR DESCRIPTION
Description:

In the UI you can create these entry types:

- Posix (default for dsidm)
- Basic (similar to nsUserAccount but without posix requirements)
- Traditional (old style entries from DS 1.3)
- Service account

Add a user "--user-type" option to dsiadm users to specifiy these optional types. The default is stil "posix".

relates: https://github.com/389ds/389-ds-base/issues/7464

## Summary by Sourcery

Add support in the dsidm CLI for managing multiple user entry types beyond the default POSIX users.

New Features:
- Introduce CLI selection of user entry type via a --user-type option for list, get, get-dn, create, delete, modify, and rename operations.
- Add schema-specific account abstractions for Basic, Traditional, and Service user accounts alongside existing POSIX-style accounts.

Enhancements:
- Align user account management code with f-string formatting and fix minor documentation typos.

Tests:
- Extend and add CLI tests to cover user-type selection, including end-to-end create/list/get/modify/rename/delete flows for basic, posix, traditional, and service users.