### PR TITLE
Issue 7503 - Fix test DN comparison to be case-insensitive

### DIFF
--- a/dirsrvtests/tests/suites/features/ldap_controls_test.py
+++ b/dirsrvtests/tests/suites/features/ldap_controls_test.py
@@ -72,7 +72,7 @@ def test_postread_ctrl_modify(topology_st):
 
     log.info("Verify PostReadControl response is properly encoded")
     assert resp_ctrls, "Server should return PostReadControl"
-    assert resp_ctrls[0].dn == user.dn, "Control should return correct DN"
+    assert resp_ctrls[0].dn.lower() == user.dn.lower(), "Control should return correct DN"
     assert 'description' in resp_ctrls[0].entry, "Control should return description attribute"
     assert 'cn' in resp_ctrls[0].entry, "Control should return cn attribute"
 


### PR DESCRIPTION
Description: Fix test DN comparison to be case-insensitive in test_postread_ctrl_modify.
 
  The test was comparing resp_ctrls[0].dn == user.dn using a case-sensitive
  string comparison. However, LDAP DN comparison is case-insensitive by
  definition.

  The root cause is an inconsistency in lib389: config_001004002.py creates
  the People OU as 'ou=people' (lowercase), while UserAccounts uses 
  'ou=People' (capital P) as the default RDN. As a result, the PostReadControl
  returns the DN with the actual stored case ('ou=people'), while user.dn
  holds 'ou=People', causing the assertion to fail.

  Fix by using .lower() on both sides to reflect correct LDAP DN comparison
  semantics.
  
  Relates: https://github.com/389ds/389-ds-base/issues/7503

## Summary by Sourcery

Bug Fixes:
- Correct the PostReadControl modify test to compare DNs case-insensitively, avoiding failures due to differing DN case.