### PR TITLE
Issue 7147 - entrycache_eviction_test CI test is failing

### DIFF
--- a/ldap/servers/slapd/back-ldbm/back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/back-ldbm.h
@@ -320,8 +320,9 @@ typedef struct
 #define HASHLOC(mem, node) (u_long) & (((mem *)0L)->node)
 
 /* type to set ep_type */
-#define CACHE_TYPE_ENTRY 0
-#define CACHE_TYPE_DN    1
+#define CACHE_TYPE_ENTRY     0
+#define CACHE_TYPE_DN        1
+#define CACHE_TYPE_UNKNOWN   2
 
 struct backcommon
 {
@@ -336,6 +337,7 @@ struct backcommon
 #define ENTRY_STATE_INVALID    0x8  /* cache entry is invalid and needs to be removed */
 #define ENTRY_STATE_UNAVAILABLE 0xf /* entry is not fully created or is deleted */
 #define ENTRY_STATE_PINNED     0x10 /* cache entry is pinned (never removed by the lru) */
+#define ENTRY_STATE_LRU        0x20 /* cache entry is queued in the lru */
     int32_t ep_refcnt;              /* entry reference cnt */
     size_t ep_size;                 /* for cache tracking */
     struct timespec ep_create_time; /* the time the entry was added to the cache */

--- a/ldap/servers/slapd/back-ldbm/backentry.c
+++ b/ldap/servers/slapd/back-ldbm/backentry.c
@@ -25,7 +25,7 @@ backentry_free(struct backentry **bep)
     ep = *bep;
 
     PR_ASSERT(ep->ep_state & (ENTRY_STATE_DELETED | ENTRY_STATE_NOTINCACHE | ENTRY_STATE_INVALID));
-    PR_ASSERT((ep->ep_state & ENTRY_STATE_LRU) == 0);
+    PR_ASSERT((ep->ep_state & (ENTRY_STATE_LRU | ENTRY_STATE_PINNED)) == 0);
     if (ep->ep_entry != NULL) {
         slapi_entry_free(ep->ep_entry);
     }

--- a/ldap/servers/slapd/back-ldbm/backentry.c
+++ b/ldap/servers/slapd/back-ldbm/backentry.c
@@ -25,6 +25,7 @@ backentry_free(struct backentry **bep)
     ep = *bep;
 
     PR_ASSERT(ep->ep_state & (ENTRY_STATE_DELETED | ENTRY_STATE_NOTINCACHE | ENTRY_STATE_INVALID));
+    PR_ASSERT((ep->ep_state & ENTRY_STATE_LRU) == 0);
     if (ep->ep_entry != NULL) {
         slapi_entry_free(ep->ep_entry);
     }
@@ -42,7 +43,7 @@ backentry_alloc()
     struct backentry *ec;
     ec = (struct backentry *)slapi_ch_calloc(1, sizeof(struct backentry));
     ec->ep_state = ENTRY_STATE_NOTINCACHE;
-    ec->ep_type = CACHE_TYPE_ENTRY;
+    ec->ep_type = CACHE_TYPE_UNKNOWN;
 #ifdef LDAP_CACHE_DEBUG
     ec->debug_sig = 0x45454545;
 #endif

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -512,6 +512,7 @@ lru_delete(struct cache *cache, void *ptr)
     }
     e = (struct backcommon *)ptr;
     PR_ASSERT(e->ep_state & ENTRY_STATE_LRU);
+    PR_ASSERT(e->ep_state & ENTRY_STATE_PINNED);
 
 #ifdef LDAP_CACHE_DEBUG_LRU
     pinned_verify(cache, __LINE__);

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -511,11 +511,13 @@ lru_delete(struct cache *cache, void *ptr)
         return;
     }
     e = (struct backcommon *)ptr;
+    PR_ASSERT(e->ep_state & ENTRY_STATE_LRU);
 
 #ifdef LDAP_CACHE_DEBUG_LRU
     pinned_verify(cache, __LINE__);
     lru_verify(cache, e, 1);
 #endif
+    e->ep_state &= ~ENTRY_STATE_LRU;
     if (e->ep_lruprev)
         e->ep_lruprev->ep_lrunext = e->ep_lrunext;
     else
@@ -543,11 +545,14 @@ lru_add(struct cache *cache, void *ptr)
     e = (struct backcommon *)ptr;
     ASSERT(e->ep_refcnt == 0);
     ASSERT((e->ep_state & ENTRY_STATE_PINNED) == 0);
+    PR_ASSERT((e->ep_state & ENTRY_STATE_LRU) == 0);
+    PR_ASSERT(e->ep_type != CACHE_TYPE_UNKNOWN);
 
 #ifdef LDAP_CACHE_DEBUG_LRU
     pinned_verify(cache, __LINE__);
     lru_verify(cache, e, 0);
 #endif
