### PR TITLE
Issue 7500 - Prevent unsigned integer underflow during stalled import

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import.c
@@ -1765,16 +1765,28 @@ bdb_import_monitor_threads(ImportJob *job, int *status)
             /* Now calculate our rate of progress overall for this chunk */
             if (time_now != job->start_time) {
                 /* log a cute chart of the worker progress */
+                uint32_t history_size = 0;
+                double rate = 0.0;
+
                 bdb_import_log_status_start(job);
                 bdb_import_log_status_add_line(job,
-                                           "Index status for import of %s:", job->inst->inst_name);
+                                               "Index status for import of %s:",
+                                               job->inst->inst_name);
                 bdb_import_log_status_add_line(job,
-                                           "-------Index Task-------State---Entry----Rate-");
+                        "-------Index Task-------State---Entry----Rate-");
 
                 bdb_import_push_progress_history(job, foreman->last_ID_processed,
-                                             time_now);
-                job->average_progress_rate =
-                    (double)(HISTORY(IMPORT_JOB_PROG_HISTORY_SIZE - 1) + 1 - foreman->first_ID) /
+                                                 time_now);
+
+                history_size = HISTORY(IMPORT_JOB_PROG_HISTORY_SIZE - 1) + 1;
+                if (foreman->first_ID > history_size) {
+                    /* Import is stalled and subtracting first_ID will
+                     * underflow the rate - so set it to 0.0 */
+                    rate = 0.0;
+                } else {
+                    rate = (double)(history_size - foreman->first_ID);
+                }
+                job->average_progress_rate = rate /
                     (double)(TIMES(IMPORT_JOB_PROG_HISTORY_SIZE - 1) - job->start_time);
                 job->recent_progress_rate =
                     PROGRESS(0, IMPORT_JOB_PROG_HISTORY_SIZE - 1);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -586,7 +586,6 @@ dbmdb_import_monitor_threads(ImportJob *job, int *status)
     int count = 1; /* 1 to prevent premature status report */
     const int display_interval = 200;
     time_t time_now = 0;
-    int i = 0;
 
     for (current_worker = job->worker_list; current_worker != NULL;
          current_worker = current_worker->next)
@@ -615,12 +614,13 @@ dbmdb_import_monitor_threads(ImportJob *job, int *status)
     dbmdb_import_clear_progress_history(job);
 
     while (!finished) {
+        size_t max_slots = ctx->workerq.max_slots;
         DS_Sleep(tenthsecond);
         finished = 1;
 
         /* Compute the number of entries processed by the workers */
         entry_processed = 0;
-        for (i=0; i<ctx->workerq.max_slots; i++) {
+        for (size_t i = 0; i < max_slots; i++) {
             entry_processed += slots[i].count;
         }
 


### PR DESCRIPTION
Description:

During a stalled import the foreman's first ID could be greater than the history progress size which leads to underflowing the rate. Check if the foreman's first ID is greater than the progress size and just set it to zero.

Only affects BDB.

Relates: https://github.com/389ds/389-ds-base/issues/7500

## Summary by Sourcery

Prevent unsigned underflow in BDB import progress rate calculation and tighten MDB import worker slot iteration.

Bug Fixes:
- Guard BDB import progress rate calculation against cases where the foreman first ID exceeds the progress history size, avoiding unsigned underflow during stalled imports.

Enhancements:
- Use a size_t loop index when aggregating MDB worker slot entry counts to better match the slots array bounds type.