### PR TITLE
Issue 7578 - schema - attribute refcount is not maintained properly

### DIFF
--- a/dirsrvtests/tests/suites/schema/schema_reload_heap_use_after_free_test.py
+++ b/dirsrvtests/tests/suites/schema/schema_reload_heap_use_after_free_test.py
@@ -1,0 +1,403 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+import threading
+import time
+import ldap
+from collections import Counter
+from lib389.schema import Schema
+from lib389.idm.domain import Domain
+from lib389.rootdse import RootDSE
+from lib389._constants import DEFAULT_SUFFIX
+from test389.topologies import topology_st as topo
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Globals for cross-thread coordination
+# ---------------------------------------------------------------------------
+stop_event = threading.Event()
+crash_detected = threading.Event()
+reload_failed = threading.Event()
+stats_lock = threading.Lock()
+stats = Counter()
+
+ITERATIONS = 10
+SEARCH_THREADS = 12
+MAX_STRESS_TEST_DURATION = 300
+
+SEARCH_ATTRS = [
+    'cn', 'sn', 'givenName', 'mail', 'uid', 'userPassword',
+    'objectClass', 'description', 'telephoneNumber', 'l', 'st',
+    'postalCode', 'street', 'ou', 'title', 'manager', 'secretary',
+    'homeDirectory', 'loginShell', 'uidNumber', 'gidNumber',
+    'memberOf', 'nsAccountLock', 'createTimestamp', 'modifyTimestamp',
+    'entrydn', 'entryid', 'numSubordinates', 'hasSubordinates',
+]
+
+
+def _is_connection_error(exc):
+    """Return True if an LDAP error likely means the server crashed."""
+    if isinstance(exc, (ldap.SERVER_DOWN, ldap.CONNECT_ERROR, ldap.UNAVAILABLE)):
+        return True
+    if isinstance(exc, ldap.LDAPError):
+        msg = str(exc).lower()
+        return any(s in msg for s in (
+            "can't contact", "connection reset",
+            "server is unavailable", "connection refused",
+            "broken pipe",
+        ))
+    return False
+
+
+def check_server_alive(inst):
+    """Quick check: can we connect and read the root DSE?"""
+    try:
+        return RootDSE(inst).exists()
+    except ldap.LDAPError as e:
+        log.error(f"check_server_alive: check_server_alive failed: {str(e)}")
+        return False
+
+
+def search_worker(inst, _worker_id):
+    """Flood LDAP searches that exercise attribute syntax lookups.
+
+    Each search forces the server to look up attribute syntax for the
+    requested attributes (cn, sn, mail, etc.) via attr_syntax_find().
+    That function acquires the read lock, looks up the asyntaxinfo node,
+    bumps the refcount, and releases the lock -- creating the race window.
+
+    We search with many attributes to maximize the number of
+    attr_syntax_find() calls per operation, widening the window.
+    """
+    conn = inst.clone()
+    conn.rebind()
+    domain = Domain(conn, DEFAULT_SUFFIX)
+    domain._list_attrlist = SEARCH_ATTRS
+
+    try:
+        while not stop_event.is_set() and not crash_detected.is_set():
+            try:
+                domain.search(scope='subtree', filter='(objectclass=*)')
+                with stats_lock:
+                    stats['searches_ok'] += 1
+            except ldap.LDAPError as e:
+                with stats_lock:
+                    stats['searches_fail'] += 1
+                    if _is_connection_error(e):
+                        stats['connection_errors'] += 1
+            except Exception as e:
+                log.error(f"search_worker: failed with unknown exception: {str(e)}")
+                with stats_lock:
+                    stats['searches_error'] += 1
+    finally:
+        conn.close()
+
+
+def schema_reload_worker(inst):
+    """Repeatedly trigger schema reload to race against query threads.
+
+    Schema reload is triggered by adding a temporary attribute type to
+    cn=schema, then deleting it. Each add/delete causes the
+    server to call attr_syntax_swap_ht(), which frees all old asyntaxinfo
+    nodes without checking reference counts.
+    """
+    schema = Schema(inst)
+
+    for i in range(ITERATIONS):
+        if stop_event.is_set() or crash_detected.is_set():
+            break
+
+        oid = f'9.9.9.9.9.{os.getpid()}.{i}'
+        attr_name = f'pocTestAttr{i}'
+        attr_params = {
+            'names': (attr_name,),
+            'oid': oid,
+            'desc': 'UAF PoC temp attr',
+            'syntax': '1.3.6.1.4.1.1466.115.121.1.15',
+            'single_value': 1,
+            'sup': (),
+            'syntax_len': None,
+            'x_ordered': None,
+            'collective': None,
+            'obsolete': None,
+            'no_user_mod': None,
+            'equality': None,
+            'substr': None,
+            'ordering': None,
+            'usage': None,
+            'x_origin': ('poc-011',),
+        }
+
+        try:
+            schema.add_attributetype(attr_params)
+            with stats_lock:
+                stats['reloads_ok'] += 1
+        except ldap.LDAPError as e:
+            log.error(f"schema_reload_worker: add_attributetype failed: {attr_name} - {str(e)}")
+            with stats_lock:
+                stats['reloads_fail'] += 1
+                if _is_connection_error(e):
+                    stats['reload_connection_errors'] += 1
+        except Exception as e:
+            log.error(f"schema_reload_worker: add_attributetype unknown exception: {attr_name} - {str(e)}")
+            with stats_lock:
+                stats['reloads_error'] += 1
+
+        time.sleep(1)
+
+        # Add anlother attirbute that should trigger a failure
+        bad_attr_name = f'pocTestAttr{i+1}'
+        attr_params['names'] = (bad_attr_name,)
+        try:
+            schema.add_attributetype(attr_params)
+        except ldap.LDAPError:
+            pass
+
+        try:
+            schema.remove_attributetype(attr_name)
+            with stats_lock:
+                stats['reloads_ok'] += 1
+        except ldap.LDAPError as e:
+            log.error(f"schema_reload_worker: remove_attributetype failed: {attr_name} - {str(e)}")
+            with stats_lock:
+                stats['reloads_fail'] += 1
+        except Exception:
+            pass
+
+        task = schema.reload()
+        task.wait(timeout=20)
+        if task.get_exit_code() != 0:
+            reload_failed.set()
+            log.error(f"schema_reload_worker: reload task failed: {str(task.get_task_log())}")
+            return
+
+        time.sleep(0.01)
+
+
+def crash_monitor(inst, check_interval=0.5):
+    """Periodically check if the server is still alive.
+
+    If the UAF is triggered, the server will crash (SIGSEGV or SIGABRT).
+    This thread detects the crash by failing to connect.
+    """
+    consecutive_failures = 0
+    while not stop_event.is_set() and not crash_detected.is_set():
+        time.sleep(check_interval)
+        try:
+            alive = check_server_alive(inst)
+            if alive:
+                consecutive_failures = 0
+            else:
+                consecutive_failures += 1
+                if consecutive_failures >= 2:
+                    crash_detected.set()
+                    with stats_lock:
+                        stats['crash_detected'] = 1
+        except Exception:
+            consecutive_failures += 1
+            if consecutive_failures >= 2:
+                crash_detected.set()
+                with stats_lock:
+                    stats['crash_detected'] = 1
+
+
+def test_schema_reload_under_load(topo):
+    """Exercise schema reload while concurrent searches stress attribute syntax lookups
+
+    Concurrent LDAP searches force repeated attr_syntax_get_by_name() calls while
+    a background thread adds and removes temporary attribute types and runs the
+    schema reload task. This widens the race window between readers releasing the
+    attribute-syntax read lock and attr_syntax_swap_ht() replacing the hash tables,
+    helping detect use-after-free or memory leaks under AddressSanitizer.
+
+    :id: d977adc1-6f92-4246-8a99-cd66f254e698
+    :setup: Standalone instance
+    :steps:
+        1. Verify the server responds to a root DSE read
+        2. Start a crash-monitor thread and multiple search threads, each with
+           its own lib389 connection, performing subtree searches that request
+           many attribute types
+        3. Start a schema-reload thread that adds a temporary attribute type,
+           removes it, and runs the schema reload task for each iteration
+        4. Wait for the reload thread to finish while logging search and reload
+           progress
+        5. Stop all threads and verify the server is still reachable
+    :expectedresults:
+        1. The server is reachable before the test begins
+        2. Search threads run without connection failures attributable to a crash
+        3. Each schema reload task completes successfully
+        4. Progress is logged until the reload thread exits
+        5. The server remains reachable after all threads stop; a crash or
+           loss of connectivity during the run indicates a defect
+    """
+
+    inst = topo.standalone
+
+    log.info('=' * 70)
+    log.info('Finding 011: Use-After-Free in Schema Reload')
+    log.info('           attr_syntax_swap_ht() — attrsyntax.c:1639-1665')
+    log.info('=' * 70)
+    log.info("")
+    log.info(f'  URI:             {inst.get_ldap_uri()}')
+    log.info(f'  Base DN:         {DEFAULT_SUFFIX}')
+    log.info(f'  Search threads:  {SEARCH_THREADS}')
+    log.info(f'  Reload iters:    {ITERATIONS}')
+    log.info("")
+    log.info('Race window: reader releases AS_LOCK_READ after lookup, before')
+    log.info('writer acquires write lock in attr_syntax_swap_ht(). The swap')
+    log.info('frees all old nodes unconditionally (ignoring refcount), so any')
+    log.info('thread still holding an asyntaxinfo* gets a dangling pointer.')
+    log.info("")
+
+    log.info('[*] Pre-flight: checking server connectivity...')
+    if not check_server_alive(inst):
+        pytest.fail('Cannot reach server. Check host/port.')
+    log.info('[+] Server is alive.')
+    log.info("")
+
+    threads = []
+
+    monitor = threading.Thread(
+        target=crash_monitor,
+        args=(inst,),
+        daemon=True,
+        name='crash-monitor'
+    )
+    monitor.start()
+
+    log.info(f'[*] Starting {SEARCH_THREADS} search flood threads...')
+    for i in range(SEARCH_THREADS):
+        t = threading.Thread(
+            target=search_worker,
+            args=(inst, i),
+            daemon=True,
+            name=f'search-{i}'
+        )
+        t.start()
+        threads.append(t)
+
+    time.sleep(1)
+
+    log.info(f'[*] Starting schema reload thread ({ITERATIONS} iterations)...')
+    log.info("")
+
+    reload_thread = threading.Thread(
+        target=schema_reload_worker,
+        args=(inst,),
+        name='schema-reload'
+    )
+    reload_thread.start()
+
+    start_time = time.monotonic()
+    try:
+        while reload_thread.is_alive():
+            reload_thread.join(timeout=5.0)
+            elapsed = time.monotonic() - start_time# Enforce a hard upper bound so the test cannot hang indefinitely
+
+            if elapsed > MAX_STRESS_TEST_DURATION:
+                pytest.fail(
+                    f"schema reload stress test exceeded max duration "
+                    f"{MAX_STRESS_TEST_DURATION}s; aborting to avoid hang"
+                )
+
+            with stats_lock:
+                s = dict(stats)
+            reloads = s.get('reloads_ok', 0)
+            searches = s.get('searches_ok', 0)
+            conn_errs = (s.get('connection_errors', 0) +
+                         s.get('reload_connection_errors', 0))
+            crashed = s.get('crash_detected', 0)
+
+            status = 'CRASH DETECTED' if crashed else 'running'
+            log.info(f'  [{elapsed:6.1f}s] reloads={reloads}  searches={searches}  '
+                  f'conn_errors={conn_errs}  status={status}')
+
+            if crash_detected.is_set():
+                break
+
+    except KeyboardInterrupt:
+        log.info('\n[!] Interrupted by user.')
+        stop_event.set()
+
+    log.info("Stopping threads...")
+    stop_event.set()
+    reload_thread.join(timeout=5)
+    monitor.join(timeout=5)
+    for t in threads:
+        t.join(timeout=5)
+
+    elapsed = time.monotonic() - start_time
+    with stats_lock:
+        s = dict(stats)
+
+    log.info("")
+    log.info('-' * 70)
+    log.info('Results')
+    log.info('-' * 70)
+    log.info(f'  Elapsed time:      {elapsed:.1f}s')
+    log.info(f'  Schema reloads:    {s.get("reloads_ok", 0)} ok, '
+             f'{s.get("reloads_fail", 0)} fail')
+    log.info(f'  LDAP searches:     {s.get("searches_ok", 0)} ok, '
+             f'{s.get("searches_fail", 0)} fail')
+    log.info(f'  Connection errors: {s.get("connection_errors", 0) + s.get("reload_connection_errors", 0)}')
+    log.info("")
+
+    if crash_detected.is_set():
+        log.info('[+] *** CRASH DETECTED ***')
+        log.info('[+] Server stopped responding during schema reload + search race.')
+        log.info('[+] This is consistent with a use-after-free in attr_syntax_swap_ht().')
+        log.info("")
+        log.info('[+] Next steps:')
+        log.info('    1. Check server logs for SIGSEGV/SIGABRT')
+        log.info('    2. If running under ASan, check for heap-use-after-free report')
+        log.info('    3. Check for core dump in /var/lib/dirsrv/slapd-<instance>/')
+        log.info('    4. In gdb: bt should show attr_syntax_find or attr_syntax_return')
+        log.info('       accessing freed memory from attr_syntax_swap_ht()')
+        assert False
+    else:
+        alive = False
+        try:
+            alive = check_server_alive(inst)
+        except Exception:
+            pass
+
+        if reload_failed.is_set():
+            log.info('[+] *** RELOAD TASK FAILED ***')
+            log.info('[+] Schema reload task failed.')
+            log.info("")
+            log.info('[+] Next steps:')
+            log.info('    1. Check server logs for errors')
+            assert False
+
+        if not alive:
+            log.info('[+] *** SERVER DOWN ***')
+            log.info('[+] Server is no longer responding after the test run.')
+            log.info('[+] Likely crashed from UAF during the race window.')
+            log.info("")
+            log.info('[+] Check server logs and core dumps.')
+            assert False
+        else:
+            log.info('[-] Server survived all iterations.')
+            log.info('    The race window was not hit in this run.')
+            log.info("")
+            log.info('    This is expected — the window is narrow. Suggestions:')
+            log.info('    - Increase --iterations (try 2000-5000)')
+            log.info('    - Increase --search-threads (try 16-32)')
+            log.info('    - Run under ASan for better detection of stale accesses')
+            log.info('    - Set MALLOC_CHECK_=3 to detect heap corruption earlier')
+            log.info('    - Run on a system with more CPU cores for tighter interleaving')
+            log.info('    - Repeat the test multiple times')
+
+
+if __name__ == '__main__':
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/schema/schema_reload_test.py
+++ b/dirsrvtests/tests/suites/schema/schema_reload_test.py
@@ -9,6 +9,7 @@
 import logging
 import pytest
 import time, ldap, re, os
