### PR TITLE
Issue 7543 - buffer overflow in slapi_dn_find_parent_ext()

### DIFF
--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -1619,6 +1619,8 @@ slapi_dn_find_parent_ext(const char *dn, int is_tombstone)
                     }
                     if (*s) {
                         return (s);
+                    } else {
+                        return (NULL);
                     }
                 }
             }


### PR DESCRIPTION
Bug description:

Buffer overflow can be triggered in slapi_dn_find_parent_ext() if the input ends with a separator.

Fix description:

Additional check is implemented to prevent the for loop from going to the next iteration when that results in a crash.

Fixes: #7543

Reviewed by: @progier389 (Thanks!)

Author: Ilia Kashintsev

## Summary by Sourcery

Bug Fixes:
- Avoid crashes in slapi_dn_find_parent_ext() caused by inputs that end with a DN separator leading to out-of-bounds access.