### PR TITLE
Issue 6419 - Error: name 'cockpit_present' is not defined

### DIFF
--- a/src/lib389/lib389/cli_ctl/cockpit.py
+++ b/src/lib389/lib389/cli_ctl/cockpit.py
@@ -27,8 +27,6 @@ def open_firewall(inst, log, args):
     """
     Open the firewall for Cockpit service
     """
-    if not cockpit_present():
-        raise ValueError("The 'cockpit' package is not installed on this system")
 
     OPEN_CMD = ['sudo', 'firewall-cmd', '--add-service=cockpit', '--permanent']
     if args.zone is not None:
@@ -43,8 +41,6 @@ def disable_cockpit(inst, log, args):
     """
     Disable Cockpit socket
     """
-    if not cockpit_present():
-        raise ValueError("The 'cockpit' package is not installed on this system")
 
     DISABLE_CMD = ['sudo', 'systemctl', 'disable', '--now', 'cockpit.socket']
     try:
@@ -57,8 +53,6 @@ def close_firewall(inst, log, args):
     """
     Close firewall for Cockpit service
     """
-    if not cockpit_present():
-        raise ValueError("The 'cockpit' package is not installed on this system")
 
     CLOSE_CMD = ['sudo', 'firewall-cmd', '--remove-service=cockpit', '--permanent']
     try:


### PR DESCRIPTION
Description:
PR #5615 removed cockpit enable check for cockpit package but open-firewall, close-firewall, and disable still called it, causing NameError. Drop those leftover checks as well so dsctl cockpit commands work again.

Fixes: https://github.com/389ds/389-ds-base/issues/6419

## Summary by Sourcery

Bug Fixes:
- Fix NameError caused by leftover cockpit_present checks in cockpit firewall and disable commands.