### PR TITLE
Issue 6176 - Add sysusers.d support and modernize systemd path detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -310,9 +310,8 @@ cockpitdir = $(prefixdir)/share/cockpit@cockpitdir@
 metainfodir = $(prefixdir)/share/metainfo/389-console
 tmpfiles_d = @tmpfiles_d@
 
-# This has to be hardcoded to /lib - $libdir changes between lib/lib64, but
-# sysctl.d is always in /lib.
-sysctldir = @prefixdir@/lib/sysctl.d
+sysctldir = @sysctl_d@
+sysusersdir = @sysusers_d@
 
 defaultuser=@defaultuser@
 defaultgroup=@defaultgroup@
@@ -573,6 +572,7 @@ dist_noinst_DATA = \
 	$(srcdir)/ldap/schema/slapd-collations.conf \
 	$(srcdir)/ldap/servers/snmp/ldap-agent.conf \
 	$(srcdir)/ldap/servers/snmp/redhat-directory.mib \
+	$(srcdir)/ldap/admin/src/389-ds-base.sysusers \
 	$(srcdir)/ldap/servers/slapd/mkDBErrStrs.py \
 	$(srcdir)/lib/ldaputil/certmap.conf \
 	$(srcdir)/m4 \
@@ -684,14 +684,18 @@ if SYSTEMD
 libexec_SCRIPTS += wrappers/ds_systemd_ask_password_acl wrappers/ds_selinux_restorecon.sh
 endif
 
-if ENABLE_COCKPIT
 install-data-hook:
+if ENABLE_COCKPIT
 	if [ "$(srcdir)" != "." ]; then cp -r $(srcdir)/src/cockpit src ; fi
 	mkdir -p src/cockpit/389-console/cockpit_dist/
 	mkdir -p $(DESTDIR)$(cockpitdir)
 	rsync -rupE src/cockpit/389-console/cockpit_dist/ $(DESTDIR)$(cockpitdir)
 	mkdir -p $(DESTDIR)$(metainfodir)
 	rsync -up src/cockpit/389-console/org.port389.cockpit_console.metainfo.xml $(DESTDIR)$(metainfodir)/org.port389.cockpit_console.metainfo.xml
+endif
+if INSTALL_SYSUSERS
+	mkdir -p $(DESTDIR)$(sysusersdir)
+	$(INSTALL_DATA) $(srcdir)/ldap/admin/src/389-ds-base.sysusers $(DESTDIR)$(sysusersdir)/$(PACKAGE_TARNAME).conf
 endif
 
 sbin_SCRIPTS =
@@ -710,7 +714,9 @@ python_DATA = ldap/admin/src/scripts/failedbinds.py \
 
 gdbautoload_DATA = ldap/admin/src/scripts/ns-slapd-gdb.py
 
+if INSTALL_SYSCTL
 dist_sysctl_DATA = ldap/admin/src/70-dirsrv.conf
+endif
 
 if USDT
 profilingstapdir = $(datadir)/$(PACKAGE_NAME)/profiling/stap
@@ -2104,6 +2110,7 @@ fixupcmd = sed \
 	-e 's,@with_selinux\@,@with_selinux@,g' \
 	-e 's,@with_systemd\@,$(WITH_SYSTEMD),g' \
 	-e 's,@tmpfiles_d\@,$(tmpfiles_d),g' \
+	-e 's,@sysusers_d\@,$(sysusersdir),g' \
 	-e 's,@pythonexec\@,@pythonexec@,g' \
 	-e 's,@sttyexec\@,@sttyexec@,g' \
 	-e 's,@initconfigdir\@,$(initconfigdir),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -542,6 +542,12 @@ if test X"$mandir" = X'${prefix}/man' ; then
    mandir='$(datadir)/man'
 fi
 
+# put libexec scripts under dirsrv subdir
+case "$libexecdir" in
+  */$PACKAGE_NAME|*/$PACKAGE_NAME/) ;;
+  *) libexecdir="$libexecdir/$PACKAGE_NAME" ;;
+esac
+
 # Shared paths for all layouts
 # relative to sysconfdir
 configdir=/$PACKAGE_NAME/config

