### PR TITLE
Issue 7655 - Slow search when using many DN syntax components and lot…

### DIFF
--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -333,6 +333,7 @@ test_ava_filter(
         for (; a != NULL; a = a->a_next) {
             if (slapi_attr_type_cmp(ava->ava_type, a->a_type, SLAPI_TYPE_CMP_SUBTYPE) == 0) {
                 if ((ftype == LDAP_FILTER_EQUALITY) &&
+                    (slapi_valueset_is_sorted(&a->a_present_values)) &&
                     (slapi_attr_is_dn_syntax_type(a->a_type))) {
                     /* This path is for a performance improvement */
 
@@ -340,6 +341,8 @@ test_ava_filter(
                      * sorted valuearray (from valueset).
                      * This improvement is limited to DN syntax attributes for
                      * which the sorted valueset was designed.
+                     * Only use it when there are enough values and the valueset is sorted
+                     * to be cheaper than a linear syntax match.
                      */
                     Slapi_Value *sval = NULL;
                     sval = slapi_value_new_berval(&ava->ava_value);

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -5107,6 +5107,15 @@ int slapi_valueset_count(const Slapi_ValueSet *vs);
 int slapi_valueset_isempty(const Slapi_ValueSet *vs);
 
 /**
+ * Checks if a \c Slapi_ValueSet structure maintains a sorted index.
+ *
+ * \param vs Pointer to the \c Slapi_ValueSet structure to check.
+ * \return 1 if the valueset has a non-NULL sorted index.
+ * \return 0 if the valueset is NULL or has no sorted index.
+ */
+int slapi_valueset_is_sorted(const Slapi_ValueSet *vs);
+
+/**
  * Initializes a \c Slapi_ValueSet with copies of the values of a \c Slapi_Mod structure.
  *
  * \param vs Pointer to the \c Slapi_ValueSet structure into which

--- a/ldap/servers/slapd/valueset.c
+++ b/ldap/servers/slapd/valueset.c
@@ -595,6 +595,15 @@ slapi_valueset_isempty(const Slapi_ValueSet *vs)
 }
 
 int
+slapi_valueset_is_sorted(const Slapi_ValueSet *vs)
+{
+    if (NULL != vs) {
+        return (vs->sorted != NULL);
+    }
+    return 0;
+}
+
+int
 valueset_isempty(const Slapi_ValueSet *vs)
 {
     if (NULL == vs) {


### PR DESCRIPTION
… of candidate entries

Bug description:
	If the entry does not contain a large valueset the call to sorted valueset is
	slighly slower
	If the filter contains many components '(attr=value)' with attr syntax being DN.
	Then the evaluation of the full filter is slower.
	In addition if the candidate list is long the overall SRCH is much slower than
	if bypass the sorted valueset.

	Tests with 300+ components and 600 IDs shows that the SRCH is twice slower

Fix description:
	Prefer direct call to plugin_call_syntax_filter_ava
	when the valueset is not sorted

fixes: #7655

Assisted by: Cursor

Reviewed by:

## Summary by Sourcery

Improve performance of DN syntax attribute equality filters by avoiding the sorted valueset path when the valueset is not sorted.

Bug Fixes:
- Fix slow search evaluations for filters with many DN syntax components over large candidate sets by selectively using direct syntax filter evaluation.

Enhancements:
- Add an API to check whether a Slapi_ValueSet maintains a sorted index and use it to guard the DN-specific optimized filter path.