### PR TITLE
Backport Issue 7519 — ignore obsolete entrydn when entryrdn is in use

### DIFF
--- a/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
+++ b/dirsrvtests/tests/suites/healthcheck/health_system_indexes_test.py
@@ -89,7 +89,8 @@ def log_buffering_enabled(topology_st, request):
     return standalone
 
 
-def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None):
+def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searched_code2=None,
+                                   isnot=False):
     # If we are using BDB as a backend, we will get error DSBLE0006 on new versions
     if (
         ds_is_newer("3.0.0")
@@ -118,23 +119,39 @@ def run_healthcheck_and_flush_log(topology, instance, searched_code, json, searc
         log.info("Use healthcheck with --json option")
         args.json = json
         health_check_run(instance, topology.logcap.log, args)
-        assert topology.logcap.contains(searched_code)
-        log.info("healthcheck returned searched code: %s" % searched_code)
+        if isnot:
+            assert not topology.logcap.contains(searched_code)
+            log.info("healthcheck did not return searched code: %s" % searched_code)
+        else:
+            assert topology.logcap.contains(searched_code)
+            log.info("healthcheck returned searched code: %s" % searched_code)
 
         if searched_code2 is not None:
-            assert topology.logcap.contains(searched_code2)
-            log.info("healthcheck returned searched code: %s" % searched_code2)
+            if isnot:
+                assert not topology.logcap.contains(searched_code2)
+                log.info("healthcheck did not return searched code: %s" % searched_code2)
+            else:
+                assert topology.logcap.contains(searched_code2)
+                log.info("healthcheck returned searched code: %s" % searched_code2)
     else:
         log.info("Use healthcheck without --json option")
         args.json = json
         health_check_run(instance, topology.logcap.log, args)
 
-        assert topology.logcap.contains(searched_code)
-        log.info("healthcheck returned searched code: %s" % searched_code)
+        if isnot:
+            assert not topology.logcap.contains(searched_code)
+            log.info("healthcheck did not return searched code: %s" % searched_code)
+        else:
+            assert topology.logcap.contains(searched_code)
+            log.info("healthcheck returned searched code: %s" % searched_code)
 
         if searched_code2 is not None:
-            assert topology.logcap.contains(searched_code2)
-            log.info("healthcheck returned searched code: %s" % searched_code2)
+            if isnot:
+                assert not topology.logcap.contains(searched_code2)
+                log.info("healthcheck did not return searched code: %s" % searched_code2)
+            else:
+                assert topology.logcap.contains(searched_code2)
+                log.info("healthcheck returned searched code: %s" % searched_code2)
 
     log.info("Clear the log")
     topology.logcap.flush()
@@ -1252,6 +1269,48 @@ def test_index_check_fixes_multiple_issues(topology_st):
 
     log.info("Start the server")
     standalone.start()
+
+
+
+def test_ignore_entrydn_index(topology_st, log_buffering_enabled):
+    """Healthcheck reports DSBLE0008 when entrydn index is configured.
+
+    :id: 65abefe0-2e6b-45e0-8604-fb33d734e412
+    :setup: Standalone instance
+    :steps:
+        1. Add obsolete entrydn index to userroot
+        2. Run healthcheck
+        3. Remove entrydn index
+        4. Run healthcheck again
+    :expectedresults:
+        1. Success
+        2. healthcheck reports DSBLE0008
+        3. Success
+        4. healthcheck no longer reports DSBLE0008
+    """
+
+    RET_CODE = "DSBLE0008"
+    standalone = topology_st.standalone
+    backend = Backends(standalone).get("userRoot")
+
+    log.info("Add obsolete entrydn index configuration")
+    backend.add_index("entrydn", ["eq"])
+    standalone.restart()
+
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE)
+
+    log.info("Remove entrydn index configuration")
+    entrydn_index = Index(
+        standalone,
+        "cn=entrydn,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config",
+    )
+    entrydn_index.delete()
+    standalone.restart()
+
+    # Only check DSBLE0008 is gone
+    run_healthcheck_and_flush_log(topology_st, standalone, json=False, searched_code=RET_CODE, isnot=True)
+    run_healthcheck_and_flush_log(topology_st, standalone, json=True, searched_code=RET_CODE, isnot=True)
 
 
 if __name__ == "__main__":

--- a/dirsrvtests/tests/suites/indexes/regression_test.py
+++ b/dirsrvtests/tests/suites/indexes/regression_test.py
@@ -541,6 +541,61 @@ def test_task_status(topo):
     assert reindex_task.get_exit_code() == 0
 
 
+def test_reindex_entrydn_only_is_noop(topo):
+    """Reindex of obsolete entrydn alone must not rebuild all indexes.
+
+    When entryrdn is in use, leftover entrydn index config is ignored. A
+    reindex task for only entrydn must warn, finish successfully, and not
+    fall through to a full attribute rebuild.
+
+    :id: e3bbda7a-82f0-409f-a926-d86835c56aaa
+    :setup: Standalone instance
+    :steps:
+        1. Add obsolete entrydn index configuration
+        2. Clear the error log and restart
+        3. Run an online reindex task for entrydn only
+        4. Check task exit code and log messages
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Task completes with exit code 0
+        4. Log shows entrydn is no longer applicable / no applicable
+           indexes; no "Indexing attribute: cn" (full rebuild)
+    """
+    inst = topo.standalone
+    backend = Backends(inst).get(DEFAULT_BENAME)
+
+    log.info("Add obsolete entrydn index configuration")
+    backend.add_index("entrydn", ["eq"])
+    inst.restart()
+
+    log.info("Clear error log so assertions are limited to this reindex")
+    inst.deleteErrorLogs(restart=True)
+
+    log.info("Reindex entrydn only")
+    tasks = Tasks(inst)
+    tasks.reindex(
+        suffix=DEFAULT_SUFFIX,
+        attrname='entrydn',
+        args={TASK_WAIT: True}
+    )
+    reindex_task = Task(inst, tasks.dn)
+    assert reindex_task.get_exit_code() == 0
+    task_log = reindex_task.get_task_log() or ""
+    assert "no longer applicable" in task_log.lower() or \
+           "no applicable indexes" in task_log.lower(), \
+           f"Unexpected task log: {task_log}"
+
+    errlog = DirsrvErrorLog(inst)
+    assert errlog.match(".*no longer applicable") or errlog.match(".*No applicable indexes")
+    assert not errlog.match(".*Indexing attribute: cn"), \
+        "entrydn-only reindex must not fall through to a full index rebuild"
+
+    log.info("Remove obsolete entrydn index configuration")
+    Index(inst, f"cn=entrydn,cn=index,cn={DEFAULT_BENAME},cn=ldbm database,cn=plugins,cn=config").delete()
+    inst.restart()
+
+
 def count_keys(inst, bename, attr, prefix=''):
     indexfile = os.path.join(inst.dbdir, bename, attr + '.db')
     # (bdb - we should also accept a version number for .db suffix)

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1493,11 +1493,11 @@ bdb_db2index(Slapi_PBlock *pb)
                     slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing: %s\n",
                                   inst->inst_name, LDBM_ENTRYRDN_STR);
                     index_ext |= DB2INDEX_ENTRYRDN;
