### PR TITLE
Issue 7503 - Change variable names in libglobs.c to match their definitions

### DIFF
--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -1192,11 +1192,11 @@ static struct config_get_and_set
      (void **)&global_slapdFrontendConfig.tls_check_crl,
      CONFIG_SPECIAL_TLS_CHECK_CRL, (ConfigGetFunc)config_get_tls_check_crl,
      "none" /* Allow reset to this value */},
-    {CONFIG_MAXCONTROLSPEROP_ATTRIBUTE, config_set_maxcontrolsperop,
+    {CONFIG_MAXCONTROLS_PER_OP_ATTRIBUTE, config_set_maxcontrolsperop,
      NULL, 0,
-     (void **)&global_slapdFrontendConfig.maxcontrolsperop,
+     (void **)&global_slapdFrontendConfig.maxcontrols_per_op,
      CONFIG_INT, (ConfigGetFunc)config_get_maxcontrolsperop,
-     SLAPD_DEFAULT_MAXCONTROLSPEROP_STR},
+     SLAPD_DEFAULT_MAXCONTROLS_PER_OP_STR},
     /* End config */
     };
 


### PR DESCRIPTION
The fix for issue 7503 used the variables CONFIG_MAXCONTROLSPEROP_ATTRIBUTE, maxcontrolsperop, and SLAPD_DEFAULT_MAXCONTROLSPEROP_STR in ldap/servers/slapd/libglobs.c. 
However, these variables were defined in ldap/servers/slapd/slap.h as CONFIG_MAXCONTROLS_PER_OP_ATTRIBUTE, maxcontrols_per_op, and SLAPD_DEFAULT_MAXCONTROLS_PER_OP_STR, respectively. I've changed the calls to these variables in libglobs.c to match their definitions.

## Summary by Sourcery

Bug Fixes:
- Fix mismatched configuration attribute, struct member, and default string names for max controls per operation in libglobs.c.