### PR TITLE
Issue 7595 - Reduce Actions queue saturation

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -3,32 +3,49 @@ import sys
 import glob
 import json
 
+SUITES_PATH = "dirsrvtests/tests/suites"
+
+
+def is_valid_suite_dir(suite):
+    test_path = os.path.join(SUITES_PATH, suite)
+    return (
+        os.path.isdir(test_path)
+        and not os.path.islink(test_path)
+        and not suite.startswith(".")
+        and suite != "__pycache__"
+    )
+
+
+def is_valid_suite_file(suite):
+    test_path = os.path.join(SUITES_PATH, suite)
+    return (
+        os.path.isfile(test_path)
+        and not os.path.islink(test_path)
+        and suite.endswith(".py")
+    )
+
+
 # If we have arguments passed to the script, use them as the test names to run
 if len(sys.argv) > 1:
     suites = sys.argv[1:]
     valid_suites = []
     # Validate if the path is a valid file or directory with files
     for suite in suites:
-        test_path = os.path.join("dirsrvtests/tests/suites/", suite)
-        if os.path.exists(test_path) and not os.path.islink(test_path):
-            if os.path.isfile(test_path) and test_path.endswith(".py"):
-                valid_suites.append(suite)
-            elif os.path.isdir(test_path):
-                valid_suites.append(suite)
+        if is_valid_suite_file(suite) or is_valid_suite_dir(suite):
+            valid_suites.append(suite)
     suites = valid_suites
 
 else:
     # Use tests from the source
-    suites = next(os.walk('dirsrvtests/tests/suites/'))[1]
+    suites = [suite for suite in next(os.walk(SUITES_PATH))[1] if is_valid_suite_dir(suite)]
 
     # Run each replication test module separately to speed things up
     suites.remove('replication')
-    repl_tests = glob.glob('dirsrvtests/tests/suites/replication/*_test.py')
-    suites += [repl_test.replace('dirsrvtests/tests/suites/', '') for repl_test in repl_tests]
+    repl_tests = glob.glob(os.path.join(SUITES_PATH, 'replication/*_test.py'))
+    suites += [repl_test.replace(f'{SUITES_PATH}/', '') for repl_test in repl_tests]
     suites.sort()
 
 suites_list = [{ "suite": suite} for suite in suites]
 matrix = {"include": suites_list}
 
 print(json.dumps(matrix))
-

--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -2,6 +2,9 @@ name: Rust Tests
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # Run daily at midnight UTC

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,6 +2,10 @@ name: Compile
 on:
   pull_request:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -33,7 +37,7 @@ jobs:
             cpp-compiler: g++
             cflags:  "-O2 -g"
 
-          - name: GCC strict
+          - name: GCC Strict
             image: quay.io/389ds/ci-images:fedora
             compiler: gcc
             cpp-compiler: g++

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -2,6 +2,9 @@ name: LMDB Test
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
@@ -64,6 +67,7 @@ jobs:
     needs: build
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix: ${{ fromJson(needs.build.outputs.matrix) }}
 
     steps:
@@ -149,4 +153,3 @@ jobs:
           pytest.html
           assets
           .playwright-screenshots
-

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,9 +2,13 @@ name: npm-audit-ci
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
@@ -64,6 +67,7 @@ jobs:
     needs: build
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix: ${{ fromJson(needs.build.outputs.matrix) }}
 
     steps:
@@ -155,4 +159,3 @@ jobs:
           pytest.html
           assets
           .playwright-screenshots
-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,11 @@ name: Validate tests and minimal Python version
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Description: Test and LMDB Test each generate large pytest matrices, which can submit hundreds of GitHub-hosted runner jobs when multiple PRs, branches, schedules, or Renovate updates trigger CI together.

Limit both pytest matrix workflows with strategy.max-parallel so each workflow run releases test jobs in smaller batches while preserving full matrix coverage. Also fix the GCC Strict compile matrix name and ignore cache/hidden suite directories when generating the pytest matrix.

Related: https://github.com/389ds/389-ds-base/issues/7595

Reviewed by: ?

## Summary by Sourcery

Limit CI test matrix concurrency and tighten matrix generation to avoid invalid suites and hidden directories.

Enhancements:
- Refine pytest matrix generation to ignore hidden, cache, and symlinked suite entries while handling replication tests via a shared suites path constant.
- Standardize the GCC Strict compile job name in the compile workflow.

CI:
- Set max-parallel to 6 for both pytest and LMDB pytest matrix workflows to throttle concurrent GitHub-hosted jobs.