+from lib389.config import Config
 from lib389.schema import Schema
 from lib389.utils import ensure_bytes
 from test389.topologies import topology_st as topo
@@ -284,6 +285,30 @@ def test_invalid_schema(topo):
         assert False
     else:
         log.info("The invalid schema is not present on the server")
+
+
+def test_schema_reload_schemamod_off(topo):
+    """Schema reload fails with error 53 when nsslapd-schemamod is off.
+
+    :id: 59684513-ccf7-42a0-8819-0ba147c0bbaf
+    :setup: Standalone instance
+    :steps:
+        1. Set nsslapd-schemamod to off under cn=config
+        2. Attempt to run a schema reload task
+        3. Restore nsslapd-schemamod to on
+    :expectedresults:
+        1. The configuration attribute is set successfully
+        2. Schema reload is rejected with LDAP_UNWILLING_TO_PERFORM (53)
+        3. Schema modification is re-enabled
+    """
+    config = Config(topo.standalone)
+    config.replace('nsslapd-schemamod', 'off')
+    try:
+        schema = Schema(topo.standalone)
+        with pytest.raises(ldap.UNWILLING_TO_PERFORM):
+            schema.reload(schema_dir=topo.standalone.schemadir)
+    finally:
+        config.replace('nsslapd-schemamod', 'on')
 
 
 if __name__ == '__main__':

