### PR TITLE
Issue 7815 - Support nsslapd-attribute-name-exceptions when adding entries

### DIFF
--- a/dirsrvtests/tests/suites/syntax/acceptance_test.py
+++ b/dirsrvtests/tests/suites/syntax/acceptance_test.py
@@ -9,7 +9,7 @@
 import ldap
 import pytest
 import os
-from lib389.schema import Schema
+from lib389.schema import Schema, SchemaLegacy
 from lib389.config import Config
 from lib389.idm.user import UserAccounts
 from lib389.idm.group import Group, Groups
@@ -287,6 +287,77 @@ def test_escaped_space(topo, request):
             ldc.unbind()
         except:
             pass
+
+    request.addfinalizer(fin)
+
+
+def test_attrname_exceptions_dn_syntax(topo, request):
+    """Test that nsslapd-attribute-name-exceptions allows underscores in
+    attribute names used within DN-valued attributes during entry add and
+    import operations.
+
+    :id: 1a507c3e-31c9-489b-80b4-e3169edc5a5e
+    :customerscenario: True
+    :setup: Standalone Instance
+    :steps:
+        1. Enable nsslapd-attribute-name-exceptions and nsslapd-syntaxcheck
+        2. Add a custom attribute type with an underscore in its name
+        3. Add a custom objectclass using that attribute
+        4. Add an entry using the underscored attribute
+        5. Add a seeAlso value containing a DN with the underscored attribute type
+        6. Verify the entry and seeAlso value were accepted
+    :expectedresults:
+        1. Success
+        2. Success
+        3. Success
+        4. Success
+        5. Success
+        6. Success
+    """
+    inst = topo.standalone
+    config = Config(inst)
+
+    config.replace('nsslapd-attribute-name-exceptions', 'on')
+    config.replace('nsslapd-syntaxcheck', 'on')
+
+    schema = SchemaLegacy(inst)
+    schema.add_attribute(
+        "( 9.9.9.9.1 NAME 'test_underscore_attr' "
+        "DESC 'Test attribute with underscore' "
+        "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 "
+        "X-ORIGIN 'user defined' )"
+    )
+    schema.add_objectclass(
+        "( 9.9.9.9.2 NAME 'testUnderscoreOC' "
+        "DESC 'Test OC with underscore attr' SUP top AUXILIARY "
+        "MAY test_underscore_attr "
+        "X-ORIGIN 'user defined' )"
+    )
+
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    user = users.create(properties={
+        'uid': 'underscore_test_user',
+        'cn': 'underscore_test_user',
+        'sn': 'user',
+        'uidNumber': '9901',
+        'gidNumber': '9901',
+        'homeDirectory': '/home/underscore_test_user',
+    })
+    user.add('objectclass', 'testUnderscoreOC')
+    user.add('test_underscore_attr', 'some value')
+
+    dn_with_underscore = 'test_underscore_attr=some value,%s' % DEFAULT_SUFFIX
+    user.add('seeAlso', dn_with_underscore)
+
+    entry = user.get_attr_vals_utf8('seeAlso')
+    assert dn_with_underscore in entry
+
+    def fin():
+        try:
+            user.delete()
+        except ldap.LDAPError:
+            pass
+        config.replace('nsslapd-attribute-name-exceptions', 'off')
 
     request.addfinalizer(fin)
 

--- a/dirsrvtests/tests/suites/syntax/acceptance_test.py
+++ b/dirsrvtests/tests/suites/syntax/acceptance_test.py
@@ -9,7 +9,8 @@
 import ldap
 import pytest
 import os
-from lib389.schema import Schema, SchemaLegacy
+from lib389.schema import Schema, OBJECT_MODEL_PARAMS 
+from ldap.schema.models import AttributeType, ObjectClass
 from lib389.config import Config
 from lib389.idm.user import UserAccounts
 from lib389.idm.group import Group, Groups
@@ -320,19 +321,31 @@ def test_attrname_exceptions_dn_syntax(topo, request):
     config.replace('nsslapd-attribute-name-exceptions', 'on')
     config.replace('nsslapd-syntaxcheck', 'on')
 
