### PR TITLE
Fix DNS keyword ACI test failures on RHEL 9.x (IPv4-mapped address)

### DIFF
--- a/dirsrvtests/tests/suites/acl/conftest.py
+++ b/dirsrvtests/tests/suites/acl/conftest.py
@@ -11,6 +11,8 @@ This is the config file for keywords test scripts.
 
 """
 
+import socket
+
 import pytest
 
 from lib389._constants import DEFAULT_SUFFIX, PW_DM
@@ -18,6 +20,47 @@ from lib389.idm.user import  UserAccounts
 from lib389.idm.organizationalunit import OrganizationalUnit, OrganizationalUnits
 from lib389.topologies import topology_st as topo
 from lib389.idm.domain import Domain
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_ipv4_mapped_hosts(request, topo):
+    """Register the IPv4-mapped IPv6 address in /etc/hosts and remove it on teardown.
+
+    When DS binds on :: (dual-stack), IPv4 clients appear as ::ffff:x.x.x.x
+    at the socket layer. NSPR's PR_GetHostByAddr calls gethostbyaddr_r with
+    AF_INET6, and glibc-2.34 (RHEL 9.x) does not auto-unmap IPv4-mapped
+    addresses, so the plain IPv4 entry in /etc/hosts is not found and the
+    DNS keyword ACI evaluation fails with INSUFFICIENT_ACCESS.
+    Adding the ::ffff:<ip> form ensures the reverse lookup succeeds.
+    """
+    host = topo.standalone.host
+    ip = socket.gethostbyname(host)
+    mapped = f"::ffff:{ip}"
+
+    with open("/etc/hosts") as f:
+        already_present = any(
+            line.split()[0] == mapped and host in line.split()
+            for line in f
+            if line.split() and not line.startswith('#')
+        )
+
+    if already_present:
+        yield
+        return
+
+    entry = f"{mapped}   {host}\n"
+    with open("/etc/hosts", "a") as f:
+        f.write(entry)
+
+    def remove_entry():
+        with open("/etc/hosts") as f:
+            lines = f.readlines()
+        with open("/etc/hosts", "w") as f:
+            f.writelines(line for line in lines if line != entry)
+
+    request.addfinalizer(remove_entry)
+
+    yield
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Problem

The `acl/keywords_test.py` DNS keyword tests (`test_user_can_access_the_data_when_connecting_from_internal_ds_network_only` etc.) fail in idm-ci on RHEL 9.x with:

```
INSUFFICIENT_ACCESS
```

## Root Cause

When 389-ds binds on `::` (dual-stack), IPv4 clients appear as `::ffff:x.x.x.x` at the socket layer (`accept()` returns the IPv4-mapped form). The ACL engine calls `PR_GetHostByAddr()` → `gethostbyaddr_r(::ffff:x.x.x.x, 16, AF_INET6)` (confirmed via `objdump` of `libnspr4.so`).

On **glibc-2.34** (RHEL 9.x), `gethostbyaddr_r` with `AF_INET6` and an IPv4-mapped address does **not** auto-unmap it, so the plain IPv4 entry in `/etc/hosts` is not found → hostname lookup returns `NULL` → DNS keyword ACI fails.

On **glibc-2.39** (RHEL 10.x), the auto-unmap happens and the lookup succeeds, so the tests pass there without this fix.

## Fix

Add a `module`-scoped `autouse` fixture to `conftest.py` that registers `::ffff:<ip>   <hostname>` in `/etc/hosts` before the keywords test module runs. This ensures `gethostbyaddr_r` finds the hostname regardless of glibc version.

## Verification

Validated with trigger-test-suite #15591 on RHEL 9.2: all 16 `acl/keywords_test.py` tests pass with this fixture in place.

## Summary by Sourcery

Ensure DNS keyword ACL tests handle IPv4-mapped client addresses on RHEL 9.x by normalizing host resolution in the ACL test suite.

Enhancements:
- Add a module-scoped autouse fixture to register IPv4-mapped IPv6 addresses for the test directory server host so reverse DNS lookups succeed on glibc versions without auto-unmapping.

Tests:
- Stabilize acl/keywords DNS keyword tests across platforms by guaranteeing hostname resolution for IPv4-mapped connections.