### PR TITLE
Issue 7595 - Skip redundant CI runs to relieve the Actions queue

### DIFF
--- a/.github/scripts/pr_scope.py
+++ b/.github/scripts/pr_scope.py
@@ -1,0 +1,52 @@
+import json
+import os
+import sys
+import urllib.request
+
+# Print "webui" when the PR only touches the Cockpit UI, so the matrix
+# shrinks to that suite. On any doubt, print nothing (full matrix).
+UI_PREFIX = "src/cockpit/389-console/"
+PER_PAGE = 100
+MAX_PAGES = 3
+
+
+def changed_files(repo, pr_number, token):
+    files = []
+    for page in range(1, MAX_PAGES + 1):
+        url = (f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files"
+               f"?per_page={PER_PAGE}&page={page}")
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            batch = json.load(response)
+        for entry in batch:
+            files.append(entry["filename"])
+            # A rename lists only its new path in "filename"; the old
+            # path must count too, or a move out of another tree would
+            # pass as UI-only.
+            previous = entry.get("previous_filename")
+            if previous:
+                files.append(previous)
+        if len(batch) < PER_PAGE:
+            return files
+    return None
+
+
+def main():
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if len(sys.argv) != 2 or not repo:
+        return 0
+    try:
+        files = changed_files(repo, sys.argv[1], token)
+    except Exception:
+        return 0
+    if files and all(name.startswith(UI_PREFIX) for name in files):
+        print("webui")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -5,7 +5,22 @@ on:
     branches:
       - main
       - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
@@ -20,10 +35,40 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip unchanged nightly runs
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Push successes count too: this workflow still triggers on
+          # push and takes no inputs, so any green push run at this sha
+          # is full coverage.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --status success --branch "$GITHUB_REF_NAME" --limit 20 --json headSha,event \
+            --jq '[.[] | select(.event == "push" or .event == "schedule")][0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   rust-tests:
     name: Cargo Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:fedora
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,26 @@ name: CodeQL
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
+    # Weekly even without commits: CodeQL query packs update
+    # independently of the tree.
     - cron: '0 0 * * 0'
   workflow_dispatch:
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,10 +1,25 @@
 name: Compile
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   push:
     branches:
       - main
       - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -1,11 +1,15 @@
 name: LMDB Test
 
 on:
-  push:
-    branches:
-      - main
-      - "389-ds-base-*"
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
@@ -13,7 +17,7 @@ on:
       pytest_tests:
         description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
         required: false
-        default: false
+        default: ''
       debug_enabled:
         description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
@@ -29,10 +33,39 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip the nightly when nothing changed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only scheduled successes count: dispatch runs may be partial
+          # (pytest_tests) and this workflow has no push runs.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --event schedule --status success --branch "$GITHUB_REF_NAME" \
+            --limit 1 --json headSha --jq '.[0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful scheduled run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
@@ -44,9 +77,18 @@ jobs:
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Check if the diff is limited to the Web UI
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "suites=$(python3 .github/scripts/pr_scope.py ${{ github.event.pull_request.number }})" >>$GITHUB_OUTPUT
+
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})" >>$GITHUB_OUTPUT
+        env:
+          SUITES: ${{ steps.scope.outputs.suites || github.event.inputs.pytest_tests }}
+        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py $SUITES)" >>$GITHUB_OUTPUT
 
       - name: Build RPMs
         run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms

--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -1,0 +1,53 @@
+name: Nightly Dispatch
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch tests for changed release branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Start full test runs on release branches with new commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # X.Y and X.Y.Z branches with commits in the last 30 days,
+          # each head dispatched at most once (a failed run needs a
+          # human, not a nightly retry; a manual partial dispatch also
+          # counts as that head's run). The run-list check has no
+          # --event filter on purpose: on branches that still carry
+          # push triggers, the push run for a head must count or every
+          # backport would run twice. Empty inputs override old
+          # branches' broken pytest_tests default of "false".
+          now=$(date +%s)
+          branches=$(gh api "repos/$GITHUB_REPOSITORY/branches?per_page=100" --paginate \
+            --jq '.[] | select(.name | test("^389-ds-base-[0-9]+\\.[0-9]+(\\.[0-9]+)?$")) | "\(.name) \(.commit.sha)"' || true)
+          while read -r branch sha; do
+            [ -z "$branch" ] && continue
+            committed=$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha" --jq '.commit.committer.date' || true)
+            if [ -n "$committed" ]; then
+              cs=$(date -d "$committed" +%s 2>/dev/null || echo 0)
+              if [ "$cs" -gt 0 ] && [ $(( now - cs )) -gt $(( 30 * 86400 )) ]; then
+                continue
+              fi
+            fi
+            for workflow in pytest.yml lmdbpytest.yml; do
+              last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" \
+                --branch "$branch" --limit 1 --json headSha --jq '.[0].headSha' || true)
+              if [ "$last" = "$sha" ]; then
+                continue
+              fi
+              echo "Dispatching $workflow on $branch ($sha)"
+              gh workflow run "$workflow" --repo "$GITHUB_REPOSITORY" --ref "$branch" \
+                -f pytest_tests= -f debug_enabled= ||
+                echo "Dispatch failed for $branch (no dispatchable $workflow on that ref)"
+            done
+          done <<< "$branches"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -5,8 +5,25 @@ on:
     branches:
       - main
       - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
+    # No sha gate on this nightly: audit-ci results drift with the npm
+    # advisory database even when the tree is unchanged.
     - cron:  '0 0 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,11 +1,15 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
-      - "389-ds-base-*"
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
@@ -13,7 +17,7 @@ on:
       pytest_tests:
         description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
         required: false
-        default: false
+        default: ''
       debug_enabled:
         description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
@@ -29,10 +33,39 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip the nightly when nothing changed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only scheduled successes count: dispatch runs may be partial
+          # (pytest_tests) and this workflow has no push runs.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --event schedule --status success --branch "$GITHUB_REF_NAME" \
+            --limit 1 --json headSha --jq '.[0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful scheduled run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
@@ -44,9 +77,18 @@ jobs:
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Check if the diff is limited to the Web UI
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "suites=$(python3 .github/scripts/pr_scope.py ${{ github.event.pull_request.number }})" >>$GITHUB_OUTPUT
+
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})" >>$GITHUB_OUTPUT
+        env:
+          SUITES: ${{ steps.scope.outputs.suites || github.event.inputs.pytest_tests }}
+        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py $SUITES)" >>$GITHUB_OUTPUT
 
       - name: Build RPMs
         run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,22 @@ on:
     branches:
       - main
       - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Description:
The org's free plan allows 20 concurrent Actions jobs, while each push/PR event schedules ~222 (111 suites x 2 backends). Full runs take 40+ hours; backport sweeps take days. Remove the runs whose result is already known:

- Drop push triggers from the test workflows: backports already pass full PR CI. A nightly dispatcher instead runs each release branch (X.Y and X.Y.Z) that changed in the last 30 days, once per head commit. (Push runs use the workflow on the pushed ref, so this needs backporting to active branches to fully take effect.)
- Skip main's nightly when HEAD already passed the previous one.
- Ignore doc-only paths (markdown, docs/agents, docs/design, LICENSE, .packit.yaml) in the test and CodeQL workflows. docs/slapi.doxy.in and the doxygen assets stay CI-visible because make all consumes them.
- Run only the webui suite for PRs that touch nothing outside src/cockpit/389-console; renamed files count both their old and new path.
- Fix the pytest_tests default: "false" made bare manual dispatches run an empty matrix. The dispatcher also passes explicit empty inputs so older branch workflows run in full.

Gates fail open, including on gate job failure, and there are no required status checks, so skipped workflows cannot block merges.

Relates: https://github.com/389ds/389-ds-base/issues/7595

Reviewed by: ?

## Summary by Sourcery

Reduce redundant CI workload while preserving coverage for relevant code changes, nightly validation, and recently updated release branches.

New Features:
- Add nightly dispatching for recently changed release branches and reduce pull-request test matrices to the Web UI suite when changes are isolated to the Cockpit console.

Bug Fixes:
- Correct manual test-dispatch defaults so unspecified test selections run the full suite, including on older branch workflows.

Enhancements:
- Eliminate redundant push-triggered test runs and skip unchanged nightly test runs while keeping gating fail-open.
- Exclude documentation- and metadata-only changes from test and CodeQL workflows while retaining build-relevant documentation inputs.

CI:
- Reduce GitHub Actions load by consolidating release-branch coverage into scheduled dispatches and avoiding duplicate CI execution.