### PR TITLE
Issue 7468 - RFE - Add HIBP HTTP client

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1188,6 +1188,13 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 
 libslapd_la_CPPFLAGS = $(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(SASL_CFLAGS) $(DB_INC) $(KERBEROS_CFLAGS) $(PCRE_CFLAGS) $(SVRCORE_INCLUDES)
 libslapd_la_LIBADD = $(LDAPSDK_LINK) $(SASL_LINK) $(NSS_LINK) $(NSPR_LINK) $(KERBEROS_LIBS) $(PCRE_LIBS) $(THREADLIB) $(SYSTEMD_LIBS) libsvrcore.la $(RSLAPD_LIB) $(OPENSSL_LIBS)
+
+if ENABLE_HIBP
+libslapd_la_SOURCES += ldap/servers/slapd/hibp_client.c
+libslapd_la_CPPFLAGS += $(CURL_CFLAGS)
+libslapd_la_LIBADD += $(CURL_LIBS)
+dist_noinst_HEADERS += ldap/servers/slapd/hibp.h
+endif
 # If asan is enabled, it creates special libcrypt interceptors. However, they are
 # detected by the first load of libasan at runtime, and what is in the linked lib
 # so we need libcrypt to be present as soon as libasan is loaded for the interceptors
@@ -2002,6 +2009,12 @@ test_slapd_LDFLAGS = $(AM_CPPFLAGS) $(CMOCKA_LINKS)
 # We need to pull in plugin header paths too:
 test_slapd_CPPFLAGS =	$(AM_CPPFLAGS) $(DSPLUGIN_CPPFLAGS) $(DSINTERNAL_CPPFLAGS) \
 						-I$(srcdir)/ldap/servers/plugins/pwdstorage
+
+if ENABLE_HIBP
+test_slapd_SOURCES += test/libslapd/hibp/parse.c
+test_slapd_LDADD += $(CURL_LIBS)
+test_slapd_CPPFLAGS += $(CURL_CFLAGS)
+endif
 
 endif
 #------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -882,6 +882,18 @@ AC_SUBST(nss_libdir)
 
 PKG_CHECK_MODULES([OPENSSL], [openssl])
 
+AC_MSG_CHECKING(whether to enable HIBP password breach checking)
+AC_ARG_ENABLE(hibp, AS_HELP_STRING([--enable-hibp], [Enable HIBP password breach checking (default: no)]),
+              [], [enable_hibp=no])
+if test "x$enable_hibp" = "xyes"; then
+    AC_MSG_RESULT(yes)
+    PKG_CHECK_MODULES([CURL], [libcurl >= 7.40.0])
+    AC_DEFINE([ENABLE_HIBP], [1], [Enable HIBP password breach checking])
+else
+    AC_MSG_RESULT(no)
+fi
+AM_CONDITIONAL([ENABLE_HIBP], [test "x$enable_hibp" = "xyes"])
+
 m4_include(m4/openldap.m4)
 if test $with_bundle_libdb = no; then
     m4_include(m4/db.m4)

--- a/configure.ac
+++ b/configure.ac
@@ -887,7 +887,7 @@ AC_ARG_ENABLE(hibp, AS_HELP_STRING([--enable-hibp], [Enable HIBP password breach
               [], [enable_hibp=no])
 if test "x$enable_hibp" = "xyes"; then
     AC_MSG_RESULT(yes)
-    PKG_CHECK_MODULES([CURL], [libcurl >= 7.40.0])
+    PKG_CHECK_MODULES([CURL], [libcurl >= 7.61])
     AC_DEFINE([ENABLE_HIBP], [1], [Enable HIBP password breach checking])
 else
     AC_MSG_RESULT(no)

--- a/ldap/servers/slapd/hibp.h
+++ b/ldap/servers/slapd/hibp.h
@@ -1,0 +1,49 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2026 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#pragma once
+
+#include "slap.h"
+
+/*
+ * Function pointer for pluggable SHA-1 implementation
+ * Allows for different hash implementations (FIPS vs non FIPS)
+ */
+typedef int (*hibp_hash_fn)(const char *input, size_t len, unsigned char *digest);
+
+/* Set the hash provider, called during initialisation */
+void hibp_set_hash_provider(hibp_hash_fn fn);
+
+/* Initialise the HIBP subsystem */
+int hibp_init(void);
+
+/*
+ * Check if password appears in breach database
+ * Returns: >0 = breach count, 0 = not found, -1 = error
+ */
+int hibp_check_password(const char *password, passwdPolicy *pwpolicy);
+
+/*
+ * Convert password to uppercase SHA-1 hex string (40 chars + null terminator)
+ * Returns: 0 on success, -1 on error
+ */
+int hibp_sha1_hex(const char *password, char *hex_output);
+
+/* Test wrapper, expose hibp_parse_response for testing
+ * Returns: breach count if found, 0 if not found, -1 on error
+ */
+int hibp_parse_response_wrapper(char *response_data, const char *suffix);
+
+/* Test wrapper, expose hibp_write_callback for testing
+ * Returns: buffer size on success, -1 on error
+ */
+int hibp_write_callback_wrapper(const char *data, size_t data_len, size_t chunk_size, char **out_data);
+
+/* Set mock API response for testing */
+void hibp_set_mock_response(const char *response);
+

--- a/ldap/servers/slapd/hibp_client.c
+++ b/ldap/servers/slapd/hibp_client.c
@@ -1,0 +1,551 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2026 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+/*
+ * hibp_client.c - DS HIBP client
+ */
+
+#include "hibp.h"
+#include "prinit.h"
+#include <curl/curl.h>
+#include <pk11pub.h>
+
+#define HIBP_API_URL "https://api.pwnedpasswords.com/range/"
+#define HIBP_API_TIMEOUT_SECS 10
+#define HIBP_CURL_INIT_OK 0
+#define HIBP_CURL_INIT_FAILED -1
+#define HIBP_SHA1_DIGEST_BYTES 20
+#define HIBP_SHA1_HEX_PREFIX_LEN 5
+#define HIBP_SHA1_HEX_SUFFIX_LEN (HIBP_SHA1_DIGEST_BYTES * 2 - HIBP_SHA1_HEX_PREFIX_LEN)
+#define HIBP_RESPONSE_INITIAL_SIZE (8 * 1024)       /* 8 KB */
+#define HIBP_RESPONSE_MAX_SIZE     (1024 * 1024)    /* 1 MB */
+
+/*
+ * Hash provider abstraction layer
+ *
+ * Allows for different SHA-1 implementations for FIPS and non-FIPS mode
+ *
+ * Future:  Standalone implementation for FIPS mode if NSS SHA-1 is restricted
+ */
+typedef int (*hibp_hash_fn)(const char *input, size_t len, unsigned char *digest);
+static hibp_hash_fn g_hash_provider = NULL;
+
+/*
+ * Default non FIPS mode hash provider using NSS
+ *
+ * Returns: 0 on success, -1 on error
+ */
+static int
+hibp_sha1_nss(const char *input, size_t len, unsigned char *digest)
+{
+    SECStatus rv = PK11_HashBuf(SEC_OID_SHA1, digest, (unsigned char *)input, len);
+    return (rv == SECSuccess) ? 0 : -1;
+}
+
+/* Set custom hash provider
+ *
+ * Must be called during initialisation
+ */
+void
+hibp_set_hash_provider(hibp_hash_fn fn)
+{
+    g_hash_provider = fn;
+}
+
+/*
+ * Get the current hash provider
+ *
+ * Returns: hash provider function pointer
+ */
+static hibp_hash_fn
+hibp_get_hash_provider(void)
+{
+    return g_hash_provider ? g_hash_provider : hibp_sha1_nss;
+}
+
+typedef struct hibp_response
+{
+    char *data;
+    size_t size;
+    size_t capacity;
+} HIBPResponse;
+
+/* One time curl initialisation */
+static PRCallOnceType g_curl_init_control = {0};
+static int g_curl_init_result = HIBP_CURL_INIT_FAILED;
+
+/* Mock API response for testing */
+static const char *g_mock_response = NULL;
+
+void
+hibp_set_mock_response(const char *response)
+{
+    g_mock_response = response;
+}
+
+/*
+ * libcurl callback to handle response data
+ *
+ * Can be called multiple times per request as data chunks arrive,
+ * appending to the response buffer.
+ *
+ * Returns: number of bytes handled, 0 on error
+ */
+static size_t
+hibp_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    HIBPResponse *response = (HIBPResponse *)userp;
+    size_t real_size;
+    size_t required;
+    size_t new_capacity;
+    char *new_data = NULL;
+
+    if (!response || !response->data) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                      "Invalid HIBP response buffer\n");
+        return 0;
+    }
+
+    if (nmemb > 0 && size > SIZE_MAX / nmemb) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                      "HIBP response size overflow\n");
+        return 0;
+    }
+
+    /* Calculate the size of the incoming response buffer */
+    real_size = size * nmemb;
+
+    if (real_size > SIZE_MAX - response->size - 1) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                      "HIBP response buffer size overflow\n");
+        return 0;
+    }
+
+    /* Calculate the total required size of the response buffer */
+    required = response->size + real_size + 1;
+
+    if (required > HIBP_RESPONSE_MAX_SIZE) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                      "HIBP response exceeded maximum size\n");
+        return 0;
+    }
+
+    /* Does the size of the response buffer need to be grown to hold the incoming data */
+    if (required > response->capacity) {
+        new_capacity = response->capacity;
+
+        if (new_capacity == 0) {
+            new_capacity = HIBP_RESPONSE_INITIAL_SIZE;
+        }
+
+        /* Double the buffer size until it can hold the incoming data */
+        while (new_capacity < required) {
+            if (new_capacity > HIBP_RESPONSE_MAX_SIZE / 2) {
+                new_capacity = HIBP_RESPONSE_MAX_SIZE;
+                break;
+            }
+            new_capacity *= 2;
+        }
+
+        /* Has the buffer been grown enough */
+        if (new_capacity < required) {
+            slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                          "HIBP response buffer cannot grow enough\n");
+            return 0;
+        }
+
+        new_data = slapi_ch_realloc(response->data, new_capacity);
+        if (!new_data) {
+            slapi_log_err(SLAPI_LOG_ERR, "hibp_write_callback",
+                          "Failed to allocate HIBP response buffer\n");
+            return 0;
+        }
+
+        response->data = new_data;
+        response->capacity = new_capacity;
+    }
+
+    memcpy(response->data + response->size, contents, real_size);
+    response->size += real_size;
+    response->data[response->size] = '\0';
+
+    return real_size;
+}
+
+/*
+ * Test wrapper for hibp_write_callback buffer handling
+ *
+ * Exposes the static hibp_write_callback function for testing
+ *
+ * Simulates how libcurl delivers data by calling hibp_write_callback
+ * multiple times with chunks of input data. This allows for testing
+ * buffer growth and overflow logic without network calls.
+ *
+ * Returns: buffer size on success, -1 on error
+ */
+int
+hibp_write_callback_wrapper(const char *data, size_t data_len, size_t chunk_size, char **out_data)
+{
+    HIBPResponse response = {0};
+    size_t offset = 0;
+    size_t bytes_to_write;
+    size_t written;
+
+    /* Allocate initial buffer */
+    response.capacity = HIBP_RESPONSE_INITIAL_SIZE;
+    response.data = slapi_ch_calloc(1, response.capacity);
+    if (!response.data) {
+        *out_data = NULL;
+        return -1;
+    }
+    response.size = 0;
+
+    /* Feed data in chunks, simulating curl callbacks */
+    while (offset < data_len) {
+        bytes_to_write = data_len - offset;
+        if (bytes_to_write > chunk_size) {
+            bytes_to_write = chunk_size;
+        }
+
+        written = hibp_write_callback((void *)(data + offset), 1, bytes_to_write, &response);
+        if (written != bytes_to_write) {
+            slapi_ch_free((void **)&response.data);
+            *out_data = NULL;
+            return -1;
+        }
+        offset += written;
+    }
+
+    *out_data = response.data;
+    return (int)response.size;
+}
+
+/*
+ * Initialise the libcurl library only once
+ *
+ * Returns: PR_SUCCESS on success, PR_FAILURE on error
+ */
+static PRStatus
+hibp_curl_global_init(void)
+{
+    CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if (res != CURLE_OK) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_curl_global_init",
+                      "Curl global init failed: %s\n", curl_easy_strerror(res));
+        g_curl_init_result = HIBP_CURL_INIT_FAILED;
+        return PR_FAILURE;
+    }
+    g_curl_init_result = HIBP_CURL_INIT_OK;
+    return PR_SUCCESS;
+}
+
+/*
+ * Ensure libcurl library is initialised before use
+ *
+ * Returns: 0 on success, -1 on error
+ */
+static int
+hibp_ensure_curl_init(void)
+{
+    if (PR_CallOnce(&g_curl_init_control, hibp_curl_global_init) != PR_SUCCESS) {
+        return HIBP_CURL_INIT_FAILED;
+    }
+    return g_curl_init_result;
+}
+
+/*
+ * Convert plaintext password to uppercase SHA-1 hex string
+ *
+ * Uses the current hash provider (NSS by default)
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int
+hibp_sha1_hex(const char *password, char *hex_output)
+{
+    unsigned char sha1_digest[HIBP_SHA1_DIGEST_BYTES];
+    hibp_hash_fn hash_fn;
+
+    if (!password || !hex_output) {
+        return -1;
+    }
+
+    hash_fn = hibp_get_hash_provider();
+    if (hash_fn(password, strlen(password), sha1_digest) != 0) {
+        hex_output[0] = '\0';
+        return -1;
+    }
+
+    for (int i = 0; i < HIBP_SHA1_DIGEST_BYTES; i++) {
+        sprintf(&hex_output[i * 2], "%02X", sha1_digest[i]);
+    }
+    hex_output[HIBP_SHA1_DIGEST_BYTES * 2] = '\0';
+
+    return 0;
+}
+
+/*
+ * Query HIBP API with hash prefix to get matching suffixes
+ *
+ * Returns: 0 on success, -1 on error
+ */
+static int
+hibp_query_api(const char *prefix, const char *api_url, HIBPResponse *response, int timeout)
+{
+    char url[512];
+    char error_buffer[CURL_ERROR_SIZE] = {0};
+    CURL *curl = NULL;
+    CURLcode res;
+    long response_code;
+    int n;
+
+    /* Are we using a mock response for testing */
+    if (g_mock_response != NULL) {
+        size_t mock_len = strlen(g_mock_response);
+        response->data = slapi_ch_malloc(mock_len + 1);
+        if (response->data == NULL) {
+            return -1;
+        }
+        memcpy(response->data, g_mock_response, mock_len + 1);
+        response->size = mock_len;
+        response->capacity = mock_len + 1;
+        return 0;
+    }
+
+    /* Ensure libcurl library is initialised */
+    if (hibp_ensure_curl_init() != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
+                      "curl_global_init() failed\n");
+        return -1;
+    }
+
+    /* Get a libcurl handle for this request */
+    curl = curl_easy_init();
+    if (!curl) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
+                      "curl_easy_init() failed\n");
+        return -1;
+    }
+
+    /* Build the API URL, use HIBP_API_URL by default */
+    if (api_url && strlen(api_url) > 0) {
+        n = snprintf(url, sizeof(url), "%s%s", api_url, prefix);
+    } else {
+        n = snprintf(url, sizeof(url), "%s%s", HIBP_API_URL, prefix);
+    }
+    if (n < 0 || (size_t)n >= sizeof(url)) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api", "URL too long or encoding error\n");
+        curl_easy_cleanup(curl);
+        return -1;
+    }
+
+    /* Initialise the response buffer */
+    response->capacity = HIBP_RESPONSE_INITIAL_SIZE;
+    response->data = slapi_ch_calloc(1, response->capacity);
+    response->size = 0;
+
+    /* Set libcurl options, validate critical ones */
+    if (curl_easy_setopt(curl, CURLOPT_URL, url) != CURLE_OK ||
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, hibp_write_callback) != CURLE_OK ||
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, response) != CURLE_OK ||
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L) != CURLE_OK ||
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L) != CURLE_OK) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
+                      "Failed to set critical libcurl options\n");
+        slapi_ch_free((void **)&response->data);
+        curl_easy_cleanup(curl);
+        return -1;
+    }
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "389-ds-hibp-client/1.0");
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)timeout);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
+
+    /* Send HTTP request, blocks until response is received or timeout expires */
+    res = curl_easy_perform(curl);
+    if (res != CURLE_OK) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
+                      "curl_easy_perform() failed: %s (%s) for URL %s\n",
+                      curl_easy_strerror(res), error_buffer, url);
+        slapi_ch_free((void **)&response->data);
+        curl_easy_cleanup(curl);
+        return -1;
+    }
+
+    /* HTTP transaction successful, check the HTTP response code */
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+    if (response_code != 200) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
+                      "HTTP error %ld for URL %s\n", response_code, url);
+        slapi_ch_free((void **)&response->data);
+        curl_easy_cleanup(curl);
+        return -1;
+    }
+
+    curl_easy_cleanup(curl);
+    return 0;
+}
+
+/*
+ * Parse HIBP API response to find matching hash suffix
+ *
+ * Iterates through the response buffer line by line, looking for the
+ * matching hash suffix.
+ *
+ * Returns: breach count if found, 0 if not found, -1 on error
+ */
+static int
+hibp_parse_response(HIBPResponse *response, const char *suffix)
+{
+    char *line = NULL;
+    char *next_line = NULL;
+    char *cr = NULL;
+    char *colon = NULL;
+    char *count_str = NULL;
+    char *endptr = NULL;
+    long count = 0;
+
+    if (!response || !response->data || !suffix) {
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_parse_response",
+                      "Invalid response or suffix\n");
+        return -1;
+    }
+
+    line = response->data;
+
+    while (line && *line) {
+        // line: 1E4C9B93F3F0682250B6CF8331B7EE68FD8:10429567\r\n */
+        next_line = strchr(line, '\n');
+        if (next_line) {
+            *next_line = '\0';
+            next_line++;
+        }
+
+        cr = strchr(line, '\r');
+        if (cr) {
+            *cr = '\0';
+        }
+
+        // line: "1E4C9B93F3F0682250B6CF8331B7EE68FD8:10429567"
+        colon = strchr(line, ':');
+        if (colon) {
+            *colon = '\0';
+            count_str = colon + 1;
+            // Line: "1E4C9B93F3F0682250B6CF8331B7EE68FD8"
+            // count_str: "10429567"
+            if (strcasecmp(line, suffix) == 0) {
+                endptr = NULL;
+                count = strtol(count_str, &endptr, 10);
+                if (endptr == count_str || count < 0 || count > INT_MAX) {
+                    return 0;  /* Treat an invalid count as not found */
+                }
+                return (int)count;
+            }
+        }
+
+        line = next_line;
+    }
+
+    return 0;
+}
+
+/*
+ * Test wrapper for hibp_parse_response parsing logic
+ *
+ * Exposes the static hibp_parse_response function for testing
+ *
+ * Takes response data as a string and converts it to HIBPResponse struct
+ *
+ * Returns: breach count if found, 0 if not found, -1 on error
+ */
+int
+hibp_parse_response_wrapper(char *response_data, const char *suffix)
+{
+    HIBPResponse response = {0};
+    response.data = response_data;
+    response.size = strlen(response_data);
+    return hibp_parse_response(&response, suffix);
+}
+
+/*
+ * Check if password appears in HIBP breach database
+ *
+ * Converts password to SHA-1, queries the HIBP API using hash prefix
+ * and checks for a matching suffix
+ *
+ * Returns: breach count if found, 0 if not found, -1 on error
+ */
+int
+hibp_check_password(const char *password, passwdPolicy *pwpolicy)
+{
+    char sha1_hex[HIBP_SHA1_DIGEST_BYTES * 2 + 1];
+    char prefix[HIBP_SHA1_HEX_PREFIX_LEN + 1];
+    char suffix[HIBP_SHA1_HEX_SUFFIX_LEN + 1];
+    HIBPResponse response = {0};
+    int result = -1;
+    int timeout;
+
+    if (!password || !pwpolicy) {
+        slapi_log_err(SLAPI_LOG_PWDPOLICY, "hibp_check_password",
+                        "Invalid input: password or password policy is NULL\n");
+        return -1;
+    }
+
+    /* Generate plaintext password hash */
+    if (hibp_sha1_hex(password, sha1_hex) != 0) {
+        slapi_log_err(SLAPI_LOG_PWDPOLICY, "hibp_check_password",
+                        "Failed to convert password to SHA-1 hash\n");
+        return -1;
+    }
+
+    /* Split hash into prefix and suffix */
+    strncpy(prefix, sha1_hex, HIBP_SHA1_HEX_PREFIX_LEN);
+    prefix[HIBP_SHA1_HEX_PREFIX_LEN] = '\0';
+    strcpy(suffix, sha1_hex + HIBP_SHA1_HEX_PREFIX_LEN);
+
+    slapi_log_err(SLAPI_LOG_DEBUG, "hibp_check_password", "Checking prefix: %s\n", prefix);
+
+    /* Configure timeout */
+    if (pwpolicy->pw_breach_db_timeout > 0) {
+        timeout = pwpolicy->pw_breach_db_timeout;
+    } else {
+        timeout = HIBP_API_TIMEOUT_SECS;
+    }
+
+    /* Query the HIBP API with hash prefix */
+    if (hibp_query_api(prefix, pwpolicy->pw_breach_db_url, &response, timeout) == 0) {
+        result = hibp_parse_response(&response, suffix);
+        slapi_ch_free((void **)&response.data);
+    }
+
+    return result;
+}
+
+/*
+ * Initialise HIBP subsystem
+ *
+ * Must be called before hibp_check_password
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int
+hibp_init(void)
+{
+    if (slapd_pk11_isFIPS()) {
+        /*
+         * TODO: If NSS SHA-1 fails in FIPS mode, switch to standalone implementation.
+         */
+        slapi_log_err(SLAPI_LOG_WARNING, "hibp_init",
+                      "FIPS mode detected - HIBP password checking may not work "
+                      "if SHA-1 is restricted\n");
+    } else {
+        hibp_set_hash_provider(hibp_sha1_nss);
+    }
+
+    return hibp_ensure_curl_init();
+}

