### PR TITLE
Issue 7635 - Integer Underflow in {SMD5} Password Comparison

### DIFF
--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -177,24 +177,39 @@ def test_smd5_reject_short_hash(topology_st):
         5. Server remains up
     """
     inst = topology_st.standalone
+    orig_allow_hashed = inst.config.get_attr_val_utf8('nsslapd-allow-hashed-passwords') or 'off'
+    orig_upgrade_hash = inst.config.get_attr_val_utf8('nsslapd-enable-upgrade-hash') or 'off'
+
     inst.config.set('nsslapd-allow-hashed-passwords', 'on')
     inst.config.set('nsslapd-enable-upgrade-hash', 'off')
 
-    # Ensure a clean start in case a prior run crashed the process.
-    inst.start()
+    inst.restart()
 
-    users = UserAccounts(inst, DEFAULT_SUFFIX)
-    user = users.create_test_user()
-    short_hash = _craft_smd5_short_hash(3)
+    user = None
+    try:
+        users = UserAccounts(inst, DEFAULT_SUFFIX)
+        user = users.create_test_user()
+        short_hash = _craft_smd5_short_hash(3)
 
-    log.info('Setting truncated SMD5 hash')
-    user.set('userPassword', short_hash)
+        log.info('Setting truncated SMD5 hash')
+        user.set('userPassword', short_hash)
 
-    with pytest.raises(ldap.INVALID_CREDENTIALS):
-        user.bind('doesntmatter')
+        with pytest.raises(ldap.INVALID_CREDENTIALS):
+            user.bind('doesntmatter')
 
-    assert inst.status(), 'Server crashed comparing short SMD5 hash'
-    user.delete()
+        assert inst.status(), 'Server crashed comparing short SMD5 hash'
+    finally:
+        if user is not None:
+            try:
+                if user.exists():
+                    user.delete()
+            except ldap.LDAPError:
+                pass
+        try:
+            inst.config.set('nsslapd-allow-hashed-passwords', orig_allow_hashed)
+            inst.config.set('nsslapd-enable-upgrade-hash', orig_upgrade_hash)
+        except ldap.LDAPError:
+            pass
 
 
 def test_pbkdf2_algo(topology_st):

--- a/dirsrvtests/tests/suites/password/pwd_algo_test.py
+++ b/dirsrvtests/tests/suites/password/pwd_algo_test.py
@@ -6,6 +6,7 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import base64
 import pytest
 from lib389.tasks import *
 from lib389.utils import *
@@ -149,6 +150,51 @@ def test_pwd_algo_test(topology_st, algo):
             pytest.skip("Not implemented")
     _test_algo(topology_st.standalone, algo)
     log.info('Test %s PASSED' % algo)
+
+
+def _craft_smd5_short_hash(decoded_length=3):
+    """Return a {SMD5} hash whose decoded length is less than MD5_LENGTH (16)."""
+    payload = bytes(range(1, decoded_length + 1))
+    return '{SMD5}' + base64.b64encode(payload).decode()
+
+
+def test_smd5_reject_short_hash(topology_st):
+    """Reject {SMD5} stored hashes shorter than MD5_LENGTH without crashing
+
+    :id: 246e702d-9c63-4a28-b4f5-31596b1fc840
+    :setup: Standalone instance
+    :steps:
+        1. Enable nsslapd-allow-hashed-passwords
+        2. Create a test user
+        3. Set userPassword to a truncated {SMD5} hash (decoded length < 16)
+        4. Attempt bind as that user
+        5. Verify the server is still running
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Bind fails with ldap.INVALID_CREDENTIALS
+        5. Server remains up
+    """
+    inst = topology_st.standalone
+    inst.config.set('nsslapd-allow-hashed-passwords', 'on')
+    inst.config.set('nsslapd-enable-upgrade-hash', 'off')
+
+    # Ensure a clean start in case a prior run crashed the process.
+    inst.start()
+
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user = users.create_test_user()
+    short_hash = _craft_smd5_short_hash(3)
+
+    log.info('Setting truncated SMD5 hash')
+    user.set('userPassword', short_hash)
+
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user.bind('doesntmatter')
+
+    assert inst.status(), 'Server crashed comparing short SMD5 hash'
+    user.delete()
 
 
 def test_pbkdf2_algo(topology_st):

--- a/ldap/servers/plugins/pwdstorage/smd5_pwd.c
+++ b/ldap/servers/plugins/pwdstorage/smd5_pwd.c
@@ -70,6 +70,13 @@ smd5_pw_cmp(const char *userpwd, const char *dbpwd)
         goto loser;
     }
 
+    if (hash_len < MD5_LENGTH) {
+        slapi_log_err(SLAPI_LOG_PLUGIN, SALTED_MD5_SUBSYSTEM_NAME,
+                      "smd5_pw_cmp: decoded hash length %u is too short\n",
+                      hash_len);
+        goto loser;
+    }
+
     salt.bv_val = (void *)(dbhash + MD5_LENGTH); /* salt starts after hash value */
     salt.bv_len = hash_len - MD5_LENGTH;         /* remaining bytes must be salt */
 


### PR DESCRIPTION
Description;
smd5_pw_cmp() does not validate the decoded length of a stored {SMD5} hash before computing the salt offset and length. Truncated hashes could produce an incorrect salt length during password comparison.

Fix:
Add a length check in smd5_pwd.c to reject decoded hashes shorter than MD5_LENGTH. Added CI test for validation.

Fixes: https://github.com/389ds/389-ds-base/issues/7635

Reviewed by:

## Summary by Sourcery

Validate SMD5 password hash length before comparison to prevent crashes with truncated hashes.

Bug Fixes:
- Reject {SMD5} password hashes whose decoded length is shorter than the MD5 digest to avoid incorrect salt handling and potential crashes.

Tests:
- Add regression test that sets a truncated {SMD5} hash, verifies bind fails with invalid credentials, and ensures the server remains running.