--- a/ldap/admin/src/389-ds-base.sysusers
+++ b/ldap/admin/src/389-ds-base.sysusers
@@ -1,0 +1,3 @@
+#Type Name     ID             GECOS                   Home directory       Shell
+g     dirsrv   389
+u     dirsrv   389:dirsrv     "user for 389-ds-base"  /usr/share/dirsrv/   /sbin/nologin

--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -44,6 +44,7 @@ inst_dir = @serverdir@/slapd-{instance_name}
 plugin_dir = @serverplugindir@
 system_schema_dir = @systemschemadir@
 tmpfiles_d = @tmpfiles_d@
+sysusers_d = @sysusers_d@
 
 ; These values can be altered in an installation of ds
 user = dirsrv

--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -45,50 +45,58 @@ if test "$with_systemd" = yes; then
         systemd_defs="-DWITH_SYSTEMD"
     fi
 
-    # Check for the pkg config provided unit paths
-    if test -n "$PKG_CONFIG" ; then
-       default_systemdsystemunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd`
-       default_systemdsystemconfdir=`$PKG_CONFIG --variable=systemdsystemconfdir systemd`
-    fi
+    # Detect systemd directories from pkg-config.
+    # Each --with-* flag is an optional override.
 
+    # systemd unit dir
+    default_systemdsystemunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd 2>/dev/null`
+    if test -z "$default_systemdsystemunitdir" ; then
+       default_systemdsystemunitdir='$(prefixdir)/lib/systemd/system'
+    fi
     AC_MSG_CHECKING(for --with-systemdsystemunitdir)
     AC_ARG_WITH([systemdsystemunitdir],
        AS_HELP_STRING([--with-systemdsystemunitdir=PATH],
-                      [Directory for systemd service files (default: $with_systemdsystemunitdir)])
+                      [Directory for systemd service files (default: auto-detected from pkg-config)])
     )
     if test "$with_systemdsystemunitdir" = yes ; then
-      if test -n "$default_systemdsystemunitdir" ; then
-        with_systemdsystemunitdir=$default_systemdsystemunitdir
-        AC_MSG_RESULT([$with_systemdsystemunitdir])
-      else
-        AC_MSG_ERROR([You must specify --with-systemdsystemconfdir=/full/path/to/systemd/system directory])
-      fi
+      with_systemdsystemunitdir=$default_systemdsystemunitdir
     elif test "$with_systemdsystemunitdir" = no ; then
       with_systemdsystemunitdir=
     else
-      AC_MSG_RESULT([$with_systemdsystemunitdir])
+      if test -n "$with_systemdsystemunitdir" ; then
+        : # user-provided value, keep it
+      else
+        with_systemdsystemunitdir=$default_systemdsystemunitdir
+      fi
     fi
+    AC_MSG_RESULT([$with_systemdsystemunitdir])
     AC_SUBST(with_systemdsystemunitdir)
 
+    # systemd system conf dir
+    default_systemdsystemconfdir=`$PKG_CONFIG --variable=systemdsystemconfdir systemd 2>/dev/null`
+    if test -z "$default_systemdsystemconfdir" ; then
+       default_systemdsystemconfdir='$(sysconfdir)/systemd/system'
+    fi
     AC_MSG_CHECKING(for --with-systemdsystemconfdir)
     AC_ARG_WITH([systemdsystemconfdir],
        AS_HELP_STRING([--with-systemdsystemconfdir=PATH],
-                      [Directory for systemd service files (default: $with_systemdsystemconfdir)])
+                      [Directory for systemd system configuration (default: auto-detected from pkg-config)])
     )
     if test "$with_systemdsystemconfdir" = yes ; then