--- a/ldap/servers/slapd/hibp_client.c
+++ b/ldap/servers/slapd/hibp_client.c
@@ -44,6 +44,8 @@ static int
 hibp_sha1_nss(const char *input, size_t len, unsigned char *digest)
 {
     if (!slapd_nss_is_initialized()) {
+        slapi_log_err(SLAPI_LOG_WARNING, "hibp_sha1_nss",
+                      "NSS not initialised - enable security to use HIBP breach checking\n");
         return -1;
     }
     SECStatus rv = PK11_HashBuf(SEC_OID_SHA1, digest, (unsigned char *)input, len);
@@ -308,10 +310,10 @@ hibp_query_api(const char *prefix, const char *api_url, HIBPResponse *response, 
     int n;
 
     /* Are we using a mock response for testing */
-    if (g_mock_response != NULL) {
+    if (g_mock_response) {
         size_t mock_len = strlen(g_mock_response);
         response->data = slapi_ch_malloc(mock_len + 1);
-        if (response->data == NULL) {
+        if (!response->data) {
             return -1;
         }
         memcpy(response->data, g_mock_response, mock_len + 1);

--- a/ldap/servers/slapd/hibp_client.c
+++ b/ldap/servers/slapd/hibp_client.c
@@ -43,6 +43,9 @@ static hibp_hash_fn g_hash_provider = NULL;
 static int
 hibp_sha1_nss(const char *input, size_t len, unsigned char *digest)
 {
+    if (!slapd_nss_is_initialized()) {
+        return -1;
+    }
     SECStatus rv = PK11_HashBuf(SEC_OID_SHA1, digest, (unsigned char *)input, len);
     return (rv == SECSuccess) ? 0 : -1;
 }
@@ -491,15 +494,15 @@ hibp_check_password(const char *password, passwdPolicy *pwpolicy)
     int timeout;
 
     if (!password || !pwpolicy) {
-        slapi_log_err(SLAPI_LOG_PWDPOLICY, "hibp_check_password",
-                        "Invalid input: password or password policy is NULL\n");
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_check_password",
+                      "password or password policy is NULL\n");
         return -1;
     }
 
     /* Generate plaintext password hash */
     if (hibp_sha1_hex(password, sha1_hex) != 0) {
-        slapi_log_err(SLAPI_LOG_PWDPOLICY, "hibp_check_password",
-                        "Failed to convert password to SHA-1 hash\n");
+        slapi_log_err(SLAPI_LOG_ERR, "hibp_check_password",
+                      "Failed to convert password to SHA-1 hash\n");
         return -1;
     }
 
@@ -507,8 +510,6 @@ hibp_check_password(const char *password, passwdPolicy *pwpolicy)
     strncpy(prefix, sha1_hex, HIBP_SHA1_HEX_PREFIX_LEN);
     prefix[HIBP_SHA1_HEX_PREFIX_LEN] = '\0';
     strcpy(suffix, sha1_hex + HIBP_SHA1_HEX_PREFIX_LEN);
-
-    slapi_log_err(SLAPI_LOG_DEBUG, "hibp_check_password", "Checking prefix: %s\n", prefix);
 
     /* Configure timeout */
     if (pwpolicy->pw_breach_db_timeout > 0) {

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1750,6 +1750,9 @@ pwpolicy_init_defaults (passwdPolicy *pw_policy)
     pw_policy->pw_admin_user = NULL;
     pw_policy->pw_is_legacy = LDAP_ON;
     pw_policy->pw_track_update_time = LDAP_OFF;
+    pw_policy->pw_check_breach = LDAP_OFF;
+    pw_policy->pw_breach_db_url = NULL;
+    pw_policy->pw_breach_db_timeout = 10;
 }
 
 static void

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1934,6 +1934,9 @@ typedef struct passwordpolicyarray
     Slapi_DN **pw_admin_user;
     slapi_onoff_t pw_admin_skip_info;  /* Skip updating password information in target entry */
     char *pw_local_dn; /* DN of the subtree/user policy */
+    slapi_onoff_t pw_check_breach;     /* Check passwords against HIBP breach database */
+    char *pw_breach_db_url;            /* Custom breach database API URL (default HIBP) */
+    int pw_breach_db_timeout;          /* Timeout for breach database queries in seconds */
 
 } passwdPolicy;
 #define PWDPOLICY_DEBUG "PWDPOLICY_DEBUG"

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -60,6 +60,9 @@
 # Build cockpit plugin
 %bcond cockpit 1
 
+# Build HIBP password breach checking (requires libcurl)
+%bcond hibp 0
+
 # fedora 15 and later uses tmpfiles.d
 # otherwise, comment this out
 %{!?with_tmpfiles_d: %global with_tmpfiles_d %{_sysconfdir}/tmpfiles.d}
@@ -128,6 +131,9 @@ BuildRequires:    libdb-devel
 BuildRequires:    net-snmp-devel
 BuildRequires:    bzip2-devel
 BuildRequires:    openssl-devel
+%if %{with hibp}
+BuildRequires:    libcurl-devel
+%endif
 # the following is for the pam passthru auth plug-in
 BuildRequires:    pam-devel
 BuildRequires:    systemd-units
@@ -474,6 +480,9 @@ autoreconf -fiv
            $ASAN_FLAGS $MSAN_FLAGS $TSAN_FLAGS $UBSAN_FLAGS $RUST_FLAGS $CLANG_FLAGS $COCKPIT_FLAGS \
 %if 0%{?fedora} >= 34 || 0%{?rhel} >= 9
            --with-libldap-r=no \
+%endif
+%if %{with hibp}
+	  --enable-hibp \
 %endif
            --enable-cmocka
 

--- a/test/libslapd/hibp/parse.c
+++ b/test/libslapd/hibp/parse.c
@@ -1,0 +1,264 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2026 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#include "../../test_slapd.h"
+#include <string.h>
+#include <pthread.h>
+#include <nss.h>
+#include <hibp.h>
+
+#define HIBP_SHA1_HEX_LENGTH 41  /* 40 hex chars + null terminator */
+
+/* Global NSS state for standalone testing */
+static int g_nss_initialised = 0;
+
+/* Ensure NSS is initialised */
+static void
+ensure_nss_init(void)
+{
+    if (!g_nss_initialised) {
+        if (NSS_NoDB_Init(NULL) != SECSuccess) {
+            fprintf(stderr, "Fatal error: unable to initialize the NSS subcomponent.");
+            return;
+        }
+        g_nss_initialised = 1;
+    }
+}
+
+/* SHA-1 conversion tests */
+void
+test_hibp_sha1_hex(void **state)
+{
+    char hex_output[HIBP_SHA1_HEX_LENGTH];
+    char long_password[1024];
+
+    (void)state; /* Unused */
+    ensure_nss_init();
+
+    /* Basic password */
+    assert_int_equal(hibp_sha1_hex("password", hex_output), 0);
+    assert_string_equal(hex_output, "5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8");
+
+    /* Empty string */
+    assert_int_equal(hibp_sha1_hex("", hex_output), 0);
+    assert_string_equal(hex_output, "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709");
+
+    /* Special characters */
+    assert_int_equal(hibp_sha1_hex("P@ssw0rd!", hex_output), 0);
+    assert_string_equal(hex_output, "076D3E6C4B9F654B5B220B9045B7458AB6B4CBC6");
+
+    /* Unicode characters */
+    assert_int_equal(hibp_sha1_hex("rúnfhocal", hex_output), 0);
+    assert_int_equal(strlen(hex_output), 40);
+
+    /* Long password */
+    memset(long_password, 'A', 1000);
+    long_password[1000] = '\0';
+    assert_int_equal(hibp_sha1_hex(long_password, hex_output), 0);
+    assert_int_equal(strlen(hex_output), 40);
+}
+
+/* Response parsing tests */
+void
+test_hibp_parse_response(void **state)
+{
+    int result;
+
+    (void)state; /* Unused */
+
+    /* Found */
+    char response1[] = "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n"
+                       "00D4F6E8FA6EECAD2A3AA415EEC418D38EC:2\r\n";
+    result = hibp_parse_response_wrapper(response1, "00D4F6E8FA6EECAD2A3AA415EEC418D38EC");
+    assert_int_equal(result, 2);
+
+    /* Not found */
+    char response2[] = "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n";
+    result = hibp_parse_response_wrapper(response2, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    assert_int_equal(result, 0);
+
+    /* Empty */
+    char response3[] = "";
+    result = hibp_parse_response_wrapper(response3, "0018A45C4D1DEF81644B54AB7F969B88D65");
+    assert_int_equal(result, 0);
+
+    /* Case insensitive */
+    char response4[] = "ABCDEF1234567890ABCDEF1234567890ABCDE:42\r\n";
+    result = hibp_parse_response_wrapper(response4, "abcdef1234567890abcdef1234567890abcde");
+    assert_int_equal(result, 42);
+
+    /* Malformed (no colon) */
+    char response5[] = "NOSEPARATOR\r\n";
+    result = hibp_parse_response_wrapper(response5, "NOSEPARATOR");
+    assert_int_equal(result, 0);
+
+    /* Invalid count */
+    char response6[] = "INVALID234567890ABCDEF1234567890ABCDE:notanumber\r\n";
+    result = hibp_parse_response_wrapper(response6, "INVALID234567890ABCDEF1234567890ABCDE");
+    assert_int_equal(result, 0);
+
+    /* Large count */
+    char response7[] = "0018A45C4D1DEF81644B54AB7F969B88D65:3861493\r\n";
+    result = hibp_parse_response_wrapper(response7, "0018A45C4D1DEF81644B54AB7F969B88D65");
+    assert_int_equal(result, 3861493);
+}
+
+/* Buffer handling tests */
+void
+test_hibp_buffer_handling(void **state)
+{
+    char *out_data = NULL;
+    char *large_response = NULL;
+    char *huge_data = NULL;
+    int result;
+    const char *small_response = "0018A45C4D1DEF81644B54AB7F969B88D65:123\r\n";
+    const char *line = "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n";
+    size_t line_len = strlen(line);
+    size_t offset = 0;
+    size_t response_size = 16000;
+
+    (void)state; /* Unused */
+
+    /* Small response fits in initial buffer */
+    result = hibp_write_callback_wrapper(small_response, strlen(small_response), 1024, &out_data);
+    assert_true(result > 0);
+    assert_non_null(out_data);
+    assert_string_equal(out_data, small_response);
+    slapi_ch_free_string(&out_data);
+
+    /* Large response requires buffer growth */
+    large_response = slapi_ch_calloc(1, response_size + 1);
+    while (offset + line_len < response_size) {
+        memcpy(large_response + offset, line, line_len);
+        offset += line_len;
+    }
+    large_response[offset] = '\0';
+    result = hibp_write_callback_wrapper(large_response, strlen(large_response), 512, &out_data);
+    assert_true(result > 8192);
+    assert_non_null(out_data);
+    slapi_ch_free_string(&large_response);
+    slapi_ch_free_string(&out_data);
+
+    /* Exceeds max size (1MB) */
+    huge_data = slapi_ch_calloc(1, 1024 * 1024 + 100);
+    memset(huge_data, 'A', 1024 * 1024 + 99);
+    result = hibp_write_callback_wrapper(huge_data, 1024 * 1024 + 99, 8192, &out_data);
+    assert_int_equal(result, -1);
+    assert_null(out_data);
+    slapi_ch_free_string(&huge_data);
+}
+
+/* Integration tests using mock API response */
+void
+test_hibp_api_integration(void **state)
+{
+    int result;
+    passwdPolicy policy = {0};
+
+    /*
+     * Mock HIBP response for "password" (SHA1: 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8)
+     * This simulates a response that does contain the password suffix
+     */
+    const char *mock_breached_response =
+        "1D2DA4053E34E76F6576ED1DA63134B5E2A:2\r\n"
+        "1D72CD07550416C216D8AD296BF5C0AE8E0:10\r\n"
+        "1E4C9B93F3F0682250B6CF8331B7EE68FD8:10429567\r\n"  /* "password" suffix */
+        "1E4D895C4A3EFBC6E7A22E5CE8F6A4AF52C:4\r\n";
+
+    /*
+     * Mock HIBP response for "xK9#mQ2$vL7@nP4!wR8^tY1&" {SHA1: 42C0A9886C5AF8846C8E6AED554B3165AAC} 
+     * This simulates a response that does not contain the password suffix
+     */
+    const char *mock_safe_response =
+        "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n"
+        "00D4F6E8FA6EECAD2A3AA415EEC418D38EC:2\r\n"
+        "1234567890ABCDEF1234567890ABCDEF123:5\r\n";
+
+    (void)state; /* Unused */
+    ensure_nss_init();
+
+    /* Initialise client */
+    result = hibp_init();
+    assert_int_equal(result, 0);
+
+    /* Test NULL inputs */
+    result = hibp_check_password(NULL, &policy);
+    assert_int_equal(result, -1);
+    result = hibp_check_password("password", NULL);
+    assert_int_equal(result, -1);
+
+    policy.pw_breach_db_timeout = 10;
+    policy.pw_breach_db_url = NULL;
+
+    /* Test breached password with mock */
+    hibp_set_mock_response(mock_breached_response);
+    result = hibp_check_password("password", &policy);
+    assert_int_equal(result, 10429567);
+
+    /* Test safe password with mock */
+    hibp_set_mock_response(mock_safe_response);
+    result = hibp_check_password("xK9#mQ2$vL7@nP4!wR8^tY1&", &policy);
+    assert_int_equal(result, 0);
+
+    /* Reset mock for other tests */
+    hibp_set_mock_response(NULL);
+}
+
+/* Thread worker for concurrent test */
+static void *
+hibp_thread_worker(void *arg)
+{
+    int *result = (int *)arg;
+    passwdPolicy policy = {0};
+    policy.pw_breach_db_timeout = 10;
+    policy.pw_breach_db_url = NULL;
+
+    *result = hibp_check_password("password", &policy);
+    return NULL;
+}
+
+#define HIBP_TEST_THREADS 4
+
+/* Concurrent test using mock response */
+void
+test_hibp_concurrent_requests(void **state)
+{
+    int result;
+    int results[HIBP_TEST_THREADS] = {0};
+    pthread_t threads[HIBP_TEST_THREADS];
+    int i;
+
+    /* Set mock response to "password" (SHA1: 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8) */
+    const char *mock_response =
+        "1E4C9B93F3F0682250B6CF8331B7EE68FD8:10429567\r\n";
+
+    (void)state; /* Unused */
+    ensure_nss_init();
+
+    result = hibp_init();
+    assert_int_equal(result, 0);
+
+    /* Set mock response before spawning threads */
+    hibp_set_mock_response(mock_response);
+
+    for (i = 0; i < HIBP_TEST_THREADS; i++) {
+        pthread_create(&threads[i], NULL, hibp_thread_worker, &results[i]);
+    }
+
+    for (i = 0; i < HIBP_TEST_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    /* All threads should find the breached password */
+    for (i = 0; i < HIBP_TEST_THREADS; i++) {
+        assert_int_equal(results[i], 10429567);
+    }
+
+    /* Reset mock */
+    hibp_set_mock_response(NULL);
+}

--- a/test/libslapd/hibp/parse.c
+++ b/test/libslapd/hibp/parse.c
@@ -17,6 +17,13 @@
 /* Global NSS state for standalone testing */
 static int g_nss_initialised = 0;
 
+/* Stub for slapd_nss_is_initialized() */
+int
+slapd_nss_is_initialized(void)
+{
+    return g_nss_initialised;
+}
+
 /* Ensure NSS is initialised */
 static void
 ensure_nss_init(void)

--- a/test/libslapd/test.c
+++ b/test/libslapd/test.c
@@ -52,6 +52,14 @@ run_libslapd_tests(void)
         cmocka_unit_test(test_libslapd_csngen_time_backwards),
         cmocka_unit_test(test_libslapd_csngen_multiple_clock_failures),
         cmocka_unit_test(test_libslapd_csngen_seqnum_handling),
+#ifdef ENABLE_HIBP
+        /* HIBP password breach checking tests */
+        cmocka_unit_test(test_hibp_sha1_hex),
+        cmocka_unit_test(test_hibp_parse_response),
+        cmocka_unit_test(test_hibp_buffer_handling),
+        cmocka_unit_test(test_hibp_api_integration),
+        cmocka_unit_test(test_hibp_concurrent_requests),
+#endif
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/test_slapd.h
+++ b/test/test_slapd.h
@@ -75,6 +75,15 @@ void test_libslapd_csngen_time_backwards(void **state);
 void test_libslapd_csngen_multiple_clock_failures(void **state);
 void test_libslapd_csngen_seqnum_handling(void **state);
 
+#ifdef ENABLE_HIBP
+/* libslapd-hibp */
+void test_hibp_sha1_hex(void **state);
+void test_hibp_parse_response(void **state);
+void test_hibp_buffer_handling(void **state);
+void test_hibp_api_integration(void **state);
+void test_hibp_concurrent_requests(void **state);
+#endif
+
 /* plugins */
 
 void test_plugin_hello(void **state);


### PR DESCRIPTION
Description:
Implement an HTTP client for querying the Have I Been Pwned (HIBP) Pwned Passwords API using the k-anonymity model. This is the first commit toward password breach detection in 389 Directory Server. Requires libcurl (optional dependency, enabled via --enable-hibp).

- HTTP transport using libcurl
- SHA-1 hashing via NSS
- Unit tests with mock transport

Fixes:	https://github.com/389ds/389-ds-base/issues/7468

Reviewed by:

## Summary by Sourcery

Introduce an optional HIBP-based password breach checking client and wire it into the slapd password policy with supporting configuration, build flags, and tests.

New Features:
- Add a Have I Been Pwned (HIBP) HTTP client for password breach checking using the k-anonymity SHA-1 range API.
- Extend password policy configuration with options to enable breach checking, specify a breach database URL, and configure query timeouts.

Enhancements:
- Integrate libcurl and NSS-based SHA-1 hashing behind a pluggable hash-provider abstraction for the HIBP client.
- Initialize default breach-checking-related password policy fields and HIBP subsystem setup within slapd.

Build:
- Add an optional --enable-hibp configure flag that pulls in libcurl, defines ENABLE_HIBP, and conditionally builds the HIBP client and its tests.

Tests:
- Add unit tests for HIBP SHA-1 conversion, API response parsing, response buffer handling, mocked API integration, and concurrent request handling under the libslapd test suite.