### PR TITLE
Issue 7468 - RFE - HIBP response caching

### DIFF
--- a/ldap/servers/slapd/hibp.h
+++ b/ldap/servers/slapd/hibp.h
@@ -11,39 +11,80 @@
 #include "slap.h"
 
 /*
- * Function pointer for pluggable SHA-1 implementation
- * Allows for different hash implementations (FIPS vs non FIPS)
+ * Core HIBP API
  */
-typedef int (*hibp_hash_fn)(const char *input, size_t len, unsigned char *digest);
-
-/* Set the hash provider, called during initialisation */
-void hibp_set_hash_provider(hibp_hash_fn fn);
 
 /* Initialise the HIBP subsystem */
 int hibp_init(void);
 
+/* Shutdown the HIBP subsystem */
+void hibp_shutdown(void);
+
 /*
  * Check if password appears in breach database
+ *
  * Returns: >0 = breach count, 0 = not found, -1 = error
  */
 int hibp_check_password(const char *password, passwdPolicy *pwpolicy);
 
 /*
+ * Hash provider abstraction
+ */
+
+/* Function pointer for pluggable SHA-1 implementation */
+typedef int (*hibp_hash_fn)(const char *input, size_t len, unsigned char *digest);
+
+/* Set the hash provider, called during initialisation */
+void hibp_set_hash_provider(hibp_hash_fn fn);
+
+/*
  * Convert password to uppercase SHA-1 hex string (40 chars + null terminator)
+ *
  * Returns: 0 on success, -1 on error
  */
 int hibp_sha1_hex(const char *password, char *hex_output);
 
-/* Test wrapper, expose hibp_parse_response for testing
- * Returns: breach count if found, 0 if not found, -1 on error
+/*
+ * Cache API
  */
-int hibp_parse_response_wrapper(char *response_data, const char *suffix);
 
-/* Test wrapper, expose hibp_write_callback for testing
- * Returns: buffer size on success, -1 on error
+/*
+ * Initialise the HIBP cache
+ *
+ * Returns: 0 on success, -1 on error
  */
-int hibp_write_callback_wrapper(const char *data, size_t data_len, size_t chunk_size, char **out_data);
+int hibp_cache_init(size_t max_size, int32_t ttl_seconds);
+
+/* Destroy cache and free all resources */
+void hibp_cache_destroy(void);
+
+/*
+ * Get cached response for prefix
+ *
+ * Returns: response data (caller must free), NULL if not cached
+ */
+char *hibp_cache_get(const char *prefix, size_t *response_size);
+
+/* Store response in cache */
+void hibp_cache_put(const char *prefix, const char *response_data, size_t response_size);
+
+/*
+ * Test helpers - expose internal functions for unit testing
+ */
 
 /* Set mock API response for testing */
 void hibp_set_mock_response(const char *response);
 
+/*
+ * Test wrapper for hibp_parse_response
+ *
+ * Returns: breach count if found, 0 if not found, -1 on error
+ */
+int hibp_parse_response_wrapper(char *response_data, const char *suffix);
+
+/*
+ * Test wrapper for hibp_write_callback buffer handling
+ *
+ * Returns: buffer size on success, -1 on error
+ */
+int hibp_write_callback_wrapper(const char *data, size_t data_len, size_t chunk_size, char **out_data);

--- a/ldap/servers/slapd/hibp_client.c
+++ b/ldap/servers/slapd/hibp_client.c
@@ -12,8 +12,10 @@
 
 #include "hibp.h"
 #include "prinit.h"
+#include "prlock.h"
 #include <curl/curl.h>
 #include <pk11pub.h>
+#include <inttypes.h>
 
 #define HIBP_API_URL "https://api.pwnedpasswords.com/range/"
 #define HIBP_API_TIMEOUT_SECS 10
@@ -79,6 +81,341 @@ typedef struct hibp_response
     size_t size;
     size_t capacity;
 } HIBPResponse;
