### PR TITLE
Issue 7611 - PBKDF2 password verification should reject invalid iteration counts

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_pwstorage_scheme_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_pwstorage_scheme_test.py
@@ -11,10 +11,19 @@ import json
 import pytest
 from lib389.cli_base import FakeArgs
 from lib389.cli_conf.plugins.pwstorage import (
+    pbkdf2_delete_accept_max_iterations,
     pbkdf2_get_accept_max_iterations,
     pbkdf2_set_accept_max_iterations,
+    pbkdf2_variant_get_accept_max_iterations,
+    pbkdf2_variant_set_accept_max_iterations,
 )
-from lib389.password_plugins import PBKDF2SHA256LegacyPlugin
+from lib389.password_plugins import (
+    PBKDF2Plugin,
+    PBKDF2SHA1Plugin,
+    PBKDF2SHA256LegacyPlugin,
+    PBKDF2SHA256Plugin,
+    PBKDF2SHA512Plugin,
+)
 from test389.topologies import topology_st
 
 from . import check_value_in_log_and_reset
@@ -26,6 +35,13 @@ LEGACY_VARIANT = 'pbkdf2-sha256-legacy'
 ACCEPT_MAX_ATTR = 'nsslapd-pwdPBKDF2AcceptMaxIterations'
 PBKDF2_CONFIG_OC = 'pwdPBKDF2PluginConfig'
 ROUNDTRIP_ACCEPT_MAX = 60000
+
+RUST_PBKDF2_VARIANTS = [
+    ('pbkdf2', PBKDF2Plugin),
+    ('pbkdf2-sha1', PBKDF2SHA1Plugin),
+    ('pbkdf2-sha256', PBKDF2SHA256Plugin),
+    ('pbkdf2-sha512', PBKDF2SHA512Plugin),
+]
 
 
 @pytest.fixture(scope='function')
@@ -48,6 +64,36 @@ def legacy_pbkdf2_plugin(topology_st, request):
     request.addfinalizer(fin)
     topology_st.logcap.flush()
     return plugin
