### PR TITLE
Issue 7710 - MemberOf deferred update - Use condvar instead of sleep loop

### DIFF
--- a/ldap/servers/plugins/memberof/memberof.c
+++ b/ldap/servers/plugins/memberof/memberof.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include "slapi-plugin.h"
 #include "string.h"
 #include "nspr.h"
@@ -51,6 +52,7 @@ static void *_PluginID = NULL;
 static Slapi_DN *_ConfigAreaDN = NULL;
 static Slapi_RWLock *config_rwlock = NULL;
 static Slapi_DN* _pluginDN = NULL;
+static Slapi_DN** ignored_containers_sdn = NULL;
 static int usetxn = 0;
 static int premodfn = 0;
 static PRLock *fixup_lock = NULL;
@@ -132,6 +134,7 @@ static int memberof_postop_close(Slapi_PBlock *pb);
 int memberof_push_deferred_task(Slapi_PBlock *pb);
 
 /* supporting cast */
+static bool is_ignored_container(Slapi_DN *sdn, Slapi_PBlock *pb);
 static int memberof_oktodo(Slapi_PBlock *pb);
 static Slapi_DN *memberof_getsdn(Slapi_PBlock *pb);
 static int memberof_modop_one(Slapi_PBlock *pb, MemberOfConfig *config, int mod_op, Slapi_DN *op_this_sdn, Slapi_DN *op_to_sdn);
@@ -409,7 +412,8 @@ memberof_monitor_init(const char *dn)
 
     monitor_dn = slapi_create_dn_string(dn);
     if (!monitor_dn) {
-        slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM, "Failed to create monitor DN string\n");
+        slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
+                      "memberof_monitor_init - Failed to create monitor DN string\n");
         return;
     }
 
@@ -418,10 +422,10 @@ memberof_monitor_init(const char *dn)
                                        LDAP_SCOPE_BASE, "(objectclass=*)", memberof_monitor_search, NULL);
 
         slapi_log_err(SLAPI_LOG_TRACE, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Initialised deferred memberof plugin monitor\n");
+                      "memberof_monitor_init - Initialised deferred memberof plugin monitor\n");
     } else {
         slapi_log_err(SLAPI_LOG_WARNING, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failed to initialise deferred memberof plugin monitor\n");
+                      "memberof_monitor_init - Failed to initialise deferred memberof plugin monitor\n");
     }
 
     slapi_ch_free_string(&monitor_dn);
@@ -481,7 +485,6 @@ memberof_postop_init(Slapi_PBlock *pb)
      * Get plugin identity and stored it for later use
      * Used for internal operations
      */
-
     slapi_pblock_get(pb, SLAPI_PLUGIN_IDENTITY, &memberof_plugin_identity);
     PR_ASSERT(memberof_plugin_identity);
     memberof_set_plugin_id(memberof_plugin_identity);
@@ -496,7 +499,6 @@ memberof_postop_init(Slapi_PBlock *pb)
            slapi_pblock_set(pb, SLAPI_PLUGIN_CLOSE_FN, (void *)memberof_postop_close) != 0);
 
     if (!ret) {
-
         if (slapi_register_plugin("bepostoperation",        /* op type */
                                   1,                        /* Enabled */
                                   "memberof_bepostop_init", /* this function desc */
@@ -505,10 +507,9 @@ memberof_postop_init(Slapi_PBlock *pb)
                                   NULL,
                                   memberof_plugin_identity  /* access control */)) {
             slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "memberof_postop_init - memberof_be_postop_init Failed\n");
+                          "memberof_postop_init - slapi_register_plugin: memberof_be_postop_init Failed\n");
             ret = 1;
         }
-
     }
 
     if (!ret && !usetxn &&
@@ -520,7 +521,7 @@ memberof_postop_init(Slapi_PBlock *pb)
                               NULL,                          /* ? */
                               memberof_plugin_identity /* access control */)) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "memberof_postop_init - Failed\n");
+                      "memberof_postop_init - slapi_register_plugin: memberof_internal_postop_init failed\n");
         ret = -1;
     } else if (ret) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
@@ -538,11 +539,11 @@ memberof_postop_init(Slapi_PBlock *pb)
                                       NULL,                  /* ? */
                                       memberof_plugin_identity /* access control */)) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "memberof_preop_init - Failed\n");