-                } else if (strcasecmp(attrs[i] + 1, LDBM_ENTRYDN_STR) == 0) {
+                } else if (ldbm_index_entrydn_should_ignore(attrs[i] + 1)) {
                     slapi_task_log_notice(task, "%s: Requested to index %s, but the index is no longer applicable",
                                           inst->inst_name, LDBM_ENTRYDN_STR);
                     slapi_log_err(SLAPI_LOG_WARNING,
-                                  "bdb_db2index", "%s: Requested to index %s,but the index is no longer applicable\n",
+                                  "bdb_db2index", "%s: Requested to index %s, but the index is no longer applicable\n",
                                   inst->inst_name, LDBM_ENTRYDN_STR);
                     goto err_out;
                 } else {

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1494,12 +1494,13 @@ bdb_db2index(Slapi_PBlock *pb)
                                   inst->inst_name, LDBM_ENTRYRDN_STR);
                     index_ext |= DB2INDEX_ENTRYRDN;
                 } else if (ldbm_index_entrydn_should_ignore(attrs[i] + 1)) {
+                    /* Warn and skip obsolete entrydn*/
                     slapi_task_log_notice(task, "%s: Requested to index %s, but the index is no longer applicable",
                                           inst->inst_name, LDBM_ENTRYDN_STR);
                     slapi_log_err(SLAPI_LOG_WARNING,
                                   "bdb_db2index", "%s: Requested to index %s, but the index is no longer applicable\n",
                                   inst->inst_name, LDBM_ENTRYDN_STR);
-                    goto err_out;
+                    break;
                 } else {
                     if (strcasecmp(attrs[i] + 1, SLAPI_ATTR_OBJECTCLASS) == 0) {
                         index_ext |= DB2INDEX_OBJECTCLASS;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_ldif2db.c
@@ -1477,6 +1477,25 @@ bdb_db2index(Slapi_PBlock *pb)
             }
             switch (attrs[i][0]) {
             case 't': /* attribute type to index */
+            {
+                char *basename = slapi_ch_strdup(attrs[i] + 1);
+                char *colon = strchr(basename, ':');
+
+                if (colon != NULL) {
+                    *colon = '\0';
+                }
+                if (ldbm_index_entrydn_should_ignore(basename)) {
+                    /* Warn and skip obsolete entrydn */
+                    slapi_task_log_notice(task, "%s: Requested to index %s, but the index is no longer applicable",
+                                          inst->inst_name, LDBM_ENTRYDN_STR);
+                    slapi_log_err(SLAPI_LOG_WARNING,
+                                  "bdb_db2index", "%s: Requested to index %s, but the index is no longer applicable\n",
+                                  inst->inst_name, LDBM_ENTRYDN_STR);
+                    slapi_ch_free_string(&basename);
+                    break;
+                }
+                slapi_ch_free_string(&basename);
+
                 db2index_add_indexed_attr(be, attrs[i]);
                 ainfo_get(be, attrs[i] + 1, &ai);
                 /* the ai was added above, if it didn't already exist */
@@ -1493,14 +1512,6 @@ bdb_db2index(Slapi_PBlock *pb)
                     slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index", "%s: Indexing: %s\n",
                                   inst->inst_name, LDBM_ENTRYRDN_STR);
                     index_ext |= DB2INDEX_ENTRYRDN;
-                } else if (ldbm_index_entrydn_should_ignore(attrs[i] + 1)) {
-                    /* Warn and skip obsolete entrydn*/
-                    slapi_task_log_notice(task, "%s: Requested to index %s, but the index is no longer applicable",
-                                          inst->inst_name, LDBM_ENTRYDN_STR);
-                    slapi_log_err(SLAPI_LOG_WARNING,
-                                  "bdb_db2index", "%s: Requested to index %s, but the index is no longer applicable\n",
-                                  inst->inst_name, LDBM_ENTRYDN_STR);
-                    break;
                 } else {
                     if (strcasecmp(attrs[i] + 1, SLAPI_ATTR_OBJECTCLASS) == 0) {
                         index_ext |= DB2INDEX_OBJECTCLASS;
@@ -1518,6 +1529,7 @@ bdb_db2index(Slapi_PBlock *pb)
                 }
                 dblayer_erase_index_file(be, ai, PR_TRUE, i);
                 break;
+            }
             case 'T': /* VLV Search to index */
                 vlvip = vlv_find_searchname((attrs[i]) + 1, be);
                 if (vlvip == NULL) {
@@ -1541,6 +1553,18 @@ bdb_db2index(Slapi_PBlock *pb)
                 }
                 break;
             }