+
+
+@pytest.fixture(scope='function')
+def rust_pbkdf2_plugin(topology_st, request):
+    def _get(variant, plugin_class):
+        plugin = plugin_class(topology_st.standalone)
+        original_accept_max = plugin.get_attr_val_utf8(ACCEPT_MAX_ATTR)
+        original_rounds = plugin.get_attr_val_utf8('nsslapd-pwdPBKDF2NumIterations')
+        original_config_oc = plugin.present('objectClass', PBKDF2_CONFIG_OC)
+
+        def fin():
+            cleanup_plugin = plugin_class(topology_st.standalone)
+            if original_config_oc:
+                cleanup_plugin.ensure_present('objectClass', PBKDF2_CONFIG_OC)
+            if original_accept_max is None:
+                cleanup_plugin.remove_all(ACCEPT_MAX_ATTR)
+            else:
+                cleanup_plugin.replace(ACCEPT_MAX_ATTR, original_accept_max)
+            if original_rounds is None:
+                cleanup_plugin.remove_all('nsslapd-pwdPBKDF2NumIterations')
+            else:
+                cleanup_plugin.replace('nsslapd-pwdPBKDF2NumIterations', original_rounds)
+            if not original_config_oc:
+                cleanup_plugin.ensure_removed('objectClass', PBKDF2_CONFIG_OC)
+
+        request.addfinalizer(fin)
+        topology_st.logcap.flush()
+        return plugin
+
+    return _get
 
 
 def test_dsconf_legacy_pbkdf2_accept_max_get_default(topology_st,
@@ -168,3 +214,149 @@ def test_dsconf_legacy_pbkdf2_accept_max_validation(topology_st,
                 topology_st.standalone, None, topology_st.logcap.log, args
             )
         assert legacy_pbkdf2_plugin.get_accept_max_iterations() == ROUNDTRIP_ACCEPT_MAX
+
+
+@pytest.mark.parametrize('variant,plugin_class', RUST_PBKDF2_VARIANTS)
+def test_dsconf_rust_pbkdf2_accept_max_get_default(topology_st,
+                                                   rust_pbkdf2_plugin,
+                                                   variant,
+                                                   plugin_class):
+    """Verify dsconf reports the Rust PBKDF2 default accepted maximum
+
+    :id: 76c8d53c-3f4e-4743-aa12-e2da92a9b620
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Remove the configured accepted maximum and lower generation rounds
+        2. Get the accepted maximum through the dsconf handler
+    :expectedresults:
+        1. Accept-max attr is absent and rounds are lowered
+        2. The built-in accept-max default is reported (independent of rounds)
+    """
+    plugin = rust_pbkdf2_plugin(variant, plugin_class)
+    plugin.remove_all(ACCEPT_MAX_ATTR)
+    plugin.set_rounds(20000)
+    assert plugin.get_attr_val_utf8(ACCEPT_MAX_ATTR) is None
+    assert plugin.get_rounds() == 20000
+    assert plugin.get_accept_max_iterations() == plugin_class.ACCEPT_MAX_DEFAULT
+
+    args = FakeArgs()
+    args.variant = variant
+    args.json = False
+    pbkdf2_variant_get_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+
+    check_value_in_log_and_reset(
+        topology_st,
+        check_value=(
+            f'Current accept max iterations for {variant}: '
+            f'{plugin_class.ACCEPT_MAX_DEFAULT}'
+        ),
+    )
+
+
+@pytest.mark.parametrize('variant,plugin_class', RUST_PBKDF2_VARIANTS)
+def test_dsconf_rust_pbkdf2_accept_max_set_delete_roundtrip(topology_st,
+                                                            rust_pbkdf2_plugin,
+                                                            variant,
+                                                            plugin_class,
+                                                            capsys):
+    """Verify dsconf set/get/delete for Rust PBKDF2 accepted maximum
+
+    :id: 974845c9-294c-4c99-b3a2-85438eab7d20
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Set accept-max through dsconf and check the restart notice
+        2. Get accept-max as JSON
+        3. Delete the override and check the restart notice
+        4. Confirm lib389 reports the built-in default again
+    :expectedresults:
+        1. Value is stored and restart is mentioned
+        2. JSON contains the configured value
+        3. Override is removed and restart is mentioned
+        4. Default accept-max is returned
+    """
+    plugin = rust_pbkdf2_plugin(variant, plugin_class)
+    plugin.remove_all(ACCEPT_MAX_ATTR)
+
+    args = FakeArgs()
+    args.variant = variant
+    args.iterations = ROUNDTRIP_ACCEPT_MAX
+    pbkdf2_variant_set_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+    check_value_in_log_and_reset(
+        topology_st,
+        content_list=[
+            f'Successfully set accept max iterations for {variant} '
+            f'to {ROUNDTRIP_ACCEPT_MAX}',
+            'A server restart is required for the change to take effect',
+        ],
+    )
+    assert plugin.get_accept_max_iterations() == ROUNDTRIP_ACCEPT_MAX
+
+    args.json = True
+    capsys.readouterr()
+    pbkdf2_variant_get_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result == {
+        'type': 'entry',
+        'dn': plugin._dn,
+        'attrs': {
+            'nsslapd-pwdpbkdf2acceptmaxiterations': [ROUNDTRIP_ACCEPT_MAX],
+        },
+    }
+
+    args.json = False
+    topology_st.logcap.flush()
+    pbkdf2_delete_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+    check_value_in_log_and_reset(
+        topology_st,
+        content_list=[
+            f'Successfully removed accept max iterations override for {variant}',
+            'A server restart is required for the change to take effect',
+        ],
+    )
+    assert plugin.get_attr_val_utf8(ACCEPT_MAX_ATTR) is None
+    assert plugin.get_accept_max_iterations() == plugin_class.ACCEPT_MAX_DEFAULT
+
+
+@pytest.mark.parametrize('variant,plugin_class', RUST_PBKDF2_VARIANTS)
+def test_dsconf_rust_pbkdf2_accept_max_validation(topology_st,
+                                                  rust_pbkdf2_plugin,
+                                                  variant,
+                                                  plugin_class):
+    """Verify dsconf rejects Rust PBKDF2 accepted maxima outside bounds
+
+    :id: 2ff7f630-c69a-4ea1-b278-2eed0500f995
+    :parametrized: yes
+    :setup: Standalone instance
+    :steps:
+        1. Store a valid accepted maximum
+        2. Try values below the minimum and above the maximum
+        3. Read the stored accepted maximum
+    :expectedresults:
+        1. Valid value is stored
+        2. ValueError is raised for each invalid value
+        3. Stored value is unchanged
+    """
+    plugin = rust_pbkdf2_plugin(variant, plugin_class)
+    plugin.set_accept_max_iterations(ROUNDTRIP_ACCEPT_MAX)
+
+    args = FakeArgs()
+    args.variant = variant
+    for invalid_value in (
+            plugin_class.ACCEPT_MAX_MIN - 1,
+            plugin_class.ACCEPT_MAX_MAX + 1):
+        args.iterations = invalid_value
+        with pytest.raises(ValueError):
+            pbkdf2_variant_set_accept_max_iterations(
+                topology_st.standalone, None, topology_st.logcap.log, args
+            )
+        assert plugin.get_accept_max_iterations() == ROUNDTRIP_ACCEPT_MAX

--- a/dirsrvtests/tests/suites/pwp_storage/storage_test.py
+++ b/dirsrvtests/tests/suites/pwp_storage/storage_test.py
@@ -31,6 +31,7 @@ from lib389.utils import ds_is_older
 pytestmark = pytest.mark.tier1
 
 PBKDF2_NUM_ITERATIONS_DEFAULT = 100000
+FRESH_INSTALL_ACCEPT_MAX = 600000
 
 PBKDF2_SCHEMES = [
     ('PBKDF2-SHA1', PBKDF2SHA1Plugin, PBKDF2_NUM_ITERATIONS_DEFAULT),
@@ -547,6 +548,56 @@ def test_pbkdf2_invalid_accept_max_soft_fallback(topo, new_user):
         pwd_hash = new_user.get_attr_val_utf8('userPassword')
         assert pwd_hash.startswith(
             f'{{PBKDF2-SHA256}}{PBKDF2_NUM_ITERATIONS_DEFAULT}$'
+        )
+        topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
+    finally:
+        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        plugin.remove_all('nsslapd-pwdpbkdf2acceptmaxiterations')
+        topo.standalone.restart()
+
+
+def test_pbkdf2_missing_accept_max_allows_existing_600k_hash(topo, new_user):
+    """Missing accept-max falls back to 10m and still verifies existing 600k hashes
+
+    :id: 33776566-dd5c-4ef6-a8db-eb3d15c0d66e
+    :setup: Standalone
+    :steps:
+        1. Configure PBKDF2-SHA256 with 600,000 generation rounds
+        2. Store a user password hashed at 600,000 rounds
+        3. Remove accept-max (upgraded install without the attribute) and restart
+        4. Bind with the existing password
+        5. Confirm the soft-fallback accept-max is logged as 10,000,000
+    :expectedresults:
+        1. Pass
+        2. Stored hash uses 600,000 rounds
+        3. Server starts without accept-max configured
+        4. Existing 600k hash still authenticates
+        5. Runtime default accept-max is 10,000,000
+    """
+    scheme_name = 'PBKDF2-SHA256'
+    plugin = PBKDF2SHA256Plugin(topo.standalone)
+    try:
+        topo.standalone.config.loglevel((ErrorLog.DEFAULT, ErrorLog.PLUGIN))
+        plugin.set_accept_max_iterations(FRESH_INSTALL_ACCEPT_MAX)
+        plugin.set_rounds(FRESH_INSTALL_ACCEPT_MAX)
+        topo.standalone.restart()
+        topo.standalone.config.replace('passwordStorageScheme', scheme_name)
+
+        new_user.set('userPassword', 'Secret123')
+        pwd_hash = new_user.get_attr_val_utf8('userPassword')
+        assert pwd_hash.startswith(
+            f'{{PBKDF2-SHA256}}{FRESH_INSTALL_ACCEPT_MAX}$'
+        )
+
+        plugin.remove_all('nsslapd-pwdpbkdf2acceptmaxiterations')
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        topo.standalone.deleteErrorLogs()
+        topo.standalone.restart()
+
+        assert plugin.get_attr_val_utf8('nsslapd-pwdPBKDF2AcceptMaxIterations') is None
+        assert topo.standalone.searchErrorsLog(
+            f'PBKDF2 accept max iterations set to {PBKDF2SHA256Plugin.ACCEPT_MAX_DEFAULT}'
         )
         topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
     finally:

--- a/dirsrvtests/tests/suites/pwp_storage/storage_test.py
+++ b/dirsrvtests/tests/suites/pwp_storage/storage_test.py
@@ -416,6 +416,146 @@ def test_check_pbkdf2_sha512(topo):
     user.delete()
 
 
+def test_pbkdf2_accept_max_independent_of_rounds(topo, new_user):
+    """Lowering generation rounds must not break binds to stronger stored hashes
+
+    :id: 0b9b580b-655e-4844-8363-a3856963f22a
+    :setup: Standalone
+    :steps:
+        1. Configure PBKDF2-SHA256 with 30,000 rounds and accept-max 50,000
+        2. Set a user password and verify the hash uses 30,000 rounds
+        3. Lower generation rounds to 15,000 and restart
+        4. Bind with the existing password
+        5. Reset the password and verify new hashes use 15,000 rounds
+    :expectedresults:
+        1. Pass
+        2. Pass
+        3. Pass
+        4. Existing stronger hash still authenticates
+        5. New hashes use the lowered generation rounds
+    """
+    scheme_name = 'PBKDF2-SHA256'
+    plugin = PBKDF2SHA256Plugin(topo.standalone)
+    try:
+        topo.standalone.config.loglevel((ErrorLog.DEFAULT, ErrorLog.PLUGIN))
+        plugin.set_accept_max_iterations(50000)
+        plugin.set_rounds(30000)
+        topo.standalone.restart()
+        topo.standalone.config.replace('passwordStorageScheme', scheme_name)
+
+        new_user.set('userPassword', 'Secret123')
+        pwd_hash = new_user.get_attr_val_utf8('userPassword')
+        assert pwd_hash.startswith('{PBKDF2-SHA256}30000$')
+
+        plugin.set_rounds(15000)
+        topo.standalone.restart()
+
+        topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
+        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
+
+        new_user.set('userPassword', 'Secret123')
+        pwd_hash = new_user.get_attr_val_utf8('userPassword')
+        assert pwd_hash.startswith('{PBKDF2-SHA256}15000$')
+        topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
+    finally:
+        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        plugin.remove_all('nsslapd-pwdpbkdf2acceptmaxiterations')
+        topo.standalone.restart()
+
+
+def test_pbkdf2_encrypt_caps_rounds_to_accept_max(topo, new_user):
+    """Generation rounds above accept-max are capped for new hashes
+
+    :id: b6016b0c-5880-4dda-b9b0-e29ca0fd5c2f
+    :setup: Standalone
+    :steps:
+        1. Configure PBKDF2-SHA256 with rounds 30,000 and accept-max 15,000
+        2. Restart and inspect the error log for the capping message
+        3. Set a user password
+        4. Verify the stored hash uses 15,000 rounds and authenticates
+    :expectedresults:
+        1. Pass
+        2. Cap message is logged
+        3. Pass
+        4. Hash is capped and bind succeeds
+    """
+    scheme_name = 'PBKDF2-SHA256'
+    plugin = PBKDF2SHA256Plugin(topo.standalone)
+    try:
+        topo.standalone.restart()
+        topo.standalone.config.loglevel((ErrorLog.DEFAULT, ErrorLog.PLUGIN))
+        topo.standalone.deleteErrorLogs()
+
+        plugin.set_accept_max_iterations(15000)
+        plugin.set_rounds(30000)
+        topo.standalone.restart()
+        topo.standalone.config.replace('passwordStorageScheme', scheme_name)
+
+        assert topo.standalone.searchErrorsLog(
+            'Configured 30000 rounds; capping at the configured accept max 15000'
+        )
+
+        new_user.set('userPassword', 'Secret123')
+        pwd_hash = new_user.get_attr_val_utf8('userPassword')
+        assert pwd_hash.startswith('{PBKDF2-SHA256}15000$')
+        topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
+    finally:
+        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        plugin.remove_all('nsslapd-pwdpbkdf2acceptmaxiterations')
+        topo.standalone.restart()
+
+
+def test_pbkdf2_invalid_accept_max_soft_fallback(topo, new_user):
+    """Invalid accept-max config falls back to the default and keeps the plugin up
+
+    :id: 4712ae96-63a6-4c0c-bd1e-469f31df6ef3
+    :setup: Standalone
+    :steps:
+        1. Write an out-of-range accept-max directly into the plugin entry
+        2. Restart the server
+        3. Set a password with the default PBKDF2-SHA256 scheme
+        4. Verify authentication still works
+    :expectedresults:
+        1. Pass
+        2. Server starts and logs the soft fallback
+        3. Hash uses the default generation rounds
+        4. Bind succeeds
+    """
+    scheme_name = 'PBKDF2-SHA256'
+    plugin = PBKDF2SHA256Plugin(topo.standalone)
+    try:
+        topo.standalone.restart()
+        topo.standalone.config.loglevel((ErrorLog.DEFAULT, ErrorLog.PLUGIN))
+        topo.standalone.deleteErrorLogs()
+
+        plugin.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
+        plugin.replace('nsslapd-pwdPBKDF2AcceptMaxIterations', '999')
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        topo.standalone.restart()
+        topo.standalone.config.replace('passwordStorageScheme', scheme_name)
+
+        assert topo.standalone.searchErrorsLog(
+            'Invalid nsslapd-pwdPBKDF2AcceptMaxIterations value 999'
+        )
+        assert topo.standalone.searchErrorsLog(
+            f'PBKDF2 accept max iterations set to {PBKDF2SHA256Plugin.ACCEPT_MAX_DEFAULT}'
+        )
+
+        new_user.set('userPassword', 'Secret123')
+        pwd_hash = new_user.get_attr_val_utf8('userPassword')
+        assert pwd_hash.startswith(
+            f'{{PBKDF2-SHA256}}{PBKDF2_NUM_ITERATIONS_DEFAULT}$'
+        )
+        topo.standalone.simple_bind_s(new_user.dn, 'Secret123')
+    finally:
+        topo.standalone.simple_bind_s(DN_DM, PASSWORD)
+        plugin.remove_all('nsslapd-pwdpbkdf2numiterations')
+        plugin.remove_all('nsslapd-pwdpbkdf2acceptmaxiterations')
+        topo.standalone.restart()
+
+
 def test_check_ssha512(topo):
     """Check password scheme SSHA512.
 

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -206,6 +206,7 @@ nsslapd-pluginId: PBKDF2
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -220,6 +221,7 @@ nsslapd-pluginId: PBKDF2-SHA1
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA1\
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -234,6 +236,7 @@ nsslapd-pluginId: PBKDF2-SHA256
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA256\
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -248,6 +251,7 @@ nsslapd-pluginId: PBKDF2-SHA512
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA512
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=AES,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -263,6 +263,7 @@ nsslapd-pluginId: PBKDF2
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -277,6 +278,7 @@ nsslapd-pluginId: PBKDF2-SHA1
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA1\
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -291,6 +293,7 @@ nsslapd-pluginId: PBKDF2-SHA256
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA256\
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
@@ -305,6 +308,7 @@ nsslapd-pluginId: PBKDF2-SHA512
 nsslapd-pluginVersion: none
 nsslapd-pluginVendor: 389 Project
 nsslapd-pluginDescription: PBKDF2-SHA512
+nsslapd-pwdPBKDF2AcceptMaxIterations: 600000
 
 dn: cn=AES,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top

--- a/ldap/servers/slapd/fedse.c
+++ b/ldap/servers/slapd/fedse.c
@@ -241,7 +241,8 @@ static const char *internal_entries[] =
         "nsslapd-pluginId: PBKDF2\n"
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: PBKDF2\n",
+        "nsslapd-pluginDescription: PBKDF2\n"
+        "nsslapd-pwdPBKDF2AcceptMaxIterations: 600000\n",
 
         "dn: cn=PBKDF2-SHA1,cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"
@@ -255,7 +256,8 @@ static const char *internal_entries[] =
         "nsslapd-pluginId: PBKDF2-SHA1\n"
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: PBKDF2-SHA1\n",
+        "nsslapd-pluginDescription: PBKDF2-SHA1\n"
+        "nsslapd-pwdPBKDF2AcceptMaxIterations: 600000\n",
 
         "dn: cn=PBKDF2-SHA256,cn=Password Storage Schemes,cn=plugins,cn=config\n"
         "objectclass: top\n"
@@ -269,7 +271,23 @@ static const char *internal_entries[] =
         "nsslapd-pluginId: PBKDF2-SHA256\n"
         "nsslapd-pluginVersion: none\n"
         "nsslapd-pluginVendor: 389 Project\n"
-        "nsslapd-pluginDescription: PBKDF2-SHA256\n",
+        "nsslapd-pluginDescription: PBKDF2-SHA256\n"
+        "nsslapd-pwdPBKDF2AcceptMaxIterations: 600000\n",
+
+        "dn: cn=PBKDF2-SHA512,cn=Password Storage Schemes,cn=plugins,cn=config\n"
+        "objectclass: top\n"
+        "objectclass: nsSlapdPlugin\n"
+        "objectClass: pwdPBKDF2PluginConfig\n"
+        "cn: PBKDF2-SHA512\n"
+        "nsslapd-pluginpath: libpwdchan-plugin\n"
+        "nsslapd-plugininitfunc: pwdchan_pbkdf2_sha512_plugin_init\n"
+        "nsslapd-plugintype: pwdstoragescheme\n"
+        "nsslapd-pluginenabled: on\n"
+        "nsslapd-pluginId: PBKDF2-SHA512\n"
+        "nsslapd-pluginVersion: none\n"
+        "nsslapd-pluginVendor: 389 Project\n"
+        "nsslapd-pluginDescription: PBKDF2-SHA512\n"
+        "nsslapd-pwdPBKDF2AcceptMaxIterations: 600000\n",
 };
 
 static int NUM_INTERNAL_ENTRIES = sizeof(internal_entries) / sizeof(internal_entries[0]);

--- a/src/lib389/lib389/cli_conf/plugins/pwstorage.py
+++ b/src/lib389/lib389/cli_conf/plugins/pwstorage.py
@@ -34,9 +34,7 @@ def _get_pbkdf2_plugin(inst, variant):
 def pbkdf2_get_iterations(inst, basedn, log, args):
     log = log.getChild('pbkdf2_get_iterations')
     plugin = _get_pbkdf2_plugin(inst, args.variant)
-    
     attr = 'nsslapd-pwdpbkdf2numiterations'
-    
     if hasattr(args, 'json') and args.json:
         vals = {}
         rounds = plugin.get_rounds()
@@ -81,6 +79,38 @@ def pbkdf2_set_accept_max_iterations(inst, basedn, log, args):
         f'Successfully set accept max iterations for {args.variant} to {args.iterations}. '
         'A server restart is required for the change to take effect'
     )
+
+
+def pbkdf2_variant_get_accept_max_iterations(inst, basedn, log, args):
+    log = log.getChild('pbkdf2_variant_get_accept_max_iterations')
+    plugin = _get_pbkdf2_plugin(inst, args.variant)
+    attr = 'nsslapd-pwdpbkdf2acceptmaxiterations'
+    if hasattr(args, 'json') and args.json:
+        vals = {}
+        accept_max = plugin.get_accept_max_iterations()
+        vals[attr] = [accept_max]
+        print(json.dumps({
+            "type": "entry",
+            "dn": plugin._dn,
+            "attrs": vals
+        }, indent=4))
+    else:
+        accept_max = plugin.get_accept_max_iterations()
+        log.info(f'Current accept max iterations for {args.variant}: {accept_max}')
+
+
+def pbkdf2_variant_set_accept_max_iterations(inst, basedn, log, args):
+    log = log.getChild('pbkdf2_variant_set_accept_max_iterations')
+    plugin = _get_pbkdf2_plugin(inst, args.variant)
+    plugin.set_accept_max_iterations(args.iterations)
+    log.info(f'Successfully set accept max iterations for {args.variant} to {args.iterations}')
+
+
+def pbkdf2_delete_accept_max_iterations(inst, basedn, log, args):
+    log = log.getChild('pbkdf2_delete_accept_max_iterations')
+    plugin = _get_pbkdf2_plugin(inst, args.variant)
+    plugin.delete_accept_max_iterations()
+    log.info(f'Successfully removed accept max iterations override for {args.variant}')
 
 
 def create_parser(subparsers):
@@ -130,3 +160,22 @@ def create_parser(subparsers):
                                                   formatter_class=CustomHelpFormatter)
         set_iter.add_argument('iterations', type=int, help='Number of iterations (10,000-10,000,000)')
         set_iter.set_defaults(func=pbkdf2_set_iterations, variant=variant)
+
+        get_accept = variant_subcommands.add_parser(
+            'get-accept-max-iterations',
+            help='Get maximum iterations accepted from stored hashes on bind',
+            formatter_class=CustomHelpFormatter)
+        get_accept.set_defaults(func=pbkdf2_variant_get_accept_max_iterations, variant=variant)
+
+        set_accept = variant_subcommands.add_parser(
+            'set-accept-max-iterations',
+            help='Set maximum iterations accepted from stored hashes on bind',
+            formatter_class=CustomHelpFormatter)
+        set_accept.add_argument('iterations', type=int, help='Maximum iterations accepted on bind (>= 10,000)')
+        set_accept.set_defaults(func=pbkdf2_variant_set_accept_max_iterations, variant=variant)
+
+        delete_accept = variant_subcommands.add_parser(
+            'delete-accept-max-iterations',
+            help='Remove accept max iterations override (default to encrypt rounds)',
+            formatter_class=CustomHelpFormatter)
+        delete_accept.set_defaults(func=pbkdf2_delete_accept_max_iterations, variant=variant)

--- a/src/lib389/lib389/cli_conf/plugins/pwstorage.py
+++ b/src/lib389/lib389/cli_conf/plugins/pwstorage.py
@@ -34,7 +34,9 @@ def _get_pbkdf2_plugin(inst, variant):
 def pbkdf2_get_iterations(inst, basedn, log, args):
     log = log.getChild('pbkdf2_get_iterations')
     plugin = _get_pbkdf2_plugin(inst, args.variant)
+
     attr = 'nsslapd-pwdpbkdf2numiterations'
+
     if hasattr(args, 'json') and args.json:
         vals = {}
         rounds = plugin.get_rounds()
@@ -120,7 +122,20 @@ def create_parser(subparsers):
 
     legacy_variant = 'pbkdf2-sha256-legacy'
     for variant in sorted((*PBKDF2_VARIANTS, legacy_variant)):
-        variant_parser = scheme_subcommands.add_parser(variant, help=f'Manage {variant.upper()} scheme',
+        if variant == 'pbkdf2':
+            variant_help = (
+                'Manage legacy PBKDF2 scheme ({PBKDF2}); settings are independent '
+                'of pbkdf2-sha1 even though both use SHA-1'
+            )
+        elif variant == 'pbkdf2-sha1':
+            variant_help = (
+                'Manage PBKDF2-SHA1 scheme ({PBKDF2-SHA1}); settings are independent '
+                'of legacy pbkdf2 even though both use SHA-1'
+            )
+        else:
+            variant_help = f'Manage {variant.upper()} scheme'
+
+        variant_parser = scheme_subcommands.add_parser(variant, help=variant_help,
                                                        formatter_class=CustomHelpFormatter)
 
         variant_subcommands = variant_parser.add_subparsers(help='action')

--- a/src/lib389/lib389/cli_conf/plugins/pwstorage.py
+++ b/src/lib389/lib389/cli_conf/plugins/pwstorage.py
@@ -55,7 +55,10 @@ def pbkdf2_set_iterations(inst, basedn, log, args):
     log = log.getChild('pbkdf2_set_iterations')
     plugin = _get_pbkdf2_plugin(inst, args.variant)
     plugin.set_rounds(args.iterations)
-    log.info(f'Successfully set number of iterations for {args.variant} to {args.iterations}')
+    log.info(
+        f'Successfully set number of iterations for {args.variant} to {args.iterations}. '
+        'A server restart is required for the change to take effect'
+    )
 
 
 def pbkdf2_get_accept_max_iterations(inst, basedn, log, args):
@@ -105,14 +108,20 @@ def pbkdf2_variant_set_accept_max_iterations(inst, basedn, log, args):
     log = log.getChild('pbkdf2_variant_set_accept_max_iterations')
     plugin = _get_pbkdf2_plugin(inst, args.variant)
     plugin.set_accept_max_iterations(args.iterations)
-    log.info(f'Successfully set accept max iterations for {args.variant} to {args.iterations}')
+    log.info(
+        f'Successfully set accept max iterations for {args.variant} to {args.iterations}. '
+        'A server restart is required for the change to take effect'
+    )
 
 
 def pbkdf2_delete_accept_max_iterations(inst, basedn, log, args):
     log = log.getChild('pbkdf2_delete_accept_max_iterations')
     plugin = _get_pbkdf2_plugin(inst, args.variant)
     plugin.delete_accept_max_iterations()
-    log.info(f'Successfully removed accept max iterations override for {args.variant}')
+    log.info(
+        f'Successfully removed accept max iterations override for {args.variant}. '
+        'A server restart is required for the change to take effect'
+    )
 
 
 def create_parser(subparsers):
@@ -186,11 +195,14 @@ def create_parser(subparsers):
             'set-accept-max-iterations',
             help='Set maximum iterations accepted from stored hashes on bind',
             formatter_class=CustomHelpFormatter)
-        set_accept.add_argument('iterations', type=int, help='Maximum iterations accepted on bind (>= 10,000)')
+        set_accept.add_argument(
+            'iterations',
+            type=int,
+            help='Maximum iterations accepted on bind (10,000-10,000,000)')
         set_accept.set_defaults(func=pbkdf2_variant_set_accept_max_iterations, variant=variant)
 
         delete_accept = variant_subcommands.add_parser(
             'delete-accept-max-iterations',
-            help='Remove accept max iterations override (default to encrypt rounds)',
+            help='Remove accept max iterations override, revert to default',
             formatter_class=CustomHelpFormatter)
         delete_accept.set_defaults(func=pbkdf2_delete_accept_max_iterations, variant=variant)

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -59,24 +59,24 @@ class PBKDF2BasePlugin(PasswordPlugin):
     def __init__(self, instance, dn):
         super(PBKDF2BasePlugin, self).__init__(instance, dn)
         self._create_objectclasses.append('pwdPBKDF2PluginConfig')
-        
+
     def set_rounds(self, rounds):
         """Set the number of rounds for PBKDF2 hashing (requires restart)
-        
+
         :param rounds: Number of rounds
         :type rounds: int
         """
         # Ensure the pwdPBKDF2PluginConfig objectClass is present
         self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
-        
+
         rounds = int(rounds)
         if rounds < 10000 or rounds > 10000000:
             raise ValueError("PBKDF2 rounds must be between 10,000 and 10,000,000")
         self.replace('nsslapd-pwdPBKDF2NumIterations', str(rounds))
-        
+
     def get_rounds(self):
         """Get the current number of rounds
-        
+
         :param use_json: Whether to return JSON formatted output
         :type use_json: bool
         :returns: Current rounds setting or JSON string
@@ -86,6 +86,35 @@ class PBKDF2BasePlugin(PasswordPlugin):
         if rounds:
             return rounds
         return self.DEFAULT_ROUNDS
+
+    def set_accept_max_iterations(self, accept_max):
+        """Set the maximum PBKDF2 iterations accepted from stored hashes on bind.
+
+        :param accept_max: Maximum iteration count accepted on compare
+        :type accept_max: int
+        """
+        self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
+
+        accept_max = int(accept_max)
+        if accept_max < 10000:
+            raise ValueError("PBKDF2 accept max iterations must be at least 10,000")
+        self.replace('nsslapd-pwdPBKDF2AcceptMaxIterations', str(accept_max))
+
+    def get_accept_max_iterations(self):
+        """Get the maximum PBKDF2 iterations accepted from stored hashes on bind.
+
+        :returns: Configured accept max, or encrypt rounds if unset
+        :rtype: int
+        """
+        accept_max = self.get_attr_val_int('nsslapd-pwdPBKDF2AcceptMaxIterations')
+        if accept_max:
+            return accept_max
+        return self.get_rounds()
+
+    def delete_accept_max_iterations(self):
+        """Remove the accept max iterations override (default to encrypt rounds)."""
+        self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
+        self.remove_all('nsslapd-pwdPBKDF2AcceptMaxIterations')
 
 
 class PBKDF2Plugin(PBKDF2BasePlugin):

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -55,6 +55,10 @@ class SSHAPlugin(PasswordPlugin):
 class PBKDF2BasePlugin(PasswordPlugin):
     """Base class for all PBKDF2 variants"""
     DEFAULT_ROUNDS = 100000
+    # Independent verification ceiling default
+    ACCEPT_MAX_DEFAULT = 100000
+    ACCEPT_MAX_MIN = 10000
+    ACCEPT_MAX_MAX = 10000000
 
     def __init__(self, instance, dn):
         super(PBKDF2BasePlugin, self).__init__(instance, dn)
@@ -88,7 +92,7 @@ class PBKDF2BasePlugin(PasswordPlugin):
         return self.DEFAULT_ROUNDS
 
     def set_accept_max_iterations(self, accept_max):
-        """Set the maximum PBKDF2 iterations accepted from stored hashes on bind.
+        """Set the maximum PBKDF2 iterations accepted from stored hashes on bind (requires restart).
 
         :param accept_max: Maximum iteration count accepted on compare
         :type accept_max: int
@@ -96,23 +100,25 @@ class PBKDF2BasePlugin(PasswordPlugin):
         self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
 
         accept_max = int(accept_max)
-        if accept_max < 10000:
-            raise ValueError("PBKDF2 accept max iterations must be at least 10,000")
+        if accept_max < self.ACCEPT_MAX_MIN or accept_max > self.ACCEPT_MAX_MAX:
+            raise ValueError(
+                "PBKDF2 accept max iterations must be between 10,000 and 10,000,000"
+            )
         self.replace('nsslapd-pwdPBKDF2AcceptMaxIterations', str(accept_max))
 
     def get_accept_max_iterations(self):
         """Get the maximum PBKDF2 iterations accepted from stored hashes on bind.
 
-        :returns: Configured accept max, or encrypt rounds if unset
+        :returns: Configured accept max, or default if unset
         :rtype: int
         """
         accept_max = self.get_attr_val_int('nsslapd-pwdPBKDF2AcceptMaxIterations')
         if accept_max:
             return accept_max
-        return self.get_rounds()
+        return self.ACCEPT_MAX_DEFAULT
 
     def delete_accept_max_iterations(self):
-        """Remove the accept max iterations override (default to encrypt rounds)."""
+        """Remove the accept max iterations override, revert to default."""
         self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
         self.remove_all('nsslapd-pwdPBKDF2AcceptMaxIterations')
 

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -55,8 +55,7 @@ class SSHAPlugin(PasswordPlugin):
 class PBKDF2BasePlugin(PasswordPlugin):
     """Base class for all PBKDF2 variants"""
     DEFAULT_ROUNDS = 100000
-    # Independent verification ceiling default
-    ACCEPT_MAX_DEFAULT = 100000
+    ACCEPT_MAX_DEFAULT = 10000000
     ACCEPT_MAX_MIN = 10000
     ACCEPT_MAX_MAX = 10000000
 

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -26,6 +26,13 @@ const MAX_PBKDF2_ROUNDS: usize = 10_000_000;
 
 const PBKDF2_ROUNDS_ATTR: &str = "nsslapd-pwdPBKDF2NumIterations";
 const PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR: &str = "nsslapd-pwdPBKDF2AcceptMaxIterations";
+
+// Scheme identifiers, used for per-scheme config and atomics below.
+const SCHEME_PBKDF2: &str = "PBKDF2";
+const SCHEME_PBKDF2_SHA1: &str = "PBKDF2-SHA1";
+const SCHEME_PBKDF2_SHA256: &str = "PBKDF2-SHA256";
+const SCHEME_PBKDF2_SHA512: &str = "PBKDF2-SHA512";
+
 // Each algorithm gets its own atomic counter for thread-safe round and accept max iterations
 static PBKDF2_ROUNDS: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA1: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
@@ -89,7 +96,7 @@ mod pbkdf2 {
 
     impl super::Pbkdf2Plugin for PwdChanPbkdf2 {
         fn digest_type() -> MessageDigest { MessageDigest::sha1() }
-        fn scheme_name() -> &'static str { "PBKDF2" }
+        fn scheme_name() -> &'static str { SCHEME_PBKDF2 }
     }
 }
 
@@ -101,7 +108,7 @@ mod pbkdf2_sha1 {
 
     impl super::Pbkdf2Plugin for PwdChanPbkdf2Sha1 {
         fn digest_type() -> MessageDigest { MessageDigest::sha1() }
-        fn scheme_name() -> &'static str { "PBKDF2-SHA1" }
+        fn scheme_name() -> &'static str { SCHEME_PBKDF2_SHA1 }
     }
 }
 
@@ -113,7 +120,7 @@ mod pbkdf2_sha256 {
 
     impl super::Pbkdf2Plugin for PwdChanPbkdf2Sha256 {
         fn digest_type() -> MessageDigest { MessageDigest::sha256() }
-        fn scheme_name() -> &'static str { "PBKDF2-SHA256" }
+        fn scheme_name() -> &'static str { SCHEME_PBKDF2_SHA256 }
     }
 }
 
@@ -125,7 +132,7 @@ mod pbkdf2_sha512 {
 
     impl super::Pbkdf2Plugin for PwdChanPbkdf2Sha512 {
         fn digest_type() -> MessageDigest { MessageDigest::sha512() }
-        fn scheme_name() -> &'static str { "PBKDF2-SHA512" }
+        fn scheme_name() -> &'static str { SCHEME_PBKDF2_SHA512 }
     }
 }
 
@@ -143,7 +150,7 @@ macro_rules! impl_slapi_pbkdf2_plugin {
 
             fn start(pb: &mut PblockRef) -> Result<(), PluginError> {
                 log_error!(ErrorLevel::Trace, "{} plugin start", Self::scheme_name());
-                PwdChanCrypto::handle_pbkdf2_config(pb, Self::digest_type())?;
+                PwdChanCrypto::handle_pbkdf2_config(pb, Self::scheme_name())?;
                 Ok(())
             }
 
@@ -161,11 +168,11 @@ macro_rules! impl_slapi_pbkdf2_plugin {
             }
 
             fn pwd_storage_encrypt(cleartext: &str) -> Result<String, PluginError> {
-                PwdChanCrypto::pbkdf2_encrypt(cleartext, Self::digest_type())
+                PwdChanCrypto::pbkdf2_encrypt(cleartext, Self::digest_type(), Self::scheme_name())
             }
 
             fn pwd_storage_compare(cleartext: &str, encrypted: &str) -> Result<bool, PluginError> {
-                PwdChanCrypto::pbkdf2_compare(cleartext, encrypted, Self::digest_type())
+                PwdChanCrypto::pbkdf2_compare(cleartext, encrypted, Self::digest_type(), Self::scheme_name())
             }
         }
     };
@@ -178,13 +185,13 @@ impl_slapi_pbkdf2_plugin!(pbkdf2_sha256::PwdChanPbkdf2Sha256);
 impl_slapi_pbkdf2_plugin!(pbkdf2_sha512::PwdChanPbkdf2Sha512);
 
 impl PwdChanCrypto {
-    fn validate_pbkdf2_config_rounds(rounds: usize) -> Result<(), PluginError> {
-        if rounds < MIN_PBKDF2_ROUNDS || rounds > MAX_PBKDF2_ROUNDS {
+    fn validate_pbkdf2_rounds(value: usize) -> Result<(), PluginError> {
+        if value < MIN_PBKDF2_ROUNDS || value > MAX_PBKDF2_ROUNDS {
             #[cfg(not(test))]
             log_error!(
                 ErrorLevel::Error,
-                "Invalid PBKDF2 number of iterations {}, must be between {} and {}",
-                rounds,
+                "Invalid PBKDF2 iteration count {}, must be between {} and {}",
+                value,
                 MIN_PBKDF2_ROUNDS,
                 MAX_PBKDF2_ROUNDS
             );
@@ -194,25 +201,16 @@ impl PwdChanCrypto {
         Ok(())
     }
 
-    fn validate_pbkdf2_stored_iterations(iterations: usize, digest: MessageDigest,
-    ) -> Result<(), PluginError> {
-        if iterations < MIN_PBKDF2_ROUNDS {
-            #[cfg(not(test))]
-            log_error!(
-                ErrorLevel::Warning,
-                "PBKDF2 iteration count {} is below minimum {}",
-                iterations,
-                MIN_PBKDF2_ROUNDS
-            );
-            return Err(PluginError::InvalidConfiguration);
-        }
+    fn validate_pbkdf2_stored_iterations(iterations: usize, scheme: &str) -> Result<(), PluginError> {
+        Self::validate_pbkdf2_rounds(iterations)?;
 
-        let accept_max = Self::get_pbkdf2_accept_max(digest)?;
+        let accept_max = Self::get_pbkdf2_accept_max(scheme)?;
         if iterations > accept_max {
             #[cfg(not(test))]
             log_error!(
                 ErrorLevel::Warning,
-                "PBKDF2 iteration count {} exceeds accept max {}",
+                "{} iteration count {} exceeds accept max {}",
+                scheme,
                 iterations,
                 accept_max
             );
@@ -223,8 +221,7 @@ impl PwdChanCrypto {
     }
 
     #[inline(always)]
-    fn pbkdf2_decompose(encrypted: &str, digest: MessageDigest,
-    ) -> Result<(usize, Vec<u8>, Vec<u8>), PluginError>
+    fn pbkdf2_decompose(encrypted: &str, scheme: &str) -> Result<(usize, Vec<u8>, Vec<u8>), PluginError>
     {
         let mut part_iter = encrypted.split('$');
 
@@ -239,7 +236,7 @@ impl PwdChanCrypto {
                 })
             })?;
 
-        Self::validate_pbkdf2_stored_iterations(iter, digest)?;
+        Self::validate_pbkdf2_stored_iterations(iter, scheme)?;
 
         let salt = part_iter
             .next()
@@ -272,8 +269,9 @@ impl PwdChanCrypto {
         cleartext: &str,
         encrypted: &str,
         digest: MessageDigest,
+        scheme: &str,
     ) -> Result<bool, PluginError> {
-        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted, digest)
+        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted, scheme)
             .map_err(|e| {
                 match e {
                     // Iteration bounds are logged in validate_pbkdf2_stored_iterations.
@@ -302,18 +300,19 @@ impl PwdChanCrypto {
         .map(|()| hash_input == hash_expected)
     }
 
-    fn pbkdf2_encrypt(cleartext: &str, digest: MessageDigest) -> Result<String, PluginError> {
-        let rounds = Self::get_pbkdf2_rounds(digest)?;
+    fn scheme_format(scheme: &str) -> Result<(usize, usize, &'static str), PluginError> {
+        match scheme {
+            SCHEME_PBKDF2 => Ok((PBKDF2_SHA1_EXTRACT, 72, "{PBKDF2}")),
+            SCHEME_PBKDF2_SHA1 => Ok((PBKDF2_SHA1_EXTRACT, 80, "{PBKDF2-SHA1}")),
+            SCHEME_PBKDF2_SHA256 => Ok((PBKDF2_SHA256_EXTRACT, 100, "{PBKDF2-SHA256}")),
+            SCHEME_PBKDF2_SHA512 => Ok((PBKDF2_SHA512_EXTRACT, 140, "{PBKDF2-SHA512}")),
+            _ => Err(PluginError::Unknown),
+        }
+    }
 
-        let (hash_length, str_length, header) = if digest == MessageDigest::sha1() {
-            (PBKDF2_SHA1_EXTRACT, 80, "{PBKDF2-SHA1}")
-        } else if digest == MessageDigest::sha256() {
-            (PBKDF2_SHA256_EXTRACT, 100, "{PBKDF2-SHA256}")
-        } else if digest == MessageDigest::sha512() {
-            (PBKDF2_SHA512_EXTRACT, 140, "{PBKDF2-SHA512}")
-        } else {
-            return Err(PluginError::Unknown);
-        };
+    fn pbkdf2_encrypt(cleartext: &str, digest: MessageDigest, scheme: &str) -> Result<String, PluginError> {
+        let rounds = Self::get_pbkdf2_rounds(scheme)?;
+        let (hash_length, str_length, header) = Self::scheme_format(scheme)?;
 
         // generate salt
         let mut salt: Vec<u8> = (0..PBKDF2_SALT_LEN).map(|_| 0).collect();
@@ -339,7 +338,7 @@ impl PwdChanCrypto {
         let mut output = String::with_capacity(str_length);
         // Write the header
         output.push_str(header);
-        
+
         // The iter + delim
         write!(&mut output, "{}$", rounds).map_err(|e| {
             log_error!(ErrorLevel::Error, "Format Error -> {:?}", e);
@@ -350,36 +349,77 @@ impl PwdChanCrypto {
         // Push the delim
         output.push('$');
         // Finally the base64 hash
+<<<<<<< HEAD
         general_purpose::STANDARD.encode_string(&hash_input, &mut output);
         
+=======
+        base64::encode_config_buf(&hash_input, base64::STANDARD, &mut output);
+
+>>>>>>> 987ffaa27 (first)
         Ok(output)
     }
 
-    // Private helper method to get the appropriate AtomicUsize reference
-    fn get_rounds_atomic(digest: MessageDigest) -> &'static AtomicUsize {
-        match digest {
-            d if d == MessageDigest::sha1() => &PBKDF2_ROUNDS_SHA1,
-            d if d == MessageDigest::sha256() => &PBKDF2_ROUNDS_SHA256,
-            d if d == MessageDigest::sha512() => &PBKDF2_ROUNDS_SHA512,
-            _ => &PBKDF2_ROUNDS,
+    fn get_rounds_atomic(scheme: &str) -> Result<&'static AtomicUsize, PluginError> {
+        match scheme {
+            SCHEME_PBKDF2 => Ok(&PBKDF2_ROUNDS),
+            SCHEME_PBKDF2_SHA1 => Ok(&PBKDF2_ROUNDS_SHA1),
+            SCHEME_PBKDF2_SHA256 => Ok(&PBKDF2_ROUNDS_SHA256),
+            SCHEME_PBKDF2_SHA512 => Ok(&PBKDF2_ROUNDS_SHA512),
+            _ => Err(PluginError::Unknown),
         }
     }
 
-    fn get_accept_max_atomic(digest: MessageDigest) -> &'static AtomicUsize {
-        match digest {
-            d if d == MessageDigest::sha1() => &PBKDF2_ACCEPT_MAX_SHA1,
-            d if d == MessageDigest::sha256() => &PBKDF2_ACCEPT_MAX_SHA256,
-            d if d == MessageDigest::sha512() => &PBKDF2_ACCEPT_MAX_SHA512,
-            _ => &PBKDF2_ACCEPT_MAX,
+    fn get_accept_max_atomic(scheme: &str) -> Result<&'static AtomicUsize, PluginError> {
+        match scheme {
+            SCHEME_PBKDF2 => Ok(&PBKDF2_ACCEPT_MAX),
+            SCHEME_PBKDF2_SHA1 => Ok(&PBKDF2_ACCEPT_MAX_SHA1),
+            SCHEME_PBKDF2_SHA256 => Ok(&PBKDF2_ACCEPT_MAX_SHA256),
+            SCHEME_PBKDF2_SHA512 => Ok(&PBKDF2_ACCEPT_MAX_SHA512),
+            _ => Err(PluginError::Unknown),
         }
     }
 
-    fn digest_name(digest: MessageDigest) -> &'static str {
-        match digest {
-            d if d == MessageDigest::sha1() => "PBKDF2-SHA1",
-            d if d == MessageDigest::sha256() => "PBKDF2-SHA256",
-            d if d == MessageDigest::sha512() => "PBKDF2-SHA512",
-            _ => "PBKDF2",
+    #[cfg(test)]
+    fn set_test_rounds(scheme: &str, rounds: Option<usize>) {
+        match scheme {
+            SCHEME_PBKDF2 => TEST_PBKDF2_ROUNDS.with(|cell| cell.set(rounds)),
+            SCHEME_PBKDF2_SHA1 => TEST_PBKDF2_ROUNDS_SHA1.with(|cell| cell.set(rounds)),
+            SCHEME_PBKDF2_SHA256 => TEST_PBKDF2_ROUNDS_SHA256.with(|cell| cell.set(rounds)),
+            SCHEME_PBKDF2_SHA512 => TEST_PBKDF2_ROUNDS_SHA512.with(|cell| cell.set(rounds)),
+            _ => {}
+        }
+    }
+
+    #[cfg(test)]
+    fn get_test_rounds(scheme: &str) -> Option<usize> {
+        match scheme {
+            SCHEME_PBKDF2 => TEST_PBKDF2_ROUNDS.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA1 => TEST_PBKDF2_ROUNDS_SHA1.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA256 => TEST_PBKDF2_ROUNDS_SHA256.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA512 => TEST_PBKDF2_ROUNDS_SHA512.with(|cell| cell.get()),
+            _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    fn set_test_accept_max(scheme: &str, accept_max: Option<usize>) {
+        match scheme {
+            SCHEME_PBKDF2 => TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.set(accept_max)),
+            SCHEME_PBKDF2_SHA1 => TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.set(accept_max)),
+            SCHEME_PBKDF2_SHA256 => TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.set(accept_max)),
+            SCHEME_PBKDF2_SHA512 => TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.set(accept_max)),
+            _ => {}
+        }
+    }
+
+    #[cfg(test)]
+    fn get_test_accept_max(scheme: &str) -> Option<usize> {
+        match scheme {
+            SCHEME_PBKDF2 => TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA1 => TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA256 => TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.get()),
+            SCHEME_PBKDF2_SHA512 => TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.get()),
+            _ => None,
         }
     }
 
@@ -408,25 +448,17 @@ impl PwdChanCrypto {
         })
     }
 
-    fn handle_pbkdf2_config(pb: &mut PblockRef, digest: MessageDigest) -> Result<(), PluginError> {
-        let mut rounds = Self::get_rounds_atomic(digest).load(Ordering::Relaxed);
+    fn handle_pbkdf2_config(pb: &mut PblockRef, scheme: &str) -> Result<(), PluginError> {
+        let mut rounds = Self::get_pbkdf2_rounds(scheme)?;
+        let mut source = "default";
 
         let entry = pb.get_op_add_entryref()
             .map_err(|_| PluginError::InvalidConfiguration)?;
 
         if entry.get_attr(PBKDF2_ROUNDS_ATTR).is_some() {
             rounds = Self::parse_config_usize_attr(&entry, PBKDF2_ROUNDS_ATTR)?;
+            source = "configuration";
         }
-
-        Self::set_pbkdf2_rounds(digest, rounds)?;
-
-        let digest_name = Self::digest_name(digest);
-        log_error_ext!(
-            ErrorLevel::Info,
-            digest_name,
-            "Number of iterations set to {}",
-            rounds,
-        );
 
         let mut accept_max = rounds;
 
@@ -434,11 +466,27 @@ impl PwdChanCrypto {
             accept_max = Self::parse_config_usize_attr(&entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR)?;
         }
 
-        Self::set_pbkdf2_accept_max(digest, accept_max)?;
+        // Preserve accept_max >= rounds: raise accept_max first when needed.
+        let current_rounds = Self::get_pbkdf2_rounds(scheme)?;
+        if accept_max >= current_rounds {
+            Self::set_pbkdf2_accept_max(scheme, accept_max)?;
+            Self::set_pbkdf2_rounds(scheme, rounds)?;
+        } else {
+            Self::set_pbkdf2_rounds(scheme, rounds)?;
+            Self::set_pbkdf2_accept_max(scheme, accept_max)?;
+        }
 
         log_error_ext!(
             ErrorLevel::Info,
-            digest_name,
+            scheme,
+            "Number of iterations set to {} from {}",
+            rounds,
+            source,
+        );
+
+        log_error_ext!(
+            ErrorLevel::Info,
+            scheme,
             "PBKDF2 accept max iterations set to {}",
             accept_max,
         );
@@ -446,127 +494,103 @@ impl PwdChanCrypto {
         Ok(())
     }
 
-    fn set_pbkdf2_rounds(digest: MessageDigest, rounds: usize) -> Result<(), PluginError> {
-        Self::validate_pbkdf2_config_rounds(rounds)?;
+    fn set_pbkdf2_rounds(scheme: &str, rounds: usize) -> Result<(), PluginError> {
+        Self::validate_pbkdf2_rounds(rounds)?;
+
+        // Skip when accept max is unset (0); compare then falls back to rounds.
+        #[cfg(test)]
+        let configured_accept_max = Self::get_test_accept_max(scheme);
+        #[cfg(not(test))]
+        let configured_accept_max = {
+            let accept_max = Self::get_accept_max_atomic(scheme)?.load(Ordering::Relaxed);
+            if accept_max == 0 {
+                None
+            } else {
+                Some(accept_max)
+            }
+        };
+        if let Some(accept_max) = configured_accept_max {
+            if rounds > accept_max {
+                #[cfg(not(test))]
+                log_error_ext!(
+                    ErrorLevel::Error,
+                    scheme,
+                    "Invalid rounds {} for {}, must be <= {} {}",
+                    rounds,
+                    scheme,
+                    PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
+                    accept_max
+                );
+                return Err(PluginError::InvalidConfiguration);
+            }
+        }
 
         #[cfg(test)]
         {
-            // In test mode, store in thread-local storage
-            match digest {
-                d if d == MessageDigest::sha1() => {
-                    TEST_PBKDF2_ROUNDS_SHA1.with(|cell| cell.set(Some(rounds)));
-                },
-                d if d == MessageDigest::sha256() => {
-                    TEST_PBKDF2_ROUNDS_SHA256.with(|cell| cell.set(Some(rounds)));
-                },
-                d if d == MessageDigest::sha512() => {
-                    TEST_PBKDF2_ROUNDS_SHA512.with(|cell| cell.set(Some(rounds)));
-                },
-                _ => {
-                    TEST_PBKDF2_ROUNDS.with(|cell| cell.set(Some(rounds)));
-                },
-            }
+            Self::set_test_rounds(scheme, Some(rounds));
         }
 
         #[cfg(not(test))]
         {
-            Self::get_rounds_atomic(digest).store(rounds, Ordering::Relaxed);
+            Self::get_rounds_atomic(scheme)?.store(rounds, Ordering::Relaxed);
         }
 
         Ok(())
     }
 
-    fn get_pbkdf2_rounds(digest: MessageDigest) -> Result<usize, PluginError> {
+    fn get_pbkdf2_rounds(scheme: &str) -> Result<usize, PluginError> {
         #[cfg(test)]
         {
-            // In test mode, try to get from thread-local storage first
-            let thread_local_value = match digest {
-                d if d == MessageDigest::sha1() => {
-                    TEST_PBKDF2_ROUNDS_SHA1.with(|cell| cell.get())
-                },
-                d if d == MessageDigest::sha256() => {
-                    TEST_PBKDF2_ROUNDS_SHA256.with(|cell| cell.get())
-                },
-                d if d == MessageDigest::sha512() => {
-                    TEST_PBKDF2_ROUNDS_SHA512.with(|cell| cell.get())
-                },
-                _ => {
-                    TEST_PBKDF2_ROUNDS.with(|cell| cell.get())
-                },
-            };
-            
-            // If thread-local value exists, use it; otherwise fall back to global
-            if let Some(value) = thread_local_value {
+            if let Some(value) = Self::get_test_rounds(scheme) {
                 return Ok(value);
             }
         }
-        
-        // If not in test mode or no thread-local value, use global
-        Ok(Self::get_rounds_atomic(digest).load(Ordering::Relaxed))
+
+        Ok(Self::get_rounds_atomic(scheme)?.load(Ordering::Relaxed))
     }
 
-    fn set_pbkdf2_accept_max(digest: MessageDigest, accept_max: usize) -> Result<(), PluginError> {
-        if accept_max < MIN_PBKDF2_ROUNDS {
+    fn set_pbkdf2_accept_max(scheme: &str, accept_max: usize) -> Result<(), PluginError> {
+        Self::validate_pbkdf2_rounds(accept_max)?;
+
+        let rounds = Self::get_pbkdf2_rounds(scheme)?;
+        if accept_max < rounds {
             #[cfg(not(test))]
-            log_error!(
+            log_error_ext!(
                 ErrorLevel::Error,
-                "Invalid PBKDF2 accept max iterations {}, must be at least {}",
+                scheme,
+                "Invalid {} value {} for {}, must be >= configured rounds {}",
+                PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
                 accept_max,
-                MIN_PBKDF2_ROUNDS
+                scheme,
+                rounds
             );
             return Err(PluginError::InvalidConfiguration);
         }
 
         #[cfg(test)]
         {
-            match digest {
-                d if d == MessageDigest::sha1() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.set(Some(accept_max)));
-                }
-                d if d == MessageDigest::sha256() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.set(Some(accept_max)));
-                }
-                d if d == MessageDigest::sha512() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.set(Some(accept_max)));
-                }
-                _ => {
-                    TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.set(Some(accept_max)));
-                }
-            }
+            Self::set_test_accept_max(scheme, Some(accept_max));
         }
 
         #[cfg(not(test))]
         {
-            Self::get_accept_max_atomic(digest).store(accept_max, Ordering::Relaxed);
+            Self::get_accept_max_atomic(scheme)?.store(accept_max, Ordering::Relaxed);
         }
 
         Ok(())
     }
 
-    fn get_pbkdf2_accept_max(digest: MessageDigest) -> Result<usize, PluginError> {
+    fn get_pbkdf2_accept_max(scheme: &str) -> Result<usize, PluginError> {
         #[cfg(test)]
         {
-            let thread_local_value = match digest {
-                d if d == MessageDigest::sha1() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.get())
-                }
-                d if d == MessageDigest::sha256() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.get())
-                }
-                d if d == MessageDigest::sha512() => {
-                    TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.get())
-                }
-                _ => TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.get()),
-            };
-
-            if let Some(value) = thread_local_value {
+            if let Some(value) = Self::get_test_accept_max(scheme) {
                 return Ok(value);
             }
         }
 
-        let accept_max = Self::get_accept_max_atomic(digest).load(Ordering::Relaxed);
+        let accept_max = Self::get_accept_max_atomic(scheme)?.load(Ordering::Relaxed);
         if accept_max == 0 {
-            return Self::get_pbkdf2_rounds(digest);
+            return Self::get_pbkdf2_rounds(scheme);
         }
 
         Ok(accept_max)
@@ -598,60 +622,124 @@ mod tests {
         TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.set(None));
         TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.set(None));
 
-        // Set default values for this thread
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), DEFAULT_PBKDF2_ROUNDS).unwrap();
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), DEFAULT_PBKDF2_ROUNDS).unwrap();
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), DEFAULT_PBKDF2_ROUNDS).unwrap();
-        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), DEFAULT_PBKDF2_ROUNDS).unwrap();
-        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), DEFAULT_PBKDF2_ROUNDS).unwrap();
-        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha512(), DEFAULT_PBKDF2_ROUNDS).unwrap();
+        // Set default values for each scheme independently
+        for scheme in [
+            SCHEME_PBKDF2,
+            SCHEME_PBKDF2_SHA1,
+            SCHEME_PBKDF2_SHA256,
+            SCHEME_PBKDF2_SHA512,
+        ] {
+            PwdChanCrypto::set_pbkdf2_rounds(scheme, DEFAULT_PBKDF2_ROUNDS).unwrap();
+            PwdChanCrypto::set_pbkdf2_accept_max(scheme, DEFAULT_PBKDF2_ROUNDS).unwrap();
+        }
     }
 
     #[test]
     fn test_pbkdf2_encrypt_with_different_rounds() {
         // Reset to defaults first
         reset_pbkdf2_rounds();
-        
-        // Set different rounds for each algorithm
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), 15000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 20000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), 25000).is_ok());
 
