### PR TITLE
Issue 7506 - CLI/UI - Add option to list accounts by status

### DIFF
--- a/dirsrvtests/tests/suites/clu/dsidm_account_list_test.py
+++ b/dirsrvtests/tests/suites/clu/dsidm_account_list_test.py
@@ -1,0 +1,453 @@
+# --- BEGIN COPYRIGHT BLOCK ---
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+#
+# License: GPL (version 3 or any later version).
+# See LICENSE for details.
+# --- END COPYRIGHT BLOCK ---
+#
+import json
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from lib389 import DEFAULT_SUFFIX
+from lib389._constants import DN_CONFIG, DN_PLUGIN, PASSWORD
+from lib389.cli_base import FakeArgs
+from lib389.cli_idm.account import (
+    list as account_list,
+    PLUGIN_DISABLED_MSG,
+    PLUGIN_INCOMPLETE_MSG,
+)
+from lib389.idm.role import FilteredRoles
+from lib389.idm.user import UserAccounts
+from lib389.plugins import AccountPolicyPlugin, AccountPolicyConfig, AccountPolicyConfigs
+from test389.topologies import topology_st
+from . import check_value_in_log_and_reset
+
+pytestmark = pytest.mark.tier1
+
+DEBUGGING = os.getenv("DEBUGGING", default=False)
+if DEBUGGING:
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+else:
+    logging.getLogger(__name__).setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+PLUGIN_ACCT_POLICY = "Account Policy Plugin"
+ACCP_DN = "cn={},{}".format(PLUGIN_ACCT_POLICY, DN_PLUGIN)
+ACCP_CONF = "{},{}".format(DN_CONFIG, ACCP_DN)
+INACTIVITY_LIMIT = 60
+USER_PW = PASSWORD
+
+USER_LOCKED = "list_user_locked"
+USER_ROLE = "list_user_role"
+USER_INACTIVE = "list_user_inactive"
+USER_EXPIRED = "list_user_expired"
+USER_EXPIRING = "list_user_expiring"
+USER_MUST_RESET = "list_user_must_reset"
+USER_NEVER_LOGIN = "list_user_never_login"
+USER_NOPW = "list_user_nopw"
+
+ROLE_NAME = "ListLockedRole"
+
+
+def _make_list_args(**kwargs):
+    """Build FakeArgs for dsidm account list, with every filter defaulted off."""
+    args = FakeArgs()
+    args.json = False
+    args.locked = False
+    args.expired_password = False
+    args.expiring_password = None
+    args.inactive = False
+    args.never_logged_in = False
+    args.must_reset_password = False
+    for key, value in kwargs.items():
+        setattr(args, key, value)
+    return args
+
+
+def _create_user(inst, uid, name, password=None):
+    users = UserAccounts(inst, DEFAULT_SUFFIX)
+    if users.exists(name):
+        users.get(name).delete()
+    properties = {
+        'uid': name,
+        'cn': name,
+        'sn': name,
+        'uidNumber': str(uid),
+        'gidNumber': str(uid),
+        'homeDirectory': '/home/{}'.format(name),
+    }
+    if password is not None:
+        properties['userPassword'] = password
+    return users.create(properties=properties)
+
+
+def _dn_in(entries, dn):
+    dn_l = dn.lower()
+    return any(entry.lower() == dn_l for entry in entries)
+
+
+def _run_list_json(topology_st, **flags):
+    args = _make_list_args(json=True, **flags)
+    topology_st.logcap.flush()
+    account_list(topology_st.standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+    outputs = topology_st.logcap.get_raw_outputs()
+    assert outputs, "dsidm account list produced no output"
+    return json.loads(outputs[0])
+
+
+def _run_list_text(topology_st, **flags):
+    args = _make_list_args(json=False, **flags)
+    topology_st.logcap.flush()
+    account_list(topology_st.standalone, DEFAULT_SUFFIX, topology_st.logcap.log, args)
+
+
+@pytest.fixture(scope="function")
+def account_list_users(topology_st, request):
+    """Create users covering each account-list filter and enable required plugins/policies."""
+    inst = topology_st.standalone
+    config = inst.config
+
+    saved_pwp = {
+        'passwordMustChange': config.get_attr_val_utf8('passwordMustChange'),
+        'passwordExp': config.get_attr_val_utf8('passwordExp'),
+        'passwordMaxAge': config.get_attr_val_utf8('passwordMaxAge'),
+    }
+
+    plugin = AccountPolicyPlugin(inst)
+    if plugin.status():
+        plugin.disable()
+        inst.restart()
+
+    # passwordExp + passwordMaxAge > 1 day, passwordMustChange still off so an
+    # admin password set records a real expiration time (not 19700101000000Z).
+    # Create anyone who must bind later while the password is still valid.
+    config.replace('passwordExp', 'on')
+    config.replace('passwordMaxAge', '90000')
+    config.replace('passwordMustChange', 'off')
+
+    user_expiring = _create_user(inst, 4100, USER_EXPIRING, USER_PW)
+    user_expiring.replace('userPassword', USER_PW)
+    user_locked = _create_user(inst, 4103, USER_LOCKED, USER_PW)
+    user_locked.replace('userPassword', USER_PW)
+    user_role = _create_user(inst, 4104, USER_ROLE, USER_PW)
+    user_role.replace('userPassword', USER_PW)
+    user_inactive = _create_user(inst, 4105, USER_INACTIVE, USER_PW)
+    user_inactive.replace('userPassword', USER_PW)
+    user_never_login = _create_user(inst, 4106, USER_NEVER_LOGIN, USER_PW)
+    user_never_login.replace('userPassword', USER_PW)
+    user_nopw = _create_user(inst, 4107, USER_NOPW)
+
+    # Short max age so this password is expired after a brief wait.
+    config.replace('passwordMaxAge', '2')
+    user_expired = _create_user(inst, 4101, USER_EXPIRED, USER_PW)
+    user_expired.replace('userPassword', USER_PW)
+
+    # Admin reset with passwordMustChange=on sets passwordExpirationTime to epoch.
+    config.replace('passwordMustChange', 'on')
+    user_must_reset = _create_user(inst, 4102, USER_MUST_RESET, USER_PW)
+    user_must_reset.replace('userPassword', USER_PW)
+
+    user_locked.replace('nsAccountLock', 'true')
+
+    roles = FilteredRoles(inst, DEFAULT_SUFFIX)
+    if roles.exists(ROLE_NAME):
+        role = roles.get(ROLE_NAME)
+        try:
+            role.unlock()
+        except ValueError:
+            pass
+        role.delete()
+    role = roles.create(properties={
+        'cn': ROLE_NAME,
+        'nsRoleFilter': '(uid={})'.format(USER_ROLE),
+    })
+    role.lock()
+
+    plugin.enable()
+    plugin.set('nsslapd-pluginarg0', ACCP_CONF)
+    accp_configs = AccountPolicyConfigs(inst)
+    accp_configs.ensure_state(
+        properties={
+            'cn': 'config',
+            'alwaysrecordlogin': 'yes',
+            'stateattrname': 'lastLoginTime',
+            'altstateattrname': '1.1',
+            'specattrname': 'acctPolicySubentry',
+            'limitattrname': 'accountInactivityLimit',
+            'accountInactivityLimit': str(INACTIVITY_LIMIT),
+        }
+    )
+    inst.restart()
+
+    users_c = UserAccounts(inst, DEFAULT_SUFFIX)
+    user_locked = users_c.get(USER_LOCKED)
+    user_role = users_c.get(USER_ROLE)
+    user_inactive = users_c.get(USER_INACTIVE)
+    user_expired = users_c.get(USER_EXPIRED)
+    user_expiring = users_c.get(USER_EXPIRING)
+    user_must_reset = users_c.get(USER_MUST_RESET)
+    user_never_login = users_c.get(USER_NEVER_LOGIN)
+    user_nopw = users_c.get(USER_NOPW)
+
+    # Bind with a valid password so lastLoginTime is recorded, then age it.
+    conn = user_inactive.bind(USER_PW)
+    conn.unbind()
+    past_time = datetime.utcnow() - timedelta(seconds=INACTIVITY_LIMIT * 2)
+    user_inactive.replace('lastLoginTime', past_time.strftime('%Y%m%d%H%M%SZ'))
+
+    # lastLoginTime present but no password → the "no password" bucket.
+    user_nopw.replace('lastLoginTime', datetime.utcnow().strftime('%Y%m%d%H%M%SZ'))
+
+    # passwordMaxAge=2: wait until expiration time is in the past.
+    time.sleep(3)
+
+    users = {
+        'locked': user_locked,
+        'role': user_role,
+        'inactive': user_inactive,
+        'expired': user_expired,
+        'expiring': user_expiring,
+        'must_reset': user_must_reset,
+        'never_login': user_never_login,
+        'nopw': user_nopw,
+        'role_obj': role,
+    }
+
+    def fin():
+        if DEBUGGING:
+            return
+        log.info('Cleaning up account list test users and plugin/policy settings')
+        try:
+            if role.exists():
+                try:
+                    role.unlock()
+                except ValueError:
+                    pass
+                role.delete()
+        except Exception as e:
+            log.error('Failed to remove role: {}'.format(e))
+        for user in (user_locked, user_role, user_inactive, user_expired,
+                     user_expiring, user_must_reset, user_never_login, user_nopw):
+            try:
+                if user.exists():
+                    user.delete()
+            except Exception as e:
+                log.error('Failed to remove user {}: {}'.format(user.dn, e))
+        try:
+            if plugin.status():
+                plugin.disable()
+            for attr, value in saved_pwp.items():
+                if value is not None:
+                    inst.config.replace(attr, value)
+            inst.restart()
+        except Exception as e:
+            log.error('Failed to restore plugin/password policy: {}'.format(e))
+
+    request.addfinalizer(fin)
+    return users
+
+
+def test_dsidm_account_list_requires_account_policy_plugin(topology_st):
+    """--inactive and --never-logged-in fail when Account Policy plugin is off
+
+    :id: 22dd8513-3386-4b85-9f16-711d9a8cc340
+    :setup: Standalone instance with Account Policy plugin disabled
+    :steps:
+        1. Confirm the Account Policy plugin is not enabled
+        2. Run dsidm account list --inactive
+        3. Run dsidm account list --never-logged-in
+        4. Run dsidm account list --locked
+    :expectedresults:
+        1. Plugin is disabled
+        2. The command fails because the plugin is not enabled
+        3. The command fails because the plugin is not enabled
+        4. --locked succeeds because it does not require the plugin
+    """
+    inst = topology_st.standalone
+    plugin = AccountPolicyPlugin(inst)
+    if plugin.status():
+        plugin.disable()
+        inst.restart()
+    assert plugin.status() is False
+
+    topology_st.logcap.flush()
+    with pytest.raises(ValueError) as excinfo:
+        account_list(inst, DEFAULT_SUFFIX, topology_st.logcap.log,
+                     _make_list_args(inactive=True))
+    assert PLUGIN_DISABLED_MSG in str(excinfo.value)
+
+    topology_st.logcap.flush()
+    with pytest.raises(ValueError) as excinfo:
+        account_list(inst, DEFAULT_SUFFIX, topology_st.logcap.log,
+                     _make_list_args(never_logged_in=True))
+    assert PLUGIN_DISABLED_MSG in str(excinfo.value)
+
+    locked = _run_list_json(topology_st, locked=True)
+    assert 'directly_locked' in locked
+
+
+def test_dsidm_account_list_locked_with_incomplete_account_policy(topology_st, request):
+    """--locked still lists nsAccountLock users when Account Policy config is incomplete
+
+    :id: bcb8141d-8fab-4647-8439-5e72a1080add
+    :setup: Standalone instance with Account Policy plugin enabled but missing
+            inactivity-policy attributes
+    :steps:
+        1. Enable the Account Policy plugin with an incomplete config entry
+        2. Create a directly locked user
+        3. Run dsidm account list --locked
+        4. Run dsidm account list --inactive
+    :expectedresults:
+        1. Plugin is enabled
+        2. The locked user exists
+        3. The locked user is listed
+        4. --inactive fails because the plugin is not fully configured
+    """
+    inst = topology_st.standalone
+    plugin = AccountPolicyPlugin(inst)
+    accp_configs = AccountPolicyConfigs(inst)
+    created = []
+
+    def fin():
+        if DEBUGGING:
+            return
+        log.info('Cleaning up incomplete account-policy locked-list test')
+        for user_obj in created:
+            try:
+                if user_obj.exists():
+                    user_obj.delete()
+            except Exception as e:
+                log.error('Failed to remove user: {}'.format(e))
+        try:
+            if plugin.status():
+                plugin.disable()
+            inst.restart()
+        except Exception as e:
+            log.error('Failed to disable Account Policy plugin: {}'.format(e))
+
+    request.addfinalizer(fin)
+
+    plugin.enable()
+    plugin.set('nsslapd-pluginarg0', ACCP_CONF)
+    accp_configs.ensure_state(properties={'cn': 'config'})
+    config = AccountPolicyConfig(inst, ACCP_CONF)
+    for attr in ('stateattrname', 'altstateattrname', 'specattrname',
+                 'limitattrname', 'accountInactivityLimit', 'alwaysrecordlogin'):
+        config.remove_all(attr)
+    inst.restart()
+    assert plugin.status() is True
+
+    user = _create_user(inst, 4108, 'list_user_locked_incomplete', USER_PW)
+    user.replace('nsAccountLock', 'true')
+    created.append(user)
+
+    locked = _run_list_json(topology_st, locked=True)
+    assert _dn_in(locked['directly_locked']['accounts'], user.dn)
+
+    topology_st.logcap.flush()
+    with pytest.raises(ValueError) as excinfo:
+        account_list(inst, DEFAULT_SUFFIX, topology_st.logcap.log,
+                     _make_list_args(inactive=True))
+    assert PLUGIN_INCOMPLETE_MSG in str(excinfo.value)
+
+
+def test_dsidm_account_list_options(topology_st, account_list_users):
+    """dsidm account list filters return the matching accounts when configured
+
+    :id: 7856c78f-56b3-481f-a841-43c05f898980
+    :setup: Standalone instance with Account Policy plugin, password policy
+            (passwordMustChange=on, passwordExp=on, passwordMaxAge 90000 then 2),
+            and users covering locked, role-locked, inactive, expired, expiring,
+            must-reset, never-logged-in, and no-password states
+    :steps:
+        1. List locked accounts (json and text)
+        2. List expired-password accounts
+        3. List passwords expiring within 2 days and within 1 day
+        4. List inactive accounts
+        5. List must-reset-password accounts
+        6. List never-logged-in accounts
+    :expectedresults:
+        1. Direct lock, role lock, and inactivity lock are each reported
+        2. The expired-password user is listed, and the must-reset user is not
+        3. The 90000s-max-age user is listed for 2 days and not for 1 day;
+           already-expired and must-reset users are not listed as expiring
+        4. The inactive user is listed
+        5. The must-reset user is listed
+        6. The never-logged-in user and the no-password user are listed
+    """
+    users = account_list_users
+
+    log.info('List locked accounts')
+    locked = _run_list_json(topology_st, locked=True)
+    assert _dn_in(locked['directly_locked']['accounts'], users['locked'].dn), (
+        "expected {} in directly_locked, got {}".format(
+            users['locked'].dn, locked))
+    assert _dn_in(locked['indirectly_locked']['accounts'], users['role'].dn), (
+        "expected {} in indirectly_locked, got {}".format(
+            users['role'].dn, locked))
+    assert _dn_in(locked['inactivity_locked']['accounts'], users['inactive'].dn), (
+        "expected {} in inactivity_locked, got {}".format(
+            users['inactive'].dn, locked))
+    _run_list_text(topology_st, locked=True)
+    check_value_in_log_and_reset(topology_st, content_list=[
+        users['locked'].dn,
+        users['role'].dn,
+        users['inactive'].dn,
+        'Directly locked accounts',
+        'Indirectly locked accounts',
+        'Inactivity locked accounts',
+    ])
+
+    log.info('List expired password accounts')
+    expired = _run_list_json(topology_st, expired_password=True)
+    assert _dn_in(expired['expired_password']['accounts'], users['expired'].dn)
+    assert not _dn_in(expired['expired_password']['accounts'], users['must_reset'].dn)
+    _run_list_text(topology_st, expired_password=True)
+    check_value_in_log_and_reset(topology_st, check_value=users['expired'].dn)
+
+    log.info('List expiring password accounts (2 days includes 90000s max age)')
+    expiring = _run_list_json(topology_st, expiring_password='2')
+    assert _dn_in(expiring['expiring_password']['accounts'], users['expiring'].dn)
+    assert not _dn_in(expiring['expiring_password']['accounts'], users['expired'].dn)
+    assert not _dn_in(expiring['expiring_password']['accounts'], users['must_reset'].dn)
+    _run_list_text(topology_st, expiring_password='2')
+    check_value_in_log_and_reset(topology_st, check_value=users['expiring'].dn)
+
+    log.info('List expiring password accounts (1 day excludes 90000s max age)')
+    expiring_one_day = _run_list_json(topology_st, expiring_password='1')
+    assert not _dn_in(expiring_one_day['expiring_password']['accounts'], users['expiring'].dn)
+
+    log.info('List inactive accounts')
+    inactive = _run_list_json(topology_st, inactive=True)
+    assert _dn_in(inactive['inactive_accounts']['accounts'], users['inactive'].dn)
+    _run_list_text(topology_st, inactive=True)
+    check_value_in_log_and_reset(topology_st, check_value=users['inactive'].dn)
+
+    log.info('List must-reset password accounts')
+    must_reset = _run_list_json(topology_st, must_reset_password=True)
+    assert _dn_in(must_reset['must_reset_password']['accounts'], users['must_reset'].dn)
+    _run_list_text(topology_st, must_reset_password=True)
+    check_value_in_log_and_reset(topology_st, check_value=users['must_reset'].dn)
+
+    log.info('List never-logged-in and no-password accounts')
+    never_logged = _run_list_json(topology_st, never_logged_in=True)
+    assert _dn_in(never_logged['never_logged_in']['accounts'], users['never_login'].dn)
+    assert _dn_in(never_logged['no_password']['accounts'], users['nopw'].dn)
+    _run_list_text(topology_st, never_logged_in=True)
+    check_value_in_log_and_reset(topology_st, content_list=[
+        users['never_login'].dn,
+        users['nopw'].dn,
+        'Never logged in accounts',
+        'No password accounts',
+    ])
+
+
+if __name__ == '__main__':
+    CURRENT_FILE = os.path.realpath(__file__)
+    pytest.main(["-s", CURRENT_FILE])

--- a/src/cockpit/389-console/src/LDAPEditor.jsx
+++ b/src/cockpit/389-console/src/LDAPEditor.jsx
@@ -42,7 +42,7 @@ import CreateRootSuffix from './lib/ldap_editor/lib/rootSuffix.jsx';
 import { ENTRY_MENU } from './lib/ldap_editor/lib/constants.jsx';
 import EditorTableView from './lib/ldap_editor/tableView.jsx';
 import EditorTreeView from './lib/ldap_editor/treeView.jsx';
-import { SearchDatabase } from './lib/ldap_editor/search.jsx';
+import { SearchDatabase, AccountReports } from './lib/ldap_editor/search.jsx';
 import GenericWizard from './lib/ldap_editor/wizards/genericWizard.jsx';
 import { EffectivePwpModal } from './lib/ldap_editor/effectivePwpModal.jsx';
 import { SyncAltIcon } from '@patternfly/react-icons';
@@ -1273,6 +1273,17 @@ export class LDAPEditor extends React.Component {
                     <Tab eventKey={2} title={<TabTitleText>{_("Search")}</TabTitleText>}>
                         <SearchDatabase
                             key={this.state.suffixList + this.state.searchBase}
+                            serverId={this.props.serverId}
+                            suffixList={this.state.suffixList}
+                            attributes={this.state.attributes}
+                            searchBase={this.state.searchBase}
+                            allObjectclasses={this.state.allObjectclasses}
+                            addNotification={this.props.addNotification}
+                        />
+                    </Tab>
+                    <Tab eventKey={3} title={<TabTitleText>{_("Account Reports")}</TabTitleText>}>
+                        <AccountReports
+                            key={this.state.suffixList + "reports"}
                             serverId={this.props.serverId}
                             suffixList={this.state.suffixList}
                             attributes={this.state.attributes}

--- a/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/lib/utils.jsx
@@ -237,7 +237,8 @@ function parseSearchResult(searchResult) {
         const accountObjectclasses = ['nsaccount', 'nsperson', 'simplesecurityobject',
             'organization', 'person', 'account', 'organizationalunit',
             'netscapeserver', 'domain', 'posixaccount', 'shadowaccount',
-            'posixgroup', 'mailrecipient', 'nsroledefinition'];
+            'posixgroup', 'mailrecipient', 'nsroledefinition', 'inetorgperson',
+            'organizationalperson', 'nsorgperson'];
         if (isAttributeLine(currentLine, 'dn:')) {
             // Convert base64-encoded DNs
             const pos = currentLine.indexOf(':');

--- a/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
+++ b/src/cockpit/389-console/src/lib/ldap_editor/search.jsx
@@ -50,6 +50,29 @@ import { EffectivePwpModal } from './effectivePwpModal.jsx';
 
 const _ = cockpit.gettext;
 
+const SEARCH_COLUMNS = [
+    {
+        title: _("Entry DN"),
+        cellFormatters: [expandable]
+    },
+    {
+        title: _("Child Entries")
+    },
+    {
+        title: _("Last Modified")
+    }
+];
+
+const REPORT_COLUMNS = [
+    {
+        title: _("Entry DN"),
+        cellFormatters: [expandable]
+    },
+    {
+        title: _("Status")
+    }
+];
+
 export class SearchDatabase extends React.Component {
     constructor (props) {
         super(props);
@@ -84,19 +107,12 @@ export class SearchDatabase extends React.Component {
             isCustomAttrOpen: false,
             isConfirmModalOpen: false,
             checkIfLocked: false,
+            // Account reports
+            reportType: "locked",
+            expiringDays: 7,
+            tableMode: this.props.view === "reports" ? "report" : "search",
             // Table
-            columns: [
-                {
-                    title: _("Entry DN"),
-                    cellFormatters: [expandable]
-                },
-                {
-                    title: _("Child Entries")
-                },
-                {
-                    title: _("Last Modified")
-                }
-            ],
+            columns: this.props.view === "reports" ? REPORT_COLUMNS : SEARCH_COLUMNS,
             rows: [],
             page: 0,
             perPage: 10,
@@ -229,6 +245,8 @@ export class SearchDatabase extends React.Component {
                 rows: [],
                 isExpanded: false,
                 searching: true,
+                tableMode: "search",
+                columns: SEARCH_COLUMNS,
             }, () => {
                 const params = {
                     serverId: this.props.serverId,
@@ -240,6 +258,200 @@ export class SearchDatabase extends React.Component {
                     addNotification: this.props.addNotification,
                 };
                 getSearchEntries(params, this.processResults);
+            });
+        };
+
+        this.handleReportTypeChange = (event, value) => {
+            const reportType = typeof value === "string" ? value : event.target.value;
+            this.setState({ reportType });
+        };
+
+        this.getReportHelpText = () => {
+            switch (this.state.reportType) {
+            case "locked":
+                return _("Accounts locked directly (nsAccountLock), through a role, or by inactivity.");
+            case "expired-password":
+                return _("Accounts whose password has already expired.");
+            case "expiring-password":
+                return _("Accounts whose password will expire within the selected number of days.");
+            case "inactive":
+                return _("Accounts that exceeded the inactivity limit. Requires the Account Policy Plugin to be enabled.");
+            case "must-reset-password":
+                return _("Accounts that must reset their password at next login.");
+            case "never-logged-in":
+                return _("Accounts that have never logged in, or have no password. Requires the Account Policy Plugin to be enabled.");
+            default:
+                return "";
+            }
+        };
+
+        this.getReportGroups = (reportType, data) => {
+            if (reportType === "locked") {
+                return [
+                    {
+                        status: _("Directly locked"),
+                        entryState: "directly locked through nsAccountLock",
+                        accounts: data.directly_locked ? data.directly_locked.accounts : []
+                    },
+                    {
+                        status: _("Indirectly locked"),
+                        entryState: "indirectly locked through a Role",
+                        accounts: data.indirectly_locked ? data.indirectly_locked.accounts : []
+                    },
+                    {
+                        status: _("Inactivity locked"),
+                        entryState: "inactivity limit exceeded",
+                        accounts: data.inactivity_locked ? data.inactivity_locked.accounts : []
+                    }
+                ];
+            }
+            if (reportType === "expired-password") {
+                return [{
+                    status: _("Expired password"),
+                    entryState: "",
+                    accounts: data.expired_password ? data.expired_password.accounts : []
+                }];
+            }
+            if (reportType === "expiring-password") {
+                return [{
+                    status: _("Expiring password"),
+                    entryState: "",
+                    accounts: data.expiring_password ? data.expiring_password.accounts : []
+                }];
+            }
+            if (reportType === "inactive") {
+                return [{
+                    status: _("Inactive"),
+                    entryState: "inactivity limit exceeded",
+                    accounts: data.inactive_accounts ? data.inactive_accounts.accounts : []
+                }];
+            }
+            if (reportType === "must-reset-password") {
+                return [{
+                    status: _("Must reset password"),
+                    entryState: "",
+                    accounts: data.must_reset_password ? data.must_reset_password.accounts : []
+                }];
+            }
+            if (reportType === "never-logged-in") {
+                return [
+                    {
+                        status: _("Never logged in"),
+                        entryState: "",
+                        accounts: data.never_logged_in ? data.never_logged_in.accounts : []
+                    },
+                    {
+                        status: _("No password"),
+                        entryState: "",
+                        accounts: data.no_password ? data.no_password.accounts : []
+                    }
+                ];
+            }
+            return [];
+        };
+
+        this.handleGenerateReport = () => {
+            const reportBase = this.state.baseDN || this.state.searchSuffix;
+            if (!reportBase || this.state.searching) {
+                return;
+            }
+            this.setState({
+                rows: [],
+                isExpanded: false,
+                searching: true,
+                tableMode: "report",
+                columns: REPORT_COLUMNS,
+            }, () => {
+                const cmd = [
+                    "dsidm", "-j",
+                    "ldapi://%2fvar%2frun%2fslapd-" + this.props.serverId + ".socket",
+                    "-b", reportBase,
+                    "account", "list"
+                ];
+                if (this.state.reportType === "expiring-password") {
+                    cmd.push("--expiring-password", String(this.state.expiringDays));
+                } else {
+                    cmd.push("--" + this.state.reportType);
+                }
+                log_cmd("handleGenerateReport", "Run dsidm account list report", cmd);
+                cockpit
+                        .spawn(cmd, { superuser: "require", err: "message" })
+                        .done(content => {
+                            this.processReportResults(content);
+                        })
+                        .fail(err => {
+                            this.props.addNotification(
+                                "error",
+                                cockpit.format(_("Failed to generate account report: $0"), getApiErrorMessage(err))
+                            );
+                            this.setState({
+                                searching: false,
+                                rows: [],
+                                pagedRows: [],
+                                total: 0,
+                                page: 1
+                            });
+                        });
+            });
+        };
+
+        this.processReportResults = (content) => {
+            let data = {};
+            try {
+                const jsonStart = content.indexOf("{");
+                data = JSON.parse(jsonStart >= 0 ? content.substring(jsonStart) : content);
+            } catch (e) {
+                this.props.addNotification(
+                    "error",
+                    _("Failed to parse the account list report")
+                );
+                this.setState({
+                    searching: false,
+                    rows: [],
+                    pagedRows: [],
+                    total: 0,
+                    page: 1
+                });
+                return;
+            }
+
+            const groups = this.getReportGroups(this.state.reportType, data);
+            const resultRows = [];
+            let rowNumber = 0;
+            groups.forEach(group => {
+                const accounts = group.accounts || [];
+                accounts.forEach(dn => {
+                    resultRows.push(
+                        {
+                            isOpen: false,
+                            cells: [
+                                { title: dn },
+                                group.status
+                            ],
+                            rawdn: dn,
+                            isLockable: this.state.reportType === "locked" || this.state.reportType === "inactive",
+                            isRole: false,
+                            entryState: group.entryState,
+                            isUser: true,
+                            userPwpLookup: null,
+                        },
+                        {
+                            parent: rowNumber,
+                            cells: [
+                                { title: this.initialResultText }
+                            ]
+                        }
+                    );
+                    rowNumber += 2;
+                });
+            });
+
+            this.setState({
+                searching: false,
+                rows: resultRows,
+                pagedRows: resultRows.slice(0, 2 * this.state.perPage),
+                total: resultRows.length / 2,
+                page: 1
             });
         };
 
@@ -299,17 +511,20 @@ export class SearchDatabase extends React.Component {
 
     componentDidMount() {
         const suffixList = this.props.suffixList;
-        const searchBase = this.props.searchBase;
-        let baseDN = searchBase; // Drop down list of selected suffix
+        const searchBase = this.props.searchBase || "";
+        let baseDN = "";
         for (const suffix of suffixList) {
-            if (baseDN.includes(suffix)) {
+            if ((searchBase === suffix || searchBase.endsWith("," + suffix))
+                    && suffix.length > baseDN.length) {
                 baseDN = suffix;
-                break;
             }
         }
+        if (!baseDN && suffixList.length > 0) {
+            baseDN = suffixList[0];
+        }
         this.setState({
-            searchBase: searchBase || (suffixList.length > 0 ? suffixList[0] : ""),
-            searchSuffix: this.props.suffixList.length > 0 ? this.props.suffixList[0] : "",
+            searchBase: searchBase || baseDN,
+            searchSuffix: baseDN,
             baseDN
         });
     }
@@ -538,12 +753,12 @@ export class SearchDatabase extends React.Component {
         });
     }
 
-    handleSuffixChange (e) {
-        const value = e.target.value;
+    handleSuffixChange (e, value) {
+        const suffix = (typeof value === "string" && value !== "") ? value : e.target.value;
         this.setState({
-            searchSuffix: value,
-            searchBase: value,
-            baseDN: value,
+            searchSuffix: suffix,
+            searchBase: suffix,
+            baseDN: suffix,
         });
     }
 
@@ -593,7 +808,11 @@ export class SearchDatabase extends React.Component {
                         entryMenuIsOpen: !this.state.entryMenuIsOpen,
                         refreshEntryTime: Date.now()
                     }, () => {
-                        this.handleSearch();
+                        if (this.state.tableMode === "report") {
+                            this.handleGenerateReport();
+                        } else {
+                            this.handleSearch();
+                        }
                         this.handleConfirmModalToggle();
                     });
                 })
@@ -612,7 +831,11 @@ export class SearchDatabase extends React.Component {
                         entryMenuIsOpen: !this.state.entryMenuIsOpen,
                         refreshEntryTime: Date.now()
                     }, () => {
-                        this.handleSearch();
+                        if (this.state.tableMode === "report") {
+                            this.handleGenerateReport();
+                        } else {
+                            this.handleSearch();
+                        }
                         this.handleConfirmModalToggle();
                     });
                 });
