### PR TITLE
Issue 7528 - Retry the CI image pull instead of failing the job

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -115,6 +115,17 @@ jobs:
     - name: Run pytest in a container
       run: |
         set -x
+        # quay.io pulls transiently time out (issue 7528); an implicit pull
+        # by 'docker run' has no retry, so pull explicitly with backoff
+        for i in 1 2 3 4 5; do
+          sudo docker pull quay.io/389ds/ci-images:test && break
+          if [ "$i" -eq 5 ]; then
+            echo "Image pull failed after $i attempts"
+            exit 1
+          fi
+          echo "Pull failed, retrying in $((i * 15))s..."
+          sleep $((i * 15))
+        done
         CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -115,6 +115,17 @@ jobs:
     - name: Run pytest in a container
       run: |
         set -x
+        # quay.io pulls transiently time out (issue 7528); an implicit pull
+        # by 'docker run' has no retry, so pull explicitly with backoff
+        for i in 1 2 3 4 5; do
+          sudo docker pull quay.io/389ds/ci-images:test && break
+          if [ "$i" -eq 5 ]; then
+            echo "Image pull failed after $i attempts"
+            exit 1
+          fi
+          echo "Pull failed, retrying in $((i * 15))s..."
+          sleep $((i * 15))
+        done
         CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do


### PR DESCRIPTION
Bug Description: Test jobs die before pytest starts when the implicit image pull of the bare 'docker run quay.io/389ds/ci-images:test' hits a transient quay.io timeout (exit 125).

Fix Description: Pull the image explicitly before docker run, retrying up to 5 times with increasing backoff, and fail the step only after the last attempt. This covers a transient timeout, not a longer registry outage.

Fixes: https://github.com/389ds/389-ds-base/issues/7528

Reviewed by: ?

## Summary by Sourcery

Improve CI Docker-based pytest jobs to handle transient quay.io image pull timeouts more robustly before running tests.

Bug Fixes:
- Prevent CI pytest jobs from failing immediately when Docker implicitly pulling the quay.io test image hits a transient timeout by adding explicit pull retries with backoff.

CI:
- Add explicit, retried Docker image pulls with exponential-style backoff to pytest-related GitHub workflows before starting containers.