### PR TITLE
Issue 4701 - Fix UAF when excluding attrs from retro changelog

### DIFF
--- a/ldap/servers/plugins/retrocl/retrocl.c
+++ b/ldap/servers/plugins/retrocl/retrocl.c
@@ -741,6 +741,12 @@ retrocl_attr_in_exclude_attrs(char *attr, int attrlen)
     return 0;
 }
 
+char **
+retrocl_get_exclude_attrs(void)
+{
+    return retrocl_exclude_attrs;
+}
+
 static int
 retrocl_config_modify(Slapi_PBlock *pb, Slapi_Entry *e, Slapi_Entry *entryAfter, int *returncode, char *returntext, void *arg)
 {

--- a/ldap/servers/plugins/retrocl/retrocl.h
+++ b/ldap/servers/plugins/retrocl/retrocl.h
@@ -147,5 +147,6 @@ extern char *retrocl_get_config_str(const char *attrt);
 
 int retrocl_entry_in_scope(Slapi_Entry *e);
 int retrocl_attr_in_exclude_attrs(char *attr, int attrlen);
+char **retrocl_get_exclude_attrs(void);
 
 #endif /* _H_RETROCL */

--- a/ldap/servers/plugins/retrocl/retrocl_po.c
+++ b/ldap/servers/plugins/retrocl/retrocl_po.c
@@ -416,7 +416,6 @@ entry2reple(Slapi_Entry *e, Slapi_Entry *oe, int optype)
     struct berval *vals[2];
     struct berval val;
     int len;
-    Slapi_Attr *attrs = NULL;
 
     vals[0] = &val;
     vals[1] = NULL;
@@ -433,16 +432,7 @@ entry2reple(Slapi_Entry *e, Slapi_Entry *oe, int optype)
     }
     slapi_entry_add_values(e, retrocl_changetype, vals);
 