+    e->ep_state |= ENTRY_STATE_LRU;
     e->ep_lruprev = NULL;
     e->ep_lrunext = cache->c_lruhead;
     cache->c_lruhead = e;
@@ -837,8 +842,10 @@ entrycache_flush(struct cache *cache)
                           "Unexpected NULL entry while flushing cache - LRU list may be corrupted\n");
             break;
         }
+        PR_ASSERT(e->ep_state & ENTRY_STATE_LRU);
         ASSERT(e->ep_refcnt == 0);
         e->ep_refcnt++;
+        e->ep_state &= ~ENTRY_STATE_LRU;
         if (entrycache_remove_int(cache, e) < 0) {
             slapi_log_err(SLAPI_LOG_ERR,
                           "entrycache_flush", "Unable to delete entry\n");
@@ -1595,6 +1602,7 @@ cache_return(struct cache *cache, void **ptr)
         return;
     }
     bep = *(struct backcommon **)ptr;
+    PR_ASSERT((bep->ep_state & ENTRY_STATE_LRU) == 0);
     if (CACHE_TYPE_ENTRY == bep->ep_type) {
         entrycache_return(cache, (struct backentry **)ptr, PR_FALSE);
     } else if (CACHE_TYPE_DN == bep->ep_type) {
@@ -1647,7 +1655,7 @@ entrycache_return(struct cache *cache, struct backentry **bep, PRBool locked)
                 backentry_free(bep);
             } else {
                 pinned_verify(cache, __LINE__);
-                if (!pinned_add(cache, e)) {
+                if (!pinned_add(cache, e) && ((e->ep_state & ENTRY_STATE_LRU) == 0)) {
                     lru_add(cache, e);
                 }
                 pinned_verify(cache, __LINE__);
@@ -1693,6 +1701,7 @@ cache_find_dn(struct cache *cache, const char *dn, unsigned long ndnlen)
         }
         if (e->ep_refcnt == 0 && (e->ep_state & ENTRY_STATE_PINNED) == 0)
             lru_delete(cache, (void *)e);
+        PR_ASSERT((e->ep_state & ENTRY_STATE_LRU) == 0);
         e->ep_refcnt++;
         cache->c_stats.hits++;
     }
@@ -1723,6 +1732,7 @@ cache_find_id(struct cache *cache, ID id)
         }
         if (e->ep_refcnt == 0 && (e->ep_state & ENTRY_STATE_PINNED) == 0)
             lru_delete(cache, (void *)e);
+        PR_ASSERT((e->ep_state & ENTRY_STATE_LRU) == 0);
         e->ep_refcnt++;
         cache->c_stats.hits++;
     }
@@ -1753,6 +1763,7 @@ cache_find_uuid(struct cache *cache, const char *uuid)
         }
         if (e->ep_refcnt == 0 && (e->ep_state & ENTRY_STATE_PINNED) == 0)
             lru_delete(cache, (void *)e);
+        PR_ASSERT((e->ep_state & ENTRY_STATE_LRU) == 0);
         e->ep_refcnt++;
         cache->c_stats.hits++;
     }
@@ -2504,7 +2515,9 @@ dncache_flush(struct cache *cache)
                           "Unexpected NULL entry while flushing cache - LRU list may be corrupted\n");
             break;
         }
+        PR_ASSERT(dn->ep_state & ENTRY_STATE_LRU);
         ASSERT(dn->ep_refcnt == 0);
+        dn->ep_state &= ~ENTRY_STATE_LRU;
         dn->ep_refcnt++;
         if (dncache_remove_int(cache, dn) < 0) {
             slapi_log_err(SLAPI_LOG_ERR, "dncache_flush", "Unable to delete entry\n");


### PR DESCRIPTION
Fix entry cache LRU list corruption by preventing pinned_add to add the entry in the LRU if it is already there

Issue: #7147 

Reviewed by: @tbordaz  (Thanks!)

## Summary by Sourcery

Prevent LRU list corruption in the entry and DN caches and ensure cache entries are not added multiple times to the LRU.

Bug Fixes:
- Guard against adding cache entries to the LRU list when they are already present to avoid list corruption.
- Ensure entry and DN cache flush operations correctly maintain and clear LRU state to prevent inconsistent cache state.

Enhancements:
- Introduce explicit ENTRY_STATE_LRU tracking on cache entries and add assertions around LRU operations to detect misuse early.
- Add a CACHE_TYPE_UNKNOWN type and use it for newly allocated backentries until their concrete cache type is known.