### PR TITLE
Issue 2779 - Streamline SPEC file for potential inclusion in Fedora

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -111,10 +111,12 @@ ifeq ($(COCKPIT_ON), 1)
 endif
 	rm -rf dist/$(NAME_VERSION)
 	cd dist/sources ; \
-	if [ $(BUNDLE_JEMALLOC) -eq 1 ]; then \
+	if [ $(BUNDLE_JEMALLOC) -eq 1 ] && [ ! -f $(JEMALLOC_TARBALL) ]; then \
 		curl -LO $(JEMALLOC_URL) ; \
 	fi ; \
-	curl -LO $(LIBDB_URL) ;
+	if [ ! -f $(LIBDB_TARBALL) ]; then \
+		curl -LO $(LIBDB_URL) ; \
+	fi
 
 rpmroot:
 	rm -rf $(RPMBUILD)

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -1,4 +1,7 @@
-%global pkgname   dirsrv
+%global pkgname dirsrv
+
+# Exclude i686 architecture
+ExcludeArch: i686
 
 %bcond bundle_jemalloc 1
 %if %{with bundle_jemalloc}
@@ -22,7 +25,7 @@
 %endif
 
 %bcond repl_reports 0
-%if 0%{?fedora} >= 40
+%if 0%{?fedora} >= 40 && 0%{?fedora} < 44
 %bcond repl_reports 1
 %endif
 
@@ -58,9 +61,17 @@
 %endif
 
 # Build cockpit plugin
+# Enabled on Fedora and EPEL community builds.
+# Disabled on RHEL/CentOS Stream unless RHDS (distribution contains "dsrv").
+%if 0%{?rhel} && !0%{?epel}
+%bcond cockpit %(echo "%{?distribution}" | grep -q dsrv && echo 1 || echo 0)
+%else
 %bcond cockpit 1
+%endif
 
-%bcond hibp 0
+# HIBP password breach checking
+%bcond hibp 1
+
 %bcond usdt 1
 
 # Perl log analyzer (logconv.pl)
@@ -88,16 +99,12 @@ Name:             389-ds-base
 Version:          __VERSION__%{?prerel}
 Release:          %{autorelease -n %{?with_asan:-e asan}}%{?dist}
 License:          GPL-3.0-or-later WITH GPL-3.0-389-ds-base-exception AND (0BSD OR Apache-2.0 OR MIT) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT OR Zlib) AND (Apache-2.0 OR MIT) AND (CC-BY-4.0 AND MIT) AND (MIT OR Apache-2.0) AND Unicode-DFS-2016 AND (MIT OR CC0-1.0) AND (MIT OR Unlicense) AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MIT AND ISC AND MPL-2.0 AND PSF-2.0
-URL:              https://www.port389.org/
-Obsoletes:        %{name} <= 1.4.0.9
-Obsoletes:        %{name}-legacy-tools < 1.4.4.6
-Obsoletes:        %{name}-legacy-tools-debuginfo < 1.4.4.6
-Provides:         ldif2ldbm
+URL:              https://www.port389.org
 
 ##### Bundled cargo crates list - START #####
 ##### Bundled cargo crates list - END #####
 
-# Attach the buildrequires to the top level package:
+# BuildRequires for the main package:
 BuildRequires:    nspr-devel
 BuildRequires:    nss-devel >= 3.34
 BuildRequires:    openldap-clients
@@ -109,6 +116,8 @@ BuildRequires:    libicu-devel
 BuildRequires:    pcre2-devel
 BuildRequires:    cracklib-devel
 BuildRequires:    json-c-devel
+BuildRequires:    libxcrypt-devel
+BuildRequires:    zlib-devel
 %if %{with clang}
 BuildRequires:    libatomic
 BuildRequires:    clang
@@ -133,18 +142,20 @@ BuildRequires:    libdb-devel
 %endif
 %endif
 
-# The following are needed to build the snmp ldap-agent
+# For SNMP ldap-agent
 BuildRequires:    net-snmp-devel
 BuildRequires:    bzip2-devel
 BuildRequires:    openssl-devel
