### PR TITLE
Issue 7519 - Ignore obsolete entrydn index when entryrdn is enabled

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -1143,6 +1143,47 @@ def test_index_check_fixes_multiple_issues(topology_st):
     standalone.start()
 
 
+
+def test_ignore_entrydn_index(topology_st, log_buffering_enabled):
+    """Healthcheck reports DSBLE0008 when entrydn index is configured.
+
+    :id: 65abefe0-2e6b-45e0-8604-fb33d734e412
+    :setup: Standalone instance
+    :steps:
+        1. Add obsolete entrydn index to userroot
+        2. Run healthcheck
+        3. Remove entrydn index
+        4. Run healthcheck again
+    :expectedresults:
+        1. Success
+        2. healthcheck reports DSBLE0008
+        3. Success
+        4. healthcheck reports no issues found
+    """
+
+    RET_CODE = "DSBLE0008"
+    standalone = topology_st.standalone
+    backend = Backends(standalone).get("userRoot")
+
+    log.info("Add obsolete entrydn index configuration")
+    backend.add_index("entrydn", ["eq"])
+    standalone.restart()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Remove entrydn index configuration")
+    entrydn_index = Index(
+        standalone,
+        "cn=entrydn,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config",
+    )
+    entrydn_index.delete()
+    standalone.restart()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=CMD_OUTPUT)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=JSON_OUTPUT)
+
+
 if __name__ == "__main__":
     # Run isolated
     # -s for DEBUG mode

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1534,24 +1534,22 @@ bdb_db2index(Slapi_PBlock *pb)
                                       CONFIG_ENTRYRDN_SWITCH);
                         goto err_out;
                     }
