### PR TITLE
Issue 7147 - Fix DN cache ownership during online reindex

### DIFF
--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -1002,6 +1002,13 @@ def test_concurrent_modifications_during_indexing(topo, homeDirectory_index_clea
     else:
         log.info("Indexing completed too quickly to observe UNWILLING_TO_PERFORM")
 
+    # On slow machines the reindex can outlive the monitoring loop; the final
+    # modifications below are only expected to succeed once it is done.
+    log.info("Waiting for the indexing task to complete")
+    reindex_task.wait(timeout=600)
+    exit_code = reindex_task.get_exit_code()
+    assert exit_code == 0, f"Reindex task failed or timed out: {exit_code}"
+
     test_users[0].replace('sn', 'final_test')
     assert test_users[0].get_attr_val_utf8('sn') == 'final_test'
 

--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -2312,7 +2312,7 @@ dncache_find_id(struct cache *cache, ID id)
     cache_lock(cache);
     if (find_hash(cache->c_idtable, &id, sizeof(ID), (void **)&bdn)) {
         /* need to check entry state */
-        if (bdn->ep_state != 0) {
+        if ((bdn->ep_state & ENTRY_STATE_UNAVAILABLE) != 0) {
             /* entry is deleted or not fully created yet */
             cache_unlock(cache);
             LOG("<= dncache_find_id (NOT FOUND)\n");
@@ -2320,6 +2320,7 @@ dncache_find_id(struct cache *cache, ID id)
         }
         if (bdn->ep_refcnt == 0)
             lru_delete(cache, (void *)bdn);
+        PR_ASSERT((bdn->ep_state & ENTRY_STATE_LRU) == 0);
         bdn->ep_refcnt++;
         cache->c_stats.hits++;
     }

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -1030,8 +1030,10 @@ bdb_index_producer(void *param)
             char *normdn = NULL;
             struct backdn *bdn = dncache_find_id(&inst->inst_dncache, temp_id);
             if (bdn) {
-                /* don't free dn */
-                normdn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
+                /* Copy the dn: normdn is unconditionally freed below and
+                 * the cached bdn may be evicted once the reference is
+                 * returned. */
+                normdn = slapi_ch_strdup(slapi_sdn_get_dn(bdn->dn_sdn));
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
             } else {
                 Slapi_DN *sdn = NULL;
@@ -1083,8 +1085,8 @@ bdb_index_producer(void *param)
                                                rdn, pdn ? "," : "", pdn ? pdn : "");
                     slapi_ch_free_string(&pdn);
                 }
-                /* dn is not dup'ed in slapi_sdn_new_dn_byref.
-                 * It's set to bdn and put in the dn cache. */
+                /* The dn cache gets its own copy of normdn;
+                 * normdn stays owned by this scope. */
                 sdn = slapi_sdn_new_normdn_byval((const char *)normdn);
                 bdn = backdn_init(sdn, temp_id, 0);
                 CACHE_ADD(&inst->inst_dncache, bdn, NULL);
@@ -1436,6 +1438,7 @@ bdb_upgradedn_producer(void *param)
     Slapi_Attr *ud_attr = NULL;
     char *ecopy = NULL;
     char *normdn = NULL;
+    char *owned_normdn = NULL;
     char *rdn = NULL;       /* original rdn */
     int is_dryrun = 0;      /* FLAG_DRYRUN */
     int chk_dn_norm = 0;    /* FLAG_UPGRADEDNFORMAT */
@@ -1568,6 +1571,7 @@ bdb_upgradedn_producer(void *param)
         ecopy = (char *)slapi_ch_malloc(data.dsize + 1);
         memcpy(ecopy, data.dptr, data.dsize);
         *(ecopy + data.dsize) = '\0';
+        slapi_ch_free_string(&owned_normdn);
         normdn = NULL;
         do_dn_norm = 0;
         do_dn_norm_sp = 0;
@@ -1583,14 +1587,14 @@ bdb_upgradedn_producer(void *param)
         } else {
             bdn = dncache_find_id(&inst->inst_dncache, temp_id);
             if (bdn) {
-                /* don't free normdn */
-                normdn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
+                /* Keep an owned copy after returning the cache reference. */
+                owned_normdn = slapi_ch_strdup(slapi_sdn_get_dn(bdn->dn_sdn));
+                normdn = owned_normdn;
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
                 dn_in_cache = 1;
             } else {
-                /* free normdn */
                 rc = entryrdn_lookup_dn(be, rdn, temp_id,
-                                        (char **)&normdn, NULL, NULL);
+                                        &owned_normdn, NULL, NULL);
                 if (rc) {
                     /* We cannot use the entryrdn index;
                      * Compose dn from the entries in id2entry */
@@ -1634,28 +1638,22 @@ bdb_upgradedn_producer(void *param)
                             continue;
                         }
                     }