-        // Verify rounds are correctly set
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha1()).unwrap(), 15000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha256()).unwrap(), 20000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha512()).unwrap(), 25000);
+        // Set different rounds for each scheme
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, 15000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA512, 25000).is_ok());
+
+        // Verify rounds are correctly set per scheme
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA1).unwrap(), 15000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA256).unwrap(), 20000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA512).unwrap(), 25000);
 
         let test_password = "test_password";
 
-        // Test SHA1
-        let sha1_result = PwdChanCrypto::pbkdf2_encrypt(test_password, MessageDigest::sha1()).unwrap();
-        // Check if it has the header and extract the rounds
+        // Test SHA1 (PBKDF2-SHA1 scheme)
+        let sha1_result = PwdChanCrypto::pbkdf2_encrypt(
+            test_password,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        )
+        .unwrap();
         assert!(sha1_result.starts_with("{PBKDF2-SHA1}"));
         let sha1_no_header = sha1_result.replace("{PBKDF2-SHA1}", "");
         let sha1_parts: Vec<&str> = sha1_no_header.split('$').collect();
         let rounds: usize = sha1_parts[0].parse().unwrap();
         assert_eq!(rounds, 15000, "SHA1 rounds should be 15000, got {}", rounds);
-        
+
         // Test SHA256
