### PR TITLE
Issue 7547 - Heap buffer overflow in ldap_utf8prev()

### DIFF
--- a/ldap/servers/slapd/str2filter.c
+++ b/ldap/servers/slapd/str2filter.c
@@ -313,8 +313,11 @@ str2simple(char *str, int unescape_filter)
 
     PR_ASSERT(str);
 
-    if ((s = strchr(str, '=')) == NULL) {
+    if ((s = strchr(str, '=')) == NULL || s == str) {
         return (NULL);
+    }
+    if (s[-1] & 0x80) {
+        return NULL;
     }
     value = s;
     LDAP_UTF8INC(value);


### PR DESCRIPTION
Bug description:

Heap buffer overflow in ldap_utf8prev() can be triggered via str2simple if '=' is not preceded by proper symbols.

Fix description:

Additional checks are added to account for '=' being preceded by nothing or by non-ASCII bytes.

Fixes: #7547

Author: Ilia Kashintsev

## Summary by Sourcery

Bug Fixes:
- Reject filter strings where '=' is the first character or appears in the middle of a UTF-8 multibyte sequence to prevent heap buffer overreads in ldap_utf8prev().