### PR TITLE
Issue 7263 - UI - Use cockpit.file API for temporary file writes

### DIFF
--- a/src/cockpit/389-console/src/dsModals.jsx
+++ b/src/cockpit/389-console/src/dsModals.jsx
@@ -10,7 +10,8 @@ import {
     valid_dn,
     valid_db_name,
     callCmdStreamPassword,
-    getApiErrorMessage
+    getApiErrorMessage,
+    replaceFileContent
 } from "./lib/tools.jsx";
 import {
     Button,
@@ -287,16 +288,12 @@ export class CreateInstanceModal extends React.Component {
                                              * Success we have our setup file and it has the correct permissions.
                                              * Now populate the setup file...
                                              */
-                                            const cmd = [
-                                                '/bin/sh', '-c',
-                                                '/usr/bin/echo -e \'' + setup_inf + '\' >> ' + setup_file
-                                            ];
-
-                                            let createBuffer = "";
+                                            const setupFileContent = setup_inf.endsWith("\n")
+                                                ? setup_inf
+                                                : setup_inf + "\n";
                                             // Do not log inf file as it contains the DM password
-                                            log_cmd("handleCreateInstance", "Apply changes to INF file...", "");
-                                            cockpit
-                                                    .spawn(cmd, { superuser: "require", err: "message" })
+                                            log_cmd("handleCreateInstance", "Apply changes to INF file...", [setup_file]);
+                                            replaceFileContent(setup_file, setupFileContent)
                                                     .fail(err => {
                                                         this.setState({
                                                             loadingCreate: false
@@ -307,55 +304,71 @@ export class CreateInstanceModal extends React.Component {
                                                         );
                                                     })
                                                     .done(() => {
-                                                        /*
-                                                         * Next, create the instance...
-                                                         */
-                                                        const cmd = ["dscreate", "-j", "from-file", setup_file];
-                                                        log_cmd("handleCreateInstance", "Creating instance...", cmd);
+                                                        const final_chmod_cmd = ["chmod", "600", setup_file];
+                                                        log_cmd("handleCreateInstance", "Reset INF file permissions after write...", final_chmod_cmd);
                                                         cockpit
-                                                                .spawn(cmd, {
-                                                                    superuser: "require",
-                                                                    err: "message"
-                                                                })
+                                                                .spawn(final_chmod_cmd, { superuser: "require", err: "message" })
                                                                 .fail(err => {
-                                                                    const errMsg = getApiErrorMessage(err.message);
-                                                                    cockpit.spawn(rm_cmd, { superuser: "require" }); // Remove Inf file with clear text password
+                                                                    cockpit.spawn(rm_cmd, { superuser: "require", err: "message" }); // Remove Inf file with clear text password
                                                                     this.setState({
                                                                         loadingCreate: false
                                                                     });
                                                                     addNotification(
                                                                         "error",
-                                                                        `${errMsg}`
+                                                                        cockpit.format(_("Failed to set permissions on setup file $0: $1"), setup_file, err.message)
                                                                     );
                                                                 })
                                                                 .done(() => {
-                                                                    // Success!!!  Now set Root DN pw, and cleanup everything up...
-                                                                    log_cmd("handleCreateInstance", "Instance creation complete, remove INF file...", rm_cmd);
-                                                                    cockpit.spawn(rm_cmd, { superuser: "require" });
+                                                                    /*
+                                                                     * Next, create the instance...
+                                                                     */
+                                                                    const cmd = ["dscreate", "-j", "from-file", setup_file];
+                                                                    log_cmd("handleCreateInstance", "Creating instance...", cmd);
+                                                                    cockpit
+                                                                            .spawn(cmd, {
+                                                                                superuser: "require",
+                                                                                err: "message"
+                                                                            })
+                                                                            .fail(err => {
+                                                                                const errMsg = getApiErrorMessage(err.message);
+                                                                                cockpit.spawn(rm_cmd, { superuser: "require" }); // Remove Inf file with clear text password
+                                                                                this.setState({
+                                                                                    loadingCreate: false
+                                                                                });
+                                                                                addNotification(
+                                                                                    "error",
+                                                                                    `${errMsg}`
+                                                                                );
+                                                                            })
+                                                                            .done(() => {
+                                                                                // Success!!!  Now set Root DN pw, and cleanup everything up...
+                                                                                log_cmd("handleCreateInstance", "Instance creation complete, remove INF file...", rm_cmd);
+                                                                                cockpit.spawn(rm_cmd, { superuser: "require" });
 
-                                                                    const dm_pw_cmd = ['dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + newServerId + '.socket',
-                                                                        'directory_manager', 'password_change'];
-                                                                    const config = {
-                                                                        cmd: dm_pw_cmd,
-                                                                        promptArg: "",
-                                                                        passwd: createDMPassword,
-                                                                        addNotification,
-                                                                        success_msg: cockpit.format(_("Successfully created instance: slapd-$0"), createServerId),
-                                                                        error_msg: _("Failed to set Directory Manager password"),
-                                                                        state_callback: () => { this.setState({ loadingCreate: false }) },
-                                                                        reload_func: loadInstanceList,
-                                                                        reload_arg: createServerId,
-                                                                        ext_func: closeHandler,
-                                                                        ext_arg: "",
-                                                                        funcName: "handleCreateInstance",
-                                                                        funcDesc: _("Set Directory Manager password...")
-                                                                    };
-                                                                    callCmdStreamPassword(config);
-                                                                })
-                                                                .stream(line => {
-                                                                    this.setState({
-                                                                        createBuffer: this.state.createBuffer + line
-                                                                    });
+                                                                                const dm_pw_cmd = ['dsconf', '-j', 'ldapi://%2fvar%2frun%2fslapd-' + newServerId + '.socket',
+                                                                                    'directory_manager', 'password_change'];
+                                                                                const config = {
+                                                                                    cmd: dm_pw_cmd,
+                                                                                    promptArg: "",
+                                                                                    passwd: createDMPassword,
+                                                                                    addNotification,
+                                                                                    success_msg: cockpit.format(_("Successfully created instance: slapd-$0"), createServerId),
+                                                                                    error_msg: _("Failed to set Directory Manager password"),
+                                                                                    state_callback: () => { this.setState({ loadingCreate: false }) },
+                                                                                    reload_func: loadInstanceList,
+                                                                                    reload_arg: createServerId,
+                                                                                    ext_func: closeHandler,
+                                                                                    ext_arg: "",
+                                                                                    funcName: "handleCreateInstance",
+                                                                                    funcDesc: _("Set Directory Manager password...")
+                                                                                };
+                                                                                callCmdStreamPassword(config);
+                                                                            })
+                                                                            .stream(line => {
+                                                                                this.setState({
+                                                                                    createBuffer: this.state.createBuffer + line
+                                                                                });
+                                                                            });
                                                                 });
                                                     });
                                         });

--- a/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
+++ b/src/cockpit/389-console/src/lib/security/certificateManagement.jsx
@@ -25,7 +25,7 @@ import {
     ExportCertModal,
 } from "./securityModals.jsx";
 import PropTypes from "prop-types";
-import { getApiErrorMessage, log_cmd } from "../../lib/tools.jsx";
+import { getApiErrorMessage, log_cmd, replaceFileContent } from "../../lib/tools.jsx";
 
 const _ = cockpit.gettext;
 
@@ -515,15 +515,12 @@ export class CertificateManagement extends React.Component {
         if (this.state.certRadioUpload && this.state.uploadValue) {
             // Certificate was copied and pasted.  Need to create a tmp file for import
             const certFile = this.props.certDir + "/tmp-cert-" + Date.now() + ".tmp";
-            const certText = this.state.uploadValue;
-            const create_cert_cmd = [
-                '/bin/sh', '-c',
-                '/usr/bin/echo -e \'' + certText + '\' > ' + certFile
-            ];
+            const certText = this.state.uploadValue.endsWith("\n")
+                ? this.state.uploadValue
+                : this.state.uploadValue + "\n";
 
-            log_cmd("addCert", "creating tmp cert file for importing: ", create_cert_cmd);
-            cockpit
-                    .spawn(create_cert_cmd, { superuser: "require", err: "message" })
+            log_cmd("addCert", "Creating tmp cert file for importing", [certFile]);
+            replaceFileContent(certFile, certText)
                     .done(() => {
                         const cmd = [
                             "dsconf", "-j", "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",

--- a/src/cockpit/389-console/src/lib/tools.jsx
+++ b/src/cockpit/389-console/src/lib/tools.jsx
@@ -2,6 +2,19 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
+export function replaceFileContent(filePath, content, options = { superuser: "require" }) {
+    const fileHandle = cockpit.file(filePath, options);
+    return fileHandle
+            .replace(content)
+            .always(() => {
+                try {
+                    fileHandle.close();
+                } catch (err) {
+                    console.error("Error closing file handle:", err);
+                }
+            });
+}
+
 export function searchFilter(searchFilterValue, columnsToSearch, rows) {
     if (searchFilterValue && rows && rows.length) {
         const filteredRows = [];


### PR DESCRIPTION
Description: Replace shell-based echo writes with cockpit.file().replace() for pasted certificate imports and temporary instance setup INF files. This avoids shell quoting issues, keeps sensitive file contents out of command logs, and resets setup INF permissions after atomic replacement before running dscreate.

Fixes: https://github.com/389ds/389-ds-base/issues/7263

Reviewed by: ?

## Summary by Sourcery

Replace shell-based file writes in Cockpit UI with cockpit.file-based helpers for safer temporary file handling during instance creation and certificate import.

Bug Fixes:
- Avoid shell quoting issues and leaking sensitive content into command logs when writing temporary setup INF and certificate files.

Enhancements:
- Introduce a reusable replaceFileContent helper that uses cockpit.file().replace() with proper handle cleanup.
- Update instance creation workflow to write setup INF files via cockpit.file and explicitly reset file permissions before running dscreate.
- Update certificate import workflow to create temporary certificate files via cockpit.file instead of shell echo commands.