### PR TITLE
Issue 7652 - Fix acl_test after fixing anonymous bind with password

### DIFF
--- a/dirsrvtests/tests/suites/acl/acl_test.py
+++ b/dirsrvtests/tests/suites/acl/acl_test.py
@@ -1255,6 +1255,7 @@ def test_rdn_write_modrdn_anonymous(topology_m2, rdn_write_setup):
     ANONYMOUS_DN = ""
     topology_m2.ms["supplier1"].close()
     topology_m2.ms["supplier1"].binddn = ANONYMOUS_DN
+    topology_m2.ms['supplier1'].bindpw = None
     topology_m2.ms["supplier1"].open()
     msg_id = topology_m2.ms["supplier1"].search_ext("", ldap.SCOPE_BASE, "objectclass=*")
     rtype, rdata, rmsgid, response_ctrl = topology_m2.ms["supplier1"].result3(msg_id)


### PR DESCRIPTION
Description:
Fixing acl test after bind result with NULL dn and non NULL password behavior was changed. The test now also sets password to NULL in order to perform its actions as intended.

Relates: #7652
Author: Lenka Doudova
Reviewer: ???

## Summary by Sourcery

Tests:
- Update acl_test anonymous bind setup to explicitly clear the bind password so the test runs as intended under the new bind semantics.