### PR TITLE
Issue 7475 - Fix CI test failures

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
@@ -262,8 +262,11 @@ def test_task_timeout(topo):
     task = ExportTask(inst)
     task.export_suffix_to_ldif(export_ldif, DEFAULT_SUFFIX)
     task.wait(timeout=.5, sleep_interval=.5)
-    assert task.get_exit_code() is None
-    task.wait(timeout=0)
+    if task.get_exit_code() is None:
+        task.wait(timeout=0)
+    else:
+        log.info('Export task completed before timeout - skipping timeout check')
+        assert task.get_exit_code() == 0
 
     # Test timeout for schema validate task
     task = SyntaxValidateTask(inst).create(properties={

--- a/dirsrvtests/tests/suites/export/export_reindex_tombstone_test.py
+++ b/dirsrvtests/tests/suites/export/export_reindex_tombstone_test.py
@@ -13,7 +13,7 @@ import ldap
 from lib389.idm.user import UserAccounts
 from lib389.idm.domain import Domain
 from lib389.tombstone import Tombstones
-from lib389.topologies import topology_m2 as topo_m2
+from test389.topologies import topology_m2 as topo_m2
 from lib389._constants import DEFAULT_SUFFIX, DEFAULT_BENAME, ErrorLog
 from lib389.utils import *
 from lib389.backend import Backends

--- a/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
+++ b/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
@@ -24,12 +24,13 @@ log = logging.getLogger(__name__)
 
 FD_ATTR = "nsslapd-maxdescriptors"
 RESRV_FD_ATTR = "nsslapd-reservedescriptors"
-GLOBAL_LIMIT = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+SLAPD_DEFAULT_MAXDESCRIPTORS = 1048576
+MAX_FD_VAL = min(resource.getrlimit(resource.RLIMIT_NOFILE)[1], SLAPD_DEFAULT_MAXDESCRIPTORS)
 SYSTEMD_LIMIT = ensure_str(check_output("systemctl show -p LimitNOFILE dirsrv@standalone1".split(" ")).strip()).split('=')[1]
 CUSTOM_VAL = str(int(SYSTEMD_LIMIT) - 10)
 RESRV_DESC_VAL_LOW = 10
-TOO_HIGH_VAL = str(GLOBAL_LIMIT * 2)
-TOO_HIGH_VAL2 = str(int(SYSTEMD_LIMIT) * 2)
+TOO_HIGH_VAL = str(MAX_FD_VAL + 1)
+TOO_HIGH_VAL2 = str(MAX_FD_VAL + 1)
 TOO_LOW_VAL = "0"
 
 @pytest.mark.skipif(ds_is_older("1.4.1.2"), reason="Not implemented")

--- a/dirsrvtests/tests/suites/retrocl/basic_test.py
+++ b/dirsrvtests/tests/suites/retrocl/basic_test.py
@@ -428,10 +428,10 @@ def test_retrocl_trimming_entries(topology_st):
     :id: d7b7cf72-f47c-4b43-b25d-10f7f0ad86f2
     :setup: Standalone Instance
     :steps:
-        1. Enable retro changelog with aggressive trimming settings
-        2. Count existing changelog entries before test
-        3. Add multiple entries to create new changelog records
-        4. Verify we added the expected number of entries
+        1. Enable retro changelog without trimming
+        2. Add multiple entries to create new changelog records
+        3. Verify we added the expected number of entries
+        4. Configure aggressive trimming settings and restart
         5. Enable plugin logging and wait for trimming to occur
         6. Verify changelog entries were reduced by checking error log and count
     :expectedresults:
@@ -446,15 +446,11 @@ def test_retrocl_trimming_entries(topology_st):
     inst = topology_st.standalone
     max_entries = 10
 
-    log.info('Enable retro changelog plugin')
+    log.info('Enable retro changelog plugin without trimming')
     rcl = RetroChangelogPlugin(inst)
     rcl.enable()
-
-    log.info('Configure aggressive trimming: 10s maxage, 5s trim interval')
-    rcl.replace('nsslapd-changelogmaxage', '10s')
-    rcl.replace('nsslapd-changelog-trim-interval', '5s')
-
-    log.info('Restart instance to apply changes')
+    rcl.remove_all('nsslapd-changelogmaxage')
+    rcl.remove_all('nsslapd-changelog-trim-interval')
     inst.restart()
 
     log.info('Count existing changelog entries before test')
@@ -483,6 +479,10 @@ def test_retrocl_trimming_entries(topology_st):
     added_entries = new_count - initial_count
     assert added_entries == max_entries
     log.info(f'Successfully added {added_entries} changelog entries (total: {new_count})')
+
+    log.info('Configure aggressive trimming: 10s maxage, 5s trim interval')
+    rcl.replace('nsslapd-changelogmaxage', '10s')
+    rcl.replace('nsslapd-changelog-trim-interval', '5s')
 
     log.info('Enable plugin logging to monitor trimming')
     inst.config.set('nsslapd-errorlog-level', '65536')

--- a/src/lib389/doc/source/replica.rst
+++ b/src/lib389/doc/source/replica.rst
@@ -11,7 +11,7 @@ Still, it is better if you'll use the 'create_topology' method for basic initial
 
   ::
 
-    from lib389.topologies import create_topology
+    from test389.topologies import create_topology
 
     topology = create_topology({ReplicaRole.SUPPLIER: 2,
                                 ReplicaRole.CONSUMER: 2})


### PR DESCRIPTION
Description:
`retrocl`, `resource_limits` and `clu` test suites are flaky and fail from time to time.

Fixes: https://github.com/389ds/389-ds-base/issues/7475

## Summary by Sourcery

Stabilize flaky CI tests in retro changelog, export task timeout, and file-descriptor limit suites.

Bug Fixes:
- Adjust retro changelog trimming test flow to start without trimming and apply aggressive trimming only after generating entries to avoid timing-related flakiness.
- Relax export task timeout expectations so the test tolerates tasks that complete before the initial timeout instead of failing.
- Use fixed default max descriptor limits in file-descriptor limit tests to avoid environment-dependent failures when system limits vary.