### PR TITLE
Issue 7664 - RFE - Add equality lookup tables for large OR filters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1134,6 +1134,7 @@ libslapd_la_SOURCES = ldap/servers/slapd/add.c \
 	ldap/servers/slapd/features.c \
 	ldap/servers/slapd/fileio.c \
 	ldap/servers/slapd/filter.c \
+	ldap/servers/slapd/filter_or_lookup.c \
 	ldap/servers/slapd/filtercmp.c \
 	ldap/servers/slapd/filterentry.c \
 	ldap/servers/slapd/generation.c \

--- a/dirsrvtests/tests/suites/filter/filter_large_filter_interaction_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_large_filter_interaction_test.py
@@ -1,0 +1,248 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+"""Functional interactions between large equality ORs and costly reads.
+
+4,200 entries share the substring and approximate keys, an indexed AND
+selects exactly 612 of them, and a 355-branch DN equality family appears
+in every filter.
+"""
+
+import ldap
+import logging
+import os
+import pytest
+
+from ldap.controls import SimplePagedResultsControl
+from lib389.utils import ensure_str
+from test389.topologies import topology_st as topo
+
+from .filter_large_filter_support import (
+    APPROX_ATTR,
+    EXCLUDED_ONE,
+    EXCLUDED_TWO,
+    FALLBACK_ATTR,
+    GUARD_ATTR,
+    GUARD_VALUE,
+    HIT_POSITIONS,
+    OUTER_A,
+    OUTER_B,
+    OUTER_VALUE,
+    SUBSTRING_ATTR,
+    TEST_BASE,
+    combined_assertions,
+    combined_filter,
+    dn_or,
+    hit_assertions,
+    interaction_data,
+    lookup_disabled,
+    miss_assertions,
+    search_dns,
+)
+
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def test_large_nested_dn_or_true_root_all_miss(topo, interaction_data):
+    """A true-root all-miss OR keeps the complex fallback exact.
+
+    :id: 143f667f-75f9-44e7-a835-29cf1ea4a250
+    :setup: Standalone instance with synthetic schema and 4,200 entries
+    :steps:
+        1. Search an indexed outer AND containing a 355-branch missing DN OR,
+           a missing equality, and a guarded two-NOT fallback
+        2. Repeat with the optional equality lookup disabled when supported
+        3. Run a base-object health search
+    :expectedresults:
+        1. LDAP succeeds with no DNs
+        2. LDAP succeeds with the identical empty result
+        3. LDAP succeeds and returns exactly the test container
+    """
+    inst = topo.standalone
+    large_miss = dn_or(miss_assertions())
+    filterstr = (
+        f"(&({OUTER_A}={OUTER_VALUE})({OUTER_B}={OUTER_VALUE})"
+        f"(|{large_miss}({FALLBACK_ATTR}=absent)"
+        f"(&({GUARD_ATTR}={GUARD_VALUE})"
+        f"(!({EXCLUDED_ONE}=*))(!({EXCLUDED_TWO}=*)))))"
+    )
+
+    result_type, dns = search_dns(inst, filterstr)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == []
+
+    with lookup_disabled(inst):
+        disabled_type, disabled_dns = search_dns(inst, filterstr)
+    assert disabled_type == ldap.RES_SEARCH_RESULT
+    assert disabled_dns == []
+
+    health_type, health_dns = search_dns(
+        inst, "(objectClass=*)", base=TEST_BASE,
+        scope=ldap.SCOPE_BASE
+    )
+    assert health_type == ldap.RES_SEARCH_RESULT
+    assert health_dns == [TEST_BASE.lower()]
+
+
+@pytest.mark.parametrize(
+    "position", HIT_POSITIONS,
+    ids=["early", "middle", "late"],
+)
+def test_large_dn_or_early_middle_late_hits(topo, interaction_data, position):
+    """The same normalized DN hit is exact at every table-walk position.
+
+    :id: d563ea60-aacd-4949-a0ef-b2f29fd994aa
+    :parametrized: yes
+    :setup: Standalone instance with a 612-entry selected cohort
+    :steps:
+        1. Put the live DN assertion at the beginning, middle, or end of a
+           355-branch family and search under the indexed outer AND
+        2. Repeat with the optional equality lookup disabled when supported
+    :expectedresults:
+        1. LDAP succeeds with exactly the independently recorded 204 DNs
+        2. The disabled path returns the same exact DNs
+    """
+    inst = topo.standalone
+    expected = interaction_data["hit_dns"][position]
+    filterstr = (f"(&({OUTER_A}={OUTER_VALUE})"
+                 f"({OUTER_B}={OUTER_VALUE})"
+                 f"{dn_or(hit_assertions(position))})")
+
+    result_type, dns = search_dns(inst, filterstr)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == expected
+
+    with lookup_disabled(inst):
+        disabled_type, disabled_dns = search_dns(inst, filterstr)
+    assert disabled_type == ldap.RES_SEARCH_RESULT
+    assert disabled_dns == expected
+
+
+@pytest.mark.parametrize(
+    "cost_component",
+    [
+        f"({SUBSTRING_ATTR}=*xanadu*)",
+        f"({APPROX_ATTR}~=Xanadu)",
+    ],
+    ids=["substring", "approximate"],
+)
+def test_large_dn_or_with_costly_component(
+        topo, interaction_data, cost_component):
+    """A large DN OR combines exactly with a broad costly component.
+
+    :id: ad85665d-9c66-4aa1-a52d-438eb3672692
+    :parametrized: yes
+    :setup: 4,200 broad postings, a 612-entry equality bound, and a 355 DN OR
+    :steps:
+        1. Search the combined filter
+        2. Repeat with the optional equality lookup disabled when supported
+    :expectedresults:
+        1. LDAP succeeds with exactly 612 DNs
+        2. LDAP succeeds with the same DNs
+    """
+    inst = topo.standalone
+    expected = interaction_data["selected_dns"]
+    filterstr = combined_filter(cost_component)
+
+    result_type, dns = search_dns(inst, filterstr)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == expected
+
+    with lookup_disabled(inst):
+        disabled_type, disabled_dns = search_dns(inst, filterstr)
+    assert disabled_type == ldap.RES_SEARCH_RESULT
+    assert disabled_dns == expected
+
+
+def test_root_or_with_costly_and_stays_exact(
+        topo, interaction_data):
+    """A root OR containing a costly AND returns the exact union.
+
+    :id: 4cf11d97-4a79-42e7-b188-363646b5af12
+    :setup: Standalone instance with the reusable interaction dataset
+    :steps:
+        1. Put the 355-branch DN family beside a substring-bearing AND under
+           a root OR and run the search
+        2. Repeat with the optional equality lookup disabled when supported
+    :expectedresults:
+        1. LDAP succeeds with exactly 612 DNs
+        2. LDAP succeeds with the identical exact DN set
+    """
+    inst = topo.standalone
+    expected = interaction_data["selected_dns"]
+    filterstr = (
+        f"(|{dn_or(combined_assertions())}"
+        f"(&({OUTER_A}={OUTER_VALUE})({OUTER_B}={OUTER_VALUE})"
+        f"({SUBSTRING_ATTR}=*xanadu*)))"
+    )
+
+    result_type, dns = search_dns(inst, filterstr)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == expected
+
+    with lookup_disabled(inst):
+        disabled_type, disabled_dns = search_dns(inst, filterstr)
+    assert disabled_type == ldap.RES_SEARCH_RESULT
+    assert disabled_dns == expected
+
+
+def test_complete_paging_large_dn_or_with_substring(topo, interaction_data):
+    """Complete paging preserves the combined filter's exact DN set.
+
+    :id: 9e47b6aa-8954-452f-90cd-b7c3a694aa67
+    :setup: Standalone instance with the reusable interaction dataset
+    :steps:
+        1. Page through the combined large-DN-OR and substring filter
+           with a page size of 97 until the server returns an empty cookie
+    :expectedresults:
+        1. Every page succeeds and the union of all pages is exactly the
+           independently recorded 612 DNs
+    """
+    inst = topo.standalone
+    expected = interaction_data["selected_dns"]
+    filterstr = combined_filter(f"({SUBSTRING_ATTR}=*xanadu*)")
+    request = SimplePagedResultsControl(True, size=97, cookie="")
+    collected = []
+    pages = 0
+
+    while True:
+        msgid = inst.search_ext(
+            TEST_BASE, ldap.SCOPE_SUBTREE, filterstr, ["1.1"],
+            serverctrls=[request]
+        )
+        result_type, result_data, _, response_controls = inst.result3(msgid)
+        assert result_type == ldap.RES_SEARCH_RESULT
+        collected.extend(
+            ensure_str(dn).lower() for dn, _ in result_data if dn
+        )
+        pages += 1
+
+        paged_controls = [
+            control for control in response_controls
+            if control.controlType == SimplePagedResultsControl.controlType
+        ]
+        assert paged_controls
+        if not paged_controls[0].cookie:
+            break
+        request.cookie = paged_controls[0].cookie
+
+    assert pages >= 7
+    assert sorted(collected) == expected
+
+
+if __name__ == "__main__":
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/filter/filter_large_filter_support.py
+++ b/dirsrvtests/tests/suites/filter/filter_large_filter_support.py
@@ -1,0 +1,439 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+"""Shared synthetic data and helpers for large-filter tests.
+
+This module contains no tests. Functional and sanitizer modules share its
+workloads without importing one test module from another.
+"""
+
+import ldap
+import pytest
+
+from contextlib import contextmanager
+from ldap.filter import escape_filter_chars
+from ldap.schema.models import AttributeType, ObjectClass
+from lib389._constants import DEFAULT_SUFFIX, TASK_WAIT
+from lib389._mapped_object import DSLdapObject, DSLdapObjects
+from lib389.backend import Backends
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.schema import OBJECT_MODEL_PARAMS, ObjectclassKind, Schema
+from lib389.tasks import Tasks
+from lib389.utils import ensure_str
+
+
+TOTAL_ENTRIES = 4200
+SELECTED_ENTRIES = 612
+DN_BRANCHES = 355
+
+TEST_OU = "LargeFilterInteraction"
+TEST_BASE = f"ou={TEST_OU},{DEFAULT_SUFFIX}"
+
+OUTER_A = "lfOuterA"
+OUTER_B = "lfOuterB"
+DN_ATTR = "lfDnValue"
+SUBSTRING_ATTR = "lfSubstringValue"
+APPROX_ATTR = "lfApproxValue"
+FALLBACK_ATTR = "lfFallbackValue"
+GUARD_ATTR = "lfGuardValue"
+EXCLUDED_ONE = "lfExcludedOne"
+EXCLUDED_TWO = "lfExcludedTwo"
+AUX_OC = "lfInteractionAux"
+
+OUTER_VALUE = "selected"
+GUARD_VALUE = "guarded"
+HIT_POSITIONS = (0, DN_BRANCHES // 2, DN_BRANCHES - 1)
+HIT_COHORT_SIZE = SELECTED_ENTRIES // len(HIT_POSITIONS)
+LIVE_DNS = tuple(
+    f"cn=lf-live-target-{i},ou=References,{DEFAULT_SUFFIX}"
+    for i in range(len(HIT_POSITIONS))
+)
+
+OR_LOOKUP_ATTR = "nsslapd-enable-or-filter-lookup"
+
+OWNERSHIP_TEST_OU = "LargeFilterOwnership"
+OWNERSHIP_TEST_BASE = f"ou={OWNERSHIP_TEST_OU},{DEFAULT_SUFFIX}"
+OWNERSHIP_EMPTY_RANGE_ATTR = "lfEmptyRange"
+OWNERSHIP_AUX_OC = "lfOwnershipAux"
+OWNERSHIP_ENTRY_COUNT = 16
+NOT_FIRST_EMPTY_RANGE_FILTER = (
+    f"(&(!(uid=lf-ownership-absent))(objectClass=person)"
+    f"({OWNERSHIP_EMPTY_RANGE_ATTR}>=0))"
+)
+
+
+ATTRIBUTE_SPECS = (
+    {"name": OUTER_A, "oid": "1.3.6.1.4.1.2312.999.2026.1",
+     "desc": "large filter outer selector A",
+     "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": OUTER_B, "oid": "1.3.6.1.4.1.2312.999.2026.2",
+     "desc": "large filter outer selector B",
+     "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": DN_ATTR, "oid": "1.3.6.1.4.1.2312.999.2026.3",
+     "desc": "large filter DN equality value",
+     "equality": "distinguishedNameMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.12"},
+    {"name": SUBSTRING_ATTR, "oid": "1.3.6.1.4.1.2312.999.2026.4",
+     "desc": "large filter substring value", "equality": "caseIgnoreMatch",
+     "substr": "caseIgnoreSubstringsMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": APPROX_ATTR, "oid": "1.3.6.1.4.1.2312.999.2026.5",
+     "desc": "large filter approximate value",
+     "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": FALLBACK_ATTR, "oid": "1.3.6.1.4.1.2312.999.2026.6",
+     "desc": "large filter absent fallback", "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": GUARD_ATTR, "oid": "1.3.6.1.4.1.2312.999.2026.7",
+     "desc": "large filter fallback guard", "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": EXCLUDED_ONE, "oid": "1.3.6.1.4.1.2312.999.2026.8",
+     "desc": "large filter unindexed presence sentinel one",
+     "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+    {"name": EXCLUDED_TWO, "oid": "1.3.6.1.4.1.2312.999.2026.9",
+     "desc": "large filter unindexed presence sentinel two",
+     "equality": "caseIgnoreMatch",
+     "syntax": "1.3.6.1.4.1.1466.115.121.1.15"},
+)
+
+OBJECTCLASS_MAY = (
+    OUTER_A, OUTER_B, DN_ATTR, SUBSTRING_ATTR, APPROX_ATTR, FALLBACK_ATTR,
+    GUARD_ATTR, EXCLUDED_ONE, EXCLUDED_TWO,
+)
+
+INDEX_DEFINITIONS = (
+    (OUTER_A, ["eq"]),
+    (OUTER_B, ["eq"]),
+    (DN_ATTR, ["eq"]),
+    (SUBSTRING_ATTR, ["eq", "sub"]),
+    (APPROX_ATTR, ["eq", "approx"]),
+)
+
+
+class LargeFilterEntry(DSLdapObject):
+    """One deterministic synthetic interaction entry."""
+
+    def __init__(self, instance, dn=None):
+        super(LargeFilterEntry, self).__init__(instance, dn)
+        self._rdn_attribute = "uid"
+        self._must_attributes = ["uid", "cn", "sn"]
+        self._create_objectclasses = [
+            "top", "person", "organizationalPerson", "inetOrgPerson", AUX_OC
+        ]
+        self._protected = False
+
+
+class LargeFilterEntries(DSLdapObjects):
+    """Collection used to create interaction entries through lib389."""
+
+    def __init__(self, instance, basedn):
+        super(LargeFilterEntries, self).__init__(instance)
+        self._objectclasses = [AUX_OC]
+        self._filterattrs = ["uid"]
+        self._childobject = LargeFilterEntry
+        self._basedn = basedn
+
+
+class OwnershipEntry(DSLdapObject):
+    """One person used by the NOT-first ownership workload."""
+
+    def __init__(self, instance, dn=None):
+        super(OwnershipEntry, self).__init__(instance, dn)
+        self._rdn_attribute = "uid"
+        self._must_attributes = ["uid", "cn", "sn"]
+        self._create_objectclasses = [
+            "top", "person", "organizationalPerson", "inetOrgPerson",
+            OWNERSHIP_AUX_OC,
+        ]
+        self._protected = False
+
+
+class OwnershipEntries(DSLdapObjects):
+    """Collection used to create NOT-first ownership entries."""
+
+    def __init__(self, instance, basedn):
+        super(OwnershipEntries, self).__init__(instance)
+        self._objectclasses = [OWNERSHIP_AUX_OC]
+        self._filterattrs = ["uid"]
+        self._childobject = OwnershipEntry
+        self._basedn = basedn
+
+
+def entry_uid(index):
+    return f"lf-interaction-{index:05d}"
+
+
+def entry_dn(index):
+    return f"uid={entry_uid(index)},{TEST_BASE}"
+
+
+def ghost_dn(index):
+    return f"cn=lf-ghost-{index:04d},ou=References,{DEFAULT_SUFFIX}"
+
+
+@contextmanager
+def lookup_disabled(inst):
+    """Disable the equality lookup when the server exposes it.
+
+    On servers without the attribute the context is a no-op and the caller
+    just repeats the same search.
+    """
+    old_value = inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR)
+    if old_value is None:
+        yield
+        return
+    inst.config.replace(OR_LOOKUP_ATTR, "off")
+    try:
+        yield
+    finally:
+        inst.config.replace(OR_LOOKUP_ATTR, old_value)
+
+
+def search_dns(inst, filterstr, base=TEST_BASE, scope=ldap.SCOPE_SUBTREE):
+    """Run a complete search and return the LDAP result type and exact DNs."""
+    msgid = inst.search_ext(base, scope, filterstr, ["1.1"])
+    result_type, result_data, _, _ = inst.result3(msgid)
+    dns = sorted(ensure_str(dn).lower() for dn, _ in result_data if dn)
+    return result_type, dns
+
+
+@contextmanager
+def ownership_workload(inst, remove_on_exit=True):
+    """Create the exact NOT-first workload and optionally remove it on exit."""
+    schema = Schema(inst)
+    backend = Backends(inst).get("userRoot")
+    attr_added = False
+    objectclass_added = False
+    index_added = False
+    setup_succeeded = False
+    container = None
+
+    try:
+        attr_params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+        attr_params.update({
+            "names": (OWNERSHIP_EMPTY_RANGE_ATTR,),
+            "oid": "1.3.6.1.4.1.2312.999.2026.20",
+            "desc": "emptied indexed range for NOT-first ownership test",
+            "equality": "integerMatch",
+            "ordering": "integerOrderingMatch",
+            "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
+            "single_value": 1,
+            "x_origin": ("389-ds large filter tests",),
+        })
+        schema.add_attributetype(attr_params)
+        attr_added = True
+
+        oc_params = OBJECT_MODEL_PARAMS[ObjectClass].copy()
+        oc_params.update({
+            "names": (OWNERSHIP_AUX_OC,),
+            "oid": "1.3.6.1.4.1.2312.999.2026.21",
+            "desc": "auxiliary class for NOT-first ownership test",
+            "kind": ObjectclassKind.AUXILIARY.value,
+            "sup": ("top",),
+            "may": (OWNERSHIP_EMPTY_RANGE_ATTR,),
+            "x_origin": ("389-ds large filter tests",),
+        })
+        schema.add_objectclass(oc_params)
+        objectclass_added = True
+
+        backend.add_index(
+            OWNERSHIP_EMPTY_RANGE_ATTR, ["eq"],
+            matching_rules=["integerOrderingMatch"]
+        )
+        index_added = True
+        assert Tasks(inst).reindex(
+            benamebase="userRoot",
+            attrname=[OWNERSHIP_EMPTY_RANGE_ATTR],
+            args={TASK_WAIT: True},
+        ) == 0
+        index = backend.get_index(OWNERSHIP_EMPTY_RANGE_ATTR)
+        assert index is not None
+        assert index.get_attr_vals_utf8_l("nsIndexType") == ["eq"]
+        assert index.get_attr_vals_utf8_l("nsMatchingRule") == [
+            "integerorderingmatch"
+        ]
+
+        container = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(
+            properties={"ou": OWNERSHIP_TEST_OU}
+        )
+        entries = OwnershipEntries(inst, OWNERSHIP_TEST_BASE)
+        created = []
+        for entry_index in range(OWNERSHIP_ENTRY_COUNT):
+            uid = f"lf-ownership-{entry_index:03d}"
+            created.append(entries.create(properties={
+                "uid": uid,
+                "cn": f"Large Filter Ownership {entry_index:03d}",
+                "sn": f"Ownership{entry_index:03d}",
+            }))
+
+        result_type, dns = search_dns(
+            inst, f"(objectClass={OWNERSHIP_AUX_OC})",
+            base=OWNERSHIP_TEST_BASE, scope=ldap.SCOPE_ONELEVEL
+        )
+        assert result_type == ldap.RES_SEARCH_RESULT
+        assert dns == sorted(entry.dn.lower() for entry in created)
+
+        created[0].add(OWNERSHIP_EMPTY_RANGE_ATTR, "0")
+        created[0].remove_all(OWNERSHIP_EMPTY_RANGE_ATTR)
+        result_type, dns = search_dns(
+            inst, f"({OWNERSHIP_EMPTY_RANGE_ATTR}>=0)",
+            base=OWNERSHIP_TEST_BASE, scope=ldap.SCOPE_SUBTREE
+        )
+        assert result_type == ldap.RES_SEARCH_RESULT
+        assert dns == []
+
+        setup_succeeded = True
+        yield {"backend": backend, "entries": created}
+    finally:
+        if remove_on_exit or not setup_succeeded:
+            try:
+                if container is not None:
+                    container.delete(recursive=True)
+            finally:
+                try:
+                    if index_added:
+                        backend.del_index(OWNERSHIP_EMPTY_RANGE_ATTR)
+                finally:
+                    if objectclass_added:
+                        schema.remove_objectclass(OWNERSHIP_AUX_OC)
+                    if attr_added:
+                        schema.remove_attributetype(OWNERSHIP_EMPTY_RANGE_ATTR)
+
+
+def dn_or(assertions):
+    return "(|%s)" % "".join(
+        f"({DN_ATTR}={escape_filter_chars(value)})" for value in assertions
+    )
+
+
+def miss_assertions():
+    return [ghost_dn(i) for i in range(DN_BRANCHES)]
+
+
+def hit_assertions(position):
+    """Put the sole live assertion at a requested table-walk position."""
+    assertions = miss_assertions()
+    assertions[position] = LIVE_DNS[HIT_POSITIONS.index(position)]
+    return assertions
+
+
+def combined_assertions():
+    """Return 355 branches whose three live values cover all 612 selected."""
+    assertions = miss_assertions()
+    for position, value in zip(HIT_POSITIONS, LIVE_DNS):
+        assertions[position] = value
+    return assertions
+
+
+def combined_filter(cost_component):
+    """A 612-entry bound, a 355-branch DN OR, and one costly component."""
+    return (f"(&({OUTER_A}={OUTER_VALUE})"
+            f"{dn_or(combined_assertions())}"
+            f"{cost_component})")
+
+
+@pytest.fixture(scope="module")
+def interaction_data(topo):
+    """Create schema, indexes, and all entries through live lib389 APIs."""
+    inst = topo.standalone
+    schema = Schema(inst)
+    backend = Backends(inst).get("userRoot")
+    added_attrs = []
+    added_indexes = []
+    objectclass_added = False
+    container = None
+
+    try:
+        for spec in ATTRIBUTE_SPECS:
+            params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+            params.update({
+                "names": (spec["name"],),
+                "oid": spec["oid"],
+                "desc": spec["desc"],
+                "equality": spec["equality"],
+                "substr": spec.get("substr"),
+                "syntax": spec["syntax"],
+                "single_value": 1,
+                "x_origin": ("389-ds large filter tests",),
+            })
+            schema.add_attributetype(params)
+            added_attrs.append(spec["name"])
+
+        oc_params = OBJECT_MODEL_PARAMS[ObjectClass].copy()
+        oc_params.update({
+            "names": (AUX_OC,),
+            "oid": "1.3.6.1.4.1.2312.999.2026.10",
+            "desc": "auxiliary class for large filter interaction tests",
+            "kind": ObjectclassKind.AUXILIARY.value,
+            "sup": ("top",),
+            "may": OBJECTCLASS_MAY,
+            "x_origin": ("389-ds large filter tests",),
+        })
+        schema.add_objectclass(oc_params)
+        objectclass_added = True
+
+        for attr, index_types in INDEX_DEFINITIONS:
+            backend.add_index(attr, index_types)
+            added_indexes.append(attr)
+        backend.reindex(attrs=added_indexes, wait=True)
+
+        container = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(
+            properties={"ou": TEST_OU}
+        )
+        entries = LargeFilterEntries(inst, TEST_BASE)
+        for i in range(TOTAL_ENTRIES):
+            props = {
+                "uid": entry_uid(i),
+                "cn": f"Large Filter Common Xanadu Entry {i:05d}",
+                "sn": f"Interaction{i:05d}",
+                SUBSTRING_ATTR: f"Common Xanadu indexed value {i:05d}",
+                APPROX_ATTR: "Xanadu",
+            }
+            if i < SELECTED_ENTRIES:
+                props.update({
+                    OUTER_A: OUTER_VALUE,
+                    OUTER_B: OUTER_VALUE,
+                    DN_ATTR: LIVE_DNS[i // HIT_COHORT_SIZE],
+                    GUARD_ATTR: GUARD_VALUE,
+                    # Makes the complex fallback branch false; the second
+                    # excluded attribute stays absent and neither has a
+                    # presence index.
+                    EXCLUDED_ONE: "present",
+                })
+            entries.create(properties=props)
+
+        yield {
+            "backend": backend,
+            "selected_dns": sorted(
+                entry_dn(i).lower() for i in range(SELECTED_ENTRIES)
+            ),
+            "hit_dns": {
+                position: sorted(
+                    entry_dn(i).lower()
+                    for i in range(cohort * HIT_COHORT_SIZE,
+                                   (cohort + 1) * HIT_COHORT_SIZE)
+                )
+                for cohort, position in enumerate(HIT_POSITIONS)
+            },
+        }
+    finally:
+        try:
+            if container is not None:
+                container.delete(recursive=True)
+        finally:
+            try:
+                for attr in reversed(added_indexes):
+                    backend.del_index(attr)
+            finally:
+                if objectclass_added:
+                    schema.remove_objectclass(AUX_OC)
+                for attr in reversed(added_attrs):
+                    schema.remove_attributetype(attr)

--- a/dirsrvtests/tests/suites/filter/filter_or_lookup_feature_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_lookup_feature_test.py
@@ -1,0 +1,591 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+
+"""Strict feature contracts for the large equality-OR lookup evaluator.
+
+These tests require the lookup configuration attribute and its debug
+summary, and fail on a server without the feature.  Result-only coverage
+lives in ``filter_or_lookup_test.py``.
+"""
+
+import os
+import re
+from contextlib import contextmanager
+
+import ldap
+import pytest
+from ldap.filter import escape_filter_chars
+from ldap.schema.models import AttributeType
+
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.extensibleobject import UnsafeExtensibleObjects
+from lib389.idm.directorymanager import DirectoryManager
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.schema import OBJECT_MODEL_PARAMS, Schema
+from lib389.utils import ensure_str
+from test389.topologies import topology_st as topo
+
+
+pytestmark = pytest.mark.tier1
+
+OR_LOOKUP_ATTR = 'nsslapd-enable-or-filter-lookup'
+ERRORLOG_LEVEL_BACKLDBM = '524288'
+ERRORLOG_LEVEL_FILTER = '32'
+ENG_LOG_PATTERN = '.*OR filter equality lookup engaged.*'
+ENG_LOG_RE = re.compile(
+    r'OR filter equality lookup engaged: (\d+) node\(s\), largest (\d+) branches')
+AVA_LOG_RE = re.compile(
+    r'^\[[^\r\n]+\]\s+-\s+DEBUG\s+-\s+test_ava_filter\s+-\s+'
+    r'=>\s*AVA:\s*(?P<attr>[^~<>=\s]+)=(?P<value>[^\r\n]*)\r?$',
+    re.MULTILINE | re.IGNORECASE)
+
+FEATURE_ATTRS = ('olFeatureLookupA', 'olFeatureLookupB', 'olFeatureLookupC')
+FEATURE_TIME_ATTR = 'olFeatureLookupTime'
+
+
+def escaped_equalities(attr, values):
+    """Build equality components without an enclosing Boolean node."""
+    return ''.join(
+        f'({attr}={escape_filter_chars(ensure_str(value))})' for value in values)
+
+
+def escaped_or_of(attr, values):
+    """Build an equality OR while preserving filter-special characters."""
+    return f'(|{escaped_equalities(attr, values)})'
+
+
+def search_dns_result(conn, filterstr, base=DEFAULT_SUFFIX,
+                      scope=ldap.SCOPE_SUBTREE):
+    """Run an asynchronous search and require an LDAP search result."""
+    msgid = conn.search_ext(base, scope, filterstr, ['1.1'])
+    rtype, rdata, _, _ = conn.result3(msgid)
+    assert rtype == ldap.RES_SEARCH_RESULT
+    return sorted(ensure_str(dn).lower() for dn, _ in rdata if dn is not None)
+
+
+def eng_summaries(inst):
+    """Return all stable lookup-summary ``(nodes, largest)`` pairs."""
+    summaries = []
+    for line in inst.ds_error_log.match(ENG_LOG_PATTERN):
+        match = ENG_LOG_RE.search(line)
+        assert match is not None
+        summaries.append((int(match.group(1)), int(match.group(2))))
+    return summaries
+
+
+@contextmanager
+def error_log_window(inst):
+    """Capture bytes appended to one stable active error log."""
+    path = inst.ds_paths.error_log
+    fd = os.open(path, os.O_RDONLY | getattr(os, 'O_CLOEXEC', 0))
+    window = {'text': None}
+    try:
+        initial = os.fstat(fd)
+        identity = (initial.st_dev, initial.st_ino)
+        begin = initial.st_size
+        guard_at = max(0, begin - 4096)
+        guard = os.pread(fd, begin - guard_at, guard_at)
+
+        yield window
+
+        active = os.stat(path)
+        assert (active.st_dev, active.st_ino) == identity, \
+            'error log rotated during strict operation window'
+        assert active.st_size >= begin, \
+            'error log was truncated during strict operation window'
+        assert os.pread(fd, begin - guard_at, guard_at) == guard, \
+            'error log prefix changed during strict operation window'
+
+        end = active.st_size
+        chunks = []
+        offset = begin
+        while offset < end:
+            chunk = os.pread(fd, end - offset, offset)
+            assert chunk, 'error log shrank while reading strict operation window'
+            chunks.append(chunk)
+            offset += len(chunk)
+
+        final_fd = os.fstat(fd)
+        final_active = os.stat(path)
+        assert (final_fd.st_dev, final_fd.st_ino) == identity
+        assert (final_active.st_dev, final_active.st_ino) == identity
+        assert final_fd.st_size >= end and final_active.st_size >= end, \
+            'error log shrank while closing strict operation window'
+        assert os.pread(fd, begin - guard_at, guard_at) == guard, \
+            'error log prefix changed while reading strict operation window'
+        window['text'] = b''.join(chunks).decode('utf-8', errors='replace')
+    finally:
+        os.close(fd)
+
+
+def window_summaries(text):
+    """Parse lookup summaries from one strict operation log window."""
+    return [(int(match.group(1)), int(match.group(2)))
+            for match in ENG_LOG_RE.finditer(text)]
+
+
+def window_avas(text):
+    """Parse equality evaluations from one strict operation log window."""
+    return [(match.group('attr').lower(), match.group('value'))
+            for match in AVA_LOG_RE.finditer(text)]
+
+
+@contextmanager
+def backend_debug_log(inst):
+    """Enable lookup summaries and filter AVA diagnostics."""
+    level = inst.config.get_attr_val_utf8('nsslapd-errorlog-level')
+    debug_level = (int(level or '0') | int(ERRORLOG_LEVEL_BACKLDBM) |
+                   int(ERRORLOG_LEVEL_FILTER))
+    inst.config.set('nsslapd-errorlog-level', str(debug_level))
+    try:
+        yield
+    finally:
+        if level is None:
+            inst.config.remove_all('nsslapd-errorlog-level')
+        else:
+            inst.config.set('nsslapd-errorlog-level', level)
+
+
+@contextmanager
+def lookup_disabled(inst):
+    """Disable the required lookup feature and restore its original value."""
+    original = inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR)
+    assert original is not None
+    try:
+        inst.config.set(OR_LOOKUP_ATTR, 'off')
+        assert inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR) == 'off'
+        yield
+    finally:
+        if inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR) != original:
+            inst.config.set(OR_LOOKUP_ATTR, original)
+
+
+@pytest.fixture(scope='module')
+def lookup_feature_data(topo):
+    """Create the minimal schema and entries needed by feature contracts."""
+    inst = topo.standalone
+    schema = Schema(inst)
+    added_attrs = []
+    created = []
+    container = None
+    dns = {}
+    try:
+        for index, name in enumerate(FEATURE_ATTRS, start=101):
+            params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+            params.update({
+                'names': (name,),
+                'oid': f'2.16.840.1.113730.3.8.999.6275.{index}',
+                'desc': 'large equality OR lookup feature contract',
+                'equality': 'caseIgnoreMatch',
+                'syntax': '1.3.6.1.4.1.1466.115.121.1.15',
+                'x_origin': ('large equality OR lookup feature test',),
+            })
+            schema.add_attributetype(params)
+            added_attrs.append(name)
+
+        params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+        params.update({
+            'names': (FEATURE_TIME_ATTR,),
+            'oid': '2.16.840.1.113730.3.8.999.6275.104',
+            'desc': 'unsupported large equality OR lookup family',
+            'equality': 'generalizedTimeMatch',
+            'syntax': '1.3.6.1.4.1.1466.115.121.1.24',
+            'x_origin': ('large equality OR lookup feature test',),
+        })
+        schema.add_attributetype(params)
+        added_attrs.append(FEATURE_TIME_ATTR)
+
+        container = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(
+            properties={'ou': 'olLookupFeatureData'})
+        objects = UnsafeExtensibleObjects(inst, container.dn)
+
+        def add_entry(key, properties):
+            entry = objects.create(properties={
+                'cn': f'ol-feature-{key}',
+                **properties,
+            })
+            created.append(entry)
+            dns[key] = entry.dn.lower()
+
+        add_entry('family-a', {'olFeatureLookupA': 'a-hit'})
+        add_entry('family-b', {'olFeatureLookupB': 'b-hit'})
+        add_entry('family-both', {
+            'olFeatureLookupA': 'a-hit',
+            'olFeatureLookupB': 'b-hit',
+        })
+        add_entry('family-c', {'olFeatureLookupC': 'c-hit'})
+        add_entry('tie-probe', {
+            'olFeatureLookupA': 'a-tie-hit',
+            'olFeatureLookupB': 'b-tie-hit',
+        })
+        add_entry('fallback-probe', {
+            'olFeatureLookupA': 'a-fallback-hit',
+            FEATURE_TIME_ATTR: '20260101000000Z',
+        })
+
+        yield {
+            'base': container.dn,
+            'dns': dns,
+        }
+    finally:
+        for entry in reversed(created):
+            if entry.exists():
+                entry.delete()
+        if container is not None and container.exists():
+            container.delete()
+        for name in reversed(added_attrs):
+            schema.remove_attributetype(name)
+
+
+def test_or_lookup_config_threshold_and_runtime_toggle(topo,
+                                                       lookup_feature_data):
+    """Require the default-on switch, 15/16 threshold, and live toggling.
+
+    :id: d89d4195-ae58-4928-84a6-dbec589baeb1
+    :setup: Standalone instance with synthetic case-ignore attributes
+    :steps:
+        1. Search equivalent 15- and 16-branch equality OR filters
+        2. Check the live default and the threshold summaries
+        3. Disable lookup and repeat the 16-branch search
+        4. Restore lookup and repeat without restarting
+    :expectedresults:
+        1. Both filters return the same exact DN set
+        2. The feature is on and only 16 branches emit a largest-16 summary
+        3. Results remain exact and no summary is emitted while disabled
+        4. Results remain exact and the 16-branch summary returns immediately
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    expected = sorted([dns['family-a'], dns['family-both']])
+    values15 = ['a-hit'] + [f'a-threshold-miss-{i:02d}' for i in range(14)]
+    values16 = values15 + ['a-threshold-miss-14']
+    filter15 = escaped_or_of('olFeatureLookupA', values15)
+    filter16 = escaped_or_of('olFeatureLookupA', values16)
+    original = inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR)
+
+    try:
+        with backend_debug_log(inst):
+            before15 = len(eng_summaries(inst))
+            assert search_dns_result(
+                inst, filter15, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == expected
+            after15 = len(eng_summaries(inst))
+
+            before16 = after15
+            assert search_dns_result(
+                inst, filter16, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == expected
+            summaries = eng_summaries(inst)[before16:]
+
+            assert original == 'on'
+            assert after15 == before15
+            assert summaries and all(largest == 16
+                                     for _, largest in summaries)
+
+            with lookup_disabled(inst):
+                before = len(eng_summaries(inst))
+                assert search_dns_result(
+                    inst, filter16, base=base,
+                    scope=ldap.SCOPE_ONELEVEL) == expected
+                assert len(eng_summaries(inst)) == before
+
+            assert inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR) == 'on'
+            before = len(eng_summaries(inst))
+            assert search_dns_result(
+                inst, filter16, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == expected
+            summaries = eng_summaries(inst)[before:]
+            assert summaries and all(largest == 16
+                                     for _, largest in summaries)
+    finally:
+        if (original is not None and
+                inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR) != original):
+            inst.config.set(OR_LOOKUP_ATTR, original)
+
+
+def test_or_lookup_dominant_family_order_independent(topo,
+                                                     lookup_feature_data):
+    """Require selection of the 64-branch family in either source order.
+
+    :id: 8e2110e6-c1f1-435c-8e5f-7f3922dd106d
+    :setup: Standalone instance with three synthetic case-ignore attributes
+    :steps:
+        1. Search an OR containing 16 A branches followed by 64 B branches
+        2. Search the same runs in the reverse source order
+    :expectedresults:
+        1. The exact A-or-B DN set returns and the summary reports largest 64
+        2. The exact result and selected family size are unchanged
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    expected = sorted([dns['family-a'], dns['family-b'], dns['family-both']])
+    a_values = ['a-hit'] + [f'a-dominant-miss-{i:02d}' for i in range(15)]
+    b_values = ['b-hit'] + [f'b-dominant-miss-{i:02d}' for i in range(63)]
+    a_run = escaped_equalities('olFeatureLookupA', a_values)
+    b_run = escaped_equalities('olFeatureLookupB', b_values)
+
+    with backend_debug_log(inst):
+        for filterstr in (f'(|{a_run}{b_run})', f'(|{b_run}{a_run})'):
+            with error_log_window(inst) as window:
+                assert search_dns_result(
+                    inst, filterstr, base=base,
+                    scope=ldap.SCOPE_ONELEVEL) == expected
+            summaries = window_summaries(window['text'])
+            assert len(summaries) == 1
+            assert summaries[0][0] > 0 and summaries[0][1] == 64
+
+
+def test_or_lookup_equal_family_tie_uses_first_source(topo,
+                                                       lookup_feature_data):
+    """Require first source occurrence as the equal-size family tie-breaker.
+
+    :id: 468d35ed-03be-4794-bf92-0da6cdaf10e0
+    :setup: A base object that matches one branch in the A and B families
+    :steps:
+        1. Search equal 16-branch A and B families with A first
+        2. Repeat the equivalent filter with B first
+        3. Inspect only each search's appended error-log bytes
+    :expectedresults:
+        1. The exact base DN returns and only the A sentinel is evaluated
+        2. The exact base DN returns and only the B sentinel is evaluated
+        3. Each search reports one selected family of 16 usable branches
+    """
+    inst = topo.standalone
+    probe_dn = lookup_feature_data['dns']['tie-probe']
+    a_values = ['a-tie-hit'] + [f'a-tie-miss-{i:02d}' for i in range(15)]
+    b_values = ['b-tie-hit'] + [f'b-tie-miss-{i:02d}' for i in range(15)]
+    a_run = escaped_equalities('olFeatureLookupA', a_values)
+    b_run = escaped_equalities('olFeatureLookupB', b_values)
+
+    with backend_debug_log(inst):
+        for filterstr, expected_ava in (
+                (f'(|{a_run}{b_run})', ('olfeaturelookupa', 'a-tie-hit')),
+                (f'(|{b_run}{a_run})', ('olfeaturelookupb', 'b-tie-hit'))):
+            with error_log_window(inst) as window:
+                assert search_dns_result(
+                    inst, filterstr, base=probe_dn,
+                    scope=ldap.SCOPE_BASE) == [probe_dn]
+
+            summaries = window_summaries(window['text'])
+            assert len(summaries) == 1
+            assert summaries[0][0] > 0 and summaries[0][1] == 16
+            avas = window_avas(window['text'])
+            assert avas and all(ava == expected_ava for ava in avas)
+
+
+def test_or_lookup_larger_unsupported_family_falls_back(topo,
+                                                         lookup_feature_data):
+    """Select a supported family over a larger unsupported family.
+
+    :id: 6e01be9a-f869-45c6-b7d5-cf11f72decdb
+    :setup: A base object matching generalizedTime and supported A families
+    :steps:
+        1. Put 64 generalizedTime branches before 16 supported A branches
+        2. Search the dedicated base object
+        3. Inspect only the search's appended error-log bytes
+    :expectedresults:
+        1. The larger family is plausible but unsupported for byte lookup
+        2. The exact base DN returns through the selected A family
+        3. The summary reports 16 and only the A sentinel is evaluated
+    """
+    inst = topo.standalone
+    probe_dn = lookup_feature_data['dns']['fallback-probe']
+    time_values = ['20260101000000Z'] + [
+        f'202602{1 + i // 24:02d}{i % 24:02d}0000Z' for i in range(63)
+    ]
+    a_values = ['a-fallback-hit'] + [
+        f'a-fallback-miss-{i:02d}' for i in range(15)
+    ]
+    filterstr = f'(|{escaped_equalities(FEATURE_TIME_ATTR, time_values)}' \
+                f'{escaped_equalities("olFeatureLookupA", a_values)})'
+
+    with backend_debug_log(inst):
+        with error_log_window(inst) as window:
+            assert search_dns_result(
+                inst, filterstr, base=probe_dn,
+                scope=ldap.SCOPE_BASE) == [probe_dn]
+
+    summaries = window_summaries(window['text'])
+    assert len(summaries) == 1
+    assert summaries[0][0] > 0 and summaries[0][1] == 16
+    avas = window_avas(window['text'])
+    expected_ava = ('olfeaturelookupa', 'a-fallback-hit')
+    assert avas and all(ava == expected_ava for ava in avas)
+
+
+def test_or_lookup_third_family_after_distractors(topo,
+                                                  lookup_feature_data):
+    """Require discovery of a 64-branch third family after distractors.
+
+    :id: 9c9bde22-983b-4a17-af10-8cc9461939da
+    :setup: Standalone instance with three synthetic case-ignore attributes
+    :steps:
+        1. Search an OR with one absent A, one absent B, and 64 C branches
+        2. Inspect the operation summary
+    :expectedresults:
+        1. Exactly the live C entry returns
+        2. The summary reports a largest family of 64 branches
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    c_values = ['c-hit'] + [f'c-third-miss-{i:02d}' for i in range(63)]
+    filterstr = ('(|(olFeatureLookupA=a-distractor)'
+                 '(olFeatureLookupB=b-distractor)'
+                 f'{escaped_equalities("olFeatureLookupC", c_values)})')
+
+    with backend_debug_log(inst):
+        before = len(eng_summaries(inst))
+        assert search_dns_result(
+            inst, filterstr, base=base,
+            scope=ldap.SCOPE_ONELEVEL) == [dns['family-c']]
+        summaries = eng_summaries(inst)[before:]
+        assert summaries and all(largest == 64 for _, largest in summaries)
+
+
+def test_or_lookup_true_root_all_miss(topo, lookup_feature_data):
+    """Require the all-miss fast decision for an unproxied root search.
+
+    The classic walk emits one ``test_ava_filter`` AVA line per branch per
+    entry.  An engaged search with zero family AVA lines therefore proves
+    the all-miss entries were decided by the table, not the walk.
+
+    :id: 3fd00a80-65fd-4945-b5f9-dc146ac1b3ec
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. Search a 16-branch all-miss family as Directory Manager
+        2. Repeat with lookup disabled
+        3. Run a base-object health search on the same connection
+    :expectedresults:
+        1. LDAP success, an exact empty result, a largest-16 summary, and no
+           family AVA evaluations in the operation window
+        2. LDAP success, the same empty result, no new summary, and the
+           classic walk's family AVA evaluations reappear
+        3. The suffix entry returns exactly
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    filterstr = escaped_or_of(
+        'olFeatureLookupA', [f'ol-root-miss-{i:02d}' for i in range(16)])
+    try:
+        with backend_debug_log(inst):
+            before = len(eng_summaries(inst))
+            with error_log_window(inst) as window:
+                assert search_dns_result(
+                    conn, filterstr, base=lookup_feature_data['base'],
+                    scope=ldap.SCOPE_ONELEVEL) == []
+            summaries = eng_summaries(inst)[before:]
+            assert summaries and all(largest == 16
+                                     for _, largest in summaries)
+            assert not [attr for attr, _ in window_avas(window['text'])
+                        if attr == 'olfeaturelookupa']
+
+            with lookup_disabled(inst):
+                before = len(eng_summaries(inst))
+                with error_log_window(inst) as window:
+                    assert search_dns_result(
+                        conn, filterstr, base=lookup_feature_data['base'],
+                        scope=ldap.SCOPE_ONELEVEL) == []
+                assert len(eng_summaries(inst)) == before
+                assert [attr for attr, _ in window_avas(window['text'])
+                        if attr == 'olfeaturelookupa']
+
+        assert search_dns_result(
+            conn, '(objectClass=*)', base=DEFAULT_SUFFIX,
+            scope=ldap.SCOPE_BASE) == [DEFAULT_SUFFIX.lower()]
+    finally:
+        conn.unbind_s()
+
+
+def test_or_lookup_all_miss_under_not_falls_back(topo, lookup_feature_data):
+    """Require the classic walk for an all-miss family under NOT.
+
+    NOT can tell false and undefined apart, so under it the no-winner
+    shortcut must not decide and the classic walk runs.
+
+    :id: b991ad4b-13f2-4886-9204-f8e22a7e94ce
+    :setup: Standalone instance with synthetic case-ignore attributes
+    :steps:
+        1. Search the negation of a 16-branch all-miss family
+        2. Inspect the operation's engagement summary and AVA evaluations
+    :expectedresults:
+        1. Exactly the container's entries return (the complement)
+        2. The table is built, and the classic walk's family AVA
+           evaluations are present
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    filterstr = '(!{})'.format(escaped_or_of(
+        'olFeatureLookupA', [f'ol-not-miss-{i:02d}' for i in range(16)]))
+    expected = sorted(dns.values())
+
+    with backend_debug_log(inst):
+        before = len(eng_summaries(inst))
+        with error_log_window(inst) as window:
+            assert search_dns_result(
+                inst, filterstr, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == expected
+        summaries = eng_summaries(inst)[before:]
+        assert summaries and all(largest == 16 for _, largest in summaries)
+        assert [attr for attr, _ in window_avas(window['text'])
+                if attr == 'olfeaturelookupa']
+
+
+def test_or_lookup_all_miss_rest_component_matches(topo, lookup_feature_data):
+    """Require the rest walk to decide matches after a no-winner pass.
+
+    After all table probes miss, the non-family branches are still
+    evaluated; a match there returns the entry without walking the family.
+
+    :id: 4d7fb9c3-ddce-40e3-9b81-beed18f2cd6f
+    :setup: Standalone instance with synthetic case-ignore attributes
+    :steps:
+        1. Search a 16-branch all-miss family OR one live non-family
+           equality
+        2. Inspect the operation's AVA evaluations
+        3. Repeat with lookup disabled
+    :expectedresults:
+        1. Exactly the non-family matches return
+        2. The rest component was evaluated per entry while the family
+           branches were not
+        3. The same exact result returns
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    filterstr = '(|{}{})'.format(
+        escaped_equalities(
+            'olFeatureLookupA', [f'ol-rest-miss-{i:02d}' for i in range(16)]),
+        '(olFeatureLookupB=b-hit)')
+    expected = sorted([dns['family-b'], dns['family-both']])
+
+    with backend_debug_log(inst):
+        before = len(eng_summaries(inst))
+        with error_log_window(inst) as window:
+            assert search_dns_result(
+                inst, filterstr, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == expected
+        summaries = eng_summaries(inst)[before:]
+        assert summaries and all(largest == 16 for _, largest in summaries)
+        avas = window_avas(window['text'])
+        assert [attr for attr, _ in avas if attr == 'olfeaturelookupb']
+        assert not [attr for attr, _ in avas if attr == 'olfeaturelookupa']
+
+    with lookup_disabled(inst):
+        assert search_dns_result(
+            inst, filterstr, base=base,
+            scope=ldap.SCOPE_ONELEVEL) == expected
+
+
+if __name__ == '__main__':
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(['-s', CURRENT_FILE])

--- a/dirsrvtests/tests/suites/filter/filter_or_lookup_feature_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_lookup_feature_test.py
@@ -47,6 +47,7 @@ AVA_LOG_RE = re.compile(
 
 FEATURE_ATTRS = ('olFeatureLookupA', 'olFeatureLookupB', 'olFeatureLookupC')
 FEATURE_TIME_ATTR = 'olFeatureLookupTime'
+FEATURE_DN_ATTR = 'olFeatureLookupDN'
 
 
 def escaped_equalities(attr, values):
@@ -201,6 +202,18 @@ def lookup_feature_data(topo):
         schema.add_attributetype(params)
         added_attrs.append(FEATURE_TIME_ATTR)
 
+        params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+        params.update({
+            'names': (FEATURE_DN_ATTR,),
+            'oid': '2.16.840.1.113730.3.8.999.6275.105',
+            'desc': 'DN-syntax large equality OR lookup family',
+            'equality': 'distinguishedNameMatch',
+            'syntax': '1.3.6.1.4.1.1466.115.121.1.12',
+            'x_origin': ('large equality OR lookup feature test',),
+        })
+        schema.add_attributetype(params)
+        added_attrs.append(FEATURE_DN_ATTR)
+
         container = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(
             properties={'ou': 'olLookupFeatureData'})
         objects = UnsafeExtensibleObjects(inst, container.dn)
@@ -228,6 +241,7 @@ def lookup_feature_data(topo):
             'olFeatureLookupA': 'a-fallback-hit',
             FEATURE_TIME_ATTR: '20260101000000Z',
         })