+# For HIBP password breach checking
 %if %{with hibp}
 BuildRequires:    libcurl-devel
 %endif
-# the following is for the pam passthru auth plug-in
+# For PAM passthru auth plug-in
 BuildRequires:    pam-devel
 BuildRequires:    systemd-units
 BuildRequires:    systemd-devel
 BuildRequires:    systemd-rpm-macros
+%{?sysusers_requires_compat}
 %if %{with usdt}
 BuildRequires:    systemtap-sdt-devel
 %endif
@@ -154,16 +165,16 @@ BuildRequires:    pkgconfig
 BuildRequires:    pkgconfig(systemd)
 BuildRequires:    pkgconfig(krb5)
 BuildRequires:    pkgconfig(libpcre2-8)
-# Needed to support regeneration of the autotool artifacts.
+# For autotools regeneration
 BuildRequires:    autoconf
 BuildRequires:    automake
 BuildRequires:    libtool
 BuildRequires:    make
-# For our documentation
+# For doxygen documentation
 BuildRequires:    doxygen
-# For tests!
+# For cmocka unit tests
 BuildRequires:    libcmocka-devel
-# For lib389 and related components.
+# For lib389
 BuildRequires:    python%{python3_pkgversion}-devel
 
 # For cockpit
@@ -173,31 +184,36 @@ BuildRequires:    /usr/bin/npm
 BuildRequires:    /usr/bin/node
 %endif
 
-# END BUILD REQUIRES
-
-# Now, attach the requires only to the package that needs them.
-# -libs has most of our runtime libs
+# Runtime requires for the main package
 Requires:         %{name}-libs = %{version}-%{release}
 Requires:         python%{python3_pkgversion}-lib389 = %{version}-%{release}
 
-# this is needed for using semanage from our setup scripts
+# For semanage in setup scripts
 Requires:         policycoreutils-python-utils
-# This is needed for our future move to python selinux interaction.
 Requires:         libsemanage-python%{python3_pkgversion}
-# the following are needed for some of our scripts
+# NoNewPrivileges support in dirsrv service units requires
+# selinux-policy with init_nnp_daemon_domain for dirsrv_t.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=2457951
+%if 0%{?rhel} == 10
+Requires:         selinux-policy >= 42.1.22-1
+%endif
+%if 0%{?fedora} == 43
+Requires:         selinux-policy >= 43.7-1
+%endif
+%if 0%{?fedora} == 44
+Requires:         selinux-policy >= 44.1-1
+%endif
+# For CLI scripts
 Requires:         openldap-clients
 Requires:         acl
-# this is needed to setup SSL if you are not using the
-# administration server package
+# For SSL/TLS setup
 Requires:         nss-tools
 %dirsrv_requires_ge nss
-# these are not found by the auto-dependency method
-# they are required to support the mandatory LDAP SASL mechs
+# Mandatory LDAP SASL mechanisms
 Requires:         cyrus-sasl-gssapi
 Requires:         cyrus-sasl-md5
-# This is optionally supported by us, as we use it in our tests
 Requires:         cyrus-sasl-plain
-# this is needed for backldbm
+# For back-ldbm
 %if %{with libbdb_ro}
 Requires:         %{name}-robdb-libs = %{version}-%{release}
 %else
@@ -210,8 +226,6 @@ Requires:         lmdb-libs
 # Needed for password dictionary checks
 Requires:         cracklib-dicts
 Requires:         json-c
-# Log compression
-Requires:         zlib-devel
 # logconv.py, MIME type
 Requires:         python3-file-magic
 # Picks up our systemd deps.
@@ -234,8 +248,15 @@ Source5:          jemalloc-5.3.0_throw_bad_alloc.patch
 %endif
 Source4:          https://fedorapeople.org/groups/389ds/libdb-5.3.28-59.tar.bz2
 
+# To override vendor/Cargo.lock/cockpit_dist from the upstream tarball
+# with separately uploaded sources
+# uncomment and replace double percent with a single one
+#Source6:          vendor-%%{version}-1.tar.gz
+#Source7:          Cargo-%%{version}-1.lock
+#Source8:          cockpit_dist-%%{version}-1.tar.bz2
+
 %description
