### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/VERSION.sh
+++ b/VERSION.sh
@@ -9,8 +9,8 @@ vendor="389 Project"
 
 # PACKAGE_VERSION is constructed from these
 VERSION_MAJOR=3
-VERSION_MINOR=2
-VERSION_MAINT=1
+VERSION_MINOR=3
+VERSION_MAINT=0
 # NOTE: VERSION_PREREL is automatically set for builds made out of a git tree
 VERSION_PREREL=
 VERSION_DATE=$(date -u +%Y%m%d%H%M)

--- a/src/lib389/pyproject.toml
+++ b/src/lib389/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lib389"
-version = "3.2.1"  # Should match the main 389-ds-base version
+version = "3.3.0"  # Should match the main 389-ds-base version
 description = "A library for accessing, testing, and configuring the 389 Directory Server"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}


### PR DESCRIPTION
## Summary by Sourcery

Bump the project and lib389 library version numbers to 3.3.0 to align with the new release.

Enhancements:
- Align lib389's declared project version with the main 389-ds-base 3.3.0 release.

Build:
- Update VERSION.sh to set the core package version to 3.3.0.