### PR TITLE
Issue 7666 - Replication performance degradation during total init on…

### DIFF
--- a/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
+++ b/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
@@ -1,0 +1,210 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import logging
+import os
+import time
+import pytest
+
+from lib389._constants import (
+    DEFAULT_SUFFIX,
+    DEFAULT_BENAME,
+    TASK_WAIT,
+    ReplicaRole,
+)
+from lib389.config import LMDB_LDBMConfig
+from lib389.dbgen import dbgen_users
+from lib389.replica import Replicas
+from lib389.tasks import Tasks
+from lib389.utils import get_default_db_lib
+from test389.topologies import create_topology
+
+pytestmark = [
+    pytest.mark.tier2,
+    pytest.mark.skipif(get_default_db_lib() == "bdb", reason="MDB-specific test"),
+]
+
+log = logging.getLogger(__name__)
+
+NUM_ENTRIES = 100_000
+REINIT_TIMEOUT = 600
+
+
+@pytest.fixture(scope="function")
+def topology_m1c1(request):
+    """Function-scoped supplier + consumer topology."""
+    return create_topology({
+        ReplicaRole.SUPPLIER: 1,
+        ReplicaRole.CONSUMER: 1,
+    }, request=request)
+
+
+@pytest.fixture(scope="function")
+def loaded_m1c1(topology_m1c1):
+    """Supplier + consumer with NUM_ENTRIES loaded and flow control tuned."""
+    supplier = topology_m1c1.ms["supplier1"]
+
+    for inst in topology_m1c1:
+        inst.config.set('nsslapd-accesslog-logbuffering', 'on')
+        inst.config.set('nsslapd-errorlog-level', '0')
+        inst.config.set('nsslapd-accesslog-level', '256')
+
+    ldif_file = os.path.join(supplier.get_ldif_dir(), "nosync_test.ldif")
+    dbgen_users(supplier, NUM_ENTRIES, ldif_file, DEFAULT_SUFFIX, generic=True)
+    Tasks(supplier).importLDIF(
+        benamebase=DEFAULT_BENAME,
+        input_file=ldif_file,
+        args={TASK_WAIT: True},
+    )
+
+    agmt = Replicas(supplier).get(DEFAULT_SUFFIX).get_agreements().list()[0]
+    agmt.replace('nsds5ReplicaFlowControlWindow', '3000')
+    agmt.replace('nsds5ReplicaFlowControlPause', '5')
+
+    return topology_m1c1, agmt
+
+
+def _do_reinit(agmt, timeout):
+    """Start total init and wait for completion."""
+    prev_end = agmt.get_attr_val_utf8('nsds5replicaLastInitEnd') or ''
+    agmt.begin_reinit()
+
+    elapsed = 0
+    while elapsed < timeout:
+        status = agmt.get_attr_val_utf8('nsds5replicaLastInitStatus') or ''
+        cur_end = agmt.get_attr_val_utf8('nsds5replicaLastInitEnd') or ''
+
+        if 'replica busy' in status:
+            return (False, status)
+        if 'Replication error' in status or 'LDAP error' in status:
+            return (False, status)
+        if cur_end != prev_end and 'Total update succeeded' in status:
+            return (True, False)
+
+        time.sleep(2)
+        elapsed += 2
+
+    return (False, f"Timeout after {timeout}s, status: {status}")
+
+
+def _create_loaded_topology():
+    """Create a fresh supplier+consumer with entries loaded and flow control tuned."""
+    topology = create_topology({
+        ReplicaRole.SUPPLIER: 1,
+        ReplicaRole.CONSUMER: 1,
+    })
+
+    supplier = topology.ms["supplier1"]
+
+    for inst in topology:
+        inst.config.set('nsslapd-accesslog-logbuffering', 'on')
+        inst.config.set('nsslapd-errorlog-level', '0')
+        inst.config.set('nsslapd-accesslog-level', '256')
+
+    ldif_file = os.path.join(supplier.get_ldif_dir(), "nosync_test.ldif")
+    dbgen_users(supplier, NUM_ENTRIES, ldif_file, DEFAULT_SUFFIX, generic=True)
+    Tasks(supplier).importLDIF(
+        benamebase=DEFAULT_BENAME,
+        input_file=ldif_file,
+        args={TASK_WAIT: True},
+    )
+
+    agmt = Replicas(supplier).get(DEFAULT_SUFFIX).get_agreements().list()[0]
+    agmt.replace('nsds5ReplicaFlowControlWindow', '3000')
+    agmt.replace('nsds5ReplicaFlowControlPause', '5')
+
+    return topology, agmt
+
+
+def test_online_import_nosync_config(topology_m1c1):
+    """Test that nsslapd-mdb-online-import-nosync can be set and read.
+
+    :id: b4f7c8a1-2d3e-4f5a-9b6c-7d8e9f0a1b2c
+    :setup: Supplier + Consumer
+    :steps:
+        1. Verify default value is "off"
+        2. Set to "on" and verify
+        3. Set back to "off" and verify
+    :expectedresults:
+        1. Default is "off"
+        2. Value is "on"
+        3. Value is "off"
+    """
+    consumer = topology_m1c1.cs["consumer1"]
+    mdb_config = LMDB_LDBMConfig(consumer)
+
+    val = mdb_config.get_attr_val_utf8('nsslapd-mdb-online-import-nosync')
+    assert val == 'off', f"Expected default 'off', got '{val}'"
+
+    mdb_config.set('nsslapd-mdb-online-import-nosync', 'on')
+    val = mdb_config.get_attr_val_utf8('nsslapd-mdb-online-import-nosync')
+    assert val == 'on', f"Expected 'on', got '{val}'"
+
+    mdb_config.set('nsslapd-mdb-online-import-nosync', 'off')
+    val = mdb_config.get_attr_val_utf8('nsslapd-mdb-online-import-nosync')
+    assert val == 'off', f"Expected 'off', got '{val}'"
+
+
+def test_online_import_nosync_throughput():
+    """Test that total init with nosync=on is faster than nosync=off.
+
+    :id: c5e8d9b2-3f4a-5b6c-0d7e-8f9a0b1c2d3e
+    :setup: Two fresh Supplier + Consumer topologies with 100K entries
+    :steps:
+        1. Run total init with nosync=off, measure time
+        2. Run total init with nosync=on, measure time
+        3. Verify nosync=on is faster than nosync=off
+    :expectedresults:
+        1. Init completes
+        2. Init completes
+        3. nosync=on is faster
+    """
+    results = {}
+
+    for nosync in ["off", "on"]:
+        topology, agmt = _create_loaded_topology()
+        consumer = topology.cs["consumer1"]
+
+        LMDB_LDBMConfig(consumer).set('nsslapd-mdb-online-import-nosync', nosync)
+
+        log.info(f"Starting total init with nosync={nosync} ...")
+        start = time.time()
+        (done, error) = _do_reinit(agmt, REINIT_TIMEOUT)
+        duration = time.time() - start
+        rate = NUM_ENTRIES / duration if duration > 0 else 0
+        log.info(f"nosync={nosync}: {duration:.1f}s, {rate:.0f} entries/sec")
+
+        for inst in topology:
+            inst.delete()
+
+        assert done, f"Total init with nosync={nosync} failed: {error}"
+        results[nosync] = {"duration": duration, "rate": rate}
+
+    log.info(
+        f"\n{'='*60}\n"
+        f"RESULT:\n"
+        f"  nosync=off: {results['off']['duration']:.1f}s "
+        f"({results['off']['rate']:.0f}/sec)\n"
+        f"  nosync=on:  {results['on']['duration']:.1f}s "
+        f"({results['on']['rate']:.0f}/sec)\n"
+        f"  Speedup:    "
+        f"{results['off']['duration'] / results['on']['duration']:.1f}x\n"
+        f"{'='*60}"
+    )
+
+    assert results['on']['duration'] < results['off']['duration'], (
+        f"nosync=on ({results['on']['duration']:.1f}s) should be faster "
+        f"than nosync=off ({results['off']['duration']:.1f}s)"
+    )
+
+
+if __name__ == '__main__':
+    # Run isolated
+    # -s for DEBUG mode
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main("-s %s" % CURRENT_FILE)

