### PR TITLE
Issue 7611 - Preserve legacy PBKDF2 hash compatibility

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_pwstorage_scheme_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_pwstorage_scheme_test.py
@@ -1,0 +1,170 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+import json
+
+import pytest
+from lib389.cli_base import FakeArgs
+from lib389.cli_conf.plugins.pwstorage import (
+    pbkdf2_get_accept_max_iterations,
+    pbkdf2_set_accept_max_iterations,
+)
+from lib389.password_plugins import PBKDF2SHA256LegacyPlugin
+from test389.topologies import topology_st
+
+from . import check_value_in_log_and_reset
+
+
+pytestmark = pytest.mark.tier1
+
+LEGACY_VARIANT = 'pbkdf2-sha256-legacy'
+ACCEPT_MAX_ATTR = 'nsslapd-pwdPBKDF2AcceptMaxIterations'
+PBKDF2_CONFIG_OC = 'pwdPBKDF2PluginConfig'
+ROUNDTRIP_ACCEPT_MAX = 60000
+
+
+@pytest.fixture(scope='function')
+def legacy_pbkdf2_plugin(topology_st, request):
+    plugin = PBKDF2SHA256LegacyPlugin(topology_st.standalone)
+    original_accept_max = plugin.get_attr_val_utf8(ACCEPT_MAX_ATTR)
+    original_config_oc = plugin.present('objectClass', PBKDF2_CONFIG_OC)
+
+    def fin():
+        cleanup_plugin = PBKDF2SHA256LegacyPlugin(topology_st.standalone)
+        if original_config_oc:
+            cleanup_plugin.ensure_present('objectClass', PBKDF2_CONFIG_OC)
+        if original_accept_max is None:
+            cleanup_plugin.remove_all(ACCEPT_MAX_ATTR)
+        else:
+            cleanup_plugin.replace(ACCEPT_MAX_ATTR, original_accept_max)
+        if not original_config_oc:
+            cleanup_plugin.ensure_removed('objectClass', PBKDF2_CONFIG_OC)
+
+    request.addfinalizer(fin)
+    topology_st.logcap.flush()
+    return plugin
+
+
+def test_dsconf_legacy_pbkdf2_accept_max_get_default(topology_st,
+                                                     legacy_pbkdf2_plugin):
+    """Verify dsconf reports the legacy PBKDF2 default accepted maximum
+
+    :id: 6a81d1f4-8437-47d4-8c6b-58d2c56412ee
+    :setup: Standalone instance
+    :steps:
+        1. Remove the configured legacy PBKDF2 accepted maximum
+        2. Get the accepted maximum through the dsconf handler
+    :expectedresults:
+        1. The plugin has no explicit accepted maximum
+        2. The shipped default of 50,000 iterations is logged
+    """
+    legacy_pbkdf2_plugin.remove_all(ACCEPT_MAX_ATTR)
+    assert legacy_pbkdf2_plugin.get_attr_val_utf8(ACCEPT_MAX_ATTR) is None
+
+    args = FakeArgs()
+    args.variant = LEGACY_VARIANT
+    args.json = False
+    pbkdf2_get_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+
+    check_value_in_log_and_reset(
+        topology_st,
+        check_value=(
+            'Current accept max iterations for '
+            f'{LEGACY_VARIANT}: {PBKDF2SHA256LegacyPlugin.ACCEPT_MAX_DEFAULT}'
+        ),
+    )
+
+
+def test_dsconf_legacy_pbkdf2_accept_max_set_get_roundtrip(
+        topology_st, legacy_pbkdf2_plugin, capsys):
+    """Verify dsconf sets and gets the legacy PBKDF2 accepted maximum
+
+    :id: 3962eea0-f70a-46f1-befd-7d3ad493830b
+    :setup: Standalone instance
+    :steps:
+        1. Remove the PBKDF2 configuration object class
+        2. Set the accepted maximum to 60,000 through the dsconf handler
+        3. Inspect the command log message
+        4. Read the plugin configuration through lib389
+        5. Get the accepted maximum as JSON through the dsconf handler
+    :expectedresults:
+        1. The plugin no longer has the configuration object class
+        2. The accepted maximum is stored successfully
+        3. The success message says that a server restart is required
+        4. The value is 60,000 and the configuration object class is restored
+        5. The JSON entry contains the plugin DN and accepted maximum
+    """
+    legacy_pbkdf2_plugin.remove_all(ACCEPT_MAX_ATTR)
+    legacy_pbkdf2_plugin.remove('objectClass', PBKDF2_CONFIG_OC)
+    assert not legacy_pbkdf2_plugin.present('objectClass', PBKDF2_CONFIG_OC)
+
+    args = FakeArgs()
+    args.variant = LEGACY_VARIANT
+    args.iterations = ROUNDTRIP_ACCEPT_MAX
+    pbkdf2_set_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+
+    check_value_in_log_and_reset(
+        topology_st,
+        content_list=[
+            f'Successfully set accept max iterations for {LEGACY_VARIANT} '
+            f'to {ROUNDTRIP_ACCEPT_MAX}',
+            'A server restart is required for the change to take effect',
+        ],
+    )
+    assert legacy_pbkdf2_plugin.get_accept_max_iterations() == ROUNDTRIP_ACCEPT_MAX
+    assert legacy_pbkdf2_plugin.present('objectClass', PBKDF2_CONFIG_OC)
+
+    args.json = True
+    capsys.readouterr()
+    pbkdf2_get_accept_max_iterations(
+        topology_st.standalone, None, topology_st.logcap.log, args
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result == {
+        'type': 'entry',
+        'dn': legacy_pbkdf2_plugin._dn,
+        'attrs': {
+            'nsslapd-pwdpbkdf2acceptmaxiterations': [ROUNDTRIP_ACCEPT_MAX],
+        },
+    }
+
+
+def test_dsconf_legacy_pbkdf2_accept_max_validation(topology_st,
+                                                    legacy_pbkdf2_plugin):
+    """Verify dsconf rejects legacy PBKDF2 accepted maxima outside its bounds
+
+    :id: 998ced54-c46f-49cf-a909-34126ea0756f
+    :setup: Standalone instance
+    :steps:
+        1. Store a valid accepted maximum of 60,000 iterations
+        2. Try to set a value below the supported minimum
+        3. Try to set a value above the supported maximum
+        4. Read the stored accepted maximum
+    :expectedresults:
+        1. The valid accepted maximum is stored
+        2. A ValueError is raised
+        3. A ValueError is raised
+        4. The stored value remains unchanged
+    """
+    legacy_pbkdf2_plugin.set_accept_max_iterations(ROUNDTRIP_ACCEPT_MAX)
+
+    args = FakeArgs()
+    args.variant = LEGACY_VARIANT
+    for invalid_value in (
+            PBKDF2SHA256LegacyPlugin.ACCEPT_MAX_MIN - 1,
+            PBKDF2SHA256LegacyPlugin.ACCEPT_MAX_MAX + 1):
+        args.iterations = invalid_value
+        with pytest.raises(ValueError):
+            pbkdf2_set_accept_max_iterations(
+                topology_st.standalone, None, topology_st.logcap.log, args
+            )
+        assert legacy_pbkdf2_plugin.get_accept_max_iterations() == ROUNDTRIP_ACCEPT_MAX

--- a/dirsrvtests/tests/suites/password/pbkdf2_upgrade_plugin_test.py
+++ b/dirsrvtests/tests/suites/password/pbkdf2_upgrade_plugin_test.py
@@ -15,7 +15,11 @@ import pytest
 from test389.topologies import topology_st
 from lib389._constants import DEFAULT_SUFFIX, DN_PWDSTORAGE_SCHEMES
 from lib389.idm.user import UserAccounts
-from lib389.password_plugins import PasswordPlugin, PBKDF2SHA256Plugin
+from lib389.password_plugins import (
+    PasswordPlugin,
+    PBKDF2SHA256LegacyPlugin,
+    PBKDF2SHA256Plugin,
+)
 from lib389.utils import ds_is_older
 
 pytestmark = pytest.mark.tier1
@@ -91,7 +95,8 @@ def test_c_pbkdf2_sha256_upgrade(topology_st, request):
         2. Remove the C plugin configuration object class to simulate an old installation
         3. Store and verify a legacy 50,000-round C PBKDF2_SHA256 password
         4. Restart the server and verify the configuration object class was restored
-        5. Verify a 60,000-round legacy hash is rejected, then raise its verifier maximum
+        5. Verify a 60,000-round legacy hash is rejected with remediation guidance,
+           then raise its verifier maximum
         6. Verify successful legacy binds migrate to the configured modern scheme
         7. Verify invalid persisted legacy configuration falls back safely
         8. Verify newly stored passwords use modern PBKDF2-SHA256 at 600,000 rounds
@@ -100,7 +105,7 @@ def test_c_pbkdf2_sha256_upgrade(topology_st, request):
         2. The legacy plugin entry matches its pre-upgrade configuration
         3. The legacy password authenticates and is transparently migrated
         4. The plugin entry is upgraded and the existing account still authenticates
-        5. The default ceiling is enforced and can be raised on the upgraded entry
+        5. The default ceiling is enforced with remediation guidance and can be raised
         6. Migrated hashes use the modern scheme and configured work factor
         7. Invalid stored values do not prevent startup
         8. New password values use the modern scheme and configured work factor
@@ -181,7 +186,13 @@ def test_c_pbkdf2_sha256_upgrade(topology_st, request):
     with pytest.raises(ldap.INVALID_CREDENTIALS):
         user.bind(password)
 
-    plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR, str(HIGH_PBKDF2_ITERATIONS))
+    assert inst.ds_error_log.match(
+        f'.*Rejected a password hash with iteration count {HIGH_PBKDF2_ITERATIONS} '
+        f'above the accepted maximum {LEGACY_PBKDF2_ITERATIONS}.*'
+        f'raise {C_PBKDF2_ACCEPT_MAX_ATTR}.*'
+    )
+
+    PBKDF2SHA256LegacyPlugin(inst).set_accept_max_iterations(HIGH_PBKDF2_ITERATIONS)
     inst.restart()
 
     plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