-    schema = SchemaLegacy(inst)
-    schema.add_attribute(
-        "( 9.9.9.9.1 NAME 'test_underscore_attr' "
-        "DESC 'Test attribute with underscore' "
-        "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 "
-        "X-ORIGIN 'user defined' )"
-    )
-    schema.add_objectclass(
-        "( 9.9.9.9.2 NAME 'testUnderscoreOC' "
-        "DESC 'Test OC with underscore attr' SUP top AUXILIARY "
-        "MAY test_underscore_attr "
-        "X-ORIGIN 'user defined' )"
-    )
+    schema = Schema(inst)
+
+    # Add new attribute with underscore
+    parameters = OBJECT_MODEL_PARAMS[AttributeType].copy()
+    parameters.update({
+        'names': ('test_underscore_attr',),
+        'oid': '9.9.9.9.1',
+        'desc': 'Test attribute with underscore',
+        'syntax': '1.3.6.1.4.1.1466.115.121.1.15',
+        'sup': (),
+        'x_origin': 'user defined',
+    })
+    schema.add_attributetype(parameters)
+
+    parameters = OBJECT_MODEL_PARAMS[ObjectClass].copy()
+    parameters.update({
+        'names': ('testUnderscoreOC',),
+        'oid': '9.9.9.9.2',
+        'desc': 'Test OC with underscore attr',
+        'sup': ('top',),
+        'kind': 1,
+        'may': ('test_underscore_attr',),
+        'x_origin': 'user defined',
+    })
+    schema.add_objectclass(parameters)
 
     users = UserAccounts(inst, DEFAULT_SUFFIX)
     user = users.create(properties={

--- a/ldap/servers/plugins/syntaxes/validate.c
+++ b/ldap/servers/plugins/syntaxes/validate.c
@@ -29,6 +29,7 @@ keystring_validate(
 {
     int rc = 0; /* assume the value is valid */
     const char *p = begin;
+    int allow_exceptions = config_get_attrname_exceptions();
 
     if ((begin == NULL) || (end == NULL)) {
         rc = 1;
@@ -38,10 +39,14 @@ keystring_validate(
     /* Per RFC4512:
      *
      *   keystring = leadkeychar *keychar
+     *
+     * When nsslapd-attribute-name-exceptions is enabled,
+     * underscores are also permitted (for compatibility
+     * with legacy directory servers such as Sun ONE DS).
      */
     if (IS_LEADKEYCHAR(*p)) {
         for (p++; p <= end; p++) {
-            if (!IS_KEYCHAR(*p)) {
+            if (!IS_KEYCHAR(*p) && !(allow_exceptions && *p == '_')) {
                 rc = 1;
                 goto exit;
             }

--- a/ldap/servers/plugins/syntaxes/validate.c
+++ b/ldap/servers/plugins/syntaxes/validate.c
@@ -29,7 +29,6 @@ keystring_validate(
 {
     int rc = 0; /* assume the value is valid */
     const char *p = begin;
-    int allow_exceptions = config_get_attrname_exceptions();
 
     if ((begin == NULL) || (end == NULL)) {
         rc = 1;
@@ -45,6 +44,7 @@ keystring_validate(
      * with legacy directory servers such as Sun ONE DS).
      */
     if (IS_LEADKEYCHAR(*p)) {
+        int allow_exceptions = config_get_attrname_exceptions();
         for (p++; p <= end; p++) {
             if (!IS_KEYCHAR(*p) && !(allow_exceptions && *p == '_')) {
                 rc = 1;


### PR DESCRIPTION
Problem Description:

When nsslapd-attribute-name-exceptions is set to on, the schema loader (schema_check_name in schema.c) correctly allows underscores in attribute names. However, the syntax validation plugins used during LDIF import and entry operations do not honor this setting. The keystring_validate function in validate.c uses the IS_KEYCHAR macro, which only permits [a-zA-Z0-9-] — no underscore. This means:

  - DN-valued attributes (like seeAlso, member) whose values contain DNs with underscored attribute types are rejected by slapi_entry_syntax_check
  - The rejection chain: slapi_entry_syntax_check → dn_validate → distinguishedname_validate → rdn_validate → keystring_validate → IS_KEYCHAR('_') = false → error

Fix Description:

ldap/servers/plugins/syntaxes/validate.c — Modified keystring_validate to check config_get_attrname_exceptions() and allow underscores when the setting is enabled, matching the behavior of schema_check_name in schema.c. Since rdn_validate, oid_validate (cis.c), and guide syntax validators all delegate to keystring_validate, they all inherit the fix automatically.

dirsrvtests/tests/suites/syntax/acceptance_test.py — Added regression test test_attrname_exceptions_dn_syntax that enables the exception, creates a schema attribute with an underscore, adds an entry using it, and verifies a seeAlso value containing a DN with the underscored attribute type is accepted.

relates: https://github.com/389ds/389-ds-base/issues/7815

Author: Michael Solberg <msolberg@redhat.com>

Assisted-by: Claude

## Summary by Sourcery

Allow syntax validation to accept underscored attribute names when nsslapd-attribute-name-exceptions is enabled.

Bug Fixes:
- Honor nsslapd-attribute-name-exceptions during syntax validation so DN-valued attributes can reference attribute types containing underscores.

Tests:
- Add a regression test covering underscored attribute types in DN values when attribute-name exceptions are enabled.