-                    /* free normdn */
-                    normdn = slapi_ch_smprintf("%s%s%s",
-                                               rdn, pdn ? "," : "", pdn ? pdn : "");
+                    slapi_ch_free_string(&owned_normdn);
+                    owned_normdn = slapi_ch_smprintf("%s%s%s",
+                                                     rdn, pdn ? "," : "", pdn ? pdn : "");
                     slapi_ch_free_string(&pdn);
                 }
+                normdn = owned_normdn;
                 if (is_dryrun) {
-                    /* if not dryrun, we may change the DN, In such case,
-                        * we need to put the new value to cache.*/
-                    /* dn is dup'ed in slapi_sdn_new_dn_byval.
-                        * It's set to bdn and put in the dn cache. */
-                    /* normdn is allocated in this scope.
-                        * Thus, we can just passin. */
-                    sdn = slapi_sdn_new_normdn_passin(normdn);
+                    /* The cache gets its own copy so normdn remains valid. */
+                    sdn = slapi_sdn_new_normdn_byval(normdn);
                     bdn = backdn_init(sdn, temp_id, 0);
                     CACHE_ADD(&inst->inst_dncache, bdn, NULL);
-                    CACHE_RETURN(&inst->inst_dncache, &bdn);
-                    /* don't free this normdn  */
-                    normdn = (char *)slapi_sdn_get_dn(sdn);
                     slapi_log_err(SLAPI_LOG_CACHE, "bdb_upgradedn_producer",
                                   "entryrdn_lookup_dn returned: %s, "
                                   "and set to dn cache\n",
                                   normdn);
+                    CACHE_RETURN(&inst->inst_dncache, &bdn);
                     dn_in_cache = 1;
                 }
             }
@@ -1801,11 +1799,10 @@ bdb_upgradedn_producer(void *param)
                                       normdn, temp_id, alt_id);
                         slapi_log_err(SLAPI_LOG_NOTICE, "bdb_upgradedn_producer",
                                       "Renaming \"%s\" to \"%s\"\n", rdn, newrdn);
-                        if (!dn_in_cache) {
-                            /* If not in dn cache, normdn needs to be freed. */
-                            slapi_ch_free_string(&normdn);
-                        }
-                        normdn = slapi_ch_smprintf("%s,%s", newrdn, parentdn);
+                        slapi_ch_free_string(&owned_normdn);
+                        owned_normdn = slapi_ch_smprintf("%s,%s", newrdn, parentdn);
+                        normdn = owned_normdn;
+                        dn_in_cache = 0;
                         slapi_ch_free_string(&newrdn);
                         slapi_ch_free_string(&parentdn);
                         /* Reset DN and RDN in the entry */
@@ -1827,17 +1824,25 @@ bdb_upgradedn_producer(void *param)
             }     /* !is_dryrun */
         }         /* if (chk_dn_norm_sp) */
 
