### PR TITLE
Issue 3555 - UI - Fix audit issue with npm - brace-expansion

### DIFF
--- a/src/cockpit/389-console/package-lock.json
+++ b/src/cockpit/389-console/package-lock.json
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Description: Run npm audit fix to address the vulnerability in brace-expansion.

Relates: https://github.com/389ds/389-ds-base/issues/3555
Relates: https://github.com/389ds/389-ds-base/issues/7527

Reviewed by: ?

## Summary by Sourcery

Update frontend dependencies to address npm audit vulnerability in brace-expansion.

Bug Fixes:
- Resolve security vulnerability reported in the brace-expansion npm dependency via lockfile updates.

Build:
- Refresh package-lock.json to incorporate patched versions of affected npm packages.