+                      "memberof_postop_init - slapi_register_plugin: memberof_preop_init failed\n");
         ret = -1;
     } else if (ret) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "memberof_preop_init - Failed\n");
+                      "memberof_postop_init - Failed\n");
         ret = -1;
     }
 
@@ -637,7 +638,7 @@ remove_deferred_task(MemberofDeferredList *deferred_list)
     MemberofDeferredTask *task;
     if ((deferred_list == NULL) || (deferred_list->current_task == 0)) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                        "Unexpected empty/not allocated deferred list\n");
+                      "remove_deferred_task - Unexpected empty/not allocated deferred list\n");
         return NULL;
     }
 
@@ -646,7 +647,7 @@ remove_deferred_task(MemberofDeferredList *deferred_list)
     if (task == NULL) {
         /* error condition current_task said there was a task available */
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Unexpected current_task counter said there was %d task(s)\n",
+                      "remove_deferred_task - Unexpected current_task counter said there was %d task(s)\n",
                       deferred_list->current_task);
         deferred_list->current_task = 0;
         return NULL;
@@ -677,7 +678,7 @@ add_deferred_task(MemberofDeferredList *deferred_list, MemberofDeferredTask *tas
 {
     if (deferred_list == NULL) {
         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                        "Not allocated deferred list\n");
+                      "add_deferred_task - Not allocated deferred list\n");
         return -1;
     }
     pthread_mutex_lock(&deferred_list->deferred_list_mutex);
@@ -766,7 +767,7 @@ deferred_modrdn_func(MemberofDeferredModrdnTask *task)
         post_sdn = slapi_entry_get_sdn(post_e);
     }
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
-                  "deferred_mod_func: target %s\n", slapi_sdn_get_dn(sdn));
+                  "deferred_modrdn_func: target %s\n", slapi_sdn_get_dn(sdn));
 
     if (pre_sdn && post_sdn && slapi_sdn_compare(pre_sdn, post_sdn) == 0) {
         /* Regarding memberof plugin, this rename is a no-op
@@ -858,7 +859,8 @@ bail:
 skip_op:
     if (ret) {
         slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failed applying deferred updates: memberof values are invalid, please run fixup task\n");
+                      "deferred_modrdn_func - Failed applying deferred updates: "
+                      "memberof values are invalid, please run fixup task\n");
         slapi_pblock_set(pb, SLAPI_RESULT_CODE, &ret);
         ret = SLAPI_PLUGIN_FAILURE;
     }
@@ -885,7 +887,7 @@ deferred_del_func(MemberofDeferredDelTask *task)
     slapi_pblock_get(pb, SLAPI_ENTRY_PRE_OP, &e);
     slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
-                  "deferred_mod_func: target %s\n", slapi_sdn_get_dn(sdn));
+                  "deferred_del_func: target %s\n", slapi_sdn_get_dn(sdn));
 
     memberof_rlock_config();
     mainConfig = memberof_get_config();
@@ -921,7 +923,8 @@ bail:
 
     if (ret) {
         slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failed applying deferred updates: memberof values are invalid, please run fixup task\n");
+                      "deferred_del_func - Failed applying deferred updates: "
+                      "memberof values are invalid, please run fixup task\n");
         slapi_pblock_set(pb, SLAPI_RESULT_CODE, &ret);
         ret = SLAPI_PLUGIN_FAILURE;
     }
@@ -948,9 +951,11 @@ deferred_add_func(MemberofDeferredAddTask *task)
     pb = task->pb;
 
     slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
-    slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
-                  "deferred_mod_func: target %s\n", slapi_sdn_get_dn(sdn));
     slapi_pblock_get(pb, SLAPI_ENTRY_POST_OP, &e);
+
+    slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
+                  "deferred_add_func: target %s\n",
+                  slapi_sdn_get_dn(sdn));
 
     /* is the entry of interest? */
     memberof_rlock_config();
@@ -988,7 +993,8 @@ deferred_add_func(MemberofDeferredAddTask *task)
 bail:
     if (ret) {
         slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failed applying deferred updates: memberof values are invalid, please run fixup task\n");
+                      "deferred_add_func - Failed applying deferred updates: "
+                      "memberof values are invalid, please run fixup task\n");
         slapi_pblock_set(pb, SLAPI_RESULT_CODE, &ret);
         ret = SLAPI_PLUGIN_FAILURE;
     }
