### PR TITLE
Issue 7627 - When it exists configured matching rule for an indexed a…

### DIFF
--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -13,6 +13,7 @@ import ldap
 import logging
 import glob
 import re
+import json
 from lib389.backend import Backend, Backends, DatabaseConfig
 from lib389.cli_ctl.dblib import DbscanHelper
 from lib389.config import LDBMConfig
@@ -23,6 +24,7 @@ from lib389.dirsrv_log import DirsrvErrorLog
 from lib389.idm.domain import Domain
 from lib389.idm.group import Groups
 from lib389.idm.nscontainer import nsContainer
+from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.index import Index
 from lib389._mapped_object import DSLdapObject, DSLdapObjects
@@ -37,6 +39,8 @@ pytestmark = pytest.mark.tier1
 SUFFIX2 = 'dc=example2,dc=com'
 BENAME2 = 'be2'
 CN_INDEX_DN = f'cn=cn,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
+PARENTID_INDEX_DN = f'cn=parentid,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
+UID_INDEX_DN = f'cn=uid,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
 
 DEBUGGING = os.getenv("DEBUGGING", default=False)
 logging.getLogger(__name__).setLevel(logging.INFO)
@@ -1396,6 +1400,320 @@ def test_large_multivalued_sn_attribute(topo):
     # Clean up
     user.delete()
     log.info("User entry deleted successfully")
