### PR TITLE
bdb: Fix nsslapd-db-compactdb-interval: 0 not disabling auto compaction

### DIFF
--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -14,6 +14,7 @@ import datetime
 from lib389.utils import get_default_db_lib
 from lib389.tasks import DBCompactTask
 from lib389.backend import DatabaseConfig
+from lib389._mapped_object import DSLdapObject
 from test389.topologies import topology_m1 as topo
 from lib389.utils import ldap, ds_is_older
 from lib389.idm.user import UserAccounts
@@ -22,6 +23,8 @@ from lib389._constants import DEFAULT_SUFFIX
 
 pytestmark = pytest.mark.tier2
 log = logging.getLogger(__name__)
+
+BDB_CONFIG_DN = "cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config"
 
 
 def test_compact_db_task(topo):
@@ -172,6 +175,103 @@ def test_no_compaction(topo):
     inst.deleteErrorLogs()
 
     time.sleep(3)
+    assert not inst.searchErrorsLog("Compacting databases")
+    inst.deleteErrorLogs(restart=False)
+
+
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
+def test_no_compaction_near_scheduled_time(topo):
+    """Test that nsslapd-db-compactdb-interval: 0 disables compaction even when
+    nsslapd-db-compactdb-time is imminent, and that nsslapd-db-compactdb-starttime
+    is not rewritten across a restart while compaction remains disabled.
+
+    :id: 47265415-0ced-484d-9f20-b461ba6f673b
+    :customerscenario: True
+    :setup: Supplier Instance
+    :steps:
+        1. Set nsslapd-db-compactdb-interval to 0 and nsslapd-db-compactdb-time
+           90 seconds in the future
+        2. Wait past that time
+        3. Check no scheduling or compaction messages appear in the error log
+        4. Record nsslapd-db-compactdb-starttime, restart the server, and
+           confirm it is unchanged
+    :expectedresults:
+        1. Success
+        2. Success
+        3. No "database compaction scheduled for" or "Compacting databases" logged
+        4. nsslapd-db-compactdb-starttime is identical before and after restart
+    """
+    inst = topo.ms["supplier1"]
+    config = DatabaseConfig(inst)
+    bdb_entry = DSLdapObject(inst, dn=BDB_CONFIG_DN)
+
+    target = datetime.datetime.now() + datetime.timedelta(seconds=90)
+    compact_time = target.strftime("%H:%M")
+
+    log.info("Setting compactdb-interval=0, compactdb-time=%s (~90s from now)", compact_time)
+    config.set([('nsslapd-db-compactdb-interval', '0'),
+                ('nsslapd-db-compactdb-time', compact_time)])
+    inst.deleteErrorLogs(restart=True)
+
+    log.info("Waiting past the configured compaction time-of-day ...")
+    time.sleep(110)
+
+    assert not inst.searchErrorsLog("database compaction scheduled for")
+    assert not inst.searchErrorsLog("Compacting databases")
+
+    starttime_before = bdb_entry.get_attr_val_utf8('nsslapd-db-compactdb-starttime')
+    log.info("nsslapd-db-compactdb-starttime before restart: %s", starttime_before)
+
+    inst.restart()
+    time.sleep(10)
+
+    starttime_after = bdb_entry.get_attr_val_utf8('nsslapd-db-compactdb-starttime')
+    log.info("nsslapd-db-compactdb-starttime after restart: %s", starttime_after)
+
+    assert starttime_before == starttime_after, \
+        "nsslapd-db-compactdb-starttime changed while compaction is disabled (interval=0)"
+    assert not inst.searchErrorsLog("database compaction scheduled for")
+
+    inst.deleteErrorLogs(restart=False)
+
+
+@pytest.mark.skipif(get_default_db_lib() == "mdb", reason="Not supported over mdb")
+def test_disable_compaction_after_already_scheduled(topo):
+    """Test that disabling compaction (interval=0) after a compaction event was
+    already queued prevents the queued event from actually running.
+
+    :id: bbddd990-5f15-44fa-af4a-de84f2ec53f4
+    :customerscenario: True
+    :setup: Supplier Instance
+    :steps:
+        1. Set a short nonzero interval/time so compaction gets scheduled
+        2. Confirm the "scheduled for" message appears
+        3. Set nsslapd-db-compactdb-interval to 0 before the scheduled time arrives
+        4. Wait past the originally scheduled time
+    :expectedresults:
+        1. Success
+        2. Scheduling message is logged
+        3. Success
+        4. Compaction does not actually run
+    """
+    inst = topo.ms["supplier1"]
+    config = DatabaseConfig(inst)
+
+    target = datetime.datetime.now() + datetime.timedelta(seconds=60)
+    compact_time = target.strftime("%H:%M")
+
+    log.info("Setting compactdb-interval=30, compactdb-time=%s (~60s from now)", compact_time)
+    config.set([('nsslapd-db-compactdb-interval', '30'),
+                ('nsslapd-db-compactdb-time', compact_time)])
+    inst.deleteErrorLogs(restart=True)
+
+    time.sleep(10)
+    assert inst.searchErrorsLog("database compaction scheduled for")
+
+    log.info("Disabling compaction before the scheduled time arrives ...")
+    config.set([('nsslapd-db-compactdb-interval', '0')])
+
+    time.sleep(70)
     assert not inst.searchErrorsLog("Compacting databases")
     inst.deleteErrorLogs(restart=False)
 

