### PR TITLE
Issue 7493 - RFE - Add ShadowAccount fixup task

### DIFF
--- a/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_attribute_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2016 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -821,6 +821,218 @@ def test_shadowaccount_user_policy(topology_st, request):
                             'shadowMax', 40)
     check_shadow_attr_value(inst, user_policy_user.dn,
                             'shadowWarning', 12)
+
+
+@pytest.mark.skipif(ds_is_older('1.3.6'), reason="Not implemented")
+def test_fixup_shadow_attributes_task(topology_st, request):
+    """fixup shadow attributes task: missing shadowLastChange, consistent entries,
+    stale shadow vs passwordExpirationTime (no force), and force when expiration is absent
+
+    :id: e7f8a9b0-1c2d-3e4f-5678-90abcdef0124
+    :setup: Standalone instance
+    :steps:
+        1. Enable passwordMustChange, passwordExp, and passwordMaxAge in cn=config
+        2. Create ShadowAccount entry A before password policy is configured
+        3. Create ShadowAccount entries B and C after passwordpolicy is set
+        4. As entry B, change password; as Directory Manager, set entry C password
+           (so C has passwordExpirationTime in the NO_TIME skip case)
+        5. Ensure entry A has no shadowLastChange (remove if the server added one)
+        6. Record shadowLastChange for entries B and C
+        7. Run fixup shadow attributes task with suffix only (no force)
+        8. Wait for task completion
+        9. Verify entry A has shadowLastChange; B and C unchanged from step 6
+        10. Set entry C passwordExpirationtime and shadowLastChange to inconsistent (stale) values
+        11. Run fixup shadow attributes task without force (suffix only)
+        12. Wait for task completion
+        13. Verify entry C shadowLastChange is recomputed from expiration and policy (not step 6)
+        14. Remove entry B passwordExpirationtime and set B shadowLastChange to a stale value
+        15. Run fixup shadow attributes task with force on
+        16. Wait for task completion
+        17. Verify entry B shadowLastChange updates (force required when passwordExpirationTime is absent)
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+        7. Success
+        8. Success
+        9. Entry A gains shadowLastChange; B and C unchanged from step 6 (C skipped for NO_TIME)
+        10. Success
+        11. Success
+        12. Success
+        13. Entry C shadowLastChange updates for stale shadow vs expiration without force
+        14. Success
+        15. Success
+        16. Success
+        17. Entry B shadowLastChange updates because force bypasses skip when expiration is missing
+    """
+    inst = topology_st.standalone
+
+    MAX_AGE = "100000"
+    EXP_TIME = "20250507185841Z"
+
+    log.info('Create ShadowAccount entry A before password policy is configured')
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user_a = users.create(properties={
+        'objectclass': ['top', 'person', 'organizationalPerson',
+                        'inetOrgPerson', 'extensibleObject', 'shadowAccount'],
+        'sn': 'Fa',
+        'cn': 'shadowFa',
+        'uid': 'shadowFa',
+        'uidNumber': '7101',
+        'gidNumber': '7101',
+        'homeDirectory': '/home/shadowFa',
+        'displayName': 'Shadow fixup A',
+        'givenname': 'ShadowFa',
+        'mail': 'shadowFa@example.com',
+        'userpassword': 'password',
+    })
+
+    log.info('Enable passwordMustChange in cn=config')
+    inst.config.replace('passwordMustChange', 'on')
+    inst.config.replace('passwordExp', 'on')
+    inst.config.replace('passwordMaxAge', MAX_AGE)
+
+    log.info('Create ShadowAccount entry B after password policy is configured')
+    user_b = users.create(properties={
+        'objectclass': ['top', 'person', 'organizationalPerson',
+                        'inetOrgPerson', 'extensibleObject', 'shadowAccount'],
+        'sn': 'Fb',
+        'cn': 'shadowFb',
+        'uid': 'shadowFb',
+        'uidNumber': '7102',
+        'gidNumber': '7102',
+        'homeDirectory': '/home/shadowFb',
+        'displayName': 'Shadow fixup B',
+        'givenname': 'ShadowFb',
+        'mail': 'shadowFb@example.com',
+        'userpassword': 'password',
+    })
+
+    log.info('Create ShadowAccount entry C')
+    user_c = users.create(properties={
+        'objectclass': ['top', 'person', 'organizationalPerson',
+                        'inetOrgPerson', 'extensibleObject', 'shadowAccount'],
+        'sn': 'Fc',
+        'cn': 'shadowFc',
+        'uid': 'shadowFc',
+        'uidNumber': '7102',
+        'gidNumber': '7102',
+        'homeDirectory': '/home/shadowFc',
+        'displayName': 'Shadow fixup B',
+        'givenname': 'ShadowFc',
+        'mail': 'shadowFc@example.com',
+        'userpassword': 'password',
+    })
+
+    def fin():
+        log.info('Cleanup: disable passwordMustChange; delete test users')
+        dm = DirectoryManager(inst)
+        dm.rebind()
+        try:
+            inst.config.replace('passwordMustChange', 'off')
+            inst.config.replace('passwordExp', 'off')
+        except Exception:
+            pass
+        for u in (user_a, user_b, user_c):
+            try:
+                if u.exists():
+                    u.delete()
+            except Exception:
+                pass
+
+    request.addfinalizer(fin)
+
+    # Update user B password so it has a current expiration time and not the
+    # "reset" value
+    user_b.rebind('password')
+    user_b.replace('userpassword', 'password0')  # Trigger valid exp time
+
+    dm = DirectoryManager(inst)
+    dm.rebind(PASSWORD)
+    user_c.replace('userpassword', 'password0')  # Trigger NO_TIME
+
+    # Gather the current values for ShadowLastChange
+    if user_a.present('shadowLastChange'):
+        log.info('Removing shadowLastChange from entry A so the non-forced fixup updates it')
+        user_a.remove_all('shadowLastChange')
+
+    assert user_b.present('shadowLastChange'), 'Entry B should have shadowLastChange before fixup'
+    b_before = int(user_b.get_attr_val_utf8('shadowLastChange'))
+    log.info('Entry B shadowLastChange before tasks: {}'.format(b_before))
+
+    c_before = int(user_c.get_attr_val_utf8('shadowLastChange'))
+    log.info('Entry C shadowLastChange before tasks: {}'.format(c_before))
+
+    #
+    # Run the task (suffix only, no force)
+    #
+    log.info('Run fixup shadow attributes task (suffix only, no force)')
+    shadow_fixup_task = ShadowFixupTask(inst)
+    shadow_fixup_task.create(suffix=DEFAULT_SUFFIX, force=False)
+    shadow_fixup_task.wait(timeout=120)
+    assert shadow_fixup_task.get_exit_code() == 0
+
+    # User A should now have ShadowLastChange
+    assert user_a.present('shadowLastChange'), 'Entry A should gain shadowLastChange'
+    a_after_first = int(user_a.get_attr_val_utf8('shadowLastChange'))
+    log.info('Entry A shadowLastChange after first task: {}'.format(a_after_first))
+
+    # User B should be the same since it has the correct values for
+    # ShadowLastChange and passwordExpirationtime
+    b_after_first = int(user_b.get_attr_val_utf8('shadowLastChange'))
+    assert b_after_first == b_before, (
+        'Entry B shadowLastChange should be unchanged without force; '
+        'got {} expected {}'.format(b_after_first, b_before))
+
+    # User C should remain unchanged because passwordExpiration is set to NO_TIME
+    c_after_first = int(user_c.get_attr_val_utf8('shadowLastChange'))
+    assert c_after_first == c_before, (
+        'Entry C shadowLastChange should be unchanged without force; '
+        'got {} expected {}'.format(c_after_first, c_before))
+
+    #
+    # Run the fixup after tweaking passwordExpirationtime
+    #
+    # Update user C passwordExpirationtime to a "stale" value which should
+    # trigger shadowLastChange to be updated
+    user_c.replace('passwordExpirationtime', EXP_TIME)
+    user_c.replace('shadowLastChange', '20000')
+    c_before = '20000'
+    log.info('Run fixup shadow attributes task (suffix only, no force; stale reconciliation)')
+    shadow_fixup_task = ShadowFixupTask(inst)
+    shadow_fixup_task.create(suffix=DEFAULT_SUFFIX, force=False)
+    shadow_fixup_task.wait(timeout=120)
+    assert shadow_fixup_task.get_exit_code() == 0
+
+    # User C should have ShadowLastChange updated to the current day
+    c_after_first = int(user_c.get_attr_val_utf8('shadowLastChange'))
+    exp_time = gentime_to_posix_time(EXP_TIME)
+    expected_val = int((exp_time - int(MAX_AGE)) / 86400)
+    assert c_after_first != int(c_before) and c_after_first == expected_val, (
+        'Entry C shadowLastChange should be changed without force; '
+        'got {} expected {}'.format(c_after_first, c_before))
+
+    #
+    # Run the fixup in force option
+    #
+    log.info('Run fixup shadow attributes task with force on')
+    # Update user B so that it would normally not be "fixed-up"
+    user_b.remove_all('passwordExpirationtime')
+    user_b.replace('shadowLastChange', '20000')
+
+    shadow_fixup_task = ShadowFixupTask(inst)
+    shadow_fixup_task.create(suffix=DEFAULT_SUFFIX, force=True)
+    shadow_fixup_task.wait(timeout=120)
+    assert shadow_fixup_task.get_exit_code() == 0
+
+    assert user_b.present('shadowLastChange')
+    b_after_force = int(user_b.get_attr_val_utf8('shadowLastChange'))
+    assert b_after_force != 20000, (
+        'Entry B shadowLastChange should change when force is on; '
+        'still {}'.format(b_after_force))
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -7379,6 +7379,19 @@ config_get_pw_warning(void)
     return retVal;
 }
 
