### PR TITLE
Issue 7733 - Typo about nsuniqueid in tombstone_to_conflict

### DIFF
--- a/ldap/servers/plugins/replication/urp_tombstone.c
+++ b/ldap/servers/plugins/replication/urp_tombstone.c
@@ -256,7 +256,11 @@ tombstone_to_conflict(
     Slapi_Mods smods;
     char csnstr[CSN_STRSIZE + 1];
 
-    char *uniqueid = slapi_entry_attr_get_charptr(tombstoneentry, "nsuiqueid");
+    /*
+     * tombstoneentry get freed by urp_fixup_add_entry so we cannot use
+     * slapi_entry_get_uniqueid (heap-use-after-free error)
+     */
+    char *uniqueid = slapi_entry_attr_get_charptr(tombstoneentry, SLAPI_ATTR_UNIQUEID);
     const char *entrydn = slapi_entry_attr_get_ref(tombstoneentry, "nscpentrydn");
     char *parentdn = slapi_dn_parent(slapi_sdn_get_ndn(conflictdn));
     const CSN *dncsn = entry_get_dncsn(tombstoneentry);


### PR DESCRIPTION
tombstone_to_conflict tries to retrieve "nsuiqueid" instead of "nsuniqueid"
So there is a risk that the internal modify get applied on a wrong entry (because nscpdn is used instead of uuid)
Note as it impacts the tombstone/conflict entry handling, (which are usually hidden) there are fair chance that the issue never got noticed

Issue: #7733

Reviewed by: @mreynolds389 

## Summary by Sourcery

Bug Fixes:
- Correct tombstone conflict handling to retrieve the entry unique identifier using the proper attribute, preventing updates from targeting an incorrect entry.