+
+
+def test_nsmatchingrule_vs_schema(topo):
+    """Check that parentid uses an integer matching rule
+
+    parentid is defined in schema with EQUALITY integerMatch and no ORDERING
+    rule. The system index configures nsMatchingRule: integerOrderingMatch so
+    range/order comparisons still use integer semantics even if the syntax
+    of parentid selects a lexicographic matching rule.
+
+    :id: 419bd59c-3bec-4e94-9bc5-9043e36787ac
+    :setup: Standalone instance
+    :steps:
+        1. Query the parentid attribute type from the schema
+        2. Read nsMatchingRule from the parentid index entry
+        3. Create 10 OUs under the suffix and one user under each OU
+        4. Stop the instance, run dbscan on parentid, and collect equality keys
+        5. Override parentid in 99user.ldif with EQUALITY caseIgnoreMatch
+        6. Clear the error logs, start the instance, and verify the schema override
+           and the INFO message about using the configured matching rule
+        7. Create 10 more OUs/users and verify dbscan keys remain in integer order
+    :expectedresults:
+        1. Schema has integer syntax and no ORDERING rule
+        2. Index nsMatchingRule contains integerOrderingMatch
+        3. Entries are created successfully
+        4. Equality keys are present and sorted numerically
+        5. 99user.ldif is written successfully
+        6. Schema uses string syntax with no ORDERING, and the error log contains
+           the configured matching rule compatibility message
+        7. Keys remain sorted numerically (nsMatchingRule wins over schema)
+    """
+    inst = topo.standalone
+    created_ous = []
+    created_users = []
+    schema_filename = os.path.join(inst.schemadir, '99user.ldif')
+    schema_backup = None
+    integer_syntax = '1.3.6.1.4.1.1466.115.121.1.27'
+    string_syntax = '1.3.6.1.4.1.1466.115.121.1.15'
+    expected_log_msg = (
+        'The attribute [parentid] does not have a valid ORDERING matching rule using integerOrderingMatch'
+    )
+
+    def _parentid_equality_keys():
+        output = inst.dbscan(bename=DEFAULT_BENAME, index='parentid',
+                             stopping=False).decode()
+        keys = []
+        for line in output.splitlines():
+            line = line.strip()
+            match = re.match(r'^(?:KEY:\s*)?=(\d+)\s*$', line)
+            if match:
+                keys.append(int(match.group(1)))
+        return keys
+
+    def _assert_integer_ordered(keys):
+        log.info("parentid equality keys from dbscan: %s", keys)
+        assert len(keys) >= 2, f"Expected at least 2 parentid equality keys, got {keys}"
+        assert any(k >= 10 for k in keys), (
+            f"Expected a multi-digit parentid key to distinguish integer vs "
+            f"lexicographic order, got {keys}"
+        )
+        integer_sorted = sorted(keys)
+        lex_sorted = sorted(keys, key=str)
+        assert keys == integer_sorted, (
+            f"parentid equality keys are not in integer order: {keys}"
+        )
+        assert integer_sorted != lex_sorted, (
+            f"Test data did not produce differing integer/lex orders: {keys}"
+        )
+
+    log.info("Check parentid schema is integer syntax but no ordering matching rule")
+    attr_result = inst.schema.query_attributetype('parentid', json=True)
+    assert attr_result is not None
+    attr_result_json = json.loads(attr_result) if isinstance(attr_result, str) else attr_result
+    assert attr_result_json['at']['syntax'] == integer_syntax, (
+        f"Expected parentid is syntax integer in the schema, got {attr_result_json['at']['syntax']}"
+    )
+    assert attr_result_json['at']['ordering'] == None, (
+        f"Expected parentid ORDERING is not defined in the schema, got {attr_result_json['at']['ordering']}"
+    )
+    log.info("parentid schema ORDERING not defined, so it uses integer syntax for ordering")
+
+    log.info("Check parentid index nsMatchingRule")
+    parentid_index = Index(inst, PARENTID_INDEX_DN)
+    matching_rules = [mr.lower() for mr in parentid_index.get_attr_vals_utf8('nsMatchingRule')]
+    assert 'integerorderingmatch' in matching_rules, (
+        f"Expected integerOrderingMatch in parentid nsMatchingRule, got {matching_rules}"
+    )
+    log.info("parentid index nsMatchingRule includes integerOrderingMatch")
+
+    try:
+        # Create 10 OUs and one user under each so parentid equality keys
+        # include distinct parent entry IDs (including values >= 10, where
+        # lexicographic and integer ordering diverge).
+        log.info("Create 10 OUs with one user under each")
+        ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+        for i in range(10):
+            ou = ous.create(properties={'ou': f'parentid-mr-test-{i}'})
+            created_ous.append(ou)
+            users = UserAccounts(inst, ou.dn, rdn=None)
+            user = users.create(properties={
+                'uid': f'parentid_user_{i}',
+                'cn': f'parentid_user_{i}',
+                'sn': f'parentid_user_{i}',
+                'uidNumber': f'{1000 + i}',
+                'gidNumber': f'{1000 + i}',
+                'homeDirectory': f'/home/parentid_user_{i}'
+            })
+            created_users.append(user)
+
+        log.info("Stop instance, scan parentid index, and override schema")
+        inst.stop()
+        keys = _parentid_equality_keys()
+        _assert_integer_ordered(keys)
+        log.info("parentid equality keys are sorted with integer ordering")
+
+        if os.path.exists(schema_filename):
+            with open(schema_filename, 'r') as schema_file:
+                schema_backup = schema_file.read()
+
+        log.info("Write parentid schema override to %s", schema_filename)
+        with open(schema_filename, 'w') as schema_file:
+            schema_file.write("dn: cn=schema\n")
+            schema_file.write(
+                "attributetypes: ( 2.16.840.1.113730.3.1.604 NAME 'parentid' "
+                "DESC 'internal server defined attribute type' "
+                "EQUALITY caseIgnoreMatch "
+                "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE "
+                "NO-USER-MODIFICATION USAGE directoryOperation "
+                "X-ORIGIN 'user defined' )\n"
+            )
+        os.chmod(schema_filename, 0o644)
+
+        log.info("Clear error logs before restart so we only see post-override messages")
+        inst.deleteErrorLogs(restart=False)
+        inst.start()
+
+        log.info("Check error log for configured matching-rule fallback message")
+        errlog = DirsrvErrorLog(inst)
+        matches = errlog.match(f'.*{re.escape(expected_log_msg)}.*')
+        assert matches, (
+            f'Expected error log message containing: {expected_log_msg}'
+        )
+        log.info("Found expected matching-rule compatibility message in error log")
+
+        log.info("Check parentid schema is string syntax but no ordering matching rule")
+        attr_result = inst.schema.query_attributetype('parentid', json=True)
+        attr_result_json = json.loads(attr_result) if isinstance(attr_result, str) else attr_result
+        assert attr_result_json['at']['syntax'] == string_syntax, (
+            f"Expected parentid is syntax string in the schema, got {attr_result_json['at']['syntax']}"
+        )
+        assert attr_result_json['at']['ordering'] == None, (
+        f"Expected parentid ORDERING is not defined after 99user.ldif override, got {attr_result_json['at']['ordering']}"
+        )
+        log.info("parentid schema ORDERING not defined")
+
+        log.info("Create 10 more OUs with one user under each after schema override")
+        ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+        for i in range(10, 20):
+            ou = ous.create(properties={'ou': f'parentid-mr-test-{i}'})
+            created_ous.append(ou)
+            users = UserAccounts(inst, ou.dn, rdn=None)
+            user = users.create(properties={
+                'uid': f'parentid_user_{i}',
+                'cn': f'parentid_user_{i}',
+                'sn': f'parentid_user_{i}',
+                'uidNumber': f'{1000 + i}',
+                'gidNumber': f'{1000 + i}',
+                'homeDirectory': f'/home/parentid_user_{i}'
+            })
+            created_users.append(user)
+
+        inst.stop()
+        try:
+            keys = _parentid_equality_keys()
+            _assert_integer_ordered(keys)
+        finally:
+            inst.start()
+        log.info("parentid equality keys remain integer-ordered after schema override")
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                user.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        for ou in reversed(created_ous):
+            try:
+                ou.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        # Restore original 99user.ldif so later tests are not affected
+        if schema_backup is not None:
+            with open(schema_filename, 'w') as schema_file:
+                schema_file.write(schema_backup)
+            inst.restart()
+        elif os.path.exists(schema_filename):
+            try:
+                with open(schema_filename, 'r') as schema_file:
+                    content = schema_file.read()
+                if "NAME 'parentid'" in content and "caseIgnoreMatch" in content:
+                    os.remove(schema_filename)
+                    inst.restart()
+            except OSError:
+                pass
+
+
+def test_index_check_detects_mismatch(topo):
+    """Check that index-check reports uid ordering mismatch when
+       integerOrderingMatch is configured but disk is lexicographic
+
+    :id: 6771055e-423d-4e84-827e-c119e6d9e560
+    :setup: Standalone instance
+    :steps:
+        1. Create a dedicated OU for the test users
+        2. Create 100 users with uid 1 through 100
+        3. Search for the users and verify the count
+        4. Add integerOrderingMatch to the uid index configuration
+        5. Run index-check and verify uid ordering mismatch is reported
+        6. Delete the created users and OU and restore the uid index
+    :expectedresults:
+        1. OU is created successfully
+        2. All users are created successfully
+        3. Exactly 100 users are found
+        4. uid index nsMatchingRule contains integerOrderingMatch
+        5. index-check output contains the uid lexicographic mismatch message
+        6. Users and OU are deleted successfully and uid index is restored
+    """
+    inst = topo.standalone
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    ou = None
+    created_users = []
+    uid_index = Index(inst, UID_INDEX_DN)
+    original_matching_rules = uid_index.get_attr_vals_utf8('nsMatchingRule') or []
+
+    try:
+        ou = ous.create(properties={'ou': 'uid-range-test'})
+        users_api = UserAccounts(inst, ou.dn, rdn=None)
+
+        log.info("Create 100 users with uid from 1 to 100")
+        for i in range(1, 101):
+            uid = str(i)
+            user = users_api.create(properties={
+                'uid': uid,
+                'cn': f'user {uid}',
+                'sn': f'user {uid}',
+                'uidNumber': str(1000 + i),
+                'gidNumber': str(1000 + i),
+                'homeDirectory': f'/home/{uid}',
+            })
+            created_users.append(user)
+
+        log.info("Verify all 100 users exist")
+        results = inst.search_s(
+            ou.dn,
+            ldap.SCOPE_ONELEVEL,
+            '(objectclass=inetOrgPerson)',
+        )
+        assert len(results) == 100
+        log.info("Found all 100 users with uid 1-100")
+
+        log.info("Add integerOrderingMatch to uid index %s", UID_INDEX_DN)
+        matching_rules = list(original_matching_rules)
+        if 'integerOrderingMatch' not in [mr.lower() for mr in matching_rules]:
+            matching_rules.append('integerOrderingMatch')
+        uid_index.replace('nsMatchingRule', matching_rules)
+        inst.restart()
+
+        matching_rules = [mr.lower() for mr in uid_index.get_attr_vals_utf8('nsMatchingRule')]
+        assert 'integerorderingmatch' in matching_rules, (
+            f"Expected integerOrderingMatch in uid nsMatchingRule, got {matching_rules}"
+        )
+        log.info("uid index nsMatchingRule includes integerOrderingMatch")
+
+        from lib389.cli_base import FakeArgs
+        from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+        expected_index_check_msg = (
+            "MISMATCH: config has integerOrderingMatch but disk is "
+            "lexicographic (suggest redindex)"
+        )
+
+        log.info("Stop instance and run index-check")
+        inst.stop()
+        inst.lint_clear_dse_cache()
+        topo.logcap.flush()
+        args = FakeArgs()
+        args.backend = DEFAULT_BENAME
+        args.fix = False
+        dbtasks_index_check(inst, topo.logcap.log, args)
+        assert topo.logcap.contains(expected_index_check_msg), (
+            f"Expected index-check output to contain: {expected_index_check_msg}"
+        )
+        topo.logcap.flush()
+        log.info("index-check reported uid ordering mismatch as expected")
+
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                user.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if ou is not None:
+            try:
+                ou.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if original_matching_rules:
+            uid_index.replace('nsMatchingRule', original_matching_rules)
+        else:
+            uid_index.remove_all('nsMatchingRule')
+        inst.restart()
 
 
 if __name__ == "__main__":

