### PR TITLE
Issue 7675 - memory leak in test_libslapd_csngen_clock_failure

### DIFF
--- a/test/libslapd/csngen/clock_error.c
+++ b/test/libslapd/csngen/clock_error.c
@@ -59,7 +59,8 @@ test_libslapd_csngen_clock_failure(void **state __attribute__((unused)))
     mock_clock_should_fail = 1;
     rc = csngen_new_csn(gen, &csn, PR_FALSE);
     assert_int_equal(rc, CSN_TIME_ERROR);
-    /* Note: csn may not be set to NULL on error, just check return code */
+    /* Free csn if allocated on error path */
+    csn_free(&csn);
     
     csngen_free(&gen);
 }
@@ -142,7 +143,8 @@ test_libslapd_csngen_multiple_clock_failures(void **state __attribute__((unused)
     for (int i = 0; i < 5; i++) {
         rc = csngen_new_csn(gen, &csn, PR_FALSE);
         assert_int_equal(rc, CSN_TIME_ERROR);
-        /* Note: csn may not be set to NULL on error, just check return code */
+        /* Free csn if allocated on error path */
+        csn_free(&csn);
     }
     
     mock_clock_should_fail = 0;


### PR DESCRIPTION
Description:
The csn_free() calls were missing in error handling paths within the CSN unit test code. This leak only occurs when running the test suite with ASAN, it does not affect production.

Fix:
Free csn if allocated on error path

Fixes: https://github.com/389ds/389-ds-base/issues/7675

Reviewed by:

## Summary by Sourcery

Ensure CSN generator tests clean up allocated CSNs on clock error paths to reflect and guard against the memory leak fix.

Bug Fixes:
- Address potential CSN allocation leaks when csngen_new_csn fails due to clock errors by freeing csn on the error path in tests.

Tests:
- Update clock failure CSN generator tests to free csn on error paths, preventing memory leaks during test execution.