### PR TITLE
Issue 7610 - Still some lib389.topologies in CI tests

### DIFF
--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -259,7 +259,7 @@ def test_unhashed_pw_switch(topo_supplier):
     inst.restart()
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in libtest/topologies.py.
+    # Topology for suites are predefined in test389/topologies.py.
 
     # enable dynamic plugins, memberof and retro cl plugin
     #

--- a/dirsrvtests/tests/suites/password/regression_test.py
+++ b/dirsrvtests/tests/suites/password/regression_test.py
@@ -259,7 +259,7 @@ def test_unhashed_pw_switch(topo_supplier):
     inst.restart()
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in lib389/topologies.py.
+    # Topology for suites are predefined in libtest/topologies.py.
 
     # enable dynamic plugins, memberof and retro cl plugin
     #

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -607,7 +607,7 @@ def test_fetch_bindDnGroup(topo_m2):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in libtest/topologies.py.
+    # Topology for suites are predefined in test389/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/dirsrvtests/tests/suites/replication/regression_m2_test.py
+++ b/dirsrvtests/tests/suites/replication/regression_m2_test.py
@@ -607,7 +607,7 @@ def test_fetch_bindDnGroup(topo_m2):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in lib389/topologies.py.
+    # Topology for suites are predefined in libtest/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/dirsrvtests/tests/suites/sasl/sasl_io_overflow_test.py
+++ b/dirsrvtests/tests/suites/sasl/sasl_io_overflow_test.py
@@ -17,7 +17,7 @@ from lib389._constants import DEFAULT_SUFFIX
 from lib389.idm.user import UserAccounts
 from lib389.saslmap import SaslMappings
 from lib389.utils import *
-from lib389.topologies import topology_st
+from libtest.topologies import topology_st
 
 pytestmark = pytest.mark.tier1
 

--- a/dirsrvtests/tests/suites/sasl/sasl_io_overflow_test.py
+++ b/dirsrvtests/tests/suites/sasl/sasl_io_overflow_test.py
@@ -17,7 +17,7 @@ from lib389._constants import DEFAULT_SUFFIX
 from lib389.idm.user import UserAccounts
 from lib389.saslmap import SaslMappings
 from lib389.utils import *
-from libtest.topologies import topology_st
+from test389.topologies import topology_st
 
 pytestmark = pytest.mark.tier1
 

--- a/dirsrvtests/tests/tickets/ticket49460_test.py
+++ b/dirsrvtests/tests/tickets/ticket49460_test.py
@@ -107,7 +107,7 @@ def test_ticket_49460(topo):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in lib389/topologies.py.
+    # Topology for suites are predefined in libtest/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/dirsrvtests/tests/tickets/ticket49460_test.py
+++ b/dirsrvtests/tests/tickets/ticket49460_test.py
@@ -107,7 +107,7 @@ def test_ticket_49460(topo):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in libtest/topologies.py.
+    # Topology for suites are predefined in test389/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/dirsrvtests/tests/tickets/ticket49471_test.py
+++ b/dirsrvtests/tests/tickets/ticket49471_test.py
@@ -57,7 +57,7 @@ def test_ticket49471(topo):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in libtest/topologies.py.
+    # Topology for suites are predefined in test389/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/dirsrvtests/tests/tickets/ticket49471_test.py
+++ b/dirsrvtests/tests/tickets/ticket49471_test.py
@@ -57,7 +57,7 @@ def test_ticket49471(topo):
 
     # If you need any test suite initialization,
     # please, write additional fixture for that (including finalizer).
-    # Topology for suites are predefined in lib389/topologies.py.
+    # Topology for suites are predefined in libtest/topologies.py.
 
     # If you need host, port or any other data about instance,
     # Please, use the instance object attributes for that (for example, topo.ms["supplier1"].serverid)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -39,7 +39,7 @@ Key paths within lib389:
 | Path | Contents |
 |------|----------|
 | `lib389/__init__.py` | Core `DirSrv` class, constants, utilities |
-| `lib389/topologies.py` | Pytest fixtures for test topologies |
+| `test389/topologies.py` | Pytest fixtures for test topologies |
 | `lib389/replica.py` | Replication, changelog classes |
 | `lib389/plugins.py` | Plugin configuration classes |
 | `lib389/idm/` | Identity management (users, groups, accounts, roles) |

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -96,10 +96,10 @@ import ldap
 import logging
 import os
 from test389.topologies import topology_st as topo
-from test389._constants import DEFAULT_SUFFIX, PASSWORD
-from test389.idm.user import UserAccounts, UserAccount
-from test389.plugins import MemberOfPlugin
-from test389.utils import ds_supports_new_changelog
+from lib389._constants import DEFAULT_SUFFIX, PASSWORD
+from lib389.idm.user import UserAccounts, UserAccount
+from lib389.plugins import MemberOfPlugin
+from lib389.utils import ds_supports_new_changelog
 
 pytestmark = pytest.mark.tier1
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -53,14 +53,14 @@ pytestmark = pytest.mark.tier1
 
 ## Test Topology Fixtures
 
-Tests use predefined topology fixtures from `lib389.topologies`:
+Tests use predefined topology fixtures from `test389.topologies`:
 
 ```python
-from lib389.topologies import topology_st as topo          # Standalone
-from lib389.topologies import topology_m2 as topo           # 2 suppliers
-from lib389.topologies import topology_m3 as topo_m3        # 3 suppliers
-from lib389.topologies import topology_m4 as topo_m4        # 4 suppliers
-from lib389.topologies import topology_m2c2 as topo_m2c2    # 2 suppliers + 2 consumers
+from test389.topologies import topology_st as topo          # Standalone
+from test389.topologies import topology_m2 as topo           # 2 suppliers
+from test389.topologies import topology_m3 as topo_m3        # 3 suppliers
+from test389.topologies import topology_m4 as topo_m4        # 4 suppliers
+from test389.topologies import topology_m2c2 as topo_m2c2    # 2 suppliers + 2 consumers
 ```
 
 Access instances via `topo.standalone`, `topo.ms["supplier1"]`, `topo.ms["supplier2"]`, etc.
@@ -95,11 +95,11 @@ import pytest
 import ldap
 import logging
 import os
-from lib389.topologies import topology_st as topo
-from lib389._constants import DEFAULT_SUFFIX, PASSWORD
-from lib389.idm.user import UserAccounts, UserAccount
-from lib389.plugins import MemberOfPlugin
-from lib389.utils import ds_supports_new_changelog
+from test389.topologies import topology_st as topo
+from test389._constants import DEFAULT_SUFFIX, PASSWORD
+from test389.idm.user import UserAccounts, UserAccount
+from test389.plugins import MemberOfPlugin
+from test389.utils import ds_supports_new_changelog
 
 pytestmark = pytest.mark.tier1
 


### PR DESCRIPTION
Some CI tests still import lib389.topologies instead of test389.topologies

Issue: #7610 

Reviewed by: @mreynolds389, @vashirov   (Thanks!)

## Summary by Sourcery

Update CI tests to use the new libtest topologies module instead of the deprecated lib389 topologies references.

Enhancements:
- Align test comments and topology imports with libtest.topologies for consistency with the current testing framework.

Tests:
- Switch sasl_io_overflow_test topology import from lib389.topologies to libtest.topologies to match updated test infrastructure.