### PR TITLE
Issue 7541 - heap-buffer-overflows in __aclp__normalize_acltxt()

### DIFF
--- a/ldap/servers/plugins/acl/aclparse.c
+++ b/ldap/servers/plugins/acl/aclparse.c
@@ -848,13 +848,15 @@ __aclp__normalize_acltxt(aci_t *aci_item, char *str)
     s = aclstr;
     while (s && ldap_utf8isspace(s))
         LDAP_UTF8INC(s);
-    assert(s);
+    if (s == NULL || *s == '\0' || *(s + 1) == '\0' || *(s + 2) == '\0') {
+        goto error;
+    }
     *(s + 2) = 'l';
 
     aclName = s + 3;
 
     s = strchr(aclstr, ';');
-    if (NULL == s) {
+    if (NULL == s || aclName >= s) {
         goto error;
     }
 


### PR DESCRIPTION
Bug description:

Various heap-buffer-overflows can be triggered with a specific input passed to acl_parse().

Fix description:

Additional checks are added to prevent OOB memory access.

Fixes: https://github.com/389ds/389-ds-base/issues/7541

Author: Ilia Kashintsev

## Summary by Sourcery

Bug Fixes:
- Prevent potential heap-buffer-overflow in ACL text normalization when parsing specially crafted ACL strings.