### PR TITLE
Issue 7595 - Skip redundant CI runs to relieve the Actions queue

### DIFF
--- a/.github/scripts/pr_scope.py
+++ b/.github/scripts/pr_scope.py
@@ -1,0 +1,52 @@
+import json
+import os
+import sys
+import urllib.request
+
+# Print "webui" when the PR only touches the Cockpit UI, so the matrix
+# shrinks to that suite. On any doubt, print nothing (full matrix).
+UI_PREFIX = "src/cockpit/389-console/"
+PER_PAGE = 100
+MAX_PAGES = 3
+
+
+def changed_files(repo, pr_number, token):
+    files = []
+    for page in range(1, MAX_PAGES + 1):
+        url = (f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files"
+               f"?per_page={PER_PAGE}&page={page}")
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            batch = json.load(response)
+        for entry in batch:
+            files.append(entry["filename"])
+            # A rename lists only its new path in "filename"; the old
+            # path must count too, or a move out of another tree would
+            # pass as UI-only.
+            previous = entry.get("previous_filename")
+            if previous:
+                files.append(previous)
+        if len(batch) < PER_PAGE:
+            return files
+    return None
+
+
+def main():
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if len(sys.argv) != 2 or not repo:
+        return 0
+    try:
+        files = changed_files(repo, sys.argv[1], token)
+    except Exception:
+        return 0
+    if files and all(name.startswith(UI_PREFIX) for name in files):
+        print("webui")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cargotest.yml
+++ b/.github/workflows/cargotest.yml
@@ -2,7 +2,25 @@ name: Rust Tests
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
@@ -13,9 +31,40 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip unchanged nightly runs
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Push successes count too: this workflow still triggers on
+          # push and takes no inputs, so any green push run at this sha
+          # is full coverage.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --status success --branch "$GITHUB_REF_NAME" --limit 20 --json headSha,event \
+            --jq '[.[] | select(.event == "push" or .event == "schedule")][0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   rust-tests:
     name: Cargo Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:fedora
     

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,7 +1,26 @@
 name: Compile
 on:
-  - pull_request
-  - push
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
+  push:
+    branches:
+      - main
+      - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
+  workflow_dispatch:
 
 permissions: 
   actions: read

--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -1,8 +1,15 @@
 name: LMDB Test
 
 on:
-  push:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
@@ -10,7 +17,7 @@ on:
       pytest_tests:
         description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
         required: false
-        default: false
+        default: ''
       debug_enabled:
         description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
@@ -22,9 +29,39 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip the nightly when nothing changed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only scheduled successes count: dispatch runs may be partial
+          # (pytest_tests) and this workflow has no push runs.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --event schedule --status success --branch "$GITHUB_REF_NAME" \
+            --limit 1 --json headSha --jq '.[0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful scheduled run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
@@ -36,9 +73,18 @@ jobs:
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Check if the diff is limited to the Web UI
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "suites=$(python3 .github/scripts/pr_scope.py ${{ github.event.pull_request.number }})" >>$GITHUB_OUTPUT
+
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})" >>$GITHUB_OUTPUT
+        env:
+          SUITES: ${{ steps.scope.outputs.suites || github.event.inputs.pytest_tests }}
+        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py $SUITES)" >>$GITHUB_OUTPUT
 
       - name: Build RPMs
         run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
@@ -56,6 +102,10 @@ jobs:
     name: LMDB Test
     runs-on: ubuntu-22.04
     needs: build
+    # The implicit success() check is false whenever any job in the
+    # transitive needs chain was skipped, so the PR-skipped gate would
+    # skip the tests too (actions/runner#491). Depend on build alone.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build.outputs.matrix) }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,8 +2,28 @@ name: npm-audit-ci
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
+    # No sha gate on this nightly: audit-ci results drift with the npm
+    # advisory database even when the tree is unchanged.
     - cron:  '0 0 * * *'
 
 permissions: 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,8 +1,15 @@
 name: Test
 
 on:
-  push:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
@@ -10,7 +17,7 @@ on:
       pytest_tests:
         description: 'Run only specified suites or test modules delimited by space, for example "basic/basic_test.py replication"'
         required: false
-        default: false
+        default: ''
       debug_enabled:
         description: 'Set to "true" to enable debugging with tmate (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
