### PR TITLE
Issue 7569 - Add CodeQL advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,76 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: quay.io/389ds/ci-images:fedora
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build_mode: manual
+          - language: python
+            build_mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install CodeQL dependencies
+        run: dnf install -y which
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build_mode }}
+          queries: +security-and-quality
+
+      - name: Configure
+        if: matrix.language == 'c-cpp'
+        run: |
+          set -o pipefail
+          (autoreconf -fvi && ./configure) 2>&1 | tee codeql-build.log
+
+      - name: Build
+        if: matrix.language == 'c-cpp'
+        run: |
+          set -o pipefail
+          make -j$(nproc) 2>&1 | tee -a codeql-build.log
+
+      - name: Upload build and configuration artifacts
+        if: always() && matrix.language == 'c-cpp'
+        uses: actions/upload-artifact@v7
+        with:
+          name: codeql-build-cpp
+          path: |
+            codeql-build.log
+            config.log
+            config.h
+          if-no-files-found: ignore
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Bug Description:
We have Coverity static analysis but no GitHub-native CodeQL/code scanning workflow. Adding CodeQL would provide PR-visible security and quality analysis for C/C++ and Python without relying on Coverity credentials or external dashboard access.

Fix Description:
Add a focused CodeQL advanced setup workflow for C/C++ and Python. The workflow follows the existing Fedora/autotools CI pattern, uses manual build mode for C/C++ analysis, enables the security-and-quality query suite, uploads useful build/config artifacts, and requires only GitHub code scanning permissions.

Related: https://github.com/389ds/389-ds-base/issues/7533
Fixes: https://github.com/389ds/389-ds-base/issues/7569

Reviewed by: ?

## Summary by Sourcery

Add a GitHub CodeQL workflow to run security and quality analysis for C/C++ and Python on main, pull requests, and a weekly schedule.

CI:
- Introduce a CodeQL GitHub Actions workflow using the Fedora CI container image to analyze C/C++ (manual build) and Python code with the security-and-quality query suite.
- Upload C/C++ build and configuration artifacts from the CodeQL job to aid in debugging analysis issues.