--- a/ldap/servers/plugins/schema_reload/schema_reload.c
+++ b/ldap/servers/plugins/schema_reload/schema_reload.c
@@ -226,6 +226,15 @@ schemareload_add(Slapi_PBlock *pb,
     task_data *mytaskdata = NULL;
     char *bind_dn;
 
+    if (config_get_schemamod() == 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "schemareload",
+                      "schemareload_add - "
+                      "Schema modification is disabled - rejecting reload task\n");
+        *returncode = LDAP_UNWILLING_TO_PERFORM;
+        rv = SLAPI_DSE_CALLBACK_ERROR;
+        goto out;
+    }
+
     *returncode = LDAP_SUCCESS;
     if (slapi_entry_attr_get_ref(e, "cn") == NULL) {
         *returncode = LDAP_OBJECT_CLASS_VIOLATION;

--- a/ldap/servers/slapd/attr.c
+++ b/ldap/servers/slapd/attr.c
@@ -288,6 +288,7 @@ slapi_attr_init_syntax(Slapi_Attr *a)
         a->a_mr_eq_plugin = asi->asi_mr_eq_plugin;
         a->a_mr_ord_plugin = asi->asi_mr_ord_plugin;
         a->a_mr_sub_plugin = asi->asi_mr_sub_plugin;
+        attr_syntax_return(asi);
     }
     if (tmp)
         slapi_ch_free_string(&tmp);

