### PR TITLE
Bump version to 2.8.1

### DIFF
--- a/VERSION.sh
+++ b/VERSION.sh
@@ -10,7 +10,7 @@ vendor="389 Project"
 # PACKAGE_VERSION is constructed from these
 VERSION_MAJOR=2
 VERSION_MINOR=8
-VERSION_MAINT=0
+VERSION_MAINT=1
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=
 VERSION_DATE=$(date -u +%Y%m%d%H%M)


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the maintenance version number from 2.8.0 to 2.8.1 in the version script.