### PR TITLE
Issue 7529 - Fix WebUI CI failure cascade and missing screenshots

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -83,6 +83,7 @@ jobs:
         sudo cp .github/daemon.json /etc/docker/daemon.json
         sudo systemctl unmask docker
         sudo systemctl start docker
+        sudo apparmor_parser -R /etc/apparmor.d/unix-chkpwd 2>/dev/null || true
 
     - name: Free disk space
       run: |
@@ -127,8 +128,12 @@ jobs:
     - name: Make the results file readable by all
       if: always()
       run: |
-        sudo chmod -f -v -R a+r pytest.*ml assets
-        sudo chmod -f -v a+x assets
+        sudo chmod -f -v -R a+r pytest.*ml assets || true
+        sudo chmod -f -v a+x assets || true
+        if [ -d .playwright-screenshots ]; then
+          sudo chmod -f -v -R a+r .playwright-screenshots
+          sudo chmod -f -v a+x .playwright-screenshots
+        fi
     - name: Sanitize filename
       if: always()
       run: echo "PYTEST_SUITE=$(echo ${{ matrix.suite }} | sed -e 's#\/#-#g')" >> $GITHUB_ENV
@@ -138,8 +143,10 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
+        include-hidden-files: true
         path: |
           pytest.xml
           pytest.html
           assets
+          .playwright-screenshots
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,6 +83,7 @@ jobs:
         sudo cp .github/daemon.json /etc/docker/daemon.json
         sudo systemctl unmask docker
         sudo systemctl start docker
+        sudo apparmor_parser -R /etc/apparmor.d/unix-chkpwd 2>/dev/null || true
 
     - name: Free disk space
       run: |
@@ -133,8 +134,12 @@ jobs:
     - name: Make the results file readable by all
       if: always()
       run: |
-        sudo chmod -f -v -R a+r pytest.*ml assets
-        sudo chmod -f -v a+x assets
+        sudo chmod -f -v -R a+r pytest.*ml assets || true
+        sudo chmod -f -v a+x assets || true
+        if [ -d .playwright-screenshots ]; then
+          sudo chmod -f -v -R a+r .playwright-screenshots
+          sudo chmod -f -v a+x .playwright-screenshots
+        fi
     - name: Sanitize filename
       if: always()
       run: echo "PYTEST_SUITE=$(echo ${{ matrix.suite }} | sed -e 's#\/#-#g')" >> $GITHUB_ENV
@@ -144,8 +149,10 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
+        include-hidden-files: true
         path: |
           pytest.xml
           pytest.html
           assets
+          .playwright-screenshots
 

--- a/dirsrvtests/tests/suites/webui/__init__.py
+++ b/dirsrvtests/tests/suites/webui/__init__.py
@@ -41,7 +41,10 @@ def check_cockpit_version_is_lower(version):
 # the iframe selection differs for chromium and firefox browser
 def determine_frame_selection(page, browser_name):
     if browser_name == 'firefox':
-        frame = page.query_selector('iframe[name=\"cockpit1:localhost/389-console\"]').content_frame()
+        element = page.query_selector('iframe[name=\"cockpit1:localhost/389-console\"]')
+        if element is None:
+            return None
+        frame = element.content_frame()
     else:
         frame = page.frame('cockpit1:localhost/389-console')
 
@@ -72,20 +75,26 @@ def remove_instance_through_lib(topology):
 
 
 def remove_instance_through_webui(topology, page, browser_name):
-    frame = check_frame_assignment(page, browser_name)
-
-    log.info('Check if instance exist')
-    if topology.standalone.exists():
-        log.info('Delete instance')
-        frame.wait_for_selector('#ds-action')
-        frame.click('#ds-action')
-        frame.click('#remove-ds')
-        frame.check('#modalChecked')
-        frame.click('//button[normalize-space(.)=\'Remove Instance\']')
+    try:
         frame = check_frame_assignment(page, browser_name)
-        frame.is_visible("#no-inst-create-btn")
-        time.sleep(1)
-        log.info('Instance deleted')
+
+        log.info('Check if instance exist')
+        if topology.standalone.exists():
+            log.info('Delete instance')
+            frame.wait_for_selector('#ds-action')
+            frame.click('#ds-action')
+            frame.click('#remove-ds')
+            frame.check('#modalChecked')
+            frame.click('//button[normalize-space(.)=\'Remove Instance\']')
+            frame = check_frame_assignment(page, browser_name)
+            frame.is_visible("#no-inst-create-btn")
+            time.sleep(1)
+            log.info('Instance deleted')
+    except Exception as e:
+        log.warning(f'WebUI instance removal failed, falling back to lib389: {e}')
+        if topology.standalone.exists():
+            topology.standalone.delete()
+            time.sleep(1)
 
 
 def setup_login(page):

--- a/dirsrvtests/tests/suites/webui/server/server_test.py
+++ b/dirsrvtests/tests/suites/webui/server/server_test.py
@@ -86,12 +86,10 @@ def test_tuning_and_limits_availability(topology_st, page, browser_name):
     :setup: Standalone instance
     :steps:
          1. Click on Tuning & Limits button on the side panel and check if Number Of Worker Threads is visible.
-         2. Click on Show Advanced Settings button.
-         3. Check if Outbound IO Timeout label is visible.
+         2. Check if Outbound IO Timeout label is visible.
     :expectedresults:
          1. Element is visible
-         2. Success
-         3. Element is visible
+         2. Element is visible
     """
     setup_login(page)
     time.sleep(1)
@@ -102,8 +100,7 @@ def test_tuning_and_limits_availability(topology_st, page, browser_name):
     frame.get_by_text("Number Of Worker Threads").wait_for()
     assert frame.get_by_text("Number Of Worker Threads").is_visible()
 
-    log.info('Open expandable section and check if element is loaded.')
-    frame.get_by_role('button', name='Show Advanced Settings').click()
+    log.info('Check if Outbound IO Timeout is visible.')
     frame.get_by_text('Outbound IO Timeout').wait_for()
     assert frame.get_by_text('Outbound IO Timeout').is_visible()
 


### PR DESCRIPTION
Description: Fix Firefox iframe crash that broke retry loop and cascaded failures. Add cleanup fallback and upload .playwright-screenshots in CI.

Fixes: #7529

Reviewed by: ???

Assisted by: Claude

## Summary by Sourcery

Improve WebUI-based instance removal robustness and capture Playwright screenshots in CI artifacts.

Bug Fixes:
- Handle missing Firefox cockpit iframe elements without crashing the WebUI tests.
- Add a lib389 fallback when WebUI instance removal fails to prevent cascading test failures.

Enhancements:
- Refine WebUI instance deletion flow to re-check the frame and confirm instance removal state.

CI:
- Include .playwright-screenshots in CI chmod steps and uploaded artifacts for pytest and lmdbpytest workflows.