### PR TITLE
Fix: DEREF_OF_NULL.RET.STAT

### DIFF
--- a/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
+++ b/ldap/servers/slapd/back-ldbm/db-bdb/bdb_import_threads.c
@@ -1743,28 +1743,41 @@ bdb_upgradedn_producer(void *param)
             }
             slapi_ch_free_string(&path);
             if (is_dryrun) {
-                rdn_bdb_has_spaces = bdb_has_spaces(rdn);
-                if (rdn_bdb_has_spaces > 0) {
-                    dn_id = slapi_ch_smprintf("%s:%u\n",
-                                              slapi_entry_get_dn_const(e), temp_id);
-                    if (EOF == fputs(dn_id, job->upgradefd)) {
-                        if (job->task) {
-                            slapi_task_log_notice(job->task,
-                                                  "%s: Error: failed to write a line \"%s\"",
-                                                  inst->inst_name, dn_id);
+                if (NULL != rdn) {
+                    rdn_bdb_has_spaces = bdb_has_spaces(rdn);
+                    if (rdn_bdb_has_spaces > 0) {
+                        dn_id = slapi_ch_smprintf("%s:%u\n",
+                                                  slapi_entry_get_dn_const(e), temp_id);
+                        if (EOF == fputs(dn_id, job->upgradefd)) {
+                            if (job->task) {
+                                slapi_task_log_notice(job->task,
+                                                      "%s: Error: failed to write a line \"%s\"",
+                                                      inst->inst_name, dn_id);
+                            }
+                            slapi_log_err(SLAPI_LOG_ERR, "bdb_upgradedn_producer",
+                                          "%s: Error: failed to write a line \"%s\"\n",
+                                          inst->inst_name, dn_id);
+                            slapi_ch_free_string(&dn_id);
+                            goto error;
                         }
-                        slapi_log_err(SLAPI_LOG_ERR, "bdb_upgradedn_producer",
-                                      "%s: Error: failed to write a line \"%s\"\n",
-                                      inst->inst_name, dn_id);
                         slapi_ch_free_string(&dn_id);
-                        goto error;
+                        if (rdn_bdb_has_spaces > 1) {
+                            /* If an rdn containing multi spaces exists,
+                             * let's check the conflict. */
+                            do_dn_norm_sp = 1;
+                        }
                     }
-                    slapi_ch_free_string(&dn_id);
-                    if (rdn_bdb_has_spaces > 1) {
-                        /* If an rdn containing multi spaces exists,
-                         * let's check the conflict. */
-                        do_dn_norm_sp = 1;
+                } else {
+                    if (job->task) {
+                        slapi_task_log_notice(job->task,
+                                              "%s: WARNING: skipping dn-norm-sp check for "
+                                              "badly formatted entry (id %lu)",
+                                              inst->inst_name, (u_long)temp_id);
                     }
+                    slapi_log_err(SLAPI_LOG_WARNING, "bdb_upgradedn_producer",
+                                  "%s: Skipping dn-norm-sp check for badly formatted "
+                                  "entry (id %lu)\n",
+                                  inst->inst_name, (u_long)temp_id);
                 }
             } else { /* !is_dryrun */
                 /* check the oid and parentid. */


### PR DESCRIPTION
Problem:
`rdn` can be NULL when passed to bdb_has_spaces() in bdb_upgradedn_producer(), leading to a potential NULL pointer dereference during a dry-run DN-format upgrade with dn-norm-sp checking enabled.
Solution: add a NULL check for rdn before calling bdb_has_spaces(), mirroring the existing check for a NULL e.
Signed-off-by: u.shevchenko@fobos-nt.ru
Signed-off-by: dinchik@altlinux.org
Fixes #7835

## Summary by Sourcery

Handle missing RDNs safely during DN-format upgrades and avoid running checks that require one.

Bug Fixes:
- Prevent NULL pointer dereferences during DN-format upgrade checks when entries lack a valid RDN.
- Skip DN normalization checks for badly formatted entries without an RDN while logging a warning.