-389 Directory Server is an LDAPv3 compliant server.  The base package includes
+389 Directory Server is an LDAPv3 compliant server. The base package includes
 the LDAP server and command line utilities for server administration.
 %if %{with asan}
 WARNING! This build is linked to Address Sanitisation libraries. This probably
@@ -257,18 +278,13 @@ some basic functions to search and read Berkeley Database records
 
 %package          libs
 Summary:          Core libraries for 389 Directory Server (%{variant})
-Provides:         svrcore = 4.1.4
-Obsoletes:        svrcore <= 4.1.3
-Conflicts:        svrcore
-# You can work this out by running LDD on libslapd.so to see what it needs in
-# isolation.
 %dirsrv_requires_ge nss
 Requires:         nspr
 Requires:         openldap
 Requires:         systemd-libs
-# Pull in sasl
+# SASL
 Requires:         cyrus-sasl-lib
-# KRB
+# Kerberos
 Requires:         krb5-libs
 %if %{with clang}
 Requires:         llvm
@@ -292,15 +308,12 @@ package to be installed with just the -libs package and without the main package
 
 %package          devel
 Summary:          Development libraries for 389 Directory Server (%{variant})
-Provides:         svrcore-devel = 4.1.4
-Obsoletes:        svrcore-devel <= 4.1.3
-Conflicts:        svrcore-devel
 Requires:         %{name}-libs = %{version}-%{release}
 Requires:         pkgconfig
 Requires:         nspr-devel
 Requires:         nss-devel >= 3.34
 Requires:         openldap-devel
-# systemd-libs contains the headers iirc.
+# For systemd headers
 Requires:         systemd-libs
 
 %description      devel
@@ -310,7 +323,6 @@ Development Libraries and headers for the 389 Directory Server base package.
 %package          snmp
 Summary:          SNMP Agent for 389 Directory Server
 Requires:         %{name} = %{version}-%{release}
-Obsoletes:        %{name} <= 1.3.5.4
 
 %description      snmp
 SNMP Agent for the 389 Directory Server base package.
@@ -357,15 +369,13 @@ Summary:  A library for accessing, testing, and configuring the 389 Directory Se
 BuildArch:        noarch
 Requires: %{name} = %{version}-%{release}
 Requires: openssl
-# This is for /usr/bin/c_rehash tool, only needed for openssl < 1.1.0
-Requires: openssl-perl
 Requires: iproute
 Requires: python%{python3_pkgversion}-libselinux
 Recommends: bash-completion
 
 %description -n python%{python3_pkgversion}-lib389
 This module contains tools and libraries for accessing, testing,
- and configuring the 389 Directory Server.
+and configuring the 389 Directory Server.
 
 %if %{with repl_reports}
 %package -n python%{python3_pkgversion}-lib389-repl-reports
@@ -403,7 +413,14 @@ cd src/lib389
 %pyproject_buildrequires -g test
 
 %prep
-%setup -q -n %{name}-%{version}
+%autosetup -p1 -n %{name}-%{version}
+%if %{defined SOURCE6}
+rm -rf vendor
+tar xzf %{SOURCE6}
+%endif
+%if %{defined SOURCE7}
+cp %{SOURCE7} src/Cargo.lock
+%endif
 
 %if %{with bundle_jemalloc}
 %setup -q -n %{name}-%{version} -T -D -b 3
@@ -413,10 +430,14 @@ cd src/lib389
 %setup -q -n %{name}-%{version} -T -D -b 4
 %endif
 
+%if %{defined SOURCE8}
+# Unpack prebuilt cockpit files
+tar xvjf %{SOURCE8} -C src/cockpit/389-console
+%endif
+
 cp %{SOURCE2} README.devel
 
 %build
-
 %if %{with clang}
 CLANG_FLAGS="--enable-clang"
 %endif