@@ -1019,7 +1025,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
     pb = task->pb;
     slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
     slapi_log_err(SLAPI_LOG_PLUGIN, MEMBEROF_PLUGIN_SUBSYSTEM,
-                  "deferred_mod_func: target %s\n", slapi_sdn_get_dn(sdn));
+                  "deferred_mod_func - target %s\n", slapi_sdn_get_dn(sdn));
     /* get the mod set */
     slapi_pblock_get(pb, SLAPI_MODIFY_MODS, &mods);
     smods = slapi_mods_new();
@@ -1064,7 +1070,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
                 /* add group DN to targets */
                 if ((ret = memberof_add_smod_list(pb, &configCopy, sdn, smod))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                                  "memberof_postop_modify - Failed to add dn (%s) to target.  "
+                                  "deferred_mod_func - Failed to add dn (%s) to target.  "
                                   "Error (%d)\n",
                                   slapi_sdn_get_dn(sdn), ret);
                     slapi_mod_done(next_mod);
@@ -1081,7 +1087,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
                 if (slapi_mod_get_num_values(smod) == 0) {
                     if ((ret = memberof_replace_list(pb, &configCopy, sdn))) {
                         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                                      "memberof_postop_modify - Failed to replace list (%s).  "
+                                      "deferred_mod_func - Failed to replace list (%s).  "
                                       "Error (%d)\n",
                                       slapi_sdn_get_dn(sdn), ret);
                         slapi_mod_done(next_mod);
@@ -1091,7 +1097,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
                     /* remove group DN from target values in smod*/
                     if ((ret = memberof_del_smod_list(pb, &configCopy, sdn, smod))) {
                         slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                                      "memberof_postop_modify: failed to remove dn (%s).  "
+                                      "deferred_mod_func: failed to remove dn (%s).  "
                                       "Error (%d)\n",
                                       slapi_sdn_get_dn(sdn), ret);
                         slapi_mod_done(next_mod);
@@ -1105,7 +1111,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
                 /* replace current values */
                 if ((ret = memberof_replace_list(pb, &configCopy, sdn))) {
                     slapi_log_err(SLAPI_LOG_ERR, MEMBEROF_PLUGIN_SUBSYSTEM,
-                                  "memberof_postop_modify - Failed to replace values in  dn (%s).  "
+                                  "deferred_mod_func - Failed to replace values in  dn (%s).  "
                                   "Error (%d)\n",
                                   slapi_sdn_get_dn(sdn), ret);
                     slapi_mod_done(next_mod);
@@ -1118,7 +1124,7 @@ deferred_mod_func(MemberofDeferredModTask *task)
                 slapi_log_err(
                     SLAPI_LOG_ERR,
                     MEMBEROF_PLUGIN_SUBSYSTEM,
-                    "memberof_postop_modify - Unknown mod type\n");
+                    "deferred_mod_func - Unknown mod type\n");
                 ret = SLAPI_PLUGIN_FAILURE;
                 break;
             }
@@ -1142,7 +1148,8 @@ bail:
                       "deferred_mod_func - fail to update new members of %s. Run fixup-task\n",
                       slapi_sdn_get_dn(task->target_sdn));
         slapi_log_err(SLAPI_LOG_ALERT, MEMBEROF_PLUGIN_SUBSYSTEM,
-                      "Failed applying deferred updates: memberof values are invalid, please run fixup task\n");
+                      "deferred_mod_func - Failed applying deferred updates: "
+                      "memberof values are invalid, please run fixup task\n");
         slapi_pblock_set(pb, SLAPI_RESULT_CODE, &ret);
         ret = SLAPI_PLUGIN_FAILURE;
     }
@@ -1422,6 +1429,19 @@ memberof_postop_start(Slapi_PBlock *pb)
         }
     }
 