-        let sha256_result = PwdChanCrypto::pbkdf2_encrypt(test_password, MessageDigest::sha256()).unwrap();
-        // Check if it has the header and extract the rounds
+        let sha256_result = PwdChanCrypto::pbkdf2_encrypt(
+            test_password,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        )
+        .unwrap();
         assert!(sha256_result.starts_with("{PBKDF2-SHA256}"));
         let sha256_no_header = sha256_result.replace("{PBKDF2-SHA256}", "");
         let sha256_parts: Vec<&str> = sha256_no_header.split('$').collect();
         let rounds: usize = sha256_parts[0].parse().unwrap();
         assert_eq!(rounds, 20000, "SHA256 rounds should be 20000, got {}", rounds);
-        
+
         // Test SHA512
-        let sha512_result = PwdChanCrypto::pbkdf2_encrypt(test_password, MessageDigest::sha512()).unwrap();
-        // Check if it has the header and extract the rounds
+        let sha512_result = PwdChanCrypto::pbkdf2_encrypt(
+            test_password,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        )
+        .unwrap();
         assert!(sha512_result.starts_with("{PBKDF2-SHA512}"));
         let sha512_no_header = sha512_result.replace("{PBKDF2-SHA512}", "");
         let sha512_parts: Vec<&str> = sha512_no_header.split('$').collect();
         let rounds: usize = sha512_parts[0].parse().unwrap();
         assert_eq!(rounds, 25000, "SHA512 rounds should be 25000, got {}", rounds);
-        
+
         // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_legacy_and_sha1_independent_config() {
+        reset_pbkdf2_rounds();
+
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2, 11000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, 12000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2, 50000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1, 60000).is_ok());
+
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2).unwrap(), 11000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA1).unwrap(), 12000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2).unwrap(), 50000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1).unwrap(), 60000);
+
+        let legacy = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2,
+        )
+        .unwrap();
+        assert!(legacy.starts_with("{PBKDF2}"));
+        let legacy_rounds: usize = legacy
+            .trim_start_matches("{PBKDF2}")
+            .split('$')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(legacy_rounds, 11000);
+
+        let sha1 = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        )
+        .unwrap();
+        assert!(sha1.starts_with("{PBKDF2-SHA1}"));
+        let sha1_rounds: usize = sha1
+            .trim_start_matches("{PBKDF2-SHA1}")
+            .split('$')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(sha1_rounds, 12000);
+
         reset_pbkdf2_rounds();
     }
 
@@ -660,15 +748,15 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        // Test different rounds for each algorithm
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), 15000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 20000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), 25000).is_ok());
+        // Test different rounds for each scheme
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, 15000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA512, 25000).is_ok());
 
