### PR TITLE
Issue 7760 - CI - harden dsconf_task_test.py

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
+++ b/dirsrvtests/tests/suites/clu/dsconf_tasks_test.py
@@ -204,7 +204,7 @@ def test_dsconf_task_watch_output(topo):
 
 
 def test_task_timeout(topo):
-    """All thath te timeoutsetting works for all "tasks"
+    """Test that the timeout setting works for all "tasks"
 
     :id: 6a6f5176-76bf-424d-bc10-d33bdfa529eb
     :setup: Standalone Instance
@@ -292,7 +292,7 @@ def test_task_timeout(topo):
         'basedn': DEFAULT_SUFFIX,
         'filter': "objectClass=*"
     })
-    task.wait(timeout=.5, sleep_interval=.5)
+    task.wait(timeout=.2, sleep_interval=.2)
     assert task.get_exit_code() is None
     task.wait(timeout=0)
 
@@ -309,7 +309,7 @@ def test_task_timeout(topo):
     """
 
     # Test timeout for usn cleanup task, first delete a bunch of users
-    for idx in range(1, 1001):
+    for idx in range(1, 2001):
         entry_idx = str(idx).zfill(6)
         dn = f"uid=user{entry_idx},ou=people,{DEFAULT_SUFFIX}"
         UserAccount(inst, dn=dn).delete()


### PR DESCRIPTION
Description:

Tasks were finishing too fast. Increase the workload so the tasks run longer

Relates: https://github.com/389ds/389-ds-base/issues/7760

## Summary by Sourcery

Harden dsconf task timeout tests by increasing workload and shortening wait intervals to make timeout behavior more reliable.

Enhancements:
- Harden task timeout coverage by increasing the cleanup workload and tightening the task wait intervals.
- Correct the task timeout test documentation typo.

Tests:
- Strengthen dsconf task timeout tests so tasks run long enough to reliably validate timeout behavior.