@@ -776,7 +999,9 @@ export class SearchDatabase extends React.Component {
 
         if (pagedRows.length === 0) {
             columns = [' '];
-            pagedRows = [{ cells: [_("No Search Results")] }];
+            pagedRows = [{
+                cells: [this.state.tableMode === "report" ? _("No matching accounts") : _("No Search Results")]
+            }];
         }
 
         const treeItemsProps = wizardName === 'acis'
@@ -794,7 +1019,7 @@ export class SearchDatabase extends React.Component {
                         editorLdapServer={this.props.serverId}
                         {...treeItemsProps}
                         setWizardOperationInfo={this.setWizardOperationInfo}
-                        onReload={this.handleSearch}
+                        onReload={this.state.tableMode === "report" ? this.handleGenerateReport : this.handleSearch}
                         allObjectclasses={this.props.allObjectclasses}
                     />
                 )}
@@ -807,6 +1032,7 @@ export class SearchDatabase extends React.Component {
                     userType={this.state.pwpModalUserType}
                     selector={this.state.pwpModalSelector}
                 />
+                {this.props.view !== "reports" &&
                 <Form className="ds-margin-top-lg" isHorizontal autoComplete="off">
                     <Grid className="ds-margin-left">
                         <div className="ds-container">
@@ -821,7 +1047,7 @@ export class SearchDatabase extends React.Component {
                                         id="searchSuffix"
                                         value={baseDN}
                                         onChange={(event, value) => {
-                                            this.handleSuffixChange(event);
+                                            this.handleSuffixChange(event, value);
                                         }}
                                         aria-label="FormSelect Input"
                                         className="ds-instance-select ds-raise-field"
@@ -1128,12 +1354,109 @@ export class SearchDatabase extends React.Component {
                             </div>
                         </div>
                     </ExpandableSection>
-                </Form>
+                </Form>}
+                {this.props.view === "reports" &&
+                        <Form className="ds-margin-top-lg" isHorizontal autoComplete="off">
+                            <Grid className="ds-margin-left">
+                                <GridItem span={2}>
+                                    <b>{_("Suffix")}</b>
+                                </GridItem>
+                                <GridItem span={5}>
+                                    <FormSelect
+                                        id="reportSuffix"
+                                        value={baseDN}
+                                        onChange={(event, value) => {
+                                            this.handleSuffixChange(event, value);
+                                        }}
+                                        aria-label={_("Suffix")}
+                                        className="ds-instance-select ds-raise-field"
+                                        isDisabled={suffixList.length === 0}
+                                        title={_("Suffix used as the base for dsidm account list.")}
+                                    >
+                                        {suffixList.map((suffix) => (
+                                            <FormSelectOption key={suffix} value={suffix} label={suffix} />
+                                        ))}
+                                        {suffixList.length === 0 &&
+                                            <FormSelectOption isDisabled key="No database" value="" label={_("No databases")} />}
+                                    </FormSelect>
+                                </GridItem>
+                            </Grid>
+                            <Grid
+                                className="ds-margin-left ds-margin-top"
+                                title={_("Select which dsidm account list report to generate.")}
+                            >
+                                <GridItem span={2}>
+                                    <b>{_("Report Type")}</b>
+                                </GridItem>
+                                <GridItem span={5}>
+                                    <FormSelect
+                                        id="reportType"
+                                        value={this.state.reportType}
+                                        onChange={this.handleReportTypeChange}
+                                        aria-label={_("Report type")}
+                                    >
+                                        <FormSelectOption value="locked" label={_("Locked accounts")} />
+                                        <FormSelectOption value="expired-password" label={_("Expired passwords")} />
+                                        <FormSelectOption value="expiring-password" label={_("Expiring passwords")} />
+                                        <FormSelectOption value="inactive" label={_("Inactive accounts")} />
+                                        <FormSelectOption value="must-reset-password" label={_("Must reset password")} />
+                                        <FormSelectOption value="never-logged-in" label={_("Never logged in")} />
+                                    </FormSelect>
+                                </GridItem>
+                            </Grid>
+                            {this.state.reportType === "expiring-password" &&
+                                <Grid
+                                    className="ds-margin-left ds-margin-top"
+                                    title={_("List accounts whose password expires within this many days.")}
+                                >
+                                    <GridItem span={2}>
+                                        <b>{_("Expires Within (days)")}</b>
+                                    </GridItem>
+                                    <GridItem span={10}>
+                                        <NumberInput
+                                            value={this.state.expiringDays}
+                                            min={1}
+                                            max={this.maxValue}
+                                            onMinus={() => { this.onMinus("expiringDays") }}
+                                            onChange={(e) => { this.onNumberChange(e, "expiringDays", 1) }}
+                                            onPlus={() => { this.onPlus("expiringDays") }}
+                                            inputName="expiringDays"
+                                            inputAriaLabel={_("Days until password expiration")}
+                                            minusBtnAriaLabel="minus"
+                                            plusBtnAriaLabel="plus"
+                                            widthChars={8}
+                                        />
+                                    </GridItem>
+                                </Grid>}
+                            <Grid className="ds-margin-left">
+                                <GridItem span={10} offset={2}>
+                                    <FormHelperText>
+                                        {this.getReportHelpText()}
+                                    </FormHelperText>
+                                </GridItem>
+                            </Grid>
+                            <Grid className="ds-margin-left ds-margin-top">
+                                <GridItem span={4}>
+                                    <Button
+                                        variant="primary"
+                                        onClick={this.handleGenerateReport}
+                                        isLoading={this.state.searching}
+                                        isDisabled={!this.state.baseDN || this.state.searching || (this.state.reportType === "expiring-password" && this.state.expiringDays < 1)}
+                                        spinnerAriaValueText={this.state.searching ? _("Generating") : undefined}
+                                        title={_("Run dsidm account list for the selected report type.")}
+                                    >
+                                        {this.state.searching ? _("Generating ...") : _("Generate Report")}
+                                    </Button>
+                                </GridItem>
+                            </Grid>
+                        </Form>}
                 <div className="ds-indent">
                     <div className={this.state.searching ? "ds-margin-top-lg ds-center" : "ds-hidden"}>
                         <TextContent>
                             <Text component={TextVariants.h3}>
-                                {_("Searching")} <i>{this.state.searchBase}</i> ...
+                                {this.state.tableMode === "report"
+                                    ? _("Generating account report ...")
+                                    : <>{_("Searching")} <i>{this.state.searchBase}</i> ...</>}
                             </Text>
                         </TextContent>
                         <Spinner className="ds-margin-top-lg" size="xl" />
@@ -1213,9 +1536,22 @@ export class SearchDatabase extends React.Component {
 SearchDatabase.propTypes = {
     attributes: PropTypes.array,
     searchBase: PropTypes.string,
+    serverId: PropTypes.string,
+    suffixList: PropTypes.array,
+    allObjectclasses: PropTypes.array,
+    addNotification: PropTypes.func,
+    view: PropTypes.string,
 };
 
 SearchDatabase.defaultProps = {
     attributes: [],
     searchBase: "",
+    serverId: "",
+    suffixList: [],
+    allObjectclasses: [],
+    view: "search",
 };
+
+export const AccountReports = (props) => (
+    <SearchDatabase {...props} view="reports" />
+);

--- a/src/lib389/lib389/cli_idm/account.py
+++ b/src/lib389/lib389/cli_idm/account.py
@@ -1,5 +1,5 @@
 # --- BEGIN COPYRIGHT BLOCK ---
-# Copyright (C) 2024, Red Hat inc,
+# Copyright (C) 2026, Red Hat inc,
 # Copyright (C) 2018, William Brown <william@blackhats.net.au>
 # All rights reserved.
 #
@@ -10,6 +10,7 @@
 import json
 import ldap
 import math
+import time
 from datetime import datetime
 from lib389.idm.account import Account, Accounts, AccountState
 from lib389.cli_idm import (
@@ -25,13 +26,373 @@ from lib389.cli_base import (
     CustomHelpFormatter
     )
 from lib389.cli_idm import _generic_rename_dn
+from lib389.plugins import AccountPolicyPlugin, AccountPolicyConfig, AccountPolicyEntry
+from lib389.cos import CosTemplates
+from lib389.mappingTree import MappingTrees
+from lib389.idm.role import Roles
+from lib389.utils import gentime_to_posix_time
 
 MANY = Accounts
 SINGULAR = Account
 
+# Admin reset with passwordMustChange=on records this sentinel expiration time.
+PW_MUST_RESET = "19700101000000z"
+_LIST_SEPARATOR = "----------------------------------------------------------"
+PLUGIN_DISABLED_MSG = "Function is not available because Account Policy Plugin is not enabled"
+PLUGIN_UNCONFIGURED_MSG = "Function is not available because Account Policy Plugin is not configured"
+PLUGIN_INCOMPLETE_MSG = "Function is not available because Account Policy Plugin is not fully configured"
+
+
+def _is_base_entry(account, basedn):
+    return account.dn.lower() == basedn.lower()
+
+
+def _iter_accounts(inst, basedn, entries=None):
+    if entries is None:
+        entries = Accounts(inst, basedn).list()
+    for account in entries:
+        if not _is_base_entry(account, basedn):
+            yield account
+
+
+def _get_disabled_role_dns(inst, root_suffix):
+    if not root_suffix:
+        return set()
+    try:
+        roles = Roles(inst, root_suffix)
+        return set(role.dn.lower() for role in roles.get_disabled_roles())
+    except ldap.NO_SUCH_OBJECT:
+        return set()
+
+
+def _load_account_policy(inst, basedn, required=False, need_limit=True):
+    """Return (plugin_enabled, state_dict) for Account Policy settings.
+
+    If required is True, raise ValueError when the plugin is disabled or
+    missing its config entry. When required is False, incomplete inactivity
+    settings are skipped so callers such as --locked can still detect
+    nsAccountLock and role locks. need_limit=False skips CoS/inactivity-limit
+    lookup (used by never-logged-in, which only needs stateattrname).
+    """
+    state_dict = {
+        "state_attr": "",
+        "alt_state_attr": "",
+        "spec_attr": "",
+        "limit_attr": "",
+        "limit": None,
+        "root_suffix": basedn,
+    }
+    acct_plugin = AccountPolicyPlugin(inst)
+    try:
+        enabled = acct_plugin.status()
+    except IndexError:
+        enabled = False
+
+    if not enabled:
+        if required:
+            raise ValueError(PLUGIN_DISABLED_MSG)
+        return False, state_dict
+
+    config_dn = acct_plugin.get_attr_val_utf8("nsslapd-pluginarg0")
+    if config_dn is None:
+        if required:
+            raise ValueError(PLUGIN_UNCONFIGURED_MSG)
+        return True, state_dict
+
+    config = AccountPolicyConfig(inst, config_dn)
+    config_settings = config.get_attrs_vals_utf8(["stateattrname", "altstateattrname",
+                                                  "specattrname", "limitattrname"])
+    state_dict["state_attr"] = (config_settings.get("stateattrname") or [""])[0]
+    state_dict["alt_state_attr"] = (config_settings.get("altstateattrname") or [""])[0]
+    state_dict["spec_attr"] = (config_settings.get("specattrname") or [""])[0]
+    state_dict["limit_attr"] = (config_settings.get("limitattrname") or [""])[0]
+
+    try:
+        mapping_trees = MappingTrees(inst)
+        state_dict["root_suffix"] = mapping_trees.get_root_suffix_by_entry(basedn)
+    except ldap.NO_SUCH_OBJECT:
+        pass
+
+    if not need_limit:
+        if required and state_dict["state_attr"] == "":
+            raise ValueError(PLUGIN_INCOMPLETE_MSG)
+        return True, state_dict
+
+    if not state_dict["state_attr"] or not state_dict["limit_attr"]:
+        if required:
+            raise ValueError(PLUGIN_INCOMPLETE_MSG)
+        # Direct and role locks do not need inactivity-policy attributes.
+        return True, state_dict
+
+    accpol_entry = config
+    if state_dict["spec_attr"]:
+        cos_entries = CosTemplates(inst, state_dict["root_suffix"])
+        for cos in cos_entries.list():
+            if cos.present(state_dict["spec_attr"]):
+                accpol_entry_dn = cos.get_attr_val_utf8_l(state_dict["spec_attr"])
+                if accpol_entry_dn:
+                    accpol_entry = AccountPolicyEntry(inst, accpol_entry_dn)
+                    break
+    state_dict["limit"] = accpol_entry.get_attr_val_utf8_l(state_dict["limit_attr"])
+    return True, state_dict
+
+
+def _emit_account_list(log, args, json_result, sections, empty_msg):
+    """Print JSON or grouped text results.
+
+    sections is a list of (title, dns) tuples used for the non-JSON path.
+    """
+    if args.json:
+        log.info(json.dumps(json_result, indent=2))
+        return
+    printed = False
+    for title, dns in sections:
+        if dns:
+            log.info("\n{} ({}):".format(title, len(dns)))
+            log.info(_LIST_SEPARATOR)
+            for dn in dns:
+                log.info("- " + dn)
+            printed = True
+    if not printed:
+        log.info(empty_msg)
+
+
+def get_status(inst, account, process_account_policy, state_dict, disabled_dns=None):
+    # Lightweight version of Account.status()
+    fetch_attrs = ["nsAccountLock", "nsRole"]
+    if state_dict["state_attr"]:
+        fetch_attrs.append(state_dict["state_attr"])
+    # "1.1" is the Account Policy "disabled" OID for altstateattrname
+    if state_dict["alt_state_attr"] and state_dict["alt_state_attr"] != "1.1":
+        fetch_attrs.append(state_dict["alt_state_attr"])
+    account_data = account.get_attrs_vals_utf8(fetch_attrs)
+
+    last_login_time = ""
+    if state_dict["state_attr"]:
+        last_login_time = account._dict_get_with_ignore_indexerror(account_data, state_dict["state_attr"])
+    if not last_login_time and state_dict["alt_state_attr"] in account_data:
+        last_login_time = account._dict_get_with_ignore_indexerror(account_data, state_dict["alt_state_attr"])
+    acct_roles = [role.lower() for role in account_data.get("nsRole", account_data.get("nsrole", []))]
+
+    if acct_roles:
+        if disabled_dns is None:
+            disabled_dns = _get_disabled_role_dns(inst, state_dict["root_suffix"])
+        for role in acct_roles:
+            if role in disabled_dns:
+                return AccountState.INDIRECTLY_LOCKED
+
+    if account._dict_get_with_ignore_indexerror(account_data, "nsAccountLock") == "true":
+        return AccountState.DIRECTLY_LOCKED
+
+    if process_account_policy and last_login_time and state_dict["limit"]:
+        remaining_time = float(state_dict["limit"]) - (time.mktime(time.gmtime()) - gentime_to_posix_time(last_login_time))
+        if remaining_time <= 0:
+            return AccountState.INACTIVITY_LIMIT_EXCEEDED
+
+    return AccountState.ACTIVATED
+
 
 def list(inst, basedn, log, args):
-    _generic_list(inst, basedn, log.getChild('_generic_list'), MANY, args)
+    if getattr(args, 'locked', False):
+        list_locked(inst, basedn, log, args)
+    elif getattr(args, 'expired_password', False):
+        list_expired_password(inst, basedn, log, args)
+    elif getattr(args, 'expiring_password', None) is not None:
+        list_expiring_password(inst, basedn, log, args)
+    elif getattr(args, 'inactive', False):
+        list_inactive(inst, basedn, log, args)
+    elif getattr(args, 'never_logged_in', False):
+        list_never_logged_in(inst, basedn, log, args)
+    elif getattr(args, 'must_reset_password', False):
+        list_must_reset_password(inst, basedn, log, args)
+    else:
+        _generic_list(inst, basedn, log.getChild('_generic_list'), MANY, args)
+
+
+def list_locked(inst, basedn, log, args):
+    process_account_policy, state_dict = _load_account_policy(inst, basedn, required=False)
+    disabled_dns = _get_disabled_role_dns(inst, state_dict["root_suffix"])
+    directly_locked_accounts = []
+    indirectly_locked_accounts = []
+    inactive_accounts = []
+
+    for account in _iter_accounts(inst, basedn):
+        state = get_status(inst, account, process_account_policy, state_dict, disabled_dns)
+        if state == AccountState.DIRECTLY_LOCKED:
+            directly_locked_accounts.append(account.dn)
+        elif state == AccountState.INDIRECTLY_LOCKED:
+            indirectly_locked_accounts.append(account.dn)
+        elif state == AccountState.INACTIVITY_LIMIT_EXCEEDED:
+            inactive_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "directly_locked": {
+                "count": len(directly_locked_accounts),
+                "accounts": directly_locked_accounts,
+            },
+            "indirectly_locked": {
+                "count": len(indirectly_locked_accounts),
+                "accounts": indirectly_locked_accounts,
+            },
+            "inactivity_locked": {
+                "count": len(inactive_accounts),
+                "accounts": inactive_accounts,
+            },
+        },
+        [
+            ("Directly locked accounts", directly_locked_accounts),
+            ("Indirectly locked accounts", indirectly_locked_accounts),
+            ("Inactivity locked accounts", inactive_accounts),
+        ],
+        "There are no locked accounts"
+    )
+
+
+def list_expired_password(inst, basedn, log, args):
+    expired_password_accounts = []
+    utc_now = gentime_to_posix_time(datetime.utcnow().strftime('%Y%m%d%H%M%SZ'))
+
+    for account in _iter_accounts(inst, basedn):
+        expire_time = account.get_attr_val_utf8_l("passwordexpirationtime")
+        if expire_time is None or expire_time == PW_MUST_RESET:
+            continue
+        if gentime_to_posix_time(expire_time) <= utc_now:
+            expired_password_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "expired_password": {
+                "count": len(expired_password_accounts),
+                "accounts": expired_password_accounts,
+            },
+        },
+        [("Expired password accounts", expired_password_accounts)],
+        "There are no expired password accounts"
+    )
+
+
+def list_must_reset_password(inst, basedn, log, args):
+    must_reset_password_accounts = []
+    for account in _iter_accounts(inst, basedn):
+        expire_time = account.get_attr_val_utf8_l("passwordexpirationtime")
+        if expire_time == PW_MUST_RESET:
+            must_reset_password_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "must_reset_password": {
+                "count": len(must_reset_password_accounts),
+                "accounts": must_reset_password_accounts,
+            },
+        },
+        [("Must reset password accounts", must_reset_password_accounts)],
+        "There are no must-reset password accounts"
+    )
+
+
+def list_expiring_password(inst, basedn, log, args):
+    try:
+        days = int(args.expiring_password)
+    except (TypeError, ValueError):
+        raise ValueError("expiring-password requires a positive number of days")
+    if days < 1:
+        raise ValueError("expiring-password requires a positive number of days")
+
+    expiring_password_accounts = []
+    utc_now_epoch = gentime_to_posix_time(datetime.utcnow().strftime('%Y%m%d%H%M%SZ'))
+    future_expire_time = utc_now_epoch + (days * 86400)
+    for account in _iter_accounts(inst, basedn):
+        expire_time = account.get_attr_val_utf8_l("passwordexpirationtime")
+        if expire_time is None or expire_time == PW_MUST_RESET:
+            continue
+        account_expire_time = gentime_to_posix_time(expire_time)
+        # Still valid, but expires within the requested window
+        if utc_now_epoch < account_expire_time <= future_expire_time:
+            expiring_password_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "expiring_password": {
+                "count": len(expiring_password_accounts),
+                "accounts": expiring_password_accounts,
+            },
+        },
+        [("Expiring password accounts within {} days".format(days), expiring_password_accounts)],
+        "There are no expiring password accounts in the next {} days".format(days)
+    )
+
+
+def list_inactive(inst, basedn, log, args):
+    process_account_policy, state_dict = _load_account_policy(inst, basedn, required=True)
+    disabled_dns = _get_disabled_role_dns(inst, state_dict["root_suffix"])
+    inactive_accounts = []
+
+    for account in _iter_accounts(inst, basedn):
+        state = get_status(inst, account, process_account_policy, state_dict, disabled_dns)
+        if state == AccountState.INACTIVITY_LIMIT_EXCEEDED:
+            inactive_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "inactive_accounts": {
+                "count": len(inactive_accounts),
+                "accounts": inactive_accounts,
+            },
+        },
+        [("Inactivity locked accounts", inactive_accounts)],
+        "There are no inactive accounts"
+    )
+
+
+def list_never_logged_in(inst, basedn, log, args):
+    _, state_dict = _load_account_policy(inst, basedn, required=True, need_limit=False)
+    state_attr = state_dict["state_attr"]
+
+    accounts_obj = Accounts(inst, basedn)
+    # Restrict to user-like objectclasses so roles/groups are not listed
+    accounts_obj._objectclasses = [
+        'person',
+        'inetOrgPerson',
+        'organizationalPerson',
+        'nsPerson',
+        'nsAccount',
+        'nsOrgPerson',
+        'account',
+        'posixAccount',
+    ]
+    never_logged_in_accounts = []
+    no_password_accounts = []
+    for account in _iter_accounts(inst, basedn, accounts_obj.list()):
+        account_settings = account.get_attrs_vals_utf8([state_attr, "userpassword"])
+        if len(account_settings.get(state_attr, [])) == 0:
+            never_logged_in_accounts.append(account.dn)
+        elif len(account_settings.get("userpassword", [])) == 0:
+            no_password_accounts.append(account.dn)
+
+    _emit_account_list(
+        log, args,
+        {
+            "never_logged_in": {
+                "count": len(never_logged_in_accounts),
+                "accounts": never_logged_in_accounts,
+            },
+            "no_password": {
+                "count": len(no_password_accounts),
+                "accounts": no_password_accounts,
+            },
+        },
+        [
+            ("Never logged in accounts", never_logged_in_accounts),
+            ("No password accounts", no_password_accounts),
+        ],
+        "There are no never-logged-in or no-password accounts"
+    )
 
 
 def get_dn(inst, basedn, log, args):
