### PR TITLE
Issue 7637 - UI - Using Arrow Keys in New Object Wizard Resulted in DOM reload

### DIFF
--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/cos.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/cos.jsx
@@ -13,23 +13,130 @@ import AddCosTemplate from './operations/addCosTemplate.jsx';
 
 const _ = cockpit.gettext;
 
+const COS_TYPE_OPTIONS = [
+    { value: 'CoSDefinition', inputId: 'radio-cos-def-step' },
+    { value: 'CoSTemplate', inputId: 'radio-cos-template-step' },
+];
+
+/*
+ * Step 1 CoS-type radios. Kept as a component so arrow-key changes update
+ * selection and sidebar steps without losing focus on the radio group.
+ */
+class CoSGetStartedStep extends React.Component {
+    focusSelectedRadio = () => {
+        const option = COS_TYPE_OPTIONS.find(opt => opt.value === this.props.selected);
+        if (!option) {
+            return;
+        }
+        requestAnimationFrame(() => {
+            document.getElementById(option.inputId)?.focus();
+        });
+    };
+
+    componentDidMount () {
+        this.focusSelectedRadio();
+    }
+
+    componentDidUpdate (prevProps) {
+        if (prevProps.selected !== this.props.selected) {
+            this.focusSelectedRadio();
+        }
+    }
+
+    handleKeyDown = (event) => {
+        const isArrow = event.key === 'ArrowUp' || event.key === 'ArrowDown' ||
+            event.key === 'ArrowLeft' || event.key === 'ArrowRight';
+        if (!isArrow) {
+            return;
+        }
+
+        event.stopPropagation();
+        event.preventDefault();
+
+        const { selected, onSelect } = this.props;
+        const currentIdx = COS_TYPE_OPTIONS.findIndex(opt => opt.value === selected);
+        if (currentIdx === -1) {
+            return;
+        }
+
+        const step = (event.key === 'ArrowDown' || event.key === 'ArrowRight') ? 1 : -1;
+        const nextIdx = (currentIdx + step + COS_TYPE_OPTIONS.length) % COS_TYPE_OPTIONS.length;
+        const next = COS_TYPE_OPTIONS[nextIdx];
+
+        onSelect(next.value);
+    };
+
+    render () {
+        const { selected, onChange } = this.props;
+
+        return (
+            <div
+                role="radiogroup"
+                aria-label={_("CoS type")}
+                onKeyDown={this.handleKeyDown}
+            >
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="CoSDefinition"
+                    isChecked={selected === 'CoSDefinition'}
+                    onChange={onChange}
+                    label={_("Create a new CoS Definition")}
+                    description={_("The CoS definition entry identifies the type of CoS used. The CoS definition entry is below the branch at which it is effective.")}
+                    name="radio-cos-step-btn-group"
+                    id="radio-cos-def-step"
+                />
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="CoSTemplate"
+                    isChecked={selected === 'CoSTemplate'}
+                    onChange={onChange}
+                    label={_("Create a new CoS Template")}
+                    description={_("The CoS template entry contains a list of the shared attribute values. Changes to the template entry attribute values are automatically applied to all the entries within the scope of the CoS.")}
+                    name="radio-cos-step-btn-group"
+                    id="radio-cos-template-step"
+                />
+            </div>
+        );
+    }
+}
+
 class CoSEntryWizard extends React.Component {
     constructor (props) {
         super(props);
 
         this.state = {
-            stepIdReached: 1,
-            getStartedStepRadio: 'CoSDefinition'
+            getStartedStepRadio: 'CoSDefinition',
+            activeWizardType: 'CoSDefinition',
         };
     }
 
-    handleOnChange = (event, _) => {
-        // console.log('event.currentTarget.value = ' + event.currentTarget.value);
-        this.setState({ getStartedStepRadio: event.currentTarget.value });
+    componentDidUpdate (prevProps) {
+        if (this.props.isWizardOpen && !prevProps.isWizardOpen) {
+            this.setState({
+                getStartedStepRadio: 'CoSDefinition',
+                activeWizardType: 'CoSDefinition',
+            });
+        }
+    }
+
+    handleOnChange = (event) => {
+        this.setSelectedCosType(event.currentTarget.value);
+    };
+
+    setSelectedCosType = (value) => {
+        this.setState(prevState => {
+            if (prevState.getStartedStepRadio === value &&
+                prevState.activeWizardType === value) {
+                return null;
+            }
+            return {
+                getStartedStepRadio: value,
+                activeWizardType: value,
+            };
+        });
     };
 
     createInitialLayout = () => {
-        // Creation of a CoS entry
         return ([
             {
                 id: 1,
@@ -53,25 +160,10 @@ class CoSEntryWizard extends React.Component {
                                 </TextContent>
                             </GridItem>
                         </Grid>
-                        <Radio
-                          className="ds-margin-top-lg"
-                          value="CoSDefinition"
-                          isChecked={this.state.getStartedStepRadio === 'CoSDefinition'}
-                          onChange={(event, _) => this.handleOnChange(event, _)}
-                          label={_("Create a new CoS Definition")}
-                          description={_("The CoS definition entry identifies the type of CoS used. The CoS definition entry is below the branch at which it is effective.")}
-                          name="radio-new-step-start"
-                          id="radio-new-step-start-1"
-                        />
-                        <Radio
-                          className="ds-margin-top-lg"
-                          value="CoSTemplate"
-                          isChecked={this.state.getStartedStepRadio === 'CoSTemplate'}
-                          onChange={(event, _) => this.handleOnChange(event, _)}
-                          label={_("Create a new CoS Template")}
-                          description={_("The CoS template entry contains a list of the shared attribute values. Changes to the template entry attribute values are automatically applied to all the entries within the scope of the CoS.")}
-                          name="radio-new-step-start"
-                          id="radio-new-step-start-2"
+                        <CoSGetStartedStep
+                            selected={this.state.getStartedStepRadio}
+                            onChange={this.handleOnChange}
+                            onSelect={this.setSelectedCosType}
                         />
                     </div>
                 )
@@ -80,9 +172,7 @@ class CoSEntryWizard extends React.Component {
     };
 
     render () {
-        const {
-            getStartedStepRadio
-        } = this.state;
+        const { activeWizardType } = this.state;
 
         const initialStep = this.createInitialLayout();
 
@@ -97,7 +187,7 @@ class CoSEntryWizard extends React.Component {
             addNotification: this.props.addNotification
         };
 
-        if (getStartedStepRadio === 'CoSDefinition') {
+        if (activeWizardType === 'CoSDefinition') {
             return (
                 <AddCosDefinition
                     {...wizardProps}
@@ -110,17 +200,17 @@ class CoSEntryWizard extends React.Component {
                     cosDefType="pointer"
                 />
             );
-        } else if (getStartedStepRadio === 'CoSTemplate') {
-            return (
-                <AddCosTemplate
-                    {...wizardProps}
-                    allObjectclasses={this.props.allObjectclasses}
-                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
-                    definitionWizardEntryDn=""
-                    stepReached={1}
-                />
-            );
         }
+
+        return (
+            <AddCosTemplate
+                {...wizardProps}
+                allObjectclasses={this.props.allObjectclasses}
+                treeViewRootSuffixes={this.props.treeViewRootSuffixes}
+                definitionWizardEntryDn=""
+                stepReached={1}
+            />
+        );
     }
 }
 

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/newEntry.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/newEntry.jsx
@@ -18,19 +18,174 @@ import GenericUpdate from './operations/genericUpdate.jsx';
 
 const _ = cockpit.gettext;
 
+const ENTRY_TYPE_OPTIONS = [
+    { value: 'User', inputId: 'radio-user-step' },
+    { value: 'Group', inputId: 'radio-group-step' },
+    { value: 'OrganizationalUnit', inputId: 'radio-ou-step' },
+    { value: 'Role', inputId: 'radio-role-step' },
+    { value: 'Custom', inputId: 'radio-custom-step' },
+];
+
+/*
+ * Step 1 entry-type radios. Kept as a component so arrow-key changes update
+ * selection in place without remounting the parent PatternFly Wizard.
+ */
+class GetStartedStep extends React.Component {
+    focusSelectedRadio = () => {
+        const option = ENTRY_TYPE_OPTIONS.find(opt => opt.value === this.props.selected);
+        if (!option) {
+            return;
+        }
+        /*
+         * Defer until after the operation wizard remounts so focus stays on the
+         * radio group instead of the wizard close button.
+         */
+        requestAnimationFrame(() => {
+            document.getElementById(option.inputId)?.focus();
+        });
+    };
+
+    componentDidMount () {
+        this.focusSelectedRadio();
+    }
+
+    componentDidUpdate (prevProps) {
+        if (prevProps.selected !== this.props.selected) {
+            this.focusSelectedRadio();
+        }
+    }
+
+    handleKeyDown = (event) => {
+        const isArrow = event.key === 'ArrowUp' || event.key === 'ArrowDown' ||
+            event.key === 'ArrowLeft' || event.key === 'ArrowRight';
+        if (!isArrow) {
+            return;
+        }
+
+        /*
+         * Stop the deprecated PatternFly Wizard from treating arrows as step
+         * navigation. Prevent default so the browser does not toggle uncontrolled
+         * checked state on inputs we drive via isChecked.
+         */
+        event.stopPropagation();
+        event.preventDefault();
+
+        const { selected, onSelect } = this.props;
+        const currentIdx = ENTRY_TYPE_OPTIONS.findIndex(opt => opt.value === selected);
+        if (currentIdx === -1) {
+            return;
+        }
+
+        const step = (event.key === 'ArrowDown' || event.key === 'ArrowRight') ? 1 : -1;
+        const nextIdx = (currentIdx + step + ENTRY_TYPE_OPTIONS.length) % ENTRY_TYPE_OPTIONS.length;
+        const next = ENTRY_TYPE_OPTIONS[nextIdx];
+
+        onSelect(next.value);
+    };
+
+    render () {
+        const { selected, onChange } = this.props;
+
+        return (
+            <div
+                role="radiogroup"
+                aria-label={_("New entry type")}
+                onKeyDown={this.handleKeyDown}
+            >
+                <Radio
+                    value="User"
+                    isChecked={selected === 'User'}
+                    onChange={onChange}
+                    label={_("Create a new User")}
+                    description={_("Add a new User (inetOrgPerson objectClass)")}
+                    name="radio-new-step-btn-group"
+                    id="radio-user-step"
+                />
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="Group"
+                    isChecked={selected === 'Group'}
+                    onChange={onChange}
+                    label={_("Create a new Group")}
+                    description={_("Add a new Group (GroupOfNames/GroupOfUniqueNames objectClass)")}
+                    name="radio-new-step-btn-group"
+                    id="radio-group-step"
+                />
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="OrganizationalUnit"
+                    isChecked={selected === 'OrganizationalUnit'}
+                    onChange={onChange}
+                    label={_("Create a new Organizational Unit")}
+                    description={_("Add a new Organizational Unit")}
+                    name="radio-new-step-btn-group"
+                    id="radio-ou-step"
+                />
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="Role"
+                    isChecked={selected === 'Role'}
+                    onChange={onChange}
+                    label={_("Create a new Role")}
+                    description={_("Add a new Role (Filtered / Managed / Nested)")}
+                    name="radio-new-step-btn-group"
+                    id="radio-role-step"
+                />
+                <Radio
+                    className="ds-margin-top-lg"
+                    value="Custom"
+                    isChecked={selected === 'Custom'}
+                    onChange={onChange}
+                    label={_("Create a new custom Entry")}
+                    description={_("Add a new entry by selecting ObjectClasses and Attributes")}
+                    name="radio-new-step-btn-group"
+                    id="radio-custom-step"
+                />
+            </div>
+        );
+    }
+}
+
 class NewEntryWizard extends React.Component {
     constructor (props) {
         super(props);
 
         this.state = {
-            stepIdReached: 1,
-            getStartedStepRadio: 'User'
+            getStartedStepRadio: 'User',
+            /*
+             * Which operation wizard is mounted. Stays stable while the user
+             * moves through the step-1 radio group so arrow keys do not remount
+             * the PatternFly Wizard and steal focus.
+             */
+            activeWizardType: 'User',
         };
     }
 
-    handleOnChange = (_, event) => {
-        // console.log('event.currentTarget.value = ' + event.currentTarget.value);
-        this.setState({ getStartedStepRadio: event.currentTarget.value });
+    componentDidUpdate (prevProps) {
+        if (this.props.isWizardOpen && !prevProps.isWizardOpen) {
+            const defaultType = this.props.createRootEntry ? 'Custom' : 'User';
+            this.setState({
+                getStartedStepRadio: defaultType,
+                activeWizardType: defaultType,
+            });
+        }
+    }
+
+    handleOnChange = (event) => {
+        this.setSelectedEntryType(event.currentTarget.value);
+    };
+
+    setSelectedEntryType = (value) => {
+        this.setState(prevState => {
+            if (prevState.getStartedStepRadio === value &&
+                prevState.activeWizardType === value) {
+                return null;
+            }
+            return {
+                getStartedStepRadio: value,
+                activeWizardType: value,
+            };
+        });
     };
 
     onToggleWizard = () => {
@@ -38,7 +193,6 @@ class NewEntryWizard extends React.Component {
     };
 
     createInitialLayout = () => {
-        // console.log(`this.props.createRootEntry = ${this.props.createRootEntry}`);
         // Creation of a root entry.
         if (this.props.createRootEntry) {
             return ([
@@ -78,57 +232,11 @@ variant="custom" isInline
                 id: 1,
                 name: _("Get Started"),
                 component: (
-                    <div>
-                        <Radio
-                            value="User"
-                            isChecked={this.state.getStartedStepRadio === 'User'}
-                            onChange={(event, _) => this.handleOnChange(_, event)}
-                            label={_("Create a new User")}
-                            description={_("Add a new User (inetOrgPerson objectClass)")}
-                            name="radio-new-step-start"
-                            id="radio-new-step-start-1"
-                        />
-                        <Radio
-                            className="ds-margin-top-lg"
-                            value="Group"
-                            isChecked={this.state.getStartedStepRadio === 'Group'}
-                            onChange={(event, _) => this.handleOnChange(_, event)}
-                            label={_("Create a new Group")}
-                            description={_("Add a new Group (GroupOfNames/GroupOfUniqueNames objectClass)")}
-                            name="group"
-                            id="radio-new-step-start-2"
-                        />
-                        <Radio
-                            className="ds-margin-top-lg"
-                            value="OrganizationalUnit"
-                            isChecked={this.state.getStartedStepRadio === 'OrganizationalUnit'}
-                            onChange={(event, _) => this.handleOnChange(_, event)}
-                            label={_("Create a new Organizational Unit")}
-                            description={_("Add a new Organizational Unit")}
-                            name="radio-new-step-start"
-                            id="radio-new-step-start-3"
-                        />
-                        <Radio
-                          className="ds-margin-top-lg"
-                          value="Role"
-                          isChecked={this.state.getStartedStepRadio === 'Role'}
-                          onChange={(event, _) => this.handleOnChange(_, event)}
-                          label={_("Create a new Role")}
-                          description={_("Add a new Role (Filtered / Managed / Nested)")}
-                          name="radio-new-step-start"
-                          id="radio-new-step-start-4"
-                        />
-                        <Radio
-                            className="ds-margin-top-lg"
-                            value="Other"
-                            isChecked={this.state.getStartedStepRadio === 'Other'}
-                            onChange={(event, _) => this.handleOnChange(_, event)}
-                            label={_("Create a new custom Entry")}
-                            description={_("Add a new entry by selecting ObjectClasses and Attributes")}
-                            name="radio-new-step-start"
-                            id="radio-new-step-start-7"
-                        />
-                    </div>
+                    <GetStartedStep
+                        selected={this.state.getStartedStepRadio}
+                        onChange={this.handleOnChange}
+                        onSelect={this.setSelectedEntryType}
+                    />
                 )
             }
         ]);
@@ -136,7 +244,7 @@ variant="custom" isInline
 
     render () {
         const {
-            getStartedStepRadio
+            activeWizardType,
         } = this.state;
 
         const initialStep = this.createInitialLayout();
@@ -149,30 +257,30 @@ variant="custom" isInline
             setWizardOperationInfo: this.props.setWizardOperationInfo,
             firstStep: initialStep,
             onReload: this.props.onReload,
-            addNotification: this.props.addNotification
+            addNotification: this.props.addNotification,
         };
 
-        if (getStartedStepRadio === 'User') {
+        if (activeWizardType === 'User') {
             return (
                 <AddUser
                     {...wizardProps}
                 />
             );
-        } else if (getStartedStepRadio === 'Group') {
+        } else if (activeWizardType === 'Group') {
             return (
                 <AddGroup
                     {...wizardProps}
-                treeViewRootSuffixes={this.props.treeViewRootSuffixes}
+                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />
             );
-        } else if (getStartedStepRadio === 'Role') {
+        } else if (activeWizardType === 'Role') {
             return (
                 <AddRole
                     {...wizardProps}
-                treeViewRootSuffixes={this.props.treeViewRootSuffixes}
+                    treeViewRootSuffixes={this.props.treeViewRootSuffixes}
                 />
             );
-        } else if (getStartedStepRadio === 'OrganizationalUnit') {
+        } else if (activeWizardType === 'OrganizationalUnit') {
             return (
                 <GenericUpdate
                     editorLdapServer={this.props.editorLdapServer}

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addLdapEntry.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/addLdapEntry.jsx
@@ -109,7 +109,15 @@ class AddLdapEntry extends React.Component {
             });
             // The function updateValuesTableRows() is called upon new seletion(s)
             // Make sure the values table is updated in case no selection was made.
-            if (id === 3) {
+            if (id === 2) {
+                // Ok we can get our single-valued attributes now
+                if (this.singleValuedAttributes.length === 0) {
+                    getSingleValuedAttributes(this.props.editorLdapServer,
+                                              (myAttrs) => {
+                                                  this.singleValuedAttributes = [...myAttrs];
+                                             });
+                }
+            } else if (id === 3) {
                 // Just call this function in order to make sure the values table is up-to-date
                 // even after navigating back and forth.
                 this.updateAttributeTableRows();
@@ -285,10 +293,6 @@ class AddLdapEntry extends React.Component {
 
     componentDidMount () {
         const ocArray = [];
-        getSingleValuedAttributes(this.props.editorLdapServer,
-                                  (myAttrs) => {
-                                      this.singleValuedAttributes = [...myAttrs];
-                                  });
 
         this.props.allObjectclasses.map(oc => {
             let selectionDisabled = false;

--- a/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/genericUpdate.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/wizards/operations/genericUpdate.jsx
@@ -142,7 +142,6 @@ class GenericUpdate extends React.Component {
     }
 
     componentDidMount () {
-        console.log('In GenericUpdate - componentDidMount()');
         // TODO:
         // Use an ldapsearch request on the schema entry.
         // Check with RHDS Engineering ( dsconf? to retrieve the list of attrs for a given oc)


### PR DESCRIPTION
Description:

When creating a new entry, or adding COS, the arrow keys did not work properly because the component would reload/remount and it would lose focus on the radio button group making it impossible to use the arrow keys to select different radio buttons.

The radios are controlled via isChecked={selected === '...'}, so React only shows a selection when state changes. Arrow keys moved focus in the DOM, but PatternFly’s onChange doesn’t run for keyboard navigation.

We need to revise how the state is ahndled to keep focus on the button group.

Assisted-by: Cursor

relates: https://github.com/389ds/389-ds-base/issues/7637

## Summary by Sourcery

Improve keyboard accessibility of the New Entry and CoS wizards by stabilizing wizard selection state and introducing focused radio-group components, allowing arrow keys to cycle options without remounting the wizard or losing focus.

New Features:
- Support keyboard-based navigation of entry-type radio options in the New Entry wizard without losing focus.
- Support keyboard-based navigation of CoS-type radio options in the CoS wizard while keeping the sidebar steps in sync.

Bug Fixes:
- Prevent arrow-key navigation in the New Entry and CoS wizards from remounting the underlying PatternFly wizard and stealing focus from the radio group.
- Ensure the selected wizard type remains stable when changing radio options so DOM reloads no longer disrupt selection state.

Enhancements:
- Refactor the "Get Started" radio groups in the New Entry and CoS wizards into dedicated components that manage focus and selection state.
- Introduce explicit wizard type state separate from the current radio selection to better control which operation wizard is mounted on step 1.