### PR TITLE
Issue 7530 - CI - Stabilize DNA plugin replication tests timing out in CI

### DIFF
--- a/dirsrvtests/tests/suites/plugins/accpol_test.py
+++ b/dirsrvtests/tests/suites/plugins/accpol_test.py
@@ -1350,6 +1350,11 @@ def test_acct_policy_consumer(topology_m1c1, request):
         except ldap.NO_SUCH_OBJECT:
             time.sleep(1)
 
+    # Pause replication before restarting supplier/consumer so release_replica
+    # can complete cleanly
+    topology_m1c1.pause_all_replicas()
+    time.sleep(5)
+
     # Configure lastLoginTime on supplier and consumer
     plugin = AccountPolicyPlugin(supplier)
     plugin.enable()
@@ -1370,6 +1375,10 @@ def test_acct_policy_consumer(topology_m1c1, request):
     accp.set('alwaysrecordlogin', 'yes')
     accp.set('stateattrname', 'lastLoginTime')
     consumer.restart(timeout=10)
+
+    # Allow replication to resume before bind tests
+    topology_m1c1.resume_all_replicas()
+    time.sleep(2)
 
     # On supplier
     # Do 3 binds with a delay to
@@ -1413,6 +1422,8 @@ def test_acct_policy_consumer(topology_m1c1, request):
 
     def fin():
         user_supplier.delete()
+        topology_m1c1.pause_all_replicas()
+        time.sleep(5)
         log.info('Disabling Global accpolicy plugin and removing pwpolicy attrs')
         try:
             plugin = AccountPolicyPlugin(supplier)

--- a/dirsrvtests/tests/suites/plugins/dna_interval_test.py
+++ b/dirsrvtests/tests/suites/plugins/dna_interval_test.py
@@ -11,6 +11,7 @@
 import logging
 import pytest
 from lib389._constants import DEFAULT_SUFFIX
+from lib389.dseldif import DSEldif
 from lib389.plugins import DNAPlugin, DNAPluginConfigs
 from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.idm.user import UserAccounts
@@ -45,10 +46,13 @@ def dna_plugin(topology_st, request):
     inst.restart()
 
     def fin():
-        inst.stop()
-        dse_ldif = DSEldif(inst)
-        dse_ldif.delete_dn(f'cn=dna config,{plugin.dn}')
-        inst.start()
+        try:
+            inst.stop()
+            dse_ldif = DSEldif(inst)
+            dse_ldif.delete_dn(f'cn=dna config,{plugin.dn}')
+        finally:
+            if not inst.status():
+                inst.start()
     request.addfinalizer(fin)
 
     return dna_config

--- a/ldap/servers/plugins/replication/repl_extop.c
+++ b/ldap/servers/plugins/replication/repl_extop.c
@@ -1376,8 +1376,9 @@ multisupplier_extop_EndNSDS50ReplicationRequest(Slapi_PBlock *pb)
             /* Outbound replication agreements need to all be restarted now */
             /* XXXGGOOD RESTART REEPL AGREEMENTS */
         } else {
-            /* Unless bail out, we return uninitialized response */
-            goto free_and_return;
+            /* No active replication session on this connection, treat as
+             * already released so the supplier can shut down cleanly */
+            response = NSDS50_REPL_REPLICA_RELEASE_SUCCEEDED;
         }
     }
 send_response:


### PR DESCRIPTION
Description:
dna_interval_test.py failed in teardown with NameError for DSEldif, leaving standalone1 stopped and causing later tests in the module to fail with SERVER_DOWN. Add pause replication around accpol_test restarts to avoid release_replica timeouts, and acknowledge endReplication on the consumer when no session is active.

Fixes: https://github.com/389ds/389-ds-base/issues/7530

Reviewed by:

## Summary by Sourcery

Stabilize replication-related plugin tests by improving replication control and teardown robustness.

Bug Fixes:
- Ensure DNA plugin teardown always restarts the standalone instance even if DSEldif handling fails.
- Handle EndReplication extended operations with no active session as successful so suppliers can shut down cleanly without timeouts.

Enhancements:
- Pause and resume replication around account policy plugin supplier/consumer restarts to prevent release_replica timeouts and reduce CI flakiness in replication tests.