@@ -239,6 +600,19 @@ like modify, locking and unlocking. To create an account, see "user" subcommand 
                                          help='list accounts that could login to the directory (returns the full DN of the entry)',
                                          formatter_class=CustomHelpFormatter)
     list_parser.set_defaults(func=list)
+    list_filters = list_parser.add_mutually_exclusive_group()
+    list_filters.add_argument('--locked', action='store_true',
+                              help='list accounts that are locked either directly (nsAccountLock), indirectly (through a role), or by inactivity')
+    list_filters.add_argument('--expired-password', action='store_true',
+                              help='list accounts that have expired passwords')
+    list_filters.add_argument('--expiring-password', type=int, metavar='DAYS',
+                              help='list accounts whose password expires within the next specified number of days')
+    list_filters.add_argument('--inactive', action='store_true',
+                              help='list accounts that are inactive. Requires the Account Policy Plugin to be configured')
+    list_filters.add_argument('--must-reset-password', action='store_true',
+                              help='list accounts that must reset their password')
+    list_filters.add_argument('--never-logged-in', action='store_true',
+                              help='list user accounts that have never logged in. Requires the Account Policy Plugin to be configured')
 
     get_dn_parser = subcommands.add_parser('get-by-dn', help='get-by-dn <dn>', formatter_class=CustomHelpFormatter)
     get_dn_parser.set_defaults(func=get_dn)