+
+/*
+ * LRU Cache for HIBP API responses
+ *
+ * Caches API responses by hash prefix.
+ * Uses double linked list for LRU ordering.
+ */
+#define HIBP_CACHE_DEFAULT_SIZE 1000    /* Default max cache entries */
+#define HIBP_CACHE_DEFAULT_TTL  86400   /* Default TTL: 24 hours in seconds */
+#define HIBP_CACHE_HASH_BUCKETS 256     /* Hash table buckets */
+#define HIBP_CACHE_HASH_MULTIPLIER 31   /* Prime multiplier for hashing */
+
+typedef struct hibp_cache_entry {
+    char prefix[HIBP_SHA1_HEX_PREFIX_LEN + 1];   /* Hash prefix key */
+    char *response_data;                         /* Cached API response */
+    size_t response_size;
+    time_t created_time;                         /* For TTL expiration */
+    struct hibp_cache_entry *prev;               /* LRU list */
+    struct hibp_cache_entry *next;               /* LRU list */
+    struct hibp_cache_entry *hash_next;          /* Hash bucket link */
+} HIBPCacheEntry;
+
+typedef struct hibp_cache {
+    HIBPCacheEntry *head;                              /* Head of linked list */
+    HIBPCacheEntry *tail;                              /* Tail of linked list */
+    HIBPCacheEntry *buckets[HIBP_CACHE_HASH_BUCKETS];  /* Hash table */
+    size_t size;                                       /* Current entry count */
+    size_t max_size;                                   /* Maximum num of entries */
+    int32_t ttl_seconds;                               /* TTL for entries */
+    PRLock *lock;                                      /* Thread safety */
+    uint64_t hits;                                     /* Cache hit counter */
+    uint64_t misses;                                   /* Cache miss counter */
+} HIBPCache;
+
+static HIBPCache *g_hibp_cache = NULL;
+
+/*
+ * Convert 5 char prefix to bucket index
+ *
+ * Returns: bucket index (0 to HIBP_CACHE_HASH_BUCKETS-1)
+ */
+static unsigned int
+hibp_cache_get_bucket(const char *prefix)
+{
+    unsigned int hash = 0;
+    for (int i = 0; i < HIBP_SHA1_HEX_PREFIX_LEN && prefix[i]; i++) {
+        hash = hash * HIBP_CACHE_HASH_MULTIPLIER + (unsigned char)prefix[i];
+    }
+    return hash % HIBP_CACHE_HASH_BUCKETS;
+}
+
+/*
+ * Unlink entry from tail of LRU list
+ *
+ * Does not free memory
+ */
+static void
+hibp_cache_lru_unlink(HIBPCache *cache, HIBPCacheEntry *entry)
+{
+    if (entry->prev) {
+        entry->prev->next = entry->next;
+    } else {
+        cache->head = entry->next;
+    }
+    if (entry->next) {
+        entry->next->prev = entry->prev;
+    } else {
+        cache->tail = entry->prev;
+    }
+    entry->prev = NULL;
+    entry->next = NULL;
+}
+
+/*
+ * Link entry to head of LRU list
+ */
+static void
+hibp_cache_lru_link(HIBPCache *cache, HIBPCacheEntry *entry)
+{
+    entry->prev = NULL;
+    entry->next = cache->head;
+    if (cache->head) {
+        cache->head->prev = entry;
+    }
+    cache->head = entry;
+    if (!cache->tail) {
+        cache->tail = entry;
+    }
+}
+
+/*
+ * Unlink entry from its hash bucket chain
+ * Does not free memory
+ */
+static void
+hibp_cache_bucket_unlink(HIBPCache *cache, HIBPCacheEntry *entry)
+{
+    unsigned int bucket = hibp_cache_get_bucket(entry->prefix);
+    HIBPCacheEntry *curr = cache->buckets[bucket];
+    HIBPCacheEntry *prev = NULL;
+
+    while (curr) {
+        if (curr == entry) {
+            if (prev) {
+                prev->hash_next = curr->hash_next;
+            } else {
+                cache->buckets[bucket] = curr->hash_next;
+            }
+            entry->hash_next = NULL;
+            return;
+        }
+        prev = curr;
+        curr = curr->hash_next;
+    }
+}
+
+/*
+ * Free a cache entry memory
+ */
+static void
+hibp_cache_entry_free(HIBPCacheEntry *entry)
+{
+    if (entry) {
+        slapi_ch_free_string(&entry->response_data);
+        slapi_ch_free((void **)&entry);
+    }
+}
+
+/*
+ * Evict least recently used entry
+ */
+static void
+hibp_cache_evict_lru(HIBPCache *cache)
+{
+    HIBPCacheEntry *victim = cache->tail;
+    if (!victim) {
+        return;
+    }
+    hibp_cache_lru_unlink(cache, victim);
+    hibp_cache_bucket_unlink(cache, victim);
+    hibp_cache_entry_free(victim);
+    cache->size--;
+}
+
+/*
+ * Check if entry has exceeded TTL
+ *
+ * Returns: 1 if expired, 0 if still valid
+ */
+static int
+hibp_cache_entry_expired(HIBPCache *cache, HIBPCacheEntry *entry)
+{
+    if (cache->ttl_seconds <= 0) {
+        return 0;
+    }
+    return (time(NULL) - entry->created_time) > cache->ttl_seconds;
+}
+
+/*
+ * Look up entry by prefix
+ *
+ * Returns: entry if found and not expired, else NULL
+ */
+static HIBPCacheEntry *
+hibp_cache_lookup(HIBPCache *cache, const char *prefix)
+{
+    unsigned int bucket = hibp_cache_get_bucket(prefix);
+    HIBPCacheEntry *entry = cache->buckets[bucket];
+
+    while (entry) {
+        if (strncmp(entry->prefix, prefix, HIBP_SHA1_HEX_PREFIX_LEN) == 0) {
+            if (hibp_cache_entry_expired(cache, entry)) {
+                /* Entry expired - remove it */
+                hibp_cache_lru_unlink(cache, entry);
+                hibp_cache_bucket_unlink(cache, entry);
+                hibp_cache_entry_free(entry);
+                cache->size--;
+                return NULL;
+            }
+            /* Move to front (most recently used) */
+            hibp_cache_lru_unlink(cache, entry);
+            hibp_cache_lru_link(cache, entry);
+            return entry;
+        }
+        entry = entry->hash_next;
+    }
+    return NULL;
+}
+
+/*
+ * Insert new entry
+ */
+static void
+hibp_cache_insert(HIBPCache *cache, const char *prefix, const char *response_data, size_t response_size)
+{
+    /* Evict if cache is full */
+    while (cache->size >= cache->max_size) {
+        hibp_cache_evict_lru(cache);
+    }
+
+    HIBPCacheEntry *entry = (HIBPCacheEntry *)slapi_ch_calloc(1, sizeof(HIBPCacheEntry));
+    strncpy(entry->prefix, prefix, HIBP_SHA1_HEX_PREFIX_LEN);
+    entry->prefix[HIBP_SHA1_HEX_PREFIX_LEN] = '\0';
+    entry->response_data = slapi_ch_malloc(response_size + 1);
+    memcpy(entry->response_data, response_data, response_size);
+    entry->response_data[response_size] = '\0';
+    entry->response_size = response_size;
+    entry->created_time = time(NULL);
+
+    /* Add to LRU list */
+    hibp_cache_lru_link(cache, entry);
+
+    /* Add to hash bucket */
+    unsigned int bucket = hibp_cache_get_bucket(prefix);
+    entry->hash_next = cache->buckets[bucket];
+    cache->buckets[bucket] = entry;
+
+    cache->size++;
+}
+
+/*
+ * Initialise the HIBP cache
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int
+hibp_cache_init(size_t max_size, int32_t ttl_seconds)
+{
+    if (g_hibp_cache) {
+        return 0;
+    }
+
+    g_hibp_cache = (HIBPCache *)slapi_ch_calloc(1, sizeof(HIBPCache));
+    g_hibp_cache->max_size = max_size > 0 ? max_size : HIBP_CACHE_DEFAULT_SIZE;
+    g_hibp_cache->ttl_seconds = ttl_seconds > 0 ? ttl_seconds : HIBP_CACHE_DEFAULT_TTL;
+    g_hibp_cache->lock = PR_NewLock();
+
+    if (!g_hibp_cache->lock) {
+        slapi_ch_free((void **)&g_hibp_cache);
+        g_hibp_cache = NULL;
+        return -1;
+    }
+
+    slapi_log_err(SLAPI_LOG_INFO, "hibp_cache_init",
+                  "HIBP cache initialised: max_size=%zu, ttl=%d seconds\n",
+                  g_hibp_cache->max_size, g_hibp_cache->ttl_seconds);
+    return 0;
+}
+
+/*
+ * Destroy cache
+ */
+void
+hibp_cache_destroy(void)
+{
+    if (!g_hibp_cache) {
+        return;
+    }
+
+    PR_Lock(g_hibp_cache->lock);
+
+    /* Free all entries */
+    HIBPCacheEntry *entry = g_hibp_cache->head;
+    while (entry) {
+        HIBPCacheEntry *next = entry->next;
+        hibp_cache_entry_free(entry);
+        entry = next;
+    }
+
+    PR_Unlock(g_hibp_cache->lock);
+    PR_DestroyLock(g_hibp_cache->lock);
+
+    slapi_log_err(SLAPI_LOG_INFO, "hibp_cache_destroy",
+                  "HIBP cache destroyed: hits=%" PRIu64 ", misses=%" PRIu64 "\n",
+                  g_hibp_cache->hits, g_hibp_cache->misses);
+
+    slapi_ch_free((void **)&g_hibp_cache);
+    g_hibp_cache = NULL;
+}
+
+/*
+ * Get a cached response for prefix
+ *
+ * Returns: Copy of response data, NULL if not cached
+ *
+ * Caller must free memory
+ */
+char *
+hibp_cache_get(const char *prefix, size_t *response_size)
+{
+    char *result = NULL;
+
+    if (!g_hibp_cache || !prefix) {
+        return NULL;
+    }
+
+    PR_Lock(g_hibp_cache->lock);
+
+    HIBPCacheEntry *entry = hibp_cache_lookup(g_hibp_cache, prefix);
+    if (entry) {
+        result = slapi_ch_malloc(entry->response_size + 1);
+        memcpy(result, entry->response_data, entry->response_size);
+        result[entry->response_size] = '\0';
+        if (response_size) {
+            *response_size = entry->response_size;
+        }
+        g_hibp_cache->hits++;
+    } else {
+        g_hibp_cache->misses++;
+    }
+
+    PR_Unlock(g_hibp_cache->lock);
+    return result;
+}
+
+/*
+ * Store response in cache
+ */
+void
+hibp_cache_put(const char *prefix, const char *response_data, size_t response_size)
+{
+    if (!g_hibp_cache || !prefix || !response_data) {
+        return;
+    }
+
+    PR_Lock(g_hibp_cache->lock);
+
+    /* Check if already cached */
+    HIBPCacheEntry *existing = hibp_cache_lookup(g_hibp_cache, prefix);
+    if (!existing) {
+        hibp_cache_insert(g_hibp_cache, prefix, response_data, response_size);
+    }
+
+    PR_Unlock(g_hibp_cache->lock);
+}
 
 /* One time curl initialisation */
 static PRCallOnceType g_curl_init_control = {0};
