### PR TITLE
Issue 7595 - Run PR tests when the nightly gate is skipped

### DIFF
--- a/.github/workflows/lmdbpytest.yml
+++ b/.github/workflows/lmdbpytest.yml
@@ -107,6 +107,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: build
+    # The implicit success() check is false whenever any job in the
+    # transitive needs chain was skipped, so the PR-skipped gate would
+    # skip the tests too (actions/runner#491). Depend on build alone.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -107,6 +107,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: build
+    # The implicit success() check is false whenever any job in the
+    # transitive needs chain was skipped, so the PR-skipped gate would
+    # skip the tests too (actions/runner#491). Depend on build alone.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     strategy:
       fail-fast: false
       max-parallel: 6


### PR DESCRIPTION
Bug Description: The gate job only exists to dedupe nightlies, so it is intentionally limited to schedule events and reports skipped on every pull_request and workflow_dispatch run. The BDB Test and LMDB Test jobs carry no explicit if condition, so they use the implicit success() status check, and that check is false whenever any job in the transitive needs chain was skipped (actions/runner#491). Since commit 4731986 those runs built the RPMs but skipped all pytest suites, while still reporting overall success.

Fix Description: Give both test jobs an explicit condition that depends on the build result alone, so the skipped gate no longer propagates past the build job. Nightly runs are unchanged: there the gate runs and succeeds, and a failed or cancelled build still skips the tests.

Relates: https://github.com/389ds/389-ds-base/issues/7595

Reviewed by: ?

## Summary by Sourcery

Ensure pull request and manual workflows execute the database test suites when their build succeeds despite the nightly gate being skipped.

Bug Fixes:
- Run the BDB and LMDB pytest jobs on pull request and manual workflows when the build succeeds, even if the nightly gate is skipped.

CI:
- Update pytest workflow conditions so cancelled or failed builds still prevent tests from running while skipped gate jobs no longer propagate to them.