### PR TITLE
Issue 7569 - Reduce noisy CodeQL false-positive alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: 389 Directory Server CodeQL config
+
+# Keep CodeQL focused on product code.  The pytest suites and vendored
+# dependency trees produce a large amount of low-value Python/static lint noise
+# and are not shipped as part of the server or lib389 runtime.
+paths-ignore:
+  - 'dirsrvtests/**'
+  - 'src/lib389/lib389/tests/**'
+  - 'src/cockpit/389-console/node_modules/**'
+  - 'vendor/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build_mode }}
-          queries: +security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+          # Keep code scanning security-focused; security-and-quality produces
+          # thousands of low-value lint/maintainability alerts in this tree.
+          queries: +security-extended
 
       - name: Configure
         if: matrix.language == 'c-cpp'


### PR DESCRIPTION
Description: Add a CodeQL configuration file and wire the workflow to use it. Keep code scanning security-focused by switching to the security-extended query suite and ignoring noisy non-product areas such as dirsrvtests, lib389 tests, Cockpit node_modules, and vendored dependencies.

Related: https://github.com/389ds/389-ds-base/issues/7569

Reviewed by: ?

## Summary by Sourcery

Configure CodeQL scanning to focus on security-relevant product code and reduce noisy false-positive alerts from non-shipped areas.

New Features:
- Introduce a centralized CodeQL configuration file to control analysis scope and behavior.

Enhancements:
- Update the CodeQL workflow to use the new config file and switch from the security-and-quality to the security-extended query suite to keep alerts security-focused.

CI:
- Exclude tests, Cockpit node_modules, and vendored dependency trees from CodeQL analysis via paths-ignore settings in the CI configuration.