@@ -482,13 +503,16 @@ popd
 %if %{with bundle_libdb}
 mkdir -p ../%{libdb_base_version}
 pushd ../%{libdb_base_version}
-tar -xjf  %{_topdir}/SOURCES/%{libdb_full_version}.tar.bz2
+tar -xjf %{_topdir}/SOURCES/%{libdb_full_version}.tar.bz2
 mv %{libdb_full_version} SOURCES
+%if 0%{?fedora}
+sed -i -e '/^CFLAGS=/s/-fno-strict-aliasing/& -std=gnu99/' %{_builddir}/%{name}-%{version}/rpm/bundle-libdb.spec.in
+%endif
 rpmbuild  --define "_topdir $PWD" -bc %{_builddir}/%{name}-%{version}/rpm/bundle-libdb.spec.in
 popd
 %endif
 
-# Rebuild the autotool artifacts now.
+# Rebuild autotools artifacts
 autoreconf -fiv
 
 %configure \
@@ -503,18 +527,11 @@ autoreconf -fiv
            --with-selinux \
            --with-systemd \
            $ASAN_FLAGS $MSAN_FLAGS $TSAN_FLAGS $UBSAN_FLAGS $RUST_FLAGS $CLANG_FLAGS $COCKPIT_FLAGS $USDT_FLAGS \
-%if 0%{?fedora} >= 34 || 0%{?rhel} >= 9
            --with-libldap-r=no \
-%endif
 %if %{with hibp}
-	  --enable-hibp \
+           --enable-hibp \
 %endif
            --enable-cmocka