+                } else if (ldbm_index_entrydn_should_ignore(attrs[i] + 1)) {
+                    slapi_task_log_notice(task, "%s: Requested to index %s, but %s is on",
+                                          inst->inst_name, LDBM_ENTRYDN_STR, CONFIG_ENTRYRDN_SWITCH);
+                    slapi_log_err(SLAPI_LOG_WARNING,
+                                  "bdb_db2index", "%s: Requested to index %s, but %s is on\n",
+                                  inst->inst_name, LDBM_ENTRYDN_STR,
+                                  CONFIG_ENTRYRDN_SWITCH);
+                    goto err_out;
                 } else if (strcasecmp(attrs[i] + 1, LDBM_ENTRYDN_STR) == 0) {
-                    if (entryrdn_get_switch()) { /* subtree-rename: on */
-                        slapi_task_log_notice(task, "%s: Requested to index %s, but %s is on",
-                                inst->inst_name, LDBM_ENTRYDN_STR, CONFIG_ENTRYRDN_SWITCH);
-                        slapi_log_err(SLAPI_LOG_WARNING,
-                                      "bdb_db2index", "%s: Requested to index %s, but %s is on\n",
-                                      inst->inst_name, LDBM_ENTRYDN_STR,
-                                      CONFIG_ENTRYRDN_SWITCH);
-                        goto err_out;
-                    } else {
-                        charray_add(&indexAttrs, attrs[i] + 1);
-                        ai->ai_indexmask |= INDEX_OFFLINE;
-                        slapi_task_log_notice(task, "%s: Indexing attribute: %s",
-                                inst->inst_name, attrs[i] + 1);
-                        slapi_log_err(SLAPI_LOG_INFO,
-                                      "bdb_db2index", "%s: Indexing attribute: %s\n",
-                                      inst->inst_name, attrs[i] + 1);
-                    }
+                    charray_add(&indexAttrs, attrs[i] + 1);
+                    ai->ai_indexmask |= INDEX_OFFLINE;
+                    slapi_task_log_notice(task, "%s: Indexing attribute: %s",
+                            inst->inst_name, attrs[i] + 1);
+                    slapi_log_err(SLAPI_LOG_INFO,
+                                  "bdb_db2index", "%s: Indexing attribute: %s\n",
+                                  inst->inst_name, attrs[i] + 1);
                 } else {
                     if (strcasecmp(attrs[i] + 1, SLAPI_ATTR_OBJECTCLASS) == 0) {
                         index_ext |= DB2INDEX_OBJECTCLASS;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -1221,6 +1221,21 @@ process_db2index_attrs(Slapi_PBlock *pb, ImportCtx_t *ctx)
             if (pt != NULL) {
                 *pt = '\0';
             }
+            if (ldbm_index_entrydn_should_ignore(attrname)) {
+                if (ctx->job && ctx->job->task && ctx->job->inst) {
+                    slapi_task_log_notice(ctx->job->task,
+                                          "%s: Requested to index %s, but %s is on",
+                                          ctx->job->inst->inst_name, LDBM_ENTRYDN_STR,
+                                          CONFIG_ENTRYRDN_SWITCH);
+                }
+                if (ctx->job && ctx->job->inst) {
+                    slapi_log_err(SLAPI_LOG_WARNING,
+                                  "process_db2index_attrs", "%s: Requested to index %s, but %s is on\n",
+                                  ctx->job->inst->inst_name, LDBM_ENTRYDN_STR, CONFIG_ENTRYRDN_SWITCH);
+                }
+                slapi_ch_free_string(&attrname);
+                break;
+            }
             slapi_ch_array_add(&ctx->indexAttrs, attrname);
             break;
         case 'T': /* VLV Search to index */

--- a/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
@@ -56,6 +56,17 @@ ldbm_index_parse_entry(ldbm_instance *inst, Slapi_Entry *e, const char *trace_st
         return LDAP_OPERATIONS_ERROR;
     }
 
+    if (ldbm_index_entrydn_should_ignore(attrValue->bv_val)) {
+        slapi_log_err(SLAPI_LOG_WARNING, "ldbm_index_parse_entry",
+                      "%s: Requested to index %s, but %s is on\n",
+                      inst->inst_name, LDBM_ENTRYDN_STR, CONFIG_ENTRYRDN_SWITCH);
+        if (index_name != NULL) {
+            slapi_ch_free_string(index_name);
+            *index_name = NULL;
+        }
+        return LDAP_SUCCESS;
+    }
+
     if (index_name != NULL) {
         slapi_ch_free_string(index_name);
         *index_name = slapi_ch_strdup(attrValue->bv_val);
@@ -140,6 +151,15 @@ ldbm_instance_index_config_add_callback(Slapi_PBlock *pb __attribute__((unused))
 
     returntext[0] = '\0';
     *returncode = ldbm_index_parse_entry(inst, e, "from DSE add", &index_name, &is_system_index, returntext);
+
+    /*
+     * ldbm_index_parse_entry returns LDAP_SUCCESS with index_name NULL only when entrydn is
+     * ignored (entryrdn on). Skip ainfo_get; the DSE entry may still be added.
+     */
+    if (*returncode == LDAP_SUCCESS && index_name == NULL) {
+        return SLAPI_DSE_CALLBACK_OK;
+    }
+
     if (*returncode == LDAP_SUCCESS) {
         struct attrinfo *ai = NULL;
         /* if the index is a "system" index, we assume it's being added by
@@ -269,6 +289,13 @@ ldbm_instance_index_config_modify_callback(Slapi_PBlock *pb __attribute__((unuse
                       edn);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    if (ldbm_index_entrydn_should_ignore(attrValue->bv_val)) {
+        slapi_log_err(SLAPI_LOG_WARNING, "ldbm_instance_index_config_modify_callback",
+                      "%s: Requested to index %s, but %s is on\n",
+                      inst->inst_name, LDBM_ENTRYDN_STR, CONFIG_ENTRYRDN_SWITCH);
+        return SLAPI_DSE_CALLBACK_OK;
     }
 
     ainfo_get(inst->inst_be, attrValue->bv_val, &ainfo);

--- a/ldap/servers/slapd/back-ldbm/misc.c
+++ b/ldap/servers/slapd/back-ldbm/misc.c
@@ -106,9 +106,19 @@ static const char *systemIndexes[] = {
 
 
 int
+ldbm_index_entrydn_should_ignore(const char *index_name)
+{
+    return entryrdn_get_switch() && index_name &&
+           (0 == strcasecmp(index_name, LDBM_ENTRYDN_STR));
+}
+
+int
 ldbm_attribute_always_indexed(const char *attrtype)
 {
     int r = 0;
+    if (ldbm_index_entrydn_should_ignore(attrtype)) {
+        return 0;
+    }
     if (NULL != attrtype) {
         int i = 0;
         while (!r && systemIndexes[i] != NULL) {

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -636,6 +636,7 @@ int ldbm_set_last_usn(Slapi_Backend *be);
  */
 void entryrdn_set_switch(int val);
 int entryrdn_get_switch(void);
+int ldbm_index_entrydn_should_ignore(const char *index_name);
 void entryrdn_set_noancestorid(int val);
 int entryrdn_get_noancestorid(void);
 int entryrdn_index_entry(backend *be, struct backentry *e, int flags, back_txn *txn);

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -34,7 +34,7 @@ from lib389.encrypted_attributes import EncryptedAttr, EncryptedAttrs
 # This is for sample entry creation.
 from lib389.configurations import get_sample_entries
 
-from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSVIRTLE0001, DSCLLE0001
+from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSBLE0008, DSVIRTLE0001, DSCLLE0001
 from lib389.plugins import USNPlugin
 
 
@@ -515,9 +515,9 @@ class Backend(DSLdapObject):
     def _lint_backend_implementation(self):
         backend_impl = self._instance.get_db_lib()
         if backend_impl == 'bdb' and ds_is_newer('3.0.0', instance=self._instance):
-            result = DSBLE0006
-            result['items'] = [self.lint_uid()]
-            yield result
+            report = copy.deepcopy(DSBLE0006)
+            report['items'] = [self.lint_uid()]
+            yield report
 
 
     def _lint_backend_implementation_cleanup_needed(self):
@@ -748,6 +748,39 @@ class Backend(DSLdapObject):
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
             report['fix'] = report['fix'].replace('BACKEND_NAME', bename)
             yield report
+
+    def _lint_obsolete_entrydn_index(self):
+        """Detect obsolete entrydn index left over from pre-entryrdn migrations."""
+        bename = self.lint_uid()
+        suffix = self.get_attr_val_utf8('nsslapd-suffix')
+        issues = []
+
+        try:
+            self.get_indexes().get('entrydn')
+            issues.append('entrydn index is configured in cn=index')
+        except ldap.NO_SUCH_OBJECT:
+            pass
+        except Exception as e:
+            self._log.debug(f"_lint_obsolete_entrydn_index - config check failed: {e}")
+            issues.append(f'Unable to check entrydn index configuration: {e}')
+
+        db_dir = os.path.join(self._instance.ds_paths.db_dir, bename)
+        if os.path.isdir(db_dir):
+            for name in os.listdir(db_dir):
+                if name == 'entrydn.db' or name.startswith('entrydn.db'):
+                    issues.append(f'entrydn database file present: {name}')
+
+        if not issues:
+            return
+
+        report = copy.deepcopy(DSBLE0008)
+        report['check'] = f'backends:{bename}:obsolete_entrydn_index'
+        report['items'] = [suffix]
+        report['detail'] = report['detail'].replace('BACKEND_NAME', bename)
+        report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+        report['fix'] = report['fix'].replace('BACKEND_NAME', bename)
+        report['fix'] = report['fix'].replace('DB_DIR', db_dir)
+        yield report
 
     def create_sample_entries(self, version):
         """Creates sample entries under nsslapd-suffix value

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -115,6 +115,22 @@ systems, you may want to reindex offline or use the --wait option to monitor tas
 """
 }
 
+DSBLE0008 = {
+    'dsle': 'DSBLE0008',
+    'severity': 'HIGH',
+    'description': 'Obsolete entrydn index configuration.',
+    'items': [],
+    'detail': """An entrydn index is configured on backend BACKEND_NAME but this server uses
+entryrdn for DN-based indexing. This can cause inconsistent search results
+and index task failures.
+""",
+    'fix': """Remove the obsolete entrydn index and on disk files, then reindex entryrdn:
+
+    # dsconf YOUR_INSTANCE backend index delete BACKEND_NAME --attr entrydn
+    # rm -f DB_DIR/entrydn.db*
+    # dsconf YOUR_INSTANCE backend index reindex BACKEND_NAME --attr entryrdn"""
+}
+
 # Config checks
 DSCLE0002 = {
     'dsle': 'DSCLE0002',


### PR DESCRIPTION
Description:
Upgraded instances can retain a leftover cn=entrydn index configuration from pre-entryrdn deployments while entryrdn is on. The server may still attempt to register or reindex entrydn, causing inconsistent search results, partially unindexed filters, and index task failures on BDB.

Fix:
When entryrdn is on, the server ignores a leftover entrydn index, logs a warning, skips registering the index on config add/modify (the DSE entry can remain), and skips entrydn during reindex. Healthcheck DSBLE0008 flags leftover cn=entrydn config or entrydn.db* and documents steps to cleanup.

Fixes: https://github.com/389ds/389-ds-base/issues/7519

Reviewed by:

## Summary by Sourcery

Detect and ignore obsolete entrydn indexes when entryrdn-based indexing is enabled, and surface this misconfiguration via healthcheck.

Bug Fixes:
- Prevent entrydn from being registered or reindexed when entryrdn is enabled to avoid inconsistent search results and index task failures on BDB and MDB backends.

Enhancements:
- Add a healthcheck lint rule and backend lint logic to detect leftover entrydn index configuration or on-disk entrydn.db files and provide guided remediation steps.
- Improve lint report generation to avoid mutating shared templates when reporting backend implementation issues.

Tests:
- Add healthcheck tests verifying that an obsolete entrydn index triggers DSBLE0008 and that the warning clears after the configuration is removed.