### PR TITLE
Issue 7709 - Add EPEL 10 target to Packit COPR builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,11 +21,12 @@ srpm_build_deps:
 actions:
   post-upstream-clone:
     - cargo install cargo-license
-    - make -f rpm.mk rpmspec
+    - make -f rpm.mk rpmroot rpmspec
   create-archive:
-    - make -f rpm.mk download-cargo-dependencies tarballs
+    - make -f rpm.mk BUNDLE_LIBDB=1 download-cargo-dependencies tarballs
     - python3 rpm/bundle-rust-npm.py -f src src/cockpit/389-console rpm/389-ds-base.spec
     - "bash -c 'ls -1 dist/sources/389-ds-base*.tar.bz2'"
+
   get-current-version:
     - rpmspec -q --qf "%{Version}" --srpm rpm/389-ds-base.spec
 
@@ -45,10 +46,20 @@ jobs:
 - job: copr_build
   trigger: pull_request
   targets:
-    - fedora-all
+    fedora-all:
+        without_opts:
+            - bundle_libdb
+    epel-10:
+        with_opts:
+            - bundle_libdb
 
 - job: copr_build
   trigger: commit
   branch: main
   targets:
-    - fedora-all
+    fedora-all:
+        without_opts:
+            - bundle_libdb
+    epel-10:
+        with_opts:
+            - bundle_libdb

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -232,9 +232,7 @@ Source2:          %{name}-devel.README
 Source3:          https://github.com/jemalloc/%{jemalloc_name}/releases/download/%{jemalloc_ver}/%{jemalloc_name}-%{jemalloc_ver}.tar.bz2
 Source5:          jemalloc-5.3.0_throw_bad_alloc.patch
 %endif
-%if %{with bundle_libdb}
 Source4:          https://fedorapeople.org/groups/389ds/libdb-5.3.28-59.tar.bz2
-%endif
 
 %description
 389 Directory Server is an LDAPv3 compliant server.  The base package includes


### PR DESCRIPTION
Description:

Add epel-10 to Packit copr build targets

relates: https://github.com/389ds/389-ds-base/issues/7709

## Summary by Sourcery

Build:
- Include epel-10 in Packit COPR build targets for both pull request and main branch commit triggers.