### PR TITLE
Issue 7284 - Creating local password policy succeeds with incorrect passwordInHistory value

### DIFF
--- a/dirsrvtests/tests/suites/password/password_policy_test.py
+++ b/dirsrvtests/tests/suites/password/password_policy_test.py
@@ -1566,9 +1566,9 @@ def test_additional_corner_cases(topo, policy_setup, _fixture_for_additional_cas
 @pytest.mark.parametrize('value,result',
                          [('0', ldap.SUCCESS),
                           ('24', ldap.SUCCESS),
-                          pytest.param('-1', ldap.CONSTRAINT_VIOLATION, marks=pytest.mark.xfail(reason='https://github.com/389ds/389-ds-base/issues/7284')),
-                          pytest.param('30', ldap.CONSTRAINT_VIOLATION, marks=pytest.mark.xfail(reason='https://github.com/389ds/389-ds-base/issues/7284')),
-                          pytest.param('a', ldap.CONSTRAINT_VIOLATION, marks=pytest.mark.xfail(reason='https://github.com/389ds/389-ds-base/issues/7284'))])
+                          ('-1', ldap.CONSTRAINT_VIOLATION),
+                          ('30', ldap.CONSTRAINT_VIOLATION),
+                          ('a', ldap.CONSTRAINT_VIOLATION)])
 def test_create_local_pwp_with_passwordInHistory(topo, value, result):
     """Verify local password policy passwordInHistory accepts only values 0-24
 

--- a/ldap/servers/slapd/add.c
+++ b/ldap/servers/slapd/add.c
@@ -766,6 +766,14 @@ op_shared_add(Slapi_PBlock *pb)
         }
         /* expand objectClass values to reflect the inheritance hierarchy */
         slapi_schema_expand_objectclasses(e);
+
+        /* Validate password policy attrs */
+        if (!internal_op) {
+            if ((err = check_pw_policy_attrs(e, NULL, errorbuf, sizeof(errorbuf))) != LDAP_SUCCESS) {
+                send_ldap_result(pb, err, NULL, errorbuf, 0, NULL);
+                goto done;
+            }
+        }
     }
 
     /*

--- a/ldap/servers/slapd/modify.c
+++ b/ldap/servers/slapd/modify.c
@@ -66,34 +66,6 @@ mod_op_image(int op)
 }
 #endif
 
-/* an AttrCheckFunc function should return an LDAP result code (LDAP_SUCCESS if all goes well). */
-typedef int (*AttrCheckFunc)(const char *attr_name, char *value, long minval, long maxval, char *errorbuf, size_t ebuflen);
-
-static struct attr_value_check
-{
-    const char *attr_name; /* the name of the attribute */
-    AttrCheckFunc checkfunc;
-    long minval;
-    long maxval;
-} AttrValueCheckList[] = {
-    {CONFIG_PW_SYNTAX_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_CHANGE_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_LOCKOUT_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_MUSTCHANGE_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_EXP_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_UNLOCK_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_HISTORY_ATTRIBUTE, attr_check_onoff, 0, 0},
-    {CONFIG_PW_MINAGE_ATTRIBUTE, check_pw_duration_value, -1, -1},
-    {CONFIG_PW_WARNING_ATTRIBUTE, check_pw_duration_value, 0, -1},
-    {CONFIG_PW_MINLENGTH_ATTRIBUTE, attr_check_minmax, 2, 512},
-    {CONFIG_PW_MAXFAILURE_ATTRIBUTE, attr_check_minmax, 1, 32767},
-    {CONFIG_PW_INHISTORY_ATTRIBUTE, attr_check_minmax, 0, 24},
-    {CONFIG_PW_LOCKDURATION_ATTRIBUTE, check_pw_duration_value, -1, -1},
-    {CONFIG_PW_RESETFAILURECOUNT_ATTRIBUTE, check_pw_resetfailurecount_value, -1, -1},
-    {CONFIG_PW_GRACELIMIT_ATTRIBUTE, attr_check_minmax, 0, -1},
-    {CONFIG_PW_STORAGESCHEME_ATTRIBUTE, check_pw_storagescheme_value, -1, -1},
-    {CONFIG_PW_MAXAGE_ATTRIBUTE, check_pw_duration_value, -1, -1}};
-
 /* This function is called to process operation that come over external connections */
 void
 do_modify(Slapi_PBlock *pb)
@@ -662,7 +634,6 @@ op_shared_modify(Slapi_PBlock *pb, int pw_change, char *old_pw)
     int err;
     LDAPMod *lc_mod = NULL;
     struct slapdplugin *p = NULL;
-    int numattr;
     char *proxydn = NULL;
     int proxy_err = LDAP_SUCCESS;
     char *errtext = NULL;
@@ -795,42 +766,13 @@ op_shared_modify(Slapi_PBlock *pb, int pw_change, char *old_pw)
 
     slapi_pblock_set(pb, SLAPI_BACKEND, be);
 
-    /* The following section checks the valid values of fine-grained
-     * password policy attributes.
-     * 1. First, it checks if the entry has "passwordpolicy" objectclass.
-     * 2. If yes, then if the mods contain any passwdpolicy specific attributes.
-     * 3. If yes, then it invokes corrosponding checking function.
-     */
+    /* Validate password policy attrs */
     if (!repl_op && !internal_op && normdn && slapi_search_get_entry(&entry_pb, sdn, NULL, &e, NULL) == LDAP_SUCCESS) {
-        Slapi_Value target;
-        slapi_value_init(&target);
-        slapi_value_set_string(&target, "passwordpolicy");
-        if ((slapi_entry_attr_has_syntax_value(e, "objectclass", &target)) == 1) {
-            numattr = sizeof(AttrValueCheckList) / sizeof(AttrValueCheckList[0]);
-            while (tmpmods && *tmpmods) {
-                if ((*tmpmods)->mod_bvalues != NULL &&
-                    !SLAPI_IS_MOD_DELETE((*tmpmods)->mod_op)) {
-                    for (size_t i = 0; i < numattr; i++) {
-                        if (slapi_attr_type_cmp((*tmpmods)->mod_type,
-                                                AttrValueCheckList[i].attr_name, SLAPI_TYPE_CMP_SUBTYPE) == 0) {
-                            /* The below function call is good for
-                             * single-valued attrs only
-                             */
-                            if ((err = AttrValueCheckList[i].checkfunc(AttrValueCheckList[i].attr_name,
-                                                                       (*tmpmods)->mod_bvalues[0]->bv_val, AttrValueCheckList[i].minval,
-                                                                       AttrValueCheckList[i].maxval, errorbuf, sizeof(errorbuf))) != LDAP_SUCCESS) {
-                                /* return error */
-                                send_ldap_result(pb, err, NULL, errorbuf, 0, NULL);
-                                goto free_and_return;
-                            }
-                        }
-                    }
-                }
-                tmpmods++;
-            } /* end of (while */
-        }     /* end of if (found */
-        value_done(&target);
-    } /* end of if (!repl_op */
+        if ((err = check_pw_policy_attrs(e, tmpmods, errorbuf, sizeof(errorbuf))) != LDAP_SUCCESS) {
+            send_ldap_result(pb, err, NULL, errorbuf, 0, NULL);
+            goto free_and_return;
+        }
+    }
 
     /* can get lastmod only after backend is selected */
     slapi_pblock_get(pb, SLAPI_BE_LASTMOD, &lastmod);

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -79,6 +79,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sechash.h>
@@ -2720,14 +2721,15 @@ static const struct pwpolicy_attr_value_check
 #define PWPOLICY_ATTR_CHECK_COUNT \
     (sizeof(pwpolicy_attr_value_checklist) / sizeof(pwpolicy_attr_value_checklist[0]))
 
-static int
+/* Local password policies only. */
+static bool
 entry_is_pwpolicy(Slapi_Entry *e)
 {
     Slapi_Value target;
-    int is_pwp;
+    bool is_pwp;
 
     if (e == NULL) {
-        return 0;
+        return false;
     }
 
     slapi_value_init(&target);

--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -2688,6 +2688,127 @@ check_pw_storagescheme_value(const char *attr_name __attribute__((unused)), char
 
     return retVal;
 }
+
+ /* pwpolicy_attr_check_fn function should return an LDAP result code (LDAP_SUCCESS if all goes well), shared by ADD and MODIFY */
+typedef int (*pwpolicy_attr_check_fn)(const char *attr_name, char *value, long minval, long maxval, char *errorbuf, size_t ebuflen);
+
+static const struct pwpolicy_attr_value_check
+{
+    const char *attr_name;
+    pwpolicy_attr_check_fn checkfunc;
+    long minval;
+    long maxval;
+} pwpolicy_attr_value_checklist[] = {
+    {CONFIG_PW_SYNTAX_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_CHANGE_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_LOCKOUT_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_MUSTCHANGE_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_EXP_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_UNLOCK_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_HISTORY_ATTRIBUTE, attr_check_onoff, 0, 0},
+    {CONFIG_PW_MINAGE_ATTRIBUTE, check_pw_duration_value, -1, -1},
+    {CONFIG_PW_WARNING_ATTRIBUTE, check_pw_duration_value, 0, -1},
+    {CONFIG_PW_MINLENGTH_ATTRIBUTE, attr_check_minmax, 2, 512},
+    {CONFIG_PW_MAXFAILURE_ATTRIBUTE, attr_check_minmax, 1, 32767},
+    {CONFIG_PW_INHISTORY_ATTRIBUTE, attr_check_minmax, 0, 24},
+    {CONFIG_PW_LOCKDURATION_ATTRIBUTE, check_pw_duration_value, -1, -1},
+    {CONFIG_PW_RESETFAILURECOUNT_ATTRIBUTE, check_pw_resetfailurecount_value, -1, -1},
+    {CONFIG_PW_GRACELIMIT_ATTRIBUTE, attr_check_minmax, 0, -1},
+    {CONFIG_PW_STORAGESCHEME_ATTRIBUTE, check_pw_storagescheme_value, -1, -1},
+    {CONFIG_PW_MAXAGE_ATTRIBUTE, check_pw_duration_value, -1, -1}};
+
+#define PWPOLICY_ATTR_CHECK_COUNT \
+    (sizeof(pwpolicy_attr_value_checklist) / sizeof(pwpolicy_attr_value_checklist[0]))
+
+static int
+entry_is_pwpolicy(Slapi_Entry *e)
+{
+    Slapi_Value target;
+    int is_pwp;
+
+    if (e == NULL) {
+        return 0;
+    }
+
+    slapi_value_init(&target);
+    slapi_value_set_string(&target, "passwordpolicy");
+    is_pwp = (slapi_entry_attr_has_syntax_value(e, "objectclass", &target) == 1);
+    value_done(&target);
+    return is_pwp;
+}
+
+/* Validate a single attr against the checklist */
+static int
+check_pwpolicy_attr_value(const char *attr_type, char *value, char *errorbuf, size_t ebuflen)
+{
+    size_t i;
+
+    if (attr_type == NULL || value == NULL) {
+        return LDAP_SUCCESS;
+    }
+
+    for (i = 0; i < PWPOLICY_ATTR_CHECK_COUNT; i++) {
+        const struct pwpolicy_attr_value_check *c = &pwpolicy_attr_value_checklist[i];
+
+        if (slapi_attr_type_cmp(attr_type, c->attr_name, SLAPI_TYPE_CMP_SUBTYPE) == 0) {
+            return c->checkfunc(c->attr_name, value, c->minval, c->maxval, errorbuf, ebuflen);
+        }
+    }
+
+    return LDAP_SUCCESS;
+}
+
+/* Passwordpolicy attr validation for ADD and MODIFY */
+int
+check_pw_policy_attrs(Slapi_Entry *e, LDAPMod **mods, char *errorbuf, size_t ebuflen)
+{
+    if (!entry_is_pwpolicy(e)) {
+        return LDAP_SUCCESS;
+    }
+
+    /* Modify */
+    if (mods != NULL) {
+        for (; *mods != NULL; mods++) {
+            int err;
+
+            if ((*mods)->mod_bvalues == NULL || SLAPI_IS_MOD_DELETE((*mods)->mod_op)) {
+                continue;
+            }
+            err = check_pwpolicy_attr_value((*mods)->mod_type,
+                                            (*mods)->mod_bvalues[0]->bv_val,
+                                            errorbuf, ebuflen);
+            if (err != LDAP_SUCCESS) {
+                return err;
+            }
+        }
+        return LDAP_SUCCESS;
+    }
+
+    /* Add */
+    {
+        Slapi_Attr *attr = NULL;
+        char *type = NULL;
+
+        for (slapi_entry_first_attr(e, &attr); attr;
+             slapi_entry_next_attr(e, attr, &attr)) {
+            Slapi_Value *val = NULL;
+            int err;
+
+            slapi_attr_get_type(attr, &type);
+            if (slapi_attr_first_value(attr, &val) == -1 || val == NULL) {
+                continue;
+            }
+            err = check_pwpolicy_attr_value(type, (char *)slapi_value_get_string(val),
+                                            errorbuf, ebuflen);
+            if (err != LDAP_SUCCESS) {
+                return err;
+            }
+        }
+    }
+
+    return LDAP_SUCCESS;
+}
+
 /* Before bind operation, check if the bind_target_entry has not overpass TPR limits
  * returns:
  *    0: TPR limits not enforced or reached

--- a/ldap/servers/slapd/pw.h
+++ b/ldap/servers/slapd/pw.h
@@ -40,6 +40,8 @@ void delete_passwdPolicy(struct passwordpolicyarray **pwpolicy);
 int check_pw_duration_value(const char *attr_name, char *value, long minval, long maxval, char *errorbuf, size_t ebuflen);
 int check_pw_resetfailurecount_value(const char *attr_name, char *value, long minval, long maxval, char *errorbuf, size_t ebuflen);
 int check_pw_storagescheme_value(const char *attr_name, char *value, long minval, long maxval, char *errorbuf, size_t ebuflen);
+/* Passwordpolicy attr validation for ADD and MODIFY */
+int check_pw_policy_attrs(Slapi_Entry *e, LDAPMod **mods, char *errorbuf, size_t ebuflen);
 
 int pw_is_pwp_admin(Slapi_PBlock *pb, struct passwordpolicyarray *pwp, int rootdn_flag);
 #define PWP_ADMIN_OR_ROOTDN 0


### PR DESCRIPTION
Description:
Creating a local password policy accepts invalid passwordrInHistory values. Updating an existing policy via dsconf localpwp set correctly rejects the same values with Constraint violation.

Fine grained password policy validation ran only on the modify path. Local policy create uses the add path, which wasnt updated, so invalid values were accepted.

Fix:
Add fine grained password policy attribute validation to the ADD path, sharing the same checks used by MODIFY.

Fixes: https://github.com/389ds/389-ds-base/issues/7284

Reviewed by:

## Summary by Sourcery

Enforce fine-grained password policy attribute validation on both add and modify operations so that invalid passwordInHistory and related values are consistently rejected.

Bug Fixes:
- Ensure creating a local password policy rejects out-of-range or invalid passwordInHistory values instead of silently accepting them.

Enhancements:
- Centralize password policy attribute validation logic in a shared helper used by add and modify paths.
- Extend password policy tests to cover local policy creation with invalid passwordInHistory values and expect constraint violations.