-        /* dn is dup'ed in slapi_sdn_new_dn_byval.
-         * It's set to bdn and put in the dn cache. */
-        /* Waited to put normdn into dncache until it could be modified in
-         * chk_dn_norm_sp. */
+        /* Wait to cache normdn until chk_dn_norm_sp can no longer change it.
+         * The cache gets its own copy so the producer can keep using normdn. */
         if (!dn_in_cache) {
-            sdn = slapi_sdn_new_normdn_passin(normdn);
+            struct backdn *oldbdn = NULL;
+
+            sdn = slapi_sdn_new_normdn_byval(normdn);
             bdn = backdn_init(sdn, temp_id, 0);
-            CACHE_ADD(&inst->inst_dncache, bdn, NULL);
-            CACHE_RETURN(&inst->inst_dncache, &bdn);
+            if (CACHE_ADD(&inst->inst_dncache, bdn, &oldbdn) == 1) {
+                if (slapi_sdn_compare(sdn, oldbdn->dn_sdn) &&
+                    cache_replace(&inst->inst_dncache, oldbdn, bdn) != 0) {
+                    slapi_log_err(SLAPI_LOG_WARNING, "bdb_upgradedn_producer",
+                                  "Failed to replace cached DN %s with %s\n",
+                                  slapi_sdn_get_dn(oldbdn->dn_sdn), normdn);
+                }
+                CACHE_RETURN(&inst->inst_dncache, &oldbdn);
+            }
             slapi_log_err(SLAPI_LOG_CACHE, "bdb_upgradedn_producer",
                           "set dn %s to dn cache\n", normdn);
+            CACHE_RETURN(&inst->inst_dncache, &bdn);
         }
         /* Check DN syntax attr values if it contains '\\' or not */
         /* Start from the rdn */
@@ -2162,6 +2167,7 @@ error:
 done:
     bdb_free_IDarray(&dn_norm_sp_conflicts);
     slapi_ch_free_string(&ecopy);