@@ -195,6 +206,7 @@ def test_c_pbkdf2_sha256_upgrade(topology_st, request):
     user.replace('userPassword', high_iteration_hash)
     assert user.get_attr_val_utf8('userPassword') == high_iteration_hash
 
+    # Persist the invalid value directly because the lib389 class rejects it.
     plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR,
                    str(C_PBKDF2_MAX_ACCEPT_ITERATIONS + 1))
     inst.restart()
@@ -214,3 +226,50 @@ def test_c_pbkdf2_sha256_upgrade(topology_st, request):
     user.replace('userPassword', new_password)
     _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
     user.bind(new_password)
+
+
+def test_c_pbkdf2_capped_benchmark_logging(topology_st, request):
+    """Verify legacy PBKDF2 benchmark ceiling startup logging
+
+    :id: 1bc1a546-4a5b-499b-8d38-c94ec1cd95a9
+    :setup: Single instance
+    :steps:
+        1. Set the legacy PBKDF2 accepted maximum to the supported minimum
+        2. Restart the server
+        3. Inspect the PBKDF2 startup messages in the error log
+    :expectedresults:
+        1. The accepted maximum is set to 2,048 iterations
+        2. The server chooses no more than 2,048 iterations
+        3. The configured maximum and chosen rounds are logged, and any
+           required cap is logged with the configured maximum
+    """
+    inst = topology_st.standalone
+    plugin = PBKDF2SHA256LegacyPlugin(inst)
+    original_accept_max = plugin.get_attr_val_utf8(C_PBKDF2_ACCEPT_MAX_ATTR)
+
+    def fin():
+        cleanup_plugin = PBKDF2SHA256LegacyPlugin(inst)
+        if original_accept_max is None:
+            cleanup_plugin.remove_all(C_PBKDF2_ACCEPT_MAX_ATTR)
+        else:
+            cleanup_plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR, original_accept_max)
+        inst.restart()
+
+    request.addfinalizer(fin)
+
+    inst.deleteErrorLogs()
+    plugin.set_accept_max_iterations(PBKDF2SHA256LegacyPlugin.ACCEPT_MAX_MIN)
+    inst.restart()
+
+    assert inst.ds_error_log.match(
+        '.*PBKDF2 accept max iterations set to 2048.*'
+    )
+    assert inst.ds_error_log.match(
+        '.*Based on CPU performance, chose 2048 rounds.*'
+    )
+    cap_messages = inst.ds_error_log.match(
+        '.*Benchmark chose .* rounds; capping at the configured accept max .*'
+    )
+    assert not cap_messages or inst.ds_error_log.match(
+        '.*capping at the configured accept max 2048.*'
+    )

--- a/dirsrvtests/tests/suites/password/pbkdf2_upgrade_plugin_test.py
+++ b/dirsrvtests/tests/suites/password/pbkdf2_upgrade_plugin_test.py
@@ -6,12 +6,43 @@
 # See LICENSE for details.
 # --- END COPYRIGHT BLOCK ---
 #
+import base64
+import hashlib
+import struct
+
+import ldap
 import pytest
 from test389.topologies import topology_st
-from lib389.password_plugins import PBKDF2SHA256Plugin
+from lib389._constants import DEFAULT_SUFFIX, DN_PWDSTORAGE_SCHEMES
+from lib389.idm.user import UserAccounts
+from lib389.password_plugins import PasswordPlugin, PBKDF2SHA256Plugin
 from lib389.utils import ds_is_older
 
 pytestmark = pytest.mark.tier1