@@ -322,6 +659,23 @@ hibp_query_api(const char *prefix, const char *api_url, HIBPResponse *response, 
         return 0;
     }
 
+    /* Check cache first */
+    if (g_hibp_cache) {
+        size_t cached_size;
+        char *cached_data = hibp_cache_get(prefix, &cached_size);
+        if (cached_data) {
+            slapi_log_err(SLAPI_LOG_INFO, "hibp_query_api",
+                          "Cache HIT for prefix %s (size=%zu bytes)\n", prefix, cached_size);
+            response->data = cached_data;
+            response->size = cached_size;
+            response->capacity = cached_size + 1;
+            return 0;
+        } else {
+            slapi_log_err(SLAPI_LOG_INFO, "hibp_query_api",
+                          "Cache MISS for prefix %s - querying API\n", prefix);
+        }
+    }
+
     /* Ensure libcurl library is initialised */
     if (hibp_ensure_curl_init() != 0) {
         slapi_log_err(SLAPI_LOG_ERR, "hibp_query_api",
@@ -390,6 +744,13 @@ hibp_query_api(const char *prefix, const char *api_url, HIBPResponse *response, 
         slapi_ch_free((void **)&response->data);
         curl_easy_cleanup(curl);
         return -1;
+    }
+
+    /* Store successful response in cache */
+    if (g_hibp_cache && response->data && response->size > 0) {
+        hibp_cache_put(prefix, response->data, response->size);
+        slapi_log_err(SLAPI_LOG_INFO, "hibp_query_api",
+                      "Cached response for prefix %s (size=%zu bytes)\n", prefix, response->size);
     }
 
     curl_easy_cleanup(curl);
@@ -550,5 +911,21 @@ hibp_init(void)
         hibp_set_hash_provider(hibp_sha1_nss);
     }
 
+    /* Initialise the response cache with defaults */
+    if (hibp_cache_init(HIBP_CACHE_DEFAULT_SIZE, HIBP_CACHE_DEFAULT_TTL) != 0) {
+        slapi_log_err(SLAPI_LOG_WARNING, "hibp_init",
+                      "Failed to initialise HIBP cache - caching disabled\n");
+    }
+
     return hibp_ensure_curl_init();
+}
+
+/*
+ * Shutdown HIBP subsystem
+ */
+void
+hibp_shutdown(void)
+{
+    hibp_cache_destroy();
+    slapi_log_err(SLAPI_LOG_INFO, "hibp_shutdown", "HIBP subsystem shutdown complete\n");
 }

