### PR TITLE
Issue 7623  - Heap Buffer Overflow in 389-ds-base Audit Log Password Masking

### DIFF
--- a/dirsrvtests/tests/suites/logging/auditlog_pwd_mask_overflow_test.py
+++ b/dirsrvtests/tests/suites/logging/auditlog_pwd_mask_overflow_test.py
@@ -1,0 +1,69 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import pytest
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.idm.user import UserAccounts, TEST_USER_PROPERTIES
+from lib389.paths import Paths
+from lib389.utils import check_asan_report
+from test389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier2
+
+log = logging.getLogger(__name__)
+
+ds_paths = Paths()
+
+
+@pytest.mark.skipif(not ds_paths.asan_enabled, reason="Don't run if ASAN is not enabled")
+def test_auditlog_pwd_mask_overflow(topo):
+    """Audit log password masking must not overflow the entry buffer
+
+    :id: 6969c95b-faeb-4d36-8824-c1564954e691
+    :setup: Standalone Instance
+    :steps:
+        1. Enable the audit log
+        2. Set the password storage scheme to CLEAR
+        3. Add a user with a one-character password
+        4. Stop the server and check the ASAN report for heap-buffer-overflow
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. No heap-buffer-overflow is reported
+    """
+    inst = topo.standalone
+
+    inst.config.set('nsslapd-auditlog-logging-enabled', 'on')
+    inst.config.set('passwordStorageScheme', 'CLEAR')
+
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user_props = TEST_USER_PROPERTIES.copy()
+    user_props.update({
+        'uid': 'asan_auditlog_user',
+        'cn': 'asan_auditlog_user',
+        'userpassword': 'a',
+    })
+    users.create(properties=user_props)
+
+    overflow_detected = False
+    try:
+        overflow_detected = check_asan_report(inst, 'heap-buffer-overflow')
+    except ValueError as e:
+        log.info('No ASAN report found (expected when no overflow): %s', e)
+
+    assert not overflow_detected, 'heap-buffer-overflow detected in ASAN report'
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/auditlog.c
+++ b/ldap/servers/slapd/auditlog.c
@@ -106,7 +106,25 @@ create_masked_entry_string(Slapi_Entry *original_entry, int *len)
 
             /* Check if this is a password attribute that needs masking */
             if (is_password_attribute(line_start)) {
-                strcpy(colon_pos + 1, " **********************");
+                const char mask[] = " **********************";
+                size_t mask_len = (sizeof mask)-1;
+                size_t avail = 0;
+
+                /* Calculate available space from colon_pos+1 to end of value */
+                if (next_line != NULL) {
+                    avail = (size_t)(next_line - (colon_pos + 1));
+                } else {
+                    avail = strlen(colon_pos + 1);
+                }
+
+                if (mask_len <= avail) {
+                    memcpy(colon_pos + 1, mask, mask_len);
+                    /* Space-fill remaining space to avoid leaking original value */
+                    memset(colon_pos + 1 + mask_len, ' ', avail - mask_len);
+                } else {
+                    /* Mask is longer than available space -- truncate mask */
+                    memcpy(colon_pos + 1, mask, avail);
+                }
             }
 
             *colon_pos = saved_colon;  /* Restore colon */


### PR DESCRIPTION
Description:

When password storage scheme is set to CLEAR and you set a password that is less than 23-bytes then a possible heap overflow is possible.

Replace the unsafe `strcpy` with a bounded copy that respects the available space in the buffer

Severity: Low (CVSS 3.3)
CWE: CWE-122 (Heap-based Buffer Overflow)

relates: https://github.com/389ds/389-ds-base/issues/7623

## Summary by Sourcery

Prevent heap buffer overflow in audit log password masking and add regression coverage for ASAN-detected overflows.

Bug Fixes:
- Fix potential heap-based buffer overflow when masking short CLEAR passwords in audit log entries.

Tests:
- Add ASAN-gated audit log test to ensure password masking does not cause heap-buffer-overflow with short CLEAR passwords.