--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -13,6 +13,7 @@ import ldap
 import logging
 import glob
 import re
+import json
 from lib389.backend import Backend, Backends, DatabaseConfig
 from lib389.cli_ctl.dblib import DbscanHelper
 from lib389.config import LDBMConfig
@@ -23,6 +24,7 @@ from lib389.dirsrv_log import DirsrvErrorLog
 from lib389.idm.domain import Domain
 from lib389.idm.group import Groups
 from lib389.idm.nscontainer import nsContainer
+from lib389.idm.organizationalunit import OrganizationalUnits
 from lib389.idm.user import UserAccount, UserAccounts
 from lib389.index import Index
 from lib389._mapped_object import DSLdapObject, DSLdapObjects
@@ -37,6 +39,9 @@ pytestmark = pytest.mark.tier1
 SUFFIX2 = 'dc=example2,dc=com'
 BENAME2 = 'be2'
 CN_INDEX_DN = f'cn=cn,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
+PARENTID_INDEX_DN = f'cn=parentid,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
+UID_INDEX_DN = f'cn=uid,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config'
+COLLATION_EN_MR_OID = '2.16.840.1.113730.3.3.2.11.1'
 
 DEBUGGING = os.getenv("DEBUGGING", default=False)
 logging.getLogger(__name__).setLevel(logging.INFO)
@@ -1396,6 +1401,572 @@ def test_large_multivalued_sn_attribute(topo):
     # Clean up
     user.delete()
     log.info("User entry deleted successfully")