+    slapi_ch_free_string(&owned_normdn);
     slapi_ch_free(&(data.data));
     slapi_ch_free_string(&rdn);
     if (job->upgradefd) {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1130,8 +1130,10 @@ bdb_db2ldif(Slapi_PBlock *pb)
 
             bdn = dncache_find_id(&inst->inst_dncache, temp_id);
             if (bdn) {
-                /* don't free dn */
-                dn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
+                /* Copy the dn: the cached bdn may be evicted and freed
+                 * once the reference is returned. */
+                dn = slapi_ch_strdup(slapi_sdn_get_dn(bdn->dn_sdn));
+                free_dn = true;
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
                 slapi_rdn_done(&psrdn);
             } else if (return_orig_dn &&
@@ -1184,10 +1186,11 @@ bdb_db2ldif(Slapi_PBlock *pb)
                     slapi_ch_free_string(&pdn);
                 }
                 slapi_rdn_done(&psrdn);
-                /* dn is not dup'ed in slapi_sdn_new_dn_passin.
-                    * It's set to bdn and put in the dn cache. */
-                /* don't free dn */
-                sdn = slapi_sdn_new_dn_passin(dn);
+                /* Copy dn into the sdn so that dn stays valid even if
+                 * the cached bdn is freed (CACHE_ADD failure or eviction
+                 * by another thread) before we are done with it. */
+                sdn = slapi_sdn_new_dn_byval(dn);
+                free_dn = true;
                 bdn = backdn_init(sdn, temp_id, 0);
                 myrc = CACHE_ADD(&inst->inst_dncache, bdn, NULL);
                 if (myrc) {
@@ -1654,6 +1657,7 @@ bdb_db2index(Slapi_PBlock *pb)
             char *pdn = NULL;
             ID pid = NOID;
             char *dn = NULL;
+            bool free_dn = false;
             struct backdn *bdn = NULL;
             Slapi_RDN psrdn = {0};
 
@@ -1694,8 +1698,10 @@ bdb_db2index(Slapi_PBlock *pb)
 
             bdn = dncache_find_id(&inst->inst_dncache, temp_id);
             if (bdn) {
-                /* don't free dn */
-                dn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
+                /* Copy the dn: the cached bdn may be evicted and freed
+                 * once the reference is returned. */
+                dn = slapi_ch_strdup(slapi_sdn_get_dn(bdn->dn_sdn));
+                free_dn = true;
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
             } else {
                 int myrc = 0;
@@ -1749,10 +1755,11 @@ bdb_db2index(Slapi_PBlock *pb)
                                            rdn, pdn ? "," : "", pdn ? pdn : "");
                     slapi_ch_free_string(&pdn);
                 }
-                /* dn is not dup'ed in slapi_sdn_new_dn_passin.
-                 * It's set to bdn and put in the dn cache. */
-                /* don't free dn */
-                sdn = slapi_sdn_new_dn_passin(dn);
+                /* Copy dn into the sdn so that dn stays valid even if
+                 * the cached bdn is freed (CACHE_ADD failure or eviction
+                 * by another thread) before we are done with it. */
+                sdn = slapi_sdn_new_dn_byval(dn);
+                free_dn = true;
                 bdn = backdn_init(sdn, temp_id, 0);
                 myrc = CACHE_ADD(&inst->inst_dncache, bdn, NULL);
                 if (myrc) {
@@ -1772,6 +1779,9 @@ bdb_db2index(Slapi_PBlock *pb)
             ep->ep_entry = slapi_str2entry_ext(dn, NULL, data.dptr,
                                                SLAPI_STR2ENTRY_NO_ENTRYDN);
             slapi_ch_free_string(&rdn);
+            if (free_dn) {
+                slapi_ch_free_string(&dn);
+            }
         }
 
         slapi_ch_free(&(data.data));
@@ -2959,7 +2969,9 @@ _export_or_index_parents(ldbm_instance *inst,
             char *pdn = NULL;
 
             bdn = dncache_find_id(&inst->inst_dncache, pid);
-            if (!bdn) {
+            if (bdn) {
+                CACHE_RETURN(&inst->inst_dncache, &bdn);
+            } else {
                 /* we put pdn to dn cache, which could be used
                  * in _get_and_add_parent_rdns */
                 rc = entryrdn_lookup_dn(be, prdn, pid, &pdn, NULL, NULL);
@@ -2971,18 +2983,18 @@ _export_or_index_parents(ldbm_instance *inst,
                     bdn = backdn_init(psdn, pid, 0);
                     myrc = CACHE_ADD(&inst->inst_dncache, bdn, NULL);
                     if (myrc) {
-                        backdn_free(&bdn);
                         slapi_log_err(SLAPI_LOG_CACHE,
                                       "_export_or_index_parents",
                                       "%s is already in the dn cache (%d)\n",
                                       pdn, myrc);
+                        backdn_free(&bdn);
                     } else {
-                        CACHE_RETURN(&inst->inst_dncache, &bdn);
                         slapi_log_err(SLAPI_LOG_CACHE,
                                       "_export_or_index_parents",
                                       "entryrdn_lookup_dn returned: %s, "
                                       "and set to dn cache\n",
                                       pdn);
+                        CACHE_RETURN(&inst->inst_dncache, &bdn);
                     }
                 }
             }

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_ldif2db.c
@@ -1014,8 +1014,10 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
 
             bdn = dncache_find_id(&inst->inst_dncache, temp_id);
             if (bdn) {
-                /* don't free dn */
-                dn = (char *)slapi_sdn_get_dn(bdn->dn_sdn);
+                /* Copy the dn: the cached bdn may be evicted and freed
+                 * once the reference is returned. */
+                dn = slapi_ch_strdup(slapi_sdn_get_dn(bdn->dn_sdn));
+                free_dn = true;
                 CACHE_RETURN(&inst->inst_dncache, &bdn);
                 slapi_rdn_done(&psrdn);
             } else if (return_orig_dn &&
@@ -1070,10 +1072,11 @@ dbmdb_db2ldif(Slapi_PBlock *pb)
                     slapi_ch_free_string(&pdn);
                 }
                 slapi_rdn_done(&psrdn);
-                /* dn is not dup'ed in slapi_sdn_new_dn_passin.
-                 * It's set to bdn and put in the dn cache. */
-                /* don't free dn */
-                sdn = slapi_sdn_new_dn_passin(dn);
+                /* Copy dn into the sdn so that dn stays valid even if
+                 * the cached bdn is freed (CACHE_ADD failure or eviction
+                 * by another thread) before we are done with it. */
+                sdn = slapi_sdn_new_dn_byval(dn);
+                free_dn = true;
                 bdn = backdn_init(sdn, temp_id, 0);
                 myrc = CACHE_ADD(&inst->inst_dncache, bdn, NULL);
                 if (myrc) {
@@ -1561,7 +1564,9 @@ _export_or_index_parents(ldbm_instance *inst,
             char *pdn = NULL;
 
             bdn = dncache_find_id(&inst->inst_dncache, pid);
-            if (!bdn) {
+            if (bdn) {
+                CACHE_RETURN(&inst->inst_dncache, &bdn);
+            } else {
                 /* we put pdn to dn cache, which could be used
                  * in _get_and_add_parent_rdns */
                 rc = entryrdn_lookup_dn(be, prdn, pid, &pdn, NULL, NULL);
@@ -1573,18 +1578,18 @@ _export_or_index_parents(ldbm_instance *inst,
                     bdn = backdn_init(psdn, pid, 0);
                     myrc = CACHE_ADD(&inst->inst_dncache, bdn, NULL);
                     if (myrc) {
-                        backdn_free(&bdn);
                         slapi_log_err(SLAPI_LOG_CACHE,
                                       "_export_or_index_parents",
                                       "%s is already in the dn cache (%d)\n",
                                       pdn, myrc);
+                        backdn_free(&bdn);
                     } else {
-                        CACHE_RETURN(&inst->inst_dncache, &bdn);
                         slapi_log_err(SLAPI_LOG_CACHE,
                                       "_export_or_index_parents",
                                       "entryrdn_lookup_dn returned: %s, "
                                       "and set to dn cache\n",
                                       pdn);
+                        CACHE_RETURN(&inst->inst_dncache, &bdn);
                     }
                 }
             }


### PR DESCRIPTION
Description: dncache_find_id() treated any nonzero ep_state as unavailable. This could hide valid DN cache entries and cause online reindex/export to recompose a DN, release it after a cache collision, and use it again.

Treat cached DNs as missing only when they are deleted, incomplete, or invalid. Valid entries queued in the LRU remain available for lookup. Give db2index, db2ldif, and upgradedn producers independent DN ownership after CACHE_RETURN.
Replace stale upgradedn cache entries after conflict renames, release parent-cache references on hits, and log cache-owned values before releasing their entries.

In the test, wait for the concurrent reindex task to finish and require a successful exit code before performing the final checks.

Fixes: https://github.com/389ds/389-ds-base/issues/7147

Reviewed by: ?

## Summary by Sourcery

Ensure DN cache entries remain valid and correctly owned during online reindexing and export operations to prevent recomposition and reuse of stale DNs.

Bug Fixes:
- Treat DN cache entries as missing only when marked unavailable so valid LRU-queued entries remain visible to lookups.
- Prevent db2index, db2ldif, and upgradedn producers from reusing cache-owned DN strings after CACHE_RETURN, avoiding use-after-free and stale DN collisions.
- Ensure parent DN caching during export/index respects existing cache entries and does not leak or double-free backdn structures.

Enhancements:
- Introduce explicit ownership of normalized DN strings in upgradedn processing and replace stale cache entries after conflict-induced renames while logging replacements.
- Adjust dncache hit handling to remove entries from the LRU list when referenced and assert that referenced entries are not still marked as LRU.
- Improve concurrent indexing regression test to wait for the reindex task to finish and validate a successful exit code before performing final modifications.

Tests:
- Extend the concurrent modifications during indexing regression test to wait for task completion and assert a zero exit code before final attribute checks.