### PR TITLE
Issue 7714 - UI - sass import rules are deprecated

### DIFF
--- a/src/cockpit/389-console/pkg/lib/patternfly/patternfly-5-cockpit.scss
+++ b/src/cockpit/389-console/pkg/lib/patternfly/patternfly-5-cockpit.scss
@@ -3,7 +3,7 @@ $pf-v5-global--font-path: "patternfly-fonts-fake-path";
 $pf-v5-global--fonticon-path: "patternfly-icons-fake-path";
 $pf-v5-global--disable-fontawesome: true !default; // Disable Font Awesome 5 Free
 
-@import "@patternfly/patternfly/patternfly-base.scss";
+@forward "@patternfly/patternfly/patternfly-base.scss";
 
 /* Import our own fonts since the PF4 font-face rules are filtered out in build.js */
-@import "./fonts";
+@forward "./fonts";


### PR DESCRIPTION
Description:

Sass no longer supports @import, and we need to use "@use" or "@forward"

relates: https://github.com/389ds/389-ds-base/issues/7714

## Summary by Sourcery

Enhancements:
- Update PatternFly cockpit SCSS to use Sass @forward for base and fonts modules instead of deprecated @import.