+        add_entry('family-dn', {FEATURE_DN_ATTR: container.dn})
 
         yield {
             'base': container.dn,
@@ -308,6 +322,45 @@ def test_or_lookup_config_threshold_and_runtime_toggle(topo,
         if (original is not None and
                 inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR) != original):
             inst.config.set(OR_LOOKUP_ATTR, original)
+
+
+def test_or_lookup_dn_family_engages(topo, lookup_feature_data):
+    """Require table engagement and parity for a DN-syntax family.
+
+    :id: 5b1f8c3e-9a0d-4f6b-8a34-cd2e05c7a911
+    :setup: Standalone instance with a distinguishedNameMatch attribute
+    :steps:
+        1. Search a 16-branch DN equality OR naming one stored value
+        2. Inspect the operation summary
+        3. Disable lookup and repeat the search
+    :expectedresults:
+        1. Exactly the DN-carrying entry returns
+        2. The summary reports a largest family of 16 branches
+        3. Results stay identical and no summary is emitted while disabled
+    """
+    inst = topo.standalone
+    base = lookup_feature_data['base']
+    dns = lookup_feature_data['dns']
+    # Misses must be fixed points of DN case normalization (lowercase,
+    # no spaces) or the DN key validation drops them below threshold.
+    values = [base] + [f'cn=ol-dn-miss-{i:02d},{base.lower()}'
+                       for i in range(15)]
+    filterstr = escaped_or_of(FEATURE_DN_ATTR, values)
+
+    with backend_debug_log(inst):
+        before = len(eng_summaries(inst))
+        assert search_dns_result(
+            inst, filterstr, base=base,
+            scope=ldap.SCOPE_ONELEVEL) == [dns['family-dn']]
+        summaries = eng_summaries(inst)[before:]
+        assert summaries and all(largest == 16 for _, largest in summaries)
+
+        with lookup_disabled(inst):
+            before = len(eng_summaries(inst))
+            assert search_dns_result(
+                inst, filterstr, base=base,
+                scope=ldap.SCOPE_ONELEVEL) == [dns['family-dn']]
+            assert len(eng_summaries(inst)) == before
 
 
 def test_or_lookup_dominant_family_order_independent(topo,

--- a/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
@@ -1,0 +1,1799 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+
+"""
+Result correctness for large equality OR filters (issue #6275).  These tests
+pin complete result sets across matching-rule normalization, multi-valued
+entries, paging, scope, referrals, ACLs, controls, CoS, tombstones, and RUV
+sentinels.  They run on builds that may optionally expose
+``nsslapd-enable-or-filter-lookup``; when that switch is
+present, searches are repeated with it disabled to assert behavioral parity.
+"""
+
+import ldap
+import logging
+import os
+import pytest
+import time
+
+from contextlib import contextmanager
+from ldap.controls import SimplePagedResultsControl
+from ldap.controls.simple import ManageDSAITControl, ProxyAuthzControl
+from ldap.controls.sss import SSSRequestControl
+from ldap.controls.vlv import VLVRequestControl
+from ldap.filter import escape_filter_chars
+from ldap.schema.models import AttributeType
+from lib389._constants import DEFAULT_SUFFIX, REPLICA_RUV_UUID
+from lib389.cos import CosPointerDefinition, CosTemplate
+from lib389.extensibleobject import UnsafeExtensibleObjects
+from lib389.idm.directorymanager import DirectoryManager
+from lib389.idm.domain import Domain
+from lib389.idm.organizationalunit import OrganizationalUnits
+from lib389.idm.user import UserAccount, UserAccounts
+from lib389.schema import OBJECT_MODEL_PARAMS, Schema
+from lib389.tombstone import Tombstones
+from lib389.utils import ensure_bytes, ensure_str
+from test389.topologies import topology_m2, topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+TOTAL_USERS = 400
+GROUPS = 20            # sn=OlSn<i % GROUPS>
+SMALL_GROUPS = 30      # 3 members each; even-numbered groups store the
+                       # member DNs with an UPPERCASE uid (case-cross data)
+BIG_GROUPS = 3         # 200 members each, exercising large multivalued
+                       # distinguished-name attributes
+BIG_GROUP_MEMBERS = 200
+PW = 'olpassword'
+
+OR_LOOKUP_ATTR = 'nsslapd-enable-or-filter-lookup'
+
+PEOPLE = f'ou=People,{DEFAULT_SUFFIX}'
+GROUPS_OU = f'ou=Groups,{DEFAULT_SUFFIX}'
+
+
+def user_uid(i):
+    return f'oluser{i:05d}'
+
+
+def user_dn(i, case_mangled=False):
+    uid = user_uid(i).upper() if case_mangled else user_uid(i)
+    return f'uid={uid},{PEOPLE}'
+
+
+@pytest.fixture(scope="module")
+def create_data(topo):
+    """Import users, groups, and a subentry; return the uid list."""
+    inst = topo.standalone
+    ldif_dir = inst.get_ldif_dir()
+    ldif_file = os.path.join(ldif_dir, 'filter_or_lookup.ldif')
+    with open(ldif_file, 'w') as f:
+        # offline import replaces the backend contents, so the LDIF must
+        # carry the suffix root and containers too; the aci restores read
+        # access for the non-Directory-Manager binds some tests use
+        f.write(f'dn: {DEFAULT_SUFFIX}\n'
+                'objectClass: top\n'
+                'objectClass: domain\n'
+                'dc: example\n'
+                'aci: (targetattr="*")(version 3.0; acl "filter test read"; '
+                'allow (read, search, compare)(userdn="ldap:///all");)\n\n'
+                f'dn: {PEOPLE}\n'
+                'objectClass: top\n'
+                'objectClass: organizationalUnit\n'
+                'ou: People\n\n'
+                f'dn: {GROUPS_OU}\n'
+                'objectClass: top\n'
+                'objectClass: organizationalUnit\n'
+                'ou: Groups\n\n')
+        for i in range(TOTAL_USERS):
+            uid = user_uid(i)
+            extra = ''
+            if i in (350, 351, 352):
+                extra += (f'employeeNumber: olemp{i:05d}\n'
+                          f'mail: {uid}@olmail.example.com\n')
+            if i in (360, 361):
+                extra += 'cn: olduptest\n'
+            if i == 370:
+                extra += 'cn;lang-en: olsubtypelang\n'
+            if i == 371:
+                extra += 'cn: OlCase MIXED Value\n'
+            f.write(f'dn: uid={uid},{PEOPLE}\n'
+                    'objectClass: top\n'
+                    'objectClass: person\n'
+                    'objectClass: organizationalPerson\n'
+                    'objectClass: inetOrgPerson\n'
+                    'objectClass: posixAccount\n'
+                    f'uid: {uid}\n'
+                    f'cn: OL User {i:05d}\n'
+                    f'cn: olalt{i:05d}\n'
+                    f'sn: OlSn{i % GROUPS}\n'
+                    f'uidNumber: {20000 + i}\n'
+                    f'gidNumber: {20000 + i}\n'
+                    f'homeDirectory: /home/{uid}\n'
+                    f'userPassword: {PW}\n'
+                    f'{extra}\n')
+        # multi-valued uid entry
+        f.write(f'dn: uid=olmultia,{PEOPLE}\n'
+                'objectClass: top\n'
+                'objectClass: person\n'
+                'objectClass: organizationalPerson\n'
+                'objectClass: inetOrgPerson\n'
+                'objectClass: posixAccount\n'
+                'uid: olmultia\n'
+                'uid: olmultib\n'
+                'cn: OL Multi\n'
+                'sn: OlMultiSn\n'
+                'uidNumber: 29999\n'
+                'gidNumber: 29999\n'
+                'homeDirectory: /home/olmultia\n'
+                f'userPassword: {PW}\n\n')
+        # an LDAP subentry: excluded from ordinary search results unless
+        # the filter names objectclass=ldapsubentry
+        f.write(f'dn: cn=olsubentry,{DEFAULT_SUFFIX}\n'
+                'objectClass: top\n'
+                'objectClass: ldapsubentry\n'
+                'objectClass: extensibleObject\n'
+                'cn: olsubentry\n'
+                'uid: olsubentryuid\n\n')
+        # small groups; even-numbered ones store their member DNs with an
+        # UPPERCASE uid RDN value (the referenced users exist lowercase)
+        for g in range(SMALL_GROUPS):
+            members = ''.join(
+                f'member: {user_dn(3 * g + j, case_mangled=(g % 2 == 0))}\n'
+                for j in range(3))
+            f.write(f'dn: cn=olgroup{g:03d},{GROUPS_OU}\n'
+                    'objectClass: top\n'
+                    'objectClass: groupOfNames\n'
+                    f'cn: olgroup{g:03d}\n'
+                    f'{members}\n')
+        # big groups exercise large multivalued DN attributes
+        for g in range(BIG_GROUPS):
+            members = ''.join(f'member: {user_dn(j)}\n'
+                              for j in range(BIG_GROUP_MEMBERS))
+            f.write(f'dn: cn=olbig{g},{GROUPS_OU}\n'
+                    'objectClass: top\n'
+                    'objectClass: groupOfNames\n'
+                    f'cn: olbig{g}\n'
+                    f'{members}\n')
+    os.chmod(ldif_file, 0o644)
+    inst.stop()
+    assert inst.ldif2db('userRoot', None, None, None, ldif_file)
+    inst.start()
+    return [user_uid(i) for i in range(TOTAL_USERS)]
+
+
+def or_of(attr, values):
+    return '(|%s)' % ''.join(f'({attr}={v})' for v in values)
+
+
+def escaped_or_of(attr, values):
+    """Build an equality OR while preserving filter-special characters."""
+    return '(|%s)' % escaped_equalities(attr, values)
+
+
+def escaped_equalities(attr, values):
+    """Build equality components without an enclosing Boolean node."""
+    return ''.join(
+        f'({attr}={escape_filter_chars(ensure_str(value))})' for value in values)
+
+
+def ghosts(n, prefix='olghost'):
+    """Generate deterministic absent-but-well-formed OR values."""
+    return [f'{prefix}{i:05d}' for i in range(n)]
+
+
+def search_uids(topo, filterstr, base=DEFAULT_SUFFIX, scope=ldap.SCOPE_SUBTREE):
+    entries = topo.standalone.search_s(base, scope, filterstr, ['uid'])
+    return sorted(ensure_str(e.getValue('uid')) for e in entries)
+
+
+def search_dns(conn, filterstr, base=DEFAULT_SUFFIX, scope=ldap.SCOPE_SUBTREE):
+    entries = conn.search_s(base, scope, filterstr, ['1.1'])
+    return sorted(e.dn.lower() for e in entries)
+
+
+def search_dns_result(conn, filterstr, base=DEFAULT_SUFFIX,
+                      scope=ldap.SCOPE_SUBTREE, serverctrls=None):
+    """Run one asynchronous search and assert its final LDAP result."""
+    msgid = conn.search_ext(base, scope, filterstr, ['1.1'],
+                            serverctrls=serverctrls)
+    rtype, rdata, _, rctrls = conn.result3(msgid)
+    assert rtype == ldap.RES_SEARCH_RESULT
+    dns = []
+    for dn, _ in rdata:
+        assert dn is not None
+        dns.append(ensure_str(dn).lower())
+    return sorted(dns), rctrls
+
+
+def paged_search_dns(conn, filterstr, page_size, base=DEFAULT_SUFFIX,
+                     scope=ldap.SCOPE_SUBTREE):
+    """Collect a complete simple-paged search, asserting each result."""
+    req = SimplePagedResultsControl(True, size=page_size, cookie='')
+    dns = []
+    while True:
+        page_dns, rctrls = search_dns_result(
+            conn, filterstr, base=base, scope=scope, serverctrls=[req])
+        dns.extend(page_dns)
+        pctrls = [c for c in rctrls
+                  if c.controlType == SimplePagedResultsControl.controlType]
+        assert len(pctrls) == 1
+        if not pctrls[0].cookie:
+            break
+        req.cookie = pctrls[0].cookie
+    return sorted(dns)
+
+
+def assert_health(conn):
+    """Assert a simple base search completes successfully and exactly."""
+    dns, _ = search_dns_result(
+        conn, '(objectClass=*)', base=DEFAULT_SUFFIX, scope=ldap.SCOPE_BASE)
+    assert dns == [DEFAULT_SUFFIX.lower()]
+
+
+def _instance(target):
+    return target.standalone if hasattr(target, 'standalone') else target
+
+
+@contextmanager
+def or_lookup_disabled(target):
+    """Disable optional lookup support, or act as a no-op when unavailable."""
+    inst = _instance(target)
+    original = inst.config.get_attr_val_utf8(OR_LOOKUP_ATTR)
+    if original is None:
+        yield
+        return
+    inst.config.set(OR_LOOKUP_ATTR, 'off')
+    try:
+        yield
+    finally:
+        inst.config.set(OR_LOOKUP_ATTR, original)
+
+
+def assert_parity(topo, conn, filterstr, base=DEFAULT_SUFFIX,
+                  scope=ldap.SCOPE_SUBTREE, serverctrls=None):
+    """Require parity with optional lookup disabled when the switch exists."""
+    def run():
+        try:
+            if serverctrls:
+                res = conn.search_ext_s(base, scope, filterstr, ['1.1'],
+                                        serverctrls=serverctrls)
+            else:
+                res = conn.search_s(base, scope, filterstr, ['1.1'])
+            # lib389 connections return Entry objects
+            return sorted(e.dn.lower() for e in res if e.dn)
+        except ldap.LDAPError as e:
+            return type(e).__name__
+
+    default_result = run()
+    with or_lookup_disabled(topo):
+        disabled_result = run()
+    assert default_result == disabled_result
+    return default_result
+
+
+SYNTH_ATTRS = (
+    {'name': 'olLookupA', 'equality': 'caseIgnoreMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.15'},
+    {'name': 'olLookupB', 'equality': 'caseIgnoreMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.15'},
+    {'name': 'olLookupC', 'equality': 'caseIgnoreMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.15'},
+    {'name': 'olCaseIgnore', 'equality': 'caseIgnoreMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.15'},
+    {'name': 'olCaseExact', 'equality': 'caseExactMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.15'},
+    {'name': 'olCaseExactIA5', 'equality': 'caseExactIA5Match',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.26'},
+    {'name': 'olCaseIgnoreIA5', 'equality': 'caseIgnoreIA5Match',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.26'},
+    {'name': 'olInteger', 'equality': 'integerMatch',
+     'ordering': 'integerOrderingMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.27'},
+    {'name': 'olNumeric', 'equality': 'numericStringMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.36'},
+    {'name': 'olTelephone', 'equality': 'telephoneNumberMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.50'},
+    {'name': 'olDistinguishedName', 'equality': 'distinguishedNameMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.12'},
+    {'name': 'olGeneralizedTime', 'equality': 'generalizedTimeMatch',
+     'ordering': 'generalizedTimeOrderingMatch',
+     'syntax': '1.3.6.1.4.1.1466.115.121.1.24'},
+)
+
+MATCH_RULE_CASES = (
+    {'id': 'case-ignore-directory-string', 'attr': 'olCaseIgnore',
+     'stored': 'Alpha  Value', 'assertion': ' alpha value '},
+    {'id': 'case-exact-directory-string', 'attr': 'olCaseExact',
+     'stored': 'Exact  Value', 'assertion': ' Exact Value '},
+    {'id': 'case-exact-ia5', 'attr': 'olCaseExactIA5',
+     'stored': 'Exact  IA5', 'assertion': ' Exact IA5 '},
+    {'id': 'case-ignore-ia5', 'attr': 'olCaseIgnoreIA5',
+     'stored': 'MiXeD  IA5', 'assertion': ' mixed ia5 '},
+    {'id': 'integer', 'attr': 'olInteger',
+     'stored': '42', 'assertion': '00042'},
+    {'id': 'numeric-string', 'attr': 'olNumeric',
+     'stored': '12 34 5', 'assertion': '12345'},
+    {'id': 'telephone-number', 'attr': 'olTelephone',
+     'stored': '+1 604-555 0100', 'assertion': '+16045550100'},
+    {'id': 'distinguished-name', 'attr': 'olDistinguishedName',
+     'stored': f'uid=OLUSER00001,{PEOPLE}',
+     'assertion': f'UID=oluser00001, OU=people, {DEFAULT_SUFFIX.upper()}'},
+)
+
+
+def matching_rule_absent_values(case_id, count=14):
+    if case_id == 'integer':
+        return [str(1000 + i) for i in range(count)]
+    if case_id == 'numeric-string':
+        return [f'900{i:03d}' for i in range(count)]
+    if case_id == 'telephone-number':
+        return [f'+1 999 555 {i:04d}' for i in range(count)]
+    if case_id == 'distinguished-name':
+        return [f'cn=ol-missing-{i:02d},{DEFAULT_SUFFIX}' for i in range(count)]
+    return [f'ol-missing-{case_id}-{i:02d}' for i in range(count)]
+
+
+@pytest.fixture(scope='module')
+def lookup_schema_data(topo, create_data):
+    """Create synthetic matching-rule attributes and LDAP entries."""
+    inst = topo.standalone
+    schema = Schema(inst)
+    added_attrs = []
+    created = []
+    container = None
+    expected_dns = {}
+    try:
+        for idx, spec in enumerate(SYNTH_ATTRS, start=1):
+            params = OBJECT_MODEL_PARAMS[AttributeType].copy()
+            params.update({
+                'names': (spec['name'],),
+                'oid': f'2.16.840.1.113730.3.8.999.6275.{idx}',
+                'desc': 'large equality OR lookup functional test',
+                'equality': spec['equality'],
+                'ordering': spec.get('ordering'),
+                'syntax': spec['syntax'],
+                'x_origin': ('large equality OR lookup test',),
+            })
+            schema.add_attributetype(params)
+            added_attrs.append(spec['name'])
+
+        container = OrganizationalUnits(inst, DEFAULT_SUFFIX).create(
+            properties={'ou': 'olLookupData'})
+        objects = UnsafeExtensibleObjects(inst, container.dn)
+
+        def add_entry(key, properties):
+            entry = objects.create(properties={
+                'cn': f'ol-{key}',
+                **properties,
+            })
+            expected_dns[key] = f'cn=ol-{key},{container.dn}'.lower()
+            created.append(entry)
+            return entry
+
+        add_entry('family-a', {'olLookupA': 'a-hit'})
+        add_entry('family-b', {'olLookupB': 'b-hit'})
+        add_entry('family-both', {'olLookupA': 'a-hit',
+                                  'olLookupB': 'b-hit'})
+        add_entry('family-c', {'olLookupC': 'c-hit'})
+        add_entry('root-simple', {'olLookupC': 'simple-match'})
+        add_entry('root-complex', {'olLookupC': 'guard-hit'})
+
+        for case in MATCH_RULE_CASES:
+            add_entry(f'match-{case["id"]}', {case['attr']: case['stored']})
+
+        add_entry('unicode-case-ignore', {
+            'olCaseIgnore': 'ÇÉLINE ÅNGSTRÖM',
+        })
+        add_entry('outside-generalized-time', {
+            'olGeneralizedTime': '20240101010203Z',
+        })
+        add_entry('escaped-dn', {
+            'olDistinguishedName': f'cn=Smith\\, Alice,{PEOPLE}',
+        })
+
+        count_assertions = [
+            f'cn=ol-count-{i:02d},{DEFAULT_SUFFIX}' for i in range(16)]
+        add_entry('dn-count-less', {
+            'olDistinguishedName': [
+                count_assertions[0],
+                f'cn=ol-less-extra,{DEFAULT_SUFFIX}',
+            ],
+        })
+        add_entry('dn-count-equal', {
+            'olDistinguishedName': [count_assertions[0]] + [
+                f'cn=ol-equal-extra-{i:02d},{DEFAULT_SUFFIX}' for i in range(15)],
+        })
+        add_entry('dn-count-more', {
+            'olDistinguishedName': [count_assertions[0]] + [
+                f'cn=ol-more-extra-{i:02d},{DEFAULT_SUFFIX}' for i in range(16)],
+        })
+
+        yield {
+            'base': container.dn,
+            'dns': expected_dns,
+            'all_dns': sorted(expected_dns.values()),
+            'dn_count_assertions': count_assertions,
+        }
+    finally:
+        for entry in reversed(created):
+            if entry.exists():
+                entry.delete()
+        if container is not None and container.exists():
+            container.delete()
+        for attr_name in reversed(added_attrs):
+            schema.remove_attributetype(attr_name)
+
+
+def test_or_big_same_attr_exact(topo, create_data):
+    """Verify a large OR of uid equalities (live values, verbatim
+    duplicates, and absent values) returns the exact result set.
+
+    :id: 7c1de2a8-40f6-4b91-9c35-d82e61f7a904
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of 120 live uids, 20 of them repeated, 60 absent
+        2. Compare the complete result set
+    :expectedresults:
+        1. Search succeeds
+        2. Exactly the 120 named users are returned, each once
+    """
+    live = create_data[100:220]
+    values = live + live[:20] + ghosts(60)
+    assert search_uids(topo, or_of('uid', values)) == sorted(live)
+
+
+def test_or_duplicate_branches(topo, create_data):
+    """Verify an OR dominated by one duplicated component returns the
+    exact result set.
+
+    :id: 2f4bb9e0-a913-45c7-8d62-03cf17e8ba56
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of 300 verbatim copies of (cn=olduptest) plus a
+           few live cn values
+    :expectedresults:
+        1. Exactly the two olduptest users and the named users return
+    """
+    values = ['olduptest'] * 300 + ['olalt00005', 'olalt00006']
+    expected = sorted([user_uid(360), user_uid(361),
+                       user_uid(5), user_uid(6)])
+    assert search_uids(topo, or_of('cn', values)) == expected
+
+
+def test_or_case_and_trim(topo, create_data):
+    """Verify assertion values differing in case or padded with spaces
+    use the attribute matching rule and return the exact expected entries.
+
+    :id: 5a0c47d1-6e28-4f9b-a1d5-92c8e04b7f13
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large uid OR whose live values are UPPERCASED
+        2. Search a large uid OR with space-padded live values
+        3. Search a large cn OR asserting a lowercase form of a stored
+           mixed-case value
+    :expectedresults:
+        1. Exactly the named users are returned
+        2. Exactly the named users are returned
+        3. Exactly the mixed-case-value user is returned
+    """
+    live = create_data[10:40]
+    upper = [v.upper() for v in live]
+    assert search_uids(topo, or_of('uid', upper + ghosts(20))) == sorted(live)
+    padded = [f' {v} ' for v in live]
+    assert search_uids(topo, or_of('uid', padded + ghosts(20))) == sorted(live)
+    values = ['olcase mixed value'] + [f'olalt{i:05d}' for i in range(20, 35)]
+    expected = sorted([user_uid(371)] + [user_uid(i) for i in range(20, 35)])
+    assert search_uids(topo, or_of('cn', values)) == expected
+
+
+def test_or_multivalued_entry(topo, create_data):
+    """Verify entries match through a non-first attribute value, both on
+    a multi-valued cn and on a multi-valued uid
+
+    :id: e93d05c2-71b8-49a4-bd06-4f1a28c9e750
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large cn OR naming only second cn values (olaltNNNNN)
+        2. Search a large uid OR naming only the second uid value of the
+           two-uid entry
+    :expectedresults:
+        1. Exactly the named users are returned
+        2. The two-uid entry is returned
+    """
+    picked = list(range(200, 230))
+    values = [f'olalt{i:05d}' for i in picked]
+    assert search_uids(topo, or_of('cn', values)) == sorted(
+        user_uid(i) for i in picked)
+    result = topo.standalone.search_s(
+        DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+        or_of('uid', ['olmultib'] + ghosts(20)), ['cn'])
+    assert [e.dn for e in result] == [f'uid=olmultia,{PEOPLE}']
+
+
+def test_or_integer_attr(topo, create_data):
+    """Verify a large OR on an INTEGER-syntax attribute (uidNumber)
+    matches through integer normalization, including leading zeros
+
+    :id: b8e61f30-2c95-4da7-8e14-70d3a9c6f582
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of 40 live uidNumbers, some written with leading
+           zeros, plus absent negative values
+    :expectedresults:
+        1. Exactly the named users are returned
+    """
+    picked = list(range(120, 160))
+    values = []
+    for n, i in enumerate(picked):
+        values.append(f'000{20000 + i}' if n % 3 == 0 else f'{20000 + i}')
+    values += ['-1', '-00042', '99999999']
+    assert search_uids(topo, or_of('uidNumber', values)) == sorted(
+        user_uid(i) for i in picked)
+
+
+def test_or_dn_member(topo, create_data):
+    """Verify a large OR on a DN-syntax attribute matches across case
+    differences in either direction and tolerates an unparseable DN
+    assertion among the components
+
+    :id: 91c25e84-d0b7-4f36-a29c-58e1f4d07b63
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of member values: a lowercase assertion of a
+           member stored UPPERCASE, an UPPERCASE assertion of a member
+           stored lowercase, one unparseable-DN value, and 16 absent
+           well-formed DNs
+    :expectedresults:
+        1. Exactly the groups holding those two members are returned
+    """
+    values = ([user_dn(6), user_dn(4, case_mangled=True), 'not a dn at all']
+              + [f'uid=olghost{i:03d},{PEOPLE}' for i in range(16)])
+    filt = or_of('member', values)
+    entries = topo.standalone.search_s(GROUPS_OU, ldap.SCOPE_SUBTREE,
+                                       filt, ['cn'])
+    got = sorted(ensure_str(e.getValue('cn')) for e in entries)
+    # user 6 is in olgroup002 (stored UPPERCASE) and every big group;
+    # user 4 is in olgroup001 (stored lowercase) and every big group
+    expected = sorted(['olgroup001', 'olgroup002',
+                       'olbig0', 'olbig1', 'olbig2'])
+    assert got == expected
+
+
+def test_or_inside_and(topo, create_data):
+    """Verify an OR evaluated under an enclosing AND (candidates broader
+    than the OR's own matches) returns the exact result set
+
+    :id: 0d7f92c6-3ab1-48e5-bc70-61e94d28a5f7
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search (&(sn=OlSn0)(|...30 uids across all sn groups...))
+    :expectedresults:
+        1. Exactly the OR's group-0 members are returned
+    """
+    in_group = [uid for i, uid in enumerate(create_data) if i % GROUPS == 0][:6]
+    other = [uid for i, uid in enumerate(create_data) if i % GROUPS == 7][:24]
+    filt = f'(&(sn=OlSn0){or_of("uid", in_group + other)})'
+    assert search_uids(topo, filt) == sorted(in_group)
+
+
+def test_or_referral_wrapper(topo, create_data):
+    """Verify a large OR on a suffix containing a referral entry (the
+    executed filter gains the (|(f)(objectclass=referral)) wrapper)
+    returns the exact result set with and without ManageDsaIT
+
+    :id: 4e8a1c59-f723-4b06-9d84-c2571e0af938
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Add a referral entry with ManageDsaIT and restart (the
+           referral-presence flag is read at backend start)
+        2. Search a large uid OR with ManageDsaIT
+        3. Search the same OR without ManageDsaIT, collecting entries
+        4. Remove the referral entry and restart
+    :expectedresults:
+        1. Referral entry is added
+        2. Exactly the named users are returned
+        3. Exactly the named users are returned among the entries
+        4. Cleanup succeeds
+    """
+    inst = topo.standalone
+    ref_dn = f'ou=OlRefOU,{DEFAULT_SUFFIX}'
+    live = create_data[40:80]
+    filt = or_of('uid', live + ghosts(20))
+    dsait = ManageDSAITControl()
+    inst.add_ext_s(ref_dn, [
+        ('objectClass', [b'top', b'referral', b'extensibleObject']),
+        ('ou', [b'OlRefOU']),
+        ('ref', [b'ldap://example.invalid/ou=Elsewhere']),
+    ], serverctrls=[dsait])
+    inst.restart()
+    try:
+        res = inst.search_ext_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, filt,
+                                ['uid'], serverctrls=[dsait])
+        got = sorted(ensure_str(e.getValue('uid')) for e in res
+                     if e.dn and e.getValue('uid'))
+        assert got == sorted(live)
+        # without ManageDsaIT the referral is returned separately; the
+        # entry result set must be identical
+        inst.set_option(ldap.OPT_REFERRALS, 0)
+        try:
+            res = inst.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, filt, ['uid'])
+            got = sorted(ensure_str(e.getValue('uid')) for e in res
+                         if e.dn and e.getValue('uid'))
+            assert got == sorted(live)
+        finally:
+            inst.set_option(ldap.OPT_REFERRALS, 1)
+    finally:
+        inst.delete_ext_s(ref_dn, serverctrls=[dsait])
+        inst.restart()
+
+
+def test_or_onelevel_nonroot(topo, create_data):
+    """Verify a one-level large OR as a regular user returns the exact
+    result set: the executed filter carries injected parentid and
+    referral components which must not take part in access checking
+
+    :id: a67b30d9-84e2-4c15-bf08-93d7f61c2ae4
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Bind as a regular user
+        2. Run a one-level search under ou=People with an OR of 40 live
+           uids and 20 absent ones
+    :expectedresults:
+        1. Bind succeeds
+        2. Exactly the named users are returned
+    """
+    live = create_data[300:340]
+    conn = UserAccount(topo.standalone, user_dn(0)).bind(PW)
+    try:
+        entries = conn.search_s(PEOPLE, ldap.SCOPE_ONELEVEL,
+                                or_of('uid', live + ghosts(20)), ['uid'])
+        got = sorted(ensure_str(e.getValue('uid')) for e in entries)
+        assert got == sorted(live)
+    finally:
+        conn.unbind_s()
+
+
+def test_or_paged(topo, create_data):
+    """Verify a paged large OR returns the exact union of pages.
+
+    :id: c50e94f7-16d3-4ba8-92c6-e08a5d7b31f9
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Run an OR of 120 live uids as a paged search, page size 30
+        2. Repeat the complete paged search with lookup disabled
+    :expectedresults:
+        1. Every page succeeds and the union is exactly the 120 named DNs
+        2. Optional lookup-disabled evaluation returns the same DN set
+    """
+    inst = topo.standalone
+    picked = create_data[150:270]
+    filt = or_of('uid', picked)
+    expected = sorted(f'uid={uid},{PEOPLE}'.lower() for uid in picked)
+    assert paged_search_dns(inst, filt, 30) == expected
+    with or_lookup_disabled(inst):
+        assert paged_search_dns(inst, filt, 30) == expected
+
+
+def test_or_after_online_mod(topo, create_data):
+    """Verify a value added over LDAP (as opposed to offline import) is
+    found by a large OR immediately, through the cached entry
+
+    :id: 6b2df8a1-59c0-4e73-8f1d-a45e90c3d267
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Add a new cn value to a user over LDAP
+        2. Search a large cn OR naming only that new value
+        3. Repeat with lookup disabled
+        4. Remove the value again
+    :expectedresults:
+        1. Modify succeeds
+        2. Exactly that user is returned
+        3. Optional lookup-disabled evaluation returns the identical DN
+        4. Cleanup succeeds
+    """
+    user = UserAccount(topo.standalone, user_dn(42))
+    user.add('cn', 'olfreshvalue')
+    try:
+        values = ['olfreshvalue'] + ghosts(20, prefix='olstale')
+        filterstr = or_of('cn', values)
+        expected = [user.dn.lower()]
+        got, _ = search_dns_result(topo.standalone, filterstr)
+        assert got == expected
+        with or_lookup_disabled(topo.standalone):
+            got_off, _ = search_dns_result(topo.standalone, filterstr)
+        assert got_off == expected
+    finally:
+        user.remove('cn', 'olfreshvalue')
+
+
+def test_or_empty_assertion_value(topo, create_data):
+    """Verify an empty assertion value among the components neither
+    matches nor disturbs the other components
+
+    :id: d1c8f2b5-07e9-4a64-b3d8-52c96e01a7f4
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large uid OR including a (uid=) component
+    :expectedresults:
+        1. Exactly the named users are returned
+    """
+    live = create_data[80:100]
+    filt = '(|%s(uid=))' % ''.join(f'(uid={v})' for v in live + ghosts(10))
+    assert search_uids(topo, filt) == sorted(live)
+
+
+def test_or_mixed_remainder(topo, create_data):
+    """Verify non-equality and other-attribute components mixed into a
+    large uid OR still match: presence, substring, extensible, and mail.
+
+    :id: 3fa96d07-b2e4-4c81-a9f5-16d80c73e2b9
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of 30 live uids plus (employeeNumber=*),
+           (mail=oluser00351@olmail.example.com), (cn=ol user 0001*), and
+           an extensible dn-syntax component naming no entry
+    :expectedresults:
+        1. The uid matches, the three employeeNumber owners, the mail
+           owner, and the cn=OL User 0001N users are all returned exactly
+    """
+    live = list(range(0, 30))
+    filt = ('(|'
+            + ''.join(f'(uid={user_uid(i)})' for i in live)
+            + '(employeeNumber=*)'
+            + '(mail=oluser00351@olmail.example.com)'
+            + '(cn=ol user 0001*)'
+            + f'(member:distinguishedNameMatch:=uid=olghost1,{PEOPLE})'
+            + ')')
+    expected = sorted(set(
+        [user_uid(i) for i in live]
+        + [user_uid(i) for i in (350, 351, 352)]   # employeeNumber owners
+        + [user_uid(351)]                          # mail owner
+        + [user_uid(i) for i in range(10, 20)]))   # cn=OL User 0001N
+    assert search_uids(topo, filt) == expected
+
+
+def test_or_subtyped_branch_and_value(topo, create_data):
+    """Verify subtype handling on both sides: a subtyped assertion
+    component (cn;lang-en=...) is matched, and a value
+    stored under a subtyped description (cn;lang-en) is matched by plain
+    cn components.
+
+    :id: 84d05b1e-c976-4f28-a1d3-670e29c8f5a1
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large cn OR that includes (cn;lang-en=olsubtypelang)
+        2. Search a large cn OR naming olsubtypelang as a plain cn value
+    :expectedresults:
+        1. The lang-en user is returned along with the plain matches
+        2. The lang-en user is returned (base-type components match
+           subtyped values)
+    """
+    plain = [f'olalt{i:05d}' for i in range(240, 260)]
+    filt = ('(|' + ''.join(f'(cn={v})' for v in plain)
+            + '(cn;lang-en=olsubtypelang))')
+    expected = sorted([user_uid(i) for i in range(240, 260)] + [user_uid(370)])
+    assert search_uids(topo, filt) == expected
+    values = plain + ['olsubtypelang']
+    assert search_uids(topo, or_of('cn', values)) == expected
+
+
+def test_or_acl_deny_attr_no_leak(topo, create_data):
+    """Verify a user denied read on uid gets no entries from a large uid
+    OR: every component is undefined without access and no match may leak
+    past the ACL boundary (CVE-2022-1949 class).
+
+    :id: f2b74e09-8ad5-4c31-96e7-d03b58f1c2a6
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Add an aci denying uid read/search to one user and bind as it
+        2. Search a large uid OR of live values
+        3. Assert parity with optional lookup disabled when available
+    :expectedresults:
+        1. Bind succeeds
+        2. No entries are returned
+        3. Optional lookup-disabled evaluation returns the same empty set
+    """
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    deny = ('(targetattr="uid")(version 3.0; acl "ol deny uid"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(1)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(topo.standalone, user_dn(1)).bind(PW)
+    try:
+        filt = or_of('uid', create_data[100:160])
+        entries = conn.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, filt, ['1.1'])
+        assert entries == []
+        assert assert_parity(topo, conn, filt) == []
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_or_acl_multi_hit_denied_parity(topo, create_data):
+    """Verify an entry whose two attribute values hit two components of
+    the OR while its attribute is denied for the bound user is excluded,
+    while every independently named accessible entry is returned.
+
+    :id: 07e3c1f8-65a9-4d02-bc84-91f5e2d70a35
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Deny uid read on the two-uid entry only (targetfilter scoped)
+           for the bind user
+        2. Search an OR naming both of its uid values plus live values
+        3. Repeat with optional lookup disabled when available
+    :expectedresults:
+        1. ACI is added
+        2. Exactly the live users return; the two-uid entry does not
+        3. Optional lookup-disabled evaluation returns the same exact set
+    """
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    deny = ('(targetattr="uid")(targetfilter="(cn=OL Multi)")'
+            '(version 3.0; acl "ol deny multi"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(2)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(topo.standalone, user_dn(2)).bind(PW)
+    try:
+        live = create_data[20:40]
+        filt = or_of('uid', ['olmultia', 'olmultib'] + live)
+        got = assert_parity(topo, conn, filt)
+        expected = sorted(f'uid={uid},{PEOPLE}'.lower() for uid in live)
+        assert got == expected
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_or_acl_mixed_allowed_denied(topo, create_data):
+    """Verify ticket 48275 semantics for a large OR: entries matching
+    an accessible component of the OR are returned even though another
+    component's attribute is denied, and entries matching only the denied
+    component are not returned
+
+    :id: 58c1a9d4-3f70-4e26-8b95-d217e60c4af8
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Deny employeeNumber read for a bind user
+        2. Search a large uid OR that also names an existing
+           employeeNumber value, as that user
+        3. Repeat with optional lookup disabled when available
+    :expectedresults:
+        1. ACI is added
+        2. Exactly the uid matches are returned: the employeeNumber
+           owner (not named by any uid component) is absent
+        3. Optional lookup-disabled evaluation returns the same exact set
+    """
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    deny = ('(targetattr="employeeNumber")(version 3.0; acl "ol deny emp"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(3)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(topo.standalone, user_dn(3)).bind(PW)
+    try:
+        live = create_data[200:240]
+        filt = ('(|' + ''.join(f'(uid={v})' for v in live)
+                + '(employeeNumber=olemp00350))')
+        got = assert_parity(topo, conn, filt)
+        assert f'uid={user_uid(350)},{PEOPLE}'.lower() not in got
+        assert sorted(got) == sorted(
+            f'uid={v},{PEOPLE}'.lower() for v in live)
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_or_acl_all_denied_all_miss(topo, create_data):
+    """Verify an all-miss OR over an unindexed attribute denied to the
+    bound user returns nothing: the classic walk scores every component
+    undefined (no access), the lookup path decides non-match, and both
+    are the same empty result at the protocol boundary.
+
+    :id: 16e18b56-ab5c-437e-8673-34750cdc39a0
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Add an aci denying l read/search to one user and bind as it
+        2. Search a 16-branch all-miss l OR
+        3. Assert parity with optional lookup disabled when available
+    :expectedresults:
+        1. Bind succeeds
+        2. No entries are returned
+        3. Optional lookup-disabled evaluation returns the same empty set
+    """
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    deny = ('(targetattr="l")(version 3.0; acl "ol deny l"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(4)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(topo.standalone, user_dn(4)).bind(PW)
+    try:
+        filt = or_of('l', [f'ol-absent-loc-{i:02d}' for i in range(16)])
+        assert assert_parity(topo, conn, filt) == []
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_not_of_or_complement(topo, create_data):
+    """Verify NOT of a large OR returns the exact complement: an absent
+    assertion is defined-false so the NOT can negate it, never undefined.
+
+    :id: 19f7d3c0-b485-4a62-9e17-c30d86f2e5b9
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search (&(objectClass=posixAccount)(!(|...20 live uids...)))
+    :expectedresults:
+        1. Exactly all posixAccount entries except the 20 are returned
+    """
+    named = create_data[60:80]
+    filt = f'(&(objectClass=posixAccount)(!{or_of("uid", named)}))'
+    expected = sorted((set(create_data) - set(named)) | {'olmultia'})
+    assert search_uids(topo, filt) == expected
+
+
+def test_not_of_or_denied_user(topo, create_data):
+    """Verify NOT of a large OR evaluates to undefined, not to a match,
+    when the bound user has no access to the OR's attribute
+
+    :id: 62a84f1b-90dc-4753-a6e8-1f4c72d09b3e
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Deny uid read for a bind user
+        2. Search (&(objectClass=posixAccount)(!(|...20 live uids...)))
+           as that user
+        3. Repeat with optional lookup disabled when available
+    :expectedresults:
+        1. ACI is added
+        2. No entries are returned (undefined components do not negate
+           into matches)
+        3. Optional lookup-disabled evaluation returns the same empty set
+    """
+    suffix = Domain(topo.standalone, DEFAULT_SUFFIX)
+    deny = ('(targetattr="uid")(version 3.0; acl "ol deny uid not"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(4)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(topo.standalone, user_dn(4)).bind(PW)
+    try:
+        named = create_data[60:80]
+        filt = f'(&(objectClass=posixAccount)(!{or_of("uid", named)}))'
+        got = assert_parity(topo, conn, filt)
+        assert got == []
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_or_cos_vattr_fallback(topo, create_data):
+    """Verify a CoS-served attribute in a large OR still matches through
+    its virtual values while an unrelated large uid OR remains exact.
+
+    :id: 47d92e6a-1b05-4f83-bc29-8e60d1f74c52
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Enable virtual-attribute evaluation
+        2. Create a CoS pointer definition and wait until its value is visible
+        3. Search a large postalCode OR naming the virtual value
+        4. Run a large uid OR
+        5. Remove the CoS entries and restore the configuration
+    :expectedresults:
+        1. Virtual attributes are evaluated
+        2. CoS is observable before the large-OR assertion begins
+        3. Exactly the People container and all user DNs are returned
+        4. Exactly the named uid entries are returned
+        5. Cleanup and restoration succeed
+    """
+    inst = topo.standalone
+    ignore_vattrs = inst.config.get_attr_val_utf8(
+        'nsslapd-ignore-virtual-attrs')
+    template = CosTemplate(inst, f'cn=olcostemplate,{DEFAULT_SUFFIX}')
+    definition = CosPointerDefinition(inst, f'cn=olcosdef,{PEOPLE}')
+    template_created = False
+    definition_created = False
+
+    def postal_values():
+        entry = inst.search_s(user_dn(0), ldap.SCOPE_BASE,
+                              '(objectClass=*)', ['postalCode'])[0]
+        return sorted(ensure_str(value)
+                      for value in entry.getValues('postalCode'))
+
+    try:
+        inst.config.set('nsslapd-ignore-virtual-attrs', 'off')
+        template.create(properties={'cn': 'olcostemplate',
+                                    'postalCode': 'olvirtualzip'})
+        template_created = True
+        definition.create(properties={
+            'cn': 'olcosdef',
+            'cosTemplateDn': f'cn=olcostemplate,{DEFAULT_SUFFIX}',
+            # Use the established pointer-CoS qualifier form.  "default
+            # operational" is not a valid combined qualifier and silently
+            # leaves this ordinary user attribute unserved on current builds.
+            'cosAttribute': 'postalCode default'})
+        definition_created = True
+        deadline = time.monotonic() + 15
+        while postal_values() != ['olvirtualzip']:
+            assert time.monotonic() < deadline
+            time.sleep(0.25)
+        values = ['olvirtualzip'] + ghosts(20, prefix='olzip')
+        got = search_dns(inst, or_of('postalCode', values), base=PEOPLE)
+        expected = sorted(
+            [PEOPLE.lower()]
+            + [user_dn(i).lower() for i in range(TOTAL_USERS)]
+            + [f'uid=olmultia,{PEOPLE}'.lower()])
+        assert got == expected
+        live = create_data[0:30]
+        assert search_uids(topo, or_of('uid', live)) == sorted(live)
+    finally:
+        if definition_created:
+            definition.delete()
+        if template_created:
+            template.delete()
+        inst.config.set('nsslapd-ignore-virtual-attrs', ignore_vattrs)
+
+
+def test_or_dn_big_group_m_guard(topo, create_data):
+    """Verify groups with more member values than the OR has components
+    still match exactly.
+
+    :id: 76e08b52-4dc9-4f17-a3b6-29c58d10e7f4
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search an OR of 20 member DNs that all appear in the big
+           groups (200 members each) and in some small groups
+    :expectedresults:
+        1. Exactly the big groups and the covering small groups return
+    """
+    values = [user_dn(i) for i in range(20)]
+    entries = topo.standalone.search_s(GROUPS_OU, ldap.SCOPE_SUBTREE,
+                                       or_of('member', values), ['cn'])
+    got = sorted(ensure_str(e.getValue('cn')) for e in entries)
+    # users 0..19 live in small groups 0..6 (3 members each) and every big
+    expected = sorted([f'olgroup{g:03d}' for g in range(7)]
+                      + [f'olbig{g}' for g in range(BIG_GROUPS)])
+    assert got == expected
+
+
+def test_or_ldapsubentry(topo, create_data):
+    """Verify a large OR does not return LDAP subentries unless the
+    filter names objectclass=ldapsubentry (issue #5170's subentry
+    regression class)
+
+    :id: 3b61e8d7-52f0-4c94-b8a3-06d97c2e14f5
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large uid OR including the subentry's uid value
+        2. Repeat with an (objectclass=ldapsubentry) component added
+    :expectedresults:
+        1. Only the regular users are returned
+        2. The subentry is returned too
+    """
+    live = create_data[0:20]
+    values = live + ['olsubentryuid']
+    assert search_uids(topo, or_of('uid', values)) == sorted(live)
+    filt = ('(|' + ''.join(f'(uid={v})' for v in values)
+            + '(objectclass=ldapsubentry))')
+    assert search_uids(topo, filt) == sorted(live + ['olsubentryuid'])
+
+
+def test_or_unknown_attr_branch(topo, create_data):
+    """Verify an attribute type unknown to the schema among the
+    components leaves the other components' matches intact (RFC 4511:
+    unknown assertions are undefined, not errors)
+
+    :id: 88f04a2c-97d6-4be1-a5c8-3e19d20b6f47
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a large uid OR including (olnosuchattribute=x)
+    :expectedresults:
+        1. Exactly the named users are returned
+    """
+    live = create_data[130:160]
+    filt = ('(|' + ''.join(f'(uid={v})' for v in live)
+            + '(olnosuchattribute=x))')
+    assert search_uids(topo, filt) == sorted(live)
+
+
+def test_or_small_large_and_optional_toggle(topo, create_data):
+    """Verify small and large ORs stay exact with the optional switch.
+
+    :id: 90b5c7e2-64af-4d18-92e0-7c3f5a8d1b06
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Search a 10-component uid OR
+        2. Search a 40-component uid OR
+        3. Repeat the large OR with optional lookup disabled
+    :expectedresults:
+        1. The exact 10-DN result is returned
+        2. The exact 40-DN result is returned
+        3. The exact 40-DN result is unchanged
+    """
+    small = create_data[0:10]
+    big = create_data[310:350]
+    assert search_uids(topo, or_of('uid', small)) == sorted(small)
+    assert search_uids(topo, or_of('uid', big)) == sorted(big)
+    with or_lookup_disabled(topo):
+        assert search_uids(topo, or_of('uid', big)) == sorted(big)
+
+
+def test_or_vlv_sort_parity(topo, create_data):
+    """Verify exact large-OR results under server-side sort plus VLV for
+    Directory Manager and for a user denied read on the sorted attribute.
+
+    :id: e5a9d013-7fc2-4368-9b04-d61e82c7f0a9
+    :setup: Standalone instance with 400 users, groups, and a subentry
+    :steps:
+        1. Run the OR with SSS(uid)+VLV controls as Directory Manager,
+           asserting optional-switch parity
+        2. Deny uid read for a bind user and repeat as that user
+    :expectedresults:
+        1. The first ten live DNs in uid sort order return exactly, with
+           optional lookup-disabled parity when available
+        2. The denied user receives an exact empty result, with optional
+           lookup-disabled parity when available
+    """
+    inst = topo.standalone
+    live = create_data[100:140]
+    filt = or_of('uid', live + ghosts(20))
+    ctrls = [SSSRequestControl(criticality=True, ordering_rules=['uid']),
+             VLVRequestControl(criticality=True, before_count=0,
+                               after_count=9, offset=1, content_count=0)]
+    expected = sorted(user_dn(i).lower() for i in range(100, 110))
+    got = assert_parity(topo, inst, filt, base=DEFAULT_SUFFIX,
+                        serverctrls=ctrls)
+    assert got == expected
+    suffix = Domain(inst, DEFAULT_SUFFIX)
+    deny = ('(targetattr="uid")(version 3.0; acl "ol deny uid vlv"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(5)}");)')
+    suffix.add('aci', deny)
+    conn = UserAccount(inst, user_dn(5)).bind(PW)
+    try:
+        denied = assert_parity(topo, conn, filt, base=DEFAULT_SUFFIX,
+                               serverctrls=ctrls)
+        assert denied == []
+    finally:
+        conn.unbind_s()
+        suffix.remove('aci', deny)
+
+
+def test_or_15_16_exact_and_optional_toggle(topo, lookup_schema_data):
+    """Verify equivalent 15- and 16-branch ORs return exact results.
+
+    :id: e7b88ea2-c876-41db-92c0-69e411a749d1
+    :setup: Standalone instance with synthetic case-ignore attributes
+    :steps:
+        1. Search equivalent 15- and 16-branch OR filters
+        2. Repeat the 16-branch operation with optional lookup disabled
+    :expectedresults:
+        1. Both searches return the same exact DN set
+        2. Optional lookup-disabled evaluation returns the same DN set
+    """
+    inst = topo.standalone
+    base = lookup_schema_data['base']
+    dns = lookup_schema_data['dns']
+    expected = sorted([
+        dns['family-a'],
+        dns['family-both'],
+    ])
+    values15 = ['a-hit'] + [f'a-threshold-miss-{i:02d}' for i in range(14)]
+    values16 = values15 + ['a-threshold-miss-14']
+    filter15 = escaped_or_of('olLookupA', values15)
+    filter16 = escaped_or_of('olLookupA', values16)
+    got15, _ = search_dns_result(
+        inst, filter15, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got15 == expected
+    got16, _ = search_dns_result(
+        inst, filter16, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got16 == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filter16, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_two_large_families_order_independent(topo, lookup_schema_data):
+    """Return exact results for two large families in either source order.
+
+    :id: 150c2e44-a436-4a0a-b3ed-b60e7ddbf3a2
+    :setup: Standalone instance with three synthetic case-ignore attributes
+    :steps:
+        1. Search one OR containing 16 A and 64 B equality branches
+        2. Repeat with the A and B source runs reversed
+    :expectedresults:
+        1. Exact A-or-B DNs return
+        2. Reversing source order leaves the result unchanged
+    """
+    inst = topo.standalone
+    base = lookup_schema_data['base']
+    dns = lookup_schema_data['dns']
+    expected = sorted([
+        dns['family-a'], dns['family-b'], dns['family-both'],
+    ])
+    a_values = ['a-hit'] + [f'a-dominant-miss-{i:02d}' for i in range(15)]
+    b_values = ['b-hit'] + [f'b-dominant-miss-{i:02d}' for i in range(63)]
+    a_run = escaped_equalities('olLookupA', a_values)
+    b_run = escaped_equalities('olLookupB', b_values)
+
+    for filterstr in (f'(|{a_run}{b_run})', f'(|{b_run}{a_run})'):
+        got, _ = search_dns_result(
+            inst, filterstr, base=base, scope=ldap.SCOPE_ONELEVEL)
+        assert got == expected
+
+
+def test_or_third_family_after_distractors(topo, lookup_schema_data):
+    """Return a large third attribute family after two distractors.
+
+    :id: 35f3cd38-59c7-41b6-b02d-5e925c844e97
+    :setup: Standalone instance with three synthetic case-ignore attributes
+    :steps:
+        1. Search an OR with one absent A, one absent B, and 64 C branches
+    :expectedresults:
+        1. Exactly the live C entry is returned
+    """
+    inst = topo.standalone
+    base = lookup_schema_data['base']
+    dns = lookup_schema_data['dns']
+    c_values = ['c-hit'] + [f'c-third-miss-{i:02d}' for i in range(63)]
+    filterstr = ('(|(olLookupA=a-distractor)(olLookupB=b-distractor)'
+                 f'{escaped_equalities("olLookupC", c_values)})')
+    got, _ = search_dns_result(
+        inst, filterstr, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got == [dns['family-c']]
+
+
+def test_or_two_large_nodes_in_and(topo, lookup_schema_data):
+    """Intersect two large OR nodes in one AND.
+
+    :id: b6c49e82-060a-4eef-a128-c6a50d537b6f
+    :setup: Standalone instance with intersecting synthetic A and B values
+    :steps:
+        1. Search one 16-branch A OR
+        2. Search an AND of separate 16-branch A and B OR nodes
+        3. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the A entries return
+        2. Exactly the A-and-B entry returns
+        3. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    base = lookup_schema_data['base']
+    dns = lookup_schema_data['dns']
+    a_values = ['a-hit'] + [f'a-two-node-miss-{i:02d}' for i in range(15)]
+    b_values = ['b-hit'] + [f'b-two-node-miss-{i:02d}' for i in range(15)]
+    filterstr = f'(&{escaped_or_of("olLookupA", a_values)}' \
+                f'{escaped_or_of("olLookupB", b_values)})'
+    expected = [dns['family-both']]
+
+    baseline_got, _ = search_dns_result(
+        inst, escaped_or_of('olLookupA', a_values), base=base,
+        scope=ldap.SCOPE_ONELEVEL)
+    assert baseline_got == sorted([dns['family-a'], dns['family-both']])
+    got, _ = search_dns_result(
+        inst, filterstr, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=base, scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+@pytest.mark.parametrize('case', MATCH_RULE_CASES,
+                         ids=[case['id'] for case in MATCH_RULE_CASES])
+def test_or_matching_rule_families(topo, lookup_schema_data, case):
+    """Exercise equality matching-rule families with large ORs.
+
+    :id: 38d8e03c-4f36-48d5-9211-cc33cda08d8a
+    :parametrized: yes
+    :setup: Standalone instance with one synthetic attribute per allowlisted rule
+    :steps:
+        1. Search 16 assertions containing a duplicate normalized live value
+           and 14 valid absent values
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the independently named matching entry is returned
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    values = ([case['assertion'], case['assertion']]
+              + matching_rule_absent_values(case['id']))
+    filterstr = escaped_or_of(case['attr'], values)
+    expected = [lookup_schema_data['dns'][f'match-{case["id"]}']]
+
+    got, _ = search_dns_result(
+        inst, filterstr, base=lookup_schema_data['base'],
+        scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_non_ascii_case_ignore(topo, lookup_schema_data):
+    """Normalize non-ASCII DirectoryString values in a large OR.
+
+    :id: 41273979-fcf8-445d-a0ab-04206bb01677
+    :setup: Standalone instance with a synthetic caseIgnoreMatch attribute
+    :steps:
+        1. Search 16 branches using a lower-case accented live assertion
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the upper-case accented stored value matches
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    assertion = 'çéline ångström'
+    values = [assertion, assertion] + [f'ø-absent-{i:02d}' for i in range(14)]
+    filterstr = escaped_or_of('olCaseIgnore', values)
+    expected = [lookup_schema_data['dns']['unicode-case-ignore']]
+
+    got, _ = search_dns_result(
+        inst, filterstr, base=lookup_schema_data['base'],
+        scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_dn_escaped_comma(topo, lookup_schema_data):
+    """Normalize a DN assertion whose RDN value contains an escaped comma.
+
+    :id: 66c4dc6a-595c-4624-941b-17463bd41b91
+    :setup: Standalone instance with a synthetic distinguishedNameMatch attribute
+    :steps:
+        1. Search 16 DN branches including a case-mangled escaped-comma DN
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the entry storing the equivalent DN is returned
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    assertion = f'CN=SMITH\\, ALICE, OU=PEOPLE, {DEFAULT_SUFFIX.upper()}'
+    values = [assertion, assertion] + [
+        f'cn=ol-dn-absent-{i:02d},{DEFAULT_SUFFIX}' for i in range(14)]
+    filterstr = escaped_or_of('olDistinguishedName', values)
+    expected = [lookup_schema_data['dns']['escaped-dn']]
+
+    got, _ = search_dns_result(
+        inst, filterstr, base=lookup_schema_data['base'],
+        scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_dn_value_count_boundaries(topo, lookup_schema_data):
+    """Cover DN entries containing 2, 16, and 17 attribute values.
+
+    :id: e480c416-53af-46bd-9650-117ba02ac17f
+    :setup: Three entries with 2, 16, and 17 DN values respectively
+    :steps:
+        1. Search a 16-assertion DN equality family matching all three entries
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. The complete three-DN set returns
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    filterstr = escaped_or_of(
+        'olDistinguishedName', lookup_schema_data['dn_count_assertions'])
+    expected = sorted(
+        lookup_schema_data['dns'][key]
+        for key in ('dn-count-less', 'dn-count-equal', 'dn-count-more'))
+
+    got, _ = search_dns_result(
+        inst, filterstr, base=lookup_schema_data['base'],
+        scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_generalized_time_matching_rule(topo, lookup_schema_data):
+    """Evaluate a large OR using generalizedTimeMatch.
+
+    :id: bfe96ed0-f0b5-4920-8908-829d80fd337e
+    :setup: Standalone instance with a generalizedTimeMatch synthetic attribute
+    :steps:
+        1. Search 16 generalized-time equality branches
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the live generalized-time entry is returned
+        2. Optional lookup-disabled evaluation returns the same DN
+    """
+    inst = topo.standalone
+    values = ['20240101010203Z', '20240101010203Z'] + [
+        f'202402{i + 1:02d}010203Z' for i in range(14)]
+    filterstr = escaped_or_of('olGeneralizedTime', values)
+    expected = [lookup_schema_data['dns']['outside-generalized-time']]
+
+    got, _ = search_dns_result(
+        inst, filterstr, base=lookup_schema_data['base'],
+        scope=ldap.SCOPE_ONELEVEL)
+    assert got == expected
+    with or_lookup_disabled(inst):
+        got_off, _ = search_dns_result(
+            inst, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+    assert got_off == expected
+
+
+def test_or_true_root_all_miss(topo, lookup_schema_data):
+    """Verify the unproxied Directory Manager all-miss result and health.
+
+    :id: 29289b81-5f4b-44ac-8e54-ccbe047116bd
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. Search a 16-branch family whose assertions are all absent
+        2. Repeat with optional lookup disabled
+        3. Run a base-object health search
+    :expectedresults:
+        1. LDAP success and an exact empty result
+        2. LDAP success and the same exact empty result
+        3. The suffix entry is returned exactly
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    filterstr = escaped_or_of(
+        'olLookupA', [f'ol-root-miss-{i:02d}' for i in range(16)])
+    try:
+        got, _ = search_dns_result(
+            conn, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+        assert got == []
+        with or_lookup_disabled(inst):
+            got_off, _ = search_dns_result(
+                conn, filterstr, base=lookup_schema_data['base'],
+                scope=ldap.SCOPE_ONELEVEL)
+        assert got_off == []
+        assert_health(conn)
+    finally:
+        conn.unbind_s()
+
+
+def test_or_true_root_nohit_simple_fallback(topo, lookup_schema_data):
+    """Evaluate a simple outer-OR fallback after a root all-miss family.
+
+    :id: 7304fc93-a9f3-4406-926b-2400c90fa6eb
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. OR a 16-branch all-miss family with one matching equality
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the independently named fallback entry is returned
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    large_miss = escaped_or_of(
+        'olLookupA', [f'ol-simple-miss-{i:02d}' for i in range(16)])
+    filterstr = f'(|{large_miss}(olLookupC=simple-match))'
+    expected = [lookup_schema_data['dns']['root-simple']]
+    try:
+        got, _ = search_dns_result(
+            conn, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+        assert got == expected
+        with or_lookup_disabled(inst):
+            got_off, _ = search_dns_result(
+                conn, filterstr, base=lookup_schema_data['base'],
+                scope=ldap.SCOPE_ONELEVEL)
+        assert got_off == expected
+    finally:
+        conn.unbind_s()
+
+
+def test_or_true_root_nohit_complex_fallback(topo, lookup_schema_data):
+    """Evaluate a guarded fallback after a root all-miss family.
+
+    :id: 287c52a2-0a19-4075-bdc7-8b6494eff9a2
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. OR a 16-branch all-miss family with an AND containing two NOTs
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Exactly the guarded fallback entry is returned
+        2. Optional lookup-disabled evaluation returns the identical DN set
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    large_miss = escaped_or_of(
+        'olLookupA', [f'ol-complex-miss-{i:02d}' for i in range(16)])
+    filterstr = (f'(|{large_miss}'
+                 '(&(olLookupC=guard-hit)(!(description=*))'
+                 '(!(employeeNumber=*))))')
+    expected = [lookup_schema_data['dns']['root-complex']]
+    try:
+        got, _ = search_dns_result(
+            conn, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+        assert got == expected
+        with or_lookup_disabled(inst):
+            got_off, _ = search_dns_result(
+                conn, filterstr, base=lookup_schema_data['base'],
+                scope=ldap.SCOPE_ONELEVEL)
+        assert got_off == expected
+    finally:
+        conn.unbind_s()
+
+
+def test_or_true_root_nohit_under_not(topo, lookup_schema_data):
+    """Negate a root all-miss family without changing semantics.
+
+    :id: 6153594a-c923-48c6-a49f-18de69bf8c9a
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. Search the NOT of a 16-branch all-miss equality OR
+        2. Repeat with optional lookup disabled
+    :expectedresults:
+        1. Every and only generated one-level entry is returned
+        2. Optional lookup-disabled evaluation returns the same complete set
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    large_miss = escaped_or_of(
+        'olLookupA', [f'ol-not-miss-{i:02d}' for i in range(16)])
+    filterstr = f'(!{large_miss})'
+    expected = lookup_schema_data['all_dns']
+    try:
+        got, _ = search_dns_result(
+            conn, filterstr, base=lookup_schema_data['base'],
+            scope=ldap.SCOPE_ONELEVEL)
+        assert got == expected
+        with or_lookup_disabled(inst):
+            got_off, _ = search_dns_result(
+                conn, filterstr, base=lookup_schema_data['base'],
+                scope=ldap.SCOPE_ONELEVEL)
+        assert got_off == expected
+    finally:
+        conn.unbind_s()
+
+
+def test_or_root_proxy_preserves_acl_semantics(topo, create_data):
+    """Apply proxied-user ACL semantics to a Directory Manager search.
+
+    :id: 563682d4-e96d-44c3-a59f-8611fc41c229
+    :setup: Standalone instance, Directory Manager bind, and uid-read deny ACI
+    :steps:
+        1. Search a large uid OR plus an allowed cn fallback as plain root
+        2. Repeat as root with a proxy authorization control for the denied user
+        3. Repeat the proxied search with optional lookup disabled
+    :expectedresults:
+        1. All named uid entries and the cn fallback return exactly
+        2. Only the cn fallback visible to the proxied identity returns
+        3. Optional lookup-disabled evaluation returns the same restricted set
+    """
+    inst = topo.standalone
+    suffix = Domain(inst, DEFAULT_SUFFIX)
+    deny = ('(targetattr="uid")(version 3.0; acl "ol proxy deny uid"; '
+            'deny (read, search, compare)'
+            f'(userdn="ldap:///{user_dn(0)}");)')
+    conn = None
+    aci_added = False
+    try:
+        suffix.add('aci', deny)
+        aci_added = True
+        live = create_data[100:120]
+        filterstr = f'(|{escaped_or_of("uid", live)}(cn=olalt00350))'
+        unrestricted = sorted(
+            [f'uid={uid},{PEOPLE}'.lower() for uid in live]
+            + [user_dn(350).lower()])
+        restricted = [user_dn(350).lower()]
+        proxy_ctrl = ProxyAuthzControl(
+            criticality=True, authzId=ensure_bytes(f'dn: {user_dn(0)}'))
+        conn = DirectoryManager(inst).bind()
+        direct, _ = search_dns_result(conn, filterstr)
+        assert direct == unrestricted
+        proxied, _ = search_dns_result(
+            conn, filterstr, serverctrls=[proxy_ctrl])
+        assert proxied == restricted
+        with or_lookup_disabled(inst):
+            proxied_off, _ = search_dns_result(
+                conn, filterstr, serverctrls=[proxy_ctrl])
+        assert proxied_off == restricted
+    finally:
+        if conn is not None:
+            conn.unbind_s()
+        if aci_added:
+            suffix.remove('aci', deny)
+
+
+def test_or_paged_cancel_cookie_health(topo, create_data):
+    """Cancel a paged large-OR search with its returned cookie.
+
+    :id: 2a860edd-e46b-40ca-84cb-b6d5d4313d03
+    :setup: Standalone instance and an independent Directory Manager bind
+    :steps:
+        1. Verify the complete nonpaged DN set for a 60-value uid OR
+        2. Read the first ten-entry page and retain its cookie
+        3. Send page size zero with that cookie
+        4. Run a base-object health search on the same connection
+    :expectedresults:
+        1. Exactly the 60 independently named entries return
+        2. Ten unique expected DNs and a nonempty cookie return
+        3. LDAP success, no entries, and an empty response cookie return
+        4. The suffix entry is returned exactly
+    """
+    inst = topo.standalone
+    conn = DirectoryManager(inst).bind()
+    live = create_data[120:180]
+    filterstr = escaped_or_of('uid', live)
+    expected = sorted(f'uid={uid},{PEOPLE}'.lower() for uid in live)
+    req = SimplePagedResultsControl(True, size=10, cookie='')
+    try:
+        complete, _ = search_dns_result(conn, filterstr)
+        assert complete == expected
+        first_page, rctrls = search_dns_result(
+            conn, filterstr, serverctrls=[req])
+        assert len(first_page) == 10
+        assert len(set(first_page)) == 10
+        assert set(first_page) < set(expected)
+        pctrls = [
+            c for c in rctrls
+            if c.controlType == SimplePagedResultsControl.controlType
+        ]
+        assert len(pctrls) == 1
+        assert pctrls[0].cookie
+
+        req.size = 0
+        req.cookie = pctrls[0].cookie
+        cancelled, rctrls = search_dns_result(
+            conn, filterstr, serverctrls=[req])
+        assert cancelled == []
+        pctrls = [
+            c for c in rctrls
+            if c.controlType == SimplePagedResultsControl.controlType
+        ]
+        assert len(pctrls) == 1
+        assert not pctrls[0].cookie
+        assert_health(conn)
+    finally:
+        conn.unbind_s()
+
+
+def test_or_paged_disconnect_reconnect_health(topo, create_data):
+    """Disconnect after a first page and reconnect cleanly.
+
+    :id: 2cb0b299-a553-4e98-843e-574880417ea8
+    :setup: Standalone instance and independent Directory Manager binds
+    :steps:
+        1. Verify the complete nonpaged DN set for a 60-value uid OR
+        2. Read one page with a nonempty cookie and disconnect
+        3. Reconnect, run a base health search, and page the search to completion
+    :expectedresults:
+        1. Exactly the 60 independently named entries return
+        2. Ten unique expected DNs and a nonempty cookie return
+        3. Health succeeds and complete paging returns the exact 60-DN set
+    """
+    inst = topo.standalone
+    live = create_data[180:240]
+    filterstr = escaped_or_of('uid', live)
+    expected = sorted(f'uid={uid},{PEOPLE}'.lower() for uid in live)
+    first_conn = DirectoryManager(inst).bind()
+    req = SimplePagedResultsControl(True, size=10, cookie='')
+    try:
+        complete, _ = search_dns_result(first_conn, filterstr)
+        assert complete == expected
+        first_page, rctrls = search_dns_result(
+            first_conn, filterstr, serverctrls=[req])
+        assert len(first_page) == 10
+        assert len(set(first_page)) == 10
+        assert set(first_page) < set(expected)
+        pctrls = [
+            c for c in rctrls
+            if c.controlType == SimplePagedResultsControl.controlType
+        ]
+        assert len(pctrls) == 1
+        assert pctrls[0].cookie
+    finally:
+        first_conn.unbind_s()
+
+    second_conn = DirectoryManager(inst).bind()
+    try:
+        assert_health(second_conn)
+        assert paged_search_dns(second_conn, filterstr, 10) == expected
+    finally:
+        second_conn.unbind_s()
+
+
+def test_or_tombstone_and_ruv_sentinel_semantics(topology_m2):
+    """Preserve exact live-entry results with tombstone and RUV branches.
+
+    :id: 5d6d47f7-b512-423a-837c-d3610a2d56ca
+    :setup: Standard two-supplier topology with live users and one tombstone
+    :steps:
+        1. Search an ordinary 20-value uid OR
+        2. Add a guaranteed-miss nsTombstone branch and search
+        3. Add a guaranteed-miss RUV-uniqueid branch and search
+        4. Repeat both sentinel filters with optional lookup disabled
+    :expectedresults:
+        1. Exactly the generated live DNs return
+        2. The same exact live DNs return and no tombstone leaks
+        3. The same exact live DNs return and no RUV entry leaks
+        4. Optional lookup-disabled evaluation returns the same exact sets
+    """
+    inst = topology_m2.ms['supplier1']
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    tombstones = Tombstones(inst, DEFAULT_SUFFIX)
+    live_users = []
+
+    def properties(uid, number):
+        return {
+            'uid': uid,
+            'cn': uid,
+            'sn': 'ol lookup replicated sentinel',
+            'uidNumber': str(number),
+            'gidNumber': '627500',
+            'homeDirectory': f'/home/{uid}',
+        }
+
+    try:
+        for i in range(20):
+            uid = f'ol-lookup-repl-{i:02d}'
+            live_users.append(users.create(
+                properties=properties(uid, 627500 + i)))
+        tomb_uid = 'ol-lookup-repl-tombstone'
+        tomb_user = users.create(properties=properties(tomb_uid, 627599))
+        tomb_user.delete()
+        created_tombstones = tombstones.filter(
+            f'(uid={escape_filter_chars(tomb_uid)})')
+        assert len(created_tombstones) == 1
+
+        large_or = escaped_or_of(
+            'uid', [f'ol-lookup-repl-{i:02d}' for i in range(20)])
+        tombstone_filter = (
+            f'(|{large_or}'
+            '(&(objectClass=nsTombstone)(uid=ol-special-guaranteed-miss)))')
+        ruv_filter = (
+            f'(|{large_or}'
+            f'(&(nsuniqueid={REPLICA_RUV_UUID})'
+            '(uid=ol-special-guaranteed-miss)))')
+        expected = sorted(
+            f'uid=ol-lookup-repl-{i:02d},{PEOPLE}'.lower()
+            for i in range(20))
+
+        ordinary, _ = search_dns_result(inst, large_or)
+        assert ordinary == expected
+
+        for filterstr in (tombstone_filter, ruv_filter):
+            got, _ = search_dns_result(inst, filterstr)
+            assert got == expected
+
+        with or_lookup_disabled(inst):
+            for filterstr in (tombstone_filter, ruv_filter):
+                got_off, _ = search_dns_result(inst, filterstr)
+                assert got_off == expected
+    finally:
+        for user in reversed(live_users):
+            if user.exists():
+                user.delete()
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
@@ -580,7 +580,7 @@ def test_or_inside_and(topo, create_data):
     :id: 0d7f92c6-3ab1-48e5-bc70-61e94d28a5f7
     :setup: Standalone instance with 400 users, groups, and a subentry
     :steps:
-        1. Search (&(sn=OlSn0)(|...30 uids across all sn groups...))
+        1. Search ``(&(sn=OlSn0)(|...30 uids across all sn groups...))``
     :expectedresults:
         1. Exactly the OR's group-0 members are returned
     """
@@ -592,7 +592,7 @@ def test_or_inside_and(topo, create_data):
 
 def test_or_referral_wrapper(topo, create_data):
     """Verify a large OR on a suffix containing a referral entry (the
-    executed filter gains the (|(f)(objectclass=referral)) wrapper)
+    executed filter gains the ``(|(f)(objectclass=referral))`` wrapper)
     returns the exact result set with and without ManageDsaIT
 
     :id: 4e8a1c59-f723-4b06-9d84-c2571e0af938
@@ -934,7 +934,7 @@ def test_not_of_or_complement(topo, create_data):
     :id: 19f7d3c0-b485-4a62-9e17-c30d86f2e5b9
     :setup: Standalone instance with 400 users, groups, and a subentry
     :steps:
-        1. Search (&(objectClass=posixAccount)(!(|...20 live uids...)))
+        1. Search ``(&(objectClass=posixAccount)(!(|...20 live uids...)))``
     :expectedresults:
         1. Exactly all posixAccount entries except the 20 are returned
     """
@@ -952,7 +952,7 @@ def test_not_of_or_denied_user(topo, create_data):
     :setup: Standalone instance with 400 users, groups, and a subentry
     :steps:
         1. Deny uid read for a bind user
-        2. Search (&(objectClass=posixAccount)(!(|...20 live uids...)))
+        2. Search ``(&(objectClass=posixAccount)(!(|...20 live uids...)))``
            as that user
         3. Repeat with optional lookup disabled when available
     :expectedresults:

--- a/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_lookup_test.py
@@ -1023,8 +1023,19 @@ def test_or_cos_vattr_fallback(topo, create_data):
             # leaves this ordinary user attribute unserved on current builds.
             'cosAttribute': 'postalCode default'})
         definition_created = True
+        # The CoS cache rebuild thread clears its change-notification flag
+        # after a rebuild finishes, so a definition ADD landing while the
+        # template's rebuild is still in flight can be silently dropped
+        # and nothing re-triggers it.  Poll, and re-arm the pipeline once
+        # with a no-op definition MODIFY if the value has not appeared by
+        # the halfway mark.
         deadline = time.monotonic() + 15
+        rearm_at = time.monotonic() + 7
+        rearmed = False
         while postal_values() != ['olvirtualzip']:
+            if not rearmed and time.monotonic() >= rearm_at:
+                definition.replace('description', 'cos-notify-rearm')
+                rearmed = True
             assert time.monotonic() < deadline
             time.sleep(0.25)
         values = ['olvirtualzip'] + ghosts(20, prefix='olzip')

--- a/dirsrvtests/tests/suites/filter/filter_or_union_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_union_test.py
@@ -1,0 +1,217 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+
+"""
+Exact result sets for OR filters across idl_set_union's consumers: the
+k-way union, the 2-list fast path, the paged ALLIDS replacement, and a
+union inside an AND.  The live-singleton case is a 100-branch scale model
+of issue #6275's shape.
+"""
+
+import ldap
+import logging
+import os
+import pytest
+
+from ldap.controls import SimplePagedResultsControl
+from lib389._constants import DEFAULT_SUFFIX
+from lib389.backend import DatabaseConfig
+from lib389.utils import ensure_str
+from test389.topologies import topology_st as topo
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+TOTAL_USERS = 500
+GROUPS = 20  # sn=OrSn<i % GROUPS>: 20 equality lists of 25 IDs each
+
+
+@pytest.fixture(scope="module")
+def create_users(topo):
+    """Import TOTAL_USERS users; sn spreads them over GROUPS equality lists."""
+    inst = topo.standalone
+    ldif_dir = inst.get_ldif_dir()
+    ldif_file = os.path.join(ldif_dir, 'filter_or_union.ldif')
+    with open(ldif_file, 'w') as f:
+        # offline import replaces the backend contents, so the LDIF must
+        # carry the suffix root and container too
+        f.write(f'dn: {DEFAULT_SUFFIX}\n'
+                'objectClass: top\n'
+                'objectClass: domain\n'
+                'dc: example\n\n'
+                f'dn: ou=People,{DEFAULT_SUFFIX}\n'
+                'objectClass: top\n'
+                'objectClass: organizationalUnit\n'
+                'ou: People\n\n')
+        for i in range(TOTAL_USERS):
+            uid = f'oruser{i:05d}'
+            f.write(f'dn: uid={uid},ou=People,{DEFAULT_SUFFIX}\n'
+                    'objectClass: top\n'
+                    'objectClass: person\n'
+                    'objectClass: organizationalPerson\n'
+                    'objectClass: inetOrgPerson\n'
+                    f'uid: {uid}\n'
+                    f'cn: Or Union Test {i:05d}\n'
+                    f'sn: OrSn{i % GROUPS}\n\n')
+    os.chmod(ldif_file, 0o644)
+    inst.stop()
+    assert inst.ldif2db('userRoot', None, None, None, ldif_file)
+    inst.start()
+    return [f'oruser{i:05d}' for i in range(TOTAL_USERS)]
+
+
+def search_uids(topo, filterstr):
+    """Return the sorted uid list the filter matches."""
+    entries = topo.standalone.search_s(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+                                       filterstr, ['uid'])
+    return sorted(ensure_str(e.getValue('uid')) for e in entries)
+
+
+def or_of(attr, values):
+    return '(|%s)' % ''.join(f'({attr}={v})' for v in values)
+
+
+def test_or_many_live_singletons(topo, create_users):
+    """Verify an OR of many existing uid equalities returns exactly
+    those entries
+
+    :id: 3e5f92c1-8a47-4d20-b6e9-15c8a0d7f342
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Search an OR of 100 distinct existing uids
+    :expectedresults:
+        1. Exactly the 100 named users are returned
+    """
+    picked = create_users[::5]  # 100 users, every 5th
+    assert len(picked) == 100
+    assert search_uids(topo, or_of('uid', picked)) == sorted(picked)
+
+
+def test_or_many_absent(topo, create_users):
+    """Verify an OR dominated by absent values still returns exactly
+    the entries of its live values
+
+    :id: 9b04d7e6-2c58-4f13-a8d0-67e3b9c1f425
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Search an OR of 150 absent uids plus 1 existing uid
+    :expectedresults:
+        1. Exactly the 1 existing user is returned
+    """
+    absent = [f'absentuser{i:05d}' for i in range(150)]
+    live = create_users[7]
+    assert search_uids(topo, or_of('uid', absent + [live])) == [live]
+
+
+def test_or_mixed_live_absent_duplicates(topo, create_users):
+    """Verify an OR mixing live values, absent values, and verbatim
+    duplicate components returns the exact de-duplicated result set
+
+    :id: c7a1f0b3-5d92-4e68-9134-fb20d6a8e571
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Search an OR of 40 live uids (20 repeated twice) and 60 absent
+    :expectedresults:
+        1. Exactly the 40 distinct live users are returned, each once
+    """
+    live = create_users[100:140]
+    absent = [f'absentuser{i:05d}' for i in range(60)]
+    values = live + live[:20] + absent
+    assert search_uids(topo, or_of('uid', values)) == sorted(live)
+
+
+def test_or_two_lists_fastpath(topo, create_users):
+    """Verify the 2-list union fast path (the issue #5170 SSSD shape)
+    returns the exact result set for an OR of two equality lists
+
+    :id: 6d82c4a9-1f35-47e0-bc76-084a9d5e213f
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Search (|(sn=OrSn0)(sn=OrSn1))
+    :expectedresults:
+        1. Exactly the 50 users of the two groups are returned
+    """
+    expected = sorted(uid for i, uid in enumerate(create_users)
+                      if i % GROUPS in (0, 1))
+    assert search_uids(topo, '(|(sn=OrSn0)(sn=OrSn1))') == expected
+
+
+def test_or_paged_allidslimit(topo, create_users):
+    """Verify a paged OR whose union crosses a lowered
+    nsslapd-idlistscanlimit still returns the exact result set: paged
+    operations replace the over-limit union with ALLIDS, which forces the
+    filter test instead of skipping it
+
+    :id: f45b8d10-93c7-4a2e-8f61-27d0c3b9e684
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Lower nsslapd-idlistscanlimit to 50
+        2. Run an OR of 120 existing uids as a paged search, page size 30
+    :expectedresults:
+        1. Limit is set
+        2. The union of the pages is exactly the 120 named users
+    """
+    inst = topo.standalone
+    db_cfg = DatabaseConfig(inst)
+    scanlimit = db_cfg.get_attr_val_utf8('nsslapd-idlistscanlimit')
+    picked = create_users[200:320]
+    filt = or_of('uid', picked)
+    try:
+        db_cfg.set([('nsslapd-idlistscanlimit', '50')])
+        req = SimplePagedResultsControl(True, size=30, cookie='')
+        collected = []
+        while True:
+            msgid = inst.search_ext(DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE,
+                                    filt, ['uid'], serverctrls=[req])
+            result_type, rdata, _, rctrls = inst.result3(msgid)
+            assert result_type == ldap.RES_SEARCH_RESULT
+            for _, attrs in rdata:
+                collected.append(ensure_str(attrs['uid'][0]))
+            pctrls = [c for c in rctrls
+                      if c.controlType == SimplePagedResultsControl.controlType]
+            assert pctrls
+            if not pctrls[0].cookie:
+                break
+            req.cookie = pctrls[0].cookie
+        assert sorted(collected) == sorted(picked)
+    finally:
+        db_cfg.set([('nsslapd-idlistscanlimit', scanlimit)])
+
+
+def test_or_inside_and(topo, create_users):
+    """Verify an OR union consumed by an enclosing AND intersection
+    returns the exact result set
+
+    :id: 82c6e3f7-0b94-45d1-a7c8-d19e5f04b263
+    :setup: Standalone instance with 500 users over 20 sn groups
+    :steps:
+        1. Search (&(sn=OrSn0)(|(uid=...)(uid=...)...)) where only some of
+           the OR's uids are in group 0
+    :expectedresults:
+        1. Exactly the OR's group-0 members are returned
+    """
+    in_group = [uid for i, uid in enumerate(create_users)
+                if i % GROUPS == 0][:3]
+    other = [uid for i, uid in enumerate(create_users)
+             if i % GROUPS == 5][:4]
+    filt = f'(&(sn=OrSn0){or_of("uid", in_group + other)})'
+    assert search_uids(topo, filt) == sorted(in_group)
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/dirsrvtests/tests/suites/filter/filter_or_union_test.py
+++ b/dirsrvtests/tests/suites/filter/filter_or_union_test.py
@@ -139,7 +139,7 @@ def test_or_two_lists_fastpath(topo, create_users):
     :id: 6d82c4a9-1f35-47e0-bc76-084a9d5e213f
     :setup: Standalone instance with 500 users over 20 sn groups
     :steps:
-        1. Search (|(sn=OrSn0)(sn=OrSn1))
+        1. Search ``(|(sn=OrSn0)(sn=OrSn1))``
     :expectedresults:
         1. Exactly the 50 users of the two groups are returned
     """
@@ -197,8 +197,8 @@ def test_or_inside_and(topo, create_users):
     :id: 82c6e3f7-0b94-45d1-a7c8-d19e5f04b263
     :setup: Standalone instance with 500 users over 20 sn groups
     :steps:
-        1. Search (&(sn=OrSn0)(|(uid=...)(uid=...)...)) where only some of
-           the OR's uids are in group 0
+        1. Search ``(&(sn=OrSn0)(|(uid=...)(uid=...)...))`` where only some
+           of the OR's uids are in group 0
     :expectedresults:
         1. Exactly the OR's group-0 members are returned
     """

--- a/dirsrvtests/tests/suites/memory_leaks/filter_not_first_lifecycle_test.py
+++ b/dirsrvtests/tests/suites/memory_leaks/filter_not_first_lifecycle_test.py
@@ -1,0 +1,1163 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+
+"""Full-lifecycle ASan coverage for NOT-first candidate ownership."""
+
+import fnmatch
+import glob
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+
+import ldap
+import pytest
+
+from ldap.controls import SimplePagedResultsControl
+from lib389._constants import DEFAULT_SUFFIX, ReplicaRole, TASK_WAIT
+from lib389.idm.directorymanager import DirectoryManager
+from lib389.idm.user import UserAccounts
+from lib389.index import VLVIndex, VLVSearch
+from lib389.paths import Paths
+from lib389.tasks import Tasks
+from lib389.utils import ensure_str, get_default_db_lib
+from test389.topologies import create_topology
+
+from ..filter.filter_large_filter_support import (
+    NOT_FIRST_EMPTY_RANGE_FILTER,
+    OR_LOOKUP_ATTR,
+    OWNERSHIP_TEST_BASE,
+    ownership_workload,
+    search_dns,
+)
+
+
+pytestmark = [
+    pytest.mark.tier2,
+    pytest.mark.skipif(get_default_db_lib() != "mdb",
+                       reason="The ownership matrix requires MDB"),
+    pytest.mark.skipif(not Paths().asan_enabled,
+                       reason="The ownership matrix requires compile-time ASan"),
+]
+
+ASAN_DROPIN = "/etc/systemd/system/dirsrv@.service.d/zz-filter-ownership-asan.conf"
+ASAN_OPTIONS = (
+    "detect_leaks=1:halt_on_error=1:disable_coredump=0:"
+    "exitcode=0:symbolize=0:fast_unwind_on_malloc=0:"
+    "malloc_context_size=64:print_suppressions=0:"
+    "log_path=/run/dirsrv/ns-slapd-%i.asan"
+)
+REPORT_SUFFIXES = ("asan", "lsan", "msan", "tsan", "ubsan")
+CORE_PATTERNS = ("core", "core.*", "core-*", "*.core")
+TARGET_STACK = (
+    "idl_alloc",
+    "index_read_ext_allids",
+    "filter_candidates_ext",
+)
+GENERIC_TLS_STACK = (
+    "dblayer_push_pvt_txn",
+    "vlv_rebuild_scope_filter",
+)
+NATIVE_TLS_STACK = (
+    "get_mdbtxnanchor",
+    "dbmdb_start_txn",
+)
+TLS_CLASSIFICATIONS = (
+    "generic-dblayer-tls",
+    "native-mdb-tls",
+)
+VLV_CONFIG_BASE = (
+    "cn=userRoot,cn=ldbm database,cn=plugins,cn=config"
+)
+VLV_SEARCH_CN = "asanOwnershipVlvSearch"
+VLV_INDEX_CN = "asanOwnershipVlvIndex"
+VLV_SEARCH_DN = f"cn={VLV_SEARCH_CN},{VLV_CONFIG_BASE}"
+VLV_INDEX_DN = f"cn={VLV_INDEX_CN},{VLV_SEARCH_DN}"
+OR_ENTRY_COUNT = 60
+OR_PAGE_SIZE = 10
+LEAK_BLOCK_RE = re.compile(
+    r"(?ms)^(?P<kind>Direct|Indirect) leak of (?P<bytes>\d+) byte\(s\) "
+    r"in (?P<objects>\d+) object\(s\).*?"
+    r"(?=^(?:Direct|Indirect) leak of |^SUMMARY:|\Z)"
+)
+INVALID_PATTERNS = (
+    "ERROR: AddressSanitizer:",
+    "AddressSanitizer:DEADLYSIGNAL",
+    "double-free",
+    "heap-use-after-free",
+    "stack-use-after-return",
+    "global-buffer-overflow",
+    "heap-buffer-overflow",
+    "LeakSanitizer has encountered a fatal error",
+    "runtime error:",
+)
+DEBUG_IDENTITY = None
+
+
+def _output(argv):
+    return subprocess.check_output(
+        argv, stderr=subprocess.STDOUT, text=True).strip()
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as artifact:
+        for block in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _build_id(path):
+    notes = _output(["readelf", "-n", path])
+    match = re.search(r"Build ID:\s*([0-9a-fA-F]+)", notes)
+    assert match is not None, notes
+    return match.group(1).lower()
+
+
+def _elf_identity(path):
+    realpath = os.path.realpath(path)
+    linkage = _output(["ldd", realpath])
+    assert "not found" not in linkage.lower()
+    return {
+        "path": realpath,
+        "sha256": _sha256(realpath),
+        "build_id": _build_id(realpath),
+        "package": _output([
+            "rpm", "-qf", "--queryformat",
+            "%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}", realpath,
+        ]),
+        "linkage": linkage,
+    }
+
+
+def _rpm_evra(path=None, package=None):
+    query = "%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}"
+    if path is not None:
+        return _output(["rpm", "-qp", "--queryformat", query, path])
+    return _output(["rpm", "-q", "--queryformat", query, package])
+
+
+def _matching_rpm(package, evra):
+    matches = []
+    for path in glob.glob("/workspace/dist/rpms/*.rpm"):
+        name = _output(["rpm", "-qp", "--queryformat", "%{NAME}", path])
+        if name == package and _rpm_evra(path=path) == evra:
+            matches.append(path)
+    assert len(matches) == 1, (package, evra, matches)
+    return {
+        "path": matches[0],
+        "sha256": _sha256(matches[0]),
+        "evra": evra,
+    }
+
+
+def _symbol_address(debug_path, symbol):
+    pattern = re.compile(
+        r"^([0-9a-fA-F]+)\s+[tT]\s+" + re.escape(symbol) + r"$"
+    )
+    for line in _output(["nm", "-an", debug_path]).splitlines():
+        match = pattern.match(line)
+        if match is not None:
+            return "0x%s" % match.group(1)
+    raise AssertionError("missing debug symbol %s in %s" %
+                         (symbol, debug_path))
+
+
+def _symbolizer():
+    path = shutil.which("eu-addr2line")
+    assert path is not None
+    return path
+
+
+def _debug_object(path):
+    build_id = _build_id(path)
+    debug_path = "/usr/lib/debug/.build-id/%s/%s.debug" % (
+        build_id[:2], build_id[2:])
+    return debug_path if os.path.isfile(debug_path) else path
+
+
+def _symbolize_address(path, address):
+    try:
+        debug_object = _debug_object(path)
+    except (AssertionError, OSError, subprocess.CalledProcessError) as error:
+        return "%s+%s\n%r" % (path, address, error)
+    result = subprocess.run([
+        _symbolizer(), "-f", "-C", "-i", "-e", debug_object, address,
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+       check=False)
+    rendered = result.stdout.strip()
+    if result.returncode != 0:
+        return "%s+%s\n%s" % (path, address, rendered)
+    return rendered
+
+
+def _install_matching_debug_rpms():
+    base_evra = _rpm_evra(package="389-ds-base")
+    selected = []
+    for package in (
+            "389-ds-base-debuginfo",
+            "389-ds-base-libs-debuginfo",
+            "389-ds-base-debugsource"):
+        rpm_identity = _matching_rpm(package, base_evra)
+        selected.append(rpm_identity)
+
+    subprocess.check_call([
+        "dnf", "install", "-y", "--disablerepo=*",
+        "--setopt=install_weak_deps=False",
+        *(item["path"] for item in selected),
+    ])
+    for package in ("389-ds-base-debuginfo",
+                    "389-ds-base-libs-debuginfo",
+                    "389-ds-base-debugsource"):
+        assert _rpm_evra(package=package) == base_evra
+
+    plugin = os.path.join(Paths().plugin_dir, "libback-ldbm.so")
+    plugin_id = _build_id(plugin)
+    debug_path = "/usr/lib/debug/.build-id/%s/%s.debug" % (
+        plugin_id[:2], plugin_id[2:])
+    assert os.path.isfile(debug_path)
+    assert _build_id(debug_path) == plugin_id
+    preflight = {}
+    for symbol in ("list_candidates", "dbmdb_start_txn"):
+        address = _symbol_address(debug_path, symbol)
+        rendered = _symbolize_address(plugin, address)
+        assert symbol in rendered, rendered
+        preflight[symbol] = {"address": address, "rendered": rendered}
+
+    return {
+        "base_evra": base_evra,
+        "rpms": selected,
+        "plugin_build_id": plugin_id,
+        "plugin_debug_path": debug_path,
+        "symbol_preflight": preflight,
+    }
+
+
+@pytest.fixture(scope="module", autouse=True)
+def compile_time_asan_runtime(request):
+    """Install matching symbols and apply one controlled ASan environment."""
+    global DEBUG_IDENTITY
+
+    assert request.config.getoption("--sanitizer") is None
+    DEBUG_IDENTITY = _install_matching_debug_rpms()
+    os.makedirs(Paths().run_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(ASAN_DROPIN), exist_ok=True)
+    previous_dropin = None
+    if os.path.exists(ASAN_DROPIN):
+        with open(ASAN_DROPIN, "rb") as dropin:
+            previous_dropin = dropin.read()
+    previous_suid = _output(["sysctl", "-n", "fs.suid_dumpable"])
+    previous_ptrace = _output([
+        "sysctl", "-n", "kernel.yama.ptrace_scope"
+    ])
+
+    try:
+        with open(ASAN_DROPIN, "w") as dropin:
+            dropin.write("[Service]\n")
+            dropin.write("UnsetEnvironment=LD_PRELOAD\n")
+            dropin.write("Environment=ASAN_OPTIONS=%s\n" % ASAN_OPTIONS)
+            dropin.write("LimitCORE=infinity\n")
+            dropin.write("TimeoutStopSec=600\n")
+        if previous_suid != "1":
+            subprocess.check_call(["sysctl", "-w", "fs.suid_dumpable=1"])
+        if previous_ptrace != "0":
+            subprocess.check_call([
+                "sysctl", "-w", "kernel.yama.ptrace_scope=0"
+            ])
+        subprocess.check_call(["systemctl", "daemon-reload"])
+        yield
+    finally:
+        cleanup_errors = []
+        try:
+            if previous_dropin is None:
+                if os.path.exists(ASAN_DROPIN):
+                    os.unlink(ASAN_DROPIN)
+            else:
+                with open(ASAN_DROPIN, "wb") as dropin:
+                    dropin.write(previous_dropin)
+        except OSError as error:
+            cleanup_errors.append(repr(error))
+        try:
+            if previous_suid != "1":
+                subprocess.check_call([
+                    "sysctl", "-w", "fs.suid_dumpable=%s" % previous_suid
+                ])
+            if previous_ptrace != "0":
+                subprocess.check_call([
+                    "sysctl", "-w",
+                    "kernel.yama.ptrace_scope=%s" % previous_ptrace,
+                ])
+            subprocess.check_call(["systemctl", "daemon-reload"])
+        except subprocess.CalledProcessError as error:
+            cleanup_errors.append(repr(error))
+        if cleanup_errors and sys.exc_info()[0] is None:
+            raise AssertionError("ASan fixture cleanup failed: %s" %
+                                 cleanup_errors)
+
+
+def _artifact_kind(name):
+    if any((".%s" % suffix) in name for suffix in REPORT_SUFFIXES):
+        return "report"
+    if any(fnmatch.fnmatch(name, pattern) for pattern in CORE_PATTERNS):
+        return "core"
+    return None
+
+
+def _artifact_roots():
+    core_pattern = _output(["sysctl", "-n", "kernel.core_pattern"])
+    assert core_pattern.startswith("/workspace/assets/cores/"), core_pattern
+    return {
+        "run-dirsrv": "/run/dirsrv",
+        "workspace-cores": "/workspace/assets/cores",
+    }, core_pattern
+
+
+def _artifact_snapshot():
+    roots, core_pattern = _artifact_roots()
+    snapshot = {}
+    for root_name, root in roots.items():
+        assert os.path.isdir(root), root
+        walk_errors = []
+
+        def onerror(error):
+            walk_errors.append(repr(error))
+
+        for directory, _subdirs, names in os.walk(root, onerror=onerror):
+            for name in names:
+                kind = _artifact_kind(name)
+                if kind is None:
+                    continue
+                path = os.path.join(directory, name)
+                stat = os.stat(path)
+                snapshot[path] = {
+                    "kind": kind,
+                    "root": root_name,
+                    "relative": os.path.relpath(path, root),
+                    "device": stat.st_dev,
+                    "inode": stat.st_ino,
+                    "size": stat.st_size,
+                    "mtime_ns": stat.st_mtime_ns,
+                    "sha256": _sha256(path),
+                }
+        assert not walk_errors, walk_errors
+    return snapshot, core_pattern
+
+
+def _new_artifacts(before, after):
+    return {
+        path: metadata for path, metadata in after.items()
+        if before.get(path) != metadata
+    }
+
+
+FRAME_RE = re.compile(
+    r"\((?P<module>/[^()]+)\+0x(?P<offset>[0-9a-fA-F]+)\)"
+)
+
+
+def _symbolize_report(raw):
+    symbolized = []
+    cache = {}
+    for line in raw.splitlines():
+        symbolized.append(line)
+        match = FRAME_RE.search(line)
+        if match is None:
+            continue
+        key = (match.group("module"), match.group("offset"))
+        if key not in cache:
+            cache[key] = _symbolize_address(key[0], "0x%s" % key[1])
+        symbolized.extend("    %s" % item
+                          for item in cache[key].splitlines())
+    return "\n".join(symbolized) + "\n"
+
+
+def _ordered_tokens(text, tokens):
+    offset = 0
+    for token in tokens:
+        offset = text.find(token, offset)
+        if offset < 0:
+            return False
+        offset += len(token)
+    return True
+
+
+def _classify_reports(artifacts):
+    reports = []
+    report_artifacts = []
+    totals = {
+        "not-first-idl": {"bytes": 0, "objects": 0},
+        "generic-dblayer-tls": {"bytes": 0, "objects": 0},
+        "native-mdb-tls": {"bytes": 0, "objects": 0},
+    }
+    invalid_access = []
+    unknown_reports = []
+    unknown_blocks = []
+
+    for path, metadata in sorted(artifacts.items()):
+        if metadata["kind"] != "report":
+            continue
+        report_artifacts.append({
+            "path": path,
+            "size": metadata["size"],
+            "sha256": metadata["sha256"],
+        })
+        if metadata["size"] == 0:
+            continue
+        with open(path, "r", errors="replace") as report_file:
+            raw = report_file.read()
+        symbolized = _symbolize_report(raw)
+        blocks = []
+        for match in LEAK_BLOCK_RE.finditer(symbolized):
+            block = match.group(0)
+            classification = "other"
+            if _ordered_tokens(block, TARGET_STACK):
+                classification = "not-first-idl"
+            elif _ordered_tokens(block, GENERIC_TLS_STACK):
+                classification = "generic-dblayer-tls"
+            elif _ordered_tokens(block, NATIVE_TLS_STACK):
+                classification = "native-mdb-tls"
+            block_data = {
+                "bytes": int(match.group("bytes")),
+                "objects": int(match.group("objects")),
+                "classification": classification,
+                "stack": block,
+            }
+            blocks.append(block_data)
+            if classification == "other":
+                unknown_blocks.append({"path": path, **block_data})
+            else:
+                totals[classification]["bytes"] += block_data["bytes"]
+                totals[classification]["objects"] += block_data["objects"]
+
+        errors = [pattern for pattern in INVALID_PATTERNS
+                  if pattern in symbolized]
+        if errors:
+            invalid_access.append({"path": path, "patterns": errors})
+        if raw.strip() and not blocks and not errors:
+            unknown_reports.append(path)
+        reports.append({
+            "path": path,
+            "size": metadata["size"],
+            "sha256": metadata["sha256"],
+            "blocks": blocks,
+            "symbolized": symbolized,
+        })
+
+    return {
+        "reports": reports,
+        "report_artifacts": report_artifacts,
+        "totals": totals,
+        "invalid_access": invalid_access,
+        "unknown_reports": unknown_reports,
+        "unknown_blocks": unknown_blocks,
+    }
+
+
+def _source_identity():
+    expected = os.environ.get("DS_EXPECTED_SOURCE_SHA", "")
+    assert re.fullmatch(r"[0-9a-f]{40}", expected), expected
+    head = _output(["git", "-C", "/workspace", "rev-parse", "HEAD"])
+    assert head == expected
+    return {
+        "expected_head": expected,
+        "head": head,
+        "short_head": _output([
+            "git", "-C", "/workspace", "rev-parse", "--short", "HEAD"
+        ]),
+        "status": _output([
+            "git", "-C", "/workspace", "status", "--short",
+            "--untracked-files=all",
+        ]),
+    }
+
+
+def _runtime_identity(inst):
+    source = _source_identity()
+    sanitizer_sysctls = {
+        "fs.suid_dumpable": _output([
+            "sysctl", "-n", "fs.suid_dumpable"
+        ]),
+        "kernel.yama.ptrace_scope": _output([
+            "sysctl", "-n", "kernel.yama.ptrace_scope"
+        ]),
+    }
+    assert sanitizer_sysctls == {
+        "fs.suid_dumpable": "1",
+        "kernel.yama.ptrace_scope": "0",
+    }
+    installed = {
+        package: _rpm_evra(package=package)
+        for package in ("389-ds-base", "389-ds-base-libs", "python3-lib389")
+    }
+    local_rpms = {
+        package: _matching_rpm(package, evra)
+        for package, evra in installed.items()
+    }
+    executable = os.path.join(inst.get_sbin_dir(), "ns-slapd")
+    plugin = os.path.join(inst.get_plugin_dir(), "libback-ldbm.so")
+    executable_identity = _elf_identity(executable)
+    plugin_identity = _elf_identity(plugin)
+    pid = inst.get_pid()
+    environ = {}
+    with open("/proc/%s/environ" % pid, "rb") as proc_environ:
+        for item in proc_environ.read().split(b"\0"):
+            key, separator, value = item.partition(b"=")
+            if separator:
+                environ[key.decode(errors="replace")] = value.decode(
+                    errors="replace")
+    with open("/proc/%s/maps" % pid, "r") as proc_maps:
+        maps = proc_maps.read()
+    with open("/proc/%s/limits" % pid, "r") as proc_limits:
+        limits = proc_limits.read()
+
+    expected_options = ASAN_OPTIONS.replace("%i", inst.serverid)
+    assert environ.get("ASAN_OPTIONS") == expected_options
+    assert "LD_PRELOAD" not in environ
+    assert "libasan.so" in maps
+    assert "libjemalloc" not in maps
+    assert "liblsan.so" not in maps
+    assert os.path.realpath(plugin) in maps
+    assert "libasan.so" in executable_identity["linkage"]
+    assert "libasan.so" in plugin_identity["linkage"]
+    core_limits = [line.split() for line in limits.splitlines()
+                   if line.startswith("Max core file size")]
+    assert len(core_limits) == 1, limits
+    assert core_limits[0][-3:-1] == ["unlimited", "unlimited"], \
+        core_limits[0]
+    assert inst.has_asan()
+    assert "asan" in installed["389-ds-base"]
+    assert source["short_head"] in installed["389-ds-base"]
+
+    return {
+        "source": source,
+        "installed": installed,
+        "local_rpms": local_rpms,
+        "executable": executable_identity,
+        "plugin": plugin_identity,
+        "environment": {
+            key: environ[key] for key in ("ASAN_OPTIONS", "LD_PRELOAD")
+            if key in environ
+        },
+        "maps": maps,
+        "limits": limits,
+        "sysctls": sanitizer_sysctls,
+        "pid": pid,
+        "serverid": inst.serverid,
+        "debug": DEBUG_IDENTITY,
+    }
+
+
+@contextmanager
+def _error_log_window(path):
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+    window = {"text": None}
+    try:
+        initial = os.fstat(fd)
+        identity = (initial.st_dev, initial.st_ino)
+        begin = initial.st_size
+        guard_at = max(0, begin - 4096)
+        guard = os.pread(fd, begin - guard_at, guard_at)
+        yield window
+
+        active = os.stat(path)
+        assert (active.st_dev, active.st_ino) == identity
+        assert active.st_size >= begin
+        assert os.pread(fd, begin - guard_at, guard_at) == guard
+        end = active.st_size
+        chunks = []
+        offset = begin
+        while offset < end:
+            chunk = os.pread(fd, end - offset, offset)
+            assert chunk
+            chunks.append(chunk)
+            offset += len(chunk)
+        final_fd = os.fstat(fd)
+        final_active = os.stat(path)
+        assert (final_fd.st_dev, final_fd.st_ino) == identity
+        assert (final_active.st_dev, final_active.st_ino) == identity
+        assert final_fd.st_size >= end and final_active.st_size >= end
+        assert os.pread(fd, begin - guard_at, guard_at) == guard
+        window["text"] = b"".join(chunks).decode(
+            "utf-8", errors="replace")
+    finally:
+        os.close(fd)
+
+
+DIAGNOSTIC_PATTERNS = (
+    re.compile(r"list_candidates\s+-\s+NOT filter", re.IGNORECASE),
+    re.compile(r"ava_candidates\s+-\s+uid=lf-ownership-absent",
+               re.IGNORECASE),
+    re.compile(r"ava_candidates\s+-\s+objectClass=person", re.IGNORECASE),
+    re.compile(r"filter_candidates_ext\s+-\s+GE\b", re.IGNORECASE),
+    re.compile(r"range_candidates\s+-\s+=> attr=lfEmptyRange",
+               re.IGNORECASE),
+    re.compile(r"range_candidates\s+-\s+<= 0\b", re.IGNORECASE),
+    re.compile(r"list_candidates\s+-\s+<=\s+NULL 2", re.IGNORECASE),
+)
+
+
+def _assert_diagnostics(text, operation_count):
+    matches = [list(pattern.finditer(text)) for pattern in DIAGNOSTIC_PATTERNS]
+    assert all(len(found) == operation_count for found in matches), [
+        len(found) for found in matches
+    ]
+    for operation_index in range(operation_count):
+        positions = [found[operation_index].start() for found in matches]
+        assert positions == sorted(positions), positions
+
+
+def _systemd_stop_state(inst):
+    properties = _output([
+        "systemctl", "show", "dirsrv@%s.service" % inst.serverid,
+        "--property=ActiveState,SubState,Result,ExecMainCode,ExecMainStatus",
+    ])
+    return dict(line.split("=", 1) for line in properties.splitlines())
+
+
+def _archive(label, artifacts, identity, summary, inst):
+    evidence_root = os.environ.get("DS_ASAN_EVIDENCE_DIR", "")
+    assert os.path.isabs(evidence_root), evidence_root
+    destination = os.path.join(evidence_root, label)
+    assert not os.path.exists(destination), destination
+    os.makedirs(destination)
+    manifest = []
+
+    for path, metadata in artifacts.items():
+        target = os.path.join(
+            destination, "artifacts", metadata["root"], metadata["relative"])
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copy2(path, target)
+        assert _sha256(target) == metadata["sha256"]
+        manifest.append({"source": path, "copy": target, **metadata})
+
+    for report in summary["reports"]:
+        target = os.path.join(
+            destination, "symbolized",
+            os.path.basename(report["path"]) + ".symbolized")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w") as output:
+            output.write(report["symbolized"])
+
+    for name, path in (("errors", inst.ds_paths.error_log),
+                       ("access", inst.ds_paths.access_log)):
+        if os.path.isfile(path):
+            target = os.path.join(destination, "logs", name)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            shutil.copy2(path, target)
+
+    for path in (
+            "/workspace/dirsrvtests/tests/suites/filter/filter_large_filter_support.py",
+            "/workspace/ldap/servers/slapd/back-ldbm/filterindex.c",
+            "/workspace/ldap/servers/slapd/back-ldbm/idl_set.c",
+            "/workspace/ldap/servers/slapd/back-ldbm/dblayer.c",
+            "/workspace/ldap/servers/slapd/back-ldbm/db-mdb/mdb_txn.c",
+            ASAN_DROPIN,
+            os.path.realpath(__file__)):
+        target = os.path.join(destination, "sources", os.path.basename(path))
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copy2(path, target)
+        manifest.append({
+            "source": path, "copy": target, "sha256": _sha256(target)
+        })
+
+    summary["archive"] = destination
+    with open(os.path.join(destination, "identity.json"), "w") as output:
+        json.dump(identity, output, indent=2, sort_keys=True)
+    with open(os.path.join(destination, "manifest.json"), "w") as output:
+        json.dump(manifest, output, indent=2, sort_keys=True)
+    with open(os.path.join(destination, "summary.json"), "w") as output:
+        json.dump(summary, output, indent=2, sort_keys=True)
+    return destination
+
+
+def _stop_collect(inst, before, identity, label):
+    expected_pid = identity["pid"]
+    stop_error = None
+    stop_text = ""
+    try:
+        with _error_log_window(inst.ds_paths.error_log) as window:
+            inst.stop(timeout=600)
+        stop_text = window["text"]
+    except Exception as error:
+        stop_error = repr(error)
+
+    stopped = not inst.status()
+    after, core_pattern = _artifact_snapshot()
+    artifacts = _new_artifacts(before, after)
+    classification = _classify_reports(artifacts)
+    cores = [path for path, metadata in artifacts.items()
+             if metadata["kind"] == "core" and metadata["size"] > 0]
+    systemd_state = _systemd_stop_state(inst) if stopped else {}
+    summary = {
+        **classification,
+        "cores": cores,
+        "core_pattern": core_pattern,
+        "expected_pid": expected_pid,
+        "pid_gone": not os.path.exists("/proc/%s" % expected_pid),
+        "stop_error": stop_error,
+        "stopped": stopped,
+        "stop_log_seen": "main - slapd stopped." in stop_text,
+        "systemd": systemd_state,
+    }
+    _archive(label, artifacts, identity, summary, inst)
+    return summary
+
+
+def _assert_common(summary):
+    assert summary["stop_error"] is None
+    assert summary["stopped"]
+    assert summary["pid_gone"]
+    assert summary["stop_log_seen"]
+    assert summary["cores"] == []
+    assert summary["invalid_access"] == []
+    assert summary["unknown_reports"] == []
+    assert summary["unknown_blocks"] == []
+    assert summary["systemd"] == {
+        "ActiveState": "inactive",
+        "SubState": "dead",
+        "Result": "success",
+        "ExecMainCode": "1",
+        "ExecMainStatus": "0",
+    }
+
+
+def _raise_phase_failure(operation_failure, collection_failure):
+    if operation_failure is not None:
+        if collection_failure is not None:
+            operation_failure[1].add_note(
+                "stop/evidence collection also failed: %r" %
+                collection_failure[1])
+        raise operation_failure[1].with_traceback(operation_failure[2])
+    if collection_failure is not None:
+        raise collection_failure[1].with_traceback(collection_failure[2])
+
+
+def _run_process_phase(inst, before, label, operation=None):
+    identity = {"pid": inst.get_pid(), "serverid": inst.serverid}
+    operation_failure = None
+    try:
+        identity = _runtime_identity(inst)
+        if operation is not None:
+            operation(inst, identity)
+    except BaseException:
+        operation_failure = sys.exc_info()
+
+    summary = None
+    collection_failure = None
+    try:
+        summary = _stop_collect(inst, before, identity, label)
+        _assert_common(summary)
+    except BaseException:
+        collection_failure = sys.exc_info()
+    _raise_phase_failure(operation_failure, collection_failure)
+    return summary
+
+
+def _cleanup_instance(inst):
+    active_failure = sys.exc_info()
+    try:
+        if inst.status():
+            inst.stop(timeout=600)
+        if inst.exists():
+            inst.delete()
+    except BaseException as cleanup_error:
+        if active_failure[1] is None:
+            raise
+        active_failure[1].add_note(
+            "instance cleanup also failed: %r" % cleanup_error)
+
+
+def _assert_health(inst, base=DEFAULT_SUFFIX):
+    result_type, dns = search_dns(
+        inst, "(objectClass=*)", base=base, scope=ldap.SCOPE_BASE
+    )
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == [base.lower()]
+
+
+def _configured_vlv_dns(inst):
+    entries = inst.search_s(
+        VLV_CONFIG_BASE, ldap.SCOPE_ONELEVEL,
+        "(objectClass=vlvSearch)", ["1.1"]
+    )
+    return sorted(entry.dn.lower() for entry in entries)
+
+
+def _verify_explicit_vlv(inst):
+    assert _configured_vlv_dns(inst) == [VLV_SEARCH_DN.lower()]
+    assert VLVSearch(inst, dn=VLV_SEARCH_DN).exists()
+    assert VLVIndex(inst, dn=VLV_INDEX_DN).exists()
+    _assert_health(inst)
+
+
+def _configure_and_reindex_vlv(inst, _identity):
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    created = [users.create_test_user(uid=48000 + index, gid=48000)
+               for index in range(16)]
+    expected_dns = sorted(entry.dn.lower() for entry in created)
+    result_type, dns = search_dns(
+        inst, "(uid=test_user_48*)", base=DEFAULT_SUFFIX)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert dns == expected_dns
+
+    vlv_search = VLVSearch(inst)
+    vlv_search.create(
+        basedn=VLV_CONFIG_BASE,
+        properties={
+            "cn": VLV_SEARCH_CN,
+            "vlvbase": DEFAULT_SUFFIX,
+            "vlvfilter": "(uid=test_user_48*)",
+            "vlvscope": str(ldap.SCOPE_SUBTREE),
+        },
+    )
+    vlv_index = VLVIndex(inst)
+    vlv_index.create(
+        basedn=VLV_SEARCH_DN,
+        properties={"cn": VLV_INDEX_CN, "vlvsort": "cn"},
+    )
+    assert Tasks(inst).reindex(
+        suffix=DEFAULT_SUFFIX,
+        attrname=vlv_index.rdn,
+        args={TASK_WAIT: True},
+        vlv=True,
+    ) == 0
+    _verify_explicit_vlv(inst)
+
+
+def _run_startup_baseline():
+    before, _core_pattern = _artifact_snapshot()
+    topology = create_topology({ReplicaRole.STANDALONE: 1}, request=None)
+    inst = topology.standalone
+    try:
+        bootstrap_pid = inst.get_pid()
+        bootstrap = _run_process_phase(
+            inst, before, "startup-bootstrap-%s" % bootstrap_pid)
+
+        before, _core_pattern = _artifact_snapshot()
+        inst.start()
+
+        def verify_default(current, _identity):
+            assert _configured_vlv_dns(current) == []
+            _assert_health(current)
+
+        startup_pid = inst.get_pid()
+        startup = _run_process_phase(
+            inst, before, "startup-default-%s" % startup_pid,
+            verify_default)
+        return {"bootstrap": bootstrap, "default_restart": startup}
+    finally:
+        _cleanup_instance(inst)
+
+
+def _run_explicit_vlv_lifecycle():
+    before, _core_pattern = _artifact_snapshot()
+    topology = create_topology({ReplicaRole.STANDALONE: 1}, request=None)
+    inst = topology.standalone
+    try:
+        reindex_pid = inst.get_pid()
+        reindex = _run_process_phase(
+            inst, before, "explicit-vlv-reindex-%s" % reindex_pid,
+            _configure_and_reindex_vlv)
+
+        starts = []
+        for start_index in (1, 2):
+            before, _core_pattern = _artifact_snapshot()
+            inst.start()
+            pid = inst.get_pid()
+            starts.append(_run_process_phase(
+                inst, before,
+                "explicit-vlv-start-%s-pid-%s" % (start_index, pid),
+                lambda current, _identity: _verify_explicit_vlv(current),
+            ))
+        return {
+            "reindex": reindex,
+            "restart_1": starts[0],
+            "restart_2": starts[1],
+        }
+    finally:
+        _cleanup_instance(inst)
+
+
+def _run_setup_matched_case(operation_count):
+    before, _core_pattern = _artifact_snapshot()
+    topology = create_topology({ReplicaRole.STANDALONE: 1}, request=None)
+    inst = topology.standalone
+    try:
+        original_pid = inst.get_pid()
+
+        def run_operations(current, _identity):
+            assert current.get_db_lib() == "mdb"
+            with ownership_workload(current, remove_on_exit=False):
+                current.config.set("nsslapd-errorlog-logbuffering", "off")
+                level = int(current.config.get_attr_val_utf8(
+                    "nsslapd-errorlog-level") or "0")
+                current.config.set(
+                    "nsslapd-errorlog-level",
+                    str(level | 1 | 32 | 524288))
+
+                with _error_log_window(current.ds_paths.error_log) as window:
+                    for _iteration in range(operation_count):
+                        result_type, dns = search_dns(
+                            current, NOT_FIRST_EMPTY_RANGE_FILTER,
+                            base=OWNERSHIP_TEST_BASE,
+                            scope=ldap.SCOPE_SUBTREE,
+                        )
+                        assert result_type == ldap.RES_SEARCH_RESULT
+                        assert dns == []
+                _assert_diagnostics(window["text"], operation_count)
+                _assert_health(current, OWNERSHIP_TEST_BASE)
+                assert current.status()
+                assert current.get_pid() == original_pid
+
+        return _run_process_phase(
+            inst, before,
+            "not-first-ops-%03d-pid-%s" %
+            (operation_count, original_pid),
+            run_operations)
+    finally:
+        _cleanup_instance(inst)
+
+
+def _or_filter(values):
+    return "(|%s)" % "".join("(uid=%s)" % value for value in values)
+
+
+def _connection_search_dns(conn, filterstr, serverctrls=None):
+    msgid = conn.search_ext(
+        DEFAULT_SUFFIX, ldap.SCOPE_SUBTREE, filterstr, ["1.1"],
+        serverctrls=serverctrls,
+    )
+    result_type, result_data, _, result_controls = conn.result3(msgid)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    dns = sorted(ensure_str(dn).lower() for dn, _ in result_data if dn)
+    return dns, result_controls
+
+
+def _response_page_control(controls):
+    matches = [control for control in controls
+               if control.controlType ==
+               SimplePagedResultsControl.controlType]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _complete_paged_dns(conn, filterstr):
+    request = SimplePagedResultsControl(
+        True, size=OR_PAGE_SIZE, cookie="")
+    dns = []
+    while True:
+        page_dns, controls = _connection_search_dns(
+            conn, filterstr, serverctrls=[request])
+        dns.extend(page_dns)
+        response = _response_page_control(controls)
+        if not response.cookie:
+            return sorted(dns)
+        request.cookie = response.cookie
+
+
+def _assert_connection_health(conn):
+    msgid = conn.search_ext(
+        DEFAULT_SUFFIX, ldap.SCOPE_BASE, "(objectClass=*)", ["1.1"])
+    result_type, result_data, _, _ = conn.result3(msgid)
+    assert result_type == ldap.RES_SEARCH_RESULT
+    assert [ensure_str(dn).lower() for dn, _ in result_data] == [
+        DEFAULT_SUFFIX.lower()
+    ]
+
+
+def _run_or_paging_case():
+    before, _core_pattern = _artifact_snapshot()
+    topology = create_topology({ReplicaRole.STANDALONE: 1}, request=None)
+    inst = topology.standalone
+    try:
+        original_pid = inst.get_pid()
+
+        def run_operations(current, _identity):
+            assert current.config.get_attr_val_utf8_l(
+                OR_LOOKUP_ATTR) == "on"
+            users = UserAccounts(current, DEFAULT_SUFFIX)
+            created = [users.create_test_user(
+                uid=49000 + index, gid=49000)
+                for index in range(OR_ENTRY_COUNT)]
+            values = ["test_user_%s" % (49000 + index)
+                      for index in range(OR_ENTRY_COUNT)]
+            expected = sorted(entry.dn.lower() for entry in created)
+            filterstr = _or_filter(values)
+
+            cancel_conn = DirectoryManager(current).bind()
+            request = SimplePagedResultsControl(
+                True, size=OR_PAGE_SIZE, cookie="")
+            try:
+                complete, _controls = _connection_search_dns(
+                    cancel_conn, filterstr)
+                assert complete == expected
+                first_page, controls = _connection_search_dns(
+                    cancel_conn, filterstr, serverctrls=[request])
+                assert len(first_page) == OR_PAGE_SIZE
+                assert set(first_page) < set(expected)
+                response = _response_page_control(controls)
+                assert response.cookie
+                request.size = 0
+                request.cookie = response.cookie
+                cancelled, controls = _connection_search_dns(
+                    cancel_conn, filterstr, serverctrls=[request])
+                assert cancelled == []
+                assert not _response_page_control(controls).cookie
+                _assert_connection_health(cancel_conn)
+            finally:
+                cancel_conn.unbind_s()
+
+            first_conn = DirectoryManager(current).bind()
+            request = SimplePagedResultsControl(
+                True, size=OR_PAGE_SIZE, cookie="")
+            try:
+                first_page, controls = _connection_search_dns(
+                    first_conn, filterstr, serverctrls=[request])
+                assert len(first_page) == OR_PAGE_SIZE
+                assert set(first_page) < set(expected)
+                assert _response_page_control(controls).cookie
+            finally:
+                first_conn.unbind_s()
+
+            second_conn = DirectoryManager(current).bind()
+            try:
+                _assert_connection_health(second_conn)
+                assert _complete_paged_dns(
+                    second_conn, filterstr) == expected
+            finally:
+                second_conn.unbind_s()
+            assert current.status()
+            assert current.get_pid() == original_pid
+
+        return _run_process_phase(
+            inst, before, "or-paging-pid-%s" % original_pid,
+            run_operations)
+    finally:
+        _cleanup_instance(inst)
+
+
+def _assert_target_matrix(results):
+    target = {
+        count: result["totals"]["not-first-idl"]
+        for count, result in results.items()
+    }
+    expected = os.environ.get("DS_EXPECT_TARGET_LEAK", "absent")
+    assert expected in {"present", "absent"}, expected
+    blocks = {
+        count: [
+            block
+            for report in result["reports"]
+            for block in report["blocks"]
+            if block["classification"] == "not-first-idl"
+        ]
+        for count, result in results.items()
+    }
+    if expected == "present":
+        assert target[0] == {"bytes": 0, "objects": 0}
+        assert blocks[0] == []
+        unit = target[1]
+        assert 120 <= unit["bytes"] <= 200, target
+        assert len(blocks[1]) == 2, blocks[1]
+        assert sorted(block["objects"] for block in blocks[1]) == [1, 1]
+        unit_bytes = sorted(block["bytes"] for block in blocks[1])
+        for count in (10, 100):
+            assert len(blocks[count]) == 2, blocks[count]
+            assert sorted(block["objects"] for block in blocks[count]) == [
+                count, count
+            ]
+            assert sorted(block["bytes"] for block in blocks[count]) == [
+                size * count for size in unit_bytes
+            ]
+            assert target[count]["bytes"] == unit["bytes"] * count, target
+            assert target[count]["objects"] == unit["objects"] * count, target
+    else:
+        assert all(value == {"bytes": 0, "objects": 0}
+                   for value in target.values()), target
+        assert all(value == [] for value in blocks.values()), blocks
+
+
+def _summary_values(*groups):
+    summaries = []
+    for group in groups:
+        if group is None:
+            continue
+        if isinstance(group, dict) and "totals" not in group:
+            summaries.extend(group.values())
+        else:
+            summaries.append(group)
+    return summaries
+
+
+def _assert_tls_matrix(baseline, explicit_vlv, all_summaries):
+    expected = os.environ.get("DS_EXPECT_TLS_LEAK", "absent")
+    assert expected in {"present", "absent"}, expected
+    if expected == "present":
+        for classification in TLS_CLASSIFICATIONS:
+            assert sum(summary["totals"][classification]["bytes"]
+                       for summary in baseline.values()) > 0
+            assert sum(summary["totals"][classification]["bytes"]
+                       for summary in explicit_vlv.values()) > 0
+    else:
+        for classification in TLS_CLASSIFICATIONS:
+            assert all(summary["totals"][classification] == {
+                "bytes": 0, "objects": 0
+            } for summary in all_summaries)
+
+
+def _assert_no_report_artifacts(summaries):
+    if os.environ.get("DS_REQUIRE_NO_REPORTS") == "1":
+        assert all(summary["report_artifacts"] == []
+                   for summary in summaries)
+
+def test_not_first_empty_range_asan_lifecycle(request):
+    """Gate NOT-first, MDB TLS, VLV, and OR lifecycles under ASan.
+
+    :id: 3b4f9ad5-c11a-41f4-a0e3-9bfe3f1990f4
+    :setup: Fresh compile-time ASan MDB processes with matching debuginfo
+    :steps:
+        1. Stop bootstrap and repeated default processes with no VLV objects
+        2. Reindex an explicit VLV and stop two restarted processes
+        3. Run setup-matched 0, 1, 10, and 100 NOT-first searches
+        4. Cancel and disconnect eligible paged OR searches
+        5. Archive, symbolize, and classify every report and core
+    :expectedresults:
+        1. Default startup has no configured VLV and every stop is clean
+        2. Both TLS roots are reproduced before and absent after their fixes
+        3. Both NOT-first chains scale before and are absent after their fix
+        4. OR results, cancellation, reconnect, and health checks are exact
+        5. No invalid access, core, unknown report, or unknown leak is present
+    """
+    assert request.config.getoption("--sanitizer") is None
+    target_expectation = os.environ.get("DS_EXPECT_TARGET_LEAK", "absent")
+    assert target_expectation in {"present", "absent", "skip"}
+
+    baseline = _run_startup_baseline()
+    explicit_vlv = _run_explicit_vlv_lifecycle()
+    results = {}
+    or_paging = None
+    if target_expectation != "skip":
+        results = {
+            count: _run_setup_matched_case(count)
+            for count in (0, 1, 10, 100)
+        }
+        _assert_target_matrix(results)
+        or_paging = _run_or_paging_case()
+
+    summaries = _summary_values(
+        baseline, explicit_vlv, results, or_paging)
+    _assert_tls_matrix(baseline, explicit_vlv, summaries)
+    _assert_no_report_artifacts(summaries)
+
+
+if __name__ == "__main__":
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/ldap/servers/slapd/back-ldbm/filterindex.c
+++ b/ldap/servers/slapd/back-ldbm/filterindex.c
@@ -864,8 +864,7 @@ list_candidates(
              * subtract from.
              */
             if (f == f_head) {
-                idl = idl_allids(be);
-                idl_set_insert_idl(idl_set, idl);
+                idl_set_insert_idl(idl_set, idl_allids(be));
             }
             /*
              * Not the first filter - good! Get the indexed type out.

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1167,6 +1167,28 @@ ldbm_back_search(Slapi_PBlock *pb)
                 tmp_err = LDAP_OPERATIONS_ERROR;
                 tmp_desc = "Could not compile regex for filter matching";
             }
+        } else if (!filter_flag_is_set(filter, SLAPI_FILTER_TOMBSTONE) &&
+                   !filter_flag_is_set(filter, SLAPI_FILTER_RUV)) {
+            /* Build the large-OR lookup tables on the operation-private,
+             * normalized dups.  Tombstone/RUV searches keep the classic
+             * walk.  VLV admits undefined filter-test results, so its
+             * tables must not claim boolean context. */
+            int32_t or_nodes = 0;
+            int32_t or_largest = 0;
+
+            or_nodes = filter_or_lookup_build(sr->sr_norm_filter, &or_largest,
+                                              !virtual_list_view);
+            if (filter_intent && sr->sr_norm_filter_intent &&
+                !filter_flag_is_set(filter_intent, SLAPI_FILTER_TOMBSTONE) &&
+                !filter_flag_is_set(filter_intent, SLAPI_FILTER_RUV)) {
+                or_nodes += filter_or_lookup_build(sr->sr_norm_filter_intent,
+                                                   &or_largest, !virtual_list_view);
+            }
+            if (or_nodes) {
+                slapi_log_err(SLAPI_LOG_BACKLDBM, "ldbm_back_search",
+                              "OR filter equality lookup engaged: %d node(s), largest %d branches\n",
+                              or_nodes, or_largest);
+            }
         }
     } else {
         slapi_log_err(SLAPI_LOG_FILTER, "ldbm_back_search", "Skipped Filter Test\n");

--- a/ldap/servers/slapd/back-ldbm/ldbm_search.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_search.c
@@ -1168,11 +1168,16 @@ ldbm_back_search(Slapi_PBlock *pb)
                 tmp_desc = "Could not compile regex for filter matching";
             }
         } else if (!filter_flag_is_set(filter, SLAPI_FILTER_TOMBSTONE) &&
-                   !filter_flag_is_set(filter, SLAPI_FILTER_RUV)) {
+                   !filter_flag_is_set(filter, SLAPI_FILTER_RUV) &&
+                   sr->sr_candidates != NULL &&
+                   (ALLIDS(sr->sr_candidates) ||
+                    IDL_NIDS(sr->sr_candidates) > 0)) {
             /* Build the large-OR lookup tables on the operation-private,
              * normalized dups.  Tombstone/RUV searches keep the classic
              * walk.  VLV admits undefined filter-test results, so its
-             * tables must not claim boolean context. */
+             * tables must not claim boolean context.  An empty candidate
+             * list never reaches the per-entry test, so a table would be
+             * built and freed unused. */
             int32_t or_nodes = 0;
             int32_t or_largest = 0;
 

--- a/ldap/servers/slapd/filter.c
+++ b/ldap/servers/slapd/filter.c
@@ -689,6 +689,7 @@ slapi_filter_dup(Slapi_Filter *f)
         return NULL;
     }
 
+    /* f_or_lookup borrows child pointers, so it is never copied. */
     out->f_choice = f->f_choice;
     out->f_hash = f->f_hash;
     out->f_flags = f->f_flags;
@@ -780,6 +781,8 @@ slapi_filter_free(struct slapi_filter *f, int recurse)
     case LDAP_FILTER_AND:
     case LDAP_FILTER_OR:
     case LDAP_FILTER_NOT:
+        /* Not gated on recurse: a non-recursive free still frees this node. */
+        filter_or_lookup_free(&f->f_or_lookup);
         if (recurse) {
             struct slapi_filter *fl, *next;
 

--- a/ldap/servers/slapd/filter_or_lookup.c
+++ b/ldap/servers/slapd/filter_or_lookup.c
@@ -1,0 +1,526 @@
+/** BEGIN COPYRIGHT BLOCK
+ * Copyright (C) 2026 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * License: GPL (version 3 or any later version).
+ * See LICENSE for details.
+ * END COPYRIGHT BLOCK **/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+/*
+ * Per-operation equality lookup tables for large OR filters.
+ *
+ * The per-entry filter test walks every OR branch for every candidate
+ * entry, and each branch re-normalizes the entry's values.  For a large
+ * OR of equality tests on one attribute the walk is inverted: normalize
+ * the entry's values once and look them up in a sorted table of the
+ * branches' normalized assertion values.  A hit is re-verified with the
+ * same access check and match call the walk would have made, so the
+ * table only selects the branch to test (see vattr_test_filter_or_lookup
+ * in filterentry.c).
+ *
+ * Tables are built only on the backend's per-search filter dups, after
+ * slapi_filter_normalize(PR_TRUE): one owner, no locking, freed with the
+ * node in slapi_filter_free.  Only syntaxes whose equality means "the
+ * normalized bytes are equal" qualify; everything else stays on the
+ * classic walk.
+ */
+
+#include "slap.h"
+#include "slapi-private.h"
+
+/*
+ * Minimum same-type equality branches before a table is built.  Small
+ * ORs (SSSD sends a handful of branches) keep the classic walk.
+ */
+#define FILTER_OR_LOOKUP_THRESHOLD 16
+
+/* Mirrors FILTER_OPTIMISE_DEPTH_LIMIT (filter.c) for the annotate walk. */
+#define FILTER_OR_LOOKUP_DEPTH_LIMIT 256
+
+/*
+ * Syntaxes whose equality compares the normalized forms byte-wise.
+ * Octetstring is absent on purpose: it is the default for attribute
+ * types unknown to schema.  Also absent: generalizedTime, boolean,
+ * bitString, and nameAndOptionalUID.
+ */
+static const char *const or_lookup_syntax_oids[] = {
+    DIRSTRING_SYNTAX_OID,
+    IA5STRING_SYNTAX_OID,
+    INTEGER_SYNTAX_OID,
+    NUMERICSTRING_SYNTAX_OID,
+    TELEPHONE_SYNTAX_OID,
+    DN_SYNTAX_OID,
+    NULL
+};
+
+/*
+ * Equality rules implemented by the in-tree string family.  A custom or
+ * collation rule may normalize differently, so anything else declines.
+ */
+static const char *const or_lookup_mr_oids[] = {
+    "2.5.13.1",                  /* distinguishedNameMatch */
+    "2.5.13.2",                  /* caseIgnoreMatch */
+    "2.5.13.5",                  /* caseExactMatch */
+    "2.5.13.8",                  /* numericStringMatch */
+    "2.5.13.14",                 /* integerMatch */
+    "2.5.13.20",                 /* telephoneNumberMatch */
+    "1.3.6.1.4.1.1466.109.114.1", /* caseExactIA5Match */
+    "1.3.6.1.4.1.1466.109.114.2", /* caseIgnoreIA5Match */
+    NULL
+};
+
+struct or_lookup_family {
+    const char *type; /* borrowed from the first branch of this family */
+    size_t eligible;
+    size_t usable;
+    size_t first_ord;
+    int32_t is_dn;
+    int32_t supported;
+};
+
+static int
+or_lookup_family_cmp(const void *ap, const void *bp)
+{
+    const struct or_lookup_family *a = (const struct or_lookup_family *)ap;
+    const struct or_lookup_family *b = (const struct or_lookup_family *)bp;
+
+    if (a->usable != b->usable) {
+        return (a->usable > b->usable) ? -1 : 1;
+    }
+    if (a->first_ord != b->first_ord) {
+        return (a->first_ord < b->first_ord) ? -1 : 1;
+    }
+    return 0;
+}
+
+static int32_t
+or_lookup_oid_in_list(const char *const *list, const char *oid)
+{
+    if (oid == NULL) {
+        return 0;
+    }
+    for (; *list; list++) {
+        if (strcmp(*list, oid) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int32_t
+or_lookup_mr_in_list(char **mr_names)
+{
+    const char *const *oid;
+
+    if (mr_names == NULL) {
+        return 0;
+    }
+    for (oid = or_lookup_mr_oids; *oid; oid++) {
+        char **name;
+        for (name = mr_names; *name; name++) {
+            if (strcmp(*name, *oid) == 0) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+/*
+ * A branch may join a table for type T iff it is an equality test on
+ * exactly T, without attribute options, whose value was normalized and
+ * passed the schema check.
+ */
+static int32_t
+or_lookup_child_hashable(const struct slapi_filter *fc, const char *type)
+{
+    if (fc->f_choice != LDAP_FILTER_EQUALITY) {
+        return 0;
+    }
+    if (fc->f_flags & (SLAPI_FILTER_INVALID_ATTR_UNDEFINE | SLAPI_FILTER_INVALID_ATTR_WARN)) {
+        return 0;
+    }
+    if ((fc->f_flags & SLAPI_FILTER_NORMALIZED_VALUE) == 0) {
+        return 0;
+    }
+    if (fc->f_ava.ava_type == NULL || fc->f_ava.ava_value.bv_val == NULL) {
+        return 0;
+    }
+    if (strchr(fc->f_ava.ava_type, ';') != NULL) {
+        return 0;
+    }
+    return (strcasecmp(fc->f_ava.ava_type, type) == 0);
+}
+
+/*
+ * filter_normalize_ava sets SLAPI_FILTER_NORMALIZED_VALUE even when DN
+ * normalization failed, leaving raw bytes under the flag.  The classic
+ * walk compares those raw against raw; a table probe never could.
+ * Accept a key only if it is a fixed point of slapi_dn_normalize_case_ext.
+ */
+static int32_t
+or_lookup_dn_key_valid(const char *key, size_t key_len)
+{
+    char *copy;
+    char *dest = NULL;
+    size_t dlen = 0;
+    int rc;
+    int32_t valid = 0;
+
+    copy = slapi_ch_malloc(key_len + 1);
+    memcpy(copy, key, key_len);
+    copy[key_len] = '\0';
+
+    rc = slapi_dn_normalize_case_ext(copy, key_len, &dest, &dlen);
+    if (rc == 0) {
+        /* normalized in place; not NUL terminated */
+        valid = (dlen == key_len && memcmp(dest, key, key_len) == 0);
+    } else if (rc > 0) {
+        valid = (dlen == key_len && memcmp(dest, key, key_len) == 0);
+        slapi_ch_free_string(&dest);
+    }
+    slapi_ch_free_string(&copy);
+    return valid;
+}
+
+/* The type qualifies when its syntax and equality rule are both allowlisted. */
+static int32_t
+or_lookup_type_supported(const char *type, int32_t *is_dn)
+{
+    Slapi_Attr sattr = {0};
+    const char *syntax_oid = NULL;
+    int32_t supported = 0;
+
+    *is_dn = 0;
+    slapi_attr_init(&sattr, type);
+    if (sattr.a_plugin == NULL) {
+        slapi_attr_init_syntax(&sattr);
+    }
+    if (sattr.a_plugin != NULL) {
+        syntax_oid = sattr.a_plugin->plg_syntax_oid;
+    }
+    if (!or_lookup_oid_in_list(or_lookup_syntax_oids, syntax_oid)) {
+        goto done;
+    }
+    if (sattr.a_mr_eq_plugin != NULL &&
+        !or_lookup_mr_in_list(sattr.a_mr_eq_plugin->plg_mr_names)) {
+        goto done;
+    }
+    *is_dn = (strcmp(syntax_oid, DN_SYNTAX_OID) == 0);
+    supported = 1;
+
+done:
+    attr_done(&sattr);
+    return supported;
+}
+
+/* Return the table-key length, or zero when the branch stays on the walk. */
+static size_t
+or_lookup_child_key_len(const struct slapi_filter *fc, const char *type,
+                        int32_t is_dn)
+{
+    size_t key_len;
+
+    if (!or_lookup_child_hashable(fc, type)) {
+        return 0;
+    }
+
+    /* filter_normalize_ava can shrink the value without refreshing bv_len. */
+    key_len = strlen(fc->f_ava.ava_value.bv_val);
+    if (key_len == 0 ||
+        (is_dn && !or_lookup_dn_key_valid(fc->f_ava.ava_value.bv_val, key_len))) {
+        return 0;
+    }
+    return key_len;
+}
+
+/* Sort by key (length, then bytes); equal keys by list position. */
+static int
+or_lookup_key_cmp(const void *ap, const void *bp)
+{
+    const struct slapi_filter_or_key *a = (const struct slapi_filter_or_key *)ap;
+    const struct slapi_filter_or_key *b = (const struct slapi_filter_or_key *)bp;
+    int rc;
+
+    if (a->ok_len != b->ok_len) {
+        return (a->ok_len < b->ok_len) ? -1 : 1;
+    }
+    rc = memcmp(a->ok_key, b->ok_key, a->ok_len);
+    if (rc != 0) {
+        return rc;
+    }
+    if (a->ok_ord != b->ok_ord) {
+        return (a->ok_ord < b->ok_ord) ? -1 : 1;
+    }
+    return 0;
+}
+
+/* bsearch comparator: probe key against a table slot (keys are unique). */
+static int
+or_lookup_probe_cmp(const void *keyp, const void *slotp)
+{
+    const struct berval *key = (const struct berval *)keyp;
+    const struct slapi_filter_or_key *slot = (const struct slapi_filter_or_key *)slotp;
+
+    if ((size_t)key->bv_len != slot->ok_len) {
+        return ((size_t)key->bv_len < slot->ok_len) ? -1 : 1;
+    }
+    return memcmp(key->bv_val, slot->ok_key, slot->ok_len);
+}
+
+struct slapi_filter *
+filter_or_lookup_probe(const struct slapi_filter_or_lookup *ol, const struct berval *key)
+{
+    const struct slapi_filter_or_key *slot;
+
+    slot = (const struct slapi_filter_or_key *)bsearch(key, ol->ol_tab, ol->ol_tab_len,
+                                                       sizeof(struct slapi_filter_or_key),
+                                                       or_lookup_probe_cmp);
+    return slot ? slot->ok_branch : NULL;
+}
+
+void
+filter_or_lookup_free(struct slapi_filter_or_lookup **ol)
+{
+    if (ol == NULL || *ol == NULL) {
+        return;
+    }
+    slapi_ch_free((void **)&(*ol)->ol_tab);
+    slapi_ch_free((void **)&(*ol)->ol_rest);
+    slapi_ch_free_string(&(*ol)->ol_type);
+    slapi_ch_free((void **)ol);
+}
+
+/*
+ * Build the table for one OR node and one type.  Returns the member
+ * count before dedup (the k the walk would have paid), or 0.
+ */
+static int32_t
+or_lookup_annotate_type(struct slapi_filter *f, const char *type, int32_t is_dn,
+                        int32_t boolean_ctx)
+{
+    struct slapi_filter *fc;
+    struct slapi_filter_or_key *tab = NULL;
+    struct slapi_filter **rest = NULL;
+    struct slapi_filter_or_lookup *ol = NULL;
+    size_t n_children = 0;
+    size_t tab_n = 0;
+    size_t rest_n = 0;
+    size_t uniq;
+    size_t i;
+    uint32_t ord = 0;
+
+    for (fc = f->f_or; fc != NULL; fc = fc->f_next) {
+        n_children++;
+    }
+
+    tab = (struct slapi_filter_or_key *)slapi_ch_calloc(n_children, sizeof(*tab));
+    rest = (struct slapi_filter **)slapi_ch_calloc(n_children, sizeof(*rest));
+
+    for (fc = f->f_or; fc != NULL; fc = fc->f_next, ord++) {
+        size_t key_len = or_lookup_child_key_len(fc, type, is_dn);
+
+        if (key_len > 0) {
+            tab[tab_n].ok_key = fc->f_ava.ava_value.bv_val;
+            tab[tab_n].ok_len = key_len;
+            tab[tab_n].ok_branch = fc;
+            tab[tab_n].ok_ord = ord;
+            tab_n++;
+        } else {
+            rest[rest_n++] = fc;
+        }
+    }
+
+    /* The preflight count and this pass must agree. */
+    if (tab_n < FILTER_OR_LOOKUP_THRESHOLD) {
+        slapi_ch_free((void **)&tab);
+        slapi_ch_free((void **)&rest);
+        return 0;
+    }
+
+    qsort(tab, tab_n, sizeof(*tab), or_lookup_key_cmp);
+    /* Collapse duplicate keys.  Same type and value means the same
+     * outcome, so which branch wins is unobservable. */
+    uniq = 0;
+    for (i = 1; i < tab_n; i++) {
+        if (tab[uniq].ok_len != tab[i].ok_len ||
+            memcmp(tab[uniq].ok_key, tab[i].ok_key, tab[i].ok_len) != 0) {
+            uniq++;
+            if (uniq != i) {
+                tab[uniq] = tab[i];
+            }
+        }
+    }
+
+    ol = (struct slapi_filter_or_lookup *)slapi_ch_calloc(1, sizeof(*ol));
+    ol->ol_type = slapi_ch_strdup(type);
+    ol->ol_type_is_dn = is_dn;
+    ol->ol_boolean_ctx = boolean_ctx;
+    ol->ol_tab = tab;
+    ol->ol_tab_len = uniq + 1;
+    ol->ol_rest = rest;
+    ol->ol_rest_len = rest_n;
+    f->f_or_lookup = ol;
+
+    return (int32_t)tab_n;
+}
+
+static int32_t
+or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
+{
+    struct slapi_filter *fc;
+    struct or_lookup_family *families = NULL;
+    struct or_lookup_family *family;
+    PLHashTable *by_type = NULL;
+    size_t n_children = 0;
+    size_t n_families = 0;
+    size_t ord = 0;
+    size_t i;
+    int32_t k = 0;
+
+    if (f->f_or_lookup != NULL) {
+        return 0;
+    }
+
+    for (fc = f->f_or; fc != NULL; fc = fc->f_next) {
+        n_children++;
+    }
+    if (n_children < FILTER_OR_LOOKUP_THRESHOLD) {
+        return 0;
+    }
+
+    /* families[] keeps first-occurrence order; the hash is lookup only. */
+    families = (struct or_lookup_family *)slapi_ch_calloc(n_children,
+                                                           sizeof(*families));
+    by_type = PL_NewHashTable((PRUint32)n_children,
+                              hashNocaseString,
+                              hashNocaseCompare,
+                              PL_CompareValues, 0, 0);
+    if (by_type == NULL) {
+        goto done;
+    }
+
+    for (fc = f->f_or; fc != NULL; fc = fc->f_next, ord++) {
+        const char *type;
+
+        if (fc->f_choice != LDAP_FILTER_EQUALITY || fc->f_ava.ava_type == NULL ||
+            strchr(fc->f_ava.ava_type, ';') != NULL) {
+            continue;
+        }
+
+        type = fc->f_ava.ava_type;
+        family = (struct or_lookup_family *)PL_HashTableLookup(by_type, type);
+        if (family == NULL) {
+            family = &families[n_families];
+            family->type = type;
+            family->first_ord = ord;
+            if (PL_HashTableAdd(by_type, family->type, family) == NULL) {
+                goto done;
+            }
+            n_families++;
+        }
+        if (or_lookup_child_hashable(fc, family->type)) {
+            family->eligible++;
+        }
+    }
+
+    /* Resolve support, then count exact usable members per family. */
+    for (i = 0; i < n_families; i++) {
+        if (families[i].eligible < FILTER_OR_LOOKUP_THRESHOLD) {
+            continue;
+        }
+        families[i].supported = or_lookup_type_supported(families[i].type,
+                                                         &families[i].is_dn);
+    }
+    for (fc = f->f_or; fc != NULL; fc = fc->f_next) {
+        if (fc->f_choice != LDAP_FILTER_EQUALITY || fc->f_ava.ava_type == NULL ||
+            strchr(fc->f_ava.ava_type, ';') != NULL) {
+            continue;
+        }
+        family = (struct or_lookup_family *)PL_HashTableLookup(by_type,
+                                                               fc->f_ava.ava_type);
+        if (family != NULL && family->supported &&
+            or_lookup_child_key_len(fc, family->type, family->is_dn) > 0) {
+            family->usable++;
+        }
+    }
+
+    PL_HashTableDestroy(by_type);
+    by_type = NULL;
+    qsort(families, n_families, sizeof(*families), or_lookup_family_cmp);
+
+    for (i = 0;
+         i < n_families && families[i].usable >= FILTER_OR_LOOKUP_THRESHOLD;
+         i++) {
+        k = or_lookup_annotate_type(f, families[i].type, families[i].is_dn,
+                                    boolean_ctx);
+        if (k > 0) {
+            break;
+        }
+    }
+
+done:
+    if (by_type != NULL) {
+        PL_HashTableDestroy(by_type);
+    }
+    slapi_ch_free((void **)&families);
+    return k;
+}
+
+static int32_t
+or_lookup_build_recurse(struct slapi_filter *f, int32_t depth, int32_t *largest,
+                        int32_t boolean_ctx)
+{
+    struct slapi_filter *fc;
+    int32_t count = 0;
+    int32_t k;
+
+    if (f == NULL || depth >= FILTER_OR_LOOKUP_DEPTH_LIMIT) {
+        return 0;
+    }
+
+    switch (f->f_choice) {
+    case LDAP_FILTER_OR:
+        k = or_lookup_annotate(f, boolean_ctx);
+        if (k > 0) {
+            count++;
+            if (k > *largest) {
+                *largest = k;
+            }
+        }
+    /* FALLTHROUGH */
+    case LDAP_FILTER_AND:
+        for (fc = f->f_list; fc != NULL; fc = fc->f_next) {
+            count += or_lookup_build_recurse(fc, depth + 1, largest, boolean_ctx);
+        }
+        break;
+    case LDAP_FILTER_NOT:
+        /* Below a NOT the -1/undefined distinction is observable again. */
+        for (fc = f->f_list; fc != NULL; fc = fc->f_next) {
+            count += or_lookup_build_recurse(fc, depth + 1, largest, 0);
+        }
+        break;
+    default:
+        break;
+    }
+    return count;
+}
+
+/*
+ * Annotate every qualifying OR node under f.  Returns the number of
+ * annotated nodes; *largest gets the biggest member count.  Caller must
+ * own f exclusively.  boolean_ctx means the operation reads the filter
+ * test as plain match/non-match (not VLV); cleared while under a NOT.
+ */
+int32_t
+filter_or_lookup_build(struct slapi_filter *f, int32_t *largest, int32_t boolean_ctx)
+{
+    if (!config_get_enable_or_filter_lookup()) {
+        return 0;
+    }
+    return or_lookup_build_recurse(f, 0, largest, boolean_ctx);
+}

--- a/ldap/servers/slapd/filter_or_lookup.c
+++ b/ldap/servers/slapd/filter_or_lookup.c
@@ -82,6 +82,18 @@ struct or_lookup_family {
     int32_t supported;
 };
 
+/*
+ * Per-child memo carried from the counting passes into the table fill,
+ * so each branch resolves its family and key length exactly once.  The
+ * family index is only valid until families[] is sorted; the fill pass
+ * matches on fam_first_ord, which survives the sort.
+ */
+struct or_lookup_child_scratch {
+    int32_t fam_idx;      /* index into families[]; -1 = no family */
+    size_t fam_first_ord; /* stable family identity; SIZE_MAX = none */
+    size_t key_len;       /* memoized or_lookup_child_key_len; 0 = unusable */
+};
+
 static int
 or_lookup_family_cmp(const void *ap, const void *bp)
 {
@@ -301,7 +313,9 @@ filter_or_lookup_free(struct slapi_filter_or_lookup **ol)
  */
 static int32_t
 or_lookup_annotate_type(struct slapi_filter *f, const char *type, int32_t is_dn,
-                        int32_t boolean_ctx)
+                        int32_t boolean_ctx,
+                        const struct or_lookup_child_scratch *scratch,
+                        size_t win_first_ord)
 {
     struct slapi_filter *fc;
     struct slapi_filter_or_key *tab = NULL;
@@ -322,7 +336,9 @@ or_lookup_annotate_type(struct slapi_filter *f, const char *type, int32_t is_dn,
     rest = (struct slapi_filter **)slapi_ch_calloc(n_children, sizeof(*rest));
 
     for (fc = f->f_or; fc != NULL; fc = fc->f_next, ord++) {
-        size_t key_len = or_lookup_child_key_len(fc, type, is_dn);
+        size_t key_len = (scratch[ord].fam_first_ord == win_first_ord)
+                             ? scratch[ord].key_len
+                             : 0;
 
         if (key_len > 0) {
             tab[tab_n].ok_key = fc->f_ava.ava_value.bv_val;
@@ -335,7 +351,8 @@ or_lookup_annotate_type(struct slapi_filter *f, const char *type, int32_t is_dn,
         }
     }
 
-    /* The preflight count and this pass must agree. */
+    /* Agrees with the preflight count by construction: both read the
+     * same per-child memo. */
     if (tab_n < FILTER_OR_LOOKUP_THRESHOLD) {
         slapi_ch_free((void **)&tab);
         slapi_ch_free((void **)&rest);
@@ -375,6 +392,7 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
     struct slapi_filter *fc;
     struct or_lookup_family *families = NULL;
     struct or_lookup_family *family;
+    struct or_lookup_child_scratch *scratch = NULL;
     PLHashTable *by_type = NULL;
     size_t n_children = 0;
     size_t n_families = 0;
@@ -396,6 +414,8 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
     /* families[] keeps first-occurrence order; the hash is lookup only. */
     families = (struct or_lookup_family *)slapi_ch_calloc(n_children,
                                                            sizeof(*families));
+    scratch = (struct or_lookup_child_scratch *)slapi_ch_calloc(
+        n_children, sizeof(*scratch));
     by_type = PL_NewHashTable((PRUint32)n_children,
                               hashNocaseString,
                               hashNocaseCompare,
@@ -406,6 +426,9 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
 
     for (fc = f->f_or; fc != NULL; fc = fc->f_next, ord++) {
         const char *type;
+
+        scratch[ord].fam_idx = -1;
+        scratch[ord].fam_first_ord = SIZE_MAX;
 
         if (fc->f_choice != LDAP_FILTER_EQUALITY || fc->f_ava.ava_type == NULL ||
             strchr(fc->f_ava.ava_type, ';') != NULL) {
@@ -423,6 +446,8 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
             }
             n_families++;
         }
+        scratch[ord].fam_idx = (int32_t)(family - families);
+        scratch[ord].fam_first_ord = family->first_ord;
         if (or_lookup_child_hashable(fc, family->type)) {
             family->eligible++;
         }
@@ -436,16 +461,15 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
         families[i].supported = or_lookup_type_supported(families[i].type,
                                                          &families[i].is_dn);
     }
-    for (fc = f->f_or; fc != NULL; fc = fc->f_next) {
-        if (fc->f_choice != LDAP_FILTER_EQUALITY || fc->f_ava.ava_type == NULL ||
-            strchr(fc->f_ava.ava_type, ';') != NULL) {
-            continue;
-        }
-        family = (struct or_lookup_family *)PL_HashTableLookup(by_type,
-                                                               fc->f_ava.ava_type);
-        if (family != NULL && family->supported &&
-            or_lookup_child_key_len(fc, family->type, family->is_dn) > 0) {
-            family->usable++;
+    for (fc = f->f_or, ord = 0; fc != NULL; fc = fc->f_next, ord++) {
+        family = (scratch[ord].fam_idx >= 0) ? &families[scratch[ord].fam_idx]
+                                             : NULL;
+        if (family != NULL && family->supported) {
+            scratch[ord].key_len =
+                or_lookup_child_key_len(fc, family->type, family->is_dn);
+            if (scratch[ord].key_len > 0) {
+                family->usable++;
+            }
         }
     }
 
@@ -457,7 +481,8 @@ or_lookup_annotate(struct slapi_filter *f, int32_t boolean_ctx)
          i < n_families && families[i].usable >= FILTER_OR_LOOKUP_THRESHOLD;
          i++) {
         k = or_lookup_annotate_type(f, families[i].type, families[i].is_dn,
-                                    boolean_ctx);
+                                    boolean_ctx, scratch,
+                                    families[i].first_ord);
         if (k > 0) {
             break;
         }
@@ -467,6 +492,7 @@ done:
     if (by_type != NULL) {
         PL_HashTableDestroy(by_type);
     }
+    slapi_ch_free((void **)&scratch);
     slapi_ch_free((void **)&families);
     return k;
 }

--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -18,12 +18,14 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include "slap.h"
+#include "slapi-private.h"
 
 static int test_filter_list(Slapi_PBlock *pb, Slapi_Entry *e, struct slapi_filter *flist, int ftype, int verify_access, int only_check_access, int *access_check_done);
 static int test_extensible_filter(Slapi_PBlock *callers_pb, Slapi_Entry *e, mr_filter_t *mrf, int verify_access, int only_check_access, int *access_check_done);
 
 static int vattr_test_filter_list_and(Slapi_PBlock *pb, Slapi_Entry *e, struct slapi_filter *flist, int ftype, int verify_access, int only_check_access, int *access_check_done);
 static int vattr_test_filter_list_or(Slapi_PBlock *pb, Slapi_Entry *e, struct slapi_filter *flist, int ftype, int verify_access, int only_check_access, int *access_check_done);
+static int vattr_test_filter_or_lookup(Slapi_PBlock *pb, Slapi_Entry *e, struct slapi_filter *f, int verify_access, int *access_check_done, int32_t *decided);
 
 static int test_filter_access(Slapi_PBlock *pb, Slapi_Entry *e, char *attr_type, struct berval *attr_val);
 static int slapi_vattr_filter_test_ext_internal(Slapi_PBlock *pb, Slapi_Entry *e, struct slapi_filter *f, int verify_access, int only_check_access, int *access_check_done);
@@ -942,10 +944,20 @@ slapi_vattr_filter_test_ext_internal(
                                         LDAP_FILTER_AND, verify_access, only_check_access, access_check_done);
         break;
 
-    case LDAP_FILTER_OR:
-        rc = vattr_test_filter_list_or(pb, e, f->f_or,
-                                       LDAP_FILTER_OR, verify_access, only_check_access, access_check_done);
+    case LDAP_FILTER_OR: {
+        int32_t decided = 0;
+        /* only_check_access mode must visit every component's ACL, so the
+         * lookup shortcut never applies there. */
+        if (f->f_or_lookup != NULL && only_check_access == 0) {
+            rc = vattr_test_filter_or_lookup(pb, e, f, verify_access,
+                                             access_check_done, &decided);
+        }
+        if (!decided) {
+            rc = vattr_test_filter_list_or(pb, e, f->f_or,
+                                           LDAP_FILTER_OR, verify_access, only_check_access, access_check_done);
+        }
         break;
+    }
 
     case LDAP_FILTER_NOT:
         slapi_log_err(SLAPI_LOG_FILTER, "vattr_test_filter_list_NOT", "=>\n");
@@ -1125,4 +1137,182 @@ vattr_test_filter_list_or(
     if (nomatch == 1)
         return undefined;
     return (nomatch);
+}
+
+/*
+ * Evaluate a large OR through its equality lookup table
+ * (filter_or_lookup.c).  Same three-valued semantics as
+ * vattr_test_filter_list_or: 0 when an accessible component matches,
+ * else -1 when some component is defined-false, else undefined (>0).
+ * The table only selects which component to test - every returned 0
+ * went through the same access check and match call the walk makes.
+ * Anything the table cannot decide exactly leaves *decided at 0 and the
+ * caller runs the classic walk.
+ *
+ * With no winner, unvisited components could still decide -1 vs
+ * undefined.  In boolean context (ol_boolean_ctx: no NOT ancestor, not
+ * VLV) no consumer can tell those apart, so the pass tests the rest
+ * branches and decides -1; outside it, the pass declines.
+ */
+static int
+vattr_test_filter_or_lookup(
+    Slapi_PBlock *pb,
+    Slapi_Entry *e,
+    struct slapi_filter *f,
+    int verify_access,
+    int *access_check_done,
+    int32_t *decided)
+{
+    const struct slapi_filter_or_lookup *ol = f->f_or_lookup;
+    Slapi_Attr *a;
+    size_t probe_hits = 0;
+    int nomatch_seen = 0; /* some table component confirmed defined-false */
+    int rc;
+
+    *decided = 0;
+
+    /* CoS or Roles could supply this type; only the classic walk
+     * consults the service providers. */
+    if (vattr_type_sp_registered(e, ol->ol_type)) {
+        return 0;
+    }
+
+    /* Many-valued DN entries are cheaper on the classic walk: its sorted
+     * valueset find is O(log m) per component, while every probe pays a
+     * DN normalization. */
+    if (ol->ol_type_is_dn) {
+        size_t m = 0;
+        for (a = e->e_attrs; a != NULL; a = a->a_next) {
+            if (slapi_attr_type_cmp(ol->ol_type, a->a_type, SLAPI_TYPE_CMP_SUBTYPE) == 0) {
+                int n = 0;
+                slapi_attr_get_numvalues(a, &n);
+                m += (size_t)n;
+            }
+        }
+        if (m > ol->ol_tab_len) {
+            return 0;
+        }
+    }
+
+    for (a = e->e_attrs; a != NULL; a = a->a_next) {
+        Slapi_Value **va;
+        size_t i;
+
+        /* Same subtype predicate as test_ava_filter: a base-type
+         * component matches subtyped values too. */
+        if (slapi_attr_type_cmp(ol->ol_type, a->a_type, SLAPI_TYPE_CMP_SUBTYPE) != 0) {
+            continue;
+        }
+        va = attr_get_present_values(a);
+        for (i = 0; va != NULL && va[i] != NULL; i++) {
+            const struct berval *bv = slapi_value_get_berval(va[i]);
+            struct berval probe = {0, NULL};
+            struct slapi_filter *branch;
+            char *copy;
+            char *norm = NULL;
+            int32_t norm_failed = 0;
+
+            if (bv == NULL || bv->bv_val == NULL) {
+                return 0;
+            }
+            /* Normalizers modify their input in place; copy the value. */
+            copy = slapi_ch_malloc(bv->bv_len + 1);
+            memcpy(copy, bv->bv_val, bv->bv_len);
+            copy[bv->bv_len] = '\0';
+            if (ol->ol_type_is_dn) {
+                char *dest = NULL;
+                size_t dlen = 0;
+                int nrc = slapi_dn_normalize_case_ext(copy, bv->bv_len, &dest, &dlen);
+                if (nrc < 0) {
+                    /* Unparseable stored DN: the walk compares its raw
+                     * bytes; the table cannot. */
+                    norm_failed = 1;
+                } else if (nrc == 0) {
+                    probe.bv_val = dest; /* in place, NUL terminated by the fold */
+                    probe.bv_len = strlen(dest); /* dlen predates the case fold */
+                } else {
+                    norm = dest;
+                    probe.bv_val = dest;
+                    probe.bv_len = strlen(dest);
+                }
+            } else {
+                /* Same normalizer and filter type as the table keys. */
+                slapi_attr_value_normalize_ext(NULL, a, NULL, copy, 1, &norm,
+                                               LDAP_FILTER_EQUALITY);
+                probe.bv_val = norm ? norm : copy;
+                probe.bv_len = strlen(probe.bv_val);
+            }
+            if (norm_failed) {
+                slapi_ch_free_string(&copy);
+                return 0;
+            }
+            branch = filter_or_lookup_probe(ol, &probe);
+            if (norm != NULL && norm != copy) {
+                slapi_ch_free_string(&norm);
+            }
+            slapi_ch_free_string(&copy);
+
+            if (branch == NULL) {
+                continue;
+            }
+            probe_hits++;
+            if (verify_access) {
+                /* Access first, on the component the value hit. */
+                rc = slapi_vattr_filter_test_ext_internal(pb, e, branch, verify_access,
+                                                          -1, access_check_done);
+                if (rc != 0) {
+                    /* No access: keep probing; another value may hit an
+                     * allowed component. */
+                    continue;
+                }
+            }
+            rc = slapi_vattr_filter_test_ext_internal(pb, e, branch, 0, 0,
+                                                      access_check_done);
+            if (rc == 0) {
+                *decided = 1;
+                return 0;
+            } else if (rc < 0) {
+                nomatch_seen = 1;
+            }
+            /* Undefined, or the confirm disagreed with the probe: the
+             * no-winner pass below decides. */
+        }
+    }
+
+    /* No winning component. */
+    if (verify_access && !ol->ol_boolean_ctx) {
+        return 0;
+    }
+    if (!ol->ol_boolean_ctx && probe_hits >= ol->ol_tab_len && !nomatch_seen) {
+        /* No defined-false in hand and possibly no unvisited component:
+         * -1 vs undefined is unknown. */
+        return 0;
+    }
+    /* A missed key scores -1 in test_ava_filter, so probe_hits below the
+     * table size means a defined-false is in hand; in boolean context the
+     * -1/undefined placement is unobservable anyway.  Test the rest
+     * branches, then decide. */
+    {
+        size_t i;
+        for (i = 0; i < ol->ol_rest_len; i++) {
+            if (verify_access) {
+                /* Access first: a match the binder cannot read must not
+                 * count. */
+                rc = slapi_vattr_filter_test_ext_internal(pb, e, ol->ol_rest[i],
+                                                          verify_access, -1,
+                                                          access_check_done);
+                if (rc != 0) {
+                    continue;
+                }
+            }
+            rc = slapi_vattr_filter_test_ext_internal(pb, e, ol->ol_rest[i], 0, 0,
+                                                      access_check_done);
+            if (rc == 0) {
+                *decided = 1;
+                return 0;
+            }
+        }
+    }
+    *decided = 1;
+    return -1;
 }

--- a/ldap/servers/slapd/filterentry.c
+++ b/ldap/servers/slapd/filterentry.c
@@ -1208,6 +1208,7 @@ vattr_test_filter_or_lookup(
             const struct berval *bv = slapi_value_get_berval(va[i]);
             struct berval probe = {0, NULL};
             struct slapi_filter *branch;
+            char stack_val[512];
             char *copy;
             char *norm = NULL;
             int32_t norm_failed = 0;
@@ -1215,8 +1216,12 @@ vattr_test_filter_or_lookup(
             if (bv == NULL || bv->bv_val == NULL) {
                 return 0;
             }
-            /* Normalizers modify their input in place; copy the value. */
-            copy = slapi_ch_malloc(bv->bv_len + 1);
+            /* Normalizers modify their input in place; copy the value.
+             * In-place results never outgrow the input, so the stack
+             * buffer needs the same bv_len + 1 bound as the heap path. */
+            copy = (bv->bv_len < sizeof(stack_val))
+                       ? stack_val
+                       : slapi_ch_malloc(bv->bv_len + 1);
             memcpy(copy, bv->bv_val, bv->bv_len);
             copy[bv->bv_len] = '\0';
             if (ol->ol_type_is_dn) {
@@ -1243,14 +1248,18 @@ vattr_test_filter_or_lookup(
                 probe.bv_len = strlen(probe.bv_val);
             }
             if (norm_failed) {
-                slapi_ch_free_string(&copy);
+                if (copy != stack_val) {
+                    slapi_ch_free_string(&copy);
+                }
                 return 0;
             }
             branch = filter_or_lookup_probe(ol, &probe);
             if (norm != NULL && norm != copy) {
                 slapi_ch_free_string(&norm);
             }
-            slapi_ch_free_string(&copy);
+            if (copy != stack_val) {
+                slapi_ch_free_string(&copy);
+            }
 
             if (branch == NULL) {
                 continue;

--- a/ldap/servers/slapd/libglobs.c
+++ b/ldap/servers/slapd/libglobs.c
@@ -266,6 +266,7 @@ slapi_onoff_t init_enable_nunc_stans;
 #endif
 slapi_onoff_t init_extract_pem;
 slapi_onoff_t init_ignore_vattrs;
+slapi_onoff_t init_enable_or_filter_lookup;
 slapi_onoff_t init_enable_upgrade_hash;
 slapi_special_filter_verify_t init_verify_filter_schema;
 slapi_onoff_t init_enable_ldapssotoken;
@@ -1221,6 +1222,10 @@ static struct config_get_and_set
      NULL, 0,
      (void **)&global_slapdFrontendConfig.ignore_vattrs,
      CONFIG_ON_OFF, (ConfigGetFunc)config_get_ignore_vattrs, &init_ignore_vattrs, NULL},
+    {CONFIG_ENABLE_OR_FILTER_LOOKUP, config_set_enable_or_filter_lookup,
+     NULL, 0,
+     (void **)&global_slapdFrontendConfig.enable_or_filter_lookup,
+     CONFIG_ON_OFF, (ConfigGetFunc)config_get_enable_or_filter_lookup, &init_enable_or_filter_lookup, NULL},
     {CONFIG_UNHASHED_PW_SWITCH_ATTRIBUTE, config_set_unhashed_pw_switch,
      NULL, 0,
      (void **)&global_slapdFrontendConfig.unhashed_pw_switch,
@@ -2061,6 +2066,7 @@ FrontendConfig_init(void)
     cfg->ndn_cache_max_size = SLAPD_DEFAULT_NDN_SIZE;
     init_sasl_mapping_fallback = cfg->sasl_mapping_fallback = LDAP_OFF;
     init_ignore_vattrs = cfg->ignore_vattrs = LDAP_ON;
+    init_enable_or_filter_lookup = cfg->enable_or_filter_lookup = LDAP_ON;
     cfg->sasl_max_bufsize = SLAPD_DEFAULT_SASL_MAXBUFSIZE;
     cfg->unhashed_pw_switch = SLAPD_DEFAULT_UNHASHED_PW_SWITCH;
     init_return_orig_type = cfg->return_orig_type = LDAP_OFF;
@@ -2532,6 +2538,14 @@ config_set_ignore_vattrs(const char *attrname, char *value, char *errorbuf, int 
     retVal = config_set_onoff(attrname, value, &(slapdFrontendConfig->ignore_vattrs), errorbuf, apply);
 
     return retVal;
+}
+
+int
+config_set_enable_or_filter_lookup(const char *attrname, char *value, char *errorbuf, int apply)
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    return config_set_onoff(attrname, value, &(slapdFrontendConfig->enable_or_filter_lookup), errorbuf, apply);
 }
 
 int32_t
@@ -6199,6 +6213,14 @@ config_get_ignore_vattrs()
     slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
 
     return (int)slapdFrontendConfig->ignore_vattrs;
+}
+
+int
+config_get_enable_or_filter_lookup()
+{
+    slapdFrontendConfig_t *slapdFrontendConfig = getFrontendConfig();
+
+    return (int)slapdFrontendConfig->enable_or_filter_lookup;
 }
 
 int32_t

--- a/ldap/servers/slapd/proto-slap.h
+++ b/ldap/servers/slapd/proto-slap.h
@@ -601,6 +601,8 @@ int config_set_allowed_sasl_mechs(const char *attrname, char *value, char *error
 int config_get_schemamod(void);
 int config_set_ignore_vattrs(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_ignore_vattrs(void);
+int config_set_enable_or_filter_lookup(const char *attrname, char *value, char *errorbuf, int apply);
+int config_get_enable_or_filter_lookup(void);
 int config_set_sasl_mapping_fallback(const char *attrname, char *value, char *errorbuf, int apply);
 int config_get_sasl_mapping_fallback(void);
 int config_get_unhashed_pw_switch(void);

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -553,12 +553,19 @@ struct subfilt
 /*
  * represents a search filter
  */
+struct slapi_filter_or_lookup; /* slapi-private.h */
 struct slapi_filter
 {
     int f_flags;
     unsigned long f_choice; /* values taken from ldap.h */
     PRUint32 f_hash;        /* for quick comparisons */
     void *assigned_decoder;
+    /*
+     * Equality lookup table for large OR nodes.  Built only on the
+     * backend's per-search filter dups; owned by this node, never copied
+     * by slapi_filter_dup, freed in slapi_filter_free.  NULL elsewhere.
+     */
+    struct slapi_filter_or_lookup *f_or_lookup;
 
     union
     {
@@ -2418,6 +2425,7 @@ typedef struct _slapdEntryPoints
 #define CONFIG_NDN_CACHE_SIZE "nsslapd-ndn-cache-max-size"
 #define CONFIG_ALLOWED_SASL_MECHS "nsslapd-allowed-sasl-mechanisms"
 #define CONFIG_IGNORE_VATTRS "nsslapd-ignore-virtual-attrs"
+#define CONFIG_ENABLE_OR_FILTER_LOOKUP "nsslapd-enable-or-filter-lookup"
 #define CONFIG_SASL_MAPPING_FALLBACK "nsslapd-sasl-mapping-fallback"
 #define CONFIG_SASL_MAXBUFSIZE "nsslapd-sasl-max-buffer-size"
 #define CONFIG_SEARCH_RETURN_ORIGINAL_TYPE "nsslapd-search-return-original-type-switch"
@@ -2762,6 +2770,7 @@ typedef struct _slapdFrontendConfig
     slapi_onoff_t return_orig_type; /* if on, search returns original type set in attr list */
     slapi_onoff_t sasl_mapping_fallback;
     slapi_onoff_t ignore_vattrs;
+    slapi_onoff_t enable_or_filter_lookup; /* equality-lookup tables for large OR filters */
     slapi_onoff_t unhashed_pw_switch; /* switch to on/off/nolog unhashed pw */
     slapi_onoff_t enable_turbo_mode;
     slapi_int_t connection_buffer;    /* values are CONNECTION_BUFFER_* below */

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -522,6 +522,39 @@ struct ava
     void *ava_private;       /* data private to syntax handler */
 };
 
+/*
+ * Lookup table for a large OR of same-attribute equality branches
+ * (filter_or_lookup.c).  Lives on the OR node's f_or_lookup, on the
+ * backend's per-search filter dups only.  Keys and branch pointers are
+ * borrowed from the child nodes, which outlive the table.
+ */
+struct slapi_filter_or_key
+{
+    const char *ok_key;             /* borrowed: branch's normalized ava_value bytes */
+    size_t ok_len;                  /* strlen(ok_key); bv_len can be stale after
+                                     * in-place normalization */
+    struct slapi_filter *ok_branch; /* borrowed child node */
+    uint32_t ok_ord;                /* list position; duplicate keys collapse to lowest */
+};
+
+struct slapi_filter_or_lookup
+{
+    char *ol_type;                       /* owned; the shared attribute type */
+    int32_t ol_type_is_dn;               /* DN syntax: value-count guard and key validation apply */
+    int32_t ol_boolean_ctx;              /* no NOT ancestor, not VLV: -1 vs undefined
+                                          * is unobservable, a no-winner pass may decide */
+    struct slapi_filter_or_key *ol_tab;  /* owned array, sorted by (ok_len, memcmp) */
+    size_t ol_tab_len;
+    struct slapi_filter **ol_rest;       /* owned array of borrowed non-table children */
+    size_t ol_rest_len;
+};
+
+int32_t filter_or_lookup_build(struct slapi_filter *f, int32_t *largest, int32_t boolean_ctx);
+void filter_or_lookup_free(struct slapi_filter_or_lookup **ol);
+struct slapi_filter *filter_or_lookup_probe(const struct slapi_filter_or_lookup *ol,
+                                            const struct berval *key);
+int32_t vattr_type_sp_registered(Slapi_Entry *e, const char *type);
+
 typedef enum {
     FILTER_TYPE_SUBSTRING,
     FILTER_TYPE_AVA,

--- a/ldap/servers/slapd/vattr.c
+++ b/ldap/servers/slapd/vattr.c
@@ -530,6 +530,26 @@ vattr_context_is_loop_msg_displayed(vattr_context **c)
 }
 
 /*
+ * Whether any virtual-attribute service provider serves "type" for this
+ * entry's namespace - the same lookup vattr_test_filter performs per
+ * component.  The OR lookup fast path declines such types so CoS and
+ * Roles keep the classic evaluation.
+ */
+int32_t
+vattr_type_sp_registered(Slapi_Entry *e, const char *type)
+{
+    Slapi_DN *sdn;
+    Slapi_Backend *be;
+    Slapi_DN *namespace_dn;
+
+    sdn = slapi_entry_get_sdn(e);
+    be = slapi_be_select(sdn);
+    namespace_dn = (Slapi_DN *)slapi_be_getsuffix(be, 0);
+
+    return (vattr_map_namespace_sp_getlist(namespace_dn, type) != NULL);
+}
+
+/*
  * vattr_test_filter:
  *
  * . tests an ava, presence or substring filter against e.


### PR DESCRIPTION
Description:
The per-entry filter test walks every OR branch for every candidate entry, and each branch re-normalizes the entry's values through the syntax plugin, so a filter like (|(uid=v1)...(uid=v1000)) costs candidates x branches even when fully indexed. The time is there, not in candidate generation: the same 1000-branch OR costs 7 ms when 999 values are absent and over a second when all are live.

Build a sorted table of the branch values once per search, on the backend's private normalized filter copy, and let each entry find its branch with one normalization and a binary search. The table only selects which branch to test: a hit still runs the same access check and match call as the classic walk, all-miss entries are decided directly where false and undefined are indistinguishable (no NOT ancestor, not VLV), and anything the table cannot decide exactly falls back to the untouched walk.

Eligibility is narrow: at least 16 equality branches on one attribute, a string-family or DN syntax whose equality is byte equality of the normalized forms, a standard matching rule, and no attribute options. The largest qualifying family wins, first occurrence breaking ties. nsslapd-enable-or-filter-lookup (default on) turns the feature off.

On a 100,000-entry database 10,000-candidate search drops from 23 s to 0.4 s, with no regression beyond noise on ineligible shapes.

Also fix a latent double free in list_candidates: idl_set_insert_idl frees an ALLIDS list it is handed, so stop keeping a local alias to it.

Coverage: result parity across matching rules, ACLs, paging, and VLV; strict log-based feature contracts; an ASan filter-lifecycle module.

Fixes: https://github.com/389ds/389-ds-base/issues/7664
Relates: https://github.com/389ds/389-ds-base/issues/6275

Assisted by: Claude (investigation and tests)

Reviewed by: ?