-      if test -n "$default_systemdsystemconfdir" ; then
-        with_systemdsystemconfdir=$default_systemdsystemconfdir
-        AC_MSG_RESULT([$with_systemdsystemconfdir])
-      else
-        AC_MSG_ERROR([You must specify --with-systemdsystemconfdir=/full/path/to/systemd/system directory])
-      fi
+      with_systemdsystemconfdir=$default_systemdsystemconfdir
     elif test "$with_systemdsystemconfdir" = no ; then
       with_systemdsystemconfdir=
     else
-      AC_MSG_RESULT([$with_systemdsystemconfdir])
+      if test -n "$with_systemdsystemconfdir" ; then
+        : # user-provided value, keep it
+      else
+        with_systemdsystemconfdir=$default_systemdsystemconfdir
+      fi
     fi
+    AC_MSG_RESULT([$with_systemdsystemconfdir])
     AC_SUBST(with_systemdsystemconfdir)
 
+    # systemd group name
     if test -z "$with_systemdgroupname" ; then
        with_systemdgroupname=$PACKAGE_NAME.target
     fi
@@ -106,24 +114,68 @@ if test "$with_systemd" = yes; then
     fi
     AC_SUBST(with_systemdgroupname)
 
-    if test -z "$with_tmpfiles_d" ; then
-       if test -d $sysconfdir/tmpfiles.d ; then
-          tmpfiles_d='$(sysconfdir)/tmpfiles.d'
-       fi
+    # tmpfiles.d dir
+    tmpfiles_d=`$PKG_CONFIG --variable=tmpfilesdir systemd 2>/dev/null`
+    if test -z "$tmpfiles_d" ; then
+       tmpfiles_d='$(prefixdir)/lib/tmpfiles.d'
     fi
     AC_MSG_CHECKING(for --with-tmpfiles-d)
     AC_ARG_WITH(tmpfiles-d,
        AS_HELP_STRING([--with-tmpfiles-d=PATH],
-                      [system uses tmpfiles.d to handle temp files/dirs (default: $tmpfiles_d)])
+                      [Directory for systemd tmpfiles.d config files (default: auto-detected from pkg-config)])
     )
     if test "$with_tmpfiles_d" = yes ; then
-      AC_MSG_ERROR([You must specify --with-tmpfiles-d=/full/path/to/tmpfiles.d directory])
+      : # keep auto-detected default
     elif test "$with_tmpfiles_d" = no ; then
       tmpfiles_d=
     else
-      tmpfiles_d=$with_tmpfiles_d
-      AC_MSG_RESULT([$tmpfiles_d])
+      if test -n "$with_tmpfiles_d" ; then
+        tmpfiles_d=$with_tmpfiles_d
+      fi
     fi
+    AC_MSG_RESULT([$tmpfiles_d])
+
+    # sysusers.d dir
+    sysusers_d=`$PKG_CONFIG --variable=sysusersdir systemd 2>/dev/null`
+    if test -z "$sysusers_d" ; then
+       sysusers_d='$(prefixdir)/lib/sysusers.d'
+    fi
+    AC_MSG_CHECKING(for --with-sysusers-d)
+    AC_ARG_WITH(sysusers-d,
+       AS_HELP_STRING([--with-sysusers-d=PATH],
+                      [Directory for systemd sysusers.d config files (default: auto-detected from pkg-config)])
+    )
+    if test "$with_sysusers_d" = yes ; then
+      : # keep auto-detected default
+    elif test "$with_sysusers_d" = no ; then
+      sysusers_d=
+    else
+      if test -n "$with_sysusers_d" ; then
+        sysusers_d=$with_sysusers_d
+      fi
+    fi
+    AC_MSG_RESULT([$sysusers_d])
+
+    # sysctl.d dir
+    sysctl_d=`$PKG_CONFIG --variable=sysctldir systemd 2>/dev/null`
+    if test -z "$sysctl_d" ; then
+       sysctl_d='$(prefixdir)/lib/sysctl.d'
+    fi
+    AC_MSG_CHECKING(for --with-sysctl-d)
+    AC_ARG_WITH(sysctl-d,
+       AS_HELP_STRING([--with-sysctl-d=PATH],
+                      [Directory for sysctl.d config files (default: auto-detected from pkg-config)])
+    )
+    if test "$with_sysctl_d" = yes ; then
+      : # keep auto-detected default
+    elif test "$with_sysctl_d" = no ; then
+      sysctl_d=
+    else
+      if test -n "$with_sysctl_d" ; then
+        sysctl_d=$with_sysctl_d
+      fi
+    fi
+    AC_MSG_RESULT([$sysctl_d])
 
 fi
 # End of with_systemd