-        // Verify each algorithm has its own rounds setting
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha1()).unwrap(), 15000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha256()).unwrap(), 20000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(MessageDigest::sha512()).unwrap(), 25000);
+        // Verify each scheme has its own rounds setting
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA1).unwrap(), 15000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA256).unwrap(), 20000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA512).unwrap(), 25000);
 
         // Reset to defaults after test
         reset_pbkdf2_rounds();
@@ -680,19 +768,21 @@ mod tests {
         reset_pbkdf2_rounds();
 
         // Test max limit - should fail
-        let result = PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), MAX_PBKDF2_ROUNDS + 1);
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, MAX_PBKDF2_ROUNDS + 1);
         assert!(result.is_err());
 
         // Test min rounds - should succeed
-        let result = PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), MIN_PBKDF2_ROUNDS);
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, MIN_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
         // Test invalid rounds for SHA256 - too low - should fail
-        let result = PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), MIN_PBKDF2_ROUNDS - 1);
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, MIN_PBKDF2_ROUNDS - 1);
         assert!(result.is_err());
 
         // Test max rounds - should succeed
-        let result = PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), MAX_PBKDF2_ROUNDS);
+        // Accept max must be raised first so max rounds is allowed.
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS).unwrap();
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
         // Reset to defaults after test
@@ -704,17 +794,57 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        // Test different accept max for each algorithm
-        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), 15000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 20000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha512(), 25000).is_ok());
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, 15000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA512, 25000).unwrap();
 
-        // Verify each algorithm has its own accept max setting
-        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha1()).unwrap(), 15000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 20000);
-        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha512()).unwrap(), 25000);
+        // Test different accept max for each scheme
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1, 15000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 20000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA512, 25000).is_ok());
+
+        // Verify each scheme has its own accept max setting
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1).unwrap(), 15000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(), 20000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA512).unwrap(), 25000);
 
         // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_accept_max_must_be_at_least_rounds() {
+        reset_pbkdf2_rounds();
+
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 50000).unwrap();
+
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 40000);
+        assert!(result.is_err());
+
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 50000);
+        assert!(result.is_ok());
+
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_rounds_must_not_exceed_accept_max() {
+        reset_pbkdf2_rounds();
+
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 20000).unwrap();
+
+        // Raising rounds above accept max would create hashes compare rejects.
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 30000);
+        assert!(result.is_err());
+
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000);
+        assert!(result.is_ok());
+
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 30000).unwrap();
+        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 30000);
+        assert!(result.is_ok());
+
         reset_pbkdf2_rounds();
     }
 
@@ -723,17 +853,25 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, MIN_PBKDF2_ROUNDS).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, MIN_PBKDF2_ROUNDS).unwrap();
+
         // Test min limit - should fail
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), MIN_PBKDF2_ROUNDS - 1);
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1, MIN_PBKDF2_ROUNDS - 1);
         assert!(result.is_err());
 
         // Test min accept max - should succeed
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), MIN_PBKDF2_ROUNDS);
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1, MIN_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
         // Test high accept max - should succeed
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 600000);
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 600000);
         assert!(result.is_ok());
+
+        // Test accept max above policy/OpenSSL limit - should fail
+        let result =
+            PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS + 1);
+        assert!(result.is_err());
 
         // Reset to defaults after test
         reset_pbkdf2_rounds();
@@ -746,23 +884,23 @@ mod tests {
 
         // Valid hash - should succeed
         let valid_hash = "10000$salt123$hash456";
-        let result = PwdChanCrypto::pbkdf2_decompose(valid_hash, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_decompose(valid_hash, SCHEME_PBKDF2_SHA256);
         assert!(result.is_ok());
         let (iter, _salt, _hash) = result.unwrap();
         assert_eq!(iter, 10000);
 
         // Iteration count above accept max - should fail
         let high_hash = format!("{}$salt123$hash456", DEFAULT_PBKDF2_ROUNDS + 1);
-        let result = PwdChanCrypto::pbkdf2_decompose(&high_hash, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_decompose(&high_hash, SCHEME_PBKDF2_SHA256);
         assert!(result.is_err());
 
         // Iteration count below min - should fail
         let low_hash = format!("{}$salt123$hash456", MIN_PBKDF2_ROUNDS - 1);
-        let result = PwdChanCrypto::pbkdf2_decompose(&low_hash, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_decompose(&low_hash, SCHEME_PBKDF2_SHA256);
         assert!(result.is_err());
 
         // Invalid format - should fail
-        let result = PwdChanCrypto::pbkdf2_decompose("invalid", MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_decompose("invalid", SCHEME_PBKDF2_SHA256);
         assert!(result.is_err());
 
         // Reset to defaults after test
@@ -774,20 +912,30 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 10000).is_ok());
-        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 10000).is_ok());
-        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 10000);
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 10000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 10000).is_ok());
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(), 10000);
 
         // Stored iterations above accept max - should fail
         let encrypted = "36000$eElFb3p1WlZBb1lt$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";
-        let result = PwdChanCrypto::pbkdf2_compare("eicieY7ahchaoCh0eeTa", encrypted, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_compare(
+            "eicieY7ahchaoCh0eeTa",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        );
         assert!(result.is_err());
 
-        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 60000).is_ok());
-        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 60000);
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 60000).is_ok());
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(), 60000);
 
         // Stored iterations within accept max - should succeed
-        let result = PwdChanCrypto::pbkdf2_compare("eicieY7ahchaoCh0eeTa", encrypted, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_compare(
+            "eicieY7ahchaoCh0eeTa",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        );
         assert!(result == Ok(true));
 
         // Reset to defaults after test
@@ -803,12 +951,22 @@ mod tests {
 
         // Stored iterations above accept max - should fail
         let high_hash = format!("{}${}", DEFAULT_PBKDF2_ROUNDS + 1, encrypted_tail);
-        let result = PwdChanCrypto::pbkdf2_compare("password", &high_hash, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_compare(
+            "password",
+            &high_hash,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        );
         assert!(result.is_err());
 
         // Stored iterations below min - should fail
         let low_hash = format!("{}${}", MIN_PBKDF2_ROUNDS - 1, encrypted_tail);
-        let result = PwdChanCrypto::pbkdf2_compare("password", &low_hash, MessageDigest::sha256());
+        let result = PwdChanCrypto::pbkdf2_compare(
+            "password",
+            &low_hash,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        );
         assert!(result.is_err());
 
         // Reset to defaults after test
@@ -820,21 +978,64 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), 10000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2, 10000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA1, 10000).unwrap();
 
+        // Legacy {PBKDF2} scheme
         let encrypted = "10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w";
-        assert!(PwdChanCrypto::pbkdf2_compare("password", encrypted, MessageDigest::sha1()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", encrypted, MessageDigest::sha1()) == Ok(false));
-        assert!(PwdChanCrypto::pbkdf2_compare("incorrect", encrypted, MessageDigest::sha1()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            encrypted,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            encrypted,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2,
+        ) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "incorrect",
+            encrypted,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2,
+        ) == Ok(false));
 
+        // {PBKDF2-SHA1} scheme
         let encrypted = "10000$ZBEH6B07rgQpJSikyvMU2w$TAA03a5IYkz1QlPsbJKvUsTqNV";
-        assert!(PwdChanCrypto::pbkdf2_compare("password", encrypted, MessageDigest::sha1()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", encrypted, MessageDigest::sha1()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            encrypted,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            encrypted,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        ) == Ok(false));
 
-        let test_enc = PwdChanCrypto::pbkdf2_encrypt("password", MessageDigest::sha1()).expect("Failed to hash");
+        let test_enc = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        )
+        .expect("Failed to hash");
         let test_enc = test_enc.replace("{PBKDF2-SHA1}", "");
-        assert!(PwdChanCrypto::pbkdf2_compare("password", &test_enc, MessageDigest::sha1()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", &test_enc, MessageDigest::sha1()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            &test_enc,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            &test_enc,
+            MessageDigest::sha1(),
+            SCHEME_PBKDF2_SHA1,
+        ) == Ok(false));
 
         // Reset to defaults after test
         reset_pbkdf2_rounds();
@@ -845,12 +1046,27 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 10000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 10000).unwrap();
 
         let encrypted = "10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
-        assert!(PwdChanCrypto::pbkdf2_compare("password", encrypted, MessageDigest::sha256()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", encrypted, MessageDigest::sha256()) == Ok(false));
-        assert!(PwdChanCrypto::pbkdf2_compare("incorrect", encrypted, MessageDigest::sha256()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "incorrect",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(false));
 
         // This is a django password with their pbkdf2_sha256$ type.
         // "pbkdf2_sha256$36000$xIEozuZVAoYm$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w="
@@ -859,15 +1075,40 @@ mod tests {
         //                      eElFb3p1WlZBb1lt
         let encrypted = "36000$eElFb3p1WlZBb1lt$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";
         assert!(
-            PwdChanCrypto::pbkdf2_compare("eicieY7ahchaoCh0eeTa", encrypted, MessageDigest::sha256()) == Ok(true)
+            PwdChanCrypto::pbkdf2_compare(
+                "eicieY7ahchaoCh0eeTa",
+                encrypted,
+                MessageDigest::sha256(),
+                SCHEME_PBKDF2_SHA256,
+            ) == Ok(true)
         );
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", encrypted, MessageDigest::sha256()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            encrypted,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(false));
 
-        let test_enc = PwdChanCrypto::pbkdf2_encrypt("password", MessageDigest::sha256()).expect("Failed to hash");
+        let test_enc = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        )
+        .expect("Failed to hash");
         // Remove the header and check.
         let test_enc = test_enc.replace("{PBKDF2-SHA256}", "");
-        assert!(PwdChanCrypto::pbkdf2_compare("password", &test_enc, MessageDigest::sha256()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", &test_enc, MessageDigest::sha256()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            &test_enc,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            &test_enc,
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        ) == Ok(false));
 
         // Reset to defaults after test
         reset_pbkdf2_rounds();
@@ -878,18 +1119,48 @@ mod tests {
         // Reset to defaults first
         reset_pbkdf2_rounds();
 
-        PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), 10000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA512, 10000).unwrap();
 
         let encrypted = "10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA";
-        assert!(PwdChanCrypto::pbkdf2_compare("password", encrypted, MessageDigest::sha512()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", encrypted, MessageDigest::sha512()) == Ok(false));
-        assert!(PwdChanCrypto::pbkdf2_compare("incorrect", encrypted, MessageDigest::sha512()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            encrypted,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            encrypted,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        ) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "incorrect",
+            encrypted,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        ) == Ok(false));
 
-        let test_enc = PwdChanCrypto::pbkdf2_encrypt("password", MessageDigest::sha512()).expect("Failed to hash");
+        let test_enc = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        )
+        .expect("Failed to hash");
         // Remove the header and check.
         let test_enc = test_enc.replace("{PBKDF2-SHA512}", "");
-        assert!(PwdChanCrypto::pbkdf2_compare("password", &test_enc, MessageDigest::sha512()) == Ok(true));
-        assert!(PwdChanCrypto::pbkdf2_compare("password!", &test_enc, MessageDigest::sha512()) == Ok(false));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password",
+            &test_enc,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        ) == Ok(true));
+        assert!(PwdChanCrypto::pbkdf2_compare(
+            "password!",
+            &test_enc,
+            MessageDigest::sha512(),
+            SCHEME_PBKDF2_SHA512,
+        ) == Ok(false));
 
         // Reset to defaults after test
         reset_pbkdf2_rounds();

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -6,9 +6,10 @@ use base64::engine::{GeneralPurpose, general_purpose::{self, GeneralPurposeConfi
 use openssl::{hash::MessageDigest, pkcs5::pbkdf2_hmac, rand::rand_bytes};
 use slapi_r_plugin::prelude::*;
 use std::fmt::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::convert::TryInto;
 use std::os::raw::c_char;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A base64 engine that tolerates non-canonical trailing bits.
 /// OpenLDAP/passlib's ab64 encoding can produce trailing bits that
@@ -21,6 +22,7 @@ const B64_PERMISSIVE: GeneralPurpose = GeneralPurpose::new(
 );
 
 const DEFAULT_PBKDF2_ROUNDS: usize = 100_000;
+const DEFAULT_PBKDF2_ACCEPT_MAX: usize = 100_000;
 const MIN_PBKDF2_ROUNDS: usize = 10_000;
 const MAX_PBKDF2_ROUNDS: usize = 10_000_000;
 
@@ -33,16 +35,30 @@ const SCHEME_PBKDF2_SHA1: &str = "PBKDF2-SHA1";
 const SCHEME_PBKDF2_SHA256: &str = "PBKDF2-SHA256";
 const SCHEME_PBKDF2_SHA512: &str = "PBKDF2-SHA512";
 
-// Each algorithm gets its own atomic counter for thread-safe round and accept max iterations
+// Rejections outside range iteration counts are logged at most once per interval.
+const PBKDF2_REJECT_LOG_INTERVAL: u64 = 300;
+
+// Each algorithm gets its own atomic counter for thread-safe round and accept max iterations.
 static PBKDF2_ROUNDS: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA1: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA256: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA512: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 
-static PBKDF2_ACCEPT_MAX: AtomicUsize = AtomicUsize::new(0);
-static PBKDF2_ACCEPT_MAX_SHA1: AtomicUsize = AtomicUsize::new(0);
-static PBKDF2_ACCEPT_MAX_SHA256: AtomicUsize = AtomicUsize::new(0);
-static PBKDF2_ACCEPT_MAX_SHA512: AtomicUsize = AtomicUsize::new(0);
+static PBKDF2_ACCEPT_MAX: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ACCEPT_MAX);
+static PBKDF2_ACCEPT_MAX_SHA1: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ACCEPT_MAX);
+static PBKDF2_ACCEPT_MAX_SHA256: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ACCEPT_MAX);
+static PBKDF2_ACCEPT_MAX_SHA512: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ACCEPT_MAX);
+
+// Rejection log throttling and suppression counters.
+static PBKDF2_REJECT_LAST_LOG: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_LAST_LOG_SHA1: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_LAST_LOG_SHA256: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_LAST_LOG_SHA512: AtomicU64 = AtomicU64::new(0);
+
+static PBKDF2_REJECT_SUPPRESSED: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_SUPPRESSED_SHA1: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_SUPPRESSED_SHA256: AtomicU64 = AtomicU64::new(0);
+static PBKDF2_REJECT_SUPPRESSED_SHA512: AtomicU64 = AtomicU64::new(0);
 
 // Thread-local storage for test environment
 #[cfg(test)]