+    if (ignored_containers_sdn == NULL) {
+        /* allocates ignored_containers_sdn of Slapi_DN* only once */
+        char *ignored_containers[4] = { "cn=config", "cn=schema", "cn=changelog", NULL};
+        size_t i;
+
+        for (i = 0; ignored_containers[i]; i++);
+        ignored_containers_sdn = (Slapi_DN **)slapi_ch_calloc(i + 1, sizeof(Slapi_DN *));
+
+        for (i = 0; ignored_containers[i]; i++) {
+            ignored_containers_sdn[i] = slapi_sdn_new_dn_byval(ignored_containers[i]);
+        }
+    }
+
     /* Set the alternate config area if one is defined. */
     slapi_pblock_get(pb, SLAPI_PLUGIN_CONFIG_AREA, &config_area);
     if (config_area) {
@@ -1581,6 +1601,11 @@ memberof_postop_close(Slapi_PBlock *pb __attribute__((unused)))
     /* Memberof monitor cleanup, unregister the callback and remove the DSE entry. */
     memberof_monitor_cleanup(MEMBEROF_MONITOR_DN);
 
+    for (size_t i = 0; ignored_containers_sdn &&ignored_containers_sdn[i]; i++) {
+        slapi_sdn_free(&ignored_containers_sdn[i]);
+    }
+    slapi_ch_free((void **)&ignored_containers_sdn);
+
     slapi_log_err(SLAPI_LOG_TRACE, MEMBEROF_PLUGIN_SUBSYSTEM,
                   "<-- memberof_postop_close\n");
     return 0;
@@ -1669,7 +1694,7 @@ memberof_postop_del(Slapi_PBlock *pb)
         deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
-        if (deferred_update) {
+        if (deferred_update && !is_ignored_container(sdn, pb)) {
             MemberofDeferredTask* task;
             Slapi_Operation *op;
             int deferred_op_running = 1;
@@ -2027,8 +2052,9 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
         mainConfig = memberof_get_config();
         deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
+        slapi_pblock_get(pb, SLAPI_TARGET_SDN, &origin_sdn);
 
-        if (deferred_update) {
+        if (deferred_update && !is_ignored_container(origin_sdn, pb)) {
             MemberofDeferredTask* task;
             Slapi_Operation *op;
             int deferred_op_running = 1;
@@ -2042,7 +2068,6 @@ memberof_postop_modrdn(Slapi_PBlock *pb)
             op = internal_operation_new(SLAPI_OPERATION_MODRDN, 0);
             slapi_pblock_set(task->d_modrdn->pb, SLAPI_OPERATION, op);
 
-            slapi_pblock_get(pb, SLAPI_TARGET_SDN, &origin_sdn);
             /* Should be freed with slapi_sdn_free(copied_sdn) */
             copied_sdn = slapi_sdn_dup(origin_sdn);
             slapi_pblock_set(task->d_modrdn->pb, SLAPI_TARGET_SDN, copied_sdn);
@@ -2344,7 +2369,7 @@ memberof_postop_modify(Slapi_PBlock *pb)
         memberof_set_entry_info(entry, NULL, &entry_info);
         memberof_unlock_config();
 
-        if (deferred_update) {
+        if (deferred_update && !is_ignored_container(sdn, pb)) {
             MemberofDeferredTask* task;
             LDAPMod **copied_mods = NULL;
             Slapi_DN *copied_sdn;
@@ -2567,6 +2592,35 @@ memberof_push_deferred_task(Slapi_PBlock *pb)
 }
 
 /*
+ * Check if the target DN is an ignored container
+ *
+ * Return true if the target DN is an ignored container or an RUV update
+ * Return false if the target DN is not an ignored container and should be
+ * considered for deferred updates
+ */
+static bool
+is_ignored_container(Slapi_DN *target_sdn, Slapi_PBlock *pb) {
+    bool ignore = false;
+    Operation *operation = NULL;
+
+    slapi_pblock_get(pb, SLAPI_OPERATION, &operation);
+    if (operation && operation_is_flag_set(operation, OP_FLAG_REPL_RUV)) {
+        /* Skip RUV updates */
+        return true;
+    }
+
+    for (size_t i = 0; ignored_containers_sdn &&ignored_containers_sdn[i]; i++) {
+        int check = slapi_sdn_issuffix(target_sdn, ignored_containers_sdn[i]);
+        if (check != 0) {
+            /* This entry is an ignored container */
+            ignore = true;
+            break;
+        }
+    }
+    return ignore;
+}
+
+/*
  * memberof_postop_add()
  *
  * All members in the membership attribute of the new entry get retrieved
@@ -2605,7 +2659,7 @@ memberof_postop_add(Slapi_PBlock *pb)
         deferred_update = mainConfig->is_lmdb ? false : mainConfig->deferred_update;
         memberof_unlock_config();
 
-        if (deferred_update) {
+        if (deferred_update && !is_ignored_container(sdn, pb)) {
             MemberofDeferredTask* task;
             Slapi_Operation *op;
             int deferred_op_running = 1;

--- a/ldap/servers/slapd/back-ldbm/ldbm_add.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_add.c
@@ -1460,17 +1460,8 @@ common_return:
             ldap_result_code = LDAP_SUCCESS;
         }
         if (!result_sent) {
-            int deferred;
-
             if (!is_internal) {
-                slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                if (deferred) {
-                    PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred && !g_get_shutdown()) {
-                        DS_Sleep(delay);
-                        slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                    }
-                }
+                slapi_pblock_wait_deferred_memberof(pb);
             }
             slapi_send_ldap_result(pb, ldap_result_code, ldap_result_matcheddn, ldap_result_message, 0, NULL);
         }

--- a/ldap/servers/slapd/back-ldbm/ldbm_delete.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_delete.c
@@ -1530,17 +1530,8 @@ diskfull_return:
             ldap_result_code = LDAP_SUCCESS;
         }
         if (!result_sent) {
-            int deferred;
-
             if (!is_internal) {
-                slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                if (deferred) {
-                    PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred && !g_get_shutdown()) {
-                        DS_Sleep(delay);
-                        slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                    }
-                }
+                slapi_pblock_wait_deferred_memberof(pb);
             }
             slapi_send_ldap_result(pb, ldap_result_code, NULL, ldap_result_message, 0, NULL);
         }

--- a/ldap/servers/slapd/back-ldbm/ldbm_modify.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modify.c
@@ -1173,17 +1173,8 @@ common_return:
         }
         if (!result_sent) {
             /* result is already sent in find_entry. */
-            int deferred;
-
             if (!is_internal) {
-                slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                if (deferred) {
-                    PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred && !g_get_shutdown()) {
-                        DS_Sleep(delay);
-                        slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                    }
-                }
+                slapi_pblock_wait_deferred_memberof(pb);
             }
             slapi_send_ldap_result(pb, ldap_result_code, NULL, ldap_result_message, 0, NULL);
         }

--- a/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
+++ b/ldap/servers/slapd/back-ldbm/ldbm_modrdn.c
@@ -1465,17 +1465,8 @@ common_return:
             ldap_result_code = LDAP_SUCCESS;
         }
         if (!result_sent) {
-            int deferred;
-
             if (!is_internal) {
-                slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                if (deferred) {
-                    PRIntervalTime delay = PR_MillisecondsToInterval(100);
-                    while (deferred && !g_get_shutdown()) {
-                        DS_Sleep(delay);
-                        slapi_pblock_get(pb, SLAPI_DEFERRED_MEMBEROF, &deferred);
-                    }
-                }
+                slapi_pblock_wait_deferred_memberof(pb);
             }
             slapi_send_ldap_result(pb, ldap_result_code, ldap_result_matcheddn,
                                    ldap_result_message, 0, NULL);

--- a/ldap/servers/slapd/pblock.c
+++ b/ldap/servers/slapd/pblock.c
@@ -17,6 +17,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
+#include <errno.h>
+#include <time.h>
 
 #ifdef PBLOCK_ANALYTICS
 
@@ -146,6 +148,73 @@ pblock_analytics_query(Slapi_PBlock *pb, int access_type)
 
 #endif
 
+/*
+ * Per-pblock deferred memberOf completion sync.
+ *
+ * Sync objects are created lazily only when memberof arms deferred work
+ * (SLAPI_DEFERRED_MEMBEROF = 1). Most operations never touch them.
+ *
+ * Ordering: memberof BE_TXN_POSTOP arms; deferred thread clears+signals;
+ * backend wait returns; then pblock destroy. Do not nest with
+ * MemberofDeferredList locks.
+ */
+static void
+pblock_deferred_memberof_sync_init(Slapi_PBlock *pb)
+{
+    pthread_condattr_t condAttr;
+    int rc;
+
+    if (pb == NULL || pb->pb_deferred_memberof_sync_inited) {
+        return;
+    }
+
+    if ((rc = pthread_mutex_init(&pb->pb_deferred_memberof_mutex, NULL)) != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "pblock_deferred_memberof_sync_init",
+                      "Cannot create deferred memberof mutex. error %d (%s)\n",
+                      rc, strerror(rc));
+        return;
+    }
+    if ((rc = pthread_condattr_init(&condAttr)) != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "pblock_deferred_memberof_sync_init",
+                      "Cannot create condition attribute. error %d (%s)\n",
+                      rc, strerror(rc));
+        pthread_mutex_destroy(&pb->pb_deferred_memberof_mutex);
+        return;
+    }
+    if ((rc = pthread_condattr_setclock(&condAttr, CLOCK_MONOTONIC)) != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "pblock_deferred_memberof_sync_init",
+                      "Cannot set condition clock. error %d (%s)\n",
+                      rc, strerror(rc));
+        pthread_condattr_destroy(&condAttr);
+        pthread_mutex_destroy(&pb->pb_deferred_memberof_mutex);
+        return;
+    }
+    if ((rc = pthread_cond_init(&pb->pb_deferred_memberof_cv, &condAttr)) != 0) {
+        slapi_log_err(SLAPI_LOG_ERR, "pblock_deferred_memberof_sync_init",
+                      "Cannot create deferred memberof condvar. error %d (%s)\n",
+                      rc, strerror(rc));
+        pthread_condattr_destroy(&condAttr);
+        pthread_mutex_destroy(&pb->pb_deferred_memberof_mutex);
+        return;
+    }
+    pthread_condattr_destroy(&condAttr);
+    pb->pb_deferred_memberof = 0;
+    pb->pb_deferred_memberof_sync_inited = 1;
+}
+
+static void
+pblock_deferred_memberof_sync_destroy(Slapi_PBlock *pb)
+{
+    if (pb == NULL || !pb->pb_deferred_memberof_sync_inited) {
+        return;
+    }
+    /* Caller must ensure no thread is waiting on this CV (op waiter returned). */
+    pthread_cond_destroy(&pb->pb_deferred_memberof_cv);
+    pthread_mutex_destroy(&pb->pb_deferred_memberof_mutex);
+    pb->pb_deferred_memberof_sync_inited = 0;
+    pb->pb_deferred_memberof = 0;
+}
+
 void
 pblock_init(Slapi_PBlock *pb)
 {
@@ -203,6 +272,8 @@ pblock_done(Slapi_PBlock *pb)
     pblock_analytics_report(pb);
     pblock_analytics_destroy(pb);
 #endif
+    /* Destroy sync before other teardown; waiter must already have returned. */
+    pblock_deferred_memberof_sync_destroy(pb);
     if (pb->pb_op != NULL) {
         operation_free(&pb->pb_op, pb->pb_conn);
         pb->pb_op = NULL;
@@ -464,7 +535,14 @@ slapi_pblock_get_conn_dn(Slapi_PBlock *pblock, void *value)
 static int32_t
 slapi_pblock_get_deferred_memberof(Slapi_PBlock *pblock, void *value)
 {
+    /* Check if deferred memberof sync is initialized if not just return 0 */
+    if (!pblock->pb_deferred_memberof_sync_inited) {
+        (*(int *)value) = 0;
+        return 0;
+    }
+    pthread_mutex_lock(&pblock->pb_deferred_memberof_mutex);
     (*(int *)value) = pblock->pb_deferred_memberof;
+    pthread_mutex_unlock(&pblock->pb_deferred_memberof_mutex);
     return 0;
 }
 
@@ -3763,8 +3841,62 @@ slapi_pblock_set_conn_dn(Slapi_PBlock *pblock, void *value)
 static int32_t
 slapi_pblock_set_deferred_memberof(Slapi_PBlock *pblock, void *value)
 {
-    pblock->pb_deferred_memberof = *((int *)value);
+    int newval = *((int *)value);
+
+    if (newval) {
+        /* Arm deferred work: create sync objects only when memberof needs them. */
+        pblock_deferred_memberof_sync_init(pblock);
+        if (!pblock->pb_deferred_memberof_sync_inited) {
+            return -1;
+        }
+        pthread_mutex_lock(&pblock->pb_deferred_memberof_mutex);
+        pblock->pb_deferred_memberof = 1;
+        pthread_mutex_unlock(&pblock->pb_deferred_memberof_mutex);
+        return 0;
+    }
+
+    /* Clear + notify: memberof completed deferred membership updates. */
+    if (!pblock->pb_deferred_memberof_sync_inited) {
+        pblock->pb_deferred_memberof = 0;
+        return 0;
+    }
+    pthread_mutex_lock(&pblock->pb_deferred_memberof_mutex);
+    pblock->pb_deferred_memberof = 0;
+    /* Wake the backend waiter for this op (memberof deferred_thread_func). */
+    pthread_cond_signal(&pblock->pb_deferred_memberof_cv);
+    pthread_mutex_unlock(&pblock->pb_deferred_memberof_mutex);
+
     return 0;
+}
+
+/*
+ * Block until deferred memberOf work for this op completes, or shutdown.
+ *
+ * Fast path: if memberof never armed deferred work on this pblock, sync was
+ * never created — return immediately (no init, no lock). That covers disabled
+ * memberof and ops that do not defer membership updates.
+ *
+ * Timedwait is only for periodically re-checking g_get_shutdown() — no DS_Sleep.
+ * Notify comes from memberof via slapi_pblock_set(SLAPI_DEFERRED_MEMBEROF, 0).
+ */
+void
+slapi_pblock_wait_deferred_memberof(Slapi_PBlock *pb)
+{
+    struct timespec wait_until = {0};
+
+    if (pb == NULL || !pb->pb_deferred_memberof_sync_inited) {
+        return;
+    }
+
+    pthread_mutex_lock(&pb->pb_deferred_memberof_mutex);
+    while (pb->pb_deferred_memberof && !g_get_shutdown()) {
+        clock_gettime(CLOCK_MONOTONIC, &wait_until);
+        wait_until.tv_sec += 1;
+        pthread_cond_timedwait(&pb->pb_deferred_memberof_cv,
+                               &pb->pb_deferred_memberof_mutex,
+                               &wait_until);
+    }
+    pthread_mutex_unlock(&pb->pb_deferred_memberof_mutex);
 }
 
 static int32_t

--- a/ldap/servers/slapd/pblock_v3.h
+++ b/ldap/servers/slapd/pblock_v3.h
@@ -228,7 +228,11 @@ typedef struct slapi_pblock
     struct _slapi_pblock_intop *pb_intop;
     struct _slapi_pblock_intplugin *pb_intplugin;
     struct _slapi_pblock_deprecated *pb_deprecated;
+    /* Deferred memberOf sync elements */
     int pb_deferred_memberof;
+    int pb_deferred_memberof_sync_inited;
+    pthread_mutex_t pb_deferred_memberof_mutex;
+    pthread_cond_t pb_deferred_memberof_cv;
 
 #ifdef PBLOCK_ANALYTICS
     uint32_t analytics_init;

--- a/ldap/servers/slapd/slap.h
+++ b/ldap/servers/slapd/slap.h
@@ -1960,6 +1960,13 @@ void slapi_pblock_set_vattr_context(Slapi_PBlock *pb, void *vattr_ctx);
 void *slapi_pblock_get_op_stack_elem(Slapi_PBlock *pb);
 void slapi_pblock_set_op_stack_elem(Slapi_PBlock *pb, void *stack_elem);
 
+/*
+ * Wait until deferred memberOf work for this operation completes (or shutdown).
+ * No-op unless memberof armed deferred work on this pblock (lazy sync).
+ * Notify is performed by memberof via SLAPI_DEFERRED_MEMBEROF set to 0.
+ */
+void slapi_pblock_wait_deferred_memberof(Slapi_PBlock *pb);
+
 /* index if substrlens */
 #define INDEX_SUBSTRBEGIN  0
 #define INDEX_SUBSTRMIDDLE 1


### PR DESCRIPTION
Description:

Currently we use a while/sleep loop to check if a deferred update is complete. Better to use a condition variable instead.

Deferred updates also needs to skip special backends:

- cn=config
- cn=schema
- cn=changelog

relates: https://github.com/389ds/389-ds-base/issues/7710

Assisted-by: Cursor

## Summary by Sourcery

Introduce per-operation synchronization for deferred memberOf updates using a pblock-based condition variable and replace backend sleep polling with this wait mechanism, while excluding special containers and RUV updates from deferred processing.

New Features:
- Add a pblock-level API to wait for completion of deferred memberOf work using a condition variable.
- Skip deferred memberOf processing for cn=config, cn=schema, cn=changelog, and replication RUV operations.

Enhancements:
- Replace backend while/sleep polling for deferred memberOf completion with a condition-variable-based wait tied to the operation pblock.
- Manage lazy initialization and teardown of deferred memberOf synchronization primitives within the pblock lifecycle.