@@ -22,9 +29,39 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Skip the nightly when nothing changed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only scheduled successes count: dispatch runs may be partial
+          # (pytest_tests) and this workflow has no push runs.
+          run=true
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "${{ github.workflow }}" \
+            --event schedule --status success --branch "$GITHUB_REF_NAME" \
+            --limit 1 --json headSha --jq '.[0].headSha' || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "No new commits since the last successful scheduled run"
+            run=false
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: gate
+    # != 'success' keeps the gate fail-open: a gate infra failure must
+    # not skip the nightly.
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
     container:
       image: quay.io/389ds/ci-images:test
     outputs:
@@ -36,9 +73,18 @@ jobs:
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Check if the diff is limited to the Web UI
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "suites=$(python3 .github/scripts/pr_scope.py ${{ github.event.pull_request.number }})" >>$GITHUB_OUTPUT
+
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})" >>$GITHUB_OUTPUT
+        env:
+          SUITES: ${{ steps.scope.outputs.suites || github.event.inputs.pytest_tests }}
+        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py $SUITES)" >>$GITHUB_OUTPUT
 
       - name: Build RPMs
         run: SKIP_AUDIT_CI=1 make -f rpm.mk dist-bz2 rpms
@@ -56,6 +102,10 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     needs: build
+    # The implicit success() check is false whenever any job in the
+    # transitive needs chain was skipped, so the PR-skipped gate would
+    # skip the tests too (actions/runner#491). Depend on build alone.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build.outputs.matrix) }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,26 @@ name: Validate tests
 
 on:
   push:
+    branches:
+      - main
+      - "389-ds-base-*"
+    paths-ignore:
+      - '**.md'
+      # not docs/**: slapi.doxy.in and the doxygen assets are build inputs
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/agents/**'
+      - 'docs/design/**'
+      - 'LICENSE*'
+      - '.packit.yaml'
+      - '.github/renovate.json'
+  workflow_dispatch:
 
 permissions: 
   actions: read


### PR DESCRIPTION
Bug Description:
Every push to this branch schedules the full test matrix against the org's 20-job concurrency limit, so a backport sweep saturates the queue for days. The results are already known: each backport passed full PR CI before it landed. A manual workflow_dispatch on this branch is broken as well - pytest_tests defaults to the string "false", which generate_matrix.py rejects, so the run reports success having executed zero tests.

Fix Description:
Backport the main-branch change. Drop the push triggers from the test workflows; main's nightly dispatcher runs this branch once per head commit instead. Narrow the push triggers of the remaining workflows to main and the release branches, and ignore doc-only paths. Fix the pytest_tests default to "".

The gate jobs are inert here, since schedule only fires on the default branch, and they fail open, so they cannot block a run. Where the surrounding lines conflicted, the pick resolves to main's side, which carries earlier queue-relief work along: the job timeout caps from issue 7296, and, on branches that lacked them, the PR-cancel concurrency groups and read-only permissions from issue 6841. The runner pins and container images are unchanged.

codeql.yml and nightly-dispatch.yml are deliberately not backported. CodeQL's only release-branch trigger is pull_request, which would add jobs instead of removing them, and the dispatcher is a single-instance orchestrator that belongs on main.

Relates: https://github.com/389ds/389-ds-base/issues/7595

Assisted by: Claude

(cherry picked from commit 4731986532fde46136f60dc1356ad77a67adb73c)

## Summary by Sourcery

Reduce redundant CI runs on backport branches while keeping relevant validation coverage and improving pull-request test targeting.

New Features:
- Automatically narrow pull-request test matrices to the Web UI suite when changes are confined to the Cockpit UI.

Bug Fixes:
- Correct manual pytest workflow inputs so runs default to no explicitly selected suites and execute normally.

Enhancements:
- Reduce redundant CI activity by restricting push workflows to main and release branches, ignoring documentation-only changes, and skipping unchanged scheduled runs.
- Preserve reliable nightly and pull-request execution with fail-open gates, explicit job timeouts, and appropriate job dependencies.

CI:
- Improve CI queue utilization across test, compile, validation, Rust, LMDB, and npm workflows while retaining relevant pull-request, schedule, and manual triggers.