--- a/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
+++ b/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
@@ -150,6 +150,39 @@ def test_online_import_nosync_config(topology_m1c1):
     assert val == 'off', f"Expected 'off', got '{val}'"
 
 
+def test_online_import_nosync_logging(loaded_m1c1):
+    """Test that MDB_NOSYNC engage/clear is logged during online import.
+
+    :id: a3b2c1d0-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+    :setup: Supplier + Consumer with entries loaded
+    :steps:
+        1. Enable nsslapd-mdb-online-import-nosync on consumer
+        2. Run total init
+        3. Check consumer error log for MDB_NOSYNC enabled message
+        4. Check consumer error log for MDB_NOSYNC cleared message
+    :expectedresults:
+        1. Config set succeeds
+        2. Total init completes
+        3. Log contains "MDB_NOSYNC enabled for online import"
+        4. Log contains "MDB_NOSYNC cleared"
+    """
+    topology, agmt = loaded_m1c1
+    consumer = topology.cs["consumer1"]
+
+    LMDB_LDBMConfig(consumer).set('nsslapd-mdb-online-import-nosync', 'on')
+
+    (done, error) = _do_reinit(agmt, REINIT_TIMEOUT)
+    assert done, f"Total init failed: {error}"
+
+    # Check that the engage message was logged
+    assert consumer.searchErrorsLog("MDB_NOSYNC enabled for online import"), \
+        "Expected 'MDB_NOSYNC enabled for online import' in consumer error log"
+
+    # Check that the clear message was logged
+    assert consumer.searchErrorsLog("MDB_NOSYNC cleared"), \
+        "Expected 'MDB_NOSYNC cleared' in consumer error log"
+
+
 def test_online_import_nosync_throughput():
     """Test that total init with nosync=on is faster than nosync=off.
 

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_config.c
@@ -499,6 +499,28 @@ dbmdb_ctx_t_db_import_stats_set(void *arg, void *value, char *errorbuf __attribu
     return retval;
 }
 
+static void *
+dbmdb_ctx_t_db_online_import_nosync_get(void *arg)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+
+    return (void *)((uintptr_t)(MDB_CONFIG(li)->dsecfg.online_import_nosync));
+}
+
+static int
+dbmdb_ctx_t_db_online_import_nosync_set(void *arg, void *value, char *errorbuf __attribute__((unused)), int phase __attribute__((unused)), int apply)
+{
+    struct ldbminfo *li = (struct ldbminfo *)arg;
+    int retval = LDAP_SUCCESS;
+    int val = (int)((uintptr_t)value);
+
+    if (apply) {
+        MDB_CONFIG(li)->dsecfg.online_import_nosync = val;
+    }
+
+    return retval;
+}
+
 static int
 dbmdb_ctx_t_set_bypass_filter_test(void *arg,
                                    void *value,
@@ -612,6 +634,7 @@ static config_info dbmdb_ctx_t_param[] = {
     {CONFIG_MAXPASSBEFOREMERGE, CONFIG_TYPE_INT, "100", &dbmdb_ctx_t_maxpassbeforemerge_get, &dbmdb_ctx_t_maxpassbeforemerge_set, 0},
     {CONFIG_DB_DURABLE_TRANSACTIONS, CONFIG_TYPE_ONOFF, "on", &dbmdb_ctx_t_db_durable_transactions_get, &dbmdb_ctx_t_db_durable_transactions_set, CONFIG_FLAG_ALWAYS_SHOW},
     {CONFIG_MDB_IMPORT_STATS, CONFIG_TYPE_ONOFF, "off", &dbmdb_ctx_t_db_import_stats_get, &dbmdb_ctx_t_db_import_stats_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
+    {CONFIG_MDB_ONLINE_IMPORT_NOSYNC, CONFIG_TYPE_ONOFF, "off", &dbmdb_ctx_t_db_online_import_nosync_get, &dbmdb_ctx_t_db_online_import_nosync_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_BYPASS_FILTER_TEST, CONFIG_TYPE_STRING, "on", &dbmdb_ctx_t_get_bypass_filter_test, &dbmdb_ctx_t_set_bypass_filter_test, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_SERIAL_LOCK, CONFIG_TYPE_ONOFF, "on", &dbmdb_ctx_t_serial_lock_get, &dbmdb_ctx_t_serial_lock_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},
     {CONFIG_CACHE_AUTOSIZE, CONFIG_TYPE_INT, "25", &mdb_config_cache_autosize_get, &mdb_config_cache_autosize_set, CONFIG_FLAG_ALWAYS_SHOW | CONFIG_FLAG_ALLOW_RUNNING_CHANGE},

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -781,23 +781,24 @@ dbmdb_import_all_done(ImportJob *job, int ret)
             index->ai->ai_indexmask &= ~INDEX_OFFLINE;
             index = index->next;
         }
-        /* Re-enable fsync before going back online */
-        {
+        /* Re-enable fsync before going back online, but only if we set it */
+        if (job->nosync_set) {
             struct ldbminfo *li = (struct ldbminfo *)inst->inst_be->be_database->plg_private;
             dbmdb_ctx_t *ctx = MDB_CONFIG(li);
             if (ctx->env) {
-                unsigned int env_flags = 0;
-                mdb_env_get_flags(ctx->env, &env_flags);
-                if (env_flags & MDB_NOSYNC) {
-                    int nosync_rc = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 0);
-                    if (nosync_rc != 0) {
-                        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_import_all_done",
-                                      "Failed to clear MDB_NOSYNC flag "
-                                      "(error %d: %s)\n",
-                                      nosync_rc, mdb_strerror(nosync_rc));
-                    }
+                int nosync_rc = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 0);
+                if (nosync_rc != 0) {
+                    slapi_log_err(SLAPI_LOG_ERR, "dbmdb_import_all_done",
+                                  "Failed to clear MDB_NOSYNC flag "
+                                  "(error %d: %s)\n",
+                                  nosync_rc, mdb_strerror(nosync_rc));
+                } else {
+                    slapi_log_err(SLAPI_LOG_INFO, "dbmdb_import_all_done",
+                                  "MDB_NOSYNC cleared. "
+                                  "Per-commit fsync re-enabled.\n");
                 }
             }
+            job->nosync_set = 0;
         }
         /* start up the instance */
         rc = dbmdb_instance_start(job->inst->inst_be, DBLAYER_NORMAL_MODE);
@@ -1171,6 +1172,30 @@ error:
         priv->dblayer_auto_tune_fn(li);
     }
 
+    /*
+     * If NOSYNC was set by us and not yet cleared (e.g. import thread failed
+     * before reaching dbmdb_import_all_done), clear it now to restore
+     * durability for all backends.
+     */
+    if (job->nosync_set) {
+        struct ldbminfo *li = inst->inst_li;
+        dbmdb_ctx_t *mdb_ctx = MDB_CONFIG(li);
+        if (mdb_ctx->env) {
+            int nosync_rc = mdb_env_set_flags(mdb_ctx->env, MDB_NOSYNC, 0);
+            if (nosync_rc != 0) {
+                slapi_log_err(SLAPI_LOG_ERR, "dbmdb_public_dbmdb_import_main",
+                              "Failed to clear MDB_NOSYNC after import failure "
+                              "(error %d: %s)\n",
+                              nosync_rc, mdb_strerror(nosync_rc));
+            } else {
+                slapi_log_err(SLAPI_LOG_INFO, "dbmdb_public_dbmdb_import_main",
+                              "MDB_NOSYNC cleared after import failure. "
+                              "Per-commit fsync re-enabled.\n");
+            }
+        }
+        job->nosync_set = 0;
+    }
+
     /* Re-enable the ndn cache */
     ndn_cache_dec_import_task();
     dbmdb_clear_dirty_flags(be);
@@ -1431,7 +1456,6 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     backend *be = NULL;
     PRThread *thread = NULL;
     int ret = 0;
-    int nosync_set = 0;  /* Track whether we set MDB_NOSYNC */
 
     slapi_pblock_get(pb, SLAPI_BACKEND, &be);
     if (be == NULL) {
@@ -1522,7 +1546,11 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
                               "Import will continue with fsync enabled.\n",
                               ret, mdb_strerror(ret));
             } else {
-                nosync_set = 1;
+                job->nosync_set = 1;
+                slapi_log_err(SLAPI_LOG_INFO, "dbmdb_bulk_import_start",
+                              "MDB_NOSYNC enabled for online import "
+                              "(nsslapd-mdb-online-import-nosync: on). "
+                              "Per-commit fsync is disabled until import completes.\n");
             }
         }
     }
@@ -1564,7 +1592,7 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     return 0;
 
 fail:
-    if (nosync_set) {
+    if (job->nosync_set) {
         dbmdb_ctx_t *ctx = MDB_CONFIG(li);
         if (ctx->env) {
             int nosync_rc = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 0);
@@ -1573,8 +1601,13 @@ fail:
                               "Failed to clear MDB_NOSYNC on failure path "
                               "(error %d: %s).\n",
                               nosync_rc, mdb_strerror(nosync_rc));
+            } else {
+                slapi_log_err(SLAPI_LOG_INFO, "dbmdb_bulk_import_start",
+                              "MDB_NOSYNC cleared on import failure path. "
+                              "Per-commit fsync re-enabled.\n");
             }
         }
+        job->nosync_set = 0;
     }
     PR_Lock(job->inst->inst_config_mutex);
     job->inst->inst_flags &= ~INST_FLAG_BUSY;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_import.c
@@ -781,6 +781,24 @@ dbmdb_import_all_done(ImportJob *job, int ret)
             index->ai->ai_indexmask &= ~INDEX_OFFLINE;
             index = index->next;
         }
+        /* Re-enable fsync before going back online */
+        {
+            struct ldbminfo *li = (struct ldbminfo *)inst->inst_be->be_database->plg_private;
+            dbmdb_ctx_t *ctx = MDB_CONFIG(li);
+            if (ctx->env) {
+                unsigned int env_flags = 0;
+                mdb_env_get_flags(ctx->env, &env_flags);
+                if (env_flags & MDB_NOSYNC) {
+                    int nosync_rc = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 0);
+                    if (nosync_rc != 0) {
+                        slapi_log_err(SLAPI_LOG_ERR, "dbmdb_import_all_done",
+                                      "Failed to clear MDB_NOSYNC flag "
+                                      "(error %d: %s)\n",
+                                      nosync_rc, mdb_strerror(nosync_rc));
+                    }
+                }
+            }
+        }
         /* start up the instance */
         rc = dbmdb_instance_start(job->inst->inst_be, DBLAYER_NORMAL_MODE);
         if (rc == 0) {
@@ -1413,6 +1431,7 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     backend *be = NULL;
     PRThread *thread = NULL;
     int ret = 0;
+    int nosync_set = 0;  /* Track whether we set MDB_NOSYNC */
 
     slapi_pblock_get(pb, SLAPI_BACKEND, &be);
     if (be == NULL) {
@@ -1484,6 +1503,30 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     if (ret != 0)
         goto fail;
 
+    /*
+     * Skip per-commit fsync during bulk import (nsslapd-mdb-online-import-nosync).
+     * Same optimization as dbmdb_ldif2db. The backend is offline so intermediate
+     * durability is not needed. The writer thread calls mdb_env_sync() at the end.
+     * Note: MDB_NOSYNC is environment-level and affects all backends.
+     */
+    if (MDB_CONFIG(li)->dsecfg.online_import_nosync) {
+        dbmdb_ctx_t *ctx = MDB_CONFIG(li);
+        unsigned int env_flags = 0;
+
+        mdb_env_get_flags(ctx->env, &env_flags);
+        if (!(env_flags & MDB_NOSYNC)) {
+            ret = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 1);
+            if (ret != 0) {
+                slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_bulk_import_start",
+                              "Failed to set MDB_NOSYNC (error %d: %s). "
+                              "Import will continue with fsync enabled.\n",
+                              ret, mdb_strerror(ret));
+            } else {
+                nosync_set = 1;
+            }
+        }
+    }
+
     /* END OF COPIED SECTION */
 
     pthread_mutex_lock(&job->wire_lock);
@@ -1521,6 +1564,18 @@ dbmdb_bulk_import_start(Slapi_PBlock *pb)
     return 0;
 
 fail:
+    if (nosync_set) {
+        dbmdb_ctx_t *ctx = MDB_CONFIG(li);
+        if (ctx->env) {
+            int nosync_rc = mdb_env_set_flags(ctx->env, MDB_NOSYNC, 0);
+            if (nosync_rc != 0) {
+                slapi_log_err(SLAPI_LOG_ERR, "dbmdb_bulk_import_start",
+                              "Failed to clear MDB_NOSYNC on failure path "
+                              "(error %d: %s).\n",
+                              nosync_rc, mdb_strerror(nosync_rc));
+            }
+        }
+    }
     PR_Lock(job->inst->inst_config_mutex);
     job->inst->inst_flags &= ~INST_FLAG_BUSY;
     PR_Unlock(job->inst->inst_config_mutex);

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -717,7 +717,7 @@ int dbmdb_make_env(dbmdb_ctx_t *ctx, int readOnly, mdb_mode_t mode)
     if (readOnly) {
         flags = MDB_RDONLY;
     }
-    if (!ctx->dsecfg.durable_transactions) {
+    if (ctx->dsecfg.dseloaded && !ctx->dsecfg.durable_transactions) {
         flags |= MDB_NOSYNC;
         slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_make_env",
                       "nsslapd-db-durable-transactions is off, "

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_instance.c
@@ -717,6 +717,12 @@ int dbmdb_make_env(dbmdb_ctx_t *ctx, int readOnly, mdb_mode_t mode)
     if (readOnly) {
         flags = MDB_RDONLY;
     }
+    if (!ctx->dsecfg.durable_transactions) {
+        flags |= MDB_NOSYNC;
+        slapi_log_err(SLAPI_LOG_WARNING, "dbmdb_make_env",
+                      "nsslapd-db-durable-transactions is off, "
+                      "MDB_NOSYNC enabled.\n");
+    }
 
     rc = mdb_env_create(&env);
     ctx->env = env;

--- a/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
+++ b/ldap/servers/slapd/back-ldbm/db-mdb/mdb_layer.h
@@ -38,10 +38,11 @@
 
 /* mdb config parameters */
 
-#define CONFIG_MDB_MAX_SIZE       "nsslapd-mdb-max-size"
-#define CONFIG_MDB_MAX_READERS    "nsslapd-mdb-max-readers"
-#define CONFIG_MDB_MAX_DBS        "nsslapd-mdb-max-dbs"
-#define CONFIG_MDB_IMPORT_STATS   "nsslapd-mdb-import-stats"
+#define CONFIG_MDB_MAX_SIZE              "nsslapd-mdb-max-size"
+#define CONFIG_MDB_MAX_READERS           "nsslapd-mdb-max-readers"
+#define CONFIG_MDB_MAX_DBS               "nsslapd-mdb-max-dbs"
+#define CONFIG_MDB_IMPORT_STATS          "nsslapd-mdb-import-stats"
+#define CONFIG_MDB_ONLINE_IMPORT_NOSYNC  "nsslapd-mdb-online-import-nosync"
 
 #define DBMDB_DB_MINSIZE             ( 4LL * MEGABYTE )
 #define DBMDB_DISK_RESERVE(disksize) ((disksize)*2ULL/1000ULL)
@@ -78,6 +79,7 @@ typedef struct
     int max_dbs;
     uint64_t max_size;
     int import_stats;
+    int online_import_nosync;
 } dbmdb_cfg_t;
 
 /* config parameters limits */

--- a/ldap/servers/slapd/back-ldbm/import.h
+++ b/ldap/servers/slapd/back-ldbm/import.h
@@ -140,6 +140,7 @@ typedef struct _ImportJob
     int numsubordinates;
     int all_vlv_init;        /* Tells if can bypass vlv initialization */
     void *writer_ctx;        /* Context used to push data in worker thread */
+    int nosync_set;          /* Track whether we set MDB_NOSYNC during online import */
 } ImportJob;
 
 #define FLAG_INDEX_ATTRS 0x01         /* should we index the attributes? */


### PR DESCRIPTION
… high-latency storage

Bug Description:
During replication total init the consumer's LMDB writer thread commits
transactions with fsync on each commit. This causes progressive
performance degradation as the database grows. This is especially
noticeable on network-attached storage, for example AWS EBS, where fsync
latency is high and grows under sustained write load.

The offline LDIF import sets MDB_NOSYNC on the LMDB environment during
import, which skips per-commit fsync, and only flushes at the end via
mdb_env_sync. But the online total init doesn't do that.

Additionally, the nsslapd-db-durable-transactions config parameter was
not honored by the LMDB backend (only BDB checked it).

Fix Description:
- Add nsslapd-mdb-online-import-nosync config parameter (default: off)
  that sets MDB_NOSYNC on the LMDB environment during online import, same
  as offline LDIF import. The final mdb_env_sync() in the writer thread
  ensures all data is flushed when import completes.

- Honor nsslapd-db-durable-transactions for the LMDB backend by
  setting MDB_NOSYNC when the environment is opened if this parameter
  is set to off. Previously this config was only effective for BDB.

Fixes: https://github.com/389ds/389-ds-base/issues/7666

## Summary by Sourcery

Bug Fixes:
- Prevent replication total initialization from suffering performance degradation on high-latency storage by disabling per-commit fsync during LMDB bulk import and re-enabling it when the instance returns online.