### PR TITLE
Issue 7537 - CI - Fix replication log monitoring parser/timing failures

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -748,8 +748,13 @@ get_entry_type(WorkerQueueData_t *wqelmt, Slapi_DN *sdn)
     int len = SLAPI_ATTR_UNIQUEID_LENGTH;
     const char *ndn = slapi_sdn_get_ndn(sdn);
 
-    if (slapi_be_issuffix(be, sdn) && (wqelmt->wait_id == 1)) {
-        return DNRC_SUFFIX;
+    if (slapi_be_issuffix(be, sdn)) {
+        /* Is this is the root suffix entry */
+        if (wqelmt->wait_id == 1) {
+            return DNRC_SUFFIX;
+        }
+        /* Duplicate root suffix entry. */
+        return DNRC_BAD_SUFFIX_ID;
     }
     if (PL_strncasecmp(ndn, SLAPI_ATTR_UNIQUEID, len) || ndn[len] != '=') {
             return DNRC_OK;
@@ -4188,9 +4193,18 @@ dbmdb_bulk_producer(void *param)
                 thread_abort(info);
                 continue;
             case DNRC_BAD_SUFFIX_ID:
-                import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
-                                  "Supplier's entry is inconsistent. (Suffix ID is %d instead of 1).", entry->id);
-                thread_abort(info);
+                import_log_notice(job, SLAPI_LOG_REPL, "dbmdb_bulk_producer",
+                                  "Skipping duplicate suffix entry \"%s\" (wire import id %d).",
+                                  slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
+                free_bulk_queue_item(&entry);
+                entry = NULL;
+                continue;
+            case DNRC_NOPARENT_DN:
+                import_log_notice(job, SLAPI_LOG_REPL, "dbmdb_bulk_producer",
+                                  "Skipping entry \"%s\" with no extractable parent DN (wire import id %d).",
+                                  slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
+                free_bulk_queue_item(&entry);
+                entry = NULL;
                 continue;
             case DNRC_NOPARENT_ID:
                 import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -749,7 +749,7 @@ get_entry_type(WorkerQueueData_t *wqelmt, Slapi_DN *sdn)
     const char *ndn = slapi_sdn_get_ndn(sdn);
 
     if (slapi_be_issuffix(be, sdn)) {
-        /* Is this is the root suffix entry */
+        /* Is this the root suffix entry */
         if (wqelmt->wait_id == 1) {
             return DNRC_SUFFIX;
         }
@@ -4193,14 +4193,14 @@ dbmdb_bulk_producer(void *param)
                 thread_abort(info);
                 continue;
             case DNRC_BAD_SUFFIX_ID:
-                import_log_notice(job, SLAPI_LOG_REPL, "dbmdb_bulk_producer",
+                import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
                                   "Skipping duplicate suffix entry \"%s\" (wire import id %d).",
                                   slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
                 free_bulk_queue_item(&entry);
                 entry = NULL;
                 continue;
             case DNRC_NOPARENT_DN:
-                import_log_notice(job, SLAPI_LOG_REPL, "dbmdb_bulk_producer",
+                import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
                                   "Skipping entry \"%s\" with no extractable parent DN (wire import id %d).",
                                   slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
                 free_bulk_queue_item(&entry);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -4193,14 +4193,14 @@ dbmdb_bulk_producer(void *param)
                 thread_abort(info);
                 continue;
             case DNRC_BAD_SUFFIX_ID:
-                import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
+                import_log_notice(job, SLAPI_LOG_WARNING, "dbmdb_bulk_producer",
                                   "Skipping duplicate suffix entry \"%s\" (wire import id %d).",
                                   slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
                 free_bulk_queue_item(&entry);
                 entry = NULL;
                 continue;
             case DNRC_NOPARENT_DN:
-                import_log_notice(job, SLAPI_LOG_ERR, "dbmdb_bulk_producer",
+                import_log_notice(job, SLAPI_LOG_WARNING, "dbmdb_bulk_producer",
                                   "Skipping entry \"%s\" with no extractable parent DN (wire import id %d).",
                                   slapi_entry_get_dn(entry->ep->ep_entry), entry->id);
                 free_bulk_queue_item(&entry);


### PR DESCRIPTION
Description:
During repl total init on LMDB, a duplicate suffix DN was mishandled and could trigger DNRC_NOPARENT_DN, aborting bulk import and crashing the joining supplier.

Fix:
Treat repeat suffix entries as DNRC_BAD_SUFFIX_ID and skip that case. Add a case for DNRC_NOPARENT_DN in dbmdb_bulk_producer, instead of defaulting to abort and generating a coredump.

Fixes: https://github.com/389ds/389-ds-base/issues/7537

Reviewed by:

## Summary by Sourcery

Handle duplicate suffix entries and missing parent DNs gracefully during LMDB replication bulk import to prevent crashes and aborted imports.

Bug Fixes:
- Treat duplicate root suffix entries as bad suffix IDs and skip them instead of aborting the bulk import.
- Handle entries with non-extractable parent DNs in the bulk producer by logging and skipping them rather than crashing.

Enhancements:
- Adjust replication import logging levels and messages when skipping problematic entries during bulk import.