### PR TITLE
Issue 7545 - Heap buffer overflow in entry.c

### DIFF
--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -120,7 +120,8 @@ str2entry_state_information_from_type(struct berval *atype,
     *value_state = VALUE_PRESENT;
     *attr_state = ATTRIBUTE_PRESENT;
     while (p != NULL) {
-        if (p[3] == 'c' && p[4] == 's' && p[5] == 'n' && p[6] == '-') {
+        if (p[0] != '\0' && p[1] != '\0' && p[2] != '\0' &&
+            p[3] == 'c' && p[4] == 's' && p[5] == 'n' && p[6] == '-') {
             CSNType t = CSN_TYPE_UNKNOWN;
             if (p[1] == 'x' && p[2] == '1') {
                 t = CSN_TYPE_UNKNOWN;


### PR DESCRIPTION
Bug description:

Heap buffer overflow in str2entry_state_information_from_type() can be triggered with a specific input, since ';' is supposed to precede enough symbols.

Fix description:

Additional strlen() check before accessing specific symbols is added.

Fixes: #7545

Reviewed by: @progier389 (thanks!)

Author: Ilia Kashintsev

## Summary by Sourcery

Bug Fixes:
- Add a string length guard in str2entry_state_information_from_type() to avoid out-of-bounds access on malformed input.