@@ -132,7 +184,12 @@ AM_CONDITIONAL([SYSTEMD],[test -n "$with_systemd"])
 AM_CONDITIONAL([with_systemd],[test -n "$with_systemd"])
 AM_CONDITIONAL([JOURNALD],[test -n "$with_journald"])
 AM_CONDITIONAL([with_systemd_journald],[test -n "$with_journald"])
+AM_CONDITIONAL([INSTALL_TMPFILES],[test -n "$tmpfiles_d"])
+AM_CONDITIONAL([INSTALL_SYSUSERS],[test -n "$sysusers_d"])
+AM_CONDITIONAL([INSTALL_SYSCTL],[test -n "$sysctl_d"])
 
 AC_SUBST(systemd_defs)
 AC_SUBST(tmpfiles_d)
+AC_SUBST(sysusers_d)
+AC_SUBST(sysctl_d)
 

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -63,10 +63,6 @@
 %bcond hibp 0
 %bcond usdt 1
 
-# fedora 15 and later uses tmpfiles.d
-# otherwise, comment this out
-%{!?with_tmpfiles_d: %global with_tmpfiles_d %{_sysconfdir}/tmpfiles.d}
-
 # systemd support
 %global groupname %{pkgname}.target
 
@@ -138,6 +134,7 @@ BuildRequires:    libcurl-devel
 BuildRequires:    pam-devel
 BuildRequires:    systemd-units
 BuildRequires:    systemd-devel
+BuildRequires:    systemd-rpm-macros
 %if %{with usdt}
 BuildRequires:    systemtap-sdt-devel
 %endif
@@ -219,6 +216,8 @@ Requires:         zlib-devel
 Requires:         python3-file-magic
 # Picks up our systemd deps.
 %{?systemd_requires}
+# Ensure sysusers are created
+%{?sysusers_requires_compat}
 
 %if %{with usdt}
 # Optional eBPF tracer for the shipped USDT bpftrace scripts.
@@ -403,8 +402,6 @@ cp %{SOURCE2} README.devel
 CLANG_FLAGS="--enable-clang"
 %endif
 
-%{?with_tmpfiles_d: TMPFILES_FLAG="--with-tmpfiles-d=%{with_tmpfiles_d}"}
-
 %if %{with asan}
 ASAN_FLAGS="--enable-asan --enable-debug"
 %endif
@@ -484,12 +481,8 @@ autoreconf -fiv
 %if %{with bundle_libdb}
            --with-bundle-libdb=%{_builddir}/%{libdb_base_version}/BUILD/%{libdb_base_dir}/dist/dist-tls \
 %endif
-           --with-selinux $TMPFILES_FLAG \
+           --with-selinux \
            --with-systemd \
-           --with-systemdsystemunitdir=%{_unitdir} \
-           --with-systemdsystemconfdir=%{_sysconfdir}/systemd/system \
-           --with-systemdgroupname=%{groupname} \
-           --libexecdir=%{_libexecdir}/%{pkgname} \
            $ASAN_FLAGS $MSAN_FLAGS $TSAN_FLAGS $UBSAN_FLAGS $RUST_FLAGS $CLANG_FLAGS $COCKPIT_FLAGS $USDT_FLAGS \
 %if 0%{?fedora} >= 34 || 0%{?rhel} >= 9
            --with-libldap-r=no \
@@ -633,23 +626,6 @@ fi
 instances="" # instances that require a restart after upgrade
 ninst=0 # number of instances found in total
 