--- a/dirsrvtests/tests/suites/config/compact_test.py
+++ b/dirsrvtests/tests/suites/config/compact_test.py
@@ -26,6 +26,34 @@ log = logging.getLogger(__name__)
 
 BDB_CONFIG_DN = "cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config"
 
+# The checkpoint thread re-evaluates compaction scheduling roughly every 2.5s
+# (DBLAYER_SLEEP_INTERVAL * 10 in bdb_layer.c), independent of any configured
+# checkpoint/compaction interval. Polling on that cadence instead of a single
+# long time.sleep() lets these tests fail fast and finish quickly.
+
+
+def _wait_for_log_line(inst, pattern, timeout=10, poll_interval=1):
+    """Poll the error log for a pattern; return as soon as it appears."""
+    elapsed = 0
+    while elapsed < timeout:
+        if inst.searchErrorsLog(pattern):
+            return True
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+    return inst.searchErrorsLog(pattern)
+
+
+def _assert_no_log_line_for(inst, patterns, duration, poll_interval=2):
+    """Poll repeatedly for `duration` seconds, failing immediately if any
+    pattern appears rather than only checking once at the end."""
+    elapsed = 0
+    while elapsed < duration:
+        for pattern in patterns:
+            assert not inst.searchErrorsLog(pattern), \
+                "Unexpected log line found: %s" % pattern
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
 
 def test_compact_db_task(topo):
     """Test creation of dbcompact task is successful
@@ -190,40 +218,36 @@ def test_no_compaction_near_scheduled_time(topo):
     :setup: Supplier Instance
     :steps:
         1. Set nsslapd-db-compactdb-interval to 0 and nsslapd-db-compactdb-time
-           90 seconds in the future
-        2. Wait past that time
-        3. Check no scheduling or compaction messages appear in the error log
-        4. Record nsslapd-db-compactdb-starttime, restart the server, and
+           15 seconds in the future
+        2. Poll past that time, failing immediately if compaction is
+           scheduled or runs
+        3. Record nsslapd-db-compactdb-starttime, restart the server, and
            confirm it is unchanged
     :expectedresults:
         1. Success
-        2. Success
-        3. No "database compaction scheduled for" or "Compacting databases" logged
-        4. nsslapd-db-compactdb-starttime is identical before and after restart
+        2. No "database compaction scheduled for" or "Compacting databases" logged
+        3. nsslapd-db-compactdb-starttime is identical before and after restart
     """
     inst = topo.ms["supplier1"]
     config = DatabaseConfig(inst)
     bdb_entry = DSLdapObject(inst, dn=BDB_CONFIG_DN)
 
-    target = datetime.datetime.now() + datetime.timedelta(seconds=90)
+    target = datetime.datetime.now() + datetime.timedelta(seconds=15)
     compact_time = target.strftime("%H:%M")
 
-    log.info("Setting compactdb-interval=0, compactdb-time=%s (~90s from now)", compact_time)
+    log.info("Setting compactdb-interval=0, compactdb-time=%s (~15s from now)", compact_time)
     config.set([('nsslapd-db-compactdb-interval', '0'),
                 ('nsslapd-db-compactdb-time', compact_time)])
     inst.deleteErrorLogs(restart=True)
 
-    log.info("Waiting past the configured compaction time-of-day ...")
-    time.sleep(110)
-
-    assert not inst.searchErrorsLog("database compaction scheduled for")
-    assert not inst.searchErrorsLog("Compacting databases")
+    log.info("Polling past the configured compaction time-of-day ...")
+    _assert_no_log_line_for(inst, ["database compaction scheduled for", "Compacting databases"],
+                             duration=30, poll_interval=2)
 
     starttime_before = bdb_entry.get_attr_val_utf8('nsslapd-db-compactdb-starttime')
     log.info("nsslapd-db-compactdb-starttime before restart: %s", starttime_before)
 
     inst.restart()
-    time.sleep(10)
 
     starttime_after = bdb_entry.get_attr_val_utf8('nsslapd-db-compactdb-starttime')
     log.info("nsslapd-db-compactdb-starttime after restart: %s", starttime_after)
