### PR TITLE
Issue 7830 - Instance creation fails when `/usr/lib` is read-only

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -309,9 +309,15 @@ gdbautoloaddir = $(prefixdir)/share/gdb/auto-load$(sbindir)
 cockpitdir = $(prefixdir)/share/cockpit@cockpitdir@
 metainfodir = $(prefixdir)/share/metainfo/389-console
 tmpfiles_d = @tmpfiles_d@
+tmpfiles_ddir = @tmpfiles_d@
+runtime_tmpfiles_d = @runtime_tmpfiles_d@
 
 sysctldir = @sysctl_d@
 sysusersdir = @sysusers_d@
+
+if INSTALL_TMPFILES
+dist_tmpfiles_d_DATA = ldap/admin/src/dirsrv.conf
+endif
 
 defaultuser=@defaultuser@
 defaultgroup=@defaultgroup@
@@ -2110,6 +2116,7 @@ fixupcmd = sed \
 	-e 's,@with_selinux\@,@with_selinux@,g' \
 	-e 's,@with_systemd\@,$(WITH_SYSTEMD),g' \
 	-e 's,@tmpfiles_d\@,$(tmpfiles_d),g' \
+	-e 's,@runtime_tmpfiles_d\@,$(runtime_tmpfiles_d),g' \
 	-e 's,@sysusers_d\@,$(sysusersdir),g' \
 	-e 's,@pythonexec\@,@pythonexec@,g' \
 	-e 's,@sttyexec\@,@sttyexec@,g' \

--- a/ldap/admin/src/defaults.inf.in
+++ b/ldap/admin/src/defaults.inf.in
@@ -44,6 +44,7 @@ inst_dir = @serverdir@/slapd-{instance_name}
 plugin_dir = @serverplugindir@
 system_schema_dir = @systemschemadir@
 tmpfiles_d = @tmpfiles_d@
+runtime_tmpfiles_d = @runtime_tmpfiles_d@
 sysusers_d = @sysusers_d@
 
 ; These values can be altered in an installation of ds
@@ -64,4 +65,3 @@ db_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/db
 db_home_dir = /dev/shm/slapd-{instance_name}
 backup_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/bak
 ldif_dir = @localstatedir@/lib/dirsrv/slapd-{instance_name}/ldif
-

--- a/ldap/admin/src/dirsrv.conf.in
+++ b/ldap/admin/src/dirsrv.conf.in
@@ -1,0 +1,2 @@
+d @localrundir@/dirsrv 0770 dirsrv dirsrv -
+d @localrundir@/lock/dirsrv 0770 dirsrv dirsrv -

--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -135,6 +135,21 @@ if test "$with_systemd" = yes; then
     fi
     AC_MSG_RESULT([$tmpfiles_d])
 
+    # Runtime-generated tmpfiles belong in the administrator configuration
+    # directory, not the vendor directory detected above.
+    runtime_tmpfiles_d='$(sysconfdir)/tmpfiles.d'
+    AC_MSG_CHECKING(for --with-runtime-tmpfiles-d)
+    AC_ARG_WITH(runtime-tmpfiles-d,
+       AS_HELP_STRING([--with-runtime-tmpfiles-d=PATH],
+                      [Directory for runtime-generated tmpfiles.d files (default: $(sysconfdir)/tmpfiles.d)])
+    )
+    if test "$with_runtime_tmpfiles_d" = no ; then
+      runtime_tmpfiles_d=
+    elif test -n "$with_runtime_tmpfiles_d" && test "$with_runtime_tmpfiles_d" != yes ; then
+      runtime_tmpfiles_d=$with_runtime_tmpfiles_d
+    fi
+    AC_MSG_RESULT([$runtime_tmpfiles_d])
+
     # sysusers.d dir
     sysusers_d=`$PKG_CONFIG --variable=sysusersdir systemd 2>/dev/null`
     if test -z "$sysusers_d" ; then
@@ -190,6 +205,6 @@ AM_CONDITIONAL([INSTALL_SYSCTL],[test -n "$sysctl_d"])
 
 AC_SUBST(systemd_defs)
 AC_SUBST(tmpfiles_d)
+AC_SUBST(runtime_tmpfiles_d)
 AC_SUBST(sysusers_d)
 AC_SUBST(sysctl_d)
-

--- a/rpm/389-ds-base.spec.in
+++ b/rpm/389-ds-base.spec.in
@@ -724,6 +724,7 @@ fi
 %dir %{_sysconfdir}/%{pkgname}/config
 %dir %{_sysconfdir}/systemd/system/%{groupname}.wants
 %{_sysusersdir}/%{name}.conf
+%{_tmpfilesdir}/dirsrv.conf
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/slapd-collations.conf
 %config(noreplace)%{_sysconfdir}/%{pkgname}/config/certmap.conf
 %{_datadir}/%{pkgname}
@@ -877,4 +878,3 @@ fi
 
 %changelog
 %autochangelog
-

--- a/src/lib389/doc/source/paths.rst
+++ b/src/lib389/doc/source/paths.rst
@@ -34,6 +34,7 @@ Usage example
         'ldif_dir',
         'initconfig_dir',
         'tmpfiles_d',
+        'runtime_tmpfiles_d',
         'sysusers_d',
     ]
 

--- a/src/lib389/lib389/instance/remove.py
+++ b/src/lib389/lib389/instance/remove.py
@@ -64,7 +64,12 @@ def remove_ds_instance(dirsrv, force=False):
     remove_paths['etc_sysconfig'] = "%s/sysconfig/dirsrv-%s" % (dirsrv.ds_paths.sysconf_dir, dirsrv.serverid)
     remove_paths['ldapi'] = dirsrv.ds_paths.ldapi
 