+
+
+def test_nsmatchingrule_vs_schema(topo):
+    """Check that parentid uses an integer matching rule
+
+    parentid is defined in schema with EQUALITY integerMatch and no ORDERING
+    rule. The system index configures nsMatchingRule: integerOrderingMatch so
+    range/order comparisons still use integer semantics even if the syntax
+    of parentid selects a lexicographic matching rule.
+
+    :id: 419bd59c-3bec-4e94-9bc5-9043e36787ac
+    :setup: Standalone instance
+    :steps:
+        1. Query the parentid attribute type from the schema
+        2. Read nsMatchingRule from the parentid index entry
+        3. Create 10 OUs under the suffix and one user under each OU
+        4. Stop the instance, run dbscan on parentid, and collect equality keys
+        5. Override parentid in 99user.ldif with EQUALITY caseIgnoreMatch
+        6. Clear the error logs, start the instance, and verify the schema override
+           and the INFO message about using the configured matching rule
+        7. Create 10 more OUs/users and verify dbscan keys remain in integer order
+    :expectedresults:
+        1. Schema has integer syntax and no ORDERING rule
+        2. Index nsMatchingRule contains integerOrderingMatch
+        3. Entries are created successfully
+        4. Equality keys are present and sorted numerically
+        5. 99user.ldif is written successfully
+        6. Schema uses string syntax with no ORDERING, and the error log contains
+           the configured matching rule compatibility message
+        7. Keys remain sorted numerically (nsMatchingRule wins over schema)
+    """
+    inst = topo.standalone
+    created_ous = []
+    created_users = []
+    schema_filename = os.path.join(inst.schemadir, '99user.ldif')
+    schema_backup = None
+    integer_syntax = '1.3.6.1.4.1.1466.115.121.1.27'
+    string_syntax = '1.3.6.1.4.1.1466.115.121.1.15'
+    expected_log_msg = (
+        'The attribute [parentid] uses ORDERING matching rule integerOrderingMatch'
+    )
+
+    def _parentid_equality_keys():
+        output = inst.dbscan(bename=DEFAULT_BENAME, index='parentid',
+                             stopping=False).decode()
+        keys = []
+        for line in output.splitlines():
+            line = line.strip()
+            match = re.match(r'^(?:KEY:\s*)?=(\d+)\s*$', line)
+            if match:
+                keys.append(int(match.group(1)))
+        return keys
+
+    def _assert_integer_ordered(keys):
+        log.info("parentid equality keys from dbscan: %s", keys)
+        assert len(keys) >= 2, f"Expected at least 2 parentid equality keys, got {keys}"
+        assert any(k >= 10 for k in keys), (
+            f"Expected a multi-digit parentid key to distinguish integer vs "
+            f"lexicographic order, got {keys}"
+        )
+        integer_sorted = sorted(keys)
+        lex_sorted = sorted(keys, key=str)
+        assert keys == integer_sorted, (
+            f"parentid equality keys are not in integer order: {keys}"
+        )
+        assert integer_sorted != lex_sorted, (
+            f"Test data did not produce differing integer/lex orders: {keys}"
+        )
+
+    log.info("Check parentid schema is integer syntax but no ordering matching rule")
+    attr_result = inst.schema.query_attributetype('parentid', json=True)
+    assert attr_result is not None
+    attr_result_json = json.loads(attr_result) if isinstance(attr_result, str) else attr_result
+    assert attr_result_json['at']['syntax'] == integer_syntax, (
+        f"Expected parentid is syntax integer in the schema, got {attr_result_json['at']['syntax']}"
+    )
+    assert attr_result_json['at']['ordering'] == None, (
+        f"Expected parentid ORDERING is not defined in the schema, got {attr_result_json['at']['ordering']}"
+    )
+    log.info("parentid schema ORDERING not defined, so it uses integer syntax for ordering")
+
+    log.info("Check parentid index nsMatchingRule")
+    parentid_index = Index(inst, PARENTID_INDEX_DN)
+    matching_rules = [mr.lower() for mr in parentid_index.get_attr_vals_utf8('nsMatchingRule')]
+    assert 'integerorderingmatch' in matching_rules, (
+        f"Expected integerOrderingMatch in parentid nsMatchingRule, got {matching_rules}"
+    )
+    log.info("parentid index nsMatchingRule includes integerOrderingMatch")
+
+    try:
+        # Create 10 OUs and one user under each so parentid equality keys
+        # include distinct parent entry IDs (including values >= 10, where
+        # lexicographic and integer ordering diverge).
+        log.info("Create 10 OUs with one user under each")
+        ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+        for i in range(10):
+            ou = ous.create(properties={'ou': f'parentid-mr-test-{i}'})
+            created_ous.append(ou)
+            users = UserAccounts(inst, ou.dn, rdn=None)
+            user = users.create(properties={
+                'uid': f'parentid_user_{i}',
+                'cn': f'parentid_user_{i}',
+                'sn': f'parentid_user_{i}',
+                'uidNumber': f'{1000 + i}',
+                'gidNumber': f'{1000 + i}',
+                'homeDirectory': f'/home/parentid_user_{i}'
+            })
+            created_users.append(user)
+
+        log.info("Stop instance, scan parentid index, and override schema")
+        inst.stop()
+        keys = _parentid_equality_keys()
+        _assert_integer_ordered(keys)
+        log.info("parentid equality keys are sorted with integer ordering")
+
+        if os.path.exists(schema_filename):
+            with open(schema_filename, 'r') as schema_file:
+                schema_backup = schema_file.read()
+
+        log.info("Write parentid schema override to %s", schema_filename)
+        with open(schema_filename, 'w') as schema_file:
+            schema_file.write("dn: cn=schema\n")
+            schema_file.write(
+                "attributetypes: ( 2.16.840.1.113730.3.1.604 NAME 'parentid' "
+                "DESC 'internal server defined attribute type' "
+                "EQUALITY caseIgnoreMatch "
+                "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE "
+                "NO-USER-MODIFICATION USAGE directoryOperation "
+                "X-ORIGIN 'user defined' )\n"
+            )
+        os.chmod(schema_filename, 0o644)
+
+        log.info("Clear error logs before restart so we only see post-override messages")
+        inst.deleteErrorLogs(restart=False)
+        inst.start()
+
+        log.info("Check error log for configured matching-rule fallback message")
+        errlog = DirsrvErrorLog(inst)
+        matches = errlog.match(f'.*{re.escape(expected_log_msg)}.*')
+        assert matches, (
+            f'Expected error log message containing: {expected_log_msg}'
+        )
+        log.info("Found expected matching-rule compatibility message in error log")
+
+        log.info("Check parentid schema is string syntax but no ordering matching rule")
+        attr_result = inst.schema.query_attributetype('parentid', json=True)
+        attr_result_json = json.loads(attr_result) if isinstance(attr_result, str) else attr_result
+        assert attr_result_json['at']['syntax'] == string_syntax, (
+            f"Expected parentid is syntax string in the schema, got {attr_result_json['at']['syntax']}"
+        )
+        assert attr_result_json['at']['ordering'] == None, (
+        f"Expected parentid ORDERING is not defined after 99user.ldif override, got {attr_result_json['at']['ordering']}"
+        )
+        log.info("parentid schema ORDERING not defined")
+
+        log.info("Create 10 more OUs with one user under each after schema override")
+        ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+        for i in range(10, 20):
+            ou = ous.create(properties={'ou': f'parentid-mr-test-{i}'})
+            created_ous.append(ou)
+            users = UserAccounts(inst, ou.dn, rdn=None)
+            user = users.create(properties={
+                'uid': f'parentid_user_{i}',
+                'cn': f'parentid_user_{i}',
+                'sn': f'parentid_user_{i}',
+                'uidNumber': f'{1000 + i}',
+                'gidNumber': f'{1000 + i}',
+                'homeDirectory': f'/home/parentid_user_{i}'
+            })
+            created_users.append(user)
+
+        inst.stop()
+        try:
+            keys = _parentid_equality_keys()
+            _assert_integer_ordered(keys)
+        finally:
+            inst.start()
+        log.info("parentid equality keys remain integer-ordered after schema override")
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                user.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        for ou in reversed(created_ous):
+            try:
+                ou.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        # Restore original 99user.ldif so later tests are not affected
+        if schema_backup is not None:
+            with open(schema_filename, 'w') as schema_file:
+                schema_file.write(schema_backup)
+            inst.restart()
+        elif os.path.exists(schema_filename):
+            try:
+                with open(schema_filename, 'r') as schema_file:
+                    content = schema_file.read()
+                if "NAME 'parentid'" in content and "caseIgnoreMatch" in content:
+                    os.remove(schema_filename)
+                    inst.restart()
+            except OSError:
+                pass
+
+
+def test_index_check_detects_mismatch(topo):
+    """Check that index-check reports uid ordering mismatch when
+       integerOrderingMatch is configured but disk is lexicographic
+
+    :id: 6771055e-423d-4e84-827e-c119e6d9e560
+    :setup: Standalone instance
+    :steps:
+        1. Create a dedicated OU for the test users
+        2. Create 100 users with uid 1 through 100
+        3. Search for the users and verify the count
+        4. Add integerOrderingMatch to the uid index configuration
+        5. Run index-check and verify uid ordering mismatch is reported
+        6. Delete the created users and OU and restore the uid index
+    :expectedresults:
+        1. OU is created successfully
+        2. All users are created successfully
+        3. Exactly 100 users are found
+        4. uid index nsMatchingRule contains integerOrderingMatch
+        5. index-check output contains the uid lexicographic mismatch message
+        6. Users and OU are deleted successfully and uid index is restored
+    """
+    inst = topo.standalone
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    ou = None
+    created_users = []
+    uid_index = Index(inst, UID_INDEX_DN)
+    original_matching_rules = uid_index.get_attr_vals_utf8('nsMatchingRule') or []
+
+    try:
+        ou = ous.create(properties={'ou': 'uid-range-test'})
+        users_api = UserAccounts(inst, ou.dn, rdn=None)
+
+        log.info("Create 100 users with uid from 1 to 100")
+        for i in range(1, 101):
+            uid = str(i)
+            user = users_api.create(properties={
+                'uid': uid,
+                'cn': f'user {uid}',
+                'sn': f'user {uid}',
+                'uidNumber': str(1000 + i),
+                'gidNumber': str(1000 + i),
+                'homeDirectory': f'/home/{uid}',
+            })
+            created_users.append(user)
+
+        log.info("Verify all 100 users exist")
+        results = inst.search_s(
+            ou.dn,
+            ldap.SCOPE_ONELEVEL,
+            '(objectclass=inetOrgPerson)',
+            escapehatch='i am sure'
+        )
+        assert len(results) == 100
+        log.info("Found all 100 users with uid 1-100")
+
+        log.info("Add integerOrderingMatch to uid index %s", UID_INDEX_DN)
+        matching_rules = list(original_matching_rules)
+        if 'integerOrderingMatch' not in [mr.lower() for mr in matching_rules]:
+            matching_rules.append('integerOrderingMatch')
+        uid_index.replace('nsMatchingRule', matching_rules)
+        inst.restart()
+
+        matching_rules = [mr.lower() for mr in uid_index.get_attr_vals_utf8('nsMatchingRule')]
+        assert 'integerorderingmatch' in matching_rules, (
+            f"Expected integerOrderingMatch in uid nsMatchingRule, got {matching_rules}"
+        )
+        log.info("uid index nsMatchingRule includes integerOrderingMatch")
+
+        from lib389.cli_base import FakeArgs
+        from lib389.cli_ctl.dbtasks import dbtasks_index_check
+
+        expected_index_check_msg = (
+            "MISMATCH: config has integerOrderingMatch but disk is "
+            "lexicographic (suggest redindex)"
+        )
+
+        log.info("Stop instance and run index-check")
+        inst.stop()
+        inst.lint_clear_dse_cache()
+        topo.logcap.flush()
+        args = FakeArgs()
+        args.backend = DEFAULT_BENAME
+        args.fix = False
+        dbtasks_index_check(inst, topo.logcap.log, args)
+        assert topo.logcap.contains(expected_index_check_msg), (
+            f"Expected index-check output to contain: {expected_index_check_msg}"
+        )
+        topo.logcap.flush()
+        log.info("index-check reported uid ordering mismatch as expected")
+
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                user.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if ou is not None:
+            try:
+                ou.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if original_matching_rules:
+            uid_index.replace('nsMatchingRule', original_matching_rules)
+        else:
+            uid_index.remove_all('nsMatchingRule')
+        inst.restart()
+
+
+def test_collation_indexing(topo):
+    """Check that cn can be indexed with an English collation matching rule
+
+    :id: cf2c9a16-adb8-4c28-b890-8c9b06cd926a
+    :setup: Standalone instance
+    :steps:
+        1. Create a dedicated OU for the test users
+        2. Create 100 users with uid 1 through 100
+        3. Add the English collation matching rule to the cn index configuration
+        4. Reindex cn and search using the collation matching rule
+        5. Stop the instance, run dbscan on cn, and verify rule-prefixed keys
+        6. Delete the created users and OU and restore the cn index
+    :expectedresults:
+        1. OU is created successfully
+        2. All users are created successfully
+        3. cn index nsMatchingRule contains the collation OID
+        4. Collation filter search returns the expected entry
+        5. cn index keys contain :2.16.840.1.113730.3.3.2.11.1:
+        6. Users and OU are deleted successfully and cn index is restored
+    """
+    inst = topo.standalone
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    ou = None
+    created_users = []
+    cn_index = Index(inst, CN_INDEX_DN)
+    original_matching_rules = cn_index.get_attr_vals_utf8('nsMatchingRule') or []
+
+    try:
+        ou = ous.create(properties={'ou': 'collation-index-test'})
+        users_api = UserAccounts(inst, ou.dn, rdn=None)
+
+        log.info("Create 100 users with uid from 1 to 100")
+        for i in range(1, 101):
+            uid = str(i)
+            user = users_api.create(properties={
+                'uid': uid,
+                'cn': f'user {uid}',
+                'sn': f'user {uid}',
+                'uidNumber': str(1000 + i),
+                'gidNumber': str(1000 + i),
+                'homeDirectory': f'/home/{uid}',
+            })
+            created_users.append(user)
+
+        log.info("Add collation matching rule to cn index %s", CN_INDEX_DN)
+        matching_rules = list(original_matching_rules)
+        if COLLATION_EN_MR_OID not in matching_rules:
+            matching_rules.append(COLLATION_EN_MR_OID)
+        cn_index.replace('nsMatchingRule', matching_rules)
+        inst.restart()
+
+        matching_rules = cn_index.get_attr_vals_utf8('nsMatchingRule') or []
+        assert COLLATION_EN_MR_OID in matching_rules, (
+            f"Expected {COLLATION_EN_MR_OID} in cn nsMatchingRule, got {matching_rules}"
+        )
+        log.info("cn index nsMatchingRule includes %s", COLLATION_EN_MR_OID)
+
+        log.info("Reindex cn with collation matching rule configured")
+        tasks = Tasks(inst)
+        assert tasks.reindex(
+            suffix=DEFAULT_SUFFIX,
+            attrname='cn',
+            args={TASK_WAIT: True},
+        ) == 0
+
+        target_user = created_users[41]
+        filterstr = f'(cn:{COLLATION_EN_MR_OID}:=user 42)'
+        log.info("Search with collation filter %s under %s", filterstr, ou.dn)
+        results = inst.search_s(ou.dn, ldap.SCOPE_ONELEVEL, filterstr, escapehatch='i am sure')
+        assert len(results) == 1
+        assert results[0].dn.lower() == target_user.dn.lower()
+        log.info("Collation indexed search returned the expected entry")
+
+        rule_key_marker = f':{COLLATION_EN_MR_OID}:'
+        log.info("Stop instance and scan cn index for keys containing %s", rule_key_marker)
+        inst.stop()
+        try:
+            output = inst.dbscan(
+                bename=DEFAULT_BENAME,
+                index='cn',
+                stopping=False,
+            ).decode()
+            collation_keys = [
+                line.strip() for line in output.splitlines()
+                if rule_key_marker in line.strip()
+            ]
+            log.info("Found %d cn collation rule keys in dbscan output",
+                     len(collation_keys))
+            assert collation_keys, (
+                f"Expected cn index keys containing '{rule_key_marker}', "
+                f"dbscan output was:\n{output[:2000]}"
+            )
+            assert len(collation_keys) >= 100, (
+                f"Expected at least 100 collation index keys, got {len(collation_keys)}"
+            )
+        finally:
+            inst.start()
+
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                user.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if ou is not None:
+            try:
+                ou.delete()
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if original_matching_rules:
+            cn_index.replace('nsMatchingRule', original_matching_rules)
+        else:
+            cn_index.remove_all('nsMatchingRule')
+        inst.restart()
+
+
+def test_uid_lexicographic_range_search(topo):
+    """Check uid equality and range searches use lexicographic ordering by default
+
+    Without an ordering matching rule on the uid index, padded numeric uid
+    values are compared as strings. A range filter (uid>=007) therefore matches
+    007, 008, and 009 but not 010. After configuring integerOrderingMatch on
+    the uid index and reindexing, the same range filter matches 010 as well.
+
+    :id: b79043a1-8fca-48a8-9353-2ca299d28ad5
+    :setup: Standalone instance
+    :steps:
+        1. Create a dedicated OU for the test users
+        2. Create 10 users with uid 001 through 010
+        3. Search with equality filter uid=005
+        4. Search with range filter uid>=007
+        5. Add integerOrderingMatch to the uid index and reindex uid
+        6. Repeat the range search uid>=007
+        7. Delete the created users and OU and restore the uid index
+    :expectedresults:
+        1. OU is created successfully
+        2. All users are created successfully
+        3. Equality search returns only uid=005
+        4. Range search returns uid 007, 008, and 009
+        5. uid index nsMatchingRule contains integerOrderingMatch
+        6. Range search returns uid 007 through 010
+        7. Users and OU are deleted successfully and uid index is restored
+    """
+    inst = topo.standalone
+    ous = OrganizationalUnits(inst, DEFAULT_SUFFIX)
+    ou = None
+    created_users = []
+    uid_index = Index(inst, UID_INDEX_DN)
+    original_matching_rules = uid_index.get_attr_vals_utf8('nsMatchingRule') or []
+
+    def _uids_from_results(results):
+        uids = []
+        for ent in results:
+            if hasattr(ent, 'getValues'):
+                uid_vals = ent.getValues('uid')
+            else:
+                _dn, attrs = ent
+                uid_vals = attrs.get('uid', [])
+            if not uid_vals:
+                continue
+            val = uid_vals[0]
+            if isinstance(val, bytes):
+                val = val.decode('utf-8')
+            uids.append(val)
+        return sorted(uids)
+
+    try:
+        ou = ous.create(properties={'ou': 'uid-range-lex-test'})
+        users_api = UserAccounts(inst, ou.dn, rdn=None)
+
+        log.info("Create 10 users with uid from 001 to 010")
+        for i in range(1, 11):
+            uid = f'{i:03d}'
+            user = users_api.create(properties={
+                'uid': uid,
+                'cn': f'user {uid}',
+                'sn': f'user {uid}',
+                'uidNumber': str(1000 + i),
+                'gidNumber': str(1000 + i),
+                'homeDirectory': f'/home/{uid}',
+            })
+            created_users.append(user)
+
+        log.info("Equality search uid=005 under %s", ou.dn)
+        eq_results = inst.search_s(ou.dn, ldap.SCOPE_ONELEVEL, '(uid=005)', escapehatch='i am sure')
+        eq_uids = _uids_from_results(eq_results)
+        assert eq_uids == ['005'], f"Expected only uid=005, got {eq_uids}"
+
+        log.info("Range search uid>=007 under %s (lexicographic ordering)", ou.dn)
+        range_results = inst.search_s(ou.dn, ldap.SCOPE_ONELEVEL, '(uid>=007)', escapehatch='i am sure')
+        range_uids = _uids_from_results(range_results)
+        assert range_uids == ['007', '008', '009', '010'], (
+            f"Expected uid 007, 008, and 009 from lexicographic range search, got {range_uids}"
+        )
+        log.info("Lexicographic uid range search returned %s", range_uids)
+        #import pdb; pdb.set_trace()
+
+        log.info("Add integerOrderingMatch to uid index %s", UID_INDEX_DN)
+        matching_rules = list(original_matching_rules)
+        if 'integerOrderingMatch' not in [mr.lower() for mr in matching_rules]:
+            matching_rules.append('integerOrderingMatch')
+        uid_index.replace('nsMatchingRule', matching_rules)
+        inst.restart()
+
+        matching_rules = [mr.lower() for mr in uid_index.get_attr_vals_utf8('nsMatchingRule')]
+        assert 'integerorderingmatch' in matching_rules, (
+            f"Expected integerOrderingMatch in uid nsMatchingRule, got {matching_rules}"
+        )
+
+        log.info("Reindex uid with integerOrderingMatch configured")
+        tasks = Tasks(inst)
+        assert tasks.reindex(
+            suffix=DEFAULT_SUFFIX,
+            attrname='uid',
+            args={TASK_WAIT: True},
+        ) == 0
+
+        log.info("Range search uid>=007 under %s (integer ordering)", ou.dn)
+        range_results = inst.search_s(ou.dn, ldap.SCOPE_ONELEVEL, '(uid>=007)', escapehatch='i am sure')
+        range_uids = _uids_from_results(range_results)
+        assert range_uids == ['007', '008', '009', '010'], (
+            f"Expected uid 007 through 010 from integer range search, got {range_uids}"
+        )
+        log.info("Integer uid range search returned %s", range_uids)
+
+    finally:
+        if not inst.status():
+            inst.start()
+        for user in reversed(created_users):
+            try:
+                #user.delete()
+                pass
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if ou is not None:
+            try:
+                #ou.delete()
+                pass
+            except ldap.NO_SUCH_OBJECT:
+                pass
+        if original_matching_rules:
+            #uid_index.replace('nsMatchingRule', original_matching_rules)
+            pass
+        else:
+            #uid_index.remove_all('nsMatchingRule')
+            pass
+        inst.restart()
 
 
 if __name__ == "__main__":

