### PR TITLE
Issue 7631 - Don't install bpftrace by default

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -222,7 +222,8 @@ Requires:         python3-file-magic
 
 %if %{with usdt}
 # Optional eBPF tracer for the shipped USDT bpftrace scripts.
-Recommends:       bpftrace
+# Use Suggests so it is not installed by default (debug-only, pulls in gcc).
+Suggests:         bpftrace
 %endif
 
 


### PR DESCRIPTION
Description: bpftrace is needed only for debugging, it doesn't need to be installed on every production system.
It also pulls in a compiler which is also prohibited on most production systems. Use Suggests instead of Recommend.

Fixes: https://github.com/389ds/389-ds-base/issues/7631

Reviewed by: ?

## Summary by Sourcery

Make bpftrace optional to avoid imposing debugging and compiler dependencies on standard installations.

Bug Fixes:
- Stop installing bpftrace as a default dependency on production systems.

Enhancements:
- Make bpftrace an optional suggested dependency for debugging use cases.