### PR TITLE
Issue 6625 - Backport get_pid to fix check_asan_report

### DIFF
--- a/src/lib389/lib389/__init__.py
+++ b/src/lib389/lib389/__init__.py
@@ -3536,3 +3536,9 @@ class DirSrv(SimpleLDAPObject, object):
         if self._containerised or container_result.returncode == 0:
             return True
         return False
+
+    def get_pid(self):
+        """
+        Get the pid of the running server
+        """
+        return pid_from_file(self.pid_file())


### PR DESCRIPTION
Description: check_asan_report() in lib389/utils.py calls inst.get_pid()
but get_pid() was not defined in the DirSrv class on this branch.
Backport the get_pid() method from 389-ds-base-2.4.

Relates: https://github.com/389ds/389-ds-base/issues/6625
Relates: https://github.com/389ds/389-ds-base/issues/6940