-
-# Avoid "Unknown key name 'XXX' in section 'Service', ignoring." warnings from systemd on older releases
-%if 0%{?rhel} && 0%{?rhel} < 9
-  sed -r -i '/^(Protect(Home|Hostname|KernelLogs)|PrivateMounts|NoExecPaths)=/d' %{_builddir}/%{name}-%{version}/wrappers/*.service.in
-%endif
 
 # lib389
 pushd ./src/lib389
@@ -523,7 +540,7 @@ pushd ./src/lib389
 popd
 
 # Generate symbolic info for debuggers
-export XCFLAGS=$RPM_OPT_FLAGS
+export XCFLAGS="%{optflags}"
 
 %make_build
 
@@ -546,7 +563,7 @@ sed -i -e "/libback-bdb/d" plugins.list
 %endif
 
 # Copy in our docs from doxygen.
-cp -r %{_builddir}/%{name}-%{version}/man/man3 $RPM_BUILD_ROOT/%{_mandir}/man3
+cp -r %{_builddir}/%{name}-%{version}/man/man3 %{buildroot}/%{_mandir}/man3
 
 # lib389
 pushd src/lib389
@@ -566,25 +583,25 @@ do
     install -p -m 0644 -D -t '%{buildroot}%{bash_completions_dir}' "${clitool}"
 done
 
-mkdir -p $RPM_BUILD_ROOT/var/log/%{pkgname}
-mkdir -p $RPM_BUILD_ROOT/var/lib/%{pkgname}
-mkdir -p $RPM_BUILD_ROOT/var/lock/%{pkgname} \
-    && chmod 770 $RPM_BUILD_ROOT/var/lock/%{pkgname}
+mkdir -p %{buildroot}/var/log/%{pkgname}
+mkdir -p %{buildroot}/var/lib/%{pkgname}
+mkdir -p %{buildroot}/var/lock/%{pkgname} \
+    && chmod 770 %{buildroot}/var/lock/%{pkgname}
 
-# for systemd
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/systemd/system/%{groupname}.wants
+# For systemd
+mkdir -p %{buildroot}%{_sysconfdir}/systemd/system/%{groupname}.wants
 
-#remove libtool and static libs
-rm -f $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/*.a
-rm -f $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/*.la
-rm -f $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/plugins/*.a
-rm -f $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/plugins/*.la
-rm -f $RPM_BUILD_ROOT%{_libdir}/libsvrcore.a
-rm -f $RPM_BUILD_ROOT%{_libdir}/libsvrcore.la
+# Remove libtool and static libs
+rm -f %{buildroot}%{_libdir}/%{pkgname}/*.a
+rm -f %{buildroot}%{_libdir}/%{pkgname}/*.la
+rm -f %{buildroot}%{_libdir}/%{pkgname}/plugins/*.a
+rm -f %{buildroot}%{_libdir}/%{pkgname}/plugins/*.la
+rm -f %{buildroot}%{_libdir}/libsvrcore.a
+rm -f %{buildroot}%{_libdir}/libsvrcore.la
 
 %if %{with bundle_jemalloc}
 pushd ../%{jemalloc_name}-%{jemalloc_ver}
-make DESTDIR="$RPM_BUILD_ROOT" install_lib install_bin
+make DESTDIR="%{buildroot}" install_lib install_bin
 cp -pa COPYING ../%{name}-%{version}/COPYING.jemalloc
 cp -pa README ../%{name}-%{version}/README.jemalloc
 popd
@@ -597,7 +614,7 @@ libdbdestdir=$PWD/../%{name}-%{version}
 cp -pa $libdbbuilddir/LICENSE $libdbdestdir/LICENSE.libdb
 cp -pa $libdbbuilddir/README $libdbdestdir/README.libdb
 cp -pa $libdbbuilddir/lgpl-2.1.txt $libdbdestdir/lgpl-2.1.txt.libdb
-cp -pa $libdbbuilddir/dist/dist-tls/.libs/%{libdb_bundle_name} $RPM_BUILD_ROOT%{_libdir}/%{pkgname}/%{libdb_bundle_name}
+cp -pa $libdbbuilddir/dist/dist-tls/.libs/%{libdb_bundle_name} %{buildroot}%{_libdir}/%{pkgname}/%{libdb_bundle_name}
 popd
 %endif
 
@@ -618,12 +635,12 @@ popd
 %endif
 
 %check
-# This checks the code, if it fails it prints why, then re-raises the fail to shortcircuit the rpm build.
+# Run cmocka unit tests
 %if %{with tsan}
 export TSAN_OPTIONS=print_stacktrace=1:second_deadlock_stack=1:history_size=7
 %endif
 %if %{without asan} && %{without msan}
-if ! make DESTDIR="$RPM_BUILD_ROOT" check; then cat ./test-suite.log && false; fi
+if ! make DESTDIR="%{buildroot}" check; then cat ./test-suite.log && false; fi
 %endif
 
 # Check import for lib389 modules
@@ -632,23 +649,17 @@ if ! make DESTDIR="$RPM_BUILD_ROOT" check; then cat ./test-suite.log && false; f
 %post
 if [ -n "$DEBUGPOSTTRANS" ] ; then
     output=$DEBUGPOSTTRANS
-    output2=${DEBUGPOSTTRANS}.upgrade
 else
     output=/dev/null
-    output2=/dev/null
 fi
 
-# reload to pick up any changes to systemd files
+# Reload to pick up any changes to systemd files
 /bin/systemctl daemon-reload >$output 2>&1 || :
 
-# find all instances
-instances="" # instances that require a restart after upgrade
-ninst=0 # number of instances found in total
-
-# Reload our sysctl before we restart (if we can)
+# Reload sysctl before restarting instances
 sysctl --system &> "$output"; true
 
-# Gather running instances, stop them, run index-check, then restart
+# Gather running instances, stop and restart them
 instbase="%{_sysconfdir}/%{pkgname}"
 instances=""
 ninst=0
@@ -659,7 +670,6 @@ for dir in "$instbase"/slapd-* ; do
     case "$dir" in *.removed) continue ;; esac
     basename=$(basename "$dir")
     inst="%{pkgname}@${basename#slapd-}"
-    inst_name="${basename#slapd-}"
     echo "found instance $inst - getting status" >> "$output" 2>&1 || :
     if /bin/systemctl -q is-active "$inst" ; then
        echo "instance $inst is running - stopping for upgrade" >> "$output" 2>&1 || :
@@ -681,7 +691,6 @@ for inst in $instances ; do
     echo "starting instance $inst" >> "$output" 2>&1 || :
     /bin/systemctl start "$inst" >> "$output" 2>&1 || :
 done
-
 
 %preun
 if [ $1 -eq 0 ]; then # Final removal
@@ -748,7 +757,7 @@ fi
 %{_mandir}/man5/dirsrv.systemd.5.gz
 %{_libdir}/%{pkgname}/python
 %dir %{_libdir}/%{pkgname}/plugins
-%{_sysctldir}/*
+%{_prefix}/lib/sysctl.d/*
 %dir %{_localstatedir}/lib/%{pkgname}
 %dir %{_localstatedir}/log/%{pkgname}
 %ghost %dir %{_localstatedir}/lock/%{pkgname}
@@ -813,11 +822,19 @@ fi
 %doc src/lib389/README.md
 %license LICENSE LICENSE.GPLv3+
 # Binaries
+%if 0%{?fedora} >= 42 || 0%{?rhel} >= 11
+%{_bindir}/dsconf
+%{_bindir}/dscreate
+%{_bindir}/dsctl
+%{_bindir}/dsidm
+%{_bindir}/openldap_to_ds
+%else
 %{_sbindir}/dsconf
 %{_sbindir}/dscreate
 %{_sbindir}/dsctl
 %{_sbindir}/dsidm
 %{_sbindir}/openldap_to_ds
+%endif
 %{_libexecdir}/%{pkgname}/dscontainer
 # Man pages
 %{_mandir}/man8/dsconf.8.gz

--- a/rpm/bundle-rust-npm.py
+++ b/rpm/bundle-rust-npm.py
@@ -191,19 +191,33 @@ def write_provides_bundled(provides_lines: List[str], spec_file: str, cleaned: b
     """Writes bundled package information to the spec file.
     Includes generated 'Provides' lines and marks the section for easy future modification.
     """
-    # Find a line index where 'Provides' ends
+    # Find a line index where 'Provides' ends in the main package section
+    # (before the first %description). If no Provides: line exists,
+    # fall back to inserting right before the first %description.
     with open(spec_file, "r") as file:
         spec_file_lines = file.readlines()
     last_provides = -1
+    first_description = -1
     for i in range(0, len(spec_file_lines)):
         if spec_file_lines[i].startswith("%description"):
+            first_description = i
             break
         if spec_file_lines[i].startswith("Provides:"):
             last_provides = i
 
+    if last_provides >= 0:
+        # Insert after the last existing Provides line (plus one blank line)
+        insert_at = last_provides + 2
+    elif first_description >= 0:
+        # No Provides found, insert before first %description
+        insert_at = first_description
+    else:
+        log.error("Could not find %description in the spec file")
+        sys.exit(1)
+
     # Insert the generated 'Provides' to the specfile
     log.info(f"Add the fresh '{SPECFILE_COMMENT_LINE}' content to {spec_file}")
-    i = last_provides + 2
+    i = insert_at
     spec_file_lines.insert(i, START_LINE)
     for line in sorted(provides_lines):
         i = i + 1


### PR DESCRIPTION
Bug Description:
For the integration with Packit we need to have a single spec file that can be reused for downstream release promotion between Fedora, CentOS Stream, and RHEL.

Fix Description:
Streamline `389-ds-base.spec.in` so that a single spec file works across Fedora, CentOS Stream, and RHEL builds.

Fixes: https://github.com/389ds/389-ds-base/issues/2779
Fixes: https://github.com/389ds/389-ds-base/issues/7485

## Summary by Sourcery

Make the RPM packaging metadata portable across Fedora, CentOS Stream, and RHEL while improving source archive handling and generated dependency metadata.

Bug Fixes:
- Prevent duplicate downloads of jemalloc and Berkeley DB source archives during RPM source preparation.
- Ensure generated bundled dependency Provides entries are inserted correctly when the spec lacks existing Provides lines.

Enhancements:
- Streamline the RPM spec to support reusable builds across Fedora, CentOS Stream, and RHEL.

Build:
- Improve RPM source fetching so existing dependency archives are reused.