--- a/ldap/servers/slapd/attrsyntax.c
+++ b/ldap/servers/slapd/attrsyntax.c
@@ -381,19 +381,21 @@ attr_syntax_return_locking_optional(struct asyntaxinfo *asi, PRBool use_lock)
         }
 
         if (delete_it) {
-            if (asi->asi_marked_for_delete) { /* one final check */
-                if (use_lock) {
-                    AS_UNLOCK_READ(name2asi_lock);
-                    AS_LOCK_WRITE(name2asi_lock);
-                }
+            if (use_lock) {
+                AS_UNLOCK_READ(name2asi_lock);
+                AS_LOCK_WRITE(name2asi_lock);
+            }
+            if (slapi_atomic_load_64(&asi->asi_refcnt, __ATOMIC_ACQUIRE) == 0 &&
+                asi->asi_marked_for_delete) /* one final check */
+            {
                 /* ref count is 0 and it's flagged for
                  * deletion, so it's safe to free now */
                 attr_syntax_remove(asi);
                 attr_syntax_free(asi);
-                if (use_lock) {
-                    AS_UNLOCK_WRITE(name2asi_lock);
-                    locked = 0;
-                }
+            }
+            if (use_lock) {
+                AS_UNLOCK_WRITE(name2asi_lock);
+                locked = 0;
             }
         }
     }