+        }
+
+        /* Were the requested attrs all skipped */
+        if (attrs && attrs[0] && !indexAttrs && !LDIF2LDBM_EXTBITS(index_ext) &&
+            numvlv == 0) {
+            slapi_task_log_notice(task, "%s: No applicable indexes to rebuild",
+                                  inst->inst_name);
+            slapi_log_err(SLAPI_LOG_INFO, "bdb_db2index",
+                          "%s: No applicable indexes to rebuild\n",
+                          inst->inst_name);
+            return_value = 0;
+            goto err_out;
         }
     }
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -1240,6 +1240,20 @@ process_db2index_attrs(Slapi_PBlock *pb, ImportCtx_t *ctx)
             if (pt != NULL) {
                 *pt = '\0';
             }
+            if (ldbm_index_entrydn_should_ignore(attrname)) {
+                if (ctx->job && ctx->job->task && ctx->job->inst) {
+                    slapi_task_log_notice(ctx->job->task,
+                                          "%s: Requested to index %s, but the index is no longer applicable",
+                                          ctx->job->inst->inst_name, LDBM_ENTRYDN_STR);
+                }
+                if (ctx->job && ctx->job->inst) {
+                    slapi_log_err(SLAPI_LOG_WARNING,
+                                  "process_db2index_attrs", "%s: Requested to index %s, but the index is no longer applicable\n",
+                                  ctx->job->inst->inst_name, LDBM_ENTRYDN_STR);
+                }
+                slapi_ch_free_string(&attrname);
+                break;
+            }
             slapi_ch_array_add(&ctx->indexAttrs, attrname);
             break;
         case 'T': /* VLV Search to index */

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -1321,6 +1321,37 @@ dbmdb_run_ldif2db(Slapi_PBlock *pb)
             job->flags |= FLAG_REINDEXING; /* call dbmdb_index_producer */
             dbmdb_import_init_writer(job, IM_INDEX);
             process_db2index_attrs(pb, job->writer_ctx);
