### PR TITLE
Issue 7534 - CI - Fix resource_limits fdlimits failures in BDB and LMDB

### DIFF
--- a/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
+++ b/dirsrvtests/tests/suites/resource_limits/fdlimits_test.py
@@ -10,11 +10,12 @@ import logging
 import pytest
 import os
 import ldap
+import resource
 from lib389.backend import Backends
 from lib389._constants import *
+from lib389 import pid_from_file
 from test389.topologies import topology_st
 from lib389.utils import ds_is_older, ensure_str, is_fips
-from subprocess import check_output
 
 pytestmark = pytest.mark.tier1
 
@@ -24,17 +25,33 @@ log = logging.getLogger(__name__)
 FD_ATTR = "nsslapd-maxdescriptors"
 RESRV_FD_ATTR = "nsslapd-reservedescriptors"
 SLAPD_DEFAULT_MAXDESCRIPTORS = 1048576
-SYSTEMD_LIMIT = ensure_str(check_output("systemctl show -p LimitNOFILE dirsrv@standalone1".split(" ")).strip()).split('=')[1]
-# Server caps maxdescriptors at min(its own rlim_max, SLAPD_DEFAULT_MAXDESCRIPTORS); pytest's rlim_max is unrelated.
-if SYSTEMD_LIMIT == "infinity":
-    MAX_FD_VAL = SLAPD_DEFAULT_MAXDESCRIPTORS
-else:
-    MAX_FD_VAL = min(int(SYSTEMD_LIMIT), SLAPD_DEFAULT_MAXDESCRIPTORS)
-CUSTOM_VAL = str(MAX_FD_VAL - 10)
 RESRV_DESC_VAL_LOW = 10
-TOO_HIGH_VAL = str(MAX_FD_VAL + 1)
-TOO_HIGH_VAL2 = str(MAX_FD_VAL + 1)
 TOO_LOW_VAL = "0"
+
+
+def get_process_fd_limit(inst):
+    """Get the file descriptor hard limit from the instance process.
+
+    Reads /proc/<pid>/limits to get RLIMIT_NOFILE hard limit.
+    Server caps maxdescriptors at min(process rlim_max, SLAPD_DEFAULT_MAXDESCRIPTORS).
+    """
+    try:
+        pid = pid_from_file(inst.pid_file())
+        with open(f"/proc/{pid}/limits", "r") as f:
+            for line in f:
+                if "Max open files" in line:
+                    log.info(line)
+                    parts = line.split()
+                    hard_limit = parts[4]
+                    if hard_limit == "unlimited":
+                        return SLAPD_DEFAULT_MAXDESCRIPTORS
+                    else:
+                        return min(int(hard_limit), SLAPD_DEFAULT_MAXDESCRIPTORS)
+    except Exception as e:
+        log.warning(f"Failed to read process limits: {e}, using default")
+        return SLAPD_DEFAULT_MAXDESCRIPTORS
+
+    return SLAPD_DEFAULT_MAXDESCRIPTORS
 
 @pytest.mark.skipif(ds_is_older("1.4.1.2"), reason="Not implemented")
 def test_fd_limits(topology_st):
@@ -54,32 +71,39 @@ def test_fd_limits(topology_st):
         4. Success
     """
 
-    # Check systemd default
+    # Get the process FD limit dynamically
+    max_fd_val = get_process_fd_limit(topology_st.standalone)
+    custom_val = str(max_fd_val - 10)
+    too_high_val = str(max_fd_val + 1)
+    log.info(f'test_fd_limits: max_fd_val={max_fd_val} custom_val={custom_val}' +
+             f'too_high_val={too_high_val}')
+
+    # Check process default
     max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == str(MAX_FD_VAL)
+    assert max_fd == str(max_fd_val)
 
     # Check custom value is applied
-    topology_st.standalone.config.set(FD_ATTR, CUSTOM_VAL)
+    topology_st.standalone.config.set(FD_ATTR, custom_val)
     max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == CUSTOM_VAL
+    assert max_fd == custom_val
 
-    # # Attempt to use value that is higher than the global system limit
+    # Attempt to use value that is higher than the process limit
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
-        topology_st.standalone.config.set(FD_ATTR, TOO_HIGH_VAL)
+        topology_st.standalone.config.set(FD_ATTR, too_high_val)
     max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == CUSTOM_VAL
+    assert max_fd == custom_val
 
-    # Attempt to use value that is higher than the value defined in the systemd service
+    # Attempt to use value that is higher than the process limit (second check)
     with pytest.raises(ldap.UNWILLING_TO_PERFORM):
-        topology_st.standalone.config.set(FD_ATTR, TOO_HIGH_VAL2)
+        topology_st.standalone.config.set(FD_ATTR, too_high_val)
     max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == CUSTOM_VAL
+    assert max_fd == custom_val
 
     # Attempt to use val that is too low
     with pytest.raises(ldap.OPERATIONS_ERROR):
         topology_st.standalone.config.set(FD_ATTR, TOO_LOW_VAL)
     max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == CUSTOM_VAL
+    assert max_fd == custom_val
 
     log.info("test_fd_limits PASSED")
 
@@ -129,21 +153,25 @@ def test_reserve_descriptors_high(topology_st):
         5. Restart instance
     :expectedresults:
         1. Success
-        2. Value of MAX_FD_VAL is returned
+        2. Value of process max FD is returned
         3. Success
-        4. Value of MAX_FD_VAL - 2 is returned
+        4. Value of process max FD - 2 is returned
         5. Instance starts correctly
     """
 
-    # Set nsslapd-maxdescriptors to a custom value
-    topology_st.standalone.config.set(FD_ATTR, str(MAX_FD_VAL))
-    max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
-    assert max_fd == str(MAX_FD_VAL)
+    # Get the process FD limit dynamically
+    max_fd_val = get_process_fd_limit(topology_st.standalone)
+    log.info(f'test_reserve_descriptors_high: max_fd_val={max_fd_val}')
 
-    # Set nsslapd-reservedescriptors to 2 less than custom value
-    topology_st.standalone.config.set(RESRV_FD_ATTR, str(MAX_FD_VAL - 2))
+    # Set nsslapd-maxdescriptors to the process max value
+    topology_st.standalone.config.set(FD_ATTR, str(max_fd_val))
+    max_fd = topology_st.standalone.config.get_attr_val_utf8(FD_ATTR)
+    assert max_fd == str(max_fd_val)
+
+    # Set nsslapd-reservedescriptors to 2 less than max value
+    topology_st.standalone.config.set(RESRV_FD_ATTR, str(max_fd_val - 2))
     resrv_fd = topology_st.standalone.config.get_attr_val_utf8(RESRV_FD_ATTR)
-    assert resrv_fd == str(MAX_FD_VAL - 2)
+    assert resrv_fd == str(max_fd_val - 2)
 
     # Verify instance restart
     topology_st.standalone.restart()


### PR DESCRIPTION
Change CI test to compute the limit from the ns-slapd process rather than relying on systemd one.

Issue: #7534 

Reviewed by: @droideck  (Thanks!)

## Summary by Sourcery

Tests:
- Adjust fdlimits tests to read RLIMIT_NOFILE from the server process via /proc rather than systemd LimitNOFILE, and base assertions on the process-specific max descriptor value.