### PR TITLE
Fix startrepl_auth_race_test.py for lib389 API compatibility

### DIFF
--- a/dirsrvtests/tests/suites/replication/startrepl_auth_race_test.py
+++ b/dirsrvtests/tests/suites/replication/startrepl_auth_race_test.py
@@ -38,6 +38,7 @@ from lib389.idm.user import UserAccounts
 from lib389.passwd import password_generate
 from lib389.replica import (
     BootstrapReplicationManager,
+    Changelog5,
     Replicas,
 )
 try:
@@ -58,7 +59,7 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope="module")
 def topo_i2(request):
     """Two standalone instances, no replication configured yet."""
-    topology = create_topology({ReplicaRole.STANDALONE: 2}, request=request)
+    topology = create_topology({ReplicaRole.STANDALONE: 2})
     return topology
 
 
@@ -140,6 +141,17 @@ def test_total_init_binddn_group_race(topo_i2):
         'nsDS5ReplicaBindDN': brm.dn,
         'nsds5replicabinddngroupcheckinterval': '0',
     })
+
+    for inst in [inst_a, inst_b]:
+        cl = Changelog5(inst)
+        try:
+            cl.create(properties={
+                'cn': 'changelog5',
+                'nsslapd-changelogdir': inst.get_changelog_dir()
+            })
+        except ldap.ALREADY_EXISTS:
+            pass
+
     log.info("Replicas configured, bootstrap manager ready")
 
     # Step 3: Bootstrap total init from A to B using direct BindDN.


### PR DESCRIPTION
Issue 7707 - Fix startrepl_auth_race_test.py for lib389 API compatibility

Bug Description:

The test `test_total_init_binddn_group_race` in `startrepl_auth_race_test.py` fails on RHEL 8.4/8.6 systems with:

```
TypeError: create_topology() got an unexpected keyword argument 'request'
```

Additionally, replication may fail because Changelog5 is not automatically created on 389-ds-base 1.4.3.

Fix Description:

1. Add Changelog5 import - Import the Changelog5 class needed for explicit changelog creation
2. Remove deprecated request parameter - The `request=request` parameter was removed from create_topology() API
3. Explicitly create Changelog5 - Create changelog5 for both replication instances to ensure replication works correctly

Tested on RHEL 8.4/8.6 with 389-ds-base 1.4.3.34.
- Before this fix: Test fails with TypeError and cannot run
- After this fix: Test runs successfully

relates: https://github.com/389ds/389-ds-base/issues/7707

Author: Viktor Ashirov

Reviewed by: ???

## Summary by Sourcery

Restore compatibility and reliable changelog setup for the replication authentication race test.

Bug Fixes:
- Fix the replication authentication race test for lib389 versions that no longer accept the deprecated topology fixture parameter.
- Ensure Changelog5 is available on both replication instances so the test runs successfully with older 389-ds-base releases.