### PR TITLE
Issue 7514 - Crash when doing moddn on very large subtree

### DIFF
--- a/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
+++ b/dirsrvtests/tests/suites/basic/ds_entrydn_test.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 # All rights reserved.
 #
 # License: GPL (version 3 or any later version).
@@ -7,12 +7,13 @@
 # --- END COPYRIGHT BLOCK ---
 
 import logging
-import pytest
 import os
-import time
-from test389.topologies import topology_st as topo
-from lib389.idm.user import UserAccount, UserAccounts
+import pytest
+from lib389.dbgen import dbgen_users, get_index
 from lib389.idm.organizationalunit import OrganizationalUnit
+from lib389.idm.user import UserAccount, UserAccounts
+from lib389.tasks import ImportTask
+from test389.topologies import topology_st as topo
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,19 @@ NEW_SUBTREE = "ou=humans,dc=Example,DC=COM"
 USER_DN = "uid=tUser,ou=People,dc=Example,DC=COM"
 NEW_USER_DN = "uid=tUser,ou=humans,dc=Example,DC=COM"
 NEW_USER_NORM_DN = "uid=tUser,ou=humans,dc=example,dc=com"
+
+IMPORT_LDIF_NAME = "ds_entrydn_import.ldif"
+NUM_IMPORT_ENTRIES = 10
+IMPORT_ENTRY_NAME = "importuser"
+IMPORT_PARENT = f"ou=people,{SUFFIX}"
+
+
+def _import_user_dns():
+    """DNs produced by dbgen_users(generic=True, entry_name=IMPORT_ENTRY_NAME)."""
+    return [
+        f"uid={IMPORT_ENTRY_NAME}{get_index(i, NUM_IMPORT_ENTRIES)},{IMPORT_PARENT}"
+        for i in range(1, NUM_IMPORT_ENTRIES + 1)
+    ]
 
 
 def test_dsentrydn(topo):
@@ -87,6 +101,43 @@ def test_dsentrydn(topo):
         if user.rdn.startswith("tUser"):
             assert user.dn == NEW_USER_NORM_DN
             break
