### PR TITLE
Issue 7833 - heap-buffer-overflow in rdn_av_swap

### DIFF
--- a/dirsrvtests/tests/suites/basic/basic_test.py
+++ b/dirsrvtests/tests/suites/basic/basic_test.py
@@ -9,6 +9,7 @@
 
 from subprocess import check_output, PIPE, run
 from lib389 import DirSrv
+from lib389.idm.account import Account
 from lib389.idm.user import UserAccount, UserAccounts
 import pytest
 from lib389.tasks import *
@@ -2546,6 +2547,25 @@ def test_conn_limits(dscreate_with_numlistener):
         c.unbind()
 
     # Step 6 is done in teardown phase by dscreate_instance finalizer
+
+
+@pytest.mark.skipif(not default_paths.asan_enabled, reason="Don't run if ASAN is not enabled")
+def test_bind_multiple_ava(topology_st):
+    """Check a bind with a specific dn.
+
+    :id: 1cd69646-a196-11f1-a7ac-c85309d5c3e3
+    :setup: standalone instance
+    :steps:
+        1. Try to perform a bind with specific DN
+        2. Rebind as Directory manager
+    :expectedresults:
+        1. Should raise ldap.INVALID_CREDENTIAL exception
+        2. Should success
+    """
+    inst = topology_st.standalone
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        Account(inst, 'seeAlso=x+member="sn=b+cn=a",dc=com').bind('foo')
+    DirectoryManager(inst).rebind()
 
 
 if __name__ == '__main__':

--- a/ldap/servers/slapd/dn.c
+++ b/ldap/servers/slapd/dn.c
@@ -26,6 +26,7 @@
 
 #undef SDN_DEBUG
 
+static char *safe_PL_strcasestr(char *start, char *end, const char *needle);
 static void add_rdn_av(char *avstart, char *avend, int *rdn_av_countp, struct berval **rdn_avsp, struct berval *avstack);
 static void reset_rdn_avs(struct berval **rdn_avsp, int *rdn_av_countp);
 static void sort_rdn_avs(struct berval *avs, int count, int escape);
@@ -127,7 +128,7 @@ static void ndn_cache_add(char *dn, size_t dn_len, char *ndn, size_t ndn_len);
 
 #define MAYBEDN(eq) (                 \
     (eq) && ((eq) != subtypestart) && \
-    ((eq) != subtypestart + strlen(subtypestart) - 3))
+    ((eq) != d - 3))
 
 #define B4TYPE 0
 #define INTYPE 1
@@ -745,8 +746,7 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                                 (ISPLUS(*(s + 1)) || subrdn_av_count > 0)) {
                                 /* if subtypestart is not valid DN,
                                   * we do not do sorting.*/
-                                char *p = PL_strcasestr(subtypestart, "\\3d");
-                                if (MAYBEDN(p)) {
+                                if (MAYBEDN(safe_PL_strcasestr(subtypestart, d, "\\3d"))) {
                                     add_rdn_av(subtypestart, d,
                                                &subrdn_av_count,
                                                &subrdn_avs,
@@ -826,8 +826,7 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                             (ISPLUSSTR(s + 1) || subrdn_av_count > 0)) {
                             /* if subtypestart is not valid DN,
                              * we do not do sorting.*/
-                            char *p = PL_strcasestr(subtypestart, "\\3d");
-                            if (MAYBEDN(p)) {
+                            if (MAYBEDN(safe_PL_strcasestr(subtypestart, d, "\\3d"))) {
                                 add_rdn_av(subtypestart, d, &subrdn_av_count,
                                            &subrdn_avs, subinitial_rdn_av_stack);
                             } else {
@@ -968,6 +967,23 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                         d += 3;
                     }
 
+                    if (subtypestart && subrdn_av_count > 0) {
+                        if (MAYBEDN(safe_PL_strcasestr(subtypestart, d, "\\3d"))) {
+                            add_rdn_av(subtypestart, d,
+                                       &subrdn_av_count,
+                                       &subrdn_avs,
+                                       subinitial_rdn_av_stack);
+                        } else {
+                            reset_rdn_avs(&subrdn_avs,
+                                          &subrdn_av_count);
+                            subtypestart = NULL;
+                        }
+                        if (subrdn_av_count > 1) {
+                            sort_rdn_avs(subrdn_avs,
+                                         subrdn_av_count, 1);
+                        }
+                    }
+
                     state = B4SEPARATOR;
                     s++;
                 }
@@ -1005,8 +1021,7 @@ slapi_dn_normalize_ext(char *src, size_t src_len, char **dest, size_t *dest_len)
                             (ISPLUS(*s) || subrdn_av_count > 0)) {
                             /* if subtypestart is not valid DN,
                              * we do not do sorting.*/
-                            char *p = PL_strcasestr(subtypestart, "\\3d");
-                            if (MAYBEDN(p)) {
+                            if (MAYBEDN(safe_PL_strcasestr(subtypestart, d, "\\3d"))) {
                                 add_rdn_av(subtypestart, d, &subrdn_av_count,
                                            &subrdn_avs, subinitial_rdn_av_stack);
                             } else {
@@ -1218,6 +1233,21 @@ slapi_create_rdn_value(const char *fmt, ...)
     }
     slapi_ch_free_string(&src);
     return dest;
+}
+
+/*
+ * NUL-safe wrapper around PL_strcasestr: temporarily NUL-terminates
+ * the buffer at 'end' so the search stays within [start, end).
+ */
+static char *
+safe_PL_strcasestr(char *start, char *end, const char *needle)
+{
+    char saved = *end;
+    char *p;
+    *end = '\0';
+    p = PL_strcasestr(start, needle);
+    *end = saved;
+    return p;
 }
 
 /*


### PR DESCRIPTION
Heap buffer overflow in dn normalization
CVE-2026-16560: heap-buffer-overflow in rdn_av_swap on quoted multivalued RDN
Fix multiple dn normalization OOB:
[1] When parsing dn with multiple rdn, the parser tracks the rdn to sort them,
but it does not finalize that tracking when closing a quote, so the list is not reset
and next tracking will try to sort wrong list leading to a write OOB
[2] Read OOB in MAYBEDN macro because strlen is used on non null terminated string
[3] Read OOB in PL_strcasestr because it is used on non null terminated string

Add bacic/basic_test.py::test_bind_multiple_ava to test the OOB with libasan build
Fixes: #7833 

Reviewed by: @vashirov  (Thanks!)

Assted by: Claude AI


## Summary by Sourcery

Harden DN normalization against out-of-bounds searches and add regression coverage for malformed multivalued RDN binds.

Bug Fixes:
- Prevent heap-buffer-overflow during normalization of quoted multivalued RDNs by constraining substring searches to the current DN component.
- Correct multivalued RDN finalization and sorting across separator handling.

Tests:
- Add an ASAN-gated regression test covering binds with quoted multivalued RDNs.