--- a/ldap/servers/slapd/back-ldbm/ldbm_attr.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attr.c
@@ -688,6 +688,7 @@ attr_index_config(
     int return_value = -1;
     int *substrlens = NULL;
     int need_compare_fn = 0;
+    struct slapdplugin *mr_ordering_plugin = NULL;
     int hasIndexType = 0;
     const char *attrsyntax_oid = NULL;
     const struct berval *attrValue;
@@ -886,6 +887,23 @@ attr_index_config(
                 do_continue = 1;                /* done with j - next j */
             }
 
+           if (!do_continue &&
+               slapi_matchingrule_is_ordering_only(attrValue->bv_val) &&
+               !a->ai_sattr.a_mr_ord_plugin) {
+                /* The ordering matching rule is not compatible with the attribute syntax
+                 * pick the plugin that supports this ordering matching rule and use it.
+                 * if there are multiple ordering matching rules for the same attribute,
+                 * use the last one that is found.
+                 */
+                mr_ordering_plugin = plugin_mr_find(attrValue->bv_val);
+                if (!mr_ordering_plugin) {
+                    slapi_log_err(SLAPI_LOG_WARNING, "attr_index_config", "%s: line %d: "
+                                  "no plugin ordering matching rule \"%s\" for the attribute \"%s\" (ignored)\n",
+                                  fname, lineno, attrValue->bv_val, a->ai_type);
+                }
+                do_continue = 1; /* done with j - next j */
+            }
+
             if (do_continue) {
                 continue; /* done with index_rules[j] */
             }
@@ -984,6 +1002,25 @@ attr_index_config(
                           a->ai_type, rc, ldap_err2string(rc));
             a->ai_key_cmp_fn = NULL;
         }
