### PR TITLE
Issue 7709 - Add EPEL 10 target to Packit COPR builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,17 +49,18 @@ jobs:
     fedora-all:
         without_opts:
             - bundle_libdb
-    epel-10:
+    epel-10-all:
         with_opts:
             - bundle_libdb
 
 - job: copr_build
   trigger: commit
   branch: main
+  preserve_project: true
   targets:
     fedora-all:
         without_opts:
             - bundle_libdb
-    epel-10:
+    epel-10-all:
         with_opts:
             - bundle_libdb

--- a/rpm.mk
+++ b/rpm.mk
@@ -114,9 +114,7 @@ endif
 	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
 		curl -LO $(JEMALLOC_URL) ; \
 	fi ; \
-	if [ $(BUNDLE_LIBDB) -eq 1 ]; then \
-		curl -LO $(LIBDB_URL) ; \
-	fi ;
+	curl -LO $(LIBDB_URL) ;
 
 rpmroot:
 	rm -rf $(RPMBUILD)
@@ -147,9 +145,7 @@ rpmbuildprep:
 	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
 		cp dist/sources/$(JEMALLOC_TARBALL) $(RPMBUILD)/SOURCES/ ; \
 	fi
-	if [ $(BUNDLE_LIBDB) -eq 1 ]; then \
-		cp dist/sources/$(LIBDB_TARBALL) $(RPMBUILD)/SOURCES/ ; \
-	fi
+	cp dist/sources/$(LIBDB_TARBALL) $(RPMBUILD)/SOURCES/
 
 srpms: rpmroot srpmdistdir download-cargo-dependencies tarballs rpmbuildprep
 	python3 rpm/bundle-rust-npm.py $(CARGO_PATH) $(NODE_MODULES_PATH) $(RPMBUILD)/SPECS/$(PACKAGE).spec -f


### PR DESCRIPTION
Bug Description:
Build fails when libdb tarball is missing, it's only downloaded when BUNDLE_LIBDB=1 is used.

Fix Description:
Make libdb tarball download and copy unconditional in rpm.mk. Replace epel-10 with epel-10-all to cover latest and branched releases.

Fixes: https://github.com/389ds/389-ds-base/issues/7709

## Summary by Sourcery

Make libdb tarball download and inclusion in RPM build sources unconditional and update Packit COPR configuration to use the epel-10-all target for bundle_libdb builds.

Bug Fixes:
- Ensure libdb tarball is always downloaded and copied into RPM build sources to prevent build failures when BUNDLE_LIBDB is disabled.

Enhancements:
- Adjust Packit COPR job configuration to build against the epel-10-all target instead of epel-10 for EPEL 10 bundle_libdb builds.