### PR TITLE
Issue 7707 - lib389: set nsDS5ReplicaBindDNGroup before ensure_agreement() in join_supplier/hub/consumer

### DIFF
--- a/src/lib389/lib389/replica.py
+++ b/src/lib389/lib389/replica.py
@@ -2214,13 +2214,15 @@ class ReplicationManager(object):
         # to allow the tot_init to occur.
         self._bootstrap_replica(from_r, to_r, to_instance)
 
+        # Set bind DN group BEFORE creating agreements: the supplier's replication
+        # thread starts immediately on agreement creation and will fail auth permanently
+        # if nsDS5ReplicaBindDNGroup is not yet configured on the consumer.
+        to_r.set('nsDS5ReplicaBindDNGroup', repl_dn)
+
         # Now put in an agreement from to -> from
         # both ends.
         self.ensure_agreement(from_instance, to_instance)
         self.ensure_agreement(to_instance, from_instance, init=True)
-
-        # Now fix our replica credentials from -> to
-        to_r.set('nsDS5ReplicaBindDNGroup', repl_dn)
 
         # Now finally test it ...
         self.test_replication(from_instance, to_instance)
@@ -2271,12 +2273,14 @@ class ReplicationManager(object):
         # to allow the tot_init to occur.
         self._bootstrap_replica(from_r, to_r, to_instance)
 
+        # Set bind DN group BEFORE creating agreements: the supplier's replication
+        # thread starts immediately on agreement creation and will fail auth permanently
+        # if nsDS5ReplicaBindDNGroup is not yet configured on the consumer.
+        to_r.set('nsDS5ReplicaBindDNGroup', repl_dn)
+
         # Now put in an agreement from to -> from
         # both ends.
         self.ensure_agreement(from_instance, to_instance)
-
-        # Now fix our replica credentials from -> to
-        to_r.set('nsDS5ReplicaBindDNGroup', repl_dn)
 
         # Now finally test it ...
         self.test_replication(from_instance, to_instance)
@@ -2325,12 +2329,14 @@ class ReplicationManager(object):
         # to allow the tot_init to occur.
         self._bootstrap_replica(from_r, to_r, to_instance)
 
+        # Set bind DN group BEFORE creating agreements: the supplier's replication
+        # thread starts immediately on agreement creation and will fail auth permanently
+        # if nsDS5ReplicaBindDNGroup is not yet configured on the consumer.
+        to_r.set('nsDS5ReplicaBindDNGroup', repl_group.dn)
+
         # Now put in an agreement from to -> from
         # both ends.
         self.ensure_agreement(from_instance, to_instance)
-
-        # Now fix our replica credentials from -> to
-        to_r.set('nsDS5ReplicaBindDNGroup', repl_group.dn)
 
         # Now finally test it ...
         # If from_instance replica isn't read-write (hub, probably), we will test it later


### PR DESCRIPTION
## Description

Fixes #7707

`join_supplier()`, `join_hub()`, and `join_consumer()` in `replica.py` set
`nsDS5ReplicaBindDNGroup` on the consumer **after** calling `ensure_agreement()`.
The supplier's replication thread starts immediately when the agreement is created
and may send a `startReplication` request before the bind DN group is configured.
`check_replica_auth()` rejects it with `LDAP_INSUFFICIENT_ACCESS` and the supplier
enters a permanent "requires administrator action" state with no retry.

This causes all tests using multi-supplier topologies (e.g. `test_cleanruv_extop_security.py`)
to fail with `Replication did not sync in time!` during topology setup.

## Fix

Move `nsDS5ReplicaBindDNGroup` before `ensure_agreement()` in all three call sites
(`join_supplier`, `join_hub`, `join_consumer`).

## Testing

Confirmed fix on RHEL 9.2 with `389-ds-base-2.2.4-20.el9_2`.

## Summary by Sourcery

Bug Fixes:
- Prevent replication setup from entering a permanent authentication failure state by configuring the replica bind DN group before replication agreements are created.