### PR TITLE
Issue 7711 - Fix typo in accountpolicy --login-history-size help text

### DIFF
--- a/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
+++ b/src/lib389/lib389/cli_conf/plugins/accountpolicy.py
@@ -103,7 +103,7 @@ def _add_parser_args(parser):
     parser.add_argument('--state-attr',
                         help='Specifies the primary time attribute used to evaluate an account policy (stateAttrName)')
     parser.add_argument('--login-history-size',
-                        help='Specifies the number of login timestamps to store (lastLoginHistSize) )')
+                        help='Specifies the number of login timestamps to store (lastLoginHistorySize)')
     parser.add_argument('--check-all-state-attrs', choices=['yes', 'no'], type=str.lower,
                         help="Check both state and alternate state attributes for account state")
 


### PR DESCRIPTION
Description: This patch corrects the typo in help text for --login-history-size argument in the Account Policy plugin CLI. It currently references lastLoginHistSize, which is not a valid attribute name. The correct attribute name is lastLoginHistorySize. It also removes an extra stray closing parenthesis in the same string.

Fixes: https://github.com/389ds/389-ds-base/issues/7711

## Summary by Sourcery

Bug Fixes:
- Fix incorrect attribute name and stray closing parenthesis in the --login-history-size help message of the Account Policy plugin CLI.