### PR TITLE
Issue 7505 - RFE - add feature to determine which password policy applies to a user

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_user_get_pwp_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_user_get_pwp_test.py
@@ -1,0 +1,662 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import json
+import logging
+import pytest
+
+from lib389 import DEFAULT_SUFFIX
+from lib389._constants import PASSWORD
+from lib389.cli_base import FakeArgs
+from lib389.cli_idm.user import get_pwp
+from lib389.config import Config
+from lib389.idm.user import (
+    BasicUserAccounts,
+    TraditionalUserAccounts,
+    nsUserAccounts,
+)
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.idm.services import ServiceAccounts
+from lib389.pwpolicy import (
+    PwPolicyManager,
+    POLICY_TYPE_GLOBAL,
+    POLICY_TYPE_USER,
+    POLICY_TYPE_SUBTREE,
+)
+from lib389.utils import ds_is_older
+from test389.topologies import topology_st
+from . import check_value_in_log_and_reset
+
+pytestmark = pytest.mark.tier1
+
+logging.getLogger(__name__).setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+PEOPLE_OU = 'ou=People'
+OTHER_OU = 'ou=other'
+CUSTOM_OU = 'ou=custom'
+
+USER_TYPES = ('posix', 'basic', 'traditional', 'service')
+
+
+def _run_get_pwp(topo, selector, user_type='posix', json_out=False, parent_dn=None):
+    args = FakeArgs()
+    args.json = json_out
+    args.user_type = user_type
+    args.selector = selector
+    args.parent_dn = parent_dn
+    topo.logcap.flush()
+    get_pwp(topo.standalone, DEFAULT_SUFFIX, topo.logcap.log, args)
+    outputs = topo.logcap.get_raw_outputs()
+    return outputs[0] if outputs else ''
+
+
+def _create_user(topo, uid):
+    users = nsUserAccounts(topo.standalone, DEFAULT_SUFFIX)
+    if users.exists(uid):
+        users.get(uid).delete()
+    return users.create(
+        'uid={}'.format(uid),
+        {
+            'uid': uid,
+            'cn': uid,
+            'displayName': uid,
+            'uidNumber': '6101',
+            'gidNumber': '7101',
+            'homeDirectory': '/home/{}'.format(uid),
+            'userPassword': PASSWORD,
+        },
+    )
+
+
+def _create_user_by_type(topo, user_type, rdn=None):
+    """Create a user account for the given dsidm user type; return (entry, selector).
+
+    :param rdn: Optional container RDN under DEFAULT_SUFFIX (e.g. 'ou=custom').
+                When None, each account type uses its default container.
+    """
+    name = 'pwp_{}_user'.format(user_type)
+    kwargs = {'rdn': rdn} if rdn is not None else {}
+
+    if user_type == 'posix':
+        accounts = nsUserAccounts(topo.standalone, DEFAULT_SUFFIX, **kwargs)
+        if accounts.exists(name):
+            accounts.get(name).delete()
+        user = accounts.create(
+            'uid={}'.format(name),
+            {
+                'uid': name,
+                'cn': name,
+                'displayName': name,
+                'uidNumber': '6201',
+                'gidNumber': '7201',
+                'homeDirectory': '/home/{}'.format(name),
+                'userPassword': PASSWORD,
+            },
+        )
+        selector = name
+    elif user_type == 'basic':
+        accounts = BasicUserAccounts(topo.standalone, DEFAULT_SUFFIX, **kwargs)
+        if accounts.exists(name):
+            accounts.get(name).delete()
+        user = accounts.create(
+            'uid={}'.format(name),
+            {
+                'uid': name,
+                'cn': name,
+                'displayName': name,
+                'userPassword': PASSWORD,
+            },
+        )
+        selector = name
+    elif user_type == 'traditional':
+        accounts = TraditionalUserAccounts(topo.standalone, DEFAULT_SUFFIX, **kwargs)
+        if accounts.exists(name):
+            accounts.get(name).delete()
+        user = accounts.create(
+            'cn={}'.format(name),
+            {
+                'cn': name,
+                'sn': name,
+                'userPassword': PASSWORD,
+            },
+        )
+        selector = name
+    elif user_type == 'service':
+        accounts = ServiceAccounts(topo.standalone, DEFAULT_SUFFIX, **kwargs)
+        if accounts.exists(name):
+            accounts.get(name).delete()
+        user = accounts.create(
+            'cn={}'.format(name),
+            {
+                'cn': name,
+                'description': 'pwp get-pwp test service',
+                'userPassword': PASSWORD,
+            },
+        )
+        selector = name
+    else:
+        raise ValueError('Unsupported user type: {}'.format(user_type))
+
+    return user, selector
+
+
+def _cleanup_local_policies(topo, user_dn, subtree_dn=None):
+    pwp = PwPolicyManager(topo.standalone)
+    try:
+        if pwp.is_user_policy(user_dn):
+            pwp.delete_local_policy(user_dn)
+    except ValueError:
+        pass
+    if subtree_dn:
+        try:
+            if pwp.is_subtree_policy(subtree_dn):
+                pwp.delete_local_policy(subtree_dn)
+        except ValueError:
+            pass
+
+
+@pytest.fixture
+def pwp_test_user(topology_st, request):
+    """Create an isolated user and remove any local policies after the test."""
+    uid = 'pwp_get_test_user'
+    user = _create_user(topology_st, uid)
+    subtree_dn = '{},{}'.format(PEOPLE_OU, DEFAULT_SUFFIX)
+
+    def fin():
+        _cleanup_local_policies(topology_st, user.dn, subtree_dn)
+
+    request.addfinalizer(fin)
+    return user
+
+
+def _user_selector(user):
+    return user.get_attr_val_utf8('uid')
+
+
+@pytest.mark.parametrize('user_type', USER_TYPES)
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_global_policy_by_user_type(topology_st, user_type):
+    """get-pwp resolves the global effective policy for each dsidm user type.
+
+    :id: 619e8040-ce33-4fa2-a8bb-75acb7b0668b
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Create a user of the given dsidm user type
+        2. Run dsidm user get-pwp for that user
+    :expectedresults:
+        1. The user entry is created successfully
+        2. get-pwp reports the global password policy
+    """
+    user, selector = _create_user_by_type(topology_st, user_type)
+    try:
+        output = _run_get_pwp(topology_st, selector, user_type=user_type)
+        assert 'dn: {}'.format(user.dn) in output
+        assert 'passwordPolicy: {}'.format(POLICY_TYPE_GLOBAL) in output
+        assert 'passwordPolicyDN: cn=config' in output
+        assert 'passwordPolicyTarget: global' in output
+        assert 'passwordchange:' in output
+        topology_st.logcap.flush()
+    finally:
+        if user.exists():
+            user.delete()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_global_policy(topology_st, pwp_test_user):
+    """Effective policy is global when the user has no local assignment.
+
+    :id: 7ef61f72-fd0e-4074-b4c5-662951103c0d
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Run dsidm user get-pwp for a user with no local policy
+    :expectedresults:
+        1. get-pwp reports the global password policy
+    """
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    check_value_in_log_and_reset(
+        topology_st,
+        check_value='passwordPolicy: {}'.format(POLICY_TYPE_GLOBAL),
+    )
+    assert 'passwordPolicyDN: cn=config' in output
+    assert 'passwordPolicyTarget: global' in output
+    assert 'passwordchange:' in output
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_subtree_policy(topology_st, pwp_test_user):
+    """Effective policy is subtree local when CoS applies a subtree policy.
+
+    :id: d599678c-7542-4d11-bd47-0542ca89e10f
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Create a subtree password policy for ou=People
+        2. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. The subtree policy is created successfully
+        2. get-pwp reports the subtree local policy and its settings
+    """
+    subtree_dn = '{},{}'.format(PEOPLE_OU, DEFAULT_SUFFIX)
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_subtree_policy(subtree_dn, {'passwordhistory': 'on', 'passwordinhistory': '10'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    check_value_in_log_and_reset(
+        topology_st,
+        check_value='passwordPolicy: {}'.format(POLICY_TYPE_SUBTREE),
+    )
+    assert 'passwordPolicyTarget: {}'.format(subtree_dn) in output
+    assert 'passwordhistory: on' in output
+    assert 'passwordinhistory: 10' in output
+    assert 'passwordchange:' not in output
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_subtree_policy_other_ou(topology_st):
+    """get-pwp resolves subtree local policy for a user under ou=other.
+
+    :id: 30f7f701-4928-4313-811c-e4a5ef2857da
+    :setup: Standalone instance
+    :steps:
+        1. Create organizational unit ou=other under the default suffix
+        2. Create a subtree password policy for ou=other
+        3. Create a posix user under ou=other using nsUserAccounts with rdn=ou=other
+        4. Run dsidm user get-pwp for the user with --parent-dn set to ou=other
+    :expectedresults:
+        1. The organizational unit entry is created successfully
+        2. The subtree policy is created successfully
+        3. The user entry is created under ou=other
+        4. get-pwp reports the subtree local policy and its settings
+    """
+    other_ou_dn = '{},{}'.format(OTHER_OU, DEFAULT_SUFFIX)
+    uid = 'pwp_other_ou_user'
+    user = None
+    pwp = PwPolicyManager(topology_st.standalone)
+    ous = OrganizationalUnits(topology_st.standalone, DEFAULT_SUFFIX)
+
+    if ous.exists('other'):
+        ou = ous.get('other')
+    else:
+        ou = ous.create(properties={'ou': 'other'})
+
+    try:
+        pwp.create_subtree_policy(other_ou_dn, {
+            'passwordhistory': 'on',
+            'passwordinhistory': '8',
+        })
+
+        accounts = nsUserAccounts(topology_st.standalone, DEFAULT_SUFFIX, rdn=OTHER_OU)
+        if accounts.exists(uid):
+            accounts.get(uid).delete()
+        user = accounts.create(
+            'uid={}'.format(uid),
+            {
+                'uid': uid,
+                'cn': uid,
+                'displayName': uid,
+                'uidNumber': '6301',
+                'gidNumber': '7301',
+                'homeDirectory': '/home/{}'.format(uid),
+                'userPassword': PASSWORD,
+            },
+        )
+
+        output = _run_get_pwp(topology_st, uid, parent_dn=other_ou_dn)
+        check_value_in_log_and_reset(
+            topology_st,
+            check_value='passwordPolicy: {}'.format(POLICY_TYPE_SUBTREE),
+        )
+        assert 'dn: {}'.format(user.dn) in output
+        assert 'passwordPolicyTarget: {}'.format(other_ou_dn) in output
+        assert 'passwordhistory: on' in output
+        assert 'passwordinhistory: 8' in output
+        assert 'passwordchange:' not in output
+        topology_st.logcap.flush()
+    finally:
+        if user is not None and user.exists():
+            _cleanup_local_policies(topology_st, user.dn, other_ou_dn)
+            user.delete()
+        else:
+            try:
+                if pwp.is_subtree_policy(other_ou_dn):
+                    pwp.delete_local_policy(other_ou_dn)
+            except ValueError:
+                pass
+        if ou.exists():
+            ou.delete()
+
+
+@pytest.mark.parametrize('user_type', USER_TYPES)
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_all_user_types_under_custom_ou(topology_st, user_type):
+    """get-pwp resolves policy for every user type under a non-default OU.
+
+    Users (including service accounts) live under ou=custom rather than their
+    default containers. parent_dn points get-pwp at that custom location.
+
+    :id: abc5e462-ec4a-429c-ae12-c8977d59d01b
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Create organizational unit ou=custom under the default suffix
+        2. Create a subtree password policy for ou=custom
+        3. Create a user of the given type under ou=custom
+        4. Run dsidm user get-pwp with parent_dn set to ou=custom,DEFAULT_SUFFIX
+    :expectedresults:
+        1. The organizational unit entry is created successfully
+        2. The subtree policy is created successfully
+        3. The user entry is created under ou=custom
+        4. get-pwp reports the subtree policy for that user DN and settings
+    """
+    custom_ou_dn = '{},{}'.format(CUSTOM_OU, DEFAULT_SUFFIX)
+    user = None
+    pwp = PwPolicyManager(topology_st.standalone)
+    ous = OrganizationalUnits(topology_st.standalone, DEFAULT_SUFFIX)
+
+    if ous.exists('custom'):
+        ou = ous.get('custom')
+    else:
+        ou = ous.create(properties={'ou': 'custom'})
+
+    try:
+        if not pwp.is_subtree_policy(custom_ou_dn):
+            pwp.create_subtree_policy(custom_ou_dn, {
+                'passwordhistory': 'on',
+                'passwordinhistory': '7',
+            })
+
+        user, selector = _create_user_by_type(topology_st, user_type, rdn=CUSTOM_OU)
+        assert custom_ou_dn.lower() in user.dn.lower()
+
+        output = _run_get_pwp(
+            topology_st,
+            selector,
+            user_type=user_type,
+            parent_dn=custom_ou_dn,
+        )
+        assert 'dn: {}'.format(user.dn) in output
+        assert 'passwordPolicy: {}'.format(POLICY_TYPE_SUBTREE) in output
+        assert 'passwordPolicyTarget: {}'.format(custom_ou_dn) in output
+        assert 'passwordhistory: on' in output
+        assert 'passwordinhistory: 7' in output
+        topology_st.logcap.flush()
+    finally:
+        if user is not None and user.exists():
+            _cleanup_local_policies(topology_st, user.dn, custom_ou_dn)
+            user.delete()
+        else:
+            try:
+                if pwp.is_subtree_policy(custom_ou_dn):
+                    pwp.delete_local_policy(custom_ou_dn)
+            except ValueError:
+                pass
+        if ou.exists():
+            # Subtree policy cleanup may leave the container; remove OU when empty.
+            try:
+                if pwp.is_subtree_policy(custom_ou_dn):
+                    pwp.delete_local_policy(custom_ou_dn)
+            except ValueError:
+                pass
+            try:
+                ou.delete()
+            except Exception:
+                pass
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_user_policy(topology_st, pwp_test_user):
+    """Effective policy is user local when the user has a user policy.
+
+    :id: f1c66bc1-af96-4a31-86e9-33703b4e6c90
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Create a user-local password policy for the test user
+        2. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. The user policy is created successfully
+        2. get-pwp reports the user local policy and its settings
+    """
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_user_policy(pwp_test_user.dn, {'passwordhistory': 'on', 'passwordinhistory': '6'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    check_value_in_log_and_reset(
+        topology_st,
+        check_value='passwordPolicy: {}'.format(POLICY_TYPE_USER),
+    )
+    assert 'passwordPolicyTarget: {}'.format(pwp_test_user.dn) in output
+    assert 'passwordhistory: on' in output
+    assert 'passwordchange:' not in output
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_user_policy_precedence(topology_st, pwp_test_user):
+    """User local policy takes precedence over subtree policy.
+
+    :id: 1e3cd24e-fa66-4f96-b276-8714b71fc43b
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Create a subtree password policy and a user-local policy with different values
+        2. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. Both policies are created successfully
+        2. get-pwp reports the user local policy, not the subtree policy
+    """
+    subtree_dn = '{},{}'.format(PEOPLE_OU, DEFAULT_SUFFIX)
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_subtree_policy(subtree_dn, {'passwordhistory': 'on', 'passwordinhistory': '10'})
+    pwp.create_user_policy(pwp_test_user.dn, {'passwordhistory': 'on', 'passwordinhistory': '4'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    assert 'passwordPolicy: {}'.format(POLICY_TYPE_USER) in output
+    assert 'passwordPolicy: {}'.format(POLICY_TYPE_SUBTREE) not in output
+    assert 'passwordinhistory: 4' in output
+    topology_st.logcap.flush()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_syntax_inheritance_on(topology_st, pwp_test_user):
+    """Syntax settings inherit from global when enabled.
+
+    :id: ac811f41-422e-4098-9fc0-e668d662ef80
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Enable global syntax checking and inheritance, set passwordminlength
+        2. Create a user-local policy without local syntax settings
+        3. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. Global syntax and inheritance settings are applied
+        2. The user policy is created successfully
+        3. get-pwp reports passwordminlength as inherited from global
+    """
+    config = Config(topology_st.standalone)
+    config.replace_many(
+        ('nsslapd-pwpolicy-inherit-global', 'on'),
+        ('passwordchecksyntax', 'on'),
+        ('passwordminlength', '16'),
+    )
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_user_policy(pwp_test_user.dn, {'passwordhistory': 'on'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    assert 'passwordminlength: 16 (inherited)' in output
+    topology_st.logcap.flush()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_syntax_inheritance_off(topology_st, pwp_test_user):
+    """Syntax settings do not inherit when global inheritance is disabled.
+
+    :id: 3d79d6ba-5d02-4e95-8156-857c85cac6c3
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Disable inheritance, enable global syntax checking, set passwordminlength
+        2. Create a user-local policy without local syntax settings
+        3. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. Global settings are applied with inheritance off
+        2. The user policy is created successfully
+        3. get-pwp does not report inherited passwordminlength
+    """
+    config = Config(topology_st.standalone)
+    config.replace_many(
+        ('nsslapd-pwpolicy-inherit-global', 'off'),
+        ('passwordchecksyntax', 'on'),
+        ('passwordminlength', '16'),
+    )
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_user_policy(pwp_test_user.dn, {'passwordhistory': 'on'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+    assert 'passwordminlength: 16 (inherited)' not in output
+    assert 'passwordminlength:' not in output
+    assert 'passwordhistory: on' in output
+    topology_st.logcap.flush()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_local_off_uses_global_syntax(topology_st, pwp_test_user):
+    """With local policies disabled, effective passwordMinLength is global.
+
+    A user-local policy may still exist with a different passwordMinLength, and
+    nsslapd-pwpolicy-inherit-global may be on with global syntax checking enabled.
+    When nsslapd-pwpolicy-local is off, get-pwp must ignore the local assignment
+    and report the global policy value.
+
+    :id: ebaf0c48-e4f1-484a-b54b-5ca913be07ab
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Set global passwordchecksyntax on, passwordminlength to 16, and
+           nsslapd-pwpolicy-inherit-global on
+        2. Create a user-local policy with passwordminlength 24
+        3. Set nsslapd-pwpolicy-local to off
+        4. Run dsidm user get-pwp for the user
+    :expectedresults:
+        1. Global syntax and inheritance settings are applied
+        2. User-local policy is created with a different passwordminlength
+        3. Local password policies are disabled on cn=config
+        4. get-pwp reports Global Policy and passwordminlength 16 (not 24)
+    """
+    global_minlen = '16'
+    local_minlen = '24'
+    config = Config(topology_st.standalone)
+    config.replace_many(
+        ('nsslapd-pwpolicy-inherit-global', 'on'),
+        ('passwordchecksyntax', 'on'),
+        ('passwordminlength', global_minlen),
+    )
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_user_policy(pwp_test_user.dn, {
+        'passwordminlength': local_minlen,
+    })
+    config.replace('nsslapd-pwpolicy-local', 'off')
+
+    try:
+        output = _run_get_pwp(topology_st, _user_selector(pwp_test_user))
+        assert 'passwordPolicy: {}'.format(POLICY_TYPE_GLOBAL) in output
+        assert 'passwordPolicyDN: cn=config' in output
+        assert 'passwordminlength: {}'.format(global_minlen) in output
+        assert 'passwordminlength: {}'.format(local_minlen) not in output
+        assert 'passwordminlength: {} (inherited)'.format(global_minlen) not in output
+        topology_st.logcap.flush()
+    finally:
+        config.replace('nsslapd-pwpolicy-local', 'on')
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_json_output(topology_st, pwp_test_user):
+    """JSON output includes policy metadata and attrs.
+
+    :id: 433b678b-15d7-4dbc-8576-ad9ff36f1049
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Run dsidm user get-pwp with JSON output enabled
+    :expectedresults:
+        1. JSON includes policy_type, policy_dn, policy_target, and attrs
+    """
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user), json_out=True)
+    result = json.loads(output)
+    assert result['policy_type'] == POLICY_TYPE_GLOBAL
+    assert result['policy_dn'] == 'cn=config'
+    assert result['policy_target'] == 'global'
+    assert 'passwordchange' in result['attrs']
+    topology_st.logcap.flush()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_json_inherited_syntax(topology_st, pwp_test_user):
+    """JSON marks inherited syntax attributes.
+
+    :id: 6706a146-61b7-40ef-a4f1-72aa6421412e
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Enable global syntax checking and inheritance, set passwordminlength
+        2. Create a user-local policy without local syntax settings
+        3. Run dsidm user get-pwp with JSON output enabled
+    :expectedresults:
+        1. Global syntax and inheritance settings are applied
+        2. The user policy is created successfully
+        3. JSON marks passwordminlength with the inherited flag
+    """
+    config = Config(topology_st.standalone)
+    config.replace_many(
+        ('nsslapd-pwpolicy-inherit-global', 'on'),
+        ('passwordchecksyntax', 'on'),
+        ('passwordminlength', '16'),
+    )
+    pwp = PwPolicyManager(topology_st.standalone)
+    pwp.create_user_policy(pwp_test_user.dn, {'passwordhistory': 'on'})
+
+    output = _run_get_pwp(topology_st, _user_selector(pwp_test_user), json_out=True)
+    result = json.loads(output)
+    assert result['attrs']['passwordminlength'] == ['16', 'inherited']
+    topology_st.logcap.flush()
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_user_not_found(topology_st):
+    """Missing user produces a clear error.
+
+    :id: 8d8a7463-4621-48fe-871f-d0d8f989b13a
+    :setup: Standalone instance
+    :steps:
+        1. Run dsidm user get-pwp for a non-existent user selector
+    :expectedresults:
+        1. get-pwp raises ValueError indicating the user was not found
+    """
+    args = FakeArgs()
+    args.json = False
+    args.user_type = 'posix'
+    args.selector = 'no_such_pwp_user'
+    args.parent_dn = None
+    with pytest.raises(ValueError, match='not found'):
+        get_pwp(topology_st.standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+
+
+@pytest.mark.skipif(ds_is_older("1.4.2"), reason="Not implemented")
+def test_get_pwp_broken_policy_reference(topology_st, pwp_test_user):
+    """Broken pwdpolicysubentry reference produces a clear error.
+
+    :id: 2fc47004-1ba9-47af-9c57-3aa34fae5500
+    :setup: Standalone instance with a test user
+    :steps:
+        1. Set the user's pwdpolicysubentry to a missing policy DN
+        2. Run dsidm user get-pwp for the test user
+    :expectedresults:
+        1. The broken policy reference is stored on the user entry
+        2. get-pwp raises ValueError indicating the policy could not be found
+    """
+    pwp_test_user.replace('pwdpolicysubentry', 'cn=missing-policy,cn=config')
+    args = FakeArgs()
+    args.json = False
+    args.user_type = 'posix'
+    args.selector = _user_selector(pwp_test_user)
+    args.parent_dn = None
+    with pytest.raises(ValueError, match='could not be found'):
+        get_pwp(topology_st.standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)

--- a/dirsrvtests/tests/suites/password/pwpolicy_effective_test.py
+++ b/dirsrvtests/tests/suites/password/pwpolicy_effective_test.py
@@ -1,0 +1,254 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+from lib389.pwpolicy import (
+    POLICY_TYPE_SUBTREE,
+    POLICY_TYPE_USER,
+    _classify_policy_from_pwdpolicysubentry,
+    _parse_policy_target_from_cn,
+)
+
+
+class _FakePwEntry(object):
+    def __init__(self, cn):
+        self._cn = cn
+
+    def get_attr_val_utf8(self, attr):
+        if attr == 'cn':
+            return self._cn
+        return None
+
+
+def test_parse_policy_target_user():
+    """Parse policy target DN from a user-local policy cn value.
+
+    :id: fd5fd30b-2b39-4643-a9fe-47ceba93a563
+    :setup: N/A (unit test)
+    :steps:
+        1. Call _parse_policy_target_from_cn with a user policy cn
+    :expectedresults:
+        1. The decoded user DN is returned
+    """
+    cn = r'cn=nsPwPolicyEntry_user,uid\3Dmark,ou\3Dpeople,dc\3Dexample,dc\3Dcom'
+    assert _parse_policy_target_from_cn(cn) == 'uid=mark,ou=people,dc=example,dc=com'
+
+
+def test_parse_policy_target_subtree():
+    """Parse policy target DN from a subtree-local policy cn value.
+
+    :id: 306e0f97-f740-44f6-af3f-9f361fb7ff2b
+    :setup: N/A (unit test)
+    :steps:
+        1. Call _parse_policy_target_from_cn with a subtree policy cn
+    :expectedresults:
+        1. The decoded subtree DN is returned
+    """
+    cn = r'cn=nsPwPolicyEntry_subtree,ou\3Dpeople,dc\3Dexample,dc\3Dcom'
+    assert _parse_policy_target_from_cn(cn) == 'ou=people,dc=example,dc=com'
+
+
+def test_parse_policy_target_invalid():
+    """Invalid policy cn values do not yield a target DN.
+
+    :id: 2614d72b-8169-481e-b25a-58c962024059
+    :setup: N/A (unit test)
+    :steps:
+        1. Call _parse_policy_target_from_cn with a non-policy cn
+    :expectedresults:
+        1. None is returned
+    """
+    assert _parse_policy_target_from_cn('cn=not-a-policy,dc=example,dc=com') is None
+
+
+def test_classify_user_policy():
+    """Classify a user-local policy from pwdpolicysubentry metadata.
+
+    :id: c0cdd29f-1dc2-4fd3-b3ae-2602a9401bdd
+    :setup: N/A (unit test)
+    :steps:
+        1. Classify a policy entry whose cn contains nsPwPolicyEntry_user
+    :expectedresults:
+        1. Policy type is User Policy and the target DN is the user DN
+    """
+    cn = r'cn=nsPwPolicyEntry_user,uid\3Dmark,ou\3Dpeople,dc\3Dexample,dc\3Dcom'
+    entry = _FakePwEntry(cn)
+    pwp_dn = 'cn=pwp,cn=nsPwPolicyContainer,ou=people,dc=example,dc=com'
+    policy_type, source, target = _classify_policy_from_pwdpolicysubentry(pwp_dn, entry)
+    assert policy_type == POLICY_TYPE_USER
+    assert source == pwp_dn
+    assert target == 'uid=mark,ou=people,dc=example,dc=com'
+
+
+def test_classify_subtree_policy():
+    """Classify a subtree-local policy from pwdpolicysubentry metadata.
+
+    :id: 1ae92b82-0004-46bb-9cf2-318698884096
+    :setup: N/A (unit test)
+    :steps:
+        1. Classify a policy entry whose cn contains nsPwPolicyEntry_subtree
+    :expectedresults:
+        1. Policy type is Subtree Policy and the target DN is the subtree DN
+    """
+    cn = r'cn=nsPwPolicyEntry_subtree,ou\3Dpeople,dc\3Dexample,dc\3Dcom'
+    entry = _FakePwEntry(cn)
+    pwp_dn = 'cn=pwp,cn=nsPwPolicyContainer,ou=people,dc=example,dc=com'
+    policy_type, source, target = _classify_policy_from_pwdpolicysubentry(pwp_dn, entry)
+    assert policy_type == POLICY_TYPE_SUBTREE
+    assert target == 'ou=people,dc=example,dc=com'
+
+
+def test_syntax_inheritance_merge():
+    """Local effective attrs merge inherited global syntax settings.
+
+    :id: 8b83b215-84ab-4f65-92cc-064325c6fd40
+    :setup: N/A (unit test)
+    :steps:
+        1. Verify on/off and inherited-value helpers
+        2. Build local effective attrs with inheritance enabled
+    :expectedresults:
+        1. Helper results match expected on/off and display rules
+        2. Explicit local attrs and inherited syntax attrs are returned
+    """
+    from lib389.pwpolicy import PwPolicyManager, _attr_is_on, _should_show_inherited_value
+
+    assert _attr_is_on('on') is True
+    assert _attr_is_on('off') is False
+    assert _should_show_inherited_value('16') is True
+    assert _should_show_inherited_value('0') is False
+    assert _should_show_inherited_value('off') is False
+
+    class _FakeInst(object):
+        log = __import__('logging').getLogger('fake')
+
+    mgr = PwPolicyManager(_FakeInst())
+    global_attrs = {
+        'nsslapd-pwpolicy-inherit-global': ['on'],
+        'passwordchecksyntax': ['on'],
+        'passwordminlength': ['16'],
+        'passwordmindigits': ['0'],
+    }
+    policy_attrs = {'passwordhistory': ['on']}
+    effective = mgr._build_local_effective_attrs(policy_attrs, global_attrs)
+    assert set(effective.keys()) == {'passwordhistory', 'passwordminlength'}
+    assert effective['passwordminlength']['values'] == ['16']
+    assert effective['passwordminlength']['inherited'] is True
+    assert effective['passwordhistory']['values'] == ['on']
+    assert effective['passwordhistory']['inherited'] is False
+    assert 'passwordchange' not in effective
+
+
+def test_local_policy_only_explicit_attrs():
+    """Local effective attrs include only explicitly stored policy settings.
+
+    :id: a9ee339e-b35b-4b3b-ac80-eef098a84ab4
+    :setup: N/A (unit test)
+    :steps:
+        1. Build local effective attrs from an entry with explicit settings
+    :expectedresults:
+        1. Only explicit password policy attributes are returned
+    """
+    from lib389.pwpolicy import PwPolicyManager
+
+    class _FakeInst(object):
+        log = __import__('logging').getLogger('fake')
+
+    mgr = PwPolicyManager(_FakeInst())
+    policy_attrs = {
+        'passwordhistory': ['on'],
+        'passwordinhistory': ['6'],
+        'cn': ['cn=nsPwPolicyEntry_user,uid=mark,ou=people,dc=example,dc=com'],
+        'objectClass': ['top', 'ldapsubentry', 'passwordpolicy'],
+    }
+    effective = mgr._build_local_effective_attrs(policy_attrs, {})
+    assert set(effective.keys()) == {'passwordhistory', 'passwordinhistory'}
+
+
+def test_local_policy_camelcase_attrs():
+    """CamelCase LDAP attribute names are normalized for local policy output.
+
+    :id: 2c2027b7-54cb-4036-ae6f-9845de7d17a8
+    :setup: N/A (unit test)
+    :steps:
+        1. Build local effective attrs from camelCase attribute names
+    :expectedresults:
+        1. Attributes are normalized to lowercase keys with correct values
+    """
+    from lib389.pwpolicy import PwPolicyManager, _normalise_attrs
+
+    class _FakeInst(object):
+        log = __import__('logging').getLogger('fake')
+
+    mgr = PwPolicyManager(_FakeInst())
+    raw_attrs = {
+        'passwordHistory': ['on'],
+        'passwordInHistory': ['10'],
+    }
+    effective = mgr._build_local_effective_attrs(_normalise_attrs(raw_attrs), {})
+    assert set(effective.keys()) == {'passwordhistory', 'passwordinhistory'}
+    assert effective['passwordhistory']['values'] == ['on']
+    assert effective['passwordinhistory']['values'] == ['10']
+
+
+def test_inheritance_with_camelcase_global():
+    """Inherited syntax works when global attrs use schema camelCase names.
+
+    :id: 892f5c84-83e5-41da-bdf1-c49a837b53f7
+    :setup: N/A (unit test)
+    :steps:
+        1. Build local effective attrs with camelCase global syntax attributes
+    :expectedresults:
+        1. Meaningful inherited syntax values are merged; empty/zero values are skipped
+    """
+    from lib389.pwpolicy import PwPolicyManager
+
+    class _FakeInst(object):
+        log = __import__('logging').getLogger('fake')
+
+    mgr = PwPolicyManager(_FakeInst())
+    policy_attrs = {'passwordhistory': ['on']}
+    global_attrs = {
+        'nsslapd-pwpolicy-inherit-global': ['on'],
+        'passwordCheckSyntax': ['on'],
+        'passwordMinLength': ['16'],
+        'passwordMinDigits': ['0'],
+    }
+    effective = mgr._build_local_effective_attrs(policy_attrs, global_attrs)
+    assert effective['passwordminlength']['values'] == ['16']
+    assert effective['passwordminlength']['inherited'] is True
+    assert 'passwordmindigits' not in effective
+
+
+def test_report_attribute_order_inherited_last():
+    """Report attribute order lists local settings before inherited ones.
+
+    :id: a0e7a32b-29b8-47ea-90a1-639c29d59c10
+    :setup: N/A (unit test)
+    :steps:
+        1. Request report attribute names for a mix of local and inherited attrs
+    :expectedresults:
+        1. Local attrs are alphabetical first, then inherited attrs
+    """
+    from lib389.pwpolicy import PwPolicyManager, POLICY_TYPE_USER
+
+    class _FakeInst(object):
+        log = __import__('logging').getLogger('fake')
+
+    mgr = PwPolicyManager(_FakeInst())
+    report = {
+        'policy_type': POLICY_TYPE_USER,
+        'attrs': {
+            'passwordminlength': {'values': ['16'], 'inherited': True},
+            'passwordhistory': {'values': ['on'], 'inherited': False},
+            'passwordinhistory': {'values': ['6'], 'inherited': False},
+        },
+    }
+    assert mgr._report_attribute_names(report) == [
+        'passwordhistory',
+        'passwordinhistory',
+        'passwordminlength',
+    ]

--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -44,6 +44,7 @@ import EditorTableView from './lib/ldap_editor/tableView.jsx';
 import EditorTreeView from './lib/ldap_editor/treeView.jsx';
 import { SearchDatabase } from './lib/ldap_editor/search.jsx';
 import GenericWizard from './lib/ldap_editor/wizards/genericWizard.jsx';
+import { EffectivePwpModal } from './lib/ldap_editor/effectivePwpModal.jsx';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { log_cmd, getApiErrorMessage } from "./lib/tools.jsx";
 
@@ -107,7 +108,29 @@ export class LDAPEditor extends React.Component {
             allObjectclasses: [],
             isConfirmModalOpen: false,
             isTreeViewAction: false,
-            currentRowKey: -1
+            currentRowKey: -1,
+            showPwpModal: false,
+            pwpModalEntryDn: '',
+            pwpModalUserType: '',
+            pwpModalSelector: '',
+        };
+
+        this.handlePwpModalClose = () => {
+            this.setState({
+                showPwpModal: false,
+                pwpModalEntryDn: '',
+                pwpModalUserType: '',
+                pwpModalSelector: '',
+            });
+        };
+
+        this.openPwpModal = (entryDn, userPwpLookup) => {
+            this.setState({
+                showPwpModal: true,
+                pwpModalEntryDn: entryDn,
+                pwpModalUserType: userPwpLookup.userType,
+                pwpModalSelector: userPwpLookup.selector,
+            });
         };
 
         this.handleConfirmModalToggle = () => {
@@ -183,6 +206,17 @@ export class LDAPEditor extends React.Component {
                     operationType: "unlock",
                     isTreeViewAction: true
                 }, () => { this.handleConfirmModalToggle() });
+                return;
+            }
+            if (aTarget.name === ENTRY_MENU.getPwp) {
+                this.setState({
+                    entryMenuIsOpen: false,
+                }, () => {
+                    this.openPwpModal(aTarget.value, {
+                        userType: aTarget.getAttribute('data-user-type'),
+                        selector: aTarget.getAttribute('data-selector'),
+                    });
+                });
                 return;
             }
 
@@ -554,7 +588,9 @@ export class LDAPEditor extends React.Component {
                     entryState: "",
                     isRole: info.isRole,
                     isLockable: info.isLockable,
-                    ldapsubentry: info.ldapsubentry
+                    ldapsubentry: info.ldapsubentry,
+                    isUser: info.isUser,
+                    userPwpLookup: info.userPwpLookup,
                 },
                 {
                     // customRowId: info.parentId + 1,
@@ -1080,6 +1116,12 @@ export class LDAPEditor extends React.Component {
                     });
                 }
             },
+            ...(rowData.isUser && rowData.userPwpLookup ? [{
+                title: _("View Password Policy ..."),
+                onClick: () => {
+                    this.openPwpModal(rowData.rawdn, rowData.userPwpLookup);
+                }
+            }] : []),
             {
                 isSeparator: true
             },
@@ -1247,6 +1289,15 @@ export class LDAPEditor extends React.Component {
                         suffixDn={this.state.emptyDN}
                         editorLdapServer={this.props.serverId}
                     />}
+                <EffectivePwpModal
+                    isOpen={this.state.showPwpModal}
+                    onClose={this.handlePwpModalClose}
+                    serverId={this.props.serverId}
+                    suffixList={this.state.suffixList}
+                    entryDn={this.state.pwpModalEntryDn}
+                    userType={this.state.pwpModalUserType}
+                    selector={this.state.pwpModalSelector}
+                />
                 <Modal
                     // TODO: Fix confirmation modal formatting and size; add operation to the tables
                     variant={ModalVariant.medium}

--- a/src/cockpit/389-console/src/lib/ldap_editor/effectivePwpModal.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/effectivePwpModal.jsx
@@ -1,0 +1,203 @@
+import cockpit from "cockpit";
+import React from "react";
+import PropTypes from "prop-types";
+import {
+    Alert,
+    Button,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    Modal,
+    ModalVariant,
+    Spinner,
+} from "@patternfly/react-core";
+import {
+    fetchUserEffectivePasswordPolicy,
+    getBaseDnForEntry,
+    getRdnInfo,
+} from "./lib/utils.jsx";
+import { getApiErrorMessage } from "../tools.jsx";
+
+const _ = cockpit.gettext;
+
+function formatPolicyAttributes(attrs) {
+    const local = [];
+    const inherited = [];
+    Object.keys(attrs || {}).sort().forEach(name => {
+        const values = attrs[name];
+        const isInherited = values.includes("inherited");
+        const displayValue = (isInherited
+            ? values.filter(v => v !== "inherited")
+            : values).join(", ");
+        const item = { name, value: displayValue, inherited: isInherited };
+        if (isInherited) {
+            inherited.push(item);
+        } else {
+            local.push(item);
+        }
+    });
+    return [...local, ...inherited];
+}
+
+export class EffectivePwpModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: true,
+            error: null,
+            report: null,
+        };
+    }
+
+    componentDidMount() {
+        if (this.props.isOpen) {
+            this.loadPolicy();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!this.props.isOpen) {
+            return;
+        }
+        if (!prevProps.isOpen ||
+            prevProps.entryDn !== this.props.entryDn ||
+            prevProps.userType !== this.props.userType ||
+            prevProps.selector !== this.props.selector) {
+            this.loadPolicy();
+        }
+    }
+
+    getCustomBaseDnForEntry(entryDn, userType) {
+        const ndn = entryDn.toLowerCase();
+        const rdnInfo = getRdnInfo(ndn);
+        return ndn.replace(rdnInfo.rdnAttr + '=' + rdnInfo.rdnVal + ",", '');
+    }
+
+    loadPolicy() {
+        const {
+            serverId,
+            suffixList,
+            entryDn,
+            userType,
+            selector,
+        } = this.props;
+
+        if (!entryDn || !userType || !selector) {
+            return;
+        }
+
+        this.setState({
+            loading: true,
+            error: null,
+            report: null,
+        });
+
+        const baseDn = getBaseDnForEntry(entryDn, suffixList);
+        if (baseDn === "") {
+            this.setState({
+                loading: false,
+                error: getApiErrorMessage(_("Unable to determine base DN for entry: " + entryDn)),
+            });
+            return;
+        }
+
+        const ndn = entryDn.toLowerCase();
+        const rdnInfo = getRdnInfo(ndn);
+        const parentBaseDn = ndn.replace(rdnInfo.rdnAttr + '=' + rdnInfo.rdnVal + ",", '');
+        fetchUserEffectivePasswordPolicy(serverId, baseDn, parentBaseDn, userType, selector)
+                .done(content => {
+                    this.setState({
+                        loading: false,
+                        report: JSON.parse(content),
+                    });
+                })
+                .fail(err => {
+                    this.setState({
+                        loading: false,
+                        error: getApiErrorMessage(err),
+                    });
+                });
+    }
+
+    render() {
+        const { isOpen, onClose, entryDn } = this.props;
+        const { loading, error, report } = this.state;
+        const policyAttrs = report ? formatPolicyAttributes(report.attrs) : [];
+
+        return (
+            <Modal
+                variant={ModalVariant.medium}
+                title={_("Effective Password Policy")}
+                isOpen={isOpen}
+                onClose={onClose}
+                actions={[
+                    <Button key="close" variant="primary" onClick={onClose}>
+                        {_("Close")}
+                    </Button>
+                ]}
+            >
+                {loading &&
+                    <div className="ds-center ds-margin-top-xlg ds-margin-bottom-md">
+                        <Spinner size="xl" />
+                    </div>}
+                {!loading && error &&
+                    <Alert variant="danger" isInline title={_("Unable to load password policy")}>
+                        {error}
+                    </Alert>}
+                {!loading && !error && report &&
+                    <>
+                        <DescriptionList
+                            isHorizontal
+                            termWidth="10rem"
+                            className="ds-margin-top"
+                        >
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("User DN")}</DescriptionListTerm>
+                                <DescriptionListDescription>{report.dn || entryDn}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("Policy Type")}</DescriptionListTerm>
+                                <DescriptionListDescription>{report.policy_type}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("Policy DN")}</DescriptionListTerm>
+                                <DescriptionListDescription>{report.policy_dn}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("Policy Target")}</DescriptionListTerm>
+                                <DescriptionListDescription>{report.policy_target}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                        <Divider />
+                        <DescriptionList
+                            isHorizontal
+                            columnModifier={{ default: "2Col" }}
+                            termWidth="14rem"
+                        >
+                            {policyAttrs.map(item => (
+                                <DescriptionListGroup key={item.name}>
+                                    <DescriptionListTerm>{item.name}</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        {item.value}
+                                        {item.inherited ? ` (${_("inherited")})` : ""}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                            ))}
+                        </DescriptionList>
+                    </>}
+            </Modal>
+        );
+    }
+}
+
+EffectivePwpModal.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    serverId: PropTypes.string.isRequired,
+    suffixList: PropTypes.array.isRequired,
+    entryDn: PropTypes.string,
+    userType: PropTypes.string,
+    selector: PropTypes.string,
+};

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/constants.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/constants.jsx
@@ -13,7 +13,8 @@ export const ENTRY_MENU = {
     acis: 'acis',
     cos: 'cos',
     delete: 'delete',
-    refresh: 'refresh'
+    refresh: 'refresh',
+    getPwp: 'getPwp'
 };
 
 // Time limit for an LDAP search request.

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -221,6 +221,89 @@ function getResourceLimits () {
     return limits;
 }
 