-# https://fedoraproject.org/wiki/Packaging:UsersAndGroups#Soft_static_allocation
-# Soft static allocation for UID and GID
-USERNAME="dirsrv"
-ALLOCATED_UID=389
-GROUPNAME="dirsrv"
-ALLOCATED_GID=389
-HOMEDIR="/usr/share/dirsrv"
-
-getent group $GROUPNAME >/dev/null || groupadd -f -g $ALLOCATED_GID -r $GROUPNAME
-if ! getent passwd $USERNAME >/dev/null ; then
-    if ! getent passwd $ALLOCATED_UID >/dev/null ; then
-      useradd -r -u $ALLOCATED_UID -g $GROUPNAME -d $HOMEDIR -s /sbin/nologin -c "user for 389-ds-base" $USERNAME
-    else
-      useradd -r -g $GROUPNAME -d $HOMEDIR -s /sbin/nologin -c "user for 389-ds-base" $USERNAME
-    fi
-fi
-
 # Reload our sysctl before we restart (if we can)
 sysctl --system &> "$output"; true
 
@@ -721,6 +697,7 @@ fi
 %config(noreplace)%{_sysconfdir}/%{pkgname}/schema/*.ldif
 %dir %{_sysconfdir}/%{pkgname}/config
 %dir %{_sysconfdir}/systemd/system/%{groupname}.wants
+%{_sysusersdir}/%{name}.conf
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/slapd-collations.conf
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/certmap.conf
 %{_datadir}/%{pkgname}
@@ -754,9 +731,7 @@ fi
 %{_mandir}/man5/dirsrv.systemd.5.gz
 %{_libdir}/%{pkgname}/python
 %dir %{_libdir}/%{pkgname}/plugins
-# This has to be hardcoded to /lib - $libdir changes between lib/lib64, but
-# sysctl.d is always in /lib.
-%{_prefix}/lib/sysctl.d/*
+%{_sysctldir}/*
 %dir %{_localstatedir}/lib/%{pkgname}
 %dir %{_localstatedir}/log/%{pkgname}
 %ghost %dir %{_localstatedir}/lock/%{pkgname}

--- a/src/lib389/doc/source/paths.rst
+++ b/src/lib389/doc/source/paths.rst
@@ -34,6 +34,7 @@ Usage example
         'ldif_dir',
         'initconfig_dir',
         'tmpfiles_d',
+        'sysusers_d',
     ]
 
 Module documentation

--- a/src/lib389/lib389/paths.py
+++ b/src/lib389/lib389/paths.py
@@ -60,6 +60,7 @@ MUST = [
     'ldif_dir',
     'initconfig_dir',
     'tmpfiles_d',
+    'sysusers_d',
 ]
 
 # will need to add the access, error, audit log later.


### PR DESCRIPTION
Bug Description:
The `dirsrv` user/group was created by downstream packaging using sysusers config rather than shipped upstream.

Several systemd directory paths were detected using fragile methods: `tmpfiles.d` relied on a filesystem check at configure time and defaulted to the wrong location (`/etc/tmpfiles.d` instead of `/usr/lib/tmpfiles.d`), `sysctldir` was hardcoded in `Makefile.am`, and `systemdsystemunitdir/confdir` required explicit `--with-*` flags because the auto-detection only worked when `yes` was passed.

Fix Description:
Add a sysusers.d config file to the upstream source and install it when systemd is enabled.

Modernize all systemd directory detection to use `pkg-config` with fallbacks.

Fixes: https://github.com/389ds/389-ds-base/issues/6176

## Summary by Sourcery

Add systemd sysusers.d support and make systemd directory detection automatic and portable.

New Features:
- Add an upstream systemd sysusers.d configuration to provision the directory service account and group when systemd integration is enabled.

Bug Fixes:
- Correct default installation locations for systemd tmpfiles.d and related configuration files.

Enhancements:
- Modernize systemd directory discovery through pkg-config with sensible fallbacks and optional configure-time overrides.
- Expose sysusers.d paths through the project path configuration and conditionally install sysctl.d, tmpfiles.d, and sysusers.d files.