### PR TITLE
Issue 7652 - change bind result with password but no dn

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -1582,6 +1582,26 @@ def test_bind_entry_missing_passwd(topology_st):
         user.bind("some_password")
 
 
+def test_bind_with_no_dn(topology_st):
+    """
+    :id: fedb831e-811e-11f1-8bfa-c85309d5c3e3
+    :setup: Standalone Instance
+    :steps:
+        1. Bind with no DN and no password
+        2. Bind with no DN and some password
+    :expectedresults:
+        1. Success
+        2. Fails with error 48
+    """
+    ldc = ldap.initialize(f'ldap://localhost:{topology_st.standalone.port}')
+    ldc.set_option(ldap.OPT_TIMEOUT, 5)
+    ldc.set_option(ldap.OPT_REFERRALS, 0)  # Do not follow referral
+    ldc.bind_s(None, None)
+    with pytest.raises(ldap.INAPPROPRIATE_AUTH):
+        ldc.bind_s(None, "Some password")
+    ldc.unbind()                   
+
+
 def test_connection_buffer_size(topology_st):
     """Test connection buffer size adjustable with different values(valid values and invalid)
 

--- a/ldap/servers/slapd/bind.c
+++ b/ldap/servers/slapd/bind.c
@@ -475,6 +475,15 @@ do_bind(Slapi_PBlock *pb)
 
         /* accept null binds */
         if (dn == NULL || *dn == '\0') {
+            if (cred.bv_len > 0) {
+                /* RFC 4513 does not specify this case. Let's reject it. */
+                send_ldap_result(pb, LDAP_INAPPROPRIATE_AUTH, NULL,
+                                 "Bind with a null DN and non-empty password is rejected", 0, NULL);
+                /* increment BindSecurityErrorcount */
+                slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsBindSecurityErrors);
+                slapi_log_security(pb, SECURITY_BIND_FAILED,  SECURITY_MSG_INVALID_PASSWD);
+                goto free_and_return;
+            }
             slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsAnonymousBinds);
             /* by definition anonymous is also unauthenticated so increment
                that counter */
@@ -487,6 +496,7 @@ do_bind(Slapi_PBlock *pb)
                                  "Anonymous access is not allowed", 0, NULL);
                 /* increment BindSecurityErrorcount */
                 slapi_counter_increment(g_get_per_thread_snmp_vars()->ops_tbl.dsBindSecurityErrors);
+                slapi_log_security(pb, SECURITY_BIND_FAILED, SECURITY_MSG_ANONYMOUS_BIND);
                 goto free_and_return;
             }
 


### PR DESCRIPTION
Reject bind operation with password and no dn whose behavior is not defined in RFC 4513

Issue: #7652

Reviewed by: @tbordaz , @mreynolds389 (Thanks!)

## Summary by Sourcery

Reject LDAP bind operations that provide a password with a null DN and add coverage to ensure anonymous binds remain allowed while password-without-DN binds are rejected.

Bug Fixes:
- Prevent undefined LDAP bind behavior by rejecting binds that use a null DN with a non-empty password.

Tests:
- Add a basic suite test verifying that binds with no DN succeed only when no password is supplied and fail with INAPPROPRIATE_AUTH when a password is provided.