### PR TITLE
Issue 7560 - lib389 - Add helper function for checking ASAN files

### DIFF
--- a/src/lib389/lib389/utils.py
+++ b/src/lib389/lib389/utils.py
@@ -2156,3 +2156,37 @@ def get_disk_space(path):
         'used': used_size,
         'percent': used_percent
     }
+
+
+def check_asan_report(inst, err_string):
+    """
+    Check if the ASAN report contains the string.
+
+    This is used for CI tests that expect an ASAN report to exist after
+    stopping the server.
+
+    :param inst: Instance object
+    :param err_string: Error string to search for
+    :return: True if the error string is found, False otherwise
+    :raises ValueError: If the ASAN report does not exist
+    """
+    if not inst.has_asan():
+        return False
+
+    asan_report = os.path.join(inst.ds_paths.run_dir,
+                               f"ns-slapd-{inst.serverid}.asan.{inst.get_pid()}")
+
+    # Now we have the pid (and the proper file name) we can stop the server
+    inst.stop()
+
+    # Check the ASAN report
+    try:
+        with open(asan_report, 'r') as f:
+            content = f.read()
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        raise ValueError(f"Failed to read ASAN report '{asan_report}': {e}")
+
+    if err_string in content:
+        return True
+
+    return False


### PR DESCRIPTION
Description:

Add a helper function for checking specific strings in an ASAN file

relates: https://github.com/389ds/389-ds-base/issues/7560

## Summary by Sourcery

New Features:
- Introduce a check_asan_report helper function to verify whether a given error string appears in an instance's ASAN report file.