+
+
+def test_dsentrydn_import_ldif(topo, request):
+    """Imported entries receive dsEntryDN matching their DN
+
+    :id: 8457793e-8374-4435-b6b7-701b58246d91
+    :setup: Standalone Instance
+    :steps:
+        1. Generate an LDIF with 10 users under ou=people using dbgen_users
+        2. Import the LDIF into the suffix
+        3. Verify each imported entry has dsentrydn set to its DN
+    :expectedresults:
+        1. LDIF file is created with 10 user entries
+        2. Online import completes successfully
+        3. All 10 entries have dsentrydn matching their DN
+    """
+    inst = topo.standalone
+
+    ldif_path = os.path.join(inst.get_ldif_dir(), IMPORT_LDIF_NAME)
+    dbgen_users(
+        inst,
+        NUM_IMPORT_ENTRIES,
+        ldif_path,
+        SUFFIX,
+        generic=True,
+        entry_name=IMPORT_ENTRY_NAME,
+        parent=IMPORT_PARENT,
+    )
+
+    import_task = ImportTask(inst)
+    import_task.import_suffix_from_ldif(ldiffile=ldif_path, suffix=SUFFIX)
+    import_task.wait()
+
+    for dn in _import_user_dns():
+        user = UserAccount(inst, dn)
+        assert user.exists(), dn
+        assert user.get_attr_val_utf8('dsentrydn') == dn
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -1,5 +1,5 @@
 /** BEGIN COPYRIGHT BLOCK
- * Copyright (C) 2020 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  * All rights reserved.
  *
  * License: GPL (version 3 or any later version).
@@ -528,6 +528,9 @@ bdb_import_producer(void *param)
             slapi_ch_free_string(&dn);
             e = slapi_str2entry_ext(normdn, NULL, estr,
                                     flags | SLAPI_STR2ENTRY_NO_ENTRYDN);
+            if (slapi_entry_attr_get_ref(e, SLAPI_ATTR_DS_ENTRYDN) == NULL) {
+                slapi_entry_attr_set_charptr(e, SLAPI_ATTR_DS_ENTRYDN, normdn);
+            }
             slapi_ch_free_string(&normdn);
         }
         FREE(estr);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -1460,6 +1460,9 @@ dbmdb_import_prepare_worker_entry(WorkerQueueData_t *wqelmnt)
         slapi_ch_free_string(&dn);
         e = slapi_str2entry_ext(normdn, NULL, estr,
                                 flags | SLAPI_STR2ENTRY_NO_ENTRYDN);
+        if (slapi_entry_attr_get_ref(e, SLAPI_ATTR_DS_ENTRYDN) == NULL) {
+            slapi_entry_attr_set_charptr(e, SLAPI_ATTR_DS_ENTRYDN, normdn);
+        }
         slapi_ch_free_string(&normdn);
     } else {
         e = slapi_str2entry(estr, flags);

--- a/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
@@ -22,7 +22,7 @@ static int moddn_newrdn_mods(Slapi_PBlock *pb, const char *olddn, struct backent
 static IDList *moddn_get_children(back_txn *ptxn, Slapi_PBlock *pb, backend *be, struct backentry *parententry, Slapi_DN *parentdn, struct backentry ***child_entries, struct backdn ***child_dns, int is_resurect_operation);
 static int modrdn_rename_entry_update_indexes(back_txn *ptxn, Slapi_PBlock *pb, struct ldbminfo *li, struct backentry *e, struct backentry **ec, Slapi_Mods *smods1, Slapi_Mods *smods2, Slapi_Mods *smods3, Slapi_Mods *smods4);
 static void mods_remove_nsuniqueid(Slapi_Mods *smods);
-static int32_t dsentrydn_modrdn_update(backend *be, const char *newdn, struct backentry *e, struct backentry **ec, back_txn *txn);
+static int32_t dsentrydn_modrdn_update(backend *be, const char *newdn, struct backentry *e, back_txn *txn);
 static int dsentrydn_moddn_rename(back_txn *ptxn, backend *be, ID id, IDList *children, const Slapi_DN *dn_parentdn, const Slapi_DN *dn_newsuperiordn, struct backentry *child_entries[]);
 
 #define MOD_SET_ERROR(rc, error, count)                                            \
@@ -1543,7 +1543,6 @@ dsentrydn_moddn_rename_child(
     Slapi_Backend *be,
     struct ldbminfo *li,
     struct backentry *e,
-    struct backentry **ec,
     size_t parentdncomps,
     char **newsuperiordns,
     size_t newsuperiordncomps)
@@ -1561,7 +1560,7 @@ dsentrydn_moddn_rename_child(
     int need = 1; /* For the '\0' */
     size_t i;
 
-    olddn = slapi_entry_attr_get_charptr((*ec)->ep_entry, SLAPI_ATTR_DS_ENTRYDN);
+    olddn = slapi_entry_attr_get_charptr(e->ep_entry, SLAPI_ATTR_DS_ENTRYDN);
     if (NULL == olddn) {
         return retval;
     }
@@ -1594,7 +1593,7 @@ dsentrydn_moddn_rename_child(
         }
     }
 
-    retval = dsentrydn_modrdn_update(be, newdn, e, ec, ptxn);
+    retval = dsentrydn_modrdn_update(be, newdn, e, ptxn);
 
 out:
     slapi_ch_free_string(&olddn);