+int32_t
+config_get_pwpolicy_local(void)
+{
+    int32_t retVal;
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    CFG_LOCK_READ(slapdFrontendConfig);
+    retVal = slapdFrontendConfig->pwpolicy_local;
+    CFG_UNLOCK_READ(slapdFrontendConfig);
+
+    return retVal;
+}
+
 int
 config_get_pwpolicy_inherit_global()
 {

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -480,6 +480,7 @@ int config_get_pw_exp(void);
 int config_get_pw_unlock(void);
 int config_get_pw_lockout(void);
 int config_get_pw_gracelimit(void);
+int32_t config_get_pwpolicy_local(void);
 int config_get_pwpolicy_inherit_global(void);
 int config_get_lastmod(void);
 int config_get_nagle(void);

--- a/ldap/servers/slapd/pw_mgmt.c
+++ b/ldap/servers/slapd/pw_mgmt.c
@@ -22,6 +22,30 @@
 /* prototypes                                                               */
 /****************************************************************************/
 
+static int shadow_fixup_task_add(Slapi_PBlock *pb __attribute__((unused)),
+                                 Slapi_Entry *e,
+                                 Slapi_Entry *eAfter __attribute__((unused)),
+                                 int *returncode,
+                                 char *returntext __attribute__((unused)),
+                                 void *arg);
+static void shadow_fixup_task_thread(void *arg);
+static void shadow_fixup_task_destructor(Slapi_Task *task);
+
+typedef struct task_data {
+    char *suffix;
+    bool force;
+} task_data;
+
+typedef struct shadow_fixup_callback_data
+{
+    int32_t rc;
+    uint32_t skipped;
+    uint32_t stale;
+    uint32_t fixed;
+    Slapi_Task *task;
+    task_data *task_data;
+} shadow_fixup_callback_data;
+
 /*
  * For chaining, particularly chain-on-update, we still need to check if the user's
  * password MUST be reset before proceeding.
@@ -335,4 +359,320 @@ pw_init(void)
                                    SLAPI_ATTR_FLAG_NOUSERMOD |
                                        SLAPI_ATTR_FLAG_NOEXPOSE);
 #endif
+
+    slapi_task_register_handler("fixup shadow attributes",
+                                shadow_fixup_task_add);
+}
+
+/*
+ * ShadowLastChange fixup task fucntions
+ */
+static void
+shadow_fixup_task_destructor(Slapi_Task *task)
+{
+    if (task) {
+        while (slapi_task_get_refcount(task) > 0) {
+            /* Yield to wait for the fixup task to finish */
+            DS_Sleep(PR_MillisecondsToInterval(100));
+        }
+        task_data *mytaskdata = (task_data *)slapi_task_get_data(task);
+        slapi_ch_free_string(&mytaskdata->suffix);
+        slapi_ch_free((void **)&mytaskdata);
+    }
+}
+
+static int
+shadow_fixup_task_add(Slapi_PBlock *pb __attribute__((unused)),
+                      Slapi_Entry *e,
+                      Slapi_Entry *eAfter __attribute__((unused)),
+                      int *returncode,
+                      char *returntext __attribute__((unused)),
+                      void *arg)
+{
+    PRThread *thread = NULL;
+    Slapi_Task *task = NULL;
+    Slapi_DN *sdn = NULL;
+    task_data *mytaskdata = NULL;
+    char *suffix = NULL;
+    bool force = false;
+    mapping_tree_node *mtn = NULL;
+    int rc = SLAPI_DSE_CALLBACK_OK;
+
+    *returncode = LDAP_SUCCESS;
+
+    /* get our suffix */
+    suffix = slapi_entry_attr_get_charptr(e, "suffix");
+    if (suffix == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_task_add",
+            "Missing suffix attribute in task entry - aborting fix up task.\n");
+        *returncode = LDAP_UNWILLING_TO_PERFORM;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    sdn = slapi_sdn_new_dn_byval(suffix);
+    if (sdn == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_task_add",
+            "Specified suffix is not a valid DN: '%s' - aborting fix up task.\n",
+            suffix);
+        slapi_sdn_free(&sdn);
+        slapi_ch_free_string(&suffix);
+        *returncode = LDAP_UNWILLING_TO_PERFORM;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    mtn = slapi_get_mapping_tree_node_by_dn(sdn);
+    if (mtn == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_task_add",
+            "Failed to get mapping tree node for suffix: '%s' - aborting fix up task.\n",
+            suffix);
+        slapi_sdn_free(&sdn);
+        slapi_ch_free_string(&suffix);
+        *returncode = LDAP_UNWILLING_TO_PERFORM;
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    slapi_sdn_free(&sdn);
+
+    /* Are we forcing the fixup on all entries? */
+    force = slapi_entry_attr_get_bool_ext(e, "force", PR_FALSE);
+
+    mytaskdata = (task_data *)slapi_ch_calloc(1, sizeof(task_data));
+    if (mytaskdata == NULL) {
+        *returncode = LDAP_OPERATIONS_ERROR;
+        slapi_ch_free_string(&suffix);
+        return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    mytaskdata->suffix = suffix;
+    mytaskdata->force = force;
+
+    /* allocate new task now */
+    task = slapi_plugin_new_task(slapi_entry_get_ndn(e), arg);
+    slapi_task_set_destructor_fn(task, shadow_fixup_task_destructor);
+    slapi_task_set_data(task, (void *)mytaskdata);
+
+    /* start the sample task as a separate thread */
+    thread = PR_CreateThread(PR_USER_THREAD, shadow_fixup_task_thread,
+                             (void *)task, PR_PRIORITY_NORMAL, PR_GLOBAL_THREAD,
+                             PR_UNJOINABLE_THREAD, SLAPD_DEFAULT_THREAD_STACKSIZE);
+    if (thread == NULL) {
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_task_add",
+                      "Unable to create task thread!\n");
+        *returncode = LDAP_OPERATIONS_ERROR;
+        slapi_task_finish(task, *returncode);
+        rc = SLAPI_DSE_CALLBACK_ERROR;
+    } else {
+        rc = SLAPI_DSE_CALLBACK_OK;
+    }
+
+    return rc;
+}
+
+/* helper function to get max age from pwp policy (global or local) */
+static int64_t
+pwp_get_max_age(char *dn)
+{
+    if (config_get_pwpolicy_local() == 1) {
+        /* Return localpwp max age (if present) */
+        passwdPolicy *pwpolicy = NULL;
+        int64_t maxAge = 0;
+
+        pwpolicy = new_passwdPolicy(NULL, dn);
+        maxAge = pwpolicy->pw_maxage;
+        delete_passwdPolicy(&pwpolicy);
+        return maxAge;
+    } else {
+        /* Return global pwp max age */
+        return config_get_pw_maxage();
+    }
+}
+
+
+
+static void
+get_shadow_fixup_result(int rc, void *cb_data)
+{
+    /* We only record a failure so we can log that the task was incomplete */
+    if (rc != 0) {
+        ((shadow_fixup_callback_data *)cb_data)->rc = rc;
+    }
+}
+
+static int
+shadow_fixup_callback(Slapi_Entry *e, void *callback_data)
+{
+    Slapi_PBlock *mod_pb = NULL;
+    Slapi_Mods smods;
+    time_t cur_time;
+    time_t ctime;
+    int64_t lastChangeTime = -1;
+    char *pwdExpireTime = NULL;
+    char *timestr = NULL;
+    int rc = 0;
+    shadow_fixup_callback_data *cb_data = (shadow_fixup_callback_data *)callback_data;
+
+    if (slapi_is_shutting_down()) {
+        slapi_task_log_notice(cb_data->task,
+            "ShadowLastChange fixup task aborted due to server shutdown");
+        slapi_task_log_status(cb_data->task,
+            "ShadowLastChange fixup task aborted due to server shutdown");
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_callback",
+            "ShadowLastChange fixup task aborted due to server shutdown\n");
+        cb_data->rc = -1;
+        return -1;
+    }
+
+    if (!slapi_entry_attr_get_ref(e, "userpassword")) {
+        /* No userpassword, then there is nothing to fixup */
+        cb_data->skipped++;
+        return 0;
+    }
+    pwdExpireTime = (char *)slapi_entry_attr_get_ref(e, "passwordExpirationTime");
+    if (slapi_entry_attr_get_ref(e, "shadowLastChange")) {
+        lastChangeTime = slapi_entry_attr_get_longlong(e, "shadowLastChange");
+    }
+
+    if (lastChangeTime != -1 && pwdExpireTime && !cb_data->task_data->force) {
+        /* Check if the current ShadowlastChange time is stale. Determine
+         * the password update time by using passwordExpirationTime and pwp
+         * max age. If the ShadowlastChange time is stale, update it. */
+        int64_t maxAge = pwp_get_max_age(slapi_entry_get_dn(e));
+        time_t pwdUpdateTime = parse_genTime(pwdExpireTime);
+
+        if (pwdUpdateTime == NO_TIME || pwdUpdateTime == NOT_FIRST_TIME ||
+            (pwdUpdateTime - maxAge) / _SEC_PER_DAY == lastChangeTime)
+        {
+            /* ShadowLastChange time is correct, skip this entry */
+            cb_data->skipped++;
+            return 0;
+        } else {
+            timestr = slapi_ch_smprintf("%ld", (pwdUpdateTime - maxAge) / _SEC_PER_DAY);
+            cb_data->stale++;
+        }
+    } else if (lastChangeTime != -1 && !cb_data->task_data->force) {
+        /* ShadowLastChange time is present, skip this entry */
+        cb_data->skipped++;
+        return 0;
+    } else {
+        /* Build the timestamp for the shadowLastChange attribute */
+        cur_time = slapi_current_utc_time();
+        ctime = cur_time / _SEC_PER_DAY;
+        timestr = slapi_ch_smprintf("%ld", ctime);
+    }
+
+    /* Update the entry */
+    mod_pb = slapi_pblock_new();
+    slapi_mods_init(&smods, 0);
+    slapi_mods_add_string(&smods, LDAP_MOD_REPLACE, "shadowLastChange",
+                          timestr);
+
+    slapi_modify_internal_set_pb_ext(mod_pb, slapi_entry_get_sdn(e),
+                                     slapi_mods_get_ldapmods_byref(&smods),
+                                     NULL,
+                                     NULL,
+                                     pw_get_componentID(),
+                                     OP_FLAG_SKIP_MODIFIED_ATTRS |
+                                     OP_FLAG_ACTION_SKIP_PWDPOLICY);
+    slapi_modify_internal_pb(mod_pb);
+    slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &rc);
+    if (rc != LDAP_SUCCESS) {
+        slapi_log_err(SLAPI_LOG_WARNING, "shadow_fixup_task_thread",
+                      "Failed to update ShadowLastChange for entry: '%s' - error: %d\n",
+                      slapi_entry_get_dn(e), rc);
+        cb_data->skipped++;
+        cb_data->rc = rc;
+    } else {
+        cb_data->fixed++;
+    }
+    slapi_ch_free_string(&timestr);
+    slapi_mods_done(&smods);
+    slapi_pblock_destroy(mod_pb);
+
+    if ((cb_data->fixed + cb_data->skipped) % 1000 == 0) {
+        slapi_task_log_notice(cb_data->task,
+            "ShadowLastChange fixup task processed %d entries",
+            cb_data->fixed + cb_data->skipped);
+    }
+
+    return 0;
+}
+
+static void
+shadow_fixup_task_thread(void *arg)
+{
+    slapi_set_thread_name("shadow-fixup");
+    Slapi_PBlock *pb = slapi_pblock_new();
+    Slapi_Task *task = (Slapi_Task *)arg;
+    task_data *mytaskdata = NULL;
+    shadow_fixup_callback_data callback_data = {0};
+    char *attrs[] = {"shadowLastChange", "passwordExpirationTime", "userpassword", NULL};
+    int fixup_count = 0;
+    int skip_count = 0;
+    int stale_count = 0;
+    int result = 0;
+
+    slapi_task_inc_refcount(task);
+
+    /* Fetch our task data from the task */
+    mytaskdata = (task_data *)slapi_task_get_data(task);
+    callback_data.task = task;
+    callback_data.task_data = mytaskdata;
+
+    /* Log start message. */
+    slapi_task_begin(task, 1);
+    slapi_task_log_notice(task, "ShadowLastChange fixup task starting (suffix: \"%s\"%s) ...",
+                          mytaskdata->suffix, mytaskdata->force ? " (force)" : "");
+    slapi_log_err(SLAPI_LOG_INFO, "shadow_fixup_task_thread",
+                  "ShadowLastChange fixup task starting (suffix: \"%s\"%s) ...\n",
+                  mytaskdata->suffix, mytaskdata->force ? " (force)" : "");
+
+    /* Search for entries that contain objectclass ShadowAccount */
+    slapi_search_internal_set_pb(pb, mytaskdata->suffix, LDAP_SCOPE_SUBTREE,
+                                 "(objectclass=ShadowAccount)", attrs, 0, 0, 0,
+                                 (void *)pw_get_componentID(), 0);
+
+    slapi_search_internal_callback_pb(pb, &callback_data,
+                                      get_shadow_fixup_result,
+                                      shadow_fixup_callback, 0);
+
+    /* Gather our callback data */
+    result = callback_data.rc;
+    fixup_count = callback_data.fixed;
+    skip_count = callback_data.skipped;
+    stale_count = callback_data.stale;
+
+    if (mytaskdata->force) {
+        slapi_task_log_notice(task,
+                "ShadowLastChange fixup task finished. Updated %d entries, skipped %d entries.",
+                fixup_count, skip_count);
+        slapi_task_log_status(task,
+                "ShadowLastChange fixup task finished. Updated %d entries, skipped %d entries.",
+                fixup_count, skip_count);
+        slapi_log_err(SLAPI_LOG_INFO, "shadow_fixup_task_thread",
+                "ShadowLastChange fixup task finished.  Updated %d entries, skipped %d entries.\n",
+                fixup_count, skip_count);
+    } else {
+        slapi_task_log_notice(task,
+                "ShadowLastChange fixup task finished. Updated %d entries (%d stale shadowLastChange, %d missing shadowLastChange), skipped %d entries.",
+                fixup_count, stale_count, fixup_count - stale_count, skip_count);
+        slapi_task_log_status(task,
+                "ShadowLastChange fixup task finished. Updated %d entries (%d stale shadowLastChange, %d missing shadowLastChange), skipped %d entries.",
+                fixup_count, stale_count, fixup_count - stale_count, skip_count);
+        slapi_log_err(SLAPI_LOG_INFO, "shadow_fixup_task_thread",
+                "ShadowLastChange fixup task finished.  Updated %d entries (%d stale shadowLastChange, %d missing shadowLastChange), skipped %d entries.\n",
+                fixup_count, stale_count, fixup_count - stale_count, skip_count);
+    }
+    if (result != LDAP_SUCCESS) {
+        slapi_task_log_notice(task,
+                "ShadowLastChange fixup task was incomplete and may need to be rerun");
+        slapi_task_log_status(task,
+                "ShadowLastChange fixup task was incomplete and may need to be rerun");
+        slapi_log_err(SLAPI_LOG_ERR, "shadow_fixup_task_thread",
+                "ShadowLastChange fixup task was incomplete and may need to be rerun\n");
+    }
+    slapi_task_inc_progress(task);
+
+    slapi_pblock_destroy(pb);
+    slapi_task_finish(task, result);
+    slapi_task_dec_refcount(task);
 }

