### PR TITLE
Issue 7832 - remove instance monitor directory when server is removed

### DIFF
--- a/dirsrvtests/tests/suites/setup_ds/remove_test.py
+++ b/dirsrvtests/tests/suites/setup_ds/remove_test.py
@@ -57,7 +57,8 @@ def test_basic(topology_st, simple_allocate):
              inst.get_changelog_dir(),
              inst.ds_paths.ldif_dir,
              inst.ds_paths.lock_dir,
-             inst.ds_paths.log_dir]
+             inst.ds_paths.log_dir,
+             os.path.join(inst.ds_paths.run_dir, f"slapd-{inst.serverid}.monitor")]
     for path in paths:
         assert not os.path.exists(path)
 

--- a/src/lib389/lib389/instance/remove.py
+++ b/src/lib389/lib389/instance/remove.py
@@ -63,6 +63,7 @@ def remove_ds_instance(dirsrv, force=False):
     remove_paths['inst_dir'] = dirsrv.ds_paths.inst_dir
     remove_paths['etc_sysconfig'] = "%s/sysconfig/dirsrv-%s" % (dirsrv.ds_paths.sysconf_dir, dirsrv.serverid)
     remove_paths['ldapi'] = dirsrv.ds_paths.ldapi
+    remove_paths['monitor_dir'] = "%s/slapd-%s.monitor" % (dirsrv.ds_paths.run_dir, dirsrv.serverid)
 
     tmpfiles_d_path = dirsrv.ds_paths.tmpfiles_d + "/dirsrv-" + dirsrv.serverid + ".conf"
 
@@ -99,7 +100,7 @@ def remove_ds_instance(dirsrv, force=False):
     # Remove parent (/var/lib/dirsrv/slapd-INST)
     shutil.rmtree(remove_paths['db_dir'].replace('db', ''), ignore_errors=True)
 
-    # Remove /run/slapd-isntance
+    # Remove /run/slapd-instance
     try:
         os.remove(f'/run/slapd-{dirsrv.serverid}.socket')
     except OSError as e:


### PR DESCRIPTION
Description:

The /run/dirsrv/slapd-INSTANCE.monitor/ directory is not removed when the instance is uninstalled.

relates: https://github.com/389ds/389-ds-base/issues/7832

## Summary by Sourcery

Remove leftover monitor runtime directories during Directory Server instance cleanup.

Bug Fixes:
- Remove the instance monitor runtime directory when a Directory Server instance is uninstalled.
- Extend removal tests to verify that the monitor directory is deleted.