@@ -245,9 +269,10 @@ def test_disable_compaction_after_already_scheduled(topo):
     :setup: Supplier Instance
     :steps:
         1. Set a short nonzero interval/time so compaction gets scheduled
-        2. Confirm the "scheduled for" message appears
+        2. Poll for the "scheduled for" message to appear
         3. Set nsslapd-db-compactdb-interval to 0 before the scheduled time arrives
-        4. Wait past the originally scheduled time
+        4. Poll past the originally scheduled time, failing immediately if
+           compaction actually runs
     :expectedresults:
         1. Success
         2. Scheduling message is logged
@@ -257,22 +282,21 @@ def test_disable_compaction_after_already_scheduled(topo):
     inst = topo.ms["supplier1"]
     config = DatabaseConfig(inst)
 
-    target = datetime.datetime.now() + datetime.timedelta(seconds=60)
+    target = datetime.datetime.now() + datetime.timedelta(seconds=15)
     compact_time = target.strftime("%H:%M")
 
-    log.info("Setting compactdb-interval=30, compactdb-time=%s (~60s from now)", compact_time)
+    log.info("Setting compactdb-interval=30, compactdb-time=%s (~15s from now)", compact_time)
     config.set([('nsslapd-db-compactdb-interval', '30'),
                 ('nsslapd-db-compactdb-time', compact_time)])
     inst.deleteErrorLogs(restart=True)
 
-    time.sleep(10)
-    assert inst.searchErrorsLog("database compaction scheduled for")
+    assert _wait_for_log_line(inst, "database compaction scheduled for", timeout=10, poll_interval=1), \
+        "Compaction was never scheduled"
 
     log.info("Disabling compaction before the scheduled time arrives ...")
     config.set([('nsslapd-db-compactdb-interval', '0')])
 
-    time.sleep(70)
-    assert not inst.searchErrorsLog("Compacting databases")
+    _assert_no_log_line_for(inst, ["Compacting databases"], duration=25, poll_interval=2)
     inst.deleteErrorLogs(restart=False)
 
 

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -3926,6 +3926,24 @@ bdb_compact(time_t when, void *arg)
     ldbm_instance *inst;
     DB *db = NULL;
     int rc = 0;