+
+C_PBKDF2_PLUGIN_DN = f'cn=PBKDF2_SHA256,{DN_PWDSTORAGE_SCHEMES}'
+C_PBKDF2_CONFIG_OC = 'pwdPBKDF2PluginConfig'
+C_PBKDF2_ACCEPT_MAX_ATTR = 'nsslapd-pwdPBKDF2AcceptMaxIterations'
+C_PBKDF2_MAX_ACCEPT_ITERATIONS = 2147483647
+LEGACY_PBKDF2_ITERATIONS = 50000
+HIGH_PBKDF2_ITERATIONS = 60000
+LEGACY_PBKDF2_SALT = b'389ds-pbkdf2-upgrade-test'.ljust(64, b'\0')
+MODERN_PBKDF2_SCHEME = 'PBKDF2-SHA256'
+MODERN_PBKDF2_ITERATIONS = 600000
+MODERN_PBKDF2_ROUNDS_ATTR = 'nsslapd-pwdPBKDF2NumIterations'
+
+
+def _legacy_pbkdf2_sha256_hash(password, iterations=LEGACY_PBKDF2_ITERATIONS):
+    digest = hashlib.pbkdf2_hmac('sha256', password.encode(), LEGACY_PBKDF2_SALT,
+                                 iterations, dklen=256)
+    payload = struct.pack('!I', iterations) + LEGACY_PBKDF2_SALT + digest
+    return '{PBKDF2_SHA256}' + base64.b64encode(payload).decode()
+
+
+def _assert_modern_pbkdf2_sha256_hash(stored_password):
+    expected_prefix = f'{{{MODERN_PBKDF2_SCHEME}}}{MODERN_PBKDF2_ITERATIONS}$'
+    assert stored_password.startswith(expected_prefix)
+
 
 @pytest.mark.skipif(ds_is_older('1.4.1'), reason="Not implemented")
 def test_pbkdf2_upgrade(topology_st):
@@ -50,3 +81,136 @@ def test_pbkdf2_upgrade(topology_st):
     assert(p3.exists())
 
 
+def test_c_pbkdf2_sha256_upgrade(topology_st, request):
+    """Verify legacy C PBKDF2_SHA256 and migrate it to modern PBKDF2-SHA256
+
+    :id: 129f0dbc-7b1d-4b6a-b6c7-1ce3266a695d
+    :setup: Single instance
+    :steps:
+        1. Configure modern PBKDF2-SHA256 with 600,000 rounds as the preferred scheme
+        2. Remove the C plugin configuration object class to simulate an old installation
+        3. Store and verify a legacy 50,000-round C PBKDF2_SHA256 password
+        4. Restart the server and verify the configuration object class was restored
+        5. Verify a 60,000-round legacy hash is rejected, then raise its verifier maximum
+        6. Verify successful legacy binds migrate to the configured modern scheme
+        7. Verify invalid persisted legacy configuration falls back safely
+        8. Verify newly stored passwords use modern PBKDF2-SHA256 at 600,000 rounds
+    :expectedresults:
+        1. The modern scheme and work factor are loaded
+        2. The legacy plugin entry matches its pre-upgrade configuration
+        3. The legacy password authenticates and is transparently migrated
+        4. The plugin entry is upgraded and the existing account still authenticates
+        5. The default ceiling is enforced and can be raised on the upgraded entry
+        6. Migrated hashes use the modern scheme and configured work factor
+        7. Invalid stored values do not prevent startup
+        8. New password values use the modern scheme and configured work factor
+    """
+    inst = topology_st.standalone
+    plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
+    modern_plugin = PBKDF2SHA256Plugin(inst)
+    original_allow_hashed = inst.config.get_attr_val_utf8('nsslapd-allow-hashed-passwords')
+    original_upgrade_hash = inst.config.get_attr_val_utf8('nsslapd-enable-upgrade-hash')
+    original_password_scheme = inst.config.get_attr_val_utf8('passwordStorageScheme')
+    original_accept_max = plugin.get_attr_val_utf8(C_PBKDF2_ACCEPT_MAX_ATTR)
+    original_modern_rounds = modern_plugin.get_attr_val_utf8(MODERN_PBKDF2_ROUNDS_ATTR)
+    user = None
+
+    def fin():
+        cleanup_plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
+        cleanup_plugin.ensure_present('objectClass', C_PBKDF2_CONFIG_OC)
+        if user is not None and user.exists():
+            user.delete()
+        if original_allow_hashed is None:
+            inst.config.remove_all('nsslapd-allow-hashed-passwords')
+        else:
+            inst.config.replace('nsslapd-allow-hashed-passwords', original_allow_hashed)
+        if original_upgrade_hash is None:
+            inst.config.remove_all('nsslapd-enable-upgrade-hash')
+        else:
+            inst.config.replace('nsslapd-enable-upgrade-hash', original_upgrade_hash)
+        if original_password_scheme is not None:
+            inst.config.replace('passwordStorageScheme', original_password_scheme)
+        if original_accept_max is None:
+            cleanup_plugin.remove_all(C_PBKDF2_ACCEPT_MAX_ATTR)
+        else:
+            cleanup_plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR, original_accept_max)
+        cleanup_modern_plugin = PBKDF2SHA256Plugin(inst)
+        if original_modern_rounds is None:
+            cleanup_modern_plugin.remove_all(MODERN_PBKDF2_ROUNDS_ATTR)
+        else:
+            cleanup_modern_plugin.replace(MODERN_PBKDF2_ROUNDS_ATTR,
+                                          original_modern_rounds)
+        inst.restart()
+
+    request.addfinalizer(fin)
+
+    modern_plugin.set_rounds(MODERN_PBKDF2_ITERATIONS)
+    inst.config.replace('passwordStorageScheme', MODERN_PBKDF2_SCHEME)
+    inst.config.replace('nsslapd-enable-upgrade-hash', 'on')
+    inst.restart()
+
+    plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
+    assert plugin.present('objectClass', C_PBKDF2_CONFIG_OC)
+    plugin.remove('objectClass', C_PBKDF2_CONFIG_OC)
+    assert not plugin.present('objectClass', C_PBKDF2_CONFIG_OC)
+
+    inst.config.replace('nsslapd-allow-hashed-passwords', 'on')
+    user = UserAccounts(inst, DEFAULT_SUFFIX).create_test_user(uid=7613, gid=7613)
+    password = 'LegacyPassword_7613'
+    legacy_hash = _legacy_pbkdf2_sha256_hash(password)
+    high_iteration_hash = _legacy_pbkdf2_sha256_hash(password, HIGH_PBKDF2_ITERATIONS)
+    user.replace('userPassword', legacy_hash)
+    assert user.get_attr_val_utf8('userPassword') == legacy_hash
+    user.bind(password)
+    _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
+
+    # Successful binds may upgrade the password to the preferred scheme.  Put
+    # the exact legacy hash back before restart so this remains an upgrade test.
+    user.replace('userPassword', legacy_hash)
+    assert user.get_attr_val_utf8('userPassword') == legacy_hash
+
+    inst.restart()
+
+    plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
+    assert plugin.present('objectClass', C_PBKDF2_CONFIG_OC)
+    assert user.get_attr_val_utf8('userPassword') == legacy_hash
+    user.bind(password)
+    _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
+
+    user.replace('userPassword', high_iteration_hash)
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user.bind(password)
+
+    plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR, str(HIGH_PBKDF2_ITERATIONS))
+    inst.restart()
+
+    plugin = PasswordPlugin(inst, dn=C_PBKDF2_PLUGIN_DN)
+    assert plugin.get_attr_val_int(C_PBKDF2_ACCEPT_MAX_ATTR) == HIGH_PBKDF2_ITERATIONS
+    user.bind(password)
+    _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
+
+    # A successful bind may transparently upgrade the stored password to the
+    # server's preferred scheme.  Restore the legacy high-iteration hash so the
+    # invalid configuration restart still exercises the verifier ceiling.
+    user.replace('userPassword', high_iteration_hash)
+    assert user.get_attr_val_utf8('userPassword') == high_iteration_hash
+
+    plugin.replace(C_PBKDF2_ACCEPT_MAX_ATTR,
+                   str(C_PBKDF2_MAX_ACCEPT_ITERATIONS + 1))
+    inst.restart()
+
+    assert inst.ds_error_log.match(
+        f'.*Invalid {C_PBKDF2_ACCEPT_MAX_ATTR} value '
+        f'{C_PBKDF2_MAX_ACCEPT_ITERATIONS + 1}.*using the default '
+        f'{LEGACY_PBKDF2_ITERATIONS}.*'
+    )
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        user.bind(password)
+    user.replace('userPassword', legacy_hash)
+    user.bind(password)
+    _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
+
+    new_password = 'ModernPassword_7613'
+    user.replace('userPassword', new_password)
+    _assert_modern_pbkdf2_sha256_hash(user.get_attr_val_utf8('userPassword'))
+    user.bind(new_password)

