### PR TITLE
Issue 7402 - remove debug print state

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/healthcheck_test.py
@@ -750,7 +750,6 @@ def test_lint_backend_implementation_wrong_files(topology_st):
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 
     inst.stop()
-    print("DEBUG trying test with server stopped!!!!!!!!")
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=False)
     run_healthcheck_and_flush_log(topology_st.logcap, inst, RET_CODE, json=True)
 


### PR DESCRIPTION
Description:

Remove debugging print state from offline healthcheck commit

relates: https://github.com/389ds/389-ds-base/issues/7402

## Summary by Sourcery

Tests:
- Remove an unnecessary debug print statement from the offline healthcheck test.