+function parseSearchResult(searchResult) {
+    const lines = searchResult.split('\n');
+    const allEntries = [];
+    let ldapsubentry = false;
+    let isRole = false;
+    let isLockable = false;
+    let objectclasses = [];
+    let dn = '';
+    let uid = '';
+    let cn = '';
+    let numSubordinates = '0';
+    let modifyTimestamp = '';
+    lines.map(currentLine => {
+        const accountObjectclasses = ['nsaccount', 'nsperson', 'simplesecurityobject',
+            'organization', 'person', 'account', 'organizationalunit',
+            'netscapeserver', 'domain', 'posixaccount', 'shadowaccount',
+            'posixgroup', 'mailrecipient', 'nsroledefinition'];
+        if (isAttributeLine(currentLine, 'dn:')) {
+            // Convert base64-encoded DNs
+            const pos = currentLine.indexOf(':');
+            if (currentLine.startsWith('dn::')) {
+                dn = b64DecodeUnicode(currentLine.substring(pos + 2).trim());
+            } else {
+                dn = currentLine.substring(pos + 1).trim();
+            }
+            ldapsubentry = false;
+            isRole = false;
+            isLockable = false;
+            objectclasses = [];
+            uid = '';
+            cn = '';
+        } else if (isAttributeLine(currentLine, 'numSubordinates:')) {
+            numSubordinates = (currentLine.split(':')[1]).trim();
+        } else if (isAttributeLine(currentLine, 'modifyTimestamp:')) {
+            modifyTimestamp = (currentLine.split(':')[1]).trim();
+        } else if (isAttributeLine(currentLine, 'uid:')) {
+            uid = currentLine.substring(currentLine.indexOf(':') + 1).trim();
+        } else if (isAttributeLine(currentLine, 'cn:')) {
+            cn = currentLine.substring(currentLine.indexOf(':') + 1).trim();
+        } else if (currentLine.toLowerCase().startsWith('objectclass:')) {
+            const ocVal = currentLine.substring(currentLine.indexOf(':') + 1).trim().toLowerCase();
+            objectclasses.push(ocVal);
+            if (ocVal === 'ldapsubentry') {
+                ldapsubentry = true;
+            } else if (ocVal === 'nsroledefinition') {
+                isRole = true;
+            }
+        }
+        for (const accountOC of accountObjectclasses) {
+            if (isAttributeLine(currentLine, `objectclass: ${accountOC}`)) {
+                isLockable = true;
+            }
+        }
+
+        if (currentLine === '' && dn !== '') {
+            const userPwpInfo = buildEntryUserPwpInfo(dn, objectclasses, uid, cn);
+            const result = JSON.stringify(
+                {
+                    dn,
+                    numSubordinates,
+                    modifyTimestamp: getModDate(modifyTimestamp, "utc"),
+                    modifyTimestampLocal: getModDate(modifyTimestamp, "local"),
+                    ldapsubentry,
+                    isRole,
+                    isLockable,
+                    isUser: userPwpInfo.isUser,
+                    userPwpLookup: userPwpInfo.userPwpLookup,
+                });
+            allEntries.push(result);
+
+            // Reset the variables:
+            dn = '';
+            numSubordinates = '0';
+            modifyTimestamp = '';
+            objectclasses = [];
+            uid = '';
+            cn = '';
+        }
+        return [];
+    });
+    return allEntries;
+}
+
 export function getSearchEntries (params, resultCallback) {
     /*
      params.serverId,
@@ -229,7 +312,7 @@ export function getSearchEntries (params, resultCallback) {
      params.searchScope
      params.sizeLimit,
      params.timeLimit
-  */
+    */
     const cmd = [
         'ldapsearch',
         '-LLL',
@@ -253,11 +336,7 @@ export function getSearchEntries (params, resultCallback) {
     ];
 
     log_cmd("getSearchEntries", "", cmd);
-    let dn = '';
-    let numSubordinates = '0';
-    let modifyTimestamp = '';
     let searchResult = null;
-    const allEntries = [];
     cockpit
             .spawn(cmd, { superuser: "require", err: 'message' }) // string.split("\n\r")
             .done(data => {
@@ -280,61 +359,7 @@ export function getSearchEntries (params, resultCallback) {
                 if (searchResult === null) {
                     return;
                 }
-                const lines = searchResult.split('\n');
-                let ldapsubentry = false;
-                let isRole = false;
-                let isLockable = false;
-                lines.map(currentLine => {
-                    const accountObjectclasses = ['nsaccount', 'nsperson', 'simplesecurityobject',
-                        'organization', 'person', 'account', 'organizationalunit',
-                        'netscapeserver', 'domain', 'posixaccount', 'shadowaccount',
-                        'posixgroup', 'mailrecipient', 'nsroledefinition'];
-                    if (isAttributeLine(currentLine, 'dn:')) {
-                        // Convert base64-encoded DNs
-                        const pos = currentLine.indexOf(':');
-                        if (currentLine.startsWith('dn::')) {
-                            dn = b64DecodeUnicode(currentLine.substring(pos + 2).trim());
-                        } else {
-                            dn = currentLine.substring(pos + 1).trim();
-                        }
-                        ldapsubentry = false;
-                        isRole = false;
-                        isLockable = false;
-                    } else if (isAttributeLine(currentLine, 'numSubordinates:')) {
-                        numSubordinates = (currentLine.split(':')[1]).trim();
-                    } else if (isAttributeLine(currentLine, 'modifyTimestamp:')) {
-                        modifyTimestamp = (currentLine.split(':')[1]).trim();
-                    } else if (isAttributeLine(currentLine, 'objectclass: ldapsubentry')) {
-                        ldapsubentry = true;
-                    } else if (isAttributeLine(currentLine, 'objectclass: nsroledefinition')) {
-                        isRole = true;
-                    }
-                    for (const accountOC of accountObjectclasses) {
-                        if (isAttributeLine(currentLine, `objectclass: ${accountOC}`)) {
-                            isLockable = true;
-                        }
-                    }
-
-                    if (currentLine === '' && dn !== '') {
-                        const result = JSON.stringify(
-                            {
-                                dn,
-                                numSubordinates,
-                                modifyTimestamp: getModDate(modifyTimestamp, "utc"),
-                                modifyTimestampLocal: getModDate(modifyTimestamp, "local"),
-                                ldapsubentry,
-                                isRole,
-                                isLockable,
-                            });
-                        allEntries.push(result);
-
-                        // Reset the variables:
-                        dn = '';
-                        numSubordinates = '0';
-                        modifyTimestamp = '';
-                    }
-                    return [];
-                });
+                const allEntries = parseSearchResult(searchResult);
                 // Process the list of entries.
                 resultCallback(allEntries, null);
             });
@@ -512,9 +537,9 @@ export function getOneLevelEntries (params, oneLevelCallback) {
         'one',
         filter,
         /* '-l',
-    timeLimit,
-    '-z',
-    sizeLimit, */
+        timeLimit,
+        '-z',
+        sizeLimit, */
         ...limits,
         '1.1',
         'numSubordinates',
@@ -523,11 +548,7 @@ export function getOneLevelEntries (params, oneLevelCallback) {
     ];
 
     log_cmd("getOneLevelEntries", "", cmd);
-    let dn = '';
-    let numSubordinates = '';
-    let modifyTimestamp = '';
     let searchResult = null;
-    const allEntries = [];
     cockpit
             .spawn(cmd, { superuser: "require", err: 'message' }) // string.split("\n\r")
             .done(data => {
@@ -553,63 +574,7 @@ export function getOneLevelEntries (params, oneLevelCallback) {
                 if (searchResult === null) {
                     return;
                 }
-                const lines = searchResult.split('\n');
-                let ldapsubentry = false;
-                let isRole = false;
-                let isLockable = false;
-                lines.map(currentLine => {
-                    const accountObjectclasses = ['nsaccount', 'nsperson', 'simplesecurityobject',
-                        'organization', 'person', 'account', 'organizationalunit',
-                        'netscapeserver', 'domain', 'posixaccount', 'shadowaccount',
-                        'posixgroup', 'mailrecipient', 'nsroledefinition'];
-                    if (isAttributeLine(currentLine, 'dn:')) {
-                        // Convert base64-encoded DNs
-                        const pos = currentLine.indexOf(':');
-                        if (currentLine.startsWith('dn::')) {
-                            dn = b64DecodeUnicode(currentLine.substring(pos + 2).trim());
-                        } else {
-                            dn = currentLine.substring(pos + 1).trim();
-                        }
-                        ldapsubentry = false;
-                        isRole = false;
-                        isLockable = false;
-                    } else if (isAttributeLine(currentLine, 'numSubordinates:')) {
-                        numSubordinates = (currentLine.split(':')[1]).trim();
-                    } else if (isAttributeLine(currentLine, 'modifyTimestamp:')) {
-                        modifyTimestamp = (currentLine.split(':')[1]).trim();
-                    } else if (isAttributeLine(currentLine, 'objectclass: ldapsubentry')) {
-                        ldapsubentry = true;
-                    } else if (isAttributeLine(currentLine, 'objectclass: nsroledefinition')) {
-                        isRole = true;
-                    }
-                    for (const accountOC of accountObjectclasses) {
-                        if (isAttributeLine(currentLine, `objectclass: ${accountOC}`)) {
-                            isLockable = true;
-                        }
-                    }
-
-                    if (currentLine === '' && dn !== '') {
-                        const result = JSON.stringify(
-                            {
-                                dn,
-                                numSubordinates,
-                                modifyTimestamp: getModDate(modifyTimestamp,
-                                                            "utc"),
-                                modifyTimestampLocal: getModDate(modifyTimestamp,
-                                                                 "local"),
-                                ldapsubentry,
-                                isRole,
-                                isLockable,
-                            });
-                        allEntries.push(result);
-
-                        // Reset the variables:
-                        dn = '';
-                        numSubordinates = '0';
-                        modifyTimestamp = '';
-                    }
-                    return [];
-                });
+                const allEntries = parseSearchResult(searchResult);
                 // Process the list of entries.
                 oneLevelCallback(allEntries, params, null);
             });
@@ -639,10 +604,10 @@ export function runGenericSearch (params, searchCallback) {
         '/usr/bin/sh',
         '-c',
         'ldapsearch -LLL -o ldif-wrap=no -Y EXTERNAL -b "' + params.baseDn +
-    '" -H ldapi://%2fvar%2frun%2fslapd-' + params.serverId + '.socket' +
-    ' -s ' + params.scope +
-    ' "' + params.filter + '" ' +
-    params.attributes
+        '" -H ldapi://%2fvar%2frun%2fslapd-' + params.serverId + '.socket' +
+        ' -s ' + params.scope +
+        ' "' + params.filter + '" ' +
+        params.attributes
     ];
 
     log_cmd("runGenericSearch", "", cmd);
@@ -1157,4 +1122,114 @@ export function getBaseDNFromTree (entrydn, treeViewRootSuffixes) {
         }
     }
     return "";
+}
+
+export function getBaseDnForEntry(entryDn, suffixList) {
+    if (!entryDn || !suffixList || suffixList.length === 0) {
+        return entryDn || "";
+    }
+    const dnLower = entryDn.toLowerCase();
+    let bestMatch = suffixList[0];
+    let found = false;
+    for (const suffix of suffixList) {
+        const suffixLower = suffix.toLowerCase();
+        if (dnLower.endsWith(suffixLower) && suffix.length >= bestMatch.length) {
+            bestMatch = suffix;
+            found = true;
+        }
+    }
+    if (found) {
+        return bestMatch;
+    } else {
+        return "";
+    }
+}
+
+export function isUserEntryForPwp(objectclasses) {
+    if (!objectclasses || objectclasses.length === 0) {
+        return false;
+    }
+    const ocs = objectclasses.map(oc => oc.toLowerCase());
+    if (ocs.includes('nsroledefinition') || ocs.includes('ldapsubentry')) {
+        return false;
+    }
+    if (ocs.includes('organizationalunit') || ocs.includes('organizationalrole')) {
+        return false;
+    }
+    if (ocs.includes('posixgroup') || ocs.includes('groupofnames') ||
+        ocs.includes('groupofuniquenames') || ocs.includes('domain')) {
+        return false;
+    }
+    if (ocs.includes('applicationprocess')) {
+        return true;
+    }
+    if (ocs.includes('posixaccount')) {
+        return true;
+    }
+    if (ocs.includes('nsperson') || ocs.includes('nsaccount') || ocs.includes('nsorgperson')) {
+        return true;
+    }
+    if (ocs.includes('person') || ocs.includes('inetorgperson') ||
+        ocs.includes('organizationalperson')) {
+        return true;
+    }
+    return false;
+}
+
+export function getUserPwpLookupFromEntry(dn, objectclasses, attrs = {}) {
+    if (!isUserEntryForPwp(objectclasses)) {
+        return null;
+    }
+    const ocs = objectclasses.map(oc => oc.toLowerCase());
+    const rdn = dn.split(',')[0];
+    const eqIdx = rdn.indexOf('=');
+    const rdnAttr = eqIdx >= 0 ? rdn.substring(0, eqIdx).toLowerCase() : '';
+    const rdnVal = eqIdx >= 0 ? rdn.substring(eqIdx + 1) : '';
+    const uid = (attrs.uid && attrs.uid[0]) || (rdnAttr === 'uid' ? rdnVal : '');
+    const cn = (attrs.cn && attrs.cn[0]) || (rdnAttr === 'cn' ? rdnVal : '');
+
+    if (ocs.includes('applicationprocess')) {
+        return cn ? { userType: 'service', selector: cn } : null;
+    }
+    if (ocs.includes('posixaccount')) {
+        return uid ? { userType: 'posix', selector: uid } : null;
+    }
+    if (ocs.includes('nsperson') || ocs.includes('nsaccount') || ocs.includes('nsorgperson')) {
+        if (uid !== '') {
+            return { userType: 'basic', selector: uid };
+        } else if (cn !== '') {
+            return { userType: 'basic', selector: cn };
+        }
+        return null;
+    }
+    if (ocs.includes('person') || ocs.includes('inetorgperson') ||
+        ocs.includes('organizationalperson')) {
+        return cn ? { userType: 'traditional', selector: cn } : null;
+    }
+    return null;
+}
+
+export function buildEntryUserPwpInfo(dn, objectclasses, uid = '', cn = '') {
+    const userPwpLookup = getUserPwpLookupFromEntry(
+        dn,
+        objectclasses,
+        {
+            uid: uid ? [uid] : [],
+            cn: cn ? [cn] : [],
+        }
+    );
+    return {
+        isUser: userPwpLookup !== null,
+        userPwpLookup,
+    };
+}
+
+export function fetchUserEffectivePasswordPolicy(serverId, baseDn, parentBaseDn, userType, selector) {
+    const cmd = [
+        "dsidm", "-j", "ldapi://%2fvar%2frun%2fslapd-" + serverId + ".socket",
+        "-b", baseDn, "user", "--user-type", userType, "get-pwp", selector,
+        "--parent-dn", parentBaseDn
+    ];
+    log_cmd("fetchUserEffectivePasswordPolicy", "Load effective password policy", cmd);
+    return cockpit.spawn(cmd, { superuser: "require", err: "message" });
 }

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -46,6 +46,7 @@ import { ENTRY_MENU } from './lib/constants.jsx';
 import EditorTableView from './tableView.jsx';
 import { getApiErrorMessage, log_cmd, valid_dn } from '../tools.jsx';
 import GenericWizard from './wizards/genericWizard.jsx';
+import { EffectivePwpModal } from './effectivePwpModal.jsx';
 
 const _ = cockpit.gettext;
 
@@ -104,6 +105,28 @@ export class SearchDatabase extends React.Component {
             isWizardOpen: false,
             wizardEntryDn: '',
             treeViewRootSuffixes: [], // TODO when aci's are ready (is there a better list of suffixes?)
+            showPwpModal: false,
+            pwpModalEntryDn: '',
+            pwpModalUserType: '',
+            pwpModalSelector: '',
+        };
+
+        this.handlePwpModalClose = () => {
+            this.setState({
+                showPwpModal: false,
+                pwpModalEntryDn: '',
+                pwpModalUserType: '',
+                pwpModalSelector: '',
+            });
+        };
+
+        this.openPwpModal = (entryDn, userPwpLookup) => {
+            this.setState({
+                showPwpModal: true,
+                pwpModalEntryDn: entryDn,
+                pwpModalUserType: userPwpLookup.userType,
+                pwpModalSelector: userPwpLookup.selector,
+            });
         };
 
         this.initialResultText = _("Loading ...");
@@ -419,7 +442,9 @@ export class SearchDatabase extends React.Component {
                                         rawdn: info.dn,
                                         isLockable: info.isLockable,
                                         isRole: info.isRole,
-                                        entryState
+                                        entryState,
+                                        isUser: info.isUser,
+                                        userPwpLookup: info.userPwpLookup,
                                     },
                                     {
                                         parent: rowNumber,
@@ -465,7 +490,9 @@ export class SearchDatabase extends React.Component {
                                 info.modifyTimestamp,
                             ],
                             rawdn: info.dn,
-                            entryState: ""
+                            entryState: "",
+                            isUser: info.isUser,
+                            userPwpLookup: info.userPwpLookup,
                         },
                         {
                             parent: rowNumber,
@@ -702,6 +729,12 @@ export class SearchDatabase extends React.Component {
                     });
                 }
             },
+            ...(rowData.isUser && rowData.userPwpLookup ? [{
+                title: _("View Password Policy ..."),
+                onClick: () => {
+                    this.openPwpModal(rowData.rawdn, rowData.userPwpLookup);
+                }
+            }] : []),
             {
                 isSeparator: true
             },
@@ -765,6 +798,15 @@ export class SearchDatabase extends React.Component {
                         allObjectclasses={this.props.allObjectclasses}
                     />
                 )}
