### PR TITLE
Issue 7496 - Fix latest GCC compiler warnings

### DIFF
--- a/ldap/servers/plugins/acl/acl.c
+++ b/ldap/servers/plugins/acl/acl.c
@@ -3653,7 +3653,7 @@ static int
 acl__attr_cached_result(struct acl_pblock *aclpb, char *attr, int access)
 {
 
-    int i, rc;
+    int rc;
     aclEvalContext *c_evalContext;
 
     if (!(access & (SLAPI_ACL_SEARCH | SLAPI_ACL_READ)))
@@ -3670,17 +3670,15 @@ acl__attr_cached_result(struct acl_pblock *aclpb, char *attr, int access)
     }
 
     if (attr == NULL) {
-        int eval_read = 0;
         /*
         **  Do I have access to at least one attribute, then I have
         ** access to the  entry.
         */
-        for (i = 0; i < c_evalContext->acle_numof_attrs; i++) {
+        for (size_t i = 0; i < c_evalContext->acle_numof_attrs; i++) {
             AclAttrEval *a_eval = &c_evalContext->acle_attrEval[i];
 
             if ((access & SLAPI_ACL_READ) && a_eval->attrEval_r_status &&
                 a_eval->attrEval_r_status < ACL_ATTREVAL_DETERMINISTIC) {
-                eval_read++;
                 if (a_eval->attrEval_r_status & ACL_ATTREVAL_SUCCESS)
                     return LDAP_SUCCESS;
                 /* rbyrne: recompute if we have to.
@@ -3712,7 +3710,7 @@ acl__attr_cached_result(struct acl_pblock *aclpb, char *attr, int access)
         return (ACL_ERR);
     }
 
-    for (i = 0; i < c_evalContext->acle_numof_attrs; i++) {
+    for (size_t i = 0; i < c_evalContext->acle_numof_attrs; i++) {
         AclAttrEval *a_eval = &c_evalContext->acle_attrEval[i];
 
         if (a_eval == NULL)

--- a/ldap/servers/plugins/collation/orfilter.c
+++ b/ldap/servers/plugins/collation/orfilter.c
@@ -510,7 +510,7 @@ or_filter_create(Slapi_PBlock *pb)
         indexer_t *ix = NULL;
         int op = SLAPI_OP_EQUAL;
         struct berval bv;
-        int reusable = MRF_ANY_TYPE;
+        /* int reusable = MRF_ANY_TYPE; */
 
         slapi_log_err(SLAPI_LOG_FILTER, COLLATE_PLUGIN_SUBSYSTEM,
                       "or_filter_create - (oid %s; type %s)\n", mrOID, mrTYPE);
@@ -552,7 +552,7 @@ or_filter_create(Slapi_PBlock *pb)
                     ix = indexer_create(or_oid);
                     if (ix != NULL) {
                         memcpy(&bv, mrVALUE, sizeof(struct berval));
-                        reusable |= MRF_ANY_VALUE;
+                        /* reusable |= MRF_ANY_VALUE; */
                     }
                     slapi_ch_free((void **)&or_oid);
                 } break;

--- a/ldap/servers/plugins/cos/cos_cache.c
+++ b/ldap/servers/plugins/cos/cos_cache.c
@@ -3075,7 +3075,6 @@ static int
 cos_cache_cmp_attr(cosAttributes *pAttr, Slapi_Value *test_this, int *result)
 {
     int ret = 0;
-    int index = 0;
     cosAttrValue *pAttrVal = pAttr->pAttrValue;
     char *the_cmp = (char *)slapi_value_get_string(test_this);
 
@@ -3092,7 +3091,6 @@ cos_cache_cmp_attr(cosAttributes *pAttr, Slapi_Value *test_this, int *result)
         }
 
         pAttrVal = pAttrVal->list.pNext;
-        index++;
     }
 
     slapi_log_err(SLAPI_LOG_TRACE, COS_PLUGIN_SUBSYSTEM, "<-- cos_cache_cmp_attr\n");
@@ -3109,7 +3107,6 @@ static int
 cos_cache_cos_2_slapi_valueset(cosAttributes *pAttr, Slapi_ValueSet **out_vs)
 {
     int ret = 0;
-    int index = 0;
     cosAttrValue *pAttrVal = pAttr->pAttrValue;
     int add_mode = 0;
     static Slapi_Attr *attr = 0; /* allocated once, never freed */
@@ -3148,7 +3145,6 @@ cos_cache_cos_2_slapi_valueset(cosAttributes *pAttr, Slapi_ValueSet **out_vs)
             }
 
             pAttrVal = pAttrVal->list.pNext;
-            index++;
         }
     } else {
         slapi_log_err(SLAPI_LOG_ERR, COS_PLUGIN_SUBSYSTEM, "cos_cache_cos_2_slapi_valueset - "

--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -3557,7 +3557,6 @@ merge_ancestors(Slapi_Value **member_ndn_val, memberof_get_groups_data *v1, memb
     Slapi_ValueSet *v1_groupvals = *((memberof_get_groups_data *)v1)->groupvals;
     Slapi_ValueSet *v2_groupvals = *((memberof_get_groups_data *)v2)->groupvals;
     Slapi_ValueSet *v2_group_norm_vals = *((memberof_get_groups_data *)v2)->group_norm_vals;
-    int merged_cnt = 0;
 
 #if MEMBEROF_CACHE_DEBUG
     {
@@ -3609,7 +3608,6 @@ merge_ancestors(Slapi_Value **member_ndn_val, memberof_get_groups_data *v1, memb
 #endif
                     slapi_valueset_add_value_ext(v2_groupvals, sval_dn, SLAPI_VALUE_FLAG_PASSIN);
                     slapi_valueset_add_value_ext(v2_group_norm_vals, sval_ndn, SLAPI_VALUE_FLAG_PASSIN);
-                    merged_cnt++;
                 } else {
 /* This ancestor was already present, free sval_ndn/sval_dn that will not be consumed */
 #if MEMBEROF_CACHE_DEBUG

--- a/ldap/servers/plugins/replication/urp_tombstone.c
+++ b/ldap/servers/plugins/replication/urp_tombstone.c
@@ -59,7 +59,7 @@ get_valid_parent_for_conflict(Slapi_Entry *entry)
     Slapi_DN *valid_DN = NULL;
 
     if (replconflict) {
-        validdn = strstr(replconflict, " (ADD) ");
+        validdn = (char *)strstr(replconflict, " (ADD) ");
         if (validdn) {
             validdn += 7;
             valid_DN = slapi_sdn_new_dn_byval(validdn);
@@ -209,7 +209,7 @@ conflict_to_tombstone(char *sessionid, Slapi_Entry *entry, CSN *opcsn)
     const char *replconflict = slapi_entry_attr_get_ref(entry, ATTR_NSDS5_REPLCONFLICT);
 
     if (replconflict) {
-        conflictdn = strstr(replconflict, " (ADD) ");
+        conflictdn = (char *)strstr(replconflict, " (ADD) ");
         if (conflictdn == NULL) {
             /* error, wrong type of conflict */
             op_result = 1;

--- a/ldap/servers/plugins/replication/windows_protocol_util.c
+++ b/ldap/servers/plugins/replication/windows_protocol_util.c
@@ -3364,8 +3364,8 @@ static char *
 extract_guid_from_tombstone_dn(const char *dn)
 {
     char *guid = NULL;
-    char *colon_offset = NULL;
-    char *comma_offset = NULL;
+    const char *colon_offset = NULL;
+    const char *comma_offset = NULL;
 
     /* example DN of tombstone:
         "CN=WDel Userdb1\\\nDEL:551706bc-ecf2-4b38-9284-9a8554171d69,CN=Deleted Objects,DC=magpie,DC=com" */

--- a/ldap/servers/plugins/uiduniq/uid.c
+++ b/ldap/servers/plugins/uiduniq/uid.c
@@ -1030,7 +1030,7 @@ preop_add(Slapi_PBlock *pb)
     }
 
     for (i = 0; attrNames && attrNames[i]; i++) {
-        char *attr_match = strchr(attrNames[i], ':');
+        char *attr_match = (char *)strchr(attrNames[i], ':');
         if (attr_match != NULL) {
             attr_match[0] = '\0';
         }
@@ -1178,7 +1178,7 @@ preop_modify(Slapi_PBlock *pb)
     for (; mods && *mods; mods++) {
         mod = *mods;
         for (i = 0; attrNames && attrNames[i]; i++) {
-            char *attr_match = strchr(attrNames[i], ':');
+            char *attr_match = (char *)strchr(attrNames[i], ':');
             if (attr_match != NULL) {
                 attr_match[0] = '\0';
             }

--- a/ldap/servers/slapd/attr.c
+++ b/ldap/servers/slapd/attr.c
@@ -323,7 +323,7 @@ slapi_attr_init_locking_optional(Slapi_Attr *a, const char *type, PRBool use_loc
             asi = attr_syntax_get_by_name_locking_optional(
                 ATTR_WITH_OCTETSTRING_SYNTAX, use_lock, 0);
         } else {
-            char *attroptions = NULL;
+            const char *attroptions = NULL;
 
             if (NULL != type) {
                 attroptions = strchr(type, ';');

--- a/ldap/servers/slapd/attrsyntax.c
+++ b/ldap/servers/slapd/attrsyntax.c
@@ -579,7 +579,7 @@ attr_syntax_exists(const char *attr_name)
 {
     struct asyntaxinfo *asi;
     char *check_attr_name = NULL;
-    char *p = NULL;
+    const char *p = NULL;
     int free_attr = 0;
 
     /* Ignore any attribute subtypes. */

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -7310,7 +7310,7 @@ int bdb_walk_dbfiles (const char *directory, const char *subdir,
             if (strncmp(DB_REGION_PREFIX, direntry->name, len) == 0) {
                 continue;
             }
-            pt = strrchr (direntry->name, *LDBM_FILENAME_SUFFIX);
+            pt = (char *)strrchr (direntry->name, *LDBM_FILENAME_SUFFIX);
             if (!pt || strcmp (pt, LDBM_FILENAME_SUFFIX)) {
                 continue;
             }

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -489,10 +489,9 @@ extensible_candidates(
                  * Search the index, for the computed keys.
                  * Collect the resulting IDs in idl.
                  */
-                size_t n;
                 struct berval **val;
                 mrTYPE = slapi_attr_basetype(mrTYPE, NULL, 0);
-                for (n = 0, val = mrVALUES; *val; ++n, ++val) {
+                for (val = mrVALUES; *val; ++val) {
                     struct berval **keys = NULL;
                     /* keys = mrINDEX (*val), conceptually.  In detail: */
                     struct berval *bvec[2];

--- a/ldap/servers/slapd/configdse.c
+++ b/ldap/servers/slapd/configdse.c
@@ -506,7 +506,7 @@ postop_modify_config_dse(Slapi_PBlock *pb,
     static int num_requires_restart = sizeof(requires_restart) / sizeof(char *);
     LDAPMod **mods;
     int i, j;
-    char *p;
+    const char *p;
 
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &mods);
     returntext[0] = '\0';

--- a/ldap/servers/slapd/connection.c
+++ b/ldap/servers/slapd/connection.c
@@ -1721,7 +1721,6 @@ connection_threadmain(void *arg)
     int replication_connection = 0; /* If this connection is from a replication supplier, we want to ensure that operation processing is serialized */
     int doshutdown = 0;
     int maxthreads = 0;
-    long bypasspollcnt = 0;
     bool is_busy = false;
 
 #if defined(hpux)
@@ -1992,7 +1991,6 @@ connection_threadmain(void *arg)
                  * so need locking from here on */
                 signal_listner(conn->c_ct_list);
             } else { /* more data in conn - just put back on work_q - bypass poll */
-                bypasspollcnt++;
                 pthread_mutex_lock(&(conn->c_mutex));
                 /* don't do this if it would put us over the max threads per conn */
                 if (conn->c_threadnumber < maxthreads) {

--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -1589,7 +1589,7 @@ slapi_dn_find_parent_ext(const char *dn, int is_tombstone)
                                  sizeof(RUV_STORAGE_ENTRY_UNIQUEID) - 1)) {
                 head = (char *)dn;
             } else {
-                head = strchr(dn, ',');
+                head = (char *)strchr(dn, ',');
                 if (head) {
                     head++;
                 } else {

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -188,8 +188,6 @@ str2entry_fast(const char *rawdn, const Slapi_RDN *srdn, const char *s, int flag
     Slapi_Entry *e;
     const char *next;
     char *ptype = NULL;
-    int nvals = 0;
-    int del_nvals = 0;
     unsigned long attr_val_cnt = 0;
     CSN *attributedeletioncsn = NULL; /* Moved to this level so that the JCM csn_free call below gets useful */
     CSNSet *valuecsnset = NULL;       /* Moved to this level so that the JCM csn_free call below gets useful */
@@ -286,8 +284,6 @@ str2entry_fast(const char *rawdn, const Slapi_RDN *srdn, const char *s, int flag
         if ((ptype == NULL) || (PL_strcasecmp(type.bv_val, ptype) != 0)) {
             slapi_ch_free_string(&ptype);
             ptype = PL_strndup(type.bv_val, type.bv_len);
-            nvals = 0;
-            del_nvals = 0;
             a = NULL;
         }
 
@@ -491,7 +487,6 @@ str2entry_fast(const char *rawdn, const Slapi_RDN *srdn, const char *s, int flag
                     &(*a)->a_deleted_values,
                     svalue,
                     SLAPI_VALUE_FLAG_PASSIN);
-                del_nvals++;
             } else {
                 /* consumes the value */
                 slapi_valueset_add_attr_value_ext(
@@ -499,7 +494,6 @@ str2entry_fast(const char *rawdn, const Slapi_RDN *srdn, const char *s, int flag
                     &(*a)->a_present_values,
                     svalue,
                     SLAPI_VALUE_FLAG_PASSIN);
-                nvals++;
             }
             if (attributedeletioncsn != NULL) {
                 attr_set_deletion_csn(*a, attributedeletioncsn);

--- a/ldap/servers/slapd/ldaputil.c
+++ b/ldap/servers/slapd/ldaputil.c
@@ -250,11 +250,11 @@ slapi_ldap_url_parse(const char *url, LDAPURLDesc **ludpp, int require_dn, int *
        replace all but the last colon with %3A
        Go to the 3rd '/' or to the end of the string (convert only the host:port part) */
     if (url) {
-        char *p = strstr(url, "://");
+        const char *p = strstr(url, "://");
         if (p) {
             int foundspace = 0;
             int coloncount = 0;
-            char *lastcolon = NULL;
+            const char *lastcolon = NULL;
 
             p += 3;
             for (; *p && (*p != '/'); p++) {
@@ -273,7 +273,7 @@ slapi_ldap_url_parse(const char *url, LDAPURLDesc **ludpp, int require_dn, int *
                 urlescaped = slapi_ch_calloc(strlen(url) * 3, sizeof(char));
                 dest = urlescaped;
                 /* copy the scheme */
-                src = strstr(url, "://");
+                src = (char *)strstr(url, "://");
                 src += 3;
                 memcpy(dest, url, src - url);
                 dest += (src - url);
@@ -531,7 +531,7 @@ setup_ol_tls_conn(LDAP *ld, int clientauth)
     if (rc != LDAP_SUCCESS) {
         rc = slapi_ldap_get_lderrno(ld, NULL, &errmsg);
         slapi_log_err(SLAPI_LOG_ERR, "setup_ol_tls_conn",
-                      "failed: unable to set REQUIRE_CERT option to %d: %d (%s) %s\n", 
+                      "failed: unable to set REQUIRE_CERT option to %d: %d (%s) %s\n",
                       ssl_strength, rc, ldap_err2string(rc), errmsg ? errmsg : "");
         slapi_ch_free_string(&errmsg);
     }
@@ -572,7 +572,7 @@ setup_ol_tls_conn(LDAP *ld, int clientauth)
     if (rc != LDAP_SUCCESS) {
         rc = slapi_ldap_get_lderrno(ld, NULL, &errmsg);
         slapi_log_err(SLAPI_LOG_ERR, "setup_ol_tls_conn",
-                      "failed: unable to set CACERTDIR option to %s: %d (%s) %s\n", 
+                      "failed: unable to set CACERTDIR option to %s: %d (%s) %s\n",
                       certdir, rc, ldap_err2string(rc), errmsg ? errmsg : "");
         slapi_ch_free_string(&errmsg);
     }
@@ -585,7 +585,7 @@ setup_ol_tls_conn(LDAP *ld, int clientauth)
         (void)getSSLVersionRange(&minstr, NULL);
         rc = slapi_ldap_get_lderrno(ld, NULL, &errmsg);
         slapi_log_err(SLAPI_LOG_ERR, "setup_ol_tls_conn",
-                      "failed: unable to set minimum TLS protocol level to %s: %d (%s) %s\n", 
+                      "failed: unable to set minimum TLS protocol level to %s: %d (%s) %s\n",
                       minstr, rc, ldap_err2string(rc), errmsg ? errmsg : "");
         slapi_ch_free_string(&minstr);
         slapi_ch_free_string(&errmsg);
@@ -596,7 +596,7 @@ setup_ol_tls_conn(LDAP *ld, int clientauth)
         if (rc != LDAP_SUCCESS) {
             rc = slapi_ldap_get_lderrno(ld, NULL, &errmsg);
             slapi_log_err(SLAPI_LOG_ERR, "setup_ol_tls_conn",
-                          "failed: unable to setup connection for TLS/SSL EXTERNAL client cert authentication: %d (%s) %s\n", 
+                          "failed: unable to setup connection for TLS/SSL EXTERNAL client cert authentication: %d (%s) %s\n",
                           rc, ldap_err2string(rc), errmsg ? errmsg : "");
             slapi_ch_free_string(&errmsg);
         }
@@ -610,7 +610,7 @@ setup_ol_tls_conn(LDAP *ld, int clientauth)
     if (rc != LDAP_SUCCESS) {
         rc = slapi_ldap_get_lderrno(ld, NULL, &errmsg);
         slapi_log_err(SLAPI_LOG_ERR, "setup_ol_tls_conn",
-                      "failed: unable to create new TLS context: %d (%s) %s\n", 
+                      "failed: unable to create new TLS context: %d (%s) %s\n",
                       rc, ldap_err2string(rc), errmsg ? errmsg : "");
         slapi_ch_free_string(&errmsg);
     }

--- a/ldap/servers/slapd/log.c
+++ b/ldap/servers/slapd/log.c
@@ -4994,7 +4994,7 @@ log__fix_rotationinfof(char *pathname)
                 break;
             }
         } else if (0 == strncmp(log_type, dirent->name, strlen(log_type)) &&
-                   (p = strchr(dirent->name, '.')) != NULL &&
+                   (p = (char *)strchr(dirent->name, '.')) != NULL &&
                    NULL != strchr(p, '-')) /* e.g., errors.20051123-165135 or errors.20051123-165135.gz */
         {
             struct logfileinfo *logp;
@@ -5174,7 +5174,7 @@ log__check_prevlogs(FILE *fp, char *pathname)
     for (dirent = PR_ReadDir(dirptr, dirflags); dirent;
          dirent = PR_ReadDir(dirptr, dirflags)) {
         if (0 == strncmp(log_type, dirent->name, strlen(log_type)) &&
-            (p = strchr(dirent->name, '.')) != NULL &&
+            (p = (char *)strchr(dirent->name, '.')) != NULL &&
             NULL != strchr(p, '-')) { /* e.g., errors.20051123-165135 or errors.20051123-165135.gz */
             PRBool is_compressed = PR_FALSE;
 

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -985,17 +985,11 @@ pw_sequence(const char *new, int32_t max_seq)
 static int
 pw_max_class_repeats(const char *new, int32_t max_repeats)
 {
-    int digits = 0;
-    int uppers = 0;
-    int lowers = 0;
-    int others = 0;
-    int i;
     enum { NONE, DIGIT, UCASE, LCASE, OTHER } prevclass = NONE;
     int sameclass = 0;
 
-    for (i = 0; new[i]; i++) {
+    for (size_t i = 0; new[i]; i++) {
         if (isdigit(new[i])) {
-            digits++;
             if (prevclass != DIGIT) {
                 prevclass = DIGIT;
                 sameclass = 1;
@@ -1003,7 +997,6 @@ pw_max_class_repeats(const char *new, int32_t max_repeats)
                 sameclass++;
             }
         } else if (isupper (new[i])) {
-            uppers++;
             if (prevclass != UCASE) {
                 prevclass = UCASE;
                 sameclass = 1;
@@ -1011,7 +1004,6 @@ pw_max_class_repeats(const char *new, int32_t max_repeats)
                 sameclass++;
             }
         } else if (islower (new[i])) {
-            lowers++;
             if (prevclass != LCASE) {
                 prevclass = LCASE;
                 sameclass = 1;
@@ -1019,7 +1011,6 @@ pw_max_class_repeats(const char *new, int32_t max_repeats)
                 sameclass++;
             }
         } else {
-            others++;
             if (prevclass != OTHER) {
                 prevclass = OTHER;
                 sameclass = 1;

--- a/ldap/servers/slapd/slapi-memberof.c
+++ b/ldap/servers/slapd/slapi-memberof.c
@@ -388,7 +388,6 @@ sm_merge_ancestors(Slapi_Value **member_ndn_val, sm_memberof_get_groups_data *v1
     Slapi_ValueSet *v2_group_norm_vals = *((sm_memberof_get_groups_data *) v2)->group_norm_vals;
     Slapi_ValueSet *v1_nsuniqueidvals = *((sm_memberof_get_groups_data *) v1)->nsuniqueidvals;
     Slapi_ValueSet *v2_nsuniqueidvals = *((sm_memberof_get_groups_data *) v2)->nsuniqueidvals;
-    int merged_cnt = 0;
 
     hint = slapi_valueset_first_value(v1_groupvals, &sval);
     hint_nsuniqueid = slapi_valueset_first_value(v1_nsuniqueidvals, &sval_2);
@@ -412,7 +411,6 @@ sm_merge_ancestors(Slapi_Value **member_ndn_val, sm_memberof_get_groups_data *v1
                     slapi_valueset_add_value_ext(v2_groupvals, sval_dn, SLAPI_VALUE_FLAG_PASSIN);
                     slapi_valueset_add_value_ext(v2_group_norm_vals, sval_ndn, SLAPI_VALUE_FLAG_PASSIN);
                     slapi_valueset_add_value_ext(v2_nsuniqueidvals, sval_nsuniqueid, SLAPI_VALUE_FLAG_PASSIN);
-                    merged_cnt++;
                 } else {
                     /* This ancestor was already present, free sval_ndn/sval_dn that will not be consumed */
 #if MEMBEROF_CACHE_DEBUG

--- a/ldap/servers/slapd/ssl.c
+++ b/ldap/servers/slapd/ssl.c
@@ -1051,7 +1051,6 @@ slapd_nss_init(int init_ssl __attribute__((unused)), int config_available __attr
     int rv = 0;
     int len = 0;
     int create_certdb = 0;
-    PRUint32 nssFlags = 0;
     char *certdir;
     char dmin[VERSION_STR_LENGTH], dmax[VERSION_STR_LENGTH];
     char smin[VERSION_STR_LENGTH], smax[VERSION_STR_LENGTH];
@@ -1117,7 +1116,6 @@ slapd_nss_init(int init_ssl __attribute__((unused)), int config_available __attr
 
     /******** Initialise NSS *********/
 
-    nssFlags &= (~NSS_INIT_READONLY);
     slapd_pk11_configurePKCS11(NULL, NULL, tokPBE, ptokPBE, NULL, NULL, NULL, NULL, 0, 0);
     secStatus = NSS_InitReadWrite(certdir);
 

--- a/ldap/servers/slapd/tools/ldclt/ldapfct.c
+++ b/ldap/servers/slapd/tools/ldclt/ldapfct.c
@@ -316,7 +316,7 @@ ldclt_dirname(const char *path)
     char sep = PR_GetDirectorySeparator();
     char *ptr = NULL;
     char *ret = NULL;
-    if (path && ((ptr = strrchr(path, sep))) && *(ptr + 1)) {
+    if (path && ((ptr = (char *)strrchr(path, sep))) && *(ptr + 1)) {
         ret = PL_strndup(path, ptr - path);
     } else {
         ret = PL_strdup(".");


### PR DESCRIPTION
Description:

Fix latest GCC (gcc-16.1.1-1) compiler warnings

relates: https://github.com/389ds/389-ds-base/issues/7496

## Summary by Sourcery

Address GCC 16 compiler warnings by tightening pointer const-correctness, cleaning up unused variables, and making minor logging/string-handling adjustments.

Enhancements:
- Add explicit casts for uses of strchr/strrchr/strstr and similar functions where results are stored in non-const pointers.
- Remove unused counters, indexes, and variables across password policy, ACL, COS, memberOf, connection handling, and SSL initialization code to satisfy -Wall/-Wextra diagnostics.
- Adjust loop indices and variable types (e.g., using size_t in array iterations) to avoid signed/unsigned and unused-variable warnings.
- Update attribute and configuration handling code to use const-qualified pointers where appropriate, improving const-correctness and reducing warnings.