### PR TITLE
Issue 7605 - Harden CI test ports against ephemeral allocation

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -126,7 +126,7 @@ jobs:
           echo "Pull failed, retrying in $((i * 15))s..."
           sleep $((i * 15))
         done
-        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb --sysctl net.ipv4.ip_local_reserved_ports=38900-39399 -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do
           echo "Waiting for container to be ready..."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,7 +126,7 @@ jobs:
           echo "Pull failed, retrying in $((i * 15))s..."
           sleep $((i * 15))
         done
-        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
+        CID=$(sudo docker run -d -h server.example.com --ulimit core=-1 --cap-add=SYS_PTRACE --privileged --rm --shm-size=4gb --sysctl net.ipv4.ip_local_reserved_ports=38900-39399 -v ${PWD}:/workspace quay.io/389ds/ci-images:test)
         until sudo docker exec $CID sh -c "systemctl is-system-running"
         do
           echo "Waiting for container to be ready..."


### PR DESCRIPTION
Bug Description: Test jobs sometimes fail at topology setup because ns-slapd can't bind one of the fixed lib389 test ports (38902, 39002, 39004, 39202 seen): PR_Bind returns EADDRINUSE and the whole module errors out. Those ports are inside the kernel's default ephemeral range (32768-60999), while the secure ports at 636xx sit outside it and have never failed, so an outgoing connection briefly grabbing a test port is the likely cause.

Fix Description: Pass --sysctl net.ipv4.ip_local_reserved_ports=38900-39399 to the test container, covering all four lib389 role ranges. Reserved ports are skipped when the kernel picks a source port but can still be bound explicitly, so the listeners are unaffected.

Fixes: https://github.com/389ds/389-ds-base/issues/7605

Reviewed by: ?

## Summary by Sourcery

CI:
- Update lmdbpytest and pytest GitHub workflows to set net.ipv4.ip_local_reserved_ports=38900-39399 on test containers, avoiding kernel ephemeral allocation of lib389 test ports.