### PR TITLE
Issue 6270 - heap-use-after-free with pwp dictionary path

### DIFF
--- a/ldap/servers/slapd/pw.c
+++ b/ldap/servers/slapd/pw.c
@@ -2430,7 +2430,7 @@ new_passwdPolicy(Slapi_PBlock *pb, const char *dn)
                     }
                 } else if (!strcasecmp(attr_name, "passwordDictPath")) {
                     if ((sval = attr_get_present_values(attr))) {
-                        pwdpolicy->pw_dict_path = (char *)slapi_value_get_string(*sval);
+                        pwdpolicy->pw_dict_path = slapi_ch_strdup(slapi_value_get_string(*sval));
                     }
                 } else if (!strcasecmp(attr_name, CONFIG_PW_TPR_MAXUSE)) {
                     if ((sval = attr_get_present_values(attr))) {
@@ -2472,7 +2472,7 @@ new_passwdPolicy(Slapi_PBlock *pb, const char *dn)
                     pwdpolicy->pw_max_class_repeats = g_pwdpolicy->pw_max_class_repeats;
                     pwdpolicy->pw_palindrome = g_pwdpolicy->pw_palindrome;
                     pwdpolicy->pw_check_dict = g_pwdpolicy->pw_check_dict;
-                    pwdpolicy->pw_dict_path = g_pwdpolicy->pw_dict_path;
+                    pwdpolicy->pw_dict_path = slapi_ch_strdup(g_pwdpolicy->pw_dict_path);
                     pwdpolicy->pw_check_breach = g_pwdpolicy->pw_check_breach;
                     slapi_ch_free_string(&pwdpolicy->pw_breach_db_url);
                     pwdpolicy->pw_breach_db_url = config_get_pw_breach_url();
@@ -2534,6 +2534,7 @@ delete_passwdPolicy(passwdPolicy **pwpolicy)
             slapi_ch_free_string(&(*(*pwpolicy)).pw_cmp_attrs);
             slapi_ch_free_string(&(*(*pwpolicy)).pw_breach_db_url);
         }
+        slapi_ch_free_string(&(*(*pwpolicy)).pw_dict_path);
         slapi_ch_free_string(&(*(*pwpolicy)).pw_local_dn);
         slapi_ch_free((void **)pwpolicy);
     }


### PR DESCRIPTION
Description:

We do not copy the dictionary path into password policy struct leading to it getting freed and later accessed. Just copy it, and then free it when the policy is destroyed.

relates: https://github.com/389ds/389-ds-base/issues/6270

## Summary by Sourcery

Fix password policy dictionary path lifetime management to prevent use-after-free errors.

Bug Fixes:
- Prevent heap-use-after-free when password policy dictionary paths outlive their source configuration values.

Enhancements:
- Ensure password policy instances own independent copies of dictionary paths and release them during policy destruction.