### PR TITLE
Issue 7554 - deref plugin null pointer dereference if ber_init fails

### DIFF
--- a/ldap/servers/plugins/deref/deref.c
+++ b/ldap/servers/plugins/deref/deref.c
@@ -357,6 +357,12 @@ deref_parse_ctrl_value(DerefSpecList *speclist, const struct berval *ctrlbv, int
     }
 
     ber = ber_init((struct berval *)ctrlbv);
+    if (!ber) {
+        *ldapcode = LDAP_UNWILLING_TO_PERFORM;
+        *ldaperrtext = "Deref control parsing failed to initialize BER element";
+        return;
+    }
+
     for (tag = ber_first_element(ber, &len, &last);
          (tag != LBER_ERROR) && (tag != LBER_END_OF_SEQORSET);
          tag = ber_next_element(ber, &len, last)) {


### PR DESCRIPTION
Description:

**CWE**: CWE-476 (NULL Pointer Dereference)

A flaw in the 389 Directory Server's dereference control plugin allows an unauthenticated attacker to crash the LDAP server when the system is under memory pressure(OOM). The deref plugin, enabled by default, fails to check for a memory allocation failure before using the result, causing the server process to terminate.

CI test 'test_deref_and_access_control' already covers this code.

relates: https://github.com/389ds/389-ds-base/issues/7554

## Summary by Sourcery

Bug Fixes:
- Prevent null pointer dereference in the dereference control plugin when BER initialization fails.