### PR TITLE
Issue 7823 - CI: stabilize test_controltype_expired_grace_limit

### DIFF
--- a/dirsrvtests/tests/suites/password/pwdPolicy_controls_sequence_test.py
+++ b/dirsrvtests/tests/suites/password/pwdPolicy_controls_sequence_test.py
@@ -68,7 +68,7 @@ def bind_and_get_control(topo):
         res_ctrls = ast.literal_eval(str(e))
         pass
 
-    topo.standalone.simple_bind(DN_DM, PASSWORD)
+    topo.standalone.simple_bind_s(DN_DM, PASSWORD)
     return res_ctrls
 
 


### PR DESCRIPTION
Bug description:
	bind_and_get_control authenticates the connection to
	directory manager before returning. The problem is
	that authentication may still pending upon return
	and teardown is called with the previous auth resulting
	in err=50 (insufficient access)

Fix description:
	Force a synchrone call (whoami_s) after DM authentication

fixes: #7823

Reviewed by:

## Summary by Sourcery

Bug Fixes:
- Stabilize the expired grace-limit control test by ensuring directory manager authentication completes before teardown.