--- a/dirsrvtests/tests/suites/password/pwp_history_test.py
+++ b/dirsrvtests/tests/suites/password/pwp_history_test.py
@@ -343,6 +343,9 @@ def test_prehashed_pwd(topology_st):
         7. Update user password with hash value
         8. Bind with hashed password cleartext
         9. Check users passwordHistory
+        10. Restart the server and bind with the pre-hashed password
+        11. Change the password so the pre-hashed password enters passwordHistory
+        12. Verify the pre-hashed password cannot be reused
 
     :expectedresults:
         1. Password history policy should be configured successfully
@@ -354,6 +357,9 @@ def test_prehashed_pwd(topology_st):
         7. Password change accepted
         8. Successful bind
         9. Users passwordHistory should contain 2 enteries
+        10. Successful bind after restart
+        11. Password change accepted
+        12. Password reuse rejected
     """
 
     # Configure password history policy and add a test user
@@ -403,6 +409,15 @@ def test_prehashed_pwd(topology_st):
         assert False
     else:
         log.info('Correct number of passwords found in history.')
+
+    # Verify the pre-hashed password remains valid after plugin startup runs again
+    topology_st.standalone.restart()
+    user.rebind('password2')
+
+    # Move the pre-hashed password into history and verify it cannot be reused
+    user.replace('userpassword', 'password3')
+    user.rebind('password3')
+    change_password(user, 'password2', success=False)
 
     # Done
     log.info('Test suite PASSED.')

--- a/ldap/ldif/template-dse-minimal.ldif.in
+++ b/ldap/ldif/template-dse-minimal.ldif.in
@@ -186,6 +186,7 @@ nsslapd-pluginenabled: on
 dn: cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin
+objectClass: pwdPBKDF2PluginConfig
 cn: PBKDF2_SHA256
 nsslapd-pluginpath: libpwdstorage-plugin
 nsslapd-plugininitfunc: pbkdf2_sha256_pwd_storage_scheme_init

--- a/ldap/ldif/template-dse.ldif.in
+++ b/ldap/ldif/template-dse.ldif.in
@@ -243,6 +243,7 @@ nsslapd-pluginenabled: on
 dn: cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config
 objectclass: top
 objectclass: nsSlapdPlugin
+objectClass: pwdPBKDF2PluginConfig
 cn: PBKDF2_SHA256
 nsslapd-pluginpath: libpwdstorage-plugin
 nsslapd-plugininitfunc: pbkdf2_sha256_pwd_storage_scheme_init

--- a/ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c
+++ b/ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c
@@ -58,11 +58,15 @@
  * it's still better than ssha512.
  */
 #define PBKDF2_MINIMUM 2048
-#define PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT 50000
 #define PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR "nsslapd-pwdPBKDF2AcceptMaxIterations"
 
 static uint32_t pbkdf2Iterations = 8192;
 static uint32_t pbkdf2AcceptMaxIterations = PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT;
+
+/* Rejections of out-of-range iteration counts are logged at most once per interval */
+#define PBKDF2_REJECT_LOG_INTERVAL 300
+static uint64_t pbkdf2RejectLastLogTime = 0;
+static uint64_t pbkdf2RejectSuppressed = 0;
 
 static const char *schemeName = PBKDF2_SHA256_SCHEME_NAME;
 static const uint32_t schemeNameLength = PBKDF2_SHA256_NAME_LEN;
@@ -245,6 +249,41 @@ pbkdf2_sha256_pw_enc(const char *pwd)
     return pbkdf2_sha256_pw_enc_rounds(pwd, pbkdf2Iterations);
 }
 
+static void
+pbkdf2_sha256_log_rejected_iterations(uint32_t iterations)
+{
+    uint64_t now = (uint64_t)slapi_current_rel_time_t();
+    uint64_t last = slapi_atomic_load_64(&pbkdf2RejectLastLogTime, __ATOMIC_RELAXED);
+
+    if (last != 0 && (now - last) < PBKDF2_REJECT_LOG_INTERVAL) {
+        slapi_atomic_incr_64(&pbkdf2RejectSuppressed, __ATOMIC_RELAXED);
+        return;
+    }
+    slapi_atomic_store_64(&pbkdf2RejectLastLogTime, now, __ATOMIC_RELAXED);
+    uint64_t suppressed = slapi_atomic_load_64(&pbkdf2RejectSuppressed, __ATOMIC_RELAXED);
+    slapi_atomic_store_64(&pbkdf2RejectSuppressed, 0, __ATOMIC_RELAXED);
+
+    if (iterations > pbkdf2AcceptMaxIterations) {
+        slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
+                      "Rejected a password hash with iteration count %" PRIu32
+                      " above the accepted maximum %" PRIu32 ". If these hashes are legitimate, raise "
+                      PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR
+                      " ('dsconf <instance> plugin pwstorage-scheme pbkdf2-sha256-legacy set-accept-max-iterations') and restart the server\n",
+                      iterations, pbkdf2AcceptMaxIterations);
+    } else {
+        slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
+                      "Rejected a password hash with iteration count %" PRIu32
+                      " below the supported minimum %" PRIu32 "\n",
+                      iterations, PBKDF2_MINIMUM);
+    }
+
+    if (suppressed > 0) {
+        slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
+                      "%" PRIu64 " additional out-of-range iteration rejections were suppressed in the last %" PRIu64 " seconds\n",
+                      suppressed, now - last);
+    }
+}
+
 int32_t
 pbkdf2_sha256_pw_cmp(const char *userpwd, const char *dbpwd)
 {
@@ -281,9 +320,7 @@ pbkdf2_sha256_pw_cmp(const char *userpwd, const char *dbpwd)
 
     /* Check if the iteration count is within range */
     if (iterations < PBKDF2_MINIMUM || iterations > pbkdf2AcceptMaxIterations) {
-        slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
-                      "PBKDF2 iteration count %" PRIu32 " is out of range (max %" PRIu32 ")\n",
-                      iterations, pbkdf2AcceptMaxIterations);
+        pbkdf2_sha256_log_rejected_iterations(iterations);
         return result;
     }
 
@@ -373,8 +410,8 @@ pbkdf2_sha256_calculate_iterations(uint64_t time_nsec)
 }
 
 
-static void
-pbkdf2_sha256_get_accept_max_iterations(Slapi_PBlock *pb, uint32_t default_max)
+static uint32_t
+pbkdf2_sha256_read_accept_max_iterations(Slapi_PBlock *pb, uint32_t default_max)
 {
     Slapi_Entry *entry = NULL;
     uint32_t accept_max = default_max;
@@ -395,9 +432,7 @@ pbkdf2_sha256_get_accept_max_iterations(Slapi_PBlock *pb, uint32_t default_max)
         }
     }
 
-    pbkdf2AcceptMaxIterations = accept_max;
-    slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
-                  "PBKDF2 accept max iterations set to %" PRIu32 "\n", accept_max);
+    return accept_max;
 }
 
 void
@@ -409,14 +444,19 @@ pbkdf2_sha256_set_accept_max_iterations(uint32_t accept_max)
 int
 pbkdf2_sha256_start(Slapi_PBlock *pb)
 {
-    /* Run the time generator */
     uint64_t time_nsec = pbkdf2_sha256_benchmark_iterations();
+    uint32_t benched_iterations = pbkdf2_sha256_calculate_iterations(time_nsec);
 
-    /* Calculate the iterations and set it globally */
-    pbkdf2Iterations = pbkdf2_sha256_calculate_iterations(time_nsec);
-    pbkdf2_sha256_get_accept_max_iterations(pb, PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT);
+    pbkdf2AcceptMaxIterations = pbkdf2_sha256_read_accept_max_iterations(pb, PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT);
+    slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
+                  "PBKDF2 accept max iterations set to %" PRIu32 "\n", pbkdf2AcceptMaxIterations);
+
+    pbkdf2Iterations = benched_iterations;
     if (pbkdf2Iterations > pbkdf2AcceptMaxIterations) {
         pbkdf2Iterations = pbkdf2AcceptMaxIterations;
+        slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
+                      "Benchmark chose %" PRIu32 " rounds; capping at the configured accept max %" PRIu32 "\n",
+                      benched_iterations, pbkdf2AcceptMaxIterations);
     }
     slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
                   "Based on CPU performance, chose %" PRIu32 " rounds\n", pbkdf2Iterations);

--- a/ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c
+++ b/ldap/servers/plugins/pwdstorage/pbkdf2_pwd.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -57,10 +58,11 @@
  * it's still better than ssha512.
  */
 #define PBKDF2_MINIMUM 2048
+#define PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT 50000
 #define PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR "nsslapd-pwdPBKDF2AcceptMaxIterations"
 
 static uint32_t pbkdf2Iterations = 8192;
-static uint32_t pbkdf2AcceptMaxIterations = 0;
+static uint32_t pbkdf2AcceptMaxIterations = PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT;
 
 static const char *schemeName = PBKDF2_SHA256_SCHEME_NAME;
 static const uint32_t schemeNameLength = PBKDF2_SHA256_NAME_LEN;
@@ -278,15 +280,10 @@ pbkdf2_sha256_pw_cmp(const char *userpwd, const char *dbpwd)
     pbkdf2_sha256_extract(dbhash, &saltItem, &iterations);
 
     /* Check if the iteration count is within range */
-    uint32_t accept_max = pbkdf2AcceptMaxIterations;
-
-    if (accept_max == 0) {
-        accept_max = pbkdf2Iterations;
-    }
-    if (iterations < PBKDF2_MINIMUM || iterations > accept_max) {
+    if (iterations < PBKDF2_MINIMUM || iterations > pbkdf2AcceptMaxIterations) {
         slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
                       "PBKDF2 iteration count %" PRIu32 " is out of range (max %" PRIu32 ")\n",
-                      iterations, accept_max);
+                      iterations, pbkdf2AcceptMaxIterations);
         return result;
     }
 
@@ -376,7 +373,7 @@ pbkdf2_sha256_calculate_iterations(uint64_t time_nsec)
 }
 
 
-static int
+static void
 pbkdf2_sha256_get_accept_max_iterations(Slapi_PBlock *pb, uint32_t default_max)
 {
     Slapi_Entry *entry = NULL;
@@ -385,21 +382,22 @@ pbkdf2_sha256_get_accept_max_iterations(Slapi_PBlock *pb, uint32_t default_max)
     /* Check config entry for accept max iterations */
     slapi_pblock_get(pb, SLAPI_ADD_ENTRY, &entry);
     if (entry != NULL && slapi_entry_attr_exists(entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR)) {
-        unsigned long configured = slapi_entry_attr_get_ulong(entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR);
+        int64_t configured = slapi_entry_attr_get_longlong(entry, PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR);
 
-        if (configured < PBKDF2_MINIMUM) {
+        if (configured < PBKDF2_MINIMUM || configured > INT_MAX) {
             slapi_log_err(SLAPI_LOG_ERR, (char *)schemeName,
-                          "Invalid %s value %lu, must be at least %" PRIu32 " \n",
-                          PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR, configured, PBKDF2_MINIMUM);
-            return -1;
+                          "Invalid %s value %" PRId64 ", must be between %" PRIu32
+                          " and %d; using the default %" PRIu32 "\n",
+                          PBKDF2_ACCEPT_MAX_ITERATIONS_ATTR, configured,
+                          PBKDF2_MINIMUM, INT_MAX, default_max);
+        } else {
+            accept_max = (uint32_t)configured;
         }
-        accept_max = (uint32_t)configured;
     }
 
     pbkdf2AcceptMaxIterations = accept_max;
     slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
-                  "PBKDF2 accept max iterations set to %" PRIu32 " \n", accept_max);
-    return 0;
+                  "PBKDF2 accept max iterations set to %" PRIu32 "\n", accept_max);
 }
 
 void
@@ -416,10 +414,14 @@ pbkdf2_sha256_start(Slapi_PBlock *pb)
 
     /* Calculate the iterations and set it globally */
     pbkdf2Iterations = pbkdf2_sha256_calculate_iterations(time_nsec);
+    pbkdf2_sha256_get_accept_max_iterations(pb, PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT);
+    if (pbkdf2Iterations > pbkdf2AcceptMaxIterations) {
+        pbkdf2Iterations = pbkdf2AcceptMaxIterations;
+    }
     slapi_log_err(SLAPI_LOG_INFO, (char *)schemeName,
                   "Based on CPU performance, chose %" PRIu32 " rounds\n", pbkdf2Iterations);
 
-    return pbkdf2_sha256_get_accept_max_iterations(pb, pbkdf2Iterations);
+    return 0;
 }
 
 /* Do we need the matching close function? */

--- a/ldap/servers/plugins/pwdstorage/pwdstorage.h
+++ b/ldap/servers/plugins/pwdstorage/pwdstorage.h
@@ -89,6 +89,8 @@ char *smd5_pw_enc(const char *pwd);
 int gost_yescrypt_pw_cmp(const char *userpwd, const char *dbpwd);
 char *gost_yescrypt_pw_enc(const char *pwd);
 
+#define PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT 50000
+
 int pbkdf2_sha256_start(Slapi_PBlock *pb);
 int pbkdf2_sha256_close(Slapi_PBlock *pb);
 SECStatus pbkdf2_sha256_hash(char *hash_out, size_t hash_out_len, SECItem *pwd, SECItem *salt, PRUint32 iterations);

--- a/ldap/servers/slapd/upgrade.c
+++ b/ldap/servers/slapd/upgrade.c
@@ -98,6 +98,59 @@ upgrade_AES_reverpwd_plugin(void)
     return uresult;
 }
 
+/*
+ * Add the PBKDF2 configuration object class to existing C PBKDF2-SHA256
+ * password storage plugin entries.
+ */
+static upgrade_status
+upgrade_pbkdf2_sha256_config(void)
+{
+    struct slapi_pblock *search_pb = slapi_pblock_new();
+    Slapi_Entry *plugin_entry = NULL;
+    Slapi_DN *sdn = NULL;
+    const char *plugin_dn = "cn=PBKDF2_SHA256,cn=Password Storage Schemes,cn=plugins,cn=config";
+    char *plugin_attr = "objectClass";
+    char *config_oc = "pwdPBKDF2PluginConfig";
+
+    sdn = slapi_sdn_new_dn_byref(plugin_dn);
+    slapi_search_get_entry(&search_pb, sdn, NULL, &plugin_entry, NULL);
+    if (plugin_entry && !slapi_entry_attr_hasvalue(plugin_entry, plugin_attr, config_oc)) {
+        Slapi_PBlock *mod_pb = slapi_pblock_new();
+        LDAPMod mod_add;
+        LDAPMod *mods[2];
+        char *add_val[2];
+        int32_t result;
+
+        add_val[0] = config_oc;
+        add_val[1] = 0;
+        mod_add.mod_op = LDAP_MOD_ADD;
+        mod_add.mod_type = plugin_attr;
+        mod_add.mod_values = add_val;
+        mods[0] = &mod_add;
+        mods[1] = 0;
+
+        slapi_modify_internal_set_pb(mod_pb, plugin_dn,
+                mods, 0, 0, (void *)plugin_get_default_component_id(), 0);
+        slapi_modify_internal_pb(mod_pb);
+        slapi_pblock_get(mod_pb, SLAPI_PLUGIN_INTOP_RESULT, &result);
+        if (result != LDAP_SUCCESS) {
+            slapi_log_err(SLAPI_LOG_ERR, "upgrade_pbkdf2_sha256_config",
+                    "Failed to add %s to '%s', error %d; continuing because "
+                    "the object class is optional\n",
+                    config_oc, plugin_dn, result);
+        } else {
+            slapi_log_err(SLAPI_LOG_NOTICE, "upgrade_pbkdf2_sha256_config",
+                    "Upgrade task: added %s to '%s'\n",
+                    config_oc, plugin_dn);
+        }
+        slapi_pblock_destroy(mod_pb);
+    }
+    slapi_search_get_entry_done(&search_pb);
+    slapi_sdn_free(&sdn);
+
+    return UPGRADE_SUCCESS;
+}
+
 static upgrade_status
 upgrade_143_entryuuid_exists(void)
 {
@@ -800,6 +853,10 @@ upgrade_server(void)
     }
 
     if (upgrade_AES_reverpwd_plugin() != UPGRADE_SUCCESS) {
+        return UPGRADE_FAILURE;
+    }
+
+    if (upgrade_pbkdf2_sha256_config() != UPGRADE_SUCCESS) {
         return UPGRADE_FAILURE;
     }
 

--- a/src/lib389/lib389/cli_conf/plugins/pwstorage.py
+++ b/src/lib389/lib389/cli_conf/plugins/pwstorage.py
@@ -10,6 +10,7 @@ import json
 from lib389.password_plugins import (
     PBKDF2Plugin,
     PBKDF2SHA1Plugin,
+    PBKDF2SHA256LegacyPlugin,
     PBKDF2SHA256Plugin,
     PBKDF2SHA512Plugin
 )
@@ -57,16 +58,69 @@ def pbkdf2_set_iterations(inst, basedn, log, args):
     log.info(f'Successfully set number of iterations for {args.variant} to {args.iterations}')
 
 
+def pbkdf2_get_accept_max_iterations(inst, basedn, log, args):
+    log = log.getChild('pbkdf2_get_accept_max_iterations')
+    plugin = PBKDF2SHA256LegacyPlugin(inst)
+    value = plugin.get_accept_max_iterations()
+
+    if hasattr(args, 'json') and args.json:
+        print(json.dumps({
+            "type": "entry",
+            "dn": plugin._dn,
+            "attrs": {'nsslapd-pwdpbkdf2acceptmaxiterations': [value]}
+        }, indent=4))
+    else:
+        log.info(f'Current accept max iterations for {args.variant}: {value}')
+
+
+def pbkdf2_set_accept_max_iterations(inst, basedn, log, args):
+    log = log.getChild('pbkdf2_set_accept_max_iterations')
+    plugin = PBKDF2SHA256LegacyPlugin(inst)
+    plugin.set_accept_max_iterations(args.iterations)
+    log.info(
+        f'Successfully set accept max iterations for {args.variant} to {args.iterations}. '
+        'A server restart is required for the change to take effect'
+    )
+
+
 def create_parser(subparsers):
     pwstorage = subparsers.add_parser('pwstorage-scheme', help='Manage password storage scheme plugins',
                                       formatter_class=CustomHelpFormatter)
     scheme_subcommands = pwstorage.add_subparsers(help='scheme')
 
-    for variant in sorted(PBKDF2_VARIANTS.keys()):
+    legacy_variant = 'pbkdf2-sha256-legacy'
+    for variant in sorted((*PBKDF2_VARIANTS, legacy_variant)):
         variant_parser = scheme_subcommands.add_parser(variant, help=f'Manage {variant.upper()} scheme',
                                                        formatter_class=CustomHelpFormatter)
-        
+
         variant_subcommands = variant_parser.add_subparsers(help='action')
+
+        if variant == legacy_variant:
+            get_accept_max = variant_subcommands.add_parser(
+                'get-accept-max-iterations',
+                help='Get maximum accepted iterations',
+                formatter_class=CustomHelpFormatter
+            )
+            get_accept_max.set_defaults(
+                func=pbkdf2_get_accept_max_iterations,
+                variant=legacy_variant
+            )
+
+            set_accept_max = variant_subcommands.add_parser(
+                'set-accept-max-iterations',
+                help='Set maximum accepted iterations',
+                formatter_class=CustomHelpFormatter
+            )
+            set_accept_max.add_argument(
+                'iterations',
+                type=int,
+                help='Maximum accepted iterations (2,048-2,147,483,647)'
+            )
+            set_accept_max.set_defaults(
+                func=pbkdf2_set_accept_max_iterations,
+                variant=legacy_variant
+            )
+            continue
 
         get_iter = variant_subcommands.add_parser('get-num-iterations', help='Get number of iterations',
                                                   formatter_class=CustomHelpFormatter)

--- a/src/lib389/lib389/password_plugins.py
+++ b/src/lib389/lib389/password_plugins.py
@@ -116,6 +116,43 @@ class PBKDF2SHA512Plugin(PBKDF2BasePlugin):
         super(PBKDF2SHA512Plugin, self).__init__(instance, dn)
 
 
+class PBKDF2SHA256LegacyPlugin(PasswordPlugin):
+    """Legacy C PBKDF2_SHA256 password storage scheme"""
+    ACCEPT_MAX_MIN = 2048
+    ACCEPT_MAX_MAX = 2147483647
+    ACCEPT_MAX_DEFAULT = 50000
+
+    def __init__(self, instance, dn=f'cn=PBKDF2_SHA256,{DN_PWDSTORAGE_SCHEMES}'):
+        super(PBKDF2SHA256LegacyPlugin, self).__init__(instance, dn)
+        self._create_objectclasses.append('pwdPBKDF2PluginConfig')
+
+    def set_accept_max_iterations(self, iterations):
+        """Set the maximum accepted PBKDF2 iteration count (requires restart)
+
+        :param iterations: Maximum accepted iteration count
+        :type iterations: int
+        """
+        self.ensure_present('objectClass', 'pwdPBKDF2PluginConfig')
+
+        iterations = int(iterations)
+        if iterations < self.ACCEPT_MAX_MIN or iterations > self.ACCEPT_MAX_MAX:
+            raise ValueError(
+                "PBKDF2 accept max iterations must be between 2,048 and 2,147,483,647"
+            )
+        self.replace('nsslapd-pwdPBKDF2AcceptMaxIterations', str(iterations))
+
+    def get_accept_max_iterations(self):
+        """Get the maximum accepted PBKDF2 iteration count
+
+        :returns: Maximum accepted iteration count
+        :rtype: int
+        """
+        iterations = self.get_attr_val_int('nsslapd-pwdPBKDF2AcceptMaxIterations')
+        if iterations:
+            return iterations
+        return self.ACCEPT_MAX_DEFAULT
+
+
 class PasswordPlugins(Plugins):
     def __init__(self, instance):
         super(PasswordPlugins, self).__init__(instance=instance)

--- a/test/plugins/pwdstorage/pbkdf2.c
+++ b/test/plugins/pwdstorage/pbkdf2.c
@@ -14,19 +14,32 @@
 #include <plbase64.h>
 #include <string.h>
 
+#define TEST_PBKDF2_ITERATIONS_LENGTH 4
+#define TEST_PBKDF2_SALT_LENGTH 64
+#define TEST_PBKDF2_HASH_LENGTH 256
 #define TEST_PBKDF2_TOTAL_LENGTH 324
 #define TEST_PBKDF2_MIN_ITERATIONS 2048
-#define TEST_PBKDF2_ACCEPT_MAX_ITERATIONS 50000
 #define TEST_PBKDF2_ACCEPT_LIMIT 10000
 
 /* Build a PBKDF2_SHA256 payload with the given iteration count */
 static void
-test_pbkdf2_prepare_hash(char *hash_bin, uint32_t iterations)
+test_pbkdf2_prepare_hash(char *hash_bin, const char *password, uint32_t iterations)
 {
     uint32_t be = htonl(iterations);
+    SECItem salt = {
+        .data = (unsigned char *)(hash_bin + TEST_PBKDF2_ITERATIONS_LENGTH),
+        .len = TEST_PBKDF2_SALT_LENGTH,
+    };
+    SECItem pwd = {
+        .data = (unsigned char *)password,
+        .len = strlen(password),
+    };
 
-    memset(hash_bin, 'A', TEST_PBKDF2_TOTAL_LENGTH);
+    memset(hash_bin, 0, TEST_PBKDF2_TOTAL_LENGTH);
     memcpy(hash_bin, &be, sizeof(be));
+    memset(salt.data, 'A', salt.len);
+    assert_true(pbkdf2_sha256_hash(hash_bin + TEST_PBKDF2_ITERATIONS_LENGTH + TEST_PBKDF2_SALT_LENGTH,
+                                   TEST_PBKDF2_HASH_LENGTH, &pwd, &salt, iterations) == SECSuccess);
 }
 
 int
@@ -34,7 +47,6 @@ test_plugin_pwdstorage_nss_setup(void **state __attribute__((unused)))
 {
     int result = NSS_Initialize(NULL, "", "", SECMOD_DB, NSS_INIT_READONLY | NSS_INIT_NOCERTDB | NSS_INIT_NOMODDB);
     assert_true(result == 0);
-    pbkdf2_sha256_set_accept_max_iterations(TEST_PBKDF2_ACCEPT_MAX_ITERATIONS);
     return result;
 }
 
@@ -101,43 +113,56 @@ void
 test_plugin_pwdstorage_pbkdf2_pw_cmp_invalid_hash(void **state __attribute__((unused)))
 {
 #if (NSS_VMAJOR * 100 + NSS_VMINOR) > 328
+    const char *password = "password";
     char hash_bin[TEST_PBKDF2_TOTAL_LENGTH];
     char hash_bin_long[TEST_PBKDF2_TOTAL_LENGTH + 4];
     char hash_b64[LDIF_BASE64_LEN(TEST_PBKDF2_TOTAL_LENGTH + 4) + 1];
 
     pbkdf2_sha256_set_accept_max_iterations(TEST_PBKDF2_ACCEPT_LIMIT);
 
-    /* Iteration count above accept max */
-    test_pbkdf2_prepare_hash(hash_bin, TEST_PBKDF2_ACCEPT_LIMIT + 1);
+    /* Iteration count at accept max */
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_ACCEPT_LIMIT);
     memset(hash_b64, 0, sizeof(hash_b64));
     assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH, hash_b64) != NULL);
-    assert_true(pbkdf2_sha256_pw_cmp("password", hash_b64) != 0);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) == 0);
+
+    /* Iteration count above accept max */
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_ACCEPT_LIMIT + 1);
+    memset(hash_b64, 0, sizeof(hash_b64));
+    assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH, hash_b64) != NULL);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) != 0);
+
+    /* Iteration count at TEST_PBKDF2_MIN_ITERATIONS */
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_MIN_ITERATIONS);
+    memset(hash_b64, 0, sizeof(hash_b64));
+    assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH, hash_b64) != NULL);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) == 0);
 
     /* Iterations count below TEST_PBKDF2_MIN_ITERATIONS */
-    test_pbkdf2_prepare_hash(hash_bin, TEST_PBKDF2_MIN_ITERATIONS - 1);
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_MIN_ITERATIONS - 1);
     memset(hash_b64, 0, sizeof(hash_b64));
     assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH, hash_b64) != NULL);
-    assert_true(pbkdf2_sha256_pw_cmp("password", hash_b64) != 0);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) != 0);
 
     /* Decoded payload shorter than TEST_PBKDF2_TOTAL_LENGTH */
-    test_pbkdf2_prepare_hash(hash_bin, TEST_PBKDF2_MIN_ITERATIONS);
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_MIN_ITERATIONS);
     memset(hash_b64, 0, sizeof(hash_b64));
     assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH - 1, hash_b64) != NULL);
-    assert_true(pbkdf2_sha256_pw_cmp("password", hash_b64) != 0);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) != 0);
 
     /* Decoded payload longer than TEST_PBKDF2_TOTAL_LENGTH */
-    test_pbkdf2_prepare_hash(hash_bin_long, TEST_PBKDF2_MIN_ITERATIONS);
+    test_pbkdf2_prepare_hash(hash_bin_long, password, TEST_PBKDF2_MIN_ITERATIONS);
     memset(hash_bin_long + TEST_PBKDF2_TOTAL_LENGTH, 'A', sizeof(hash_bin_long) - TEST_PBKDF2_TOTAL_LENGTH);
     memset(hash_b64, 0, sizeof(hash_b64));
     assert_true(PL_Base64Encode(hash_bin_long, sizeof(hash_bin_long), hash_b64) != NULL);
-    assert_true(pbkdf2_sha256_pw_cmp("password", hash_b64) != 0);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) != 0);
 
     /* Invalid base64 input */
-    test_pbkdf2_prepare_hash(hash_bin, TEST_PBKDF2_MIN_ITERATIONS);
+    test_pbkdf2_prepare_hash(hash_bin, password, TEST_PBKDF2_MIN_ITERATIONS);
     memset(hash_b64, 0, sizeof(hash_b64));
     assert_true(PL_Base64Encode(hash_bin, TEST_PBKDF2_TOTAL_LENGTH, hash_b64) != NULL);
     /* Corrupt a valid base64 char */
     hash_b64[10] = '!';
-    assert_true(pbkdf2_sha256_pw_cmp("password", hash_b64) != 0);
+    assert_true(pbkdf2_sha256_pw_cmp(password, hash_b64) != 0);
 #endif
 }

--- a/test/plugins/pwdstorage/pbkdf2.c
+++ b/test/plugins/pwdstorage/pbkdf2.c
@@ -47,6 +47,8 @@ test_plugin_pwdstorage_nss_setup(void **state __attribute__((unused)))
 {
     int result = NSS_Initialize(NULL, "", "", SECMOD_DB, NSS_INIT_READONLY | NSS_INIT_NOCERTDB | NSS_INIT_NOMODDB);
     assert_true(result == 0);
+    /* Each test starts from the shipped default ceiling regardless of test order */
+    pbkdf2_sha256_set_accept_max_iterations(PBKDF2_ACCEPT_MAX_ITERATIONS_DEFAULT);
     return result;
 }
 


### PR DESCRIPTION
Description: Use a fixed 50,000-round verification ceiling so legacy C PBKDF2_SHA256 hashes continue to authenticate across upgrades and restarts.
Cap generated legacy hashes at the configured ceiling, fall back safely on invalid configuration, and keep the optional object-class upgrade non-fatal.
Exercise migration from the legacy underscore scheme to a separately configured modern PBKDF2-SHA256 scheme at 600,000 rounds, without changing the legacy verification ceiling.
Keep the regression coverage self-contained and restore modified server state.

Relates: https://github.com/389ds/389-ds-base/issues/7611

Reviewed by: ?

## Summary by Sourcery

Preserve compatibility with legacy C PBKDF2-SHA256 password hashes while enforcing a sane verification ceiling and supporting migration to a modern PBKDF2-SHA256 scheme.

Bug Fixes:
- Ensure legacy PBKDF2_SHA256 hashes with 50,000 rounds continue to authenticate across restarts and upgrades under a fixed verification ceiling.
- Prevent misconfigured PBKDF2 iteration ceilings from breaking startup by falling back to a safe default and logging an error.
- Maintain valid pre-hashed passwords across plugin restarts and ensure they cannot be reused once moved into password history.

Enhancements:
- Introduce an upgrade step that adds the optional PBKDF2 configuration object class to existing C PBKDF2-SHA256 plugin entries without failing the upgrade if it cannot be applied.
- Set a default PBKDF2 accept-max-iterations limit, decouple it from the dynamic work-factor calculation, and cap the effective rounds at this ceiling.
- Refine PBKDF2 configuration parsing to validate iteration ceilings, clamp invalid values, and log clearer diagnostics.
- Expand unit and integration tests to cover PBKDF2 iteration ceiling behavior, legacy-to-modern PBKDF2-SHA256 migration, and safe handling of malformed hashes.