### PR TITLE
Issue 7767 - Include stdbool.h in slapi headers on 2.4

### DIFF
--- a/ldap/servers/slapd/slapi-plugin.h
+++ b/ldap/servers/slapd/slapi-plugin.h
@@ -35,6 +35,7 @@ extern "C" {
 #include "nspr.h"
 #include <syslog.h>
 #include <plhash.h>
+#include <stdbool.h>
 
 #ifdef __GNUC__
     #define __ATTRIBUTE__(x) __attribute__(x)

--- a/ldap/servers/slapd/slapi-private.h
+++ b/ldap/servers/slapd/slapi-private.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "nspr.h"
 #include "portable.h"
 #include "slapi-plugin.h"
+#include <stdbool.h>
 /*
  * XXXmcs: we can stop including slapi-plugin-compat4.h once we stop using
  * deprecated functions internally.


### PR DESCRIPTION
Description:
The public and internal plugin headers on branched 2.2/2.4 do not include <stdbool.h>. 2.6 and later do, so backports that use bool fail to compile on 2.2/2.4.

Relates: https://github.com/389ds/389-ds-base/issues/1704
Fixes: https://github.com/389ds/389-ds-base/issues/7767

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Ensure public and internal SLAPI headers provide the standard boolean type definitions so backported plugins using `bool` compile on 2.2/2.4.