+            /*
+             * If specific indexes were requested but all were skipped
+             * do not fall through to a full rebuild.
+             */
+            {
+                char **req_attrs = NULL;
+                ImportCtx_t *ctx = job->writer_ctx;
+
+                slapi_pblock_get(pb, SLAPI_DB2INDEX_ATTRS, &req_attrs);
+                if (req_attrs && req_attrs[0] && ctx &&
+                    !ctx->indexAttrs && !ctx->indexVlvs) {
+                    if (job->task) {
+                        slapi_task_log_notice(job->task,
+                                              "%s: No applicable indexes to rebuild",
+                                              job->inst->inst_name);
+                    }
+                    slapi_log_err(SLAPI_LOG_INFO, "dbmdb_run_ldif2db",
+                                  "%s: No applicable indexes to rebuild\n",
+                                  job->inst->inst_name);
+                    /* Backend was set busy before we got here */
+                    instance_set_not_busy(job->inst);
+                    if (job->task) {
+                        slapi_task_log_status(job->task, "%s: Finished indexing.",
+                                              job->inst->inst_name);
+                    }
+                    dbmdb_free_import_ctx(job);
+                    dbmdb_import_free_job(job);
+                    FREE(job);
+                    return 0;
+                }
+            }
         }
     } else {
         dbmdb_import_init_writer(job, IM_IMPORT);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import_threads.c
@@ -4404,8 +4404,10 @@ dbmdb_free_import_ctx(ImportJob *job)
         slapi_ch_free((void**)&ctx->workerq.slots);
         dbmdb_import_q_destroy(&ctx->writerq);
         dbmdb_import_q_destroy(&ctx->bulkq);
-        slapi_ch_free((void**)&ctx->id2entry->name);
-        slapi_ch_free((void**)&ctx->id2entry);
+        if (ctx->id2entry) {
+            slapi_ch_free((void**)&ctx->id2entry->name);
+            slapi_ch_free((void**)&ctx->id2entry);
+        }
         avl_free(ctx->indexes, free_ii);
         ctx->indexes = NULL;
         charray_free(ctx->indexAttrs);

--- a/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_index_config.c
@@ -56,6 +56,17 @@ ldbm_index_parse_entry(ldbm_instance *inst, Slapi_Entry *e, const char *trace_st
         return LDAP_OPERATIONS_ERROR;
     }
 
+    if (ldbm_index_entrydn_should_ignore(attrValue->bv_val)) {
+        slapi_log_err(SLAPI_LOG_WARNING, "ldbm_index_parse_entry",
+                      "%s: Requested to index %s, but the index is no longer applicable\n",
+                      inst->inst_name, LDBM_ENTRYDN_STR);
+        if (index_name != NULL) {
+            slapi_ch_free_string(index_name);
+            *index_name = NULL;
+        }
+        return LDAP_SUCCESS;
+    }
+
     if (index_name != NULL) {
         slapi_ch_free_string(index_name);
         *index_name = slapi_ch_strdup(attrValue->bv_val);
@@ -140,6 +151,15 @@ ldbm_instance_index_config_add_callback(Slapi_PBlock *pb __attribute__((unused))
 
     returntext[0] = '\0';
     *returncode = ldbm_index_parse_entry(inst, e, "from DSE add", &index_name, &is_system_index, returntext);
+
+    /*
+     * ldbm_index_parse_entry returns LDAP_SUCCESS with index_name NULL only when
+     * obsolete entrydn is ignored.
+     */
+    if (*returncode == LDAP_SUCCESS && index_name == NULL) {
+        return SLAPI_DSE_CALLBACK_OK;
+    }
+
     if (*returncode == LDAP_SUCCESS) {
         struct attrinfo *ai = NULL;
         /* if the index is a "system" index, we assume it's being added by
@@ -269,6 +289,13 @@ ldbm_instance_index_config_modify_callback(Slapi_PBlock *pb __attribute__((unuse
                       edn);
         *returncode = LDAP_UNWILLING_TO_PERFORM;
         return SLAPI_DSE_CALLBACK_ERROR;
+    }
+
+    if (ldbm_index_entrydn_should_ignore(attrValue->bv_val)) {
+        slapi_log_err(SLAPI_LOG_WARNING, "ldbm_instance_index_config_modify_callback",
+                      "%s: Requested to index %s, but the index is no longer applicable\n",
+                      inst->inst_name, LDBM_ENTRYDN_STR);
+        return SLAPI_DSE_CALLBACK_OK;
     }
 
     ainfo_get(inst->inst_be, attrValue->bv_val, &ainfo);

--- a/ldap/servers/slapd/back-ldbm/misc.c
+++ b/ldap/servers/slapd/back-ldbm/misc.c
@@ -124,9 +124,19 @@ static const char *systemIndexes[] = {
 
 
 int
+ldbm_index_entrydn_should_ignore(const char *index_name)
+{
+    /* entryrdn is always enabled; leftover entrydn indexes must be ignored */
+    return index_name && (0 == strcasecmp(index_name, LDBM_ENTRYDN_STR));
+}
+
+int
 ldbm_attribute_always_indexed(const char *attrtype)
 {
     int r = 0;
+    if (ldbm_index_entrydn_should_ignore(attrtype)) {
+        return 0;
+    }
     if (NULL != attrtype) {
         int i = 0;
         while (!r && systemIndexes[i] != NULL) {

--- a/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
+++ b/ldap/servers/slapd/back-ldbm/proto-back-ldbm.h
@@ -638,6 +638,7 @@ int ldbm_set_last_usn(Slapi_Backend *be);
 /*
  * ldbm_entryrdn.c
  */
+int ldbm_index_entrydn_should_ignore(const char *index_name);
 int entryrdn_index_entry(backend *be, struct backentry *e, int flags, back_txn *txn);
 int entryrdn_index_read(backend *be, const Slapi_DN *sdn, ID *id, back_txn *txn);
 int

--- a/src/lib389/lib389/backend.py
+++ b/src/lib389/lib389/backend.py
@@ -34,7 +34,7 @@ from lib389.encrypted_attributes import EncryptedAttr, EncryptedAttrs
 # This is for sample entry creation.
 from lib389.configurations import get_sample_entries
 
-from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSVIRTLE0001, DSCLLE0001
+from lib389.lint import DSBLE0001, DSBLE0002, DSBLE0003, DSBLE0004, DSBLE0005, DSBLE0006, DSBLE0007, DSBLE0008, DSVIRTLE0001, DSCLLE0001
 from lib389.plugins import USNPlugin
 from lib389.dseldif import DSEldif
 from lib389._mapped_object_lint import (
@@ -848,6 +848,39 @@ class Backend(DSLdapObject):
             report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
             report['fix'] = report['fix'].replace('BACKEND_NAME', bename)
             yield report
+
+    def _lint_obsolete_entrydn_index(self):
+        """Detect obsolete entrydn index left over from pre-entryrdn migrations."""
+        bename = self.lint_uid()
+        suffix = self.get_attr_val_utf8('nsslapd-suffix')
+        issues = []
+
+        try:
+            self.get_indexes().get('entrydn')
+            issues.append('entrydn index is configured in cn=index')
+        except ldap.NO_SUCH_OBJECT:
+            pass
+        except Exception as e:
+            self._log.debug(f"_lint_obsolete_entrydn_index - config check failed: {e}")
+            issues.append(f'Unable to check entrydn index configuration: {e}')
+
+        db_dir = os.path.join(self._instance.ds_paths.db_dir, bename)
+        if os.path.isdir(db_dir):
+            for name in os.listdir(db_dir):
+                if name == 'entrydn.db' or name.startswith('entrydn.db'):
+                    issues.append(f'entrydn database file present: {name}')
+
+        if not issues:
+            return
+
+        report = copy.deepcopy(DSBLE0008)
+        report['check'] = f'backends:{bename}:obsolete_entrydn_index'
+        report['items'] = [suffix]
+        report['detail'] = report['detail'].replace('BACKEND_NAME', bename)
+        report['fix'] = report['fix'].replace('YOUR_INSTANCE', self._instance.serverid)
+        report['fix'] = report['fix'].replace('BACKEND_NAME', bename)
+        report['fix'] = report['fix'].replace('DB_DIR', db_dir)
+        yield report
 
     def create_sample_entries(self, version):
         """Creates sample entries under nsslapd-suffix value

--- a/src/lib389/lib389/lint.py
+++ b/src/lib389/lib389/lint.py
@@ -116,6 +116,22 @@ systems, you may want to reindex offline or use the --wait option to monitor tas
 """
 }
 
+DSBLE0008 = {
+    'dsle': 'DSBLE0008',
+    'severity': 'HIGH',
+    'description': 'Obsolete entrydn index configuration.',
+    'items': [],
+    'detail': """An entrydn index is configured on backend BACKEND_NAME but this server uses
+entryrdn for DN-based indexing. This can cause inconsistent search results
+and index task failures.
+""",
+    'fix': """Remove the obsolete entrydn index and on disk files, then reindex entryrdn:
+
+    # dsconf YOUR_INSTANCE backend index delete BACKEND_NAME --attr entrydn
+    # rm -f DB_DIR/entrydn.db*
+    # dsconf YOUR_INSTANCE backend index reindex BACKEND_NAME --attr entryrdn"""
+}
+
 # Config checks
 DSCLE0002 = {
     'dsle': 'DSCLE0002',


### PR DESCRIPTION
Description:
Upgraded instances can retain leftover cn=entrydn while entryrdn is in use, causing bad searches and reindex failures. Fixed on 2.8 by 539cad4 (#7519/#7526). This adapts that fix for branches where nsslapd-subtree-rename-switch was removed (Issue #6639).

Fix:
Always ignore leftover entrydn by index name, skip reindex and add healthcheck DSBLE0008 + CI test.

Relates: https://github.com/389ds/389-ds-base/issues/7519
Fixes: https://github.com/389ds/389-ds-base/issues/7654

Reviewed by:

## Summary by Sourcery

Backport healthcheck and index handling changes to ignore obsolete entrydn indexes when entryrdn is in use, and surface them as a dedicated healthcheck issue.

Bug Fixes:
- Prevent db2index and index configuration operations from attempting to use obsolete entrydn indexes when entryrdn-based indexing is active, avoiding inconsistent searches and reindex failures.

Enhancements:
- Add a new DSBLE0008 lint definition and backend healthcheck to detect obsolete entrydn index configuration and on-disk entrydn database files.
- Extend healthcheck test helpers and add a new system index healthcheck test to verify DSBLE0008 is reported when entrydn is configured and no longer reported once it is removed.

Tests:
- Enhance the healthcheck test harness to assert both presence and absence of specific healthcheck codes, and add coverage for obsolete entrydn index detection.