### PR TITLE
Issue 7516 - dblayer_bulk_nextdata should not return an error when maxrecords is hit

### DIFF
--- a/dirsrvtests/tests/suites/basic/modrdn_bulk_children_test.py
+++ b/dirsrvtests/tests/suites/basic/modrdn_bulk_children_test.py
@@ -1,0 +1,96 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import pytest
+
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.idm.organizationalunit import OrganizationalUnit, OrganizationalUnits
+from lib389.idm.user import UserAccount, UserAccounts
+from test389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+log = logging.getLogger(__name__)
+
+NUM_USERS = 110
+ORGUNIT1_RDN = 'ou=people'
+ORGUNIT2_RDN = 'ou=orgunit2'
+ORGUNIT1_DN = f'{ORGUNIT1_RDN},{DEFAULT_SUFFIX}'
+ORGUNIT2_DN = f'{ORGUNIT2_RDN},{DEFAULT_SUFFIX}'
+ORGUNIT1_UNDER_ORGUNIT2_DN = f'{ORGUNIT1_RDN},{ORGUNIT2_DN}'
+
+
+def _expected_user_dn(uid_str, parent_dn):
+    return f'uid={uid_str},{parent_dn}'
+
+
+def _create_orgunit_users(inst):
+    """Create uid=1..NUM_USERS under ou=people."""
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    for uid in range(1, NUM_USERS + 1):
+        uid_str = str(uid)
+        users.create(
+            f'uid={uid_str}',
+            properties={
+                'uid': uid_str,
+                'cn': f'user {uid_str}',
+                'sn': f'user{uid_str}',
+                'uidNumber': str(1000 + uid),
+                'gidNumber': '2000',
+                'homeDirectory': f'/home/{uid_str}',
+            },
+        )
+
+
+def test_modrdn_orgunit_moves_users_under_new_superior(topo, request):
+    """Modrdn an organizational unit to a new superior and verify child user DNs
+
+    :id: 12dae475-b778-4ba6-a48b-d713ff2c0e58
+    :setup: Standalone Instance
+    :steps:
+        1. Create 110 users under ou=people (uid=1 through uid=110)
+        2. Create ou=orgunit2 under the default suffix
+        3. Modrdn ou=people with superior ou=orgunit2
+        4. Verify every uid=1..110 has a DN under ou=people,ou=orgunit2
+    :expectedresults:
+        1. All 110 users are created
+        2. orgunit2 is created
+        3. Modrdn succeeds
+        4. All 110 user DNs are uid=N,ou=people,ou=orgunit2,<suffix> and none remain at the old location
+    """
+    inst = topo.standalone
+    ou2 = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(properties={'ou': 'orgunit2'})
+    assert ou2.exists()
+
+    _create_orgunit_users(inst)
+    for uid in range(1, NUM_USERS + 1):
+        uid_str = str(uid)
+        assert UserAccount(inst, _expected_user_dn(uid_str, ORGUNIT1_DN)).exists()
+
+    people_ou = OrganizationalUnit(inst, ORGUNIT1_DN)
+    people_ou.rename(ORGUNIT1_RDN, newsuperior=ou2.dn)
+    assert OrganizationalUnit(inst, ORGUNIT1_UNDER_ORGUNIT2_DN).exists()
+    assert not OrganizationalUnit(inst, ORGUNIT1_DN).exists()
+
+    for uid in range(1, NUM_USERS + 1):
+        uid_str = str(uid)
+        expected_dn = _expected_user_dn(uid_str, ORGUNIT1_UNDER_ORGUNIT2_DN)
+        user = UserAccount(inst, expected_dn)
+        assert user.exists(), expected_dn
+        assert user.dn == expected_dn
+        old_dn = _expected_user_dn(uid_str, ORGUNIT1_DN)
+        assert not UserAccount(inst, old_dn).exists(), old_dn
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.c
@@ -21,8 +21,6 @@
 
 Slapi_ComponentId *dbmdb_componentid = NULL;
 
-#define BULKOP_MAX_RECORDS  100 /* Max records handled by a single bulk operations */
-
 #define RECNO_CACHE_INTERVAL 1000  /* 1 key added in cache for every RECNO_CACHE_INTERVAL vlv keys */
 
 /* bulkdata->v.data contents */
@@ -31,7 +29,6 @@ typedef struct {
     uint dbi_flags;          /* dbi flags */
     MDB_cursor *cursor;      /* cursor position */
     int op;                  /* MDB operation to get next value */
-    int maxrecords;          /* Number maximum of operation before moving to next block */
     MDB_val data0;           /* data got when setting the cursor */
     MDB_val data;            /* data for single or multiple operation */
     MDB_val key;             /* key */
@@ -1725,7 +1722,7 @@ int dbmdb_public_bulk_nextdata(dbi_bulk_t *bulkdata, dbi_val_t *data)
             dblayer_value_set_buffer(bulkdata->be, data, v, dbmdb_data->data_size);
         }
     } else {
-        if (!dbmdb_data->op || (*idx)++ >= dbmdb_data->maxrecords) {
+        if (!dbmdb_data->op) {
             return DBI_RC_NOTFOUND;
         }
         dblayer_value_set_buffer(bulkdata->be, data, v, dbmdb_data->data.mv_size);
@@ -1734,6 +1731,7 @@ int dbmdb_public_bulk_nextdata(dbi_bulk_t *bulkdata, dbi_val_t *data)
             rc = 0;
             dbmdb_data->op = 0;
         }
+        (*idx)++;
     }
     rc = dbmdb_map_error(__FUNCTION__, rc);
     return rc;
@@ -1898,7 +1896,6 @@ int dbmdb_public_cursor_bulkop(dbi_cursor_t *cursor,  dbi_op_t op, dbi_val_t *ke
     mdb_dbi_flags(mdb_cursor_txn(dbmdb_cur), mdb_cursor_dbi(dbmdb_cur), &dbmdb_data->dbi_flags);
     dbmdb_data->use_multiple = (dbmdb_data->dbi_flags & MDB_DUPFIXED);
     PR_ASSERT(dbmdb_data->dbi_flags & MDB_DUPSORT);
-    dbmdb_data->maxrecords = BULKOP_MAX_RECORDS;
     dbmdb_data->data.mv_data = NULL;
     dbmdb_data->data.mv_size = 0;
     dbmdb_data->op = 0;


### PR DESCRIPTION
Description:

When doing a bulk read of an index if the candidates were more than 100 it would silently stop processing the indexi read. This would lead to database corruption. This is most easily reproduced by doing a moddn with a subtree that had a lot of child entries.

relates: https://github.com/389ds/389-ds-base/issues/7516

## Summary by Sourcery

Prevent bulk index reads from treating the max-records limit as an error and add regression coverage for modrdn operations with many child entries.

Bug Fixes:
- Fix bulk index iteration to stop returning errors when hitting the configured maxrecords limit, avoiding premature termination that could lead to database corruption during operations like modrdn.

Tests:
- Add a regression test that performs a modrdn of an organizational unit with over 100 child user entries to verify all children are correctly moved under the new superior.