### PR TITLE
Issue 7770 - Testimony failure in test_cleanruv_extop_security.py

### DIFF
--- a/dirsrvtests/tests/suites/replication/cleanruv_extop_security_test.py
+++ b/dirsrvtests/tests/suites/replication/cleanruv_extop_security_test.py
@@ -423,9 +423,6 @@ def test_authorization_revocation(topology_m2, init_bind_user):
         5. User is re-added to group
         6. Group membership synchronized
         7. Operation succeeds again (user re-authorized)
-    :cleanup:
-        - User is re-added to group (in finally block)
-        - Group cache is synchronized (in finally block)
     """
     supplier1 = topology_m2.ms["supplier1"]
     supplier2 = topology_m2.ms["supplier2"]


### PR DESCRIPTION
Bug Description:
`test_cleanruv_extop_security.py` fails testimony validation. It also should be renamed to `cleanruv_extop_security_test.py` to be picked up by pytest test discovery.

Fix Description:
Remove unsupported docstring section, rename the file.

Fixes: https://github.com/389ds/389-ds-base/issues/7770

## Summary by Sourcery

Update the clean RUV extended-operation security test to satisfy validation and test discovery requirements.

Bug Fixes:
- Fix testimony validation for the clean RUV extended-operation security test.

Tests:
- Rename the clean RUV extended-operation security test so pytest discovers it.