+    time_t compactdb_interval;
+
+    /*
+     * The interval may have been set to 0 (compaction disabled) after
+     * this one-shot event was already queued via slapi_eq_once_rel().
+     * Re-check the live config before doing any real work.
+     */
+    PR_Lock(li->li_config_mutex);
+    compactdb_interval = (time_t)BDB_CONFIG(li)->bdb_compactdb_interval;
+    PR_Unlock(li->li_config_mutex);
+
+    if (compactdb_interval == 0) {
+        slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact",
+                      "database compaction skipped - auto-compaction is "
+                      "disabled (nsslapd-db-compactdb-interval: 0)\n");
+        compaction_scheduled = PR_FALSE;
+        return;
+    }
 
     for (inst_obj = objset_first_obj(li->li_instance_set);
          inst_obj;
@@ -4067,12 +4085,17 @@ bdb_checkpoint_threadmain(void *param)
          * already had a preexisting time set.  This way regardless if we
          * restart the server we will still compact at the expected interval */
         time_t curr_time = slapi_current_utc_time();
-        if (compactdb_interval < (curr_time - compactdb_start_time)) {
-            /* the interval has now been passed, trigger compaction right away */
-            compactdb_interval = 1;
-        } else {
-            compactdb_interval = compactdb_interval - (curr_time - compactdb_start_time);
+        if (compactdb_interval > 0) {
+            if (compactdb_interval < (curr_time - compactdb_start_time)) {
+                /* the interval has now been passed, trigger compaction right away */
+                compactdb_interval = 1;
+            } else {
+                compactdb_interval = compactdb_interval - (curr_time - compactdb_start_time);
+            }
         }
+        /* else: compaction is disabled (interval == 0) - leave compactdb_interval
+         * at 0. The main loop re-checks the live config every iteration and
+         * gates scheduling on that, independent of compactdb_expire's state. */
     }
 
     /* assumes bdb_force_checkpoint worked */
@@ -4093,13 +4116,18 @@ bdb_checkpoint_threadmain(void *param)
         if (compactdb_interval_update != compactdb_interval_orig) {
             /* Compact interval was changed, so reset the timer */
             time_t curr_time = slapi_current_utc_time();
-            if (compactdb_interval_update < (curr_time - compactdb_start_time)) {
-                /* the new interval has now been passed, trigger compaction right away */
-                compactdb_interval = 1;
-            } else {
-                compactdb_interval = compactdb_interval_update - (curr_time - compactdb_start_time);
+            if (compactdb_interval_update > 0) {
+                if (compactdb_interval_update < (curr_time - compactdb_start_time)) {
+                    /* the new interval has now been passed, trigger compaction right away */
+                    compactdb_interval = 1;
+                } else {
+                    compactdb_interval = compactdb_interval_update - (curr_time - compactdb_start_time);
+                }
+                slapi_timespec_expire_at(compactdb_interval, &compactdb_expire);
             }
-            slapi_timespec_expire_at(compactdb_interval, &compactdb_expire);
+            /* else: compactdb_interval_update is 0 - skip the timer adjustment.
+             * The scheduling block below also checks compactdb_interval_update
+             * and will short-circuit before compactdb_expire is ever consulted. */
         }
 
         /* Sleep for a while ...
@@ -4177,14 +4205,15 @@ bdb_checkpoint_threadmain(void *param)
 
         /* Compacting DB borrowing the timing of the log flush */
 
-        /*
-         * Remember that if compactdb_interval is 0, timer_expired can
-         * never occur unless the value in compactdb_interval changes.
-         *
-         * this could have been a bug in fact, where compactdb_interval
-         * was 0, if you change while running it would never take effect ....
-         */
-        if (compactdb_interval_update != compactdb_interval_orig ||
+        if (compactdb_interval_update == 0) {
+            /*
+             * Compaction is disabled. Keep compactdb_interval_orig in sync
+             * so that a future transition back to a nonzero interval is
+             * correctly detected by the != comparison below and takes
+             * effect immediately without requiring a server restart.
+             */
+            compactdb_interval_orig = 0;
+        } else if (compactdb_interval_update != compactdb_interval_orig ||
             (slapi_timespec_expire_check(&compactdb_expire) == TIMER_EXPIRED && !compaction_scheduled))
         {
             time_t scheduled_time;

--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_layer.c
@@ -3938,7 +3938,7 @@ bdb_compact(time_t when, void *arg)
     PR_Unlock(li->li_config_mutex);
 
     if (compactdb_interval == 0) {
-        slapi_log_err(SLAPI_LOG_NOTICE, "bdb_compact",
+        slapi_log_err(SLAPI_LOG_DEBUG, "bdb_compact",
                       "database compaction skipped - auto-compaction is "
                       "disabled (nsslapd-db-compactdb-interval: 0)\n");
         compaction_scheduled = PR_FALSE;


### PR DESCRIPTION
## Description
  
  Fixes #7728
  
  `nsslapd-db-compactdb-interval: 0` is documented to disable automatic database
  compaction, but `bdb_checkpoint_threadmain()` / `bdb_compact()` never checked
  for `interval == 0`, so auto-compaction kept running once a day and
  `nsslapd-db-compactdb-starttime` kept drifting on every restart.
  
   ## Fix

  Four changes, all in `bdb_layer.c`:

  1. `bdb_compact()` re-checks the live config when its scheduled callback fires
     and no-ops if `interval == 0`. This closes the race where compaction was
     already queued via `slapi_eq_once_rel()` before the admin disabled it.
     (`bdb_compact()` has exactly one call site in the codebase; the manual
     on-demand `compact db` task path never calls it, so this has no effect on
     manual compaction.)
  2. Guard the pre-loop timer-adjustment math with `interval > 0` to avoid
     computing a negative `time_t`.
  3. Guard the in-loop timer-adjustment math the same way, for the case where
     the admin changes the interval while the server is running.
  4. **Primary fix** - the scheduling block is now gated on
     `compactdb_interval_update == 0`, skipping scheduling entirely while
     keeping `compactdb_interval_orig` in sync, so re-enabling compaction later
     takes effect immediately without a server restart.

  `bdb_write_compact_start_time()` itself is intentionally left unguarded, since
  it's shared with the manual compact-task path; fix #1 already prevents the
  automatic scheduler from calling it while disabled.

  
  ## Tests
  
  Two new tests in `dirsrvtests/tests/suites/config/compact_test.py`:
  
  - `test_no_compaction_near_scheduled_time` - sets interval=0 with
    `compactdb-time` ~90s in the future, confirms no scheduling/compaction log
    lines appear, and confirms `nsslapd-db-compactdb-starttime` is unchanged
    across a restart. 
  - `test_disable_compaction_after_already_scheduled` - schedules a compaction
    with a short nonzero interval, then disables it (interval=0) before it
    fires, and confirms it never actually runs.

  Verified with `python3 -m py_compile`.

## Summary by Sourcery

Ensure setting the automatic BDB compaction interval to zero reliably disables scheduled compaction without affecting manual compaction.

Bug Fixes:
- Prevent automatic BDB compaction when `nsslapd-db-compactdb-interval` is set to 0, including compactions that were already scheduled before the setting changed.
- Prevent the compaction start time from being rewritten while automatic compaction is disabled and allow compaction to resume promptly when re-enabled.

Tests:
- Add coverage for disabling compaction near its scheduled time and after a compaction event has already been queued.