--- a/src/cockpit/389-console/src/css/ds.css
+++ b/src/cockpit/389-console/src/css/ds.css
@@ -269,11 +269,6 @@ textarea {
     float: left !important;
 }
 
-.ds-config-header {
-    margin-bottom: 30px;
-    text-align: center;
-}
-
 .ds-sub-header {
     margin-top: 10px !important;
     margin-bottom: 10px;

--- a/src/cockpit/389-console/src/database.jsx
+++ b/src/cockpit/389-console/src/database.jsx
@@ -10,6 +10,7 @@ import { Suffix } from "./lib/database/suffix.jsx";
 import { Backups } from "./lib/database/backups.jsx";
 import { GlobalPwPolicy } from "./lib/database/globalPwp.jsx";
 import { LocalPwPolicy } from "./lib/database/localPwp.jsx";
+import { PwpFixupTasks } from "./lib/database/pwpFixupTasks.jsx";
 import {
     Button,
     Card,
@@ -40,6 +41,7 @@ import {
     ExternalLinkAltIcon,
     KeyIcon,
     UsersIcon,
+    WrenchIcon,
 } from '@patternfly/react-icons';
 import { PropTypes } from "prop-types";
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
@@ -52,6 +54,7 @@ const CHAINING_CONFIG = "chaining-config";
 const BACKUP_CONFIG = "backups";
 const PWP_CONFIG = "pwpolicy";
 const LOCAL_PWP_CONFIG = "localpwpolicy";
+const PWP_FIXUP_TASK = "pwp-fixup";
 const BE_IMPL_BDB = "bdb";
 const BE_IMPL_MDB = "mdb";
 
@@ -655,6 +658,11 @@ export class Database extends React.Component {
                         icon: <UsersIcon />,
                         id: "localpwpolicy",
                     },
+                    {
+                        name: _("Fix-up Tasks"),
+                        icon: <WrenchIcon />,
+                        id: "pwp-fixup",
+                    },
                 ],
                 defaultExpanded: true
             },