--- a/ldap/servers/slapd/main.c
+++ b/ldap/servers/slapd/main.c
@@ -1108,6 +1108,9 @@ main(int argc, char **argv)
     reslimit_cleanup();
     vattr_cleanup();
     sasl_map_done();
+#ifdef ENABLE_HIBP
+    hibp_shutdown();
+#endif
 cleanup:
     slapi_ch_free_string(&(mcfg.myname));
     compute_terminate();

--- a/test/libslapd/hibp/parse.c
+++ b/test/libslapd/hibp/parse.c
@@ -9,6 +9,7 @@
 #include "../../test_slapd.h"
 #include <string.h>
 #include <pthread.h>
+#include <unistd.h>
 #include <nss.h>
 #include <hibp.h>
 
@@ -214,6 +215,125 @@ test_hibp_api_integration(void **state)
 
     /* Reset mock for other tests */
     hibp_set_mock_response(NULL);
+}
+
+/* Cache basic operations test */
+void
+test_hibp_cache_basic(void **state)
+{
+    size_t size;
+    char *result;
+
+    (void)state;
+
+    /* Init cache */
+    assert_int_equal(hibp_cache_init(10, 3600), 0);
+
+    /* Put and get */
+    hibp_cache_put("ABCDE", "response_data", 13);
+    result = hibp_cache_get("ABCDE", &size);
+    assert_non_null(result);
+    assert_string_equal(result, "response_data");
+    assert_int_equal(size, 13);
+    slapi_ch_free_string(&result);
+
+    /* Miss for unknown prefix */
+    result = hibp_cache_get("ZZZZZ", &size);
+    assert_null(result);
+
+    hibp_cache_destroy();
+}
+
+/* Cache LRU eviction test */
+void
+test_hibp_cache_eviction(void **state)
+{
+    char *result;
+
+    (void)state;
+
+    /* Small cache of 3 entries */
+    assert_int_equal(hibp_cache_init(3, 3600), 0);
+
+    /* Fill cache */
+    hibp_cache_put("AAA00", "data1", 5);
+    hibp_cache_put("BBB00", "data2", 5);
+    hibp_cache_put("CCC00", "data3", 5);
+
+    /* Add 4th - should evict AAA00 */
+    hibp_cache_put("DDD00", "data4", 5);
+
+    /* AAA00 should be evicted */
+    result = hibp_cache_get("AAA00", NULL);
+    assert_null(result);
+
+    /* Others should still exist */
+    result = hibp_cache_get("DDD00", NULL);
+    assert_non_null(result);
+    slapi_ch_free_string(&result);
+
+    hibp_cache_destroy();
+}
+
+/* Cache TTL expiration test */
+void
+test_hibp_cache_ttl(void **state)
+{
+    char *result;
+
+    (void)state;
+
+    /* Cache with 1 second TTL */
+    assert_int_equal(hibp_cache_init(10, 1), 0);
+
+    hibp_cache_put("ABCDE", "data", 4);
+
+    /* Should exist */
+    result = hibp_cache_get("ABCDE", NULL);
+    assert_non_null(result);
+    slapi_ch_free_string(&result);
+
+    /* Wait for TTL to expire */
+    sleep(2);
+
+    /* Should not exist now */
+    result = hibp_cache_get("ABCDE", NULL);
+    assert_null(result);
+
+    hibp_cache_destroy();
+}
+
+/* Cache LRU reordering on access test */
+void
+test_hibp_cache_lru_reorder(void **state)
+{
+    char *result;
+
+    (void)state;
+
+    assert_int_equal(hibp_cache_init(3, 3600), 0);
+
+    /* Fill cache: A, B, C */
+    hibp_cache_put("AAA00", "data1", 5);
+    hibp_cache_put("BBB00", "data2", 5);
+    hibp_cache_put("CCC00", "data3", 5);
+
+    /* Access A, moves it to front */
+    result = hibp_cache_get("AAA00", NULL);
+    slapi_ch_free_string(&result);
+
+    /* Add D, should evict B */
+    hibp_cache_put("DDD00", "data4", 5);
+
+    /* B should be evicted, A should remain */
+    result = hibp_cache_get("BBB00", NULL);
+    assert_null(result);
+
+    result = hibp_cache_get("AAA00", NULL);
+    assert_non_null(result);
+    slapi_ch_free_string(&result);
+
+    hibp_cache_destroy();
 }
 
 /* Thread worker for concurrent test */

