### PR TITLE
Issue 7617 - Fix wrong PR_ASSERT about entry cache

### DIFF
--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -512,7 +512,7 @@ lru_delete(struct cache *cache, void *ptr)
     }
     e = (struct backcommon *)ptr;
     PR_ASSERT(e->ep_state & ENTRY_STATE_LRU);
-    PR_ASSERT(e->ep_state & ENTRY_STATE_PINNED);
+    PR_ASSERT((e->ep_state & ENTRY_STATE_PINNED) == 0);
 
 #ifdef LDAP_CACHE_DEBUG_LRU
     pinned_verify(cache, __LINE__);


### PR DESCRIPTION
Fix crash in debug build.

Issue: #7617 

Reviewed by: @mreynolds389  (Thanks!)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect assertion on ENTRY_STATE_PINNED during LRU deletion of cache entries that caused debug-build crashes.