### PR TITLE
Issue 7562 - Error: NssSsl.add_cert() got an unexpected keyword argum…

### DIFF
--- a/src/lib389/cli/dscontainer
+++ b/src/lib389/cli/dscontainer
@@ -149,7 +149,7 @@ def _begin_setup_pem_tls():
     # Import the ca's
     for ca_path in [os.path.join(CONTAINER_TLS_SERVER_CADIR, ca) for ca in cas]:
         log.info("Enrolling -> %s" % ca_path)
-        tls.add_cert(nickname=ca_path, input_file=ca_path, ca=True)
+        tls.add_cert(nickname=ca_path, cert_file=ca_path, ca=True)
         tls.edit_cert_trust(ca_path, "C,,")
     # Import the new server-cert
     tls.add_server_key_and_cert(CONTAINER_TLS_SERVER_KEY, CONTAINER_TLS_SERVER_CERT)

--- a/src/lib389/lib389/cli_ctl/tls.py
+++ b/src/lib389/lib389/cli_ctl/tls.py
@@ -44,7 +44,7 @@ def import_client_ca(inst, log, args):
     if nickname.lower() == CERT_NAME.lower() or nickname.lower() == CA_NAME.lower():
         log.error("You may not import a CA with the nickname %s or %s" % (CERT_NAME, CA_NAME))
         return
-    tls.add_cert(nickname=nickname, input_file=cert_path)
+    tls.add_cert(nickname=nickname, cert_file=cert_path)
     tls.edit_cert_trust(nickname, "T,,")
 
 


### PR DESCRIPTION
…ent 'input_file'

Bug Description:
In #7281 `input_file` parameter was renamed to `cert_file`, but not all callers were updated. This causes a TypeError at runtime.

Fix Description:
Update dscontainer and dsctl to use the new `cert_file` parameter name.

Relates: https://github.com/389ds/389-ds-base/issues/7281
Fixes: https://github.com/389ds/389-ds-base/issues/7562

## Summary by Sourcery

Bug Fixes:
- Fix runtime TypeError in TLS certificate import by updating callers to use the renamed cert_file parameter instead of input_file.