--- a/test/libslapd/test.c
+++ b/test/libslapd/test.c
@@ -59,6 +59,10 @@ run_libslapd_tests(void)
         cmocka_unit_test(test_hibp_buffer_handling),
         cmocka_unit_test(test_hibp_api_integration),
         cmocka_unit_test(test_hibp_concurrent_requests),
+        cmocka_unit_test(test_hibp_cache_basic),
+        cmocka_unit_test(test_hibp_cache_eviction),
+        cmocka_unit_test(test_hibp_cache_ttl),
+        cmocka_unit_test(test_hibp_cache_lru_reorder),
 #endif
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/test_slapd.h
+++ b/test/test_slapd.h
@@ -82,6 +82,10 @@ void test_hibp_parse_response(void **state);
 void test_hibp_buffer_handling(void **state);
 void test_hibp_api_integration(void **state);
 void test_hibp_concurrent_requests(void **state);
+void test_hibp_cache_basic(void **state);
+void test_hibp_cache_eviction(void **state);
+void test_hibp_cache_ttl(void **state);
+void test_hibp_cache_lru_reorder(void **state);
 #endif
 
 /* plugins */


### PR DESCRIPTION
Description:
Add LRU cache for HIBP API responses to reduce latency and external API calls. The cache stores range query responses (prefix -> suffix list) rather than individual password verdicts, providing implicit negative caching since a cache hit returns the complete suffix list for matching.

- Hash table (256 buckets) plus a doubly linked list for LRU eviction
- Configurable size (default: 1000 entries) and TTL (default: 24 hours)
- Concurrency protection using NSPR locks
- Cache statistics tracking (hits/misses)
- Unit tests for cache operations

Dependencies:
- Issue 7468 - RFE - Add HIBP HTTP client
- Issue 7468 - RFE - HIBP password breach validation

Relates: https://github.com/389ds/389-ds-base/issues/7468

Reviewed by:

## Summary by Sourcery

Introduce an in-memory LRU cache for Have I Been Pwned (HIBP) range query responses and integrate it into the HIBP client lifecycle.

New Features:
- Add configurable, TTL-based LRU cache for HIBP prefix responses with hit/miss statistics.
- Cache HIBP API responses in hibp_query_api to reduce repeated external calls and latency.

Enhancements:
- Wire HIBP subsystem shutdown into the main server cleanup path to release cache resources cleanly.
- Refine HIBP public API header to separate core API, hash provider abstraction, and cache/test helper interfaces.

Tests:
- Add unit tests covering HIBP cache basic operations, LRU eviction behavior, TTL expiration, and LRU reordering under access patterns.