@@ -1201,6 +1203,9 @@ slapi_attr_is_dn_syntax_type(char *type)
             dn_syntax = ((0 == strcmp(syntaxoid, NAMEANDOPTIONALUID_SYNTAX_OID)) || (0 == strcmp(syntaxoid, DN_SYNTAX_OID)));
         }
     }
+    if (asi) {
+        attr_syntax_return(asi);
+    }
     return dn_syntax;
 }
 
@@ -1709,7 +1714,10 @@ attr_syntax_swap_ht()
     /* Free the global attr linked list */
     while (global_at) {
         next = global_at->asi_next;
-        attr_syntax_free(global_at);
+        global_at->asi_marked_for_delete = 1;
+        if (slapi_atomic_load_64(&global_at->asi_refcnt, __ATOMIC_ACQUIRE) == 0) {
+            attr_syntax_free(global_at);
+        }
         global_at = next;
     }
 

--- a/ldap/servers/slapd/schema.c
+++ b/ldap/servers/slapd/schema.c
@@ -2712,6 +2712,8 @@ add_oc_internal(struct objclass *pnew_oc, char *errorbuf, size_t errorbufsize, i
                                "The OID \"%s\" is also used by the attribute type \"%s\"",
                                pnew_oc->oc_oid, pasyntaxinfo->asi_name);
         rc = LDAP_TYPE_OR_VALUE_EXISTS;