-    tmpfiles_d_path = dirsrv.ds_paths.tmpfiles_d + "/dirsrv-" + dirsrv.serverid + ".conf"
+    tmpfiles_d_paths = []
+    for tmpfiles_d in (dirsrv.ds_paths.runtime_tmpfiles_d, dirsrv.ds_paths.tmpfiles_d):
+        if tmpfiles_d:
+            tmpfile_path = f"{tmpfiles_d}/dirsrv-{dirsrv.serverid}.conf"
+            if tmpfile_path not in tmpfiles_d_paths:
+                tmpfiles_d_paths.append(tmpfile_path)
 
     # These are handled in a special way.
     dse_ldif_path = os.path.join(dirsrv.ds_paths.config_dir, 'dse.ldif')
@@ -117,11 +122,12 @@ def remove_ds_instance(dirsrv, force=False):
         stderr = ensure_str(result.stderr)
         _log.debug(f"CMD: {args} ; STDOUT: {stdout} ; STDERR: {stderr}")
 
-        _log.debug("Removing %s" % tmpfiles_d_path)
-        try:
-            os.remove(tmpfiles_d_path)
-        except OSError as e:
-            _log.debug("Failed to remove tmpfile: " + str(e))
+        for tmpfiles_d_path in tmpfiles_d_paths:
+            _log.debug(f"Removing {tmpfiles_d_path}")
+            try:
+                os.remove(tmpfiles_d_path)
+            except OSError as e:
+                _log.debug(f"Failed to remove tmpfile: {e}")
 
     # Nor can we assume we have SELinux.
     if dirsrv.ds_paths.with_selinux:

--- a/src/lib389/lib389/instance/setup.py
+++ b/src/lib389/lib389/instance/setup.py
@@ -937,13 +937,15 @@ class SetupDs(object):
             # can trip up the logger.
             self.log.debug(f"CMD: {args} ; STDOUT: {stdout} ; STDERR: {stderr}".encode("utf-8"))
 
-            # Setup tmpfiles_d
-            tmpfile_d = ds_paths.tmpfiles_d + "/dirsrv-" + slapd['instance_name'] + ".conf"
-            with open(tmpfile_d, "w") as TMPFILE_D:
-                TMPFILE_D.write("d {} 0770 {} {}\n".format(slapd['run_dir'], slapd['user'], slapd['group']))
-                TMPFILE_D.write("d {} 0770 {} {}\n".format(slapd['lock_dir'].replace("slapd-" + slapd['instance_name'], ""),
-                                                           slapd['user'], slapd['group']))
-                TMPFILE_D.write("d {} 0770 {} {}\n".format(slapd['lock_dir'], slapd['user'], slapd['group']))
+            if ds_paths.runtime_tmpfiles_d:
+                os.makedirs(ds_paths.runtime_tmpfiles_d, exist_ok=True)
+                tmpfile_d = f"{ds_paths.runtime_tmpfiles_d}/dirsrv-{slapd['instance_name']}.conf"
+                with open(tmpfile_d, "w") as TMPFILE_D:
+                    if not ds_paths.tmpfiles_d:
+                        TMPFILE_D.write(f"d {slapd['run_dir']} 0770 {slapd['user']} {slapd['group']}\n")
+                        lock_parent = slapd['lock_dir'].replace(f"slapd-{slapd['instance_name']}", "")
+                        TMPFILE_D.write(f"d {lock_parent} 0770 {slapd['user']} {slapd['group']}\n")
+                    TMPFILE_D.write(f"d {slapd['lock_dir']} 0770 {slapd['user']} {slapd['group']}\n")
 
         # Else we need to detect other init scripts?
         # WB: No, we just install and assume that docker will start us ...

--- a/src/lib389/lib389/paths.py
+++ b/src/lib389/lib389/paths.py
@@ -265,6 +265,8 @@ class Paths(object):
             return v
         # Else get from the config
         if self._config:
+            if name == 'runtime_tmpfiles_d' and not self._config.has_option(SECTION, name):
+                return os.path.join(ensure_str(self._config.get(SECTION, 'sysconf_dir')), 'tmpfiles.d')
             if self._serverid is not None:
                 return ensure_str(self._config.get(SECTION, name).format(instance_name=self._serverid))
             else:


### PR DESCRIPTION
Bug Description:
After the tmpfiles installation change, instance creation fails when `/usr/lib` is read-only. Configs moved from writable `/etc/tmpfiles.d` to `/usr/lib`. Multiple instances also duplicate common entries such as `/run/dirsrv` and `/run/lock/dirsrv`.

Fix Description:
Split tmpfiles into system-wide config and instance-specific configs.

Fixes: https://github.com/389ds/389-ds-base/issues/7830

## Summary by Sourcery

Separate system-wide and per-instance tmpfiles configuration so instance lifecycle operations work with read-only vendor directories and avoid duplicated shared runtime entries.

Bug Fixes:
- Fix instance creation when the vendor `/usr/lib` tmpfiles directory is read-only by placing instance-specific tmpfiles configuration in the writable administrator directory.
- Prevent duplicate system-wide tmpfiles entries when multiple instances are created.

Enhancements:
- Support separate system-wide and runtime-generated tmpfiles directories, including configurable runtime tmpfiles paths and cleanup from either location.

Build:
- Install the system-wide DirSrv tmpfiles configuration separately from generated per-instance configuration.

Documentation:
- Document the additional runtime tmpfiles path.