### PR TITLE
Issue 7808 - CI - harden online_import_nosync_test

### DIFF
--- a/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
+++ b/dirsrvtests/tests/suites/replication/online_import_nosync_test.py
@@ -31,7 +31,7 @@ pytestmark = [
 
 log = logging.getLogger(__name__)
 
-NUM_ENTRIES = 100_000
+NUM_ENTRIES = 150_000
 REINIT_TIMEOUT = 600
 
 
@@ -187,7 +187,7 @@ def test_online_import_nosync_throughput():
     """Test that total init with nosync=on is faster than nosync=off.
 
     :id: c5e8d9b2-3f4a-5b6c-0d7e-8f9a0b1c2d3e
-    :setup: Two fresh Supplier + Consumer topologies with 100K entries
+    :setup: Two fresh Supplier + Consumer topologies with 150K entries
     :steps:
         1. Run total init with nosync=off, measure time
         2. Run total init with nosync=on, measure time


### PR DESCRIPTION
Description:

dirsrvtests/tests/suites/replication/online_import_nosync_test.py can be flaky and run too fast. Need to increase the load to properly measure the performance

relates: https://github.com/389ds/389-ds-base/issues/7808

## Summary by Sourcery

Harden the online import performance test by increasing its workload.

Enhancements:
- Increase the online import throughput test dataset from 100,000 to 150,000 entries to make performance comparisons more representative and reduce flakiness.

Tests:
- Update the online import test setup documentation to reflect the larger 150,000-entry dataset.