+    }
+    if (pasyntaxinfo) {
         attr_syntax_return(pasyntaxinfo);
     }
 
@@ -3343,6 +3345,8 @@ parse_attr_str(const char *input, struct asyntaxinfo **asipp, char *errorbuf, si
             if (NULL == atype->at_ordering_oid) {
                 atype->at_ordering_oid = slapi_ch_strdup(asi_parent->asi_mr_ordering);
             }
+        }
+        if (asi_parent) {
             attr_syntax_return(asi_parent);
         }
     }
@@ -4393,9 +4397,9 @@ init_schema_dse_ext(char *schemadir, Slapi_Backend *be, struct dse **local_psche
                               schema_flags, 0, 0, 0);
         }
         if (rc) {
-            slapi_log_err(SLAPI_LOG_ERR, "init_schema_dse_ext", "Could not add"
-                                                                " attribute type \"objectClass\" to the schema: %s\n",
-                          errorbuf);
+            slapi_log_err(SLAPI_LOG_ERR, "init_schema_dse_ext",
+                    "Could not add attribute type \"objectClass\" to the schema: %s\n",
+                    errorbuf);
         }
 
         rc = dse_read_file(*local_pschemadse, pb);
@@ -4935,7 +4939,7 @@ slapi_reload_schema_files(char *schemadir)
 
     if (NULL == be) {
         slapi_log_err(SLAPI_LOG_ERR, "schema_reload",
-                      "slapi_reload_schema_files failed\n");
+                      "slapi_reload_schema_files failed - be is NULL\n");
         return LDAP_LOCAL_ERROR;
     }
     slapi_be_Wlock(be); /* be lock must be outer of schemafile lock */
@@ -4971,11 +4975,12 @@ slapi_reload_schema_files(char *schemadir)
         slapi_be_Unlock(be);
         return LDAP_SUCCESS;
     } else {
+        dse_destroy(my_pschemadse); /* still need to destroy it on error */
         attr_syntax_destroy_tmp();
         reload_schemafile_unlock();
         slapi_be_Unlock(be);
         slapi_log_err(SLAPI_LOG_ERR, "schema_reload",
-                      "slapi_reload_schema_files failed\n");
+                      "slapi_reload_schema_files - init_schema_dse_ext failed\n");
         return LDAP_LOCAL_ERROR;
     }
 }


### PR DESCRIPTION
Description:

The refcount mechanism for attributes is not correctly used, and this prevents its use for synchronizing hashtable access. We increment the refcount, but we don't decrement it correctly. This can potentially cause a rare race condition with schema reload task and heap-use-after-free with searches running at the same time as the reload task.

**CWE**: CWE-416 (Use After Free) via CWE-362 (Race Condition)

CI test assisted by: Cursor

relates: https://github.com/389ds/389-ds-base/issues/7578

## Summary by Sourcery

Fix attribute syntax reference counting and cleanup during schema reload to prevent use-after-free race conditions, and add a stress test that exercises concurrent searches with schema reloads to detect crashes.

Bug Fixes:
- Correct attribute syntax reference counting by ensuring attr_syntax_return is called wherever references are taken and by guarding deletion on both refcount and deletion flags.
- Prevent premature freeing of global attribute syntax structures during hash table swaps by honoring reference counts and delete markers, avoiding use-after-free during schema reloads.
- Improve error logging in schema reload paths with clearer messages and ensure temporary DSE structures are destroyed on failure.

Tests:
- Add a multithreaded schema reload stress test that runs concurrent searches and schema reload tasks, with crash monitoring and detailed statistics, to expose heap-use-after-free or race-condition crashes in attribute syntax handling.