### PR TITLE
Issue 7602 - CI - lib389 user compare fails due to parentid mismatch

### DIFF
--- a/dirsrvtests/tests/suites/lib389/idm/user_compare_m2Repl_test.py
+++ b/dirsrvtests/tests/suites/lib389/idm/user_compare_m2Repl_test.py
@@ -15,6 +15,35 @@ from test389.topologies import topology_m2
 
 pytestmark = pytest.mark.tier1
 
+
+def _attr_values_repr(values):
+    return sorted(repr(value) for value in values)
+
+
+def _format_compare_mismatch(obj1, obj2):
+    obj1_attrs = obj1.get_compare_attrs()
+    obj2_attrs = obj2.get_compare_attrs()
+    obj1_attr_names = set(obj1_attrs)
+    obj2_attr_names = set(obj2_attrs)
+    lines = []
+
+    for attr in sorted(obj1_attr_names - obj2_attr_names):
+        lines.append(f"Only in supplier1: {attr}={_attr_values_repr(obj1_attrs[attr])}")
+
+    for attr in sorted(obj2_attr_names - obj1_attr_names):
+        lines.append(f"Only in supplier2: {attr}={_attr_values_repr(obj2_attrs[attr])}")
+
+    for attr in sorted(obj1_attr_names & obj2_attr_names):
+        if set(obj1_attrs[attr]) != set(obj2_attrs[attr]):
+            lines.append(
+                f"Different {attr}: "
+                f"supplier1={_attr_values_repr(obj1_attrs[attr])}, "
+                f"supplier2={_attr_values_repr(obj2_attrs[attr])}"
+            )
+
+    return "\n".join(lines) or "No compare attribute mismatch found"
+
+
 def test_user_compare_m2Repl(topology_m2):
     """
     User compare test between users of supplier to supplier replicaton topology.
@@ -55,7 +84,14 @@ def test_user_compare_m2Repl(topology_m2):
 
     m2_testuser = m2_users.get('testuser')
 
-    assert UserAccount.compare(m1_testuser, m2_testuser)
+    assert 'parentid' not in m1_testuser.get_compare_attrs()
+    assert 'parentid' not in m2_testuser.get_compare_attrs()
+
+    if not UserAccount.compare(m1_testuser, m2_testuser):
+        pytest.fail(
+            "Replicated user compare mismatch:\n"
+            f"{_format_compare_mismatch(m1_testuser, m2_testuser)}"
+        )
 
 
 if __name__ == '__main__':

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -158,8 +158,8 @@ class DSLdapObject(DSLogging, DSLint):
         self._create_objectclasses = []
         self._rdn_attribute = None
         self._must_attributes = None
-        # attributes, we don't want to compare
-        self._compare_exclude = ['entryid', 'modifytimestamp', 'nsuniqueid']
+        # Backend-generated attributes that are local to an instance.
+        self._compare_exclude = ['entryid', 'modifytimestamp', 'nsuniqueid', 'parentid']
         self._server_controls = None
         self._client_controls = None
         self._object_filter = '(objectClass=*)'
@@ -651,8 +651,10 @@ class DSLdapObject(DSLogging, DSLint):
 
         This comparison is a loose comparison, not a strict one i.e. "this object *is* this other object"
         It will just check if the attributes are same.
-        'nsUniqueId' attribute is not checked intentionally because we want to compare arbitrary objects
-        i.e they may have different 'nsUniqueId' but same attributes.
+        Instance-local operational attributes like 'nsUniqueId', 'entryid',
+        and 'parentid' are not checked intentionally because we want to
+        compare arbitrary objects, i.e they may have different internal
+        database identity but same attributes.
 
         Example::
 

--- a/src/lib389/lib389/_mapped_object.py
+++ b/src/lib389/lib389/_mapped_object.py
@@ -159,7 +159,8 @@ class DSLdapObject(DSLogging, DSLint):
         self._rdn_attribute = None
         self._must_attributes = None
         # Backend-generated attributes that are local to an instance.
-        self._compare_exclude = ['entryid', 'modifytimestamp', 'nsuniqueid', 'parentid']
+        self._compare_exclude = ['entryid', 'modifytimestamp', 'nsuniqueid', 'parentid',
+                                 'numsubordinates', 'hassubordinates', 'tombstonenumsubordinates']
         self._server_controls = None
         self._client_controls = None
         self._object_filter = '(objectClass=*)'


### PR DESCRIPTION
Description: Fix UserAccount.compare() failures between replicated entries where backend-local parentid values differ across suppliers. Treat parentid like entryid by excluding it from generic DSLdapObject compare attributes, since it is an internal database operational attribute generated per instance. Add regression coverage to ensure replicated user comparison does not include parentid.

Fixes: https://github.com/389ds/389-ds-base/issues/7602

Reviewed by: ?

## Summary by Sourcery

Exclude backend-local parentid from lib389 object comparison and add regression coverage for replicated user comparisons.

Bug Fixes:
- Prevent UserAccount.compare() from failing when replicated entries differ only in backend-local parentid values.

Enhancements:
- Treat parentid like other instance-local operational attributes in generic mapped object comparisons and clarify the compare() documentation comment.

Tests:
- Extend multi-supplier user comparison test to assert parentid is not part of compare attributes and provide detailed mismatch output on failure.