@@ -805,6 +813,7 @@ export class Database extends React.Component {
             treeViewItem.id === "chaining-config" ||
             treeViewItem.id === "pwpolicy" ||
             treeViewItem.id === "localpwpolicy" ||
+            treeViewItem.id === "pwp-fixup" ||
             treeViewItem.id === "backups") {
             // Nothing special to do, these configurations have already been loaded
             this.setState(prevState => {
@@ -1582,6 +1591,14 @@ export class Database extends React.Component {
                         attrs={this.state.attributes}
                         pwdStorageSchemes={this.state.pwdStorageSchemes}
                         enableTree={this.enableTree}
+                    />
+                );
+            } else if (this.state.node_name === PWP_FIXUP_TASK) {
+                db_element = (
+                    <PwpFixupTasks
+                        serverId={this.props.serverId}
+                        addNotification={this.props.addNotification}
+                        suffixes={this.state.suffixList}
                     />
                 );
             } else if (this.state.node_name === BACKUP_CONFIG) {

--- a/src/cockpit/389-console/src/lib/database/backups.jsx
+++ b/src/cockpit/389-console/src/lib/database/backups.jsx
@@ -699,7 +699,7 @@ export class Backups extends React.Component {
         return (
             <div>
                 <TextContent>
-                    <Text className="ds-config-header" component={TextVariants.h2}>
+                    <Text component={TextVariants.h2}>
                         {_("Database Backups & LDIFs")}
                     </Text>
                 </TextContent>

--- a/src/cockpit/389-console/src/lib/database/chaining.jsx
+++ b/src/cockpit/389-console/src/lib/database/chaining.jsx
@@ -560,9 +560,9 @@ export class ChainingDatabaseConfig extends React.Component {
         return (
             <div id="chaining-page" className={this.state.saving ? "ds-disabled" : ""}>
                 <TextContent>
-                    <Text className="ds-config-header" component={TextVariants.h2}>{_("Database Chaining Settings")}</Text>
+                    <Text component={TextVariants.h2}>{_("Database Chaining Settings")}</Text>
                 </TextContent>
-                <Tabs className="ds-margin-top-xlg" activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
+                <Tabs className="ds-margin-top-lg" activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
                     <Tab eventKey={0} title={<TabTitleText>{_("Default Creation Settings")}</TabTitleText>}>
                         <div className="ds-indent ds-margin-bottom-md">
                             <Grid className="ds-margin-top-xlg">

--- a/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseConfig.jsx
@@ -825,7 +825,7 @@ export class GlobalDatabaseConfig extends React.Component {
                 {spinner}
                 <div className={this.props.loading ? 'ds-fadeout' : 'ds-fadein'}>
                     <TextContent>
-                        <Text className="ds-config-header" component={TextVariants.h2}>
+                        <Text component={TextVariants.h2}>
                             {_("Global Database Configuration")}
                             <Button
                                 variant="plain"
@@ -1816,7 +1816,7 @@ export class GlobalDatabaseConfigMDB extends React.Component {
                 {spinner}
                 <div className={this.props.loading ? 'ds-fadeout' : 'ds-fadein'}>
                     <TextContent>
-                        <Text className="ds-config-header" component={TextVariants.h2}>
+                        <Text component={TextVariants.h2}>
                             {_("Global Database Configuration")}
                             <Button
                                 variant="plain"

--- a/src/cockpit/389-console/src/lib/database/databaseModal.jsx
+++ b/src/cockpit/389-console/src/lib/database/databaseModal.jsx
@@ -7,6 +7,8 @@ import {
     FormHelperText,
     FormSelect,
     FormSelectOption,
+    HelperText,
+    HelperTextItem,
     Grid,
     GridItem,
     Modal,
@@ -14,8 +16,10 @@ import {
     TextInput,
     ValidatedOptions,
 } from "@patternfly/react-core";
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { LDIFTable } from "./databaseTables.jsx";
 import PropTypes from "prop-types";
+import { valid_dn } from "../tools.jsx";
 
 
 const _ = cockpit.gettext;
@@ -379,9 +383,10 @@ class ExportModal extends React.Component {
                     key="confirm"
                     variant="primary"
                     onClick={saveHandler}
+                    isDisabled={this.props.saveBtnDisabled || spinning}
                     isLoading={spinning}
-                    spinnerAriaValueText={spinning ? _("Exporting") : undefined}
-                    isDisabled={this.props.saveBtnDisabled || spinning} {...extraPrimaryProps}
+                    spinnerAriaValueText={spinning ? _("Exporting ...") : undefined}
+                    {...extraPrimaryProps}
                 >
                     {saveBtnName}
                 </Button>
@@ -509,6 +514,144 @@ class ImportModal extends React.Component {
     }
 }
 
+class ShadowFixupModal extends React.Component {
+
+    handleSelectChange = (value) => {
+        this.props.handleChange(value);
+    }
+
+    render() {
+        const {
+            showModal,
+            closeHandler,
+            handleChange,
+            saveHandler,
+            spinning,
+            item,
+            force,
+            suffix,
+            fixupCompleted,
+            suffixes
+        } = this.props;
+        let saveBtnName = _("Run Fix-Up task");
+        const extraPrimaryProps = {};
+        if (spinning) {
+            saveBtnName = _("Fixing ...");
+            extraPrimaryProps.spinnerAriaValueText = _("Fixing");
+        }
+
+        const actions = [];
+        if (!fixupCompleted) {
+            actions.push(
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    onClick={saveHandler}
+                    isLoading={spinning}
+                    spinnerAriaValueText={spinning ? _("Fixing ...") : undefined}
+                    isDisabled={suffix === ""  || !valid_dn(suffix) || spinning || fixupCompleted}
+                    {...extraPrimaryProps}
+                >
+                    {saveBtnName}
+                </Button>
+            );
+        }
+        actions.push(
+            <Button key="close" variant="link" onClick={closeHandler}>
+                {_("Close")}
+            </Button>
+        );
+
+
+        const placeHolder = "Choose a base suffix";
+        let suffixList = [placeHolder];
+        suffixList.push.apply(suffixList, suffixes);
+
+        return (
+            <Modal
+                variant={ModalVariant.small}
+                title={_("Run Shadow Account Fixup Task")}
+                isOpen={showModal}
+                onClose={closeHandler}
+                actions={actions}
+            >
+                <Form isHorizontal autoComplete="off">
+                    <Grid className="ds-margin-top-lg" title={_("Suffix to run the fix-up task on.")}>
+                        <GridItem className="ds-label" span={1}>
+                            {_("Suffix")}
+                        </GridItem>
+                        <GridItem offset={2} span={10}>
+                            <FormSelect
+                                id="fixupShadowSuffix"
+                                name="fixupShadowSuffix"
+                                value={suffix}
+                                onChange={(event, value) => handleChange(event)}
+                                aria-label="FormSelect Input"
+                                isDisabled={spinning || fixupCompleted}
+                            >
+                                {suffixList.map((suffixOption) => (
+                                    <FormSelectOption
+                                        key={suffixOption}
+                                        value={suffixOption === placeHolder ? "" : suffixOption}
+                                        label={suffixOption}
+                                        isDisabled={suffixOption === placeHolder}
+                                        isPlaceholder={suffixOption === placeHolder}
+                                    />
+                                ))}
+                            </FormSelect>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Branch to run the fix-up task on.")}>
+                        <GridItem offset={2} span={10}>
+                            <TextInput
+                                type="text"
+                                id="fixupShadowSuffixInput"
+                                aria-describedby="horizontal-form-name-helper"
+                                isDisabled={spinning || fixupCompleted}
+                                name="fixupShadowSuffix"
+                                value={suffix}
+                                onChange={(e, val) => {
+                                    handleChange(e);
+                                }}
+                                validated={!valid_dn(suffix) ? ValidatedOptions.error : ValidatedOptions.default}
+                            />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem
+                                        icon={suffix !== "" && !valid_dn(suffix) ? <ExclamationCircleIcon /> : undefined}
+                                        variant={suffix !== "" && !valid_dn(suffix) ? ValidatedOptions.error : ValidatedOptions.default}
+                                    >
+                                        {suffix !== "" && !valid_dn(suffix) ? _("Invalid DN syntax") : _("Required field")}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
+                        </GridItem>
+                    </Grid>
+                    <Grid title={_("Update all Shadow Account users regardless if they have ShadowLastChange attribute present")}>
+                        <GridItem span={12}>
+                            <Checkbox
+                                id="fixupShadowForce"
+                                name="fixupShadowForce"
+                                onChange={(e, checked) => {
+                                    handleChange(e);
+                                }}
+                                isChecked={force}
+                                isDisabled={spinning || fixupCompleted}
+                                label={_("Force update of all users")}
+                            />
+                        </GridItem>
+                    </Grid>
+                    {item}
+                </Form>
+            </Modal>
+        );
+    }
+}
+
+
+
+
+
 // Property types and defaults
 
 CreateLinkModal.propTypes = {
@@ -574,9 +717,34 @@ ImportModal.defaultProps = {
     suffix: ""
 };
 
+ShadowFixupModal.propTypes = {
+    showModal: PropTypes.bool,
+    closeHandler: PropTypes.func,
+    handleChange: PropTypes.func,
+    saveHandler: PropTypes.func,
+    spinning: PropTypes.bool,
+    item: PropTypes.node,
+    force: PropTypes.bool,
+    suffix: PropTypes.string,
+    fixupCompleted: PropTypes.bool,
+    suffixes: PropTypes.array
+};
+
+ShadowFixupModal.defaultProps = {
+    showModal: false,
+    error: {},
+    spinning: false,
+    item: null,
+    force: false,
+    suffix: "",
+    fixupCompleted: false,
+    suffixes: []
+};
+
 export {
     ImportModal,
     ExportModal,
     CreateSubSuffixModal,
     CreateLinkModal,
+    ShadowFixupModal,
 };

--- a/src/cockpit/389-console/src/lib/database/globalPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/globalPwp.jsx
@@ -1492,8 +1492,8 @@ export class GlobalPwPolicy extends React.Component {
                     <Tabs isFilled className="ds-margin-top-lg" activeKey={this.state.activeTabKey} onSelect={this.handleNavSelect}>
                         <Tab eventKey={0} title={<TabTitleText>{_("General Settings")}</TabTitleText>}>
                             <Form className="ds-margin-left-sm" isHorizontal autoComplete="off">
-                                <Grid className="ds-margin-top-xlg" title={_("Allow subtree/user defined local password policies (nsslapd-pwpolicy-local).")}>
-                                    <GridItem span={12}>
+                                <Grid className="ds-margin-top-xlg">
+                                    <GridItem span={6} title={_("Allow subtree/user defined local password policies (nsslapd-pwpolicy-local).")}>
                                         <Checkbox
                                             id="nsslapd-pwpolicy-local"
                                             isChecked={this.state['nsslapd-pwpolicy-local']}
@@ -1503,9 +1503,7 @@ export class GlobalPwPolicy extends React.Component {
                                             label={_("Allow Local Password Policies")}
                                         />
                                     </GridItem>
-                                </Grid>
-                                <Grid title={_("If a local password policy does not defined any syntax rules then inherit the local policy syntax (nsslapd-pwpolicy-inherit-global).")}>
-                                    <GridItem span={12}>
+                                    <GridItem span={6} title={_("If a local password policy does not defined any syntax rules then inherit the local policy syntax (nsslapd-pwpolicy-inherit-global).")}>
                                         <Checkbox
                                             id="nsslapd-pwpolicy-inherit-global"
                                             isChecked={this.state["nsslapd-pwpolicy-inherit-global"]}
@@ -1516,8 +1514,8 @@ export class GlobalPwPolicy extends React.Component {
                                         />
                                     </GridItem>
                                 </Grid>
-                                <Grid title={_("Allow anyone to add a prehashed password (nsslapd-allow-hashed-passwords).")}>
-                                    <GridItem span={12}>
+                                <Grid >
+                                    <GridItem span={6} title={_("Allow anyone to add a prehashed password (nsslapd-allow-hashed-passwords).")}>
                                         <Checkbox
                                             id="nsslapd-allow-hashed-passwords"
                                             isChecked={this.state["nsslapd-allow-hashed-passwords"]}
@@ -1527,9 +1525,7 @@ export class GlobalPwPolicy extends React.Component {
                                             label={_("Allow Adding Pre-Hashed Passwords")}
                                         />
                                     </GridItem>
-                                </Grid>
-                                <Grid title={_("Allow password policy state attributes to replicate (passwordIsGlobalPolicy).")}>
-                                    <GridItem span={12}>
+                                    <GridItem span={6} title={_("Allow password policy state attributes to replicate (passwordIsGlobalPolicy).")}>
                                         <Checkbox
                                             id="passwordisglobalpolicy"
                                             isChecked={this.state.passwordisglobalpolicy}
@@ -1540,8 +1536,8 @@ export class GlobalPwPolicy extends React.Component {
                                         />
                                     </GridItem>
                                 </Grid>
-                                <Grid title={_("Record a separate timestamp specifically for the last time that the password for an entry was changed. If this is enabled, then it adds the pwdUpdateTime operational attribute to the user account entry (passwordTrackUpdateTime).")}>
-                                    <GridItem span={12}>
+                                <Grid>
+                                    <GridItem span={6} title={_("Record a separate timestamp specifically for the last time that the password for an entry was changed. If this is enabled, then it adds the pwdUpdateTime operational attribute to the user account entry (passwordTrackUpdateTime).")}>
                                         <Checkbox
                                             id="passwordtrackupdatetime"
                                             isChecked={this.state.passwordtrackupdatetime}
@@ -1551,9 +1547,7 @@ export class GlobalPwPolicy extends React.Component {
                                             label={_("Track Password Update Time")}
                                         />
                                     </GridItem>
-                                </Grid>
-                                <Grid title={_("Allow user's to change their passwords (passwordChange).")}>
-                                    <GridItem span={12}>
+                                    <GridItem span={6} title={_("Allow user's to change their passwords (passwordChange).")}>
                                         <Checkbox
                                             id="passwordchange"
                                             isChecked={this.state.passwordchange}
@@ -1565,7 +1559,7 @@ export class GlobalPwPolicy extends React.Component {
                                     </GridItem>
                                 </Grid>
                                 <Grid title={_("User must change its password after its been reset by an administrator (passwordMustChange).")}>
-                                    <GridItem span={12}>
+                                    <GridItem span={6}>
                                         <Checkbox
                                             id="passwordmustchange"
                                             isChecked={this.state.passwordmustchange}
@@ -1575,9 +1569,7 @@ export class GlobalPwPolicy extends React.Component {
                                             label={_("User Must Change Password After Reset")}
                                         />
                                     </GridItem>
-                                </Grid>
-                                <Grid title={_("Maintain a password history for each user (passwordHistory).")}>
-                                    <GridItem span={12}>
+                                    <GridItem span={6} title={_("Maintain a password history for each user (passwordHistory).")}>
                                         <div className="ds-inline">
                                             <Checkbox
                                                 id="passwordhistory"
@@ -1604,11 +1596,32 @@ export class GlobalPwPolicy extends React.Component {
                                         </div>
                                     </GridItem>
                                 </Grid>
-                                <Grid className="ds-margin-top" title={_("Set the password storage scheme (passwordstoragescheme).")}>
-                                    <GridItem span={3} className="ds-label">
+                                <Grid
+                                    title={_("Indicates the number of seconds that must pass before a user can change their password again. (passwordMinAge).")}
+                                >
+                                    <GridItem className="ds-label" span={2}>
+                                        {_("Password Minimum Age")}
+                                    </GridItem>
+                                    <GridItem span={1}>
+                                        <TextInput
+                                            value={this.state.passwordminage}
+                                            type="number"
+                                            id="passwordminage"
+                                            aria-describedby="horizontal-form-name-helper"
+                                            name="passwordminage"
+                                            {...getValidationProps("passwordminage", this.state.invalidFields)}
+                                            onChange={(e, checked) => {
+                                                this.handleGeneralChange(e);
+                                            }}
+                                        />
+                                    </GridItem>
+                                    {renderValidationError("passwordminage", this.state.invalidFields)}
+                                </Grid>
+                                <Grid title={_("Set the password storage scheme (passwordstoragescheme).")}>
+                                    <GridItem span={2} className="ds-label">
                                         {_("Password Storage Scheme")}
                                     </GridItem>
-                                    <GridItem span={9}>
+                                    <GridItem span={3}>
                                         <FormSelect
                                             id="passwordstoragescheme"
                                             value={this.state.passwordstoragescheme}
@@ -1626,13 +1639,13 @@ export class GlobalPwPolicy extends React.Component {
                                             ))}
                                         </FormSelect>
                                     </GridItem>
-                                </Grid>
-                                {isPBKDF2Scheme(this.state.passwordstoragescheme) && (
-                                    <Grid title={_("Set the number of iterations to the password storage scheme plugin entry (nsslapd-pwdPBKDF2NumIterations).")}>
-                                        <GridItem className="ds-label" span={3}>
-                                            {_("PBKDF2 Iterations")}
-                                        </GridItem>
-                                        <GridItem span={9}>
+                                    <GridItem span={5} className={
+                                            !isPBKDF2Scheme(this.state.passwordstoragescheme) ?
+                                            "ds-hidden" :
+                                            "ds-margin-left"
+                                        }
+                                    >
+                                        <div className="ds-inline">
                                             <TextInput
                                                 value={this.state[password_storage_attrs[0]] || ''}
                                                 type="number"
@@ -1643,37 +1656,17 @@ export class GlobalPwPolicy extends React.Component {
                                                     this.handlePasswordStorageChange(e);
                                                 }}
                                             />
-                                        </GridItem>
-                                    </Grid>
-                                )}
-                                <Grid
-                                    title={_("Indicates the number of seconds that must pass before a user can change their password again. (passwordMinAge).")}
-                                >
-                                    <GridItem className="ds-label" span={3}>
-                                        {_("Password Minimum Age")}
+                                        </div>
+                                        <div className="ds-inline ds-left-margin ds-lower-field">
+                                            {_("Iterations")}
+                                        </div>
                                     </GridItem>
-                                    <GridItem span={9}>
-                                        <TextInput
-                                            value={this.state.passwordminage}
-                                            type="number"
-                                            id="passwordminage"
-                                            aria-describedby="horizontal-form-name-helper"
-                                            name="passwordminage"
-                                            {...getValidationProps("passwordminage", this.state.invalidFields)}
-                                            onChange={(e, checked) => {
-                                                this.handleGeneralChange(e);
-                                            }}
-                                        />
-                                    </GridItem>
-                                    {renderValidationError("passwordminage", this.state.invalidFields)}
                                 </Grid>
-                                <Grid
-                                    title={_("The DN for a password administrator or administrator group (passwordAdminDN).")}
-                                >
-                                    <GridItem className="ds-label" span={3}>
+                                <Grid>
+                                    <GridItem className="ds-label" span={2} title={_("The DN for a password administrator or administrator group (passwordAdminDN).")}>
                                         {_("Password Administrator")}
                                     </GridItem>
-                                    <GridItem span={9}>
+                                    <GridItem span={6}>
                                         <TextInput
                                             value={this.state.passwordadmindn}
                                             type="text"
@@ -1686,17 +1679,15 @@ export class GlobalPwPolicy extends React.Component {
                                         />
                                     </GridItem>
                                 </Grid>
-                                <Grid
-                                    title={_("Disable updating password state attributes like passwordExpirationtime, passwordHistory, etc, when setting a user's password as a Password Administrator (passwordAdminSkipInfoUpdate).")}
-                                >
-                                    <GridItem offset={3} span={9}>
+                                <Grid title={_("Disable updating password state attributes like passwordExpirationtime, passwordHistory, etc, when setting a user's password as a Password Administrator (passwordAdminSkipInfoUpdate).")}                                        >
+                                    <GridItem offset={2} span={10}>
                                         <Checkbox
                                             id="passwordadminskipinfoupdate"
                                             isChecked={this.state.passwordadminskipinfoupdate}
                                             onChange={(e, checked) => {
                                                 this.handleGeneralChange(e);
                                             }}
-                                            label={_("Do not update target entry's password state attributes")}
+                                            label={_("Do not update target password state attributes")}
                                         />
                                     </GridItem>
                                 </Grid>
@@ -1896,13 +1887,12 @@ export class GlobalPwPolicy extends React.Component {
                 <Grid>
                     <GridItem span={12}>
                         <TextContent>
-                            <Text component={TextVariants.h3}>
+                            <Text component={TextVariants.h2}>
                                 {_("Global Password Policy")}
                                 <Button
                                     variant="plain"
                                     aria-label={_("Refresh global password policy settings")}
                                     onClick={this.handleLoadGlobal}
-                                    className="ds-left-margin"
                                 >
                                     <SyncAltIcon />
                                 </Button>

--- a/src/cockpit/389-console/src/lib/database/localPwp.jsx
+++ b/src/cockpit/389-console/src/lib/database/localPwp.jsx
@@ -3421,7 +3421,7 @@ export class LocalPwPolicy extends React.Component {
                 <Grid>
                     <GridItem span={12}>
                         <TextContent>
-                            <Text component={TextVariants.h3}>
+                            <Text component={TextVariants.h2}>
                                 {_("Local Password Policies")}
                                 <Button
                                     variant="plain"

--- a/src/cockpit/389-console/src/lib/database/pwpFixupTasks.tsx
+++ b/src/cockpit/389-console/src/lib/database/pwpFixupTasks.tsx
@@ -1,0 +1,173 @@
+import cockpit from "cockpit";
+import * as React from "react";
+import {
+  ChangeEvent,
+  ComponentType,
+  FunctionComponent,
+  ReactNode,
+  useState,
+} from "react";
+import { log_cmd, getApiErrorMessage } from "../tools.jsx";
+import {
+  Button,
+  Text,
+  TextContent,
+  TextVariants,
+} from "@patternfly/react-core";
+import { LogViewer } from "@patternfly/react-log-viewer";
+import { ShadowFixupModal as ShadowFixupModalUntyped } from "./databaseModal.jsx";
+const _ = cockpit.gettext;
+
+type ShadowFixupModalProps = {
+  showModal: boolean;
+  closeHandler: () => void;
+  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  saveHandler: () => void;
+  spinning: boolean;
+  item: ReactNode | null;
+  force: boolean;
+  suffix: string;
+  fixupCompleted: boolean;
+  suffixes: string[];
+};
+
+const ShadowFixupModal =
+  ShadowFixupModalUntyped as unknown as ComponentType<ShadowFixupModalProps>;
+
+export const PwpFixupTasks: FunctionComponent<{
+  serverId: string;
+  addNotification: (type: string, message: string) => void;
+  suffixes: string[];
+}> = ({ serverId, addNotification, suffixes }) => {
+  const [modalSpinning, setModalSpinning] = useState(false);
+  const [fixupShadowModalOpen, setFixupShadowModalOpen] = useState(false);
+  const [fixupShadowSuffix, setFixupShadowSuffix] = useState("");
+  const [fixupShadowForce, setFixupShadowForce] = useState(false);
+  const [fixupCompleted, setFixupCompleted] = useState(false);
+  const [fixupBuffer, setFixupBuffer] = useState("");
+
+  const openFixUpModal = () => {
+    setFixupShadowModalOpen(true);
+    setFixupShadowSuffix("");
+    setFixupShadowForce(false);
+    setFixupCompleted(false);
+    setFixupBuffer("");
+  };
+
+  const closeFixUpModal = () => {
+    setFixupShadowModalOpen(false);
+  };
+
+  const handleFixUpChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value =
+      e.target.type === "checkbox" ? e.target.checked : e.target.value;
+    const attr = e.target.name;
+    if (attr === "fixupShadowForce") {
+      setFixupShadowForce(value as unknown as boolean);
+    } else {
+      setFixupShadowSuffix(value as unknown as string);
+    }
+  };
+
+  const doShadowFixup = () => {
+    // Do Fix-Up task
+    const fixup_cmd = [
+      "dsconf",
+      "-j",
+      "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+      "pwpolicy",
+      "fixup-shadow",
+      fixupShadowSuffix,
+      "--watch",
+    ];
+
+    if (fixupShadowForce) {
+      fixup_cmd.push("--force");
+    }
+
+    setModalSpinning(true);
+    setFixupBuffer("");
+    let buffer = "";
+
+    log_cmd("doShadowFixup", "Do shadow account fixup task", fixup_cmd);
+    const proc = cockpit.spawn(fixup_cmd, {
+      pty: true,
+      superuser: "require",
+      err: "message",
+    });
+    proc.stream((line: string) => {
+      buffer += line;
+      setFixupBuffer(buffer);
+    });
+    proc
+      .done(() => {
+        setModalSpinning(false);
+        setFixupCompleted(true);
+        addNotification(
+          "success",
+          _("Successfully ran shadow account fixup task"),
+        );
+      })
+      .fail((err: Error) => {
+        const errMsg = getApiErrorMessage(err);
+        addNotification(
+          "error",
+          cockpit.format(_("Error running fixup task - $0"), errMsg),
+        );
+        setModalSpinning(false);
+      });
+  };
+
+  let fixupItem: ReactNode | null = null;
+  if (fixupBuffer !== "") {
+    fixupItem = (
+      <LogViewer
+        data={fixupBuffer}
+        isTextWrapped={false}
+        hasLineNumbers={false}
+        scrollToRow={fixupBuffer.length}
+        height="200px"
+      />
+    );
+  }
+
+  return (
+    <div>
+      <TextContent>
+        <Text component={TextVariants.h2}>
+          {_("Password Policy Fix-up Tasks")}
+        </Text>
+      </TextContent>
+      <hr />
+      <TextContent className="ds-margin-top-xlg">
+        <Text component={TextVariants.h3}>
+          {_("Shadow Account Fix-up Task")}
+        </Text>
+        <Text className="ds-margin-top-lg ds-margin-left">
+          Run a fix-up task to update users with the ShadowAccount objectclass.
+          The task will add "ShadowLastChange" attribute to users that do not
+          have that attribute.
+        </Text>
+      </TextContent>
+      <Button
+        variant="primary"
+        className="ds-margin-top-lg ds-margin-left"
+        onClick={openFixUpModal}
+      >
+        {_("Run Shadow Fix-Up Task")}
+      </Button>
+      <ShadowFixupModal
+        showModal={fixupShadowModalOpen}
+        closeHandler={closeFixUpModal}
+        handleChange={handleFixUpChange}
+        saveHandler={doShadowFixup}
+        spinning={modalSpinning}
+        item={fixupItem}
+        force={fixupShadowForce}
+        suffix={fixupShadowSuffix}
+        fixupCompleted={fixupCompleted}
+        suffixes={suffixes}
+      />
+    </div>
+  );
+};

--- a/src/cockpit/389-console/tsconfig.json
+++ b/src/cockpit/389-console/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "baseUrl": ".",
+    "paths": {
+      "_internal/*": ["pkg/lib/cockpit/_internal/*"],
+      "cockpit": ["pkg/lib/cockpit.d.ts"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "pkg/lib/**/*.ts",
+    "pkg/lib/**/*.tsx",
+    "pkg/lib/**/*.d.ts"
+  ]
+}

--- a/src/lib389/lib389/_constants.py
+++ b/src/lib389/lib389/_constants.py
@@ -162,6 +162,7 @@ DN_FIXUP_LINKED_ATTIBUTES = "cn=fixup linked attributes,%s" % DN_TASKS
 DN_AUTOMEMBER_REBUILD_TASK = "cn=automember rebuild membership,%s" % DN_TASKS
 DN_AUTOMEMBER_ABORT_REBUILD_TASK = "cn=automember abort rebuild,%s" % DN_TASKS
 DN_COMPACTDB_TASK = "cn=compact db,%s" % DN_TASKS
+DN_SHADOW_FIXUP_TASKS = "cn=fixup shadow attributes,%s" % DN_TASKS
 
 # Script Constants
 LDIF2DB = 'ldif2db'

--- a/src/lib389/lib389/cli_conf/pwpolicy.py
+++ b/src/lib389/lib389/cli_conf/pwpolicy.py
@@ -252,6 +252,32 @@ def list_schemes(inst, basedn, log, args):
             log.info(scheme)
 
 
+def fixup_shadow_last_change(inst, basedn, log, args):
+    """Create the fixup shadow attributes task (shadowLastChange) and wait for it."""
+    log = log.getChild('fixup_shadow_last_change')
+    from lib389.tasks import ShadowFixupTask
+
+    if not args.watch:
+        log.info('Adding shadowLastChange fixup task for suffix "%s"%s ...',
+                 args.suffix, ' (force)' if args.force else '')
+
+    fixup_task = ShadowFixupTask(inst)
+    fixup_task.create(args.suffix, force=args.force)
+    if args.watch:
+        fixup_task.watch()
+    else:
+        fixup_task.wait()
+    result = fixup_task.get_exit_code()
+    warning = fixup_task.get_task_warn()
+
+    if result != 0:
+        raise ValueError(f'shadowLastChange fixup task {fixup_task.dn} exited with code {result}')
+    if warning:
+        log.warning('shadowLastChange fixup task completed with warning code %s', warning)
+
+    log.info('ShadowLastChange fixup task completed successfully')
+
+
 def create_parser(subparsers):
     # Create our two parsers for local and global policies
     globalpwp_parser = subparsers.add_parser('pwpolicy', help='Manage the global password policy settings', formatter_class=CustomHelpFormatter)
@@ -352,6 +378,20 @@ def create_parser(subparsers):
     # list password storage schemes
     list_scehmes_parser = global_subcommands.add_parser('list-schemes', help='Get a list of the current password storage schemes', formatter_class=CustomHelpFormatter)
     list_scehmes_parser.set_defaults(func=list_schemes)
+    # Fix up shadowLastChange on ShadowAccount entries under a suffix
+    fixup_shadow_parser = global_subcommands.add_parser(
+        'fixup-shadow',
+        help='Create a task to set shadowLastChange on ShadowAccount entries',
+        formatter_class=CustomHelpFormatter)
+    fixup_shadow_parser.set_defaults(func=fixup_shadow_last_change)
+    fixup_shadow_parser.add_argument(
+        'suffix', help='LDAP suffix to search (subtree) for objectClass ShadowAccount')
+    fixup_shadow_parser.add_argument(
+        '--force', action='store_true',
+        help='Update all users under the suffix regardless if shadowLastChange is set.')
+    fixup_shadow_parser.add_argument(
+        '--watch', action='store_true',
+        help='Watch the task\'s status and wait for it to finish.')
 
     #############################################
     # Wrap it up.  Now that we copied all the parent arguments to the subparsers,

--- a/src/lib389/lib389/tasks.py
+++ b/src/lib389/lib389/tasks.py
@@ -476,6 +476,27 @@ class RestoreTask(Task):
         super(RestoreTask, self).__init__(instance, dn)
 
 
+class ShadowFixupTask(Task):
+    """A single instance of shadow fixup task entry
+
+    :param instance: An instance
+    :type instance: lib389.DirSrv
+    """
+
+    def __init__(self, instance, dn=None):
+        self.cn = 'shadow_fixup_' + Task.get_timestamp()
+        dn = "cn=" + self.cn + "," + DN_SHADOW_FIXUP_TASKS
+        super(ShadowFixupTask, self).__init__(instance, dn)
+
+    def create(self, suffix, force=False):
+        """Fixup shadow attributes for a given suffix"""
+        _properties = {
+            'suffix': suffix,
+            'force': 'on' if force else 'off',
+        }
+        return super(ShadowFixupTask, self).create(properties=_properties)
+
+
 class Tasks(object):
     proxied_methods = 'search_s getEntry'.split()
 


### PR DESCRIPTION
Description:

ShadowAccount attributes are generated when a password is updated, but when users are imported these "shadow" attributes are not updated. We need a fixup tasks to set ShadowLastChange if it's missing, but also to fix the value if it is stale.

Design doc:

https://www.port389.org/docs/389ds/design/shadow-fixup-design.html

Relates: https://github.com/389ds/389-ds-base/issues/7493

## Summary by Sourcery

Add server-side and client tools to run a ShadowAccount shadowLastChange fixup task, with corresponding CLI, UI, and test coverage.

New Features:
- Introduce a background directory server task to scan ShadowAccount entries under a suffix and create or correct shadowLastChange values, with optional force mode.
- Expose the shadowLastChange fixup as a lib389 CLI subcommand and cockpit UI workflow, including a dedicated modal and task page for running and monitoring the task.

Enhancements:
- Add configuration accessors and password policy UI layout refinements, including improved PBKDF2 iteration controls and field alignment.
- Improve cockpit task buttons with loading indicators and error/helper text for DN validation, and update various headings for consistency.

Tests:
- Add an integration test exercising the shadowLastChange fixup task across missing, correct, stale, and forced-update scenarios in password policy tests.