--- a/src/lib389/lib389/idm/account.py
+++ b/src/lib389/lib389/idm/account.py
@@ -76,7 +76,7 @@ class Account(DSLdapObject):
     def _dict_get_with_ignore_indexerror(self, dict, attr):
         try:
             return dict[attr][0]
-        except IndexError:
+        except (IndexError, KeyError):
             return ""
 
     def status(self):
@@ -176,7 +176,7 @@ class Account(DSLdapObject):
                                                create_time, modify_time, last_login_time, limit)
 
         # Locked indirectly through Account Policy plugin
-        if process_account_policy and last_login_time:
+        if process_account_policy and last_login_time and limit:
             # Now check the Account Policy Plugin inactivity limits
             remaining_time = float(limit) - (time.mktime(time.gmtime()) - gentime_to_posix_time(last_login_time))
             if remaining_time <= 0:


### PR DESCRIPTION
Description: Add dsidm account list filters for locked, expired, expiring, inactive, must-reset, and never-logged-in accounts, and add an Account Reports tab to the LDAP Browser. Keep expired, expiring, and must-reset lists disjoint, and make the list flags mutually exclusive.

Relates: https://github.com/389ds/389-ds-base/issues/7506

Assisted by: Cursor

## Summary by Sourcery

Add account-status reporting to the dsidm CLI and LDAP Browser.

New Features:
- Add mutually exclusive dsidm account list filters for locked, expired, expiring, inactive, must-reset, and never-logged-in accounts with grouped JSON and text output.
- Add an LDAP Browser Account Reports tab for generating and viewing account status reports by suffix.

Bug Fixes:
- Keep expired-password, expiring-password, and must-reset-password results disjoint and allow locked-account reporting with incomplete account-policy configuration.
- Improve account status handling when optional attributes or inactivity limits are absent.

Enhancements:
- Support account reports for additional user object classes and preserve the selected LDAP suffix as the report base.

Tests:
- Add tier-1 coverage for account-list filters, password-status exclusivity, account-policy prerequisites, and text/JSON report output.