### PR TITLE
Issue 7532 - CI - Fix BDB CLU dbmon tests leaving instance offline

### DIFF
--- a/dirsrvtests/tests/suites/clu/dbmon_test.py
+++ b/dirsrvtests/tests/suites/clu/dbmon_test.py
@@ -20,6 +20,8 @@ from lib389.cli_conf.monitor import db_monitor
 from lib389.monitor import MonitorLDBM
 from lib389.cli_base import FakeArgs, LogCapture
 from lib389.backend import Backends
+from lib389.dseldif import DSEldif
+
 
 pytestmark = pytest.mark.tier1
 


### PR DESCRIPTION
Fix CLU dbmon CI test by adding the missing import

Issue #7532

Reviewed by: @mreynolds389 (Thanks!)

## Summary by Sourcery

Tests:
- Update CLU dbmon test module to import the DSEldif helper needed for its execution.