### PR TITLE
rpm: fix ELN build

### DIFF
--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -61,9 +61,9 @@ ExcludeArch: i686
 %endif
 
 # Build cockpit plugin
-# Enabled on Fedora and EPEL community builds.
+# Enabled on Fedora, ELN, and EPEL community builds.
 # Disabled on RHEL/CentOS Stream unless RHDS (distribution contains "dsrv").
-%if 0%{?rhel} && !0%{?epel}
+%if 0%{?rhel} && !0%{?epel} && !0%{?eln}
 %bcond cockpit %(echo "%{?distribution}" | grep -q dsrv && echo 1 || echo 0)
 %else
 %bcond cockpit 1
@@ -505,9 +505,7 @@ mkdir -p ../%{libdb_base_version}
 pushd ../%{libdb_base_version}
 tar -xjf %{_topdir}/SOURCES/%{libdb_full_version}.tar.bz2
 mv %{libdb_full_version} SOURCES
-%if 0%{?fedora}
 sed -i -e '/^CFLAGS=/s/-fno-strict-aliasing/& -std=gnu99/' %{_builddir}/%{name}-%{version}/rpm/bundle-libdb.spec.in
-%endif
 rpmbuild  --define "_topdir $PWD" -bc %{_builddir}/%{name}-%{version}/rpm/bundle-libdb.spec.in
 popd
 %endif
@@ -568,7 +566,7 @@ cp -r %{_builddir}/%{name}-%{version}/man/man3 %{buildroot}/%{_mandir}/man3
 # lib389
 pushd src/lib389
 %pyproject_install
-%if 0%{?fedora} <= 41 || (0%{?rhel} && 0%{?rhel} <= 10)
+%if ! (0%{?fedora} >= 42 || 0%{?rhel} >= 11)
 for clitool in dsconf dscreate dsctl dsidm openldap_to_ds; do
     mv %{buildroot}%{_bindir}/$clitool %{buildroot}%{_sbindir}/
 done


### PR DESCRIPTION
Description:
As it adds no extra dependencies not already in RHEL, ELN should build the
cockpit plugin for testing purposes (but not shipped in AppStream), as it
does not have the mechanism for building the same package in multiple
configurations.

Also, libdb requires -std=gnu99 on RHEL 11 as well, as it has the latest
gcc which defaults to C23, with which libdb's old codebase is not compatible.

Finally, RHEL 11 also includes the bin-sbin merge, and therefore needs to be
handled accordingly with respect to the binaries.

See also: https://src.fedoraproject.org/rpms/389-ds-base/pull-request/24

## Summary by Sourcery

Update RPM packaging to support successful ELN and RHEL 11 builds.

Bug Fixes:
- Fix ELN/RHEL 11 RPM builds by enabling the plugin for ELN testing, using the required C standard for libdb, and accommodating the bin-sbin merge.

Build:
- Update RPM packaging for ELN and RHEL 11 compatibility.