@@ -1614,13 +1613,10 @@ dsentrydn_moddn_rename(
 {
     /* Iterate over the children list renaming every child */
     struct ldbminfo *li = (struct ldbminfo *)be->be_database->plg_private;
-    ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
-    struct backentry **child_entry_copies = NULL;
     int retval = 0;
     char **newsuperiordns = NULL;
     size_t newsuperiordncomps = 0;
     size_t parentdncomps = 0;
-    NIDS nids = children ? children->b_nids : 0;
 
     /*
      * Break down the parent entry dn into its components.
@@ -1650,29 +1646,12 @@ dsentrydn_moddn_rename(
     /*
      * Iterate over the child entries renaming them.
      */
-    child_entry_copies = (struct backentry **)slapi_ch_calloc(sizeof(struct backentry *), nids + 1);
-    for (size_t i = 0; i <= nids; i++) {
-        child_entry_copies[i] = backentry_dup(child_entries[i]);
-    }
     for (size_t i = 0; retval == 0 && child_entries[i]; i++) {
-        retval = dsentrydn_moddn_rename_child(ptxn, be, li, child_entries[i], &child_entry_copies[i],
+        retval = dsentrydn_moddn_rename_child(ptxn, be, li, child_entries[i],
                                               parentdncomps, newsuperiordns,
                                               newsuperiordncomps);
     }
 
-    if (0 == retval) {
-        for (size_t i = 0; child_entries[i]; i++) {
-            CACHE_REMOVE(&inst->inst_cache, child_entry_copies[i]);
-            CACHE_RETURN(&inst->inst_cache, &(child_entry_copies[i]));
-        }
-    } else {
-        /* failure */
-        for (size_t i = 0; child_entries[i]; i++) {
-            backentry_free(&(child_entry_copies[i]));
-        }
-    }
-
-    slapi_ch_free((void **)&child_entry_copies);
     slapi_ldap_value_free(newsuperiordns);
 
     return retval;
@@ -1683,17 +1662,18 @@ dsentrydn_modrdn_update(
     backend *be,
     const char *newdn,
     struct backentry *e,
-    struct backentry **ec,
     back_txn *txn)
 {
+    struct backentry *ec = NULL;
     int32_t ret = 0;
     int32_t cache_rc = 0;
     ldbm_instance *inst = (ldbm_instance *)be->be_instance_info;
 
     /* We have the entry, so update id2entry */
-    slapi_entry_attr_set_charptr((*ec)->ep_entry, SLAPI_ATTR_DS_ENTRYDN, newdn);
-    slapi_entry_set_dn((*ec)->ep_entry, (char *)newdn);
-    ret = id2entry_add_ext(be, *ec, txn, 1, &cache_rc);
+    ec = backentry_dup(e);
+    slapi_entry_attr_set_charptr(ec->ep_entry, SLAPI_ATTR_DS_ENTRYDN, newdn);
+    slapi_entry_set_dn(ec->ep_entry, (char *)newdn);
+    ret = id2entry_add_ext(be, ec, txn, 1, &cache_rc);
     if (cache_rc) {
         slapi_log_err(SLAPI_LOG_CACHE,
                       "dsentrydn_modrdn_update",
@@ -1713,15 +1693,21 @@ dsentrydn_modrdn_update(
         goto out;
     }
 
-    if (cache_replace(&inst->inst_cache, e, *ec) != 0) {
-        /* id2entry was updated, so update the cache */
+    if ((ret = cache_replace(&inst->inst_cache, e, ec)) == 0) {
+        CACHE_REMOVE(&inst->inst_cache, ec);
+        CACHE_RETURN(&inst->inst_cache, &ec);
+    } else {
         slapi_log_err(SLAPI_LOG_CACHE,
                       "dsentrydn_modrdn_update", "cache_replace %s -> %s failed\n",
-                      slapi_entry_get_dn(e->ep_entry), slapi_entry_get_dn((*ec)->ep_entry));
-        ret = -1;
+                      slapi_entry_get_dn(e->ep_entry),
+                      slapi_entry_get_dn(ec->ep_entry));
     }
 
 out:
+    if (ret) {
+        backentry_free(&ec);
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
Description:

Attempting to move a subtree underneath another subtree leads to an assertion failure on debug builds.

relates: https://github.com/389ds/389-ds-base/issues/7514

## Summary by Sourcery

Bug Fixes:
- Fix an assertion/crash caused by improper cleanup of child entry copies during subtree modrdn operations.