### PR TITLE
Issue 7772 - double-free when processing an invalid Session Tracking …

### DIFF
--- a/dirsrvtests/tests/suites/session_tracking/session_test.py
+++ b/dirsrvtests/tests/suites/session_tracking/session_test.py
@@ -31,6 +31,86 @@ SESSION_TRACKING_FORMAT_OID = SESSION_TRACKING_CONTROL_OID + ".1234"
 
 pytestmark = pytest.mark.tier0
 
+from ldap.controls import RequestControl
+from pyasn1.type import namedtype,univ
+from pyasn1.codec.ber import encoder
+from pyasn1_modules.rfc2251 import LDAPString,LDAPOID
+
+
+# OID constants
+SESSION_TRACKING_CONTROL_OID = "1.3.6.1.4.1.21008.108.63.1"
+
+
+class SessionTrackingControlCritical(RequestControl):
+  """
+  Class for Session Tracking Control
+  With a criticality set to TRUE
+  """
+
+  class SessionIdentifierControlValue(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+      namedtype.NamedType('sessionSourceIp',LDAPString()),
+      namedtype.NamedType('sessionSourceName',LDAPString()),
+      namedtype.NamedType('formatOID',LDAPOID()),
+      namedtype.NamedType('sessionTrackingIdentifier',LDAPString()),
+    )
+
+  controlType = SESSION_TRACKING_CONTROL_OID
+
+  def __init__(self,sessionSourceIp,sessionSourceName,formatOID,sessionTrackingIdentifier):
+    # criticality set to TRUE for test robustness
+    self.criticality = True
+    self.sessionSourceIp,self.sessionSourceName,self.formatOID,self.sessionTrackingIdentifier = \
+      sessionSourceIp,sessionSourceName,formatOID,sessionTrackingIdentifier
+
+  def encodeControlValue(self):
+    s = self.SessionIdentifierControlValue()
+    s.setComponentByName('sessionSourceIp',LDAPString(self.sessionSourceIp))
+    s.setComponentByName('sessionSourceName',LDAPString(self.sessionSourceName))
+    s.setComponentByName('formatOID',LDAPOID(self.formatOID))
+    s.setComponentByName('sessionTrackingIdentifier',LDAPString(self.sessionTrackingIdentifier))
+    return encoder.encode(s)
+
+def test_critical_session_tracking_srch(topology_st, request):
+    """Verify that a critical session tracking control
+    does not trigger double free
+
+    :id: 9b46d5e5-82ac-4a2b-90b6-0978802fc063
+    :customerscenario: False
+    :setup: Standalone instance, default backend.
+    :steps:
+        1. Loop with searches with one containing a critical control
+    :expectedresults:
+        1. The SRCH with critical control fails the other one succeeds
+    """
+
+
+    SESSION_TRACKING_IDENTIFIER = "SRCH criticality TRUE"
+    st_ctrl = SessionTrackingControlCritical(
+      SESSION_SOURCE_IP,
+      SESSION_SOURCE_NAME,
+      SESSION_TRACKING_FORMAT_OID,
+      SESSION_TRACKING_IDENTIFIER
+    )
+
+    # 1000 attempts is enough to trigger SIGSEV
+    for i in range(0, 1000):
+        try:
+            topology_st.standalone.search_ext_s(DEFAULT_SUFFIX,
+                                                ldap.SCOPE_SUBTREE,
+                                                '(uid=*)',
+                                                serverctrls=[st_ctrl])
+        except:
+            pass
+        topology_st.standalone.search_ext_s(DEFAULT_SUFFIX,
+                                            ldap.SCOPE_SUBTREE,
+                                            '(uid=*)')
+
+    def fin():
+        pass
+
+    request.addfinalizer(fin)
+
 def test_short_session_tracking_srch(topology_st, request):
     """Verify that a short session_tracking string
     is added (not truncate) during a search

--- a/ldap/servers/slapd/control.c
+++ b/ldap/servers/slapd/control.c
@@ -517,14 +517,16 @@ get_ldapmessage_controls_ext(
                 slapi_log_err(SLAPI_LOG_WARNING, "get_ldapmessage_controls_ext", "Warning: conn=%" PRIu64 " op=%d failed to parse SessionTracking control (%d)\n",
                               pb_conn ? pb_conn->c_connid : -1, pb_op ? pb_op->o_opid : -1, parse_rc);
                 slapi_ch_free_string(&session_tracking_id);
+                slapi_pblock_set(pb, SLAPI_SESSION_TRACKING, NULL);
             } else {
                 /* now replace the sid (if any) in the pblock */
                 slapi_pblock_get(pb, SLAPI_SESSION_TRACKING, &old_sid);
                 slapi_ch_free_string(&old_sid);
                 slapi_pblock_set(pb, SLAPI_SESSION_TRACKING, session_tracking_id);
             }
+        } else {
+            slapi_pblock_set(pb, SLAPI_SESSION_TRACKING, NULL);
         }
-        slapi_pblock_set(pb, SLAPI_SESSION_TRACKING, session_tracking_id);
         pwpolicy_ctrl = slapi_control_present(ctrls,
                                               LDAP_X_CONTROL_PWPOLICY_REQUEST, NULL, NULL);
         slapi_pblock_set(pb, SLAPI_PWPOLICY, &pwpolicy_ctrl);
@@ -557,6 +559,7 @@ get_ldapmessage_controls_ext(
 
 free_and_return:;
     ldap_controls_free(ctrls);
+    slapi_pblock_set(pb, SLAPI_REQCONTROLS, NULL); /* make sure controls are removed from the pblock */
     slapi_log_err(SLAPI_LOG_TRACE, "get_ldapmessage_controls_ext",
                   "<= %i\n", rc);
     return (rc);


### PR DESCRIPTION
…control

Bug description:
	The Session Tracking control is invalid if its criticality is true.
	In such case the control is rejected and the operation fails.
	The control is freed when it is rejected and freed again when
	the operation returns because the control was stored in the pblock

Fix description:
	When parsing the control, if it is rejected (and freed) then
	remove the control from the pblock

fixes: #7772

Reviewed by:

## Summary by Sourcery

Prevent rejected Session Tracking controls from remaining attached to request state after parsing failures.

Bug Fixes:
- Prevent double-free crashes when invalid critical Session Tracking controls are rejected during request processing.

Tests:
- Add a regression test that repeatedly submits critical Session Tracking controls and verifies rejected requests do not affect subsequent searches.