@@ -202,22 +218,90 @@ impl PwdChanCrypto {
     }
 
     fn validate_pbkdf2_stored_iterations(iterations: usize, scheme: &str) -> Result<(), PluginError> {
-        Self::validate_pbkdf2_rounds(iterations)?;
-
         let accept_max = Self::get_pbkdf2_accept_max(scheme)?;
-        if iterations > accept_max {
-            #[cfg(not(test))]
-            log_error!(
-                ErrorLevel::Warning,
-                "{} iteration count {} exceeds accept max {}",
-                scheme,
-                iterations,
-                accept_max
-            );
+        if iterations < MIN_PBKDF2_ROUNDS || iterations > accept_max {
+            Self::log_rejected_iterations(scheme, iterations, accept_max);
             return Err(PluginError::InvalidConfiguration);
         }
 
         Ok(())
+    }
+
+    fn get_reject_log_atomics(
+        scheme: &str,
+    ) -> Result<(&'static AtomicU64, &'static AtomicU64), PluginError> {
+        match scheme {
+            SCHEME_PBKDF2 => Ok((&PBKDF2_REJECT_LAST_LOG, &PBKDF2_REJECT_SUPPRESSED)),
+            SCHEME_PBKDF2_SHA1 => Ok((
+                &PBKDF2_REJECT_LAST_LOG_SHA1,
+                &PBKDF2_REJECT_SUPPRESSED_SHA1,
+            )),
+            SCHEME_PBKDF2_SHA256 => Ok((
+                &PBKDF2_REJECT_LAST_LOG_SHA256,
+                &PBKDF2_REJECT_SUPPRESSED_SHA256,
+            )),
+            SCHEME_PBKDF2_SHA512 => Ok((
+                &PBKDF2_REJECT_LAST_LOG_SHA512,
+                &PBKDF2_REJECT_SUPPRESSED_SHA512,
+            )),
+            _ => Err(PluginError::Unknown),
+        }
+    }
+
+    fn log_rejected_iterations(scheme: &str, iterations: usize, accept_max: usize) {
+        let Ok((last_log, suppressed_ctr)) = Self::get_reject_log_atomics(scheme) else {
+            return;
+        };
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let last = last_log.load(Ordering::Relaxed);
+
+        if last != 0 && now.saturating_sub(last) < PBKDF2_REJECT_LOG_INTERVAL {
+            suppressed_ctr.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        last_log.store(now, Ordering::Relaxed);
+        let suppressed = suppressed_ctr.swap(0, Ordering::Relaxed);
+
+        #[cfg(not(test))]
+        {
+            if iterations > accept_max {
+                log_error_ext!(
+                    ErrorLevel::Error,
+                    scheme,
+                    "Rejected a password hash with iteration count {} above the accepted maximum {}",
+                    iterations,
+                    accept_max,
+                );
+            } else {
+                log_error_ext!(
+                    ErrorLevel::Error,
+                    scheme,
+                    "Rejected a password hash with iteration count {} below the supported minimum {}",
+                    iterations,
+                    MIN_PBKDF2_ROUNDS,
+                );
+            }
+
+            if suppressed > 0 {
+                log_error_ext!(
+                    ErrorLevel::Error,
+                    scheme,
+                    "{} additional outside range iteration rejections were suppressed in the last {} seconds",
+                    suppressed,
+                    now.saturating_sub(last),
+                );
+            }
+        }
+
+        #[cfg(test)]
+        {
+            let _ = (iterations, accept_max, suppressed, last, now);
+        }
     }
 
     #[inline(always)]
@@ -311,7 +395,11 @@ impl PwdChanCrypto {
     }
 
     fn pbkdf2_encrypt(cleartext: &str, digest: MessageDigest, scheme: &str) -> Result<String, PluginError> {
-        let rounds = Self::get_pbkdf2_rounds(scheme)?;
+        let mut rounds = Self::get_pbkdf2_rounds(scheme)?;
+        let accept_max = Self::get_pbkdf2_accept_max(scheme)?;
+        if rounds > accept_max {
+            rounds = accept_max;
+        }
         let (hash_length, str_length, header) = Self::scheme_format(scheme)?;
 
         // generate salt
@@ -349,13 +437,8 @@ impl PwdChanCrypto {
         // Push the delim
         output.push('$');
         // Finally the base64 hash
-<<<<<<< HEAD
         general_purpose::STANDARD.encode_string(&hash_input, &mut output);
-        
-=======
-        base64::encode_config_buf(&hash_input, base64::STANDARD, &mut output);
 
->>>>>>> 987ffaa27 (first)
         Ok(output)
     }
 
@@ -448,33 +531,122 @@ impl PwdChanCrypto {
         })
     }
 
-    fn handle_pbkdf2_config(pb: &mut PblockRef, scheme: &str) -> Result<(), PluginError> {
-        let mut rounds = Self::get_pbkdf2_rounds(scheme)?;
-        let mut source = "default";
-
-        let entry = pb.get_op_add_entryref()
-            .map_err(|_| PluginError::InvalidConfiguration)?;
-
-        if entry.get_attr(PBKDF2_ROUNDS_ATTR).is_some() {
-            rounds = Self::parse_config_usize_attr(&entry, PBKDF2_ROUNDS_ATTR)?;
-            source = "configuration";
+    fn read_config_usize_attr(entry: &EntryRef, attr: &str) -> Option<usize> {
+        match Self::parse_config_usize_attr(entry, attr) {
+            Ok(value) => Some(value),
+            Err(_) => None,
         }
+    }
 
-        let mut accept_max = rounds;
+    // Resolve startup rounds and accept-max from optional configured values.
+    fn resolve_pbkdf2_startup_config(
+        configured_rounds: Option<usize>,
+        configured_accept_max: Option<usize>,
+    ) -> (usize, usize, &'static str, Option<usize>) {
+        let (mut rounds, source) = match configured_rounds {
+            Some(value) if Self::validate_pbkdf2_rounds(value).is_ok() => {
+                (value, "configuration")
+            }
+            _ => (DEFAULT_PBKDF2_ROUNDS, "default"),
+        };
 
-        if entry.get_attr(PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR).is_some() {
-            accept_max = Self::parse_config_usize_attr(&entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR)?;
-        }
+        let accept_max = match configured_accept_max {
+            Some(value) if Self::validate_pbkdf2_rounds(value).is_ok() => value,
+            _ => DEFAULT_PBKDF2_ACCEPT_MAX,
+        };
 
-        // Preserve accept_max >= rounds: raise accept_max first when needed.
-        let current_rounds = Self::get_pbkdf2_rounds(scheme)?;
-        if accept_max >= current_rounds {
-            Self::set_pbkdf2_accept_max(scheme, accept_max)?;
-            Self::set_pbkdf2_rounds(scheme, rounds)?;
+        let capped_from = if rounds > accept_max {
+            let original = rounds;
+            rounds = accept_max;
+            Some(original)
         } else {
-            Self::set_pbkdf2_rounds(scheme, rounds)?;
-            Self::set_pbkdf2_accept_max(scheme, accept_max)?;
+            None
+        };
+
+        (rounds, accept_max, source, capped_from)
+    }
+
+    fn handle_pbkdf2_config(pb: &mut PblockRef, scheme: &str) -> Result<(), PluginError> {
+        // Keep verification ceiling independent of generation rounds.
+        let mut configured_rounds = None;
+        let mut configured_accept_max = None;
+
+        if let Ok(entry) = pb.get_op_add_entryref() {
+            if entry.get_attr(PBKDF2_ROUNDS_ATTR).is_some() {
+                match Self::read_config_usize_attr(&entry, PBKDF2_ROUNDS_ATTR) {
+                    Some(value) if Self::validate_pbkdf2_rounds(value).is_ok() => {
+                        configured_rounds = Some(value);
+                    }
+                    Some(value) => {
+                        log_error_ext!(
+                            ErrorLevel::Error,
+                            scheme,
+                            "Invalid {} value {}, must be between {} and {}; using the default {}",
+                            PBKDF2_ROUNDS_ATTR,
+                            value,
+                            MIN_PBKDF2_ROUNDS,
+                            MAX_PBKDF2_ROUNDS,
+                            DEFAULT_PBKDF2_ROUNDS,
+                        );
+                        // Soft fallback: leave configured_rounds as None.
+                    }
+                    None => {
+                        log_error_ext!(
+                            ErrorLevel::Error,
+                            scheme,
+                            "Invalid {} value; using the default {}",
+                            PBKDF2_ROUNDS_ATTR,
+                            DEFAULT_PBKDF2_ROUNDS,
+                        );
+                    }
+                }
+            }
+
+            if entry.get_attr(PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR).is_some() {
+                match Self::read_config_usize_attr(&entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR) {
+                    Some(value) if Self::validate_pbkdf2_rounds(value).is_ok() => {
+                        configured_accept_max = Some(value);
+                    }
+                    Some(value) => {
+                        log_error_ext!(
+                            ErrorLevel::Error,
+                            scheme,
+                            "Invalid {} value {}, must be between {} and {}; using the default {}",
+                            PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
+                            value,
+                            MIN_PBKDF2_ROUNDS,
+                            MAX_PBKDF2_ROUNDS,
+                            DEFAULT_PBKDF2_ACCEPT_MAX,
+                        );
+                    }
+                    None => {
+                        log_error_ext!(
+                            ErrorLevel::Error,
+                            scheme,
+                            "Invalid {} value; using the default {}",
+                            PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
+                            DEFAULT_PBKDF2_ACCEPT_MAX,
+                        );
+                    }
+                }
+            }
         }
+
+        let (rounds, accept_max, source, capped_from) =
+            Self::resolve_pbkdf2_startup_config(configured_rounds, configured_accept_max);
+
+        if let Some(original_rounds) = capped_from {
+            log_error_ext!(
+                ErrorLevel::Info,
+                scheme,
+                "Configured {} rounds; capping at the configured accept max {}",
+                original_rounds,
+                accept_max,
+            );
+        }
+
+        Self::set_pbkdf2_accept_max(scheme, accept_max)?;
+        Self::set_pbkdf2_rounds(scheme, rounds)?;
 
         log_error_ext!(
             ErrorLevel::Info,
@@ -496,34 +668,6 @@ impl PwdChanCrypto {
 
     fn set_pbkdf2_rounds(scheme: &str, rounds: usize) -> Result<(), PluginError> {
         Self::validate_pbkdf2_rounds(rounds)?;
-
-        // Skip when accept max is unset (0); compare then falls back to rounds.
-        #[cfg(test)]
-        let configured_accept_max = Self::get_test_accept_max(scheme);
-        #[cfg(not(test))]
-        let configured_accept_max = {
-            let accept_max = Self::get_accept_max_atomic(scheme)?.load(Ordering::Relaxed);
-            if accept_max == 0 {
-                None
-            } else {
-                Some(accept_max)
-            }
-        };
-        if let Some(accept_max) = configured_accept_max {
-            if rounds > accept_max {
-                #[cfg(not(test))]
-                log_error_ext!(
-                    ErrorLevel::Error,
-                    scheme,
-                    "Invalid rounds {} for {}, must be <= {} {}",
-                    rounds,
-                    scheme,
-                    PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
-                    accept_max
-                );
-                return Err(PluginError::InvalidConfiguration);
-            }
-        }
 
         #[cfg(test)]
         {
@@ -552,21 +696,6 @@ impl PwdChanCrypto {
     fn set_pbkdf2_accept_max(scheme: &str, accept_max: usize) -> Result<(), PluginError> {
         Self::validate_pbkdf2_rounds(accept_max)?;
 
-        let rounds = Self::get_pbkdf2_rounds(scheme)?;
-        if accept_max < rounds {
-            #[cfg(not(test))]
-            log_error_ext!(
-                ErrorLevel::Error,
-                scheme,
-                "Invalid {} value {} for {}, must be >= configured rounds {}",
-                PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR,
-                accept_max,
-                scheme,
-                rounds
-            );
-            return Err(PluginError::InvalidConfiguration);
-        }
-
         #[cfg(test)]
         {
             Self::set_test_accept_max(scheme, Some(accept_max));
@@ -588,12 +717,7 @@ impl PwdChanCrypto {
             }
         }
 
-        let accept_max = Self::get_accept_max_atomic(scheme)?.load(Ordering::Relaxed);
-        if accept_max == 0 {
-            return Self::get_pbkdf2_rounds(scheme);
-        }
-
-        Ok(accept_max)
+        Ok(Self::get_accept_max_atomic(scheme)?.load(Ordering::Relaxed))
     }
 }
 
@@ -630,7 +754,7 @@ mod tests {
             SCHEME_PBKDF2_SHA512,
         ] {
             PwdChanCrypto::set_pbkdf2_rounds(scheme, DEFAULT_PBKDF2_ROUNDS).unwrap();
-            PwdChanCrypto::set_pbkdf2_accept_max(scheme, DEFAULT_PBKDF2_ROUNDS).unwrap();
+            PwdChanCrypto::set_pbkdf2_accept_max(scheme, DEFAULT_PBKDF2_ACCEPT_MAX).unwrap();
         }
     }
 
@@ -779,9 +903,7 @@ mod tests {
         let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, MIN_PBKDF2_ROUNDS - 1);
         assert!(result.is_err());
 
-        // Test max rounds - should succeed
-        // Accept max must be raised first so max rounds is allowed.
-        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS).unwrap();
+        // Test max rounds - should succeed even without raising accept max.
         let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
@@ -813,38 +935,137 @@ mod tests {
     }
 
     #[test]
-    fn test_pbkdf2_accept_max_must_be_at_least_rounds() {
+    fn test_pbkdf2_accept_max_independent_of_rounds() {
         reset_pbkdf2_rounds();
 
+        // Lowering generation rounds must not force the verification ceiling down.
         PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 50000).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, DEFAULT_PBKDF2_ACCEPT_MAX)
+            .unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).unwrap();
 
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 40000);
-        assert!(result.is_err());
+        assert_eq!(
+            PwdChanCrypto::get_pbkdf2_rounds(SCHEME_PBKDF2_SHA256).unwrap(),
+            20000
+        );
+        assert_eq!(
+            PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(),
+            DEFAULT_PBKDF2_ACCEPT_MAX
+        );
 
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 50000);
-        assert!(result.is_ok());
+        // Accept max below generation rounds is allowed; encrypt caps instead.
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 15000).is_ok());
+        assert_eq!(
+            PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(),
+            15000
+        );
 
         reset_pbkdf2_rounds();
     }
 
     #[test]
-    fn test_pbkdf2_rounds_must_not_exceed_accept_max() {
+    fn test_pbkdf2_encrypt_caps_rounds_to_accept_max() {
         reset_pbkdf2_rounds();
 
-        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000).unwrap();
-        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 20000).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 15000).unwrap();
+        PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 30000).unwrap();
 
-        // Raising rounds above accept max would create hashes compare rejects.
-        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 30000);
-        assert!(result.is_err());
+        let encrypted = PwdChanCrypto::pbkdf2_encrypt(
+            "password",
+            MessageDigest::sha256(),
+            SCHEME_PBKDF2_SHA256,
+        )
+        .unwrap();
+        let rounds: usize = encrypted
+            .trim_start_matches("{PBKDF2-SHA256}")
+            .split('$')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(rounds, 15000);
 
-        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 20000);
-        assert!(result.is_ok());
+        reset_pbkdf2_rounds();
+    }
 
-        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 30000).unwrap();
-        let result = PwdChanCrypto::set_pbkdf2_rounds(SCHEME_PBKDF2_SHA256, 30000);
-        assert!(result.is_ok());
+    #[test]
+    fn test_pbkdf2_startup_config_soft_fallback_and_cap() {
+        // Missing config -> independent defaults.
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(None, None);
+        assert_eq!(rounds, DEFAULT_PBKDF2_ROUNDS);
+        assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
+        assert_eq!(source, "default");
+        assert!(capped_from.is_none());
 
+        // Invalid values fall back to defaults (soft).
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(
+                Some(MIN_PBKDF2_ROUNDS - 1),
+                Some(MAX_PBKDF2_ROUNDS + 1),
+            );
+        assert_eq!(rounds, DEFAULT_PBKDF2_ROUNDS);
+        assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
+        assert_eq!(source, "default");
+        assert!(capped_from.is_none());
+
+        // Lowered rounds keep the independent accept-max default.
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(Some(20000), None);
+        assert_eq!(rounds, 20000);
+        assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
+        assert_eq!(source, "configuration");
+        assert!(capped_from.is_none());
+
+        // Rounds above accept-max are capped, not rejected.
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(Some(30000), Some(15000));
+        assert_eq!(rounds, 15000);
+        assert_eq!(accept_max, 15000);
+        assert_eq!(source, "configuration");
+        assert_eq!(capped_from, Some(30000));
+    }
+
+    fn reset_reject_log_state(scheme: &str) {
+        let (last_log, suppressed) = PwdChanCrypto::get_reject_log_atomics(scheme).unwrap();
+        last_log.store(0, Ordering::Relaxed);
+        suppressed.store(0, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_pbkdf2_reject_log_throttle() {
+        reset_pbkdf2_rounds();
+        reset_reject_log_state(SCHEME_PBKDF2_SHA256);
+        PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 10000).unwrap();
+
+        let (last_log, suppressed) =
+            PwdChanCrypto::get_reject_log_atomics(SCHEME_PBKDF2_SHA256).unwrap();
+
+        // First rejection records last-log time and does not suppress.
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            20000,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_err());
+        let first_log = last_log.load(Ordering::Relaxed);
+        assert_ne!(first_log, 0);
+        assert_eq!(suppressed.load(Ordering::Relaxed), 0);
+
+        // Further rejections inside the interval only bump the suppressed count.
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            20000,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_err());
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            MIN_PBKDF2_ROUNDS - 1,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_err());
+        assert_eq!(last_log.load(Ordering::Relaxed), first_log);
+        assert_eq!(suppressed.load(Ordering::Relaxed), 2);
+
+        reset_reject_log_state(SCHEME_PBKDF2_SHA256);
         reset_pbkdf2_rounds();
     }
 

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -25,11 +25,17 @@ const MIN_PBKDF2_ROUNDS: usize = 10_000;
 const MAX_PBKDF2_ROUNDS: usize = 10_000_000;
 
 const PBKDF2_ROUNDS_ATTR: &str = "nsslapd-pwdPBKDF2NumIterations";