-    /* Does this entry contain any excluded attributes */
-    for (attrs  = oe->e_attrs; attrs != NULL; attrs = attrs->a_next) {
-        if (retrocl_attr_in_exclude_attrs(attrs->a_type, strlen(attrs->a_type))) {
-            slapi_log_err(SLAPI_LOG_PLUGIN, RETROCL_PLUGIN_NAME, "entry2reple - excluding attr (%s).\n", attrs->a_type);
-            attrlist_delete(&oe->e_attrs, attrs->a_type);
-            attrs = attrs->a_next;
-        }
-    }
-
-    estr = slapi_entry2str(oe, &len);
+    estr = slapi_entry2str_exclude_attrs(oe, &len, retrocl_get_exclude_attrs());
     p = estr;
     /* Skip over the dn: line */
     while ((p = strchr(p, '\n')) != NULL) {

--- a/ldap/servers/slapd/entry.c
+++ b/ldap/servers/slapd/entry.c
@@ -1382,8 +1382,22 @@ entry2str_internal_size_valueset(const Slapi_Attr *a, const char *attrtype, cons
     return elen;
 }
 
+static int
+entry2str_attr_is_excluded(const char *attrtype, char **exclude_attrs)
+{
+    if (exclude_attrs == NULL || attrtype == NULL) {
+        return 0;
+    }
+    for (char **ex = exclude_attrs; *ex != NULL; ex++) {
+        if (strcasecmp(attrtype, *ex) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static size_t
-entry2str_internal_size_attrlist(const Slapi_Attr *attrlist, int entry2str_ctrl, int attribute_state)
+entry2str_internal_size_attrlist(const Slapi_Attr *attrlist, int entry2str_ctrl, int attribute_state, char **exclude_attrs)
 {
     size_t elen = 0;
     const Slapi_Attr *a;
@@ -1392,6 +1406,10 @@ entry2str_internal_size_attrlist(const Slapi_Attr *attrlist, int entry2str_ctrl,
         if ((entry2str_ctrl & SLAPI_DUMP_NOOPATTRS) &&
             slapi_attr_flag_is_set(a, SLAPI_ATTR_FLAG_OPATTR))
             continue;
+
+        if (entry2str_attr_is_excluded(a->a_type, exclude_attrs)) {
+            continue;
+        }
 
         /* Count the space required for the present and deleted values */
         elen += entry2str_internal_size_valueset(a, a->a_type, &a->a_present_values,
@@ -1537,7 +1555,7 @@ is_type_forbidden(const char *type)
 #endif
 
 static void
-entry2str_internal_put_attrlist(const Slapi_Attr *attrlist, int attr_state, int entry2str_ctrl, char **ecur, char **typebuf, size_t *typebuf_len)
+entry2str_internal_put_attrlist(const Slapi_Attr *attrlist, int attr_state, int entry2str_ctrl, char **ecur, char **typebuf, size_t *typebuf_len, char **exclude_attrs)
 {
     const Slapi_Attr *a;
 
@@ -1547,6 +1565,10 @@ entry2str_internal_put_attrlist(const Slapi_Attr *attrlist, int attr_state, int 
         if ((entry2str_ctrl & SLAPI_DUMP_NOOPATTRS) &&
             slapi_attr_flag_is_set(a, SLAPI_ATTR_FLAG_OPATTR))
             continue;
+
+        if (entry2str_attr_is_excluded(a->a_type, exclude_attrs)) {
+            continue;
+        }
 
         /* don't dump uniqueid if not asked */
         if (!(strcasecmp(a->a_type, SLAPI_ATTR_UNIQUEID) == 0 &&
@@ -1582,7 +1604,7 @@ entry2str_internal_put_attrlist(const Slapi_Attr *attrlist, int attr_state, int 
 }
 
 static char *
-entry2str_internal(Slapi_Entry *e, int *len, int entry2str_ctrl)
+entry2str_internal(Slapi_Entry *e, int *len, int entry2str_ctrl, char **exclude_attrs)
 {
     char *ebuf;
     char *ecur;
@@ -1609,12 +1631,12 @@ entry2str_internal(Slapi_Entry *e, int *len, int entry2str_ctrl)
     }
 
     /* Count the space required for the present attributes */
-    elen += entry2str_internal_size_attrlist(e->e_attrs, entry2str_ctrl, ATTRIBUTE_PRESENT);
+    elen += entry2str_internal_size_attrlist(e->e_attrs, entry2str_ctrl, ATTRIBUTE_PRESENT, exclude_attrs);
 
     /* Count the space required for the deleted attributes */
     if (entry2str_ctrl & SLAPI_DUMP_STATEINFO) {
         elen += entry2str_internal_size_attrlist(e->e_deleted_attrs, entry2str_ctrl,
-                                                 ATTRIBUTE_DELETED);
+                                                 ATTRIBUTE_DELETED, exclude_attrs);
     }
 
     elen += 1;
@@ -1627,11 +1649,11 @@ entry2str_internal(Slapi_Entry *e, int *len, int entry2str_ctrl)
     }
 
     /* Put the present attributes */
-    entry2str_internal_put_attrlist(e->e_attrs, ATTRIBUTE_PRESENT, entry2str_ctrl, &ecur, &typebuf, &typebuf_len);
+    entry2str_internal_put_attrlist(e->e_attrs, ATTRIBUTE_PRESENT, entry2str_ctrl, &ecur, &typebuf, &typebuf_len, exclude_attrs);
 
     /* Put the deleted attributes */
     if (entry2str_ctrl & SLAPI_DUMP_STATEINFO) {
-        entry2str_internal_put_attrlist(e->e_deleted_attrs, ATTRIBUTE_DELETED, entry2str_ctrl, &ecur, &typebuf, &typebuf_len);
+        entry2str_internal_put_attrlist(e->e_deleted_attrs, ATTRIBUTE_DELETED, entry2str_ctrl, &ecur, &typebuf, &typebuf_len, exclude_attrs);
     }
 
     *ecur = '\0';
@@ -1652,7 +1674,7 @@ entry2str_internal(Slapi_Entry *e, int *len, int entry2str_ctrl)
 }
 
 static char *
-entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl)
+entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl, char **exclude_attrs)
 {
     if (entry2str_ctrl & SLAPI_DUMP_RDN_ENTRY) /* dump rdn: ... */
     {
@@ -1686,13 +1708,13 @@ entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl)
 
         /* Count the space required for the present attributes */
         elen += entry2str_internal_size_attrlist(e->e_attrs, entry2str_ctrl,
-                                                 ATTRIBUTE_PRESENT);
+                                                 ATTRIBUTE_PRESENT, exclude_attrs);
 
         /* Count the space required for the deleted attributes */
         if (entry2str_ctrl & SLAPI_DUMP_STATEINFO) {
             elen += entry2str_internal_size_attrlist(e->e_deleted_attrs,
                                                      entry2str_ctrl,
-                                                     ATTRIBUTE_DELETED);
+                                                     ATTRIBUTE_DELETED, exclude_attrs);
         }
 
         elen += 1;
@@ -1710,13 +1732,13 @@ entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl)
         /* Put the present attributes */
         entry2str_internal_put_attrlist(e->e_attrs, ATTRIBUTE_PRESENT,
                                         entry2str_ctrl, &ecur,
-                                        &typebuf, &typebuf_len);
+                                        &typebuf, &typebuf_len, exclude_attrs);
 
         /* Put the deleted attributes */
         if (entry2str_ctrl & SLAPI_DUMP_STATEINFO) {
             entry2str_internal_put_attrlist(e->e_deleted_attrs,
                                             ATTRIBUTE_DELETED, entry2str_ctrl,
-                                            &ecur, &typebuf, &typebuf_len);
+                                            &ecur, &typebuf, &typebuf_len, exclude_attrs);
         }
 
         *ecur = '\0';
@@ -1737,7 +1759,7 @@ entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl)
         return ebuf;
     } else /* dump "dn: ..." */
     {
-        return entry2str_internal(e, len, entry2str_ctrl);
+        return entry2str_internal(e, len, entry2str_ctrl, exclude_attrs);
     }
 }
 