+    }
+    if (mr_ordering_plugin && (a->ai_sattr.a_mr_ord_plugin == NULL)) {
+        /* use the plugin ordering matching rule for the attribute in place
+         * of the default ordering matching rule
+         */
+        int rc;
+        a->ai_sattr.a_mr_ord_plugin = mr_ordering_plugin;
+        rc = attr_get_value_cmp_fn(&a->ai_sattr, &a->ai_key_cmp_fn);
+        if (rc == LDAP_SUCCESS) {
+            slapi_log_err(SLAPI_LOG_INFO,
+                "attr_index_config", "The attribute [%s] uses ORDERING matching rule %s\n",
+                a->ai_type, mr_ordering_plugin->plg_name);
+        } else {
+            slapi_log_err(SLAPI_LOG_ERR,
+                          "attr_index_config", "The attribute [%s] does not have a valid ORDERING matching rule using %s - error %d:%s\n",
+                          a->ai_type, mr_ordering_plugin->plg_name, rc, ldap_err2string(rc));
+            a->ai_key_cmp_fn = NULL;
+        }
+        a->ai_sattr.a_mr_ord_plugin = NULL;
     }
 
     if (avl_insert(&inst->inst_attrs, (caddr_t)a, ainfo_cmp, ainfo_dup) != 0) {

--- a/ldap/servers/slapd/back-ldbm/ldbm_attr.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_attr.c
@@ -687,6 +687,7 @@ attr_index_config(
     struct attrinfo *a;
     int return_value = -1;
     int *substrlens = NULL;
+    struct slapdplugin *not_compatible_ordering_mr = NULL; /* use for nsMatchingRule that are not compatible with the attribute syntax */
     int need_compare_fn = 0;
     int hasIndexType = 0;
     const char *attrsyntax_oid = NULL;
@@ -879,11 +880,38 @@ attr_index_config(
             }
             /* check if this is a simple ordering specification
                for an attribute that has no ordering matching rule */
-            if (slapi_matchingrule_is_ordering(attrValue->bv_val, attrsyntax_oid) &&
+            if (slapi_matchingrule_is_ordering_only(attrValue->bv_val) &&
                 slapi_matchingrule_can_use_compare_fn(attrValue->bv_val) &&
                 !a->ai_sattr.a_mr_ord_plugin) { /* no ordering for this attribute */
-                need_compare_fn = 1;            /* get compare func for this attr */
-                do_continue = 1;                /* done with j - next j */
+                if (need_compare_fn ||
+                    slapi_matchingrule_is_compat(attrValue->bv_val, attrsyntax_oid)) {
+                    /* The user has already specified an ordering matching rule that
+                     * is compatible with the attribute syntax (need_compare_fn)
+                     * or this new ordering matching rule is compatible with the attribute syntax.
+                     * So use the ordering matching rule from the attribute syntax.
+                     * Also ignore the configured one (if it exists) that was not compatible.
+                     */
+                    not_compatible_ordering_mr = NULL;
+                    need_compare_fn = 1;            /* get compare func for this attr */
+                    do_continue = 1;                /* done with j - next j */
+                } else {
+                    /* we are here because we have not yet decided to use an ordering matching rule
+                     * from the attribute syntax (need_compare_fn) and the new ordering matching rule
+                     * is not compatible with the attribute syntax (slapi_matchingrule_is_compatible)
+                     * so we are trying to find a plugin that supports configured ordering matching rule.
+                     */
+                    not_compatible_ordering_mr = plugin_mr_find(attrValue->bv_val);
+                    if (not_compatible_ordering_mr) {
+                        /* we found a plugin that supports this ordering matching rule
+                         * we will gather the compare function from the plugin
+                         */
+                        do_continue = 1;                /* done with j - next j */
+                    } else {
+                        slapi_log_err(SLAPI_LOG_WARNING, "attr_index_config", "%s: line %d: "
+                                        "cannot use ordering matching rule \"%s\" for the attribute \"%s\" (ignored)\n",
+                                        fname, lineno, attrValue->bv_val, a->ai_type);
+                    }
+                }
             }
 
             if (do_continue) {
@@ -984,6 +1012,24 @@ attr_index_config(
                           a->ai_type, rc, ldap_err2string(rc));
             a->ai_key_cmp_fn = NULL;
         }
+    } else if (not_compatible_ordering_mr) {
+        /* use the compare fucntion from the configured ordering matching rule
+         * need to transiantly set a_mr_ord_plugin with the plugin
+         */
+        int rc;
+        a->ai_sattr.a_mr_ord_plugin = not_compatible_ordering_mr; /* a_mr_ord_plugin is NULL if  not_compatible_ordering_mr is set */
+        rc = attr_get_value_cmp_fn(&a->ai_sattr, &a->ai_key_cmp_fn);
+        if (rc == LDAP_SUCCESS) {
+            slapi_log_err(SLAPI_LOG_INFO,
+                "attr_index_config", "The attribute [%s] uses ORDERING matching rule %s\n",
+                a->ai_type, not_compatible_ordering_mr->plg_name);
+        } else {
+            slapi_log_err(SLAPI_LOG_ERR,
+                          "attr_index_config", "The attribute [%s] does not have a valid ORDERING matching rule using %s - error %d:%s\n",
+                          a->ai_type, not_compatible_ordering_mr->plg_name, rc, ldap_err2string(rc));
+            a->ai_key_cmp_fn = NULL;
+        }
+        a->ai_sattr.a_mr_ord_plugin = NULL;
     }
 
     if (avl_insert(&inst->inst_attrs, (caddr_t)a, ainfo_cmp, ainfo_dup) != 0) {

--- a/ldap/servers/slapd/match.c
+++ b/ldap/servers/slapd/match.c
@@ -224,6 +224,22 @@ slapi_matchingrule_unregister(char *oid __attribute__((unused)))
     return (0);
 }
 
+int
+slapi_matchingrule_is_ordering_only(const char *oid_or_name)
+{
+    struct matchingRuleList *mrl = NULL;
+
+    for (mrl = g_get_global_mrl(); mrl != NULL; mrl = mrl->mrl_next) {
+        if (mrl->mr_entry->mr_name && !strcasecmp(oid_or_name, mrl->mr_entry->mr_name)) {
+            return (mrl->mr_entry->mr_name &&
+                    PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
+        }
+        if (mrl->mr_entry->mr_oid && !strcmp(oid_or_name, mrl->mr_entry->mr_oid)) {
+            return (mrl->mr_entry->mr_name &&
+                    PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
+        }
+    }
+}
 /*
   See if a matching rule for this name or OID
   is registered and is an ORDERING matching rule that applies
@@ -235,18 +251,8 @@ slapi_matchingrule_is_ordering(const char *oid_or_name, const char *syntax_oid)
     struct matchingRuleList *mrl = NULL;
 
     if (slapi_matchingrule_is_compat(oid_or_name, syntax_oid)) {
-        for (mrl = g_get_global_mrl(); mrl != NULL; mrl = mrl->mrl_next) {
-            if (mrl->mr_entry->mr_name && !strcasecmp(oid_or_name, mrl->mr_entry->mr_name)) {
-                return (mrl->mr_entry->mr_name &&
-                        PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
-            }
-            if (mrl->mr_entry->mr_oid && !strcmp(oid_or_name, mrl->mr_entry->mr_oid)) {
-                return (mrl->mr_entry->mr_name &&
-                        PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
-            }
-        }
+        return slapi_matchingrule_is_ordering_only(oid_or_name);
     }
-
     return 0;
 }
 

--- a/ldap/servers/slapd/match.c
+++ b/ldap/servers/slapd/match.c
@@ -224,6 +224,23 @@ slapi_matchingrule_unregister(char *oid __attribute__((unused)))
     return (0);
 }
 
+int
+slapi_matchingrule_is_ordering_only(const char *oid_or_name)
+{
+    struct matchingRuleList *mrl = NULL;
+
+    for (mrl = g_get_global_mrl(); mrl != NULL; mrl = mrl->mrl_next) {
+        if (mrl->mr_entry->mr_name && !strcasecmp(oid_or_name, mrl->mr_entry->mr_name)) {
+            return (mrl->mr_entry->mr_name &&
+                    PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
+        }
+        if (mrl->mr_entry->mr_oid && !strcmp(oid_or_name, mrl->mr_entry->mr_oid)) {
+            return (mrl->mr_entry->mr_name &&
+                    PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
+        }
+    }
+    return 0;
+}
 /*
   See if a matching rule for this name or OID
   is registered and is an ORDERING matching rule that applies
@@ -235,18 +252,8 @@ slapi_matchingrule_is_ordering(const char *oid_or_name, const char *syntax_oid)
     struct matchingRuleList *mrl = NULL;
 
     if (slapi_matchingrule_is_compat(oid_or_name, syntax_oid)) {
-        for (mrl = g_get_global_mrl(); mrl != NULL; mrl = mrl->mrl_next) {
-            if (mrl->mr_entry->mr_name && !strcasecmp(oid_or_name, mrl->mr_entry->mr_name)) {
-                return (mrl->mr_entry->mr_name &&
-                        PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
-            }
-            if (mrl->mr_entry->mr_oid && !strcmp(oid_or_name, mrl->mr_entry->mr_oid)) {
-                return (mrl->mr_entry->mr_name &&
-                        PL_strcasestr(mrl->mr_entry->mr_name, "ordering"));
-            }
-        }
+        return slapi_matchingrule_is_ordering_only(oid_or_name);
     }
-
     return 0;
 }
 

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5412,6 +5412,15 @@ int slapi_matchingrule_register(Slapi_MatchingRuleEntry *mrEntry);
 int slapi_matchingrule_unregister(char *oid);
 
 /**
+ * Is the given matching rule an ordering matching rule
+ *
+ * \param name_or_oid Name or OID of a matching rule
+ * \return \c TRUE if the matching rule is an ordering rule
+ * \return \c FALSE otherwise
+ */
+int slapi_matchingrule_is_ordering_only(const char *oid_or_name);
+
+/**
  * Is the given matching rule an ordering matching rule and is it
  * compatible with the given syntax?
  *

--- a/src/lib389/lib389/cli_ctl/dbtasks.py
+++ b/src/lib389/lib389/cli_ctl/dbtasks.py
@@ -436,6 +436,31 @@ def dbtasks_index_check(inst, log, args):
                     config_fixes.append((backend, index_name, "add_mr"))
                     all_ok = False
 
+
+        for index_name in dse_ldif.get_indexes(backend):
+            # for indexes others than  parentid or ancestorid
+            if index_name != "parentid" and index_name != "ancestorid":
+                config_has_int_order = _has_integer_ordering_match(dse_ldif, backend, index_name)
+                if config_has_int_order:
+                    # Check disk ordering
+                    disk_ordering = _check_disk_ordering(db_dir, backend, index_name, dbscan_path, is_mdb, log)
+                    if disk_ordering == IndexOrdering.UNKNOWN:
+                        log.info("  %s - config: %s, disk: %s",
+                                 index_name, "integer", disk_ordering.value)
+                        log.info("  %s - could not determine disk ordering, skipping", index_name)
+                        continue
+                    if disk_ordering == IndexOrdering.LEXICOGRAPHIC:
+                        log.info("  %s - config: %s, disk: %s",
+                                 index_name, "integer", disk_ordering.value)
+                        log.warning("  %s - MISMATCH: config has integerOrderingMatch but disk is lexicographic (suggest redindex)", index_name)
+                        continue
+                    if disk_ordering == IndexOrdering.INTEGER:
+                        log.info("  %s - config: %s, disk: %s",
+                                 index_name, "integer", disk_ordering.value)
+                        continue
+
+
+
     # Handle issues
     if not all_ok:
         if args.fix:


### PR DESCRIPTION
…ttribute it should be used if the schema does not define one

Bug description:
	An attribute is defined in the schema. The matching rule is optional in the schema
	so the definition falls back to the default matching rule that is lexicographic order.

	An attribute can be configured to be indexed and the configuration can define a
	matching rule 'nsMatchingRule".

	If the schema does not define a matching rule, the server should fall back to the
	configured one ('nsMatchingRule') prior to default lexicographic one

Fix description:
	At startup when binding the attribute their schema definitions
	if no matching rule is define and it existed a configured matching rule
	the default matching rule should be the configured one

fixes: #7627
fixes: #7518

Reviewed by:

## Summary by Sourcery

Honor configured ordering matching rules when schema definitions lack compatible rules and improve detection and coverage of index ordering behavior.

Bug Fixes:
- Use an indexed attribute’s configured ordering matching rule when the schema does not provide a compatible ordering rule, while preserving schema-compatible behavior.

Enhancements:
- Add index validation for detecting indexes configured with integer ordering whose on-disk ordering remains lexicographic.
- Expand regression coverage for configured matching-rule precedence, integer ordering, collation indexing, and range searches.

Tests:
- Add regression tests covering matching-rule fallback, index ordering mismatch detection, collation-based indexing, and lexicographic versus integer range behavior.