-// Each algorithm gets its own atomic counter for thread-safe round configuration
+const PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR: &str = "nsslapd-pwdPBKDF2AcceptMaxIterations";
+// Each algorithm gets its own atomic counter for thread-safe round and accept max iterations
 static PBKDF2_ROUNDS: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA1: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA256: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
 static PBKDF2_ROUNDS_SHA512: AtomicUsize = AtomicUsize::new(DEFAULT_PBKDF2_ROUNDS);
+
+static PBKDF2_ACCEPT_MAX: AtomicUsize = AtomicUsize::new(0);
+static PBKDF2_ACCEPT_MAX_SHA1: AtomicUsize = AtomicUsize::new(0);
+static PBKDF2_ACCEPT_MAX_SHA256: AtomicUsize = AtomicUsize::new(0);
+static PBKDF2_ACCEPT_MAX_SHA512: AtomicUsize = AtomicUsize::new(0);
 
 // Thread-local storage for test environment
 #[cfg(test)]
@@ -38,6 +44,10 @@ thread_local! {
     static TEST_PBKDF2_ROUNDS_SHA1: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
     static TEST_PBKDF2_ROUNDS_SHA256: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
     static TEST_PBKDF2_ROUNDS_SHA512: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
+    static TEST_PBKDF2_ACCEPT_MAX: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
+    static TEST_PBKDF2_ACCEPT_MAX_SHA1: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
+    static TEST_PBKDF2_ACCEPT_MAX_SHA256: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
+    static TEST_PBKDF2_ACCEPT_MAX_SHA512: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
 }
 
 const PBKDF2_SALT_LEN: usize = 24;
@@ -133,7 +143,7 @@ macro_rules! impl_slapi_pbkdf2_plugin {
 
             fn start(pb: &mut PblockRef) -> Result<(), PluginError> {
                 log_error!(ErrorLevel::Trace, "{} plugin start", Self::scheme_name());
-                PwdChanCrypto::handle_pbkdf2_rounds_config(pb, Self::digest_type())?;
+                PwdChanCrypto::handle_pbkdf2_config(pb, Self::digest_type())?;
                 Ok(())
             }
 
@@ -168,19 +178,68 @@ impl_slapi_pbkdf2_plugin!(pbkdf2_sha256::PwdChanPbkdf2Sha256);
 impl_slapi_pbkdf2_plugin!(pbkdf2_sha512::PwdChanPbkdf2Sha512);
 
 impl PwdChanCrypto {
+    fn validate_pbkdf2_config_rounds(rounds: usize) -> Result<(), PluginError> {
+        if rounds < MIN_PBKDF2_ROUNDS || rounds > MAX_PBKDF2_ROUNDS {
+            #[cfg(not(test))]
+            log_error!(
+                ErrorLevel::Error,
+                "Invalid PBKDF2 number of iterations {}, must be between {} and {}",
+                rounds,
+                MIN_PBKDF2_ROUNDS,
+                MAX_PBKDF2_ROUNDS
+            );
+            return Err(PluginError::InvalidConfiguration);
+        }
+
+        Ok(())
+    }
+
+    fn validate_pbkdf2_stored_iterations(iterations: usize, digest: MessageDigest,
+    ) -> Result<(), PluginError> {
+        if iterations < MIN_PBKDF2_ROUNDS {
+            #[cfg(not(test))]
+            log_error!(
+                ErrorLevel::Warning,
+                "PBKDF2 iteration count {} is below minimum {}",
+                iterations,
+                MIN_PBKDF2_ROUNDS
+            );
+            return Err(PluginError::InvalidConfiguration);
+        }
+
+        let accept_max = Self::get_pbkdf2_accept_max(digest)?;
+        if iterations > accept_max {
+            #[cfg(not(test))]
+            log_error!(
+                ErrorLevel::Warning,
+                "PBKDF2 iteration count {} exceeds accept max {}",
+                iterations,
+                accept_max
+            );
+            return Err(PluginError::InvalidConfiguration);
+        }
+
+        Ok(())
+    }
+
     #[inline(always)]
-    fn pbkdf2_decompose(encrypted: &str) -> Result<(usize, Vec<u8>, Vec<u8>), PluginError> {
+    fn pbkdf2_decompose(encrypted: &str, digest: MessageDigest,
+    ) -> Result<(usize, Vec<u8>, Vec<u8>), PluginError>
+    {
         let mut part_iter = encrypted.split('$');
 
         let iter = part_iter
             .next()
             .ok_or(PluginError::MissingValue)
             .and_then(|iter_str| {
-                usize::from_str_radix(iter_str, 10).map_err(|e| {
-                    log_error!(ErrorLevel::Error, "Invalid Integer {} -> {:?}", iter_str, e);
+                usize::from_str_radix(iter_str, 10).map_err(|_e| {
+                    #[cfg(not(test))]
+                    log_error!(ErrorLevel::Error, "Invalid Integer {} -> {:?}", iter_str, _e);
                     PluginError::InvalidStrToInt
                 })
             })?;
+
+        Self::validate_pbkdf2_stored_iterations(iter, digest)?;
 
         let salt = part_iter
             .next()
@@ -214,11 +273,18 @@ impl PwdChanCrypto {
         encrypted: &str,
         digest: MessageDigest,
     ) -> Result<bool, PluginError> {
-        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted).map_err(|e| {
-            // This means our DB content is flawed.
-            log_error!(ErrorLevel::Error, "invalid hashed pw -> {:?}", e);
-            e
-        })?;
+        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted, digest)
+            .map_err(|e| {
+                match e {
+                    // Iteration bounds are logged in validate_pbkdf2_stored_iterations.
+                    PluginError::InvalidConfiguration => e,
+                    _ => {
+                        #[cfg(not(test))]
+                        log_error!(ErrorLevel::Error, "invalid hashed pw -> {:?}", e);
+                        e
+                    }
+                }
+            })?;
         // Need to pre-alloc the space as as_mut_slice can't resize.
         let mut hash_input: Vec<u8> = (0..hash_expected.len()).map(|_| 0).collect();
 
@@ -299,75 +365,89 @@ impl PwdChanCrypto {
         }
     }
 
-    fn handle_pbkdf2_rounds_config(pb: &mut PblockRef, digest: MessageDigest) -> Result<(), PluginError> {
-        let mut rounds = Self::get_rounds_atomic(digest).load(Ordering::Relaxed);
-        let mut source = "default";
+    fn get_accept_max_atomic(digest: MessageDigest) -> &'static AtomicUsize {
+        match digest {
+            d if d == MessageDigest::sha1() => &PBKDF2_ACCEPT_MAX_SHA1,
+            d if d == MessageDigest::sha256() => &PBKDF2_ACCEPT_MAX_SHA256,
+            d if d == MessageDigest::sha512() => &PBKDF2_ACCEPT_MAX_SHA512,
+            _ => &PBKDF2_ACCEPT_MAX,
+        }
+    }
 
-        // Try to get the entry from the parameter block
+    fn digest_name(digest: MessageDigest) -> &'static str {
+        match digest {
+            d if d == MessageDigest::sha1() => "PBKDF2-SHA1",
+            d if d == MessageDigest::sha256() => "PBKDF2-SHA256",
+            d if d == MessageDigest::sha512() => "PBKDF2-SHA512",
+            _ => "PBKDF2",
+        }
+    }
+
+    fn parse_config_usize_attr(
+        entry: &EntryRef,
+        attr: &str,
+    ) -> Result<usize, PluginError> {
+        let value_array = entry
+            .get_attr(attr)
+            .ok_or(PluginError::InvalidConfiguration)?;
+        let value = value_array.first().ok_or(PluginError::InvalidConfiguration)?;
+        let value_str: String = value.as_ref().try_into().map_err(|_| {
+            log_error!(ErrorLevel::Error, "Failed to parse {} value", attr);
+            PluginError::InvalidConfiguration
+        })?;
+
+        value_str.parse::<usize>().map_err(|e| {
+            log_error!(
+                ErrorLevel::Error,
+                "Invalid {} value '{}': {}",
+                attr,
+                value_str,
+                e
+            );
+            PluginError::InvalidConfiguration
+        })
+    }
+
+    fn handle_pbkdf2_config(pb: &mut PblockRef, digest: MessageDigest) -> Result<(), PluginError> {
+        let mut rounds = Self::get_rounds_atomic(digest).load(Ordering::Relaxed);
+
         let entry = pb.get_op_add_entryref()
             .map_err(|_| PluginError::InvalidConfiguration)?;
 
-        // Check if the rounds attribute exists and get its value
-        if let Some(value_array) = entry.get_attr(PBKDF2_ROUNDS_ATTR) {
-            if let Some(value) = value_array.first() {
-                let rounds_str: String = value
-                    .as_ref()
-                    .try_into()
-                    .map_err(|_| {
-                        log_error!(
-                            ErrorLevel::Error,
-                            "Failed to parse {} value",
-                            PBKDF2_ROUNDS_ATTR
-                        );
-                        PluginError::InvalidConfiguration
-                    })?;
-
-                rounds = rounds_str.parse::<usize>().map_err(|e| {
-                    log_error!(
-                        ErrorLevel::Error,
-                        "Invalid PBKDF2 number of iterations value '{}': {}",
-                        rounds_str,
-                        e
-                    );
-                    PluginError::InvalidConfiguration
-                })?;
-                source = "configuration";
-            }
+        if entry.get_attr(PBKDF2_ROUNDS_ATTR).is_some() {
+            rounds = Self::parse_config_usize_attr(&entry, PBKDF2_ROUNDS_ATTR)?;
         }
 
         Self::set_pbkdf2_rounds(digest, rounds)?;
 
-        let digest_name = if digest == MessageDigest::sha1() {
-            "PBKDF2-SHA1"
-        } else if digest == MessageDigest::sha256() {
-            "PBKDF2-SHA256"
-        } else if digest == MessageDigest::sha512() {
-            "PBKDF2-SHA512"
-        } else {
-            "Unknown"
-        };
+        let digest_name = Self::digest_name(digest);
+        log_error_ext!(
+            ErrorLevel::Info,
+            digest_name,
+            "Number of iterations set to {}",
+            rounds,
+        );
+
+        let mut accept_max = rounds;
+
+        if entry.get_attr(PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR).is_some() {
+            accept_max = Self::parse_config_usize_attr(&entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR)?;
+        }
+
+        Self::set_pbkdf2_accept_max(digest, accept_max)?;
 
         log_error_ext!(
             ErrorLevel::Info,
             digest_name,
-            "Number of iterations set to {} from {}",
-            rounds,
-            source
+            "PBKDF2 accept max iterations set to {}",
+            accept_max,
         );
+
         Ok(())
     }
 
     fn set_pbkdf2_rounds(digest: MessageDigest, rounds: usize) -> Result<(), PluginError> {
-        if rounds < MIN_PBKDF2_ROUNDS || rounds > MAX_PBKDF2_ROUNDS {
-            log_error!(
-                ErrorLevel::Error,
-                "Invalid PBKDF2 number of iterations {}, must be between {} and {}",
-                rounds,
-                MIN_PBKDF2_ROUNDS,
-                MAX_PBKDF2_ROUNDS
-            );
-            return Err(PluginError::InvalidConfiguration);
-        }
+        Self::validate_pbkdf2_config_rounds(rounds)?;
 
         #[cfg(test)]
         {
@@ -424,6 +504,73 @@ impl PwdChanCrypto {
         // If not in test mode or no thread-local value, use global
         Ok(Self::get_rounds_atomic(digest).load(Ordering::Relaxed))
     }
+
+    fn set_pbkdf2_accept_max(digest: MessageDigest, accept_max: usize) -> Result<(), PluginError> {
+        if accept_max < MIN_PBKDF2_ROUNDS {
+            #[cfg(not(test))]
+            log_error!(
+                ErrorLevel::Error,
+                "Invalid PBKDF2 accept max iterations {}, must be at least {}",
+                accept_max,
+                MIN_PBKDF2_ROUNDS
+            );
+            return Err(PluginError::InvalidConfiguration);
+        }
+
+        #[cfg(test)]
+        {
+            match digest {
+                d if d == MessageDigest::sha1() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.set(Some(accept_max)));
+                }
+                d if d == MessageDigest::sha256() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.set(Some(accept_max)));
+                }
+                d if d == MessageDigest::sha512() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.set(Some(accept_max)));
+                }
+                _ => {
+                    TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.set(Some(accept_max)));
+                }
+            }
+        }
+
+        #[cfg(not(test))]
+        {
+            Self::get_accept_max_atomic(digest).store(accept_max, Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    fn get_pbkdf2_accept_max(digest: MessageDigest) -> Result<usize, PluginError> {
+        #[cfg(test)]
+        {
+            let thread_local_value = match digest {
+                d if d == MessageDigest::sha1() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.get())
+                }
+                d if d == MessageDigest::sha256() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.get())
+                }
+                d if d == MessageDigest::sha512() => {
+                    TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.get())
+                }
+                _ => TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.get()),
+            };
+
+            if let Some(value) = thread_local_value {
+                return Ok(value);
+            }
+        }
+
+        let accept_max = Self::get_accept_max_atomic(digest).load(Ordering::Relaxed);
+        if accept_max == 0 {
+            return Self::get_pbkdf2_rounds(digest);
+        }
+
+        Ok(accept_max)
+    }
 }
 
 #[cfg(test)]
@@ -446,11 +593,18 @@ mod tests {
         TEST_PBKDF2_ROUNDS_SHA1.with(|cell| cell.set(None));
         TEST_PBKDF2_ROUNDS_SHA256.with(|cell| cell.set(None));
         TEST_PBKDF2_ROUNDS_SHA512.with(|cell| cell.set(None));
-        
+        TEST_PBKDF2_ACCEPT_MAX.with(|cell| cell.set(None));
+        TEST_PBKDF2_ACCEPT_MAX_SHA1.with(|cell| cell.set(None));
+        TEST_PBKDF2_ACCEPT_MAX_SHA256.with(|cell| cell.set(None));
+        TEST_PBKDF2_ACCEPT_MAX_SHA512.with(|cell| cell.set(None));
+
         // Set default values for this thread
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), DEFAULT_PBKDF2_ROUNDS).unwrap();
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), DEFAULT_PBKDF2_ROUNDS).unwrap();
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), DEFAULT_PBKDF2_ROUNDS).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), DEFAULT_PBKDF2_ROUNDS).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), DEFAULT_PBKDF2_ROUNDS).unwrap();
+        PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha512(), DEFAULT_PBKDF2_ROUNDS).unwrap();
     }
 
     #[test]
@@ -546,23 +700,126 @@ mod tests {
     }
 
     #[test]
