### PR TITLE
Issue 7621 - Stack Buffer Overflow in Password checkPrefix

### DIFF
--- a/dirsrvtests/tests/suites/password/pwd_check_prefix_crash_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_check_prefix_crash_test.py
@@ -1,0 +1,59 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import pytest
+import os
+from test389.topologies import topology_m1 as topo
+from lib389.agreement import Agreements
+from lib389.replica import Replicas
+
+log = logging.getLogger(__name__)
+
+
+def test_buffer_overflow_in_check_prefix(topo):
+    """Test buffer overflow in checkPrefix
+
+    :id: 12345678-1234-1234-1234-123456789012
+    :setup: Supplier Instance
+    :steps:
+        1. Create a replica agreement with a password that has a long prefix
+        2. Check server is still running
+    :expectedresults:
+        1. The agreement is created successfully
+        2. Server is still running
+    """
+    inst = topo.ms["supplier1"]
+    prefix = 'AES-' + ('A' * 512)
+    pwd_value = ('{' + prefix + '}dGVzdA==')
+
+    log.info("Creating agreement with invalid password prefix ...")
+
+    replica = Replicas(inst).list()[0]
+    repl_agmts = Agreements(inst, basedn=replica.dn)
+    repl_agmts.create(properties={
+        'cn': 'test agmt',
+        'nsDS5ReplicaRoot': 'dc=example,dc=com',
+        'nsDS5ReplicaPort': '389',
+        'nsDS5ReplicaHost': 'localhost',
+        'nsDS5ReplicaBindMethod': 'SIMPLE',
+        'nsDS5ReplicaBindDN': 'cn=replication manager,cn=config',
+        'nsDS5ReplicaTransportInfo': 'LDAP',
+        'nsDS5ReplicaCredentials': pwd_value
+    })
+
+    log.info("Agreement added, checking server status ...")
+    assert inst.status(), "Server crashed"
+    log.info("Test passed!")
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -462,7 +462,10 @@ checkPrefix(char *cipher, char *schemaName, char **encrypt, char **algid)
                 } else {
                     char algid_buf[256];
 
-                    /* extract the algid (length is never greater than 216 */
+                    /* extract the algid - enforce buffer limit */
+                    if ((end - delim) >= (int)sizeof(algid_buf)) {
+                        return 1;  /* algid too long, error */
+                    }
                     memcpy(algid_buf, delim + 1, (end - delim));
                     algid_buf[end - delim - 1] = '\0';
                     *algid = slapi_ch_strdup(algid_buf);


### PR DESCRIPTION
Description:

A stack buffer overflow in checkPrefix() function allows a Directory Manager to crash the LDAP server by storing a reversible-encrypted attribute with an oversized algorithm ID.

Add a bounds check before the `memcpy` at `pw.c:466` to prevent the overflow.

relates: https://github.com/389ds/389-ds-base/issues/7621

## Summary by Sourcery

Prevent stack buffer overflow in password prefix handling and add a regression test to ensure the server remains stable when processing oversized algorithm IDs.

Bug Fixes:
- Add bounds checking in checkPrefix() to reject algorithm IDs that exceed the local buffer size instead of overflowing the stack.

Tests:
- Introduce an automated test that creates a replication agreement with an oversized password prefix and verifies the LDAP server continues running.