### PR TITLE
Issue 7576 - Fix leak of temporary attribute syntax hash tables after…

### DIFF
--- a/ldap/servers/slapd/attrsyntax.c
+++ b/ldap/servers/slapd/attrsyntax.c
@@ -226,6 +226,8 @@ attr_syntax_add_by_oid(const char *oid, struct asyntaxinfo *a, PRUint32 schema_f
         return;
 
     if (schema_flags & DSE_SCHEMA_LOCKED) {
+        if (0 != attr_syntax_init_tmp())
+            return;
         PL_HashTableAdd(oid2asi_tmp, oid, a);
     } else {
         if (lock) {
@@ -416,6 +418,8 @@ attr_syntax_add_by_name(struct asyntaxinfo *a, PRUint32 schema_flags, int lock)
         return;
 
     if (schema_flags & DSE_SCHEMA_LOCKED) {
+        if (0 != attr_syntax_init_tmp())
+            return;
         /* insert the attr into the temp global linked list */
         attr_syntax_insert_tmp(a);
 
@@ -1465,13 +1469,6 @@ attr_syntax_init(void)
         }
     }
 
-    if (!oid2asi_tmp) {
-        /* temporary hash table for schema reload */
-        oid2asi_tmp = PL_NewHashTable(2047, hashNocaseString,
-                                      hashNocaseCompare,
-                                      PL_CompareValues, 0, 0);
-    }
-
     if (!name2asi) {
         name2asi = PL_NewHashTable(2047, hashNocaseString,
                                    hashNocaseCompare,
@@ -1492,14 +1489,78 @@ attr_syntax_init(void)
                                    DIRSTRING_SYNTAX_OID,
                                    SLAPI_ATTR_FLAG_NOUSERMOD | SLAPI_ATTR_FLAG_NOEXPOSE);
     }
-    if (!name2asi_tmp) {
-        /* temporary hash table for schema reload */
+
+    return 0;
+}
+
+/*
+ * Create the temporary hash tables used only during schema reload.
+ * These must not be created from attr_syntax_init(): after a reload the
+ * tmp pointers are swapped into place and set to NULL, and recreating them
+ * on every attr_syntax_read_lock() would leak hash tables.
+ */
+int
+attr_syntax_init_tmp(void)
+{
+    int rc = 0;
+
+    if (0 != attr_syntax_init()) {
+        return 1;
+    }
+
+    if (!oid2asi_tmp) {
+        oid2asi_tmp = PL_NewHashTable(2047, hashNocaseString,
+                                      hashNocaseCompare,
+                                      PL_CompareValues, 0, 0);
+        if (!oid2asi_tmp) {
+            slapi_log_err(SLAPI_LOG_ERR, "attr_syntax_init_tmp",
+                          "Failed to create oid2asi_tmp hash table\n");
+            rc = 1;
+        }
+    }
+
+    if (!name2asi_tmp && rc == 0) {
         name2asi_tmp = PL_NewHashTable(2047, hashNocaseString,
                                        hashNocaseCompare,
                                        PL_CompareValues, 0, 0);
+        if (!name2asi_tmp) {
+            slapi_log_err(SLAPI_LOG_ERR, "attr_syntax_init_tmp",
+                          "Failed to create name2asi_tmp hash table\n");
+            rc = 1;
+        }
     }
 
-    return 0;
+    if (rc) {
+        /* destroy everything on failure */
+        attr_syntax_destroy_tmp();
+    }
+
+    return rc;
+}
+
+/*
+ * Discard a failed or abandoned schema reload build in the tmp tables.
+ */
+void
+attr_syntax_destroy_tmp(void)
+{
+    struct asyntaxinfo *asi;
+    struct asyntaxinfo *next;
+
+    for (asi = global_at_tmp; asi != NULL; asi = next) {
+        next = asi->asi_next;
+        attr_syntax_free(asi);
+    }
+    global_at_tmp = NULL;
+
+    if (oid2asi_tmp) {
+        PL_HashTableDestroy(oid2asi_tmp);
+        oid2asi_tmp = NULL;
+    }
+    if (name2asi_tmp) {
+        PL_HashTableDestroy(name2asi_tmp);
+        name2asi_tmp = NULL;
+    }
 }
 
 int

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -108,6 +108,8 @@ struct asyntaxinfo *attr_syntax_get_by_name_locking_optional(const char *name, P
 struct asyntaxinfo *attr_syntax_get_global_at(void);
 struct asyntaxinfo *attr_syntax_find(struct asyntaxinfo *at1, struct asyntaxinfo *at2);
 void attr_syntax_swap_ht(void);
+int attr_syntax_init_tmp(void);
+void attr_syntax_destroy_tmp(void);
 /*
  * Call attr_syntax_return(void) when you are done using a value returned
  * by attr_syntax_get_by_oid(void) or attr_syntax_get_by_name(void).

--- a/ldap/servers/slapd/schema.c
+++ b/ldap/servers/slapd/schema.c
@@ -4940,7 +4940,17 @@ slapi_reload_schema_files(char *schemadir)
     }
     slapi_be_Wlock(be); /* be lock must be outer of schemafile lock */
     reload_schemafile_lock();
+    attr_syntax_destroy_tmp();
+    if (0 != attr_syntax_init_tmp()) {
+        reload_schemafile_unlock();
+        slapi_be_Unlock(be);
+        slapi_log_err(SLAPI_LOG_ERR, "schema_reload",
+                      "slapi_reload_schema_files failed to init tmp tables\n");
+        return LDAP_LOCAL_ERROR;
+    }
     oc_delete_all_nolock();
+
+    /* Everything is cleaned up, now parse the schema again */
     rc = init_schema_dse_ext(schemadir, be, &my_pschemadse,
                              DSE_SCHEMA_NO_CHECK | DSE_SCHEMA_LOCKED);
     if (rc) {
@@ -4961,6 +4971,7 @@ slapi_reload_schema_files(char *schemadir)
         slapi_be_Unlock(be);
         return LDAP_SUCCESS;
     } else {
+        attr_syntax_destroy_tmp();
         reload_schemafile_unlock();
         slapi_be_Unlock(be);
         slapi_log_err(SLAPI_LOG_ERR, "schema_reload",


### PR DESCRIPTION
… schema reload

Description:

After attr_syntax_swap_ht() promotes the tmp tables to live use and sets oid2asi_tmp and name2asi_tmp to NULL, attr_syntax_init() was recreating them on every attr_syntax_read_lock() call (e.g. from LDAP searches via slapi_filter_schema_check), leaking PL_NewHashTable allocations.

Create the tmp tables lazily with attr_syntax_init_tmp() only during schema reload, and discard them with attr_syntax_destroy_tmp() on reload start, failure, or before rebuilding. attr_syntax_init() now initializes only the live oid2asi and name2asi tables.

relates: https://github.com/389ds/389-ds-base/issues/7576

co-authored by: Cursor

## Summary by Sourcery

Prevent leakage of temporary attribute syntax hash tables by managing their lifecycle explicitly during schema reloads.

Bug Fixes:
- Avoid leaking temporary attribute syntax hash tables that were being recreated after schema reloads.

Enhancements:
- Introduce dedicated helpers to lazily initialize and destroy temporary attribute syntax tables around schema reload operations.