+    fn test_pbkdf2_accept_max_configuration() {
+        // Reset to defaults first
+        reset_pbkdf2_rounds();
+
+        // Test different accept max for each algorithm
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), 15000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 20000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha512(), 25000).is_ok());
+
+        // Verify each algorithm has its own accept max setting
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha1()).unwrap(), 15000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 20000);
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha512()).unwrap(), 25000);
+
+        // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_accept_max_limits() {
+        // Reset to defaults first
+        reset_pbkdf2_rounds();
+
+        // Test min limit - should fail
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), MIN_PBKDF2_ROUNDS - 1);
+        assert!(result.is_err());
+
+        // Test min accept max - should succeed
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha1(), MIN_PBKDF2_ROUNDS);
+        assert!(result.is_ok());
+
+        // Test high accept max - should succeed
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 600000);
+        assert!(result.is_ok());
+
+        // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
     fn test_pbkdf2_decompose() {
+        // Reset to defaults first
+        reset_pbkdf2_rounds();
+
+        // Valid hash - should succeed
         let valid_hash = "10000$salt123$hash456";
-        let result = PwdChanCrypto::pbkdf2_decompose(valid_hash);
+        let result = PwdChanCrypto::pbkdf2_decompose(valid_hash, MessageDigest::sha256());
         assert!(result.is_ok());
         let (iter, _salt, _hash) = result.unwrap();
         assert_eq!(iter, 10000);
 
-        // Test invalid format
-        let invalid_hash = "invalid";
-        assert!(PwdChanCrypto::pbkdf2_decompose(invalid_hash).is_err());
+        // Iteration count above accept max - should fail
+        let high_hash = format!("{}$salt123$hash456", DEFAULT_PBKDF2_ROUNDS + 1);
+        let result = PwdChanCrypto::pbkdf2_decompose(&high_hash, MessageDigest::sha256());
+        assert!(result.is_err());
+
+        // Iteration count below min - should fail
+        let low_hash = format!("{}$salt123$hash456", MIN_PBKDF2_ROUNDS - 1);
+        let result = PwdChanCrypto::pbkdf2_decompose(&low_hash, MessageDigest::sha256());
+        assert!(result.is_err());
+
+        // Invalid format - should fail
+        let result = PwdChanCrypto::pbkdf2_decompose("invalid", MessageDigest::sha256());
+        assert!(result.is_err());
+
+        // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_compare_accept_max_iterations() {
+        // Reset to defaults first
+        reset_pbkdf2_rounds();
+
+        assert!(PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 10000).is_ok());
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 10000).is_ok());
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 10000);
+
+        // Stored iterations above accept max - should fail
+        let encrypted = "36000$eElFb3p1WlZBb1lt$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";
+        let result = PwdChanCrypto::pbkdf2_compare("eicieY7ahchaoCh0eeTa", encrypted, MessageDigest::sha256());
+        assert!(result.is_err());
+
+        assert!(PwdChanCrypto::set_pbkdf2_accept_max(MessageDigest::sha256(), 60000).is_ok());
+        assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(MessageDigest::sha256()).unwrap(), 60000);
+
+        // Stored iterations within accept max - should succeed
+        let result = PwdChanCrypto::pbkdf2_compare("eicieY7ahchaoCh0eeTa", encrypted, MessageDigest::sha256());
+        assert!(result == Ok(true));
+
+        // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_compare_reject_invalid_iterations() {
+        // Reset to defaults first
+        reset_pbkdf2_rounds();
+
+        let encrypted_tail = "henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
+
+        // Stored iterations above accept max - should fail
+        let high_hash = format!("{}${}", DEFAULT_PBKDF2_ROUNDS + 1, encrypted_tail);
+        let result = PwdChanCrypto::pbkdf2_compare("password", &high_hash, MessageDigest::sha256());
+        assert!(result.is_err());
+
+        // Stored iterations below min - should fail
+        let low_hash = format!("{}${}", MIN_PBKDF2_ROUNDS - 1, encrypted_tail);
+        let result = PwdChanCrypto::pbkdf2_compare("password", &low_hash, MessageDigest::sha256());
+        assert!(result.is_err());
+
+        // Reset to defaults after test
+        reset_pbkdf2_rounds();
     }
 
     #[test]
     fn pwdchan_pbkdf2_sha1_basic() {
         // Reset to defaults first
         reset_pbkdf2_rounds();
-        
+
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha1(), 10000).unwrap();
 
         let encrypted = "10000$IlfapjA351LuDSwYC0IQ8Q$saHqQTuYnjJN/tmAndT.8mJt.6w";
@@ -587,7 +844,7 @@ mod tests {
     fn pwdchan_pbkdf2_sha256_basic() {
         // Reset to defaults first
         reset_pbkdf2_rounds();
-        
+
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha256(), 10000).unwrap();
 
         let encrypted = "10000$henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
@@ -620,7 +877,7 @@ mod tests {
     fn pwdchan_pbkdf2_sha512_basic() {
         // Reset to defaults first
         reset_pbkdf2_rounds();
-        
+
         PwdChanCrypto::set_pbkdf2_rounds(MessageDigest::sha512(), 10000).unwrap();
 
         let encrypted = "10000$Je1Uw19Bfv5lArzZ6V3EPw$g4T/1sqBUYWl9o93MVnyQ/8zKGSkPbKaXXsT8WmysXQJhWy8MRP2JFudSL.N9RklQYgDPxPjnfum/F2f/TrppA";

--- a/src/plugins/pwdchan/src/lib.rs
+++ b/src/plugins/pwdchan/src/lib.rs
@@ -22,9 +22,11 @@ const B64_PERMISSIVE: GeneralPurpose = GeneralPurpose::new(
 );
 
 const DEFAULT_PBKDF2_ROUNDS: usize = 100_000;
-const DEFAULT_PBKDF2_ACCEPT_MAX: usize = 100_000;
 const MIN_PBKDF2_ROUNDS: usize = 10_000;
 const MAX_PBKDF2_ROUNDS: usize = 10_000_000;
+// Missing/invalid accept-max falls back to the highest generation limit the
+// plugin already allowed, so upgraded installs keep verifying existing hashes.
+const DEFAULT_PBKDF2_ACCEPT_MAX: usize = MAX_PBKDF2_ROUNDS;
 
 const PBKDF2_ROUNDS_ATTR: &str = "nsslapd-pwdPBKDF2NumIterations";
 const PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR: &str = "nsslapd-pwdPBKDF2AcceptMaxIterations";
@@ -355,18 +357,15 @@ impl PwdChanCrypto {
         digest: MessageDigest,
         scheme: &str,
     ) -> Result<bool, PluginError> {
-        let (iter, salt, hash_expected) = Self::pbkdf2_decompose(encrypted, scheme)
-            .map_err(|e| {
-                match e {
-                    // Iteration bounds are logged in validate_pbkdf2_stored_iterations.
-                    PluginError::InvalidConfiguration => e,
-                    _ => {
-                        #[cfg(not(test))]
-                        log_error!(ErrorLevel::Error, "invalid hashed pw -> {:?}", e);
-                        e
-                    }
-                }
-            })?;
+        let (iter, salt, hash_expected) = match Self::pbkdf2_decompose(encrypted, scheme) {
+            Ok(parts) => parts,
+            Err(PluginError::InvalidConfiguration) => return Ok(false),
+            Err(e) => {
+                #[cfg(not(test))]
+                log_error!(ErrorLevel::Error, "invalid hashed pw -> {:?}", e);
+                return Err(e);
+            }
+        };
         // Need to pre-alloc the space as as_mut_slice can't resize.
         let mut hash_input: Vec<u8> = (0..hash_expected.len()).map(|_| 0).collect();
 
@@ -538,7 +537,6 @@ impl PwdChanCrypto {
         }
     }
 
-    // Resolve startup rounds and accept-max from optional configured values.
     fn resolve_pbkdf2_startup_config(
         configured_rounds: Option<usize>,
         configured_accept_max: Option<usize>,
@@ -581,23 +579,22 @@ impl PwdChanCrypto {
                         log_error_ext!(
                             ErrorLevel::Error,
                             scheme,
-                            "Invalid {} value {}, must be between {} and {}; using the default {}",
+                            "Invalid {} value {}, must be between {} and {}",
                             PBKDF2_ROUNDS_ATTR,
                             value,
                             MIN_PBKDF2_ROUNDS,
                             MAX_PBKDF2_ROUNDS,
-                            DEFAULT_PBKDF2_ROUNDS,
                         );
-                        // Soft fallback: leave configured_rounds as None.
+                        return Err(PluginError::InvalidConfiguration);
                     }
                     None => {
                         log_error_ext!(
                             ErrorLevel::Error,
                             scheme,
-                            "Invalid {} value; using the default {}",
+                            "Invalid {} value",
                             PBKDF2_ROUNDS_ATTR,
-                            DEFAULT_PBKDF2_ROUNDS,
                         );
+                        return Err(PluginError::InvalidConfiguration);
                     }
                 }
             }
@@ -998,12 +995,8 @@ mod tests {
         assert_eq!(source, "default");
         assert!(capped_from.is_none());
 
-        // Invalid values fall back to defaults (soft).
         let (rounds, accept_max, source, capped_from) =
-            PwdChanCrypto::resolve_pbkdf2_startup_config(
-                Some(MIN_PBKDF2_ROUNDS - 1),
-                Some(MAX_PBKDF2_ROUNDS + 1),
-            );
+            PwdChanCrypto::resolve_pbkdf2_startup_config(None, Some(MAX_PBKDF2_ROUNDS + 1));
         assert_eq!(rounds, DEFAULT_PBKDF2_ROUNDS);
         assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
         assert_eq!(source, "default");
@@ -1013,6 +1006,22 @@ mod tests {
         let (rounds, accept_max, source, capped_from) =
             PwdChanCrypto::resolve_pbkdf2_startup_config(Some(20000), None);
         assert_eq!(rounds, 20000);
+        assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
+        assert_eq!(source, "configuration");
+        assert!(capped_from.is_none());
+
+        // Valid 600k rounds stay under the default (10m) accept-max ceiling.
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(Some(600_000), None);
+        assert_eq!(rounds, 600_000);
+        assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
+        assert_eq!(source, "configuration");
+        assert!(capped_from.is_none());
+
+        // Max generation rounds are accepted when accept-max is unset.
+        let (rounds, accept_max, source, capped_from) =
+            PwdChanCrypto::resolve_pbkdf2_startup_config(Some(MAX_PBKDF2_ROUNDS), None);
+        assert_eq!(rounds, MAX_PBKDF2_ROUNDS);
         assert_eq!(accept_max, DEFAULT_PBKDF2_ACCEPT_MAX);
         assert_eq!(source, "configuration");
         assert!(capped_from.is_none());
@@ -1085,8 +1094,12 @@ mod tests {
         let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA1, MIN_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
-        // Test high accept max - should succeed
-        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 600000);
+        // Fresh-install-style 600k ceiling - should succeed
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 600_000);
+        assert!(result.is_ok());
+
+        // Absolute policy maximum - should succeed
+        let result = PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, MAX_PBKDF2_ROUNDS);
         assert!(result.is_ok());
 
         // Test accept max above policy/OpenSSL limit - should fail
@@ -1111,7 +1124,7 @@ mod tests {
         assert_eq!(iter, 10000);
 
         // Iteration count above accept max - should fail
-        let high_hash = format!("{}$salt123$hash456", DEFAULT_PBKDF2_ROUNDS + 1);
+        let high_hash = format!("{}$salt123$hash456", DEFAULT_PBKDF2_ACCEPT_MAX + 1);
         let result = PwdChanCrypto::pbkdf2_decompose(&high_hash, SCHEME_PBKDF2_SHA256);
         assert!(result.is_err());
 
@@ -1137,7 +1150,7 @@ mod tests {
         assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 10000).is_ok());
         assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(), 10000);
 
-        // Stored iterations above accept max - should fail
+        // Stored iterations above accept max - normal compare failure after throttled log.
         let encrypted = "36000$eElFb3p1WlZBb1lt$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";
         let result = PwdChanCrypto::pbkdf2_compare(
             "eicieY7ahchaoCh0eeTa",
@@ -1145,7 +1158,7 @@ mod tests {
             MessageDigest::sha256(),
             SCHEME_PBKDF2_SHA256,
         );
-        assert!(result.is_err());
+        assert_eq!(result, Ok(false));
 
         assert!(PwdChanCrypto::set_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256, 60000).is_ok());
         assert_eq!(PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(), 60000);
@@ -1170,17 +1183,17 @@ mod tests {
 
         let encrypted_tail = "henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
 
-        // Stored iterations above accept max - should fail
-        let high_hash = format!("{}${}", DEFAULT_PBKDF2_ROUNDS + 1, encrypted_tail);
+        // Stored iterations above accept max - normal compare failure.
+        let high_hash = format!("{}${}", DEFAULT_PBKDF2_ACCEPT_MAX + 1, encrypted_tail);
         let result = PwdChanCrypto::pbkdf2_compare(
             "password",
             &high_hash,
             MessageDigest::sha256(),
             SCHEME_PBKDF2_SHA256,
         );
-        assert!(result.is_err());
+        assert_eq!(result, Ok(false));
 
-        // Stored iterations below min - should fail
+        // Stored iterations below min - normal compare failure.
         let low_hash = format!("{}${}", MIN_PBKDF2_ROUNDS - 1, encrypted_tail);
         let result = PwdChanCrypto::pbkdf2_compare(
             "password",
@@ -1188,9 +1201,52 @@ mod tests {
             MessageDigest::sha256(),
             SCHEME_PBKDF2_SHA256,
         );
-        assert!(result.is_err());
+        assert_eq!(result, Ok(false));
 
         // Reset to defaults after test
+        reset_pbkdf2_rounds();
+    }
+
+    #[test]
+    fn test_pbkdf2_default_accept_max_allows_600k_and_10m_boundary() {
+        reset_pbkdf2_rounds();
+
+        // Unset accept-max falls back to MAX_PBKDF2_ROUNDS so upgraded
+        // installs keep verifying hashes the plugin could previously create.
+        assert_eq!(DEFAULT_PBKDF2_ACCEPT_MAX, MAX_PBKDF2_ROUNDS);
+        assert_eq!(
+            PwdChanCrypto::get_pbkdf2_accept_max(SCHEME_PBKDF2_SHA256).unwrap(),
+            DEFAULT_PBKDF2_ACCEPT_MAX
+        );
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            600_000,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_ok());
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            MAX_PBKDF2_ROUNDS,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_ok());
+        assert!(PwdChanCrypto::validate_pbkdf2_stored_iterations(
+            MAX_PBKDF2_ROUNDS + 1,
+            SCHEME_PBKDF2_SHA256
+        )
+        .is_err());
+
+        // Compare maps out-of-range iterations to Ok(false), not Err.
+        let encrypted_tail = "henZGfPWw79Cs8ORDeVNrQ$1dTJy73v6n3bnTmTZFghxHXHLsAzKaAy8SksDfZBPIw";
+        let over_max_hash = format!("{}${}", MAX_PBKDF2_ROUNDS + 1, encrypted_tail);
+        assert_eq!(
+            PwdChanCrypto::pbkdf2_compare(
+                "password",
+                &over_max_hash,
+                MessageDigest::sha256(),
+                SCHEME_PBKDF2_SHA256,
+            ),
+            Ok(false)
+        );
+
         reset_pbkdf2_rounds();
     }
 


### PR DESCRIPTION
Description:
The Rust pwdchan PBKDF2 password verification code does not validate the extracted iteration count before invoking the PBKDF2 hash function.

Fix:
Add nsslapd-pwdPBKDF2AcceptMaxIterations configuration for each PBKDF2 plugin variant and reject stored hashes whose iteration count is below the minimum or above the configured accept maximum before password verification. Add lib389 and dsconf support to get, set, and delete the accept max setting.

Depends on the schema change adding nsslapd-pwdPBKDF2AcceptMaxIterations to pwdPBKDF2PluginConfig.

Fixes: https://github.com/389ds/389-ds-base/issues/7611

Assisted by: Cursor

Reviewed by:

## Summary by Sourcery

Enforce validation of PBKDF2 iteration counts during configuration and password verification and introduce a configurable upper bound for accepted iterations per PBKDF2 variant.

New Features:
- Add per-variant configuration of maximum accepted PBKDF2 iterations for stored hashes via the nsslapd-pwdPBKDF2AcceptMaxIterations attribute.
- Expose CLI and lib389 support to get, set, and delete the PBKDF2 accept-max-iterations setting for each PBKDF2 plugin variant.

Bug Fixes:
- Reject PBKDF2 password hashes whose stored iteration count is below the minimum or above the configured maximum during verification.

Enhancements:
- Refine PBKDF2 plugin configuration handling by sharing parsing/validation logic for numeric attributes and improving logging around invalid configuration and stored hashes.
- Extend unit tests to cover new accept-max-iterations behavior and validation of iteration bounds in PBKDF2 decomposition and comparison.