@@ -1747,7 +1769,7 @@ entry2str_internal_ext(Slapi_Entry *e, int *len, int entry2str_ctrl)
 char *
 slapi_entry2str(Slapi_Entry *e, int *len)
 {
-    return entry2str_internal(e, len, 0);
+    return entry2str_internal(e, len, 0, NULL);
 }
 
 /*
@@ -1756,7 +1778,7 @@ slapi_entry2str(Slapi_Entry *e, int *len)
 char *
 slapi_entry2str_dump_uniqueid(Slapi_Entry *e, int *len)
 {
-    return entry2str_internal(e, len, SLAPI_DUMP_UNIQUEID);
+    return entry2str_internal(e, len, SLAPI_DUMP_UNIQUEID, NULL);
 }
 
 /*
@@ -1765,7 +1787,18 @@ slapi_entry2str_dump_uniqueid(Slapi_Entry *e, int *len)
 char *
 slapi_entry2str_no_opattrs(Slapi_Entry *e, int *len)
 {
-    return entry2str_internal(e, len, SLAPI_DUMP_NOOPATTRS);
+    return entry2str_internal(e, len, SLAPI_DUMP_NOOPATTRS, NULL);
+}
+
+/*
+ * This function converts an entry to the entry string starting with "dn: ..."
+ * Attributes listed in exclude_attrs are omitted from the output. The
+ * entry itself is not modified.
+ */
+char *
+slapi_entry2str_exclude_attrs(Slapi_Entry *e, int *len, char **exclude_attrs)
+{
+    return entry2str_internal(e, len, 0, exclude_attrs);
 }
 
 /*
@@ -1776,7 +1809,7 @@ slapi_entry2str_no_opattrs(Slapi_Entry *e, int *len)
 char *
 slapi_entry2str_with_options(Slapi_Entry *e, int *len, int options)
 {
-    return entry2str_internal_ext(e, len, options);
+    return entry2str_internal_ext(e, len, options, NULL);
 }
 
 static int entry_type = -1; /* The type number assigned by the Factory for 'Entry' */

--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -1118,6 +1118,25 @@ char *slapi_entry2str_with_options(Slapi_Entry *e, int *len, int options);
 char *slapi_entry2str(Slapi_Entry *e, int *len);
 
 /**
+ * Generates an LDIF string description of an LDAP entry, omitting excluded attributes.
+ *
+ * This function behaves like slapi_entry2str(), but attributes that appear
+ * in \c exclude_attrs are not included in the output. The entry itself
+ * is not modified.
+ *
+ * \param e Entry that you want to convert into an LDIF string.
+ * \param len Length of the LDIF string returned by this function.
+ * \param exclude_attrs NULL terminated array of attribute names to omit.
+ * \return The LDIF string representation of the entry you specify.
+ * \return \c NULL if an error occurs.
+ * \warning When you no longer need to use the string, you should free it
+ *          from memory by calling the slapi_ch_free_string() function.
+ *
+ * \see slapi_entry2str()
+ */
+char *slapi_entry2str_exclude_attrs(Slapi_Entry *e, int *len, char **exclude_attrs);
+
+/**
  * Allocates memory for a new entry of the data type #Slapi_Entry.
  *
  * This function returns an empty #Slapi_Entry structure. You can call other


### PR DESCRIPTION
Description:
When exclude attributes are configured for the retro changelog plugin, add and delete operations remove the excluded attributes from the operation entry. This deletes an entry still in use and could cause a use after free when slapi_entry2str() walks the entry attribute list.

Fix:
Add slapi_entry2str_exclude_attrs() to filter out excluded attributes at serialisation time, without modifying the entry.

Fixes: https://github.com/389ds/389-ds-base/issues/4701

Reviewed by:

## Summary by Sourcery

Serialize retro changelog entries without mutating them when excluded attributes are configured.

New Features:
- Add an entry serialization API that omits specified attributes without modifying the source entry.

Bug Fixes:
- Prevent use-after-free risks in retro changelog generation when excluded attributes are configured.

Enhancements:
- Apply attribute exclusions during LDIF serialization for both present and deleted attributes.

Documentation:
- Document the new attribute-excluding entry serialization API.