+                <EffectivePwpModal
+                    isOpen={this.state.showPwpModal}
+                    onClose={this.handlePwpModalClose}
+                    serverId={this.props.serverId}
+                    suffixList={this.props.suffixList}
+                    entryDn={this.state.pwpModalEntryDn}
+                    userType={this.state.pwpModalUserType}
+                    selector={this.state.pwpModalSelector}
+                />
                 <Form className="ds-margin-top-lg" isHorizontal autoComplete="off">
                     <Grid className="ds-margin-left">
                         <div className="ds-container">

--- a/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/treeView.jsx
@@ -61,7 +61,8 @@ import { ENTRY_MENU } from './lib/constants.jsx';
 import { getApiErrorMessage, log_cmd } from "../tools.jsx";
 import {
     showCertificate,
-    b64DecodeUnicode
+    b64DecodeUnicode,
+    getUserPwpLookupFromEntry,
 } from './lib/utils.jsx';
 
 const _ = cockpit.gettext;
@@ -221,6 +222,8 @@ class EditorTreeView extends React.Component {
                 entryModTimeLocal: '',
                 entryIcon: null,
                 entryDn: '', // An empty value disables the actions dropdown menu.
+                isUserEntry: false,
+                userPwpLookup: null,
                 latestEntryRefreshTime: Date.now(),
                 searching: false,
             });
@@ -241,6 +244,9 @@ class EditorTreeView extends React.Component {
         const fullEntry = treeViewItem.fullEntry;
         const encodedValues = [];
         let isRole = false;
+        let objectclasses = [];
+        let uid = '';
+        let cn = '';
         fullEntry
                 .filter(data => (data.attribute + data.value !== '') && // Filter out empty lines
             (data.attribute !== '???: ')) // and data for empty suffix(es) and in case of failure.
@@ -281,6 +287,13 @@ class EditorTreeView extends React.Component {
                         }
                         if (myVal === 'nsroledefinition') {
                             isRole = true;
+                        }
+                        if (attrLowerCase === 'objectclass') {
+                            objectclasses.push(myVal);
+                        } else if (attrLowerCase === 'uid') {
+                            uid = val.trim();
+                        } else if (attrLowerCase === 'cn') {
+                            cn = val.trim();
                         }
                         // TODO: Use a better logic to assign icons!
                         // console.log(`!entryIcon = ${!entryIcon}`);
@@ -346,6 +359,12 @@ class EditorTreeView extends React.Component {
                     }
                 })
                 .finally(() => {
+                    const userPwpLookup = getUserPwpLookupFromEntry(
+                        entryDn,
+                        objectclasses,
+                        { uid: uid ? [uid] : [], cn: cn ? [cn] : [] }
+                    );
+                    const isUserEntry = userPwpLookup !== null;
                     const tableModificationTime = Date.now();
                     this.setState({
                         entryRows,
@@ -360,7 +379,9 @@ class EditorTreeView extends React.Component {
                         tableModificationTime,
                         entryIcon,
                         entryStateIcon,
-                        isRole
+                        isRole,
+                        isUserEntry,
+                        userPwpLookup,
                     }, () => {
                         // Now decode the encoded values.
                         // A sample object stored in the variable encodedValues looks like { index: entryRows.length, line: line }
@@ -439,18 +460,18 @@ class EditorTreeView extends React.Component {
                                                                 });
 
                                                         decodedValue =
-                                (
-                                    <>
-                                        <div>
-                                            <Alert variant={type} isInline title={diffMessage} />
-                                            <TextContent>
-                                                <TextList component={TextListVariants.dl}>
-                                                    {certItems}
-                                                </TextList>
-                                            </TextContent>
-                                        </div>
-                                    </>
-                                );
+                                                            (
+                                                                <>
+                                                                    <div>
+                                                                        <Alert variant={type} isInline title={diffMessage} />
+                                                                        <TextContent>
+                                                                            <TextList component={TextListVariants.dl}>
+                                                                                {certItems}
+                                                                            </TextList>
+                                                                        </TextContent>
+                                                                    </div>
+                                                                </>
+                                                            );
 
                                                         const newRow = [{ title: <strong>{attr}</strong> }, decodedValue];
                                                         finalRows.splice(myObj.index, 1, newRow);
@@ -499,7 +520,7 @@ class EditorTreeView extends React.Component {
             entryModTimeLocal, isEmptySuffix, isEntryTooLarge,
             tableModificationTime, showEmptySuffixModal, entryState,
             newSuffixData, isTreeLoading, refreshButtonTriggerTime,
-            latestEntryRefreshTime, entryStateIcon, timeFormat
+            latestEntryRefreshTime, entryStateIcon, timeFormat, isUserEntry, userPwpLookup
         } = this.state;
 
         const { loading } = this.props;
@@ -599,6 +620,18 @@ class EditorTreeView extends React.Component {
             >
                 {_("Class of Service ...")}
             </DropdownItem>,
+            ...(isUserEntry && userPwpLookup ? [
+                <DropdownItem
+                    key="tree-view-get-pwp"
+                    component="button"
+                    name={ENTRY_MENU.getPwp}
+                    value={entryDn}
+                    data-user-type={userPwpLookup.userType}
+                    data-selector={userPwpLookup.selector}
+                >
+                    {_("View Password Policy ...")}
+                </DropdownItem>,
+            ] : []),
             /*
             <DropdownItem
                 isDisabled

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addUser.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addUser.jsx
@@ -129,7 +129,8 @@ class AddUser extends React.Component {
 
         this.requiredAttrs = {
             'Basic Account': [
-                'cn', 'displayName',
+                // uid is not technically required, but dsidm expects it
+                'uid', 'cn', 'displayName',
             ],
             'Traditional Account': [
                 'cn', 'sn',

--- a/src/lib389/lib389/cli_idm/user.py
+++ b/src/lib389/lib389/cli_idm/user.py
@@ -7,6 +7,9 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 
+import json
+
+from lib389.pwpolicy import PwPolicyManager
 from lib389.idm.user import (
     nsUserAccount,
     nsUserAccounts,
@@ -88,6 +91,20 @@ def rename(inst, basedn, log, args, warn=True):
     _generic_rename(inst, basedn, log.getChild('_generic_rename'), MANY_DICT[args.user_type], rdn, args)
 
 
+def get_pwp(inst, basedn, log, args):
+    """Show the effective password policy for a user account."""
+    log = log.getChild('get_pwp')
+    selector = _get_arg(args.selector, msg="Enter username to look up password policy for")
+    user_type = getattr(args, 'user_type', None) or DEFAULT_USER_TYPE
+    pwp_manager = PwPolicyManager(inst)
+
+    report = pwp_manager.get_effective_policy(basedn, user_type, selector, parent_basedn=args.parent_dn)
+    if args.json:
+        log.info(json.dumps(pwp_manager.format_report_json(report), indent=4))
+    else:
+        log.info(pwp_manager.format_report_text(report))
+
+
 def create_parser(subparsers, user_type=DEFAULT_USER_TYPE):
     user_parser = subparsers.add_parser('user',
                                         help='Manage posix users.  The organizationalUnit (by default "ou=people") needs '
@@ -115,6 +132,26 @@ def create_parser(subparsers, user_type=DEFAULT_USER_TYPE):
     get_parser = subcommands.add_parser('get', help='get', formatter_class=CustomHelpFormatter)
     get_parser.set_defaults(func=get)
     get_parser.add_argument('selector', nargs='?', help='The term to search for')
+
+    get_pwp_parser = subcommands.add_parser(
+        'get-pwp',
+        help='Show the effective password policy for a user',
+        formatter_class=CustomHelpFormatter,
+        description='Resolve and display the password policy (global, user local, or subtree '
+                    'local) that applies to the user, including all effective settings.',
+    )
+    get_pwp_parser.set_defaults(func=get_pwp)
+    get_pwp_parser.add_argument(
+        'selector',
+        nargs='?',
+        help='The user identifier to look up (same as user get, typically uid)',
+    )
+    get_pwp_parser.add_argument(
+        '--parent-dn',
+        default=None,
+        help='A base DN to use for user lookups. Default is "ou=people,$SUFFIX" '
+             'for users, or "ou=services,$SUFFIX" for service accounts',
+    )
 
     get_dn_parser = subcommands.add_parser('get_dn', help='get_dn', formatter_class=CustomHelpFormatter)
     get_dn_parser.set_defaults(func=get_dn)

--- a/src/lib389/lib389/idm/services.py
+++ b/src/lib389/lib389/idm/services.py
@@ -67,7 +67,11 @@ class ServiceAccounts(DSLdapObjects):
         ]
         self._filterattrs = [RDN]
         self._childobject = ServiceAccount
-        self._basedn = '{},{}'.format(rdn, basedn)
+
+        if rdn is None:
+            self._basedn = basedn
+        else:
+            self._basedn = f'{rdn},{basedn}'
 
 
     def create_test_service(self, description="Test Service"):

--- a/src/lib389/lib389/pwpolicy.py
+++ b/src/lib389/lib389/pwpolicy.py
@@ -8,12 +8,192 @@
 
 import ldap
 from ldap import filter as ldap_filter
-from lib389._mapped_object import DSLdapObject, DSLdapObjects
+from lib389._mapped_object import DSLdapObject, DSLdapObjects, _normalise_attrs
 from lib389.backend import Backends
 from lib389.config import Config
 from lib389.idm.account import Account
 from lib389.idm.nscontainer import nsContainers, nsContainer
+from lib389.idm.user import (
+    BasicUserAccounts,
+    nsUserAccounts,
+    TraditionalUserAccounts,
+)
+from lib389.idm.services import ServiceAccounts
 from lib389.cos import CosPointerDefinitions, CosPointerDefinition, CosTemplates
+
+
+POLICY_TYPE_GLOBAL = 'Global Policy'
+POLICY_TYPE_USER = 'User Policy'
+POLICY_TYPE_SUBTREE = 'Subtree Policy'
+
+SYNTAX_POLICY_ATTRS = [
+    'passwordchecksyntax',
+    'passwordminlength',
+    'passwordmindigits',
+    'passwordminalphas',
+    'passwordminuppers',
+    'passwordminlowers',
+    'passwordminspecials',
+    'passwordmin8bit',
+    'passwordmaxrepeats',
+    'passwordpalindrome',
+    'passwordmaxsequence',
+    'passwordmaxseqsets',
+    'passwordmaxclasschars',
+    'passwordmincategories',
+    'passwordmintokenlength',
+    'passwordbadwords',
+    'passworduserattributes',
+    'passworddictcheck',
+    'passworddictpath',
+]
+
+GLOBAL_ONLY_POLICY_ATTRS = [
+    'passwordisglobalpolicy',
+    'nsslapd-pwpolicy-local',
+    'nsslapd-allow-hashed-passwords',
+    'nsslapd-pwpolicy-inherit-global',
+]
+
+USER_TYPE_ACCOUNTS = {
+    'posix': nsUserAccounts,
+    'basic': BasicUserAccounts,
+    'service': ServiceAccounts,
+    'traditional': TraditionalUserAccounts,
+}
+
+# Defaults from pwpolicy_init_defaults() in ldap/servers/slapd/libglobs.c
+LOCAL_PW_POLICY_DEFAULTS = {
+    'passwordchange': 'on',
+    'passwordmustchange': 'off',
+    'passwordchecksyntax': 'off',
+    'passwordexp': 'off',
+    'passwordsendexpiringtime': 'off',
+    'passwordminlength': '8',
+    'passwordmindigits': '0',
+    'passwordminalphas': '0',
+    'passwordminuppers': '0',
+    'passwordminlowers': '0',
+    'passwordminspecials': '0',
+    'passwordmin8bit': '0',
+    'passwordmaxrepeats': '0',
+    'passwordmincategories': '3',
+    'passwordmintokenlength': '3',
+    'passwordmaxage': '8640000',
+    'passwordminage': '0',
+    'passwordwarning': '86400',
+    'passwordhistory': 'off',
+    'passwordinhistory': '6',
+    'passwordlockout': 'off',
+    'passwordmaxfailure': '3',
+    'passwordunlock': 'on',
+    'passwordlockoutduration': '3600',
+    'passwordresetfailurecount': '600',
+    'passwordTPRMaxUse': '-1',
+    'passwordTPRDelayExpireAt': '-1',
+    'passwordTPRDelayValidFrom': '-1',
+    'passwordgracelimit': '0',
+    'passwordadmindn': '',
+    'passwordadminskipinfoupdate': 'off',
+    'passwordtrackupdatetime': 'off',
+    'passwordpalindrome': 'off',
+    'passwordmaxsequence': '0',
+    'passwordmaxseqsets': '0',
+    'passwordmaxclasschars': '0',
+    'passwordbadwords': '',
+    'passworduserattributes': '',
+    'passworddictcheck': 'off',
+    'passworddictpath': '',
+    'passwordstoragescheme': '',
+}
+
+
+def _decode_cn_dn_fragment(fragment):
+    """Decode LDAP escaped characters in a cn-stored DN fragment."""
+    return (fragment.replace('\\3D', '=').replace('\\3d', '=')
+            .replace('\\2C', ',').replace('\\2c', ','))
+
+
+def _parse_policy_target_from_cn(cn_value):
+    """Return the policy target DN encoded in a policy entry cn value."""
+    if not cn_value:
+        return None
+    cn_value = cn_value.strip("'").strip('"')
+    cn_lower = cn_value.lower()
+    prefixes = (
+        'cn=nspwpolicyentry_user,',
+        'cn=nspwpolicyentry_subtree,',
+    )
+    if not any(cn_lower.startswith(p) for p in prefixes):
+        return None
+    try:
+        dn_comps = ldap.dn.explode_dn(cn_value)
+        dn_comps.pop(0)
+        if dn_comps:
+            return ','.join(dn_comps)
+    except ldap.DECODING_ERROR:
+        # Decoding errors are ok, just proceed
+        pass
+
+    remainder = _decode_cn_dn_fragment(cn_value[cn_value.index(',') + 1:])
+    try:
+        return ldap.dn.dn2str(ldap.dn.str2dn(remainder))
+    except ldap.DECODING_ERROR:
+        # It's ok, just return the remainder
+        return remainder
+
+
+def _classify_policy_from_pwdpolicysubentry(pwp_dn, pwp_entry):
+    """Return policy type, source DN, and target DN for a local policy entry."""
+    cn = pwp_entry.get_attr_val_utf8('cn') or ''
+    cn_l = cn.lower()
+    if 'nspwpolicyentry_user' in cn_l:
+        policy_type = POLICY_TYPE_USER
+    elif 'nspwpolicyentry_subtree' in cn_l:
+        policy_type = POLICY_TYPE_SUBTREE
+    else:
+        raise ValueError(
+            'Unable to determine password policy type for entry "{}"'.format(pwp_dn))
+    target = _parse_policy_target_from_cn(cn)
+    if not target:
+        raise ValueError(
+            'Unable to parse password policy target from policy entry "{}"'.format(pwp_dn))
+    return policy_type, pwp_dn, target
+
+
+def _attr_is_on(value):
+    if value is None:
+        return False
+    return str(value).lower() in ('on', 'true', '1', 'yes')
+
+
+def _should_show_inherited_value(value):
+    """Return True when an inherited setting should appear in local policy output."""
+    if value is None:
+        return False
+    text = str(value).strip()
+    if not text or text == '0':
+        return False
+    if text.lower() == 'off':
+        return False
+    return True
+
+
+def _first_attr_value(attrs, attr_name, default=''):
+    if not attrs:
+        return default
+    values = attrs.get(attr_name, [])
+    if values:
+        return values[0]
+    attr_lower = attr_name.lower()
+    for key, vals in attrs.items():
+        if key.lower() == attr_lower and vals:
+            return vals[0]
+    return default
+
+
+def _make_attr_entry(value, inherited=False):
+    return {'values': ['' if value is None else str(value)], 'inherited': inherited}
 
 
 class PwPolicyManager(object):
@@ -72,6 +252,178 @@ class PwPolicyManager(object):
             'pwptprmaxuse': 'passwordTPRMaxUse',
             'pwptprdelayexpireat': 'passwordTPRDelayExpireAt',
             'pwptprdelayvalidfrom': 'passwordTPRDelayValidFrom'
+        }
+
+    def policy_attribute_names(self, include_global_only=False):
+        """Return sorted password policy attribute names for CLI output."""
+        names = sorted(set(self.arg_to_attr.values()))
+        if include_global_only:
+            for attr in GLOBAL_ONLY_POLICY_ATTRS:
+                if attr not in names:
+                    names.append(attr)
+            names.sort()
+        return names
+
+    def _local_policy_attribute_names(self):
+        """Return password policy attribute names stored on local policy entries."""
+        return sorted(set(self.arg_to_attr.values()) | {'passwordstoragescheme'})
+
+    def _report_attribute_names(self, report):
+        """Return attribute names to emit for a policy report."""
+        if report['policy_type'] == POLICY_TYPE_GLOBAL:
+            return self.policy_attribute_names(include_global_only=True)
+        local = []
+        inherited = []
+        for attr in sorted(report['attrs'].keys()):
+            if report['attrs'][attr].get('inherited'):
+                inherited.append(attr)
+            else:
+                local.append(attr)
+        return local + inherited
+
+    def resolve_user_dn(self, basedn, user_type, selector, parent_basedn=None):
+        """Resolve a dsidm user selector to an entry DN."""
+        if not selector:
+            raise ValueError('A user identifier is required')
+        accounts_class = USER_TYPE_ACCOUNTS.get(user_type or 'posix', nsUserAccounts)
+        if parent_basedn is not None:
+            accounts = accounts_class(self._instance, parent_basedn, rdn=None)
+        else:
+            accounts = accounts_class(self._instance, basedn)
+        if not accounts.exists(selector):
+            raise ValueError('User "{}" was not found'.format(selector))
+        return accounts.get(selector).dn
+
+    def get_effective_policy(self, basedn, user_type, selector, parent_basedn=None):
+        """Resolve the effective password policy for a user account."""
+        user_dn = self.resolve_user_dn(basedn, user_type, selector, parent_basedn)
+        user_entry = Account(self._instance, user_dn)
+        user_attrs = user_entry.get_all_attrs_utf8()
+        if not user_attrs:
+            raise ValueError('User entry "{}" was not found'.format(user_dn))
+
+        if self._instance.config.get_attr_val_utf8_l('nsslapd-pwpolicy-local') == 'on':
+            pwp_subentry_vals = user_attrs.get('pwdpolicysubentry', [])
+            pwp_dn = pwp_subentry_vals[0] if pwp_subentry_vals else None
+        else:
+            pwp_dn = None
+
+        global_attrs_raw = self._get_global_policy_attrs()
+
+        if pwp_dn is None:
+            return {
+                'dn': user_dn,
+                'policy_type': POLICY_TYPE_GLOBAL,
+                'policy_dn': Config(self._instance).dn,
+                'policy_target': 'global',
+                'attrs': self._build_global_effective_attrs(global_attrs_raw),
+            }
+
+        pwp_entry = PwPolicyEntry(self._instance, pwp_dn)
+        if not pwp_entry.exists():
+            raise ValueError(
+                'Assigned password policy entry "{}" could not be found'.format(pwp_dn))
+        if not pwp_entry.present('objectClass', 'passwordpolicy'):
+            raise ValueError(
+                'Assigned password policy entry "{}" is not a valid password policy'.format(pwp_dn))
+
+        policy_type, policy_dn, policy_target = _classify_policy_from_pwdpolicysubentry(
+            pwp_dn, pwp_entry)
+        policy_attrs_raw = _normalise_attrs(pwp_entry.get_all_attrs_utf8())
+        effective = self._build_local_effective_attrs(policy_attrs_raw, global_attrs_raw)
+
+        return {
+            'dn': user_dn,
+            'policy_type': policy_type,
+            'policy_dn': policy_dn,
+            'policy_target': policy_target,
+            'attrs': effective,
+        }
+
+    def _get_global_policy_attrs(self):
+        config = Config(self._instance)
+        attr_names = self.policy_attribute_names(include_global_only=True)
+        attrs = _normalise_attrs(config.get_attrs_vals_utf8(attr_names))
+        # Some config attributes may be returned only under schema canonical names.
+        all_attrs = _normalise_attrs(config.get_all_attrs_utf8())
+        for name in attr_names:
+            if name not in attrs or not attrs[name]:
+                if name in all_attrs and all_attrs[name]:
+                    attrs[name] = all_attrs[name]
+        return attrs
+
+    def _build_global_effective_attrs(self, global_attrs_raw):
+        effective = {}
+        for attr in self.policy_attribute_names(include_global_only=True):
+            value = _first_attr_value(global_attrs_raw, attr, LOCAL_PW_POLICY_DEFAULTS.get(attr, ''))
+            effective[attr] = _make_attr_entry(value, inherited=False)
+        return effective
+
+    def _build_local_effective_attrs(self, policy_attrs_raw, global_attrs_raw):
+        """Build attrs for a local policy: explicit entry values plus inherited syntax."""
+        policy_attrs_raw = _normalise_attrs(policy_attrs_raw)
+        global_attrs_raw = _normalise_attrs(global_attrs_raw)
+        effective = {}
+        local_attrs = set()
+
+        for attr in self._local_policy_attribute_names():
+            if attr in policy_attrs_raw and policy_attrs_raw[attr]:
+                effective[attr] = _make_attr_entry(
+                    _first_attr_value(policy_attrs_raw, attr), inherited=False)
+                local_attrs.add(attr)
+
+        if 'passwordchecksyntax' in local_attrs:
+            local_syntax_on = _attr_is_on(effective['passwordchecksyntax']['values'][0])
+        else:
+            local_syntax_on = False
+
+        inherit_global = _attr_is_on(
+            _first_attr_value(global_attrs_raw, 'nsslapd-pwpolicy-inherit-global', 'off'))
+        global_syntax_on = _attr_is_on(
+            _first_attr_value(global_attrs_raw, 'passwordchecksyntax', 'off'))
+
+        if not local_syntax_on and inherit_global and global_syntax_on:
+            for attr in SYNTAX_POLICY_ATTRS:
+                if attr == 'passwordchecksyntax' or attr in local_attrs:
+                    continue
+                value = _first_attr_value(global_attrs_raw, attr, '')
+                if not _should_show_inherited_value(value):
+                    continue
+                effective[attr] = _make_attr_entry(value, inherited=True)
+
+        return effective
+
+    def format_report_text(self, report):
+        """Format an effective policy report for human-readable CLI output."""
+        lines = [
+            'dn: {}'.format(report['dn']),
+            'passwordPolicy: {}'.format(report['policy_type']),
+            'passwordPolicyDN: {}'.format(report['policy_dn']),
+            'passwordPolicyTarget: {}'.format(report['policy_target']),
+            '------------------- Policy Settings -------------------',
+        ]
+        for attr in self._report_attribute_names(report):
+            item = report['attrs'][attr]
+            value = item['values'][0] if item['values'] else ''
+            suffix = ' (inherited)' if item.get('inherited') else ''
+            lines.append('{}: {}{}'.format(attr, value, suffix))
+        return '\n'.join(lines) + '\n'
+
+    def format_report_json(self, report):
+        """Format an effective policy report as a JSON-serializable dict."""
+        attrs_out = {}
+        for attr in self._report_attribute_names(report):
+            item = report['attrs'][attr]
+            values = list(item['values'])
+            if item.get('inherited'):
+                values.append('inherited')
+            attrs_out[attr] = values
+        return {
+            'dn': report['dn'],
+            'policy_type': report['policy_type'],
+            'policy_dn': report['policy_dn'],
+            'policy_target': report['policy_target'],
+            'attrs': attrs_out,
         }
 
     def is_subtree_policy(self, dn):


### PR DESCRIPTION
Description:

Update CLI where you can enter a user's DN and find out what password policies are apply to them (global or local) and the policy settings.

Design doc:

https://www.port389.org/docs/389ds/design/dsidm-user-get-pwp-design.html

Relates: https://github.com/389ds/389-ds-base/issues/7505

co-authored-by: Cursor

## Summary by Sourcery

Add support for resolving and displaying the effective password policy that applies to a user, and expose it via CLI and Cockpit UI.

New Features:
- Introduce dsidm `user get-pwp` command to report the effective password policy for a user, with text and JSON output options.
- Add Cockpit UI modal to view a user's effective password policy from search results, tree view, and editor views, backed by a dsidm-based helper.
- Detect user entries and derive lookup parameters for password policy resolution based on entry objectClasses and attributes.

Enhancements:
- Extend password policy management library to compute effective policies including global, user, and subtree policies, handling inheritance of syntax settings and canonical attribute names.
- Refactor Cockpit LDAP search result parsing into a reusable helper and enrich it with user metadata for password policy lookups.
- Document the new `dsidm user get-pwp` capability in the lib389 README.

Tests:
- Add CLI tests covering dsidm `user get-pwp` behavior across user types, policy types, inheritance scenarios, JSON output, and error handling.
- Add unit tests for password policy target parsing, classification, attribute merging, and reporting order.