### PR TITLE
Issue 7536 - CI - Fix backup_task_after_failure race

### DIFF
--- a/dirsrvtests/tests/suites/backups/backup_test.py
+++ b/dirsrvtests/tests/suites/backups/backup_test.py
@@ -327,7 +327,7 @@ def test_backup_task_after_failure(mytopo):
     inst = mytopo.standalone
     tasks = inst.tasks
     archive_dir1 = f'{inst.ds_paths.backup_dir}/bak1'
-    archive_dir1b = f'{inst.ds_paths.backup_dir}/bak1b'
+    dir1bidx = 1
     archive_dir2 = f'{inst.ds_paths.backup_dir}/bak2'
 
     # Sometime the backup complete too fast, so lets retry if first
@@ -342,6 +342,8 @@ def test_backup_task_after_failure(mytopo):
         done,exitCode,warningCode = (False, None, None)
         while not done:
             if os.path.isdir(archive_dir1):
+                archive_dir1b = f'{inst.ds_paths.backup_dir}/bak1b{dir1bidx}'
+                dir1bidx += 1
                 os.rename(archive_dir1, archive_dir1b)
             done,exitCode,warningCode = tasks.checkTask(tasks.entry)
             time.sleep(0.01)


### PR DESCRIPTION
Avoid the Directory Not Empty exception by ensuring that os.rename target directory is always new

Issue: #7536 

Reviewed by: @tbordaz, @droideck  (Thanks!)

## Summary by Sourcery

Ensure backup failure test renames backup directories to unique, non-existing targets to avoid race conditions in CI.

Bug Fixes:
- Prevent intermittent Directory Not Empty errors in backup_task_after_failure by avoiding renaming into an existing backup directory.

Tests:
